### PR TITLE
feat(ui+engine): Extend secrets manager

### DIFF
--- a/frontend/src/app/settings/credentials/page.tsx
+++ b/frontend/src/app/settings/credentials/page.tsx
@@ -1,15 +1,32 @@
 "use client"
 
 import { useSession } from "@/providers/session"
+import { Label } from "@radix-ui/react-label"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { PlusCircle } from "lucide-react"
+import { PlusCircle, Trash2Icon } from "lucide-react"
 
 import { Secret } from "@/types/schemas"
 import { deleteSecret, fetchAllSecrets } from "@/lib/secrets"
 import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 import { toast } from "@/components/ui/use-toast"
+import { ConfirmationDialog } from "@/components/confirmation-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import {
   NewCredentialsDialog,
@@ -63,45 +80,106 @@ export default function CredentialsPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div>
+    <div className="h-full space-y-6">
+      <div className="flex items-end justify-between">
         <h3 className="text-lg font-medium">Credentials</h3>
+        <NewCredentialsDialog>
+          <NewCredentialsDialogTrigger asChild>
+            <Button
+              variant="outline"
+              role="combobox"
+              className="ml-auto space-x-2"
+            >
+              <PlusCircle className="mr-2 h-4 w-4" />
+              Create New Secret
+            </Button>
+          </NewCredentialsDialogTrigger>
+        </NewCredentialsDialog>
       </div>
       <Separator />
-      <NewCredentialsDialog>
-        <NewCredentialsDialogTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            className="ml-auto space-x-2"
-          >
-            <PlusCircle className="mr-2 h-4 w-4" />
-            New
-          </Button>
-        </NewCredentialsDialogTrigger>
-      </NewCredentialsDialog>
+
       <div className="space-y-4">
