### PR TITLE
fix: Reference backend API domain dynamically for frontend client/server components

### DIFF
--- a/frontend/src/components/auth/login.tsx
+++ b/frontend/src/components/auth/login.tsx
@@ -1,8 +1,5 @@
 import React from "react"
 import Image from "next/image"
-// import Link from "next/link"
-import { redirect } from "next/navigation"
-import { createClient } from "@/utils/supabase/server"
 import TracecatIcon from "public/icon.png"
 
 import {
@@ -16,44 +13,16 @@ import {
   GithubOAuthButton,
   GoogleOAuthButton,
 } from "@/components/auth/oauth-buttons"
+import { AlertLevel } from "@/components/notifications"
 
 export default async function Login({
   searchParams,
 }: {
-  searchParams: { message: string }
+  searchParams: { level?: AlertLevel; message?: string }
 }) {
-  const supabase = createClient()
-  const {
-    data: { session },
-  } = await supabase.auth.getSession()
-
-  if (session) {
-    return redirect("/workflows")
-  }
-
   return (
     <div className="container flex h-full w-full items-center justify-center">
       <div className="flex w-full flex-1 flex-col justify-center gap-2 px-8 sm:max-w-md">
-        {/* <Link
-          href="/"
-          className="bg-btn-background hover:bg-btn-background-hover group absolute left-8 top-8 flex items-center rounded-md px-4 py-2 text-sm text-foreground no-underline"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="mr-2 h-4 w-4 transition-transform group-hover:-translate-x-1"
-          >
-            <polyline points="15 18 9 12 15 6" />
-          </svg>{" "}
-          Back
-        </Link> */}
         <CardHeader className="items-center space-y-2 text-center">
           <Image src={TracecatIcon} alt="Tracecat" className="mb-8 h-16 w-16" />
           <CardTitle className="text-2xl">Sign into your account</CardTitle>

--- a/frontend/src/providers/session.tsx
+++ b/frontend/src/providers/session.tsx
@@ -13,6 +13,8 @@ import { useRouter } from "next/navigation"
 import { createClient } from "@/utils/supabase/client"
 import { AuthError, Session, SupabaseClient } from "@supabase/supabase-js"
 
+import { signOutFlow } from "@/lib/auth"
+
 export type SessionContext =
   | {
       isLoading: true
@@ -125,8 +127,9 @@ export const SessionContextProvider = ({
   }, [])
 
   const signOut = useCallback(async () => {
-    await supabaseClient.auth.signOut()
-    router.push("/")
+    // Trigger sign out flow on both the client and server
+    // The below signout flow will sign out from the server and redirect to the login page
+    await signOutFlow()
     router.refresh()
   }, [supabaseClient])
 

--- a/frontend/src/utils/supabase/client.ts
+++ b/frontend/src/utils/supabase/client.ts
@@ -2,6 +2,8 @@ import { createBrowserClient } from "@supabase/ssr"
 
 export const createClient = () =>
   createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NODE_ENV === "development"
+      ? "http://localhost:8000" // In local development mode, the client (in browser) resolves localhost as the host machine
+      : process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   )

--- a/frontend/src/utils/supabase/middleware.ts
+++ b/frontend/src/utils/supabase/middleware.ts
@@ -69,7 +69,7 @@ export const updateSession = async (request: NextRequest) => {
   // Not logged in and on a protected page -> redirect to /
   if (!user && !UNPROTECTED_PATHS.includes(request.nextUrl.pathname)) {
     console.debug("User logged out, redirecting to /")
-    console.debug("Error:", error)
+    console.debug("Error: ", error?.status, error?.message)
     const redirectUrl = new URL("/", request.nextUrl.origin)
     return NextResponse.redirect(redirectUrl)
   }

--- a/tracecat/auth.py
+++ b/tracecat/auth.py
@@ -62,10 +62,6 @@ class AuthenticatedServiceClient(httpx.AsyncClient):
         if self.role.user_id:
             self.headers["Service-User-ID"] = self.role.user_id
 
-    async def __aenter__(self):
-        """Inject the service role and api key to the headers at query time."""
-        return await super().__aenter__()
-
 
 class AuthenticatedAPIClient(AuthenticatedServiceClient):
     """An authenticated httpx client to hit main API endpoints.


### PR DESCRIPTION
# Additional Changes
- Use parent `__aenter__` in `AuthenticatedServiceClient`

Closes #31 