-        {secrets ? (
+        {secrets?.length ? (
           secrets?.map((secret, idx) => (
-            <div
-              key={idx}
-              className="flex items-center justify-center space-x-4"
-            >
-              <Input className="text-sm" value={secret.name} readOnly />
-              <Input
-                className="text-sm"
-                value={`${secret.value.substring(0, 3)}...`}
-                readOnly
-              />
-              <Button variant="destructive" onClick={() => mutate(secret)}>
-                Delete
-              </Button>
-            </div>
+            <SecretsTable key={idx} secret={secret} deleteFn={mutate} />
           ))
         ) : (
-          <NoContent message="No credentials found" />
+          <NoContent
+            className="min-h-[10vh] text-sm"
+            message="No credentials found"
+          />
         )}
       </div>
     </div>
+  )
+}
+
+function SecretsTable({
+  secret,
+  deleteFn,
+}: {
+  secret: Secret
+  deleteFn: (secret: Secret) => void
+}) {
+  return (
+    <Card className="w-full border">
+      <CardHeader>
+        <div className="flex items-end justify-between">
+          <div className="space-y-2">
+            <CardTitle>{secret.name}</CardTitle>
+            <CardDescription>
+              {secret.description || "No description."}
+            </CardDescription>
+          </div>
+          <ConfirmationDialog
+            title={`Delete ${secret.name}?`}
+            description="Are you sure you want to delete this secret? This action cannot be undone."
+            onConfirm={() => deleteFn(secret)}
+          >
+            <Button
+              size="sm"
+              variant="ghost"
+              className="border border-red-500/70 bg-red-500/10 text-red-500/80 hover:bg-red-500/20 hover:text-red-500"
+            >
+              <Trash2Icon className="size-3.5" />
+            </Button>
+          </ConfirmationDialog>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow className="grid h-6 grid-cols-2 text-xs">
+              <TableHead className="col-span-1">Key</TableHead>
+              <TableHead className="col-span-1">Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {secret.keys.map(({ key }, idx) => (
+              <TableRow key={idx} className="grid grid-cols-2">
+                <TableCell className="col-span-1">
+                  <Label htmlFor="stock-1" className="sr-only">
+                    Key
+                  </Label>
+                  <span className="text-sm">{key}</span>
+                </TableCell>
+                <TableCell className="col-span-1">
+                  <Label htmlFor="price-1" className="sr-only">
+                    Value
+                  </Label>
+                  <Input
+                    className="border-none p-0 text-sm shadow-none"
+                    type="password"
+                    value="DUMMY_VALUE"
+                    readOnly
+                    disabled
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
   )
 }

--- a/frontend/src/app/settings/layout.tsx
+++ b/frontend/src/app/settings/layout.tsx
@@ -30,9 +30,9 @@ export default async function SettingsLayout({
     data: { session },
   } = await supabase.auth.getSession()
   return (
-    <>
+    <div className="no-scrollbar h-screen max-h-screen overflow-auto">
       <Navbar session={session} />
-      <div className="container mt-16 space-y-6 p-10 pb-16 md:block">
+      <div className="container space-y-6 p-10 pb-16 pt-16 md:block">
         <div className="space-y-0.5">
           <h2 className="text-2xl font-bold tracking-tight">Settings</h2>
           <p className="text-muted-foreground">
@@ -44,9 +44,9 @@ export default async function SettingsLayout({
           <aside className="-mx-4 lg:w-1/5">
             <SidebarNav items={sidebarNavItems} />
           </aside>
-          <div className="flex-1 lg:max-w-2xl">{children}</div>
+          <div className="w-full flex-1">{children}</div>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/frontend/src/components/confirmation-dialog.tsx
+++ b/frontend/src/components/confirmation-dialog.tsx
@@ -35,7 +35,7 @@ export function ConfirmationDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>Continue</AlertDialogAction>
+          <AlertDialogAction onClick={onConfirm}>Confirm</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/frontend/src/lib/secrets.ts
+++ b/frontend/src/lib/secrets.ts
@@ -6,17 +6,11 @@ import { getAuthenticatedClient } from "@/lib/api"
 
 export async function createSecret(
   maybeSession: Session | null,
-  name: string,
-  value: string
+  secret: Secret
 ) {
   try {
-    console.log("Creating secret", name, value)
     const client = getAuthenticatedClient(maybeSession)
-    const data = {
-      name,
-      value,
-    }
-    await client.put("/secrets", JSON.stringify(data), {
+    await client.put("/secrets", JSON.stringify(secret), {
       headers: {
         "Content-Type": "application/json",
       },

--- a/frontend/src/types/schemas.ts
+++ b/frontend/src/types/schemas.ts
@@ -157,10 +157,25 @@ export const caseCompletionUpdateSchema = z.object({
 })
 export type CaseCompletionUpdate = z.infer<typeof caseCompletionUpdateSchema>
 
+export const secretTypes = ["custom", "token", "oauth2"] as const
+export type SecretType = (typeof secretTypes)[number]
+
+const keyValueSchema = z.object({
+  key: z.string().min(1, "Please enter a key."),
+  value: z.string().min(1, "Please enter a value."),
+})
+
+const snakeCaseRegex = /^[a-z]+(_[a-z]+)*$/
 export const secretSchema = z.object({
   id: z.string().min(1).optional(),
-  name: z.string().min(1, "Please enter a secret name."),
-  value: z.string().min(1, "Please enter the secret value."),
+  type: z.enum(secretTypes),
+  name: z
+    .string()
+    .min(1, "Please enter a secret name.")
+    .regex(snakeCaseRegex, "Secret name must be snake case."),
+  description: z.string().max(255).nullable(),
+  // Can take different types of secrets
+  keys: z.array(keyValueSchema),
 })
 
 export type Secret = z.infer<typeof secretSchema>
@@ -168,7 +183,7 @@ export type Secret = z.infer<typeof secretSchema>
 export const integrationSchema = z.object({
   id: z.string(),
   name: z.string(),
-  description: z.string(),
+  description: z.string().nullable(),
   docstring: z.string(),
   parameters: stringToJSONSchema,
   platform: z.enum(integrationPlatforms),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,17 +8,31 @@ from tracecat.auth import (
     AuthenticatedRunnerClient,
     AuthenticatedServiceClient,
     Role,
-    decrypt_key,
-    encrypt_key,
+    decrypt,
+    decrypt_object,
+    encrypt,
+    encrypt_object,
 )
+from tracecat.config import TRACECAT__API_URL, TRACECAT__RUNNER_URL
 from tracecat.contexts import ctx_session_role
 
 
 def test_encrypt_decrypt():
     api_key = "mock_api_key"
-    encrypted_api_key = encrypt_key(api_key)
-    decrypted_api_key = decrypt_key(encrypted_api_key)
+    encrypted_api_key = encrypt(api_key)
+    decrypted_api_key = decrypt(encrypted_api_key)
     assert decrypted_api_key == api_key
+
+
+def test_encrypt_decrypt_object():
+    obj = {
+        "client_id": "TEST_CLIENT_ID",
+        "client_secret": "TEST_CLIENT_SECRET",
+        "metadata": {"value": 1},
+    }
+    encrypted_obj = encrypt_object(obj)
+    decrypted_obj = decrypt_object(encrypted_obj)
+    assert decrypted_obj == obj
 
 
 @pytest.mark.asyncio
@@ -107,7 +121,7 @@ async def test_authenticated_runner_client_init_no_role():
         assert client.headers["Service-Role"] == "tracecat-service"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert "Service-User-ID" not in client.headers
-        assert client.base_url == os.environ["TRACECAT__RUNNER_URL"]
+        assert client.base_url == TRACECAT__RUNNER_URL
 
 
 @pytest.mark.asyncio
@@ -120,7 +134,7 @@ async def test_authenticated_runner_client_init_with_role():
         assert client.headers["Service-Role"] == "mock_service_id"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert client.headers["Service-User-ID"] == "mock_user_id"
-        assert client.base_url == os.environ["TRACECAT__RUNNER_URL"]
+        assert client.base_url == TRACECAT__RUNNER_URL
 
     role = Role(type="service", service_id="mock_service_id")
     async with AuthenticatedRunnerClient(role=role) as client:
@@ -128,7 +142,7 @@ async def test_authenticated_runner_client_init_with_role():
         assert client.headers["Service-Role"] == "mock_service_id"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert "Service-User-ID" not in client.headers
-        assert client.base_url == os.environ["TRACECAT__RUNNER_URL"]
+        assert client.base_url == TRACECAT__RUNNER_URL
 
     role = Role(type="service")
     async with AuthenticatedRunnerClient(role=role) as client:
@@ -136,7 +150,7 @@ async def test_authenticated_runner_client_init_with_role():
         assert client.headers["Service-Role"] == "tracecat-service"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert "Service-User-ID" not in client.headers
-        assert client.base_url == os.environ["TRACECAT__RUNNER_URL"]
+        assert client.base_url == TRACECAT__RUNNER_URL
 
     role = Role(type="service", user_id="mock_user_id")
     async with AuthenticatedRunnerClient(role=role) as client:
@@ -144,7 +158,7 @@ async def test_authenticated_runner_client_init_with_role():
         assert client.headers["Service-Role"] == "tracecat-service"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert client.headers["Service-User-ID"] == "mock_user_id"
-        assert client.base_url == os.environ["TRACECAT__RUNNER_URL"]
+        assert client.base_url == TRACECAT__RUNNER_URL
 
 
 @pytest.mark.asyncio
@@ -162,7 +176,7 @@ async def test_authenticated_runner_client_init_role_from_context():
         assert client.headers["Service-Role"] == "mock_ctx_service_id"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert client.headers["Service-User-ID"] == "mock_ctx_user_id"
-        assert client.base_url == os.environ["TRACECAT__RUNNER_URL"]
+        assert client.base_url == TRACECAT__RUNNER_URL
 
 
 @pytest.mark.asyncio
@@ -174,7 +188,7 @@ async def test_authenticated_api_client_init_no_role():
         assert client.headers["Service-Role"] == "tracecat-service"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert "Service-User-ID" not in client.headers
-        assert client.base_url == os.environ["TRACECAT__API_URL"]
+        assert client.base_url == TRACECAT__API_URL
 
 
 @pytest.mark.asyncio
@@ -187,7 +201,7 @@ async def test_authenticated_api_client_init_with_role():
         assert client.headers["Service-Role"] == "mock_service_id"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert client.headers["Service-User-ID"] == "mock_user_id"
-        assert client.base_url == os.environ["TRACECAT__API_URL"]
+        assert client.base_url == TRACECAT__API_URL
 
     role = Role(type="service", service_id="mock_service_id")
     async with AuthenticatedAPIClient(role=role) as client:
@@ -195,7 +209,7 @@ async def test_authenticated_api_client_init_with_role():
         assert client.headers["Service-Role"] == "mock_service_id"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert "Service-User-ID" not in client.headers
-        assert client.base_url == os.environ["TRACECAT__API_URL"]
+        assert client.base_url == TRACECAT__API_URL
 
     role = Role(type="service")
     async with AuthenticatedAPIClient(role=role) as client:
@@ -203,7 +217,7 @@ async def test_authenticated_api_client_init_with_role():
         assert client.headers["Service-Role"] == "tracecat-service"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert "Service-User-ID" not in client.headers
-        assert client.base_url == os.environ["TRACECAT__API_URL"]
+        assert client.base_url == TRACECAT__API_URL
 
     role = Role(type="service", user_id="mock_user_id")
     async with AuthenticatedAPIClient(role=role) as client:
@@ -211,4 +225,4 @@ async def test_authenticated_api_client_init_with_role():
         assert client.headers["Service-Role"] == "tracecat-service"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert client.headers["Service-User-ID"] == "mock_user_id"
-        assert client.base_url == os.environ["TRACECAT__API_URL"]
+        assert client.base_url == TRACECAT__API_URL

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1350,7 +1350,13 @@ def list_secrets(
         result = session.exec(statement)
         secrets = result.all()
         return [
-            SecretResponse(id=secret.id, name=secret.name, value=secret.key)
+            SecretResponse(
+                id=secret.id,
+                type=secret.type,
+                name=secret.name,
+                description=secret.description,
+                keys=secret.keys or [],
+            )
             for secret in secrets
         ]
 
@@ -1400,8 +1406,14 @@ def create_secret(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail="Secret already exists"
             )
-        new_secret = Secret(owner_id=role.user_id, name=params.name)
-        new_secret.key = params.value  # Set and encrypt the key
+        new_secret = Secret(
+            owner_id=role.user_id,
+            name=params.name,
+            type=params.type,
+            description=params.description,
+            tags=params.tags,
+        )
+        new_secret.keys = params.keys  # Set and encrypt the key
 
         session.add(new_secret)
         session.commit()
@@ -1427,7 +1439,7 @@ def update_secret(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Secret does not exist"
             )
-        secret.key = params.value  # Set and encrypt the key
+        secret.keys = params.keys  # Set and encrypt the key
         session.add(secret)
         session.commit()
         session.refresh(secret)

--- a/tracecat/db.py
+++ b/tracecat/db.py
@@ -23,7 +23,7 @@ from sqlmodel import (
 )
 
 from tracecat import auth
-from tracecat.auth import decrypt_key, encrypt_key
+from tracecat.auth import decrypt, encrypt
 from tracecat.config import (
     TRACECAT__APP_ENV,
     TRACECAT__RUNNER_URL,
@@ -91,7 +91,7 @@ class Resource(SQLModel):
 class Secret(Resource, table=True):
     id: str | None = Field(default_factory=lambda: uuid4().hex, primary_key=True)
     name: str | None = Field(default=None, max_length=255, index=True, nullable=True)
-    encrypted_api_key: bytes | None = Field(default=None, nullable=True)
+    encrypted_secret: bytes | None = Field(default=None, nullable=True)
     owner_id: str = Field(
         sa_column=Column(String, ForeignKey("user.id", ondelete="CASCADE"))
     )
@@ -101,11 +101,11 @@ class Secret(Resource, table=True):
     def key(self) -> str | None:
         if not self.encrypted_api_key:
             return None
-        return decrypt_key(self.encrypted_api_key)
+        return decrypt(self.encrypted_api_key)
 
     @key.setter
     def key(self, value: str) -> None:
-        self.encrypted_api_key = encrypt_key(value)
+        self.encrypted_secret = encrypt(value)
 
 
 class Editor(SQLModel, table=True):

--- a/tracecat/db.py
+++ b/tracecat/db.py
@@ -2,7 +2,7 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 from uuid import uuid4
 
 import lancedb
@@ -11,7 +11,7 @@ import tantivy
 from croniter import croniter
 from pydantic import computed_field, field_validator
 from slugify import slugify
-from sqlalchemy import TIMESTAMP, Column, Engine, ForeignKey, String, text
+from sqlalchemy import JSON, TIMESTAMP, Column, Engine, ForeignKey, String, text
 from sqlmodel import (
     Field,
     Relationship,
@@ -23,7 +23,7 @@ from sqlmodel import (
 )
 
 from tracecat import auth
-from tracecat.auth import decrypt, encrypt
+from tracecat.auth import decrypt_object, encrypt_object
 from tracecat.config import (
     TRACECAT__APP_ENV,
     TRACECAT__RUNNER_URL,
@@ -31,6 +31,7 @@ from tracecat.config import (
 from tracecat.integrations import IntegrationSpec, registry
 from tracecat.labels.mitre import get_mitre_tactics_techniques
 from tracecat.logger import standard_logger
+from tracecat.types.secrets import SECRET_FACTORY, SecretBase, SecretKeyValue
 
 logger = standard_logger("db")
 
@@ -89,23 +90,43 @@ class Resource(SQLModel):
 
 
 class Secret(Resource, table=True):
+    """Secret model.
+
+    A secret can contain an arbitrary number of keys.
+    e.g.
+    """
+
     id: str | None = Field(default_factory=lambda: uuid4().hex, primary_key=True)
-    name: str | None = Field(default=None, max_length=255, index=True, nullable=True)
-    encrypted_secret: bytes | None = Field(default=None, nullable=True)
+    type: str  # "custom", "token", "oauth2"
+    name: str = Field(..., max_length=255, index=True, nullable=False)
+    description: str | None = Field(default=None, max_length=255)
+    # We store this object as encrypted bytes, but first validate that it's the correct type
+    encrypted_keys: bytes | None = Field(default=None, nullable=True)
+    tags: dict[str, str] | None = Field(sa_column=Column(JSON))
     owner_id: str = Field(
         sa_column=Column(String, ForeignKey("user.id", ondelete="CASCADE"))
     )
     owner: User | None = Relationship(back_populates="secrets")
 
-    @property
-    def key(self) -> str | None:
-        if not self.encrypted_api_key:
-            return None
-        return decrypt(self.encrypted_api_key)
+    def _validate_obj(self, value: dict[str, Any]) -> SecretBase:
+        if self.type not in SECRET_FACTORY:
+            raise ValueError(f"Invalid secret type {self.type!r}")
+        return SECRET_FACTORY[self.type].model_validate(value)
 
-    @key.setter
-    def key(self, value: str) -> None:
-        self.encrypted_secret = encrypt(value)
+    @property
+    def keys(self) -> list[SecretKeyValue] | None:
+        if not self.encrypted_keys:
+            return None
+        obj = decrypt_object(self.encrypted_keys)
+        kv = self._validate_obj(obj)
+        return [SecretKeyValue(key=k, value=v) for k, v in kv.model_dump().items()]
+
+    @keys.setter
+    def keys(self, value: list[SecretKeyValue]) -> None:
+        # Convert to dict
+        kv = {item.key: item.value for item in value}
+        self._validate_obj(kv)
+        self.encrypted_keys = encrypt_object(kv)
 
 
 class Editor(SQLModel, table=True):

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from tracecat.db import ActionRun, WorkflowRun
 from tracecat.types.actions import ActionType
+from tracecat.types.secrets import SecretKeyValue
 
 # TODO: Consistent API design
 # Action and Workflow create / update params
@@ -185,8 +186,16 @@ UpdateUserParams = CreateUserParams
 
 
 class CreateSecretParams(BaseModel):
+    # Secret types
+    # ------------
+    # - Custom: Arbitrary user-defined types
+    # - Token: A token, e.g. API Key, JWT Token (TBC)
+    # - OAuth2: OAuth2 Client Credentials (TBC)
+    type: Literal["custom"]  # Support other types later
     name: str
-    value: str
+    description: str | None = None
+    keys: list[SecretKeyValue]
+    tags: dict[str, str] | None = None
 
 
 UpdateSecretParams = CreateSecretParams
@@ -251,5 +260,7 @@ class CopyWorkflowParams(BaseModel):
 
 class SecretResponse(BaseModel):
     id: str
+    type: Literal["custom"]  # Support other types later
     name: str
-    value: str
+    description: str | None = None
+    keys: list[SecretKeyValue]

--- a/tracecat/types/secrets.py
+++ b/tracecat/types/secrets.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class SecretKeyValue(BaseModel):
+    key: str
+    value: str
+
+
+class SecretBase(BaseModel):
+    pass
+
+
+class CustomSecret(SecretBase):
+    model_config = ConfigDict(extra="allow")
+
+
+# class TokenSecret(SecretBase):
+#     token: str
+
+
+# class OAuth2Secret(SecretBase):
+#     client_id: str
+#     client_secret: str
+#     redirect_uri: str
+
+
+SecretVariant = CustomSecret  # | TokenSecret | OAuth2Secret
+
+SECRET_FACTORY: dict[str, type[SecretBase]] = {
+    "custom": CustomSecret,
+    # "token": TokenSecret,
+    # "oauth2": OAuth2Secret,
+}


### PR DESCRIPTION
# Changes
- Update the `Secret` schema so that each can contain an arbitrary number of key-value pairs. For example, you could define a 'github_secret' that can contain 'GH_ACCESS_TOKEN', 'GH_USERNAME' etc. This makes supporting complex auth/secret types (e.g. OAuth) easier down the line.
- Update the encryption corresponding to the above change. We encrypt the entire keys list as a JSON object, and store the encrypted secret as bytes (same as before).
- Update the credentials page in the settings to reflect the schema changes. The creation wizard has also been updated to accept >=1 key-value pairs.
- Update templated secret parsing in the execution engine and updated tests.

# Testing
- Ran updated tests, `test_templates.py` tests passing.
- Manual workflow run which calls URLScan API with successful console output

Closes #32 