### PR TITLE
feat: Integrate secrets manager with integration functions

### DIFF
--- a/frontend/src/types/schemas.ts
+++ b/frontend/src/types/schemas.ts
@@ -34,6 +34,7 @@ export type ActionType = (typeof actionTypes)[number]
 const integrationTypes = [
   // Example integrations
   "integrations.example.add",
+  "integrations.example.secretive_add",
   "integrations.example.subtract",
   "integrations.example.complex_example",
   "integrations.example.join",

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,6 +1,9 @@
 import pytest
 
+from tracecat.auth import Role
+from tracecat.contexts import ctx_session_role
 from tracecat.integrations._registry import Registry, registry
+from tracecat.runner.actions import run_integration_action
 
 
 @pytest.fixture(autouse=True)
@@ -8,6 +11,12 @@ def setup_tests():
     # Clear the registry before each test
     registry._integrations = {}
     registry._metadata = {}
+
+    # Role
+    service_role = Role(
+        type="service", user_id="mock_user_id", service_id="mock_service_id"
+    )
+    ctx_session_role.set(service_role)
     yield
 
 
@@ -36,3 +45,33 @@ def test_simple_integration():
     assert expected_key in registry.integrations
     assert registry.integrations[expected_key](input_data) == 3
     assert registry.metadata[expected_key]["description"] == "Test description"
+
+
+@pytest.mark.asyncio
+async def test_run_integration_action_no_secrets():
+    """Test running an integration action."""
+    # Role has already been set in the fixture
+    # Register the integration
+
+    @registry.register(
+        description="Test description",
+    )
+    def add(nums: list[int]) -> int:
+        """Adds integers together."""
+        return sum(nums)
+
+    input_data = [1, 2]
+    # Key format is "integrations.<module_name>.<function_name>"
+    # The module name would be 'test_integrations' (current file) in this case
+    expected_key = "integrations.test_integrations.add"
+    expected = 3
+
+    # assert add(input_data) == expected
+
+    # Rune the integration action
+    actual_output = await run_integration_action(
+        qualname=expected_key,
+        params={"nums": input_data},
+    )
+    actual = actual_output["output"]
+    assert actual == expected

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,38 @@
+import pytest
+
+from tracecat.integrations._registry import Registry, registry
+
+
+@pytest.fixture(autouse=True)
+def setup_tests():
+    # Clear the registry before each test
+    registry._integrations = {}
+    registry._metadata = {}
+    yield
+
+
+def test_is_singleton():
+    a = Registry()
+    b = Registry()
+    c = registry
+    assert a is b is c
+
+
+def test_simple_integration():
+    # Import the integration
+
+    @registry.register(
+        description="Test description",
+    )
+    def add(nums: list[int]) -> int:
+        """Adds integers together."""
+        return sum(nums)
+
+    input_data = [1, 2]
+    # Key format is "integrations.<module_name>.<function_name>"
+    # The module name would be 'test_integrations' (current file) in this case
+    expected_key = "integrations.test_integrations.add"
+    assert add(input_data) == 3
+    assert expected_key in registry.integrations
+    assert registry.integrations[expected_key](input_data) == 3
+    assert registry.metadata[expected_key]["description"] == "Test description"

--- a/tracecat/concurrency.py
+++ b/tracecat/concurrency.py
@@ -1,18 +1,30 @@
 from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
-from typing import Any, override
+from typing import Any, ParamSpec, override
 
 import cloudpickle
 
+from tracecat.auth import Role
+from tracecat.contexts import ctx_session_role
+from tracecat.logger import standard_logger
 
-def _apply_cloudpickle(fn: Callable[..., Any], /, *args, **kwargs):
-    fn = cloudpickle.loads(fn)
+logger = standard_logger(__name__)
+
+_P = ParamSpec("_P")
+
+
+def _run_serialized_fn(serialized_fn: bytes, role: Role, /, *args, **kwargs):
+    fn: Callable[_P, Any] = cloudpickle.loads(serialized_fn)
+    ctx_session_role.set(role)
+    logger.debug(f"{role=}")
     return fn(*args, **kwargs)
 
 
 class CloudpickleProcessPoolExecutor(ProcessPoolExecutor):
     @override
-    def submit(self, fn: Callable[..., Any], /, *args, **kwargs):
-        return super().submit(
-            _apply_cloudpickle, cloudpickle.dumps(fn), *args, **kwargs
-        )
+    def submit(self, fn: Callable[_P, Any], /, *args, **kwargs):
+        # We need to pass the role to the function running in the child process
+        role = ctx_session_role.get()
+        logger.debug(f"{role=}")
+        serialized_fn = cloudpickle.dumps(fn)
+        return super().submit(_run_serialized_fn, serialized_fn, role, *args, **kwargs)

--- a/tracecat/concurrency.py
+++ b/tracecat/concurrency.py
@@ -13,11 +13,14 @@ logger = standard_logger(__name__)
 _P = ParamSpec("_P")
 
 
-def _run_serialized_fn(serialized_fn: bytes, role: Role, /, *args, **kwargs):
-    fn: Callable[_P, Any] = cloudpickle.loads(serialized_fn)
+def _run_serialized_fn(serialized_wrapped_fn: bytes, role: Role, /, *args, **kwargs):
+    # NOTE: This is not the raw function - it is still wrapped by the `wrapper` decorator
+    wrapped_fn: Callable[_P, Any] = cloudpickle.loads(serialized_wrapped_fn)
     ctx_session_role.set(role)
     logger.debug(f"{role=}")
-    return fn(*args, **kwargs)
+    kwargs["__role"] = role
+    res = wrapped_fn(*args, **kwargs)
+    return res
 
 
 class CloudpickleProcessPoolExecutor(ProcessPoolExecutor):

--- a/tracecat/integrations/_registry.py
+++ b/tracecat/integrations/_registry.py
@@ -1,6 +1,12 @@
-import inspect
-from typing import Any, Self
+from __future__ import annotations
 
+import asyncio
+import inspect
+import os
+from typing import TYPE_CHECKING, Any, Self
+
+from tracecat import secrets as ts
+from tracecat.auth import Role
 from tracecat.integrations._meta import (
     IntegrationSpec,
     param_to_spec,
@@ -12,6 +18,9 @@ from tracecat.integrations.utils import (
     get_integration_platform,
 )
 from tracecat.logger import standard_logger
+
+if TYPE_CHECKING:
+    from tracecat.db import Secret
 
 logger = standard_logger(__name__)
 
@@ -27,12 +36,14 @@ class Registry:
     """
 
     _instance: Self = None
-    _integrations: dict[str, FunctionType] = {}
-    _metadata: dict[str, dict[str, Any]] = {}
+    _integrations: dict[str, FunctionType]
+    _metadata: dict[str, dict[str, Any]]
 
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
+            cls._integrations = {}
+            cls._metadata = {}
         return cls._instance
 
     def __contains__(self, name: str) -> bool:
@@ -41,33 +52,102 @@ class Registry:
     def __getitem__(self, name: str) -> FunctionType:
         return self.get_integration(name)
 
-    @classmethod
-    def register(cls, description: str, **integration_kwargs):
+    def register(
+        self,
+        description: str,
+        secrets: list[str] | None = None,
+        **integration_kwargs,
+    ):
         """Decorator factory to register a new integration function with additional parameters."""
 
         def decorator_register(func: FunctionType):
+            logger.info(f"Registering integration {func.__name__}")
             validate_type_constraints(func)
             platform = get_integration_platform(func)
             key = get_integration_key(func)
 
             def wrapper(*args, **kwargs):
-                return func(*args, **kwargs)
+                """Wrapper function for the integration.
 
-            if key in cls._integrations:
+                Responsibilities
+                ----------------
+                Before invoking the function:
+                1. Grab all the secrets from the secrets API.
+                2. Inject all secret keys into the execution environment.
+                3. Clean up the environment after the function has executed.
+                """
+                _secrets: list[Secret] = []
+                try:
+                    role = kwargs.pop("__role", None)
+                    # Get secrets from the secrets API
+                    self._logger = standard_logger(f"{__name__}[PID={os.getpid()}]")
+                    self._logger.info("Executing %r in subprocess", key)
+
+                    if secrets:
+                        self._logger.info(f"Pulling secrets: {secrets!r}")
+                        _secrets = self._get_secrets(role=role, secret_names=secrets)
+                        self._set_secrets(_secrets)
+
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    self._logger.error(f"Error running integration '{key}': {e}")
+                    raise
+                finally:
+                    self._logger.info(f"Cleaning up after integration '{key}'.")
+                    self._unset_secrets(_secrets)
+
+            if key in self._integrations:
                 raise ValueError(f"Integration '{key}' is already registered.")
             if not callable(func):
                 raise ValueError("Provided object is not a callable function.")
             # Store function and decorator arguments in a dict
-            cls._integrations[key] = func
-            cls._metadata[key] = {
+            self._integrations[key] = wrapper
+            self._metadata[key] = {
                 "platform": platform,
                 "description": description,
                 "return_type": str(func.__annotations__.get("return")),
+                "specification": self._create_spec(func=func, description=description),
                 **integration_kwargs,
             }
             return wrapper
 
         return decorator_register
+
+    def _get_secrets(self, role: Role, secret_names: list[str]) -> list[Secret]:
+        """Retrieve secrets from the secrets API."""
+
+        self._logger.info(f"Getting secrets {secret_names!r}")
+        return asyncio.run(ts.batch_get_secrets(role, secret_names))
+
+    def _set_secrets(self, secrets: list[Secret]):
+        """Set secrets in the environment."""
+        for secret in secrets:
+            self._logger.info(f"Setting secret {secret!r}")
+            for kv in secret.keys:
+                os.environ[kv.key] = kv.value
+
+    def _unset_secrets(self, secrets: list[Secret]):
+        for secret in secrets:
+            self._logger.info(f"Deleting secret {secret.name!r}")
+            for kv in secret.keys:
+                del os.environ[kv.key]
+
+    def _create_spec(
+        self, *, func: FunctionType, description: str | None
+    ) -> IntegrationSpec:
+        """Get the specification for a registered integration function."""
+        # Inspecting function arguments
+        params = inspect.signature(func).parameters
+        param_list = [param_to_spec(name, param) for name, param in params.items()]
+        platform = get_integration_platform(func)
+
+        return IntegrationSpec(
+            name=func.__name__,
+            description=description,
+            docstring=func.__doc__ or "No documentation provided.",
+            platform=platform,
+            parameters=param_list,
+        )
 
     @property
     def metadata(self) -> dict[str, dict[str, Any]]:
@@ -89,27 +169,9 @@ class Registry:
         """List all registered integrations."""
         return list(self._integrations.keys())
 
-    def _get_spec(self, key: str) -> IntegrationSpec:
-        func = self.integrations[key]
-
-        # Inspecting function arguments
-        params = inspect.signature(func).parameters
-        param_list = [param_to_spec(name, param) for name, param in params.items()]
-        platform = get_integration_platform(func)
-
-        metadata = self.metadata[key]
-        return IntegrationSpec(
-            name=func.__name__,
-            description=metadata["description"],
-            docstring=func.__doc__ or "No documentation provided.",
-            platform=platform,
-            parameters=param_list,
-        )
-
     def get_registered_integration_specs(self) -> list[IntegrationSpec]:
         """Convert the registry to a dictionary of integration functions."""
-
-        return [self._get_spec(key) for key in self.integrations]
+        return [self.metadata[key]["specification"] for key in self.integrations]
 
 
 registry = Registry()

--- a/tracecat/integrations/example.py
+++ b/tracecat/integrations/example.py
@@ -6,6 +6,7 @@ Note
 - You should not use these integrations in production.
 """
 
+import os
 from typing import Literal
 
 from tracecat.integrations._registry import registry
@@ -49,3 +50,14 @@ def complex_example(
 ) -> int:
     """This function has many complex parameters."""
     return 1
+
+
+@registry.register(
+    description="Test description",
+    secrets=["test_secret"],  # test_secret.TEST_KEY
+)
+def secretive_add(nums: list[int]) -> int:
+    """Adds integers together."""
+    value = os.environ["TEST_KEY"]
+    print(f"VALUE: {value}")
+    return sum(nums)

--- a/tracecat/integrations/utils.py
+++ b/tracecat/integrations/utils.py
@@ -1,7 +1,8 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, ParamSpec
 
-FunctionType = Callable[..., Any]
+_P = ParamSpec("_P")
+FunctionType = Callable[_P, Any]
 
 
 def get_integration_platform(func: FunctionType) -> str:

--- a/tracecat/logger.py
+++ b/tracecat/logger.py
@@ -7,9 +7,10 @@ import colorlog
 LOG_FORMAT = (
     "%(log_color)s%(levelname)-8s%(reset)s"
     " [%(cyan)s%(asctime)s%(reset)s]"
+    " [%(green)s%(process)d%(reset)s][%(purple)s%(thread)d%(reset)s]"
     " %(light_red)s%(module)s::%(funcName)s(%(lineno)d)%(reset)s"
     "\t%(light_purple)s%(name)s%(reset)s |"
-    " %(message)s"
+    " %(log_color)s%(message)s%(reset)s"
 )
 
 

--- a/tracecat/messaging/producer.py
+++ b/tracecat/messaging/producer.py
@@ -24,7 +24,7 @@ async def event_producer(
 
     for routing_key in routing_keys:
         await ex.publish(message, routing_key=routing_key)
-        logger.info(f" [x] {routing_key = } Sent {message.body!r}")
+        logger.debug(f" [x] {routing_key = } Sent {message.body!r}")
 
 
 async def publish(

--- a/tracecat/runner/actions.py
+++ b/tracecat/runner/actions.py
@@ -838,11 +838,11 @@ async def run_integration_action(
     custom_logger.debug(f"{params = }")
 
     params = params or {}
-    loop = asyncio.get_running_loop()
 
     func = registry[qualname]
     bound_func = partial(func, **params)
 
+    loop = asyncio.get_running_loop()
     with CloudpickleProcessPoolExecutor() as pool:
         result = await loop.run_in_executor(pool, bound_func)
 

--- a/tracecat/secrets/README.md
+++ b/tracecat/secrets/README.md
@@ -1,0 +1,68 @@
+# Secrets management
+
+## Proposed Design
+
+Move from having flat plain value secrets to a more structured approach with key-value pairs. This sets the groundwork for more advanced features like constraining secret keys to specific values, and more.
+
+The proposed design follows Modal's approach to secrets management. The user can create secrets in the secrets manager, and then reference these secrets by name in their workflows.
+
+## Proposed API
+
+This is what the changes will look like from the user's perspective.
+
+> Assuming `my_datadog_secret` and `my_github_secret` are secrets in the secrets manager.
+> `my_datadog_secret` contains the key `DATADOG_API_KEY` > `my_github_secret` contains the key `GH_ACCESS_TOKEN`, and `GH_USERNAME`
+
+In the UI:
+
+```json
+// A HTTP node:
+{
+  "headers": {
+    "Authorization": "Bearer {{ SECRETS.my_datadog_secret.DATADOG_API_KEY }}"
+  }
+}
+```
+
+For integrations:
+
+```python
+
+
+from tracecat.integrations.registry import registry
+
+@registry.register(
+    description="A simple example integration that uses secrets.",
+    secrets=["my_datadog_secret", "my_github_secret"]
+)
+def my_integration(*args, **kwargs):
+    my_datadog_secret = os.environ["DATADOG_API_KEY"]
+    my_github_user = os.environ["GH_USERNAME"]
+    my_github_secret = os.environ["GH_ACCESS_TOKEN"]
+    # Your function body...
+```
+
+## Use cases
+
+### Templated secret expressions
+
+The current implementation of this is a flat hierarchy of secrets, invoked in any input field as such: `{{ SECRETS.<secret_name> }}`.
+
+### Custom functions: Integration/code execution/data transform nodes.
+
+- When functions are registered you can specify a list of required secrets.
+- These secrets are used to validate that the user has already created these secrets. - These secrets should be then fetched from the secrets manager and passed to the integration function during execution.
+
+The gold standard is a Modal-like interface where you can write regular python code (with calls to os.environ) and the system will resolve the secrets normally.
+
+By design, we already achieve the above separation as we use a `ProcessPoolExecutor` to run custom functions. This means that inside of each child process, we can freely modify the environment without affecting the parent process.
+
+Registering secrets in the decorator does the following:
+
+- Validates that the user has already created these secrets.
+- Fetches the secrets from the secrets manager before the function executes. We might possibly need to somehow isolate each workflow's environment secrets.
+- Passes the secrets to the integration function during execution.
+
+The decorator should also wrap the function in another function that during runtime will perform the API call to get the secrets from the secrets manager, and load them into the environment.
+
+##

--- a/tracecat/secrets/__init__.py
+++ b/tracecat/secrets/__init__.py
@@ -1,0 +1,3 @@
+from tracecat.secrets.helpers import batch_get_secrets
+
+__all__ = ["batch_get_secrets"]

--- a/tracecat/secrets/helpers.py
+++ b/tracecat/secrets/helpers.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+
+from tracecat import db
+from tracecat.auth import AuthenticatedAPIClient, Role
+
+
+async def batch_get_secrets(role: Role, secret_names: list[str]) -> list[db.Secret]:
+    """Retrieve secrets from the secrets API."""
+
+    async with AuthenticatedAPIClient(role=role, http2=True) as client:
+        # NOTE(perf): This is not really batched - room for improvement
+        secret_responses = await asyncio.gather(
+            *[client.get(f"/secrets/{secret_name}") for secret_name in secret_names]
+        )
+        return [
+            db.Secret.model_validate_json(secret_bytes.content)
+            for secret_bytes in secret_responses
+        ]

--- a/tracecat/types/actions.py
+++ b/tracecat/types/actions.py
@@ -18,6 +18,7 @@ ActionType = Literal[
     "open_case",
     # Integrations
     "integrations.example.add",
+    "integrations.example.secretive_add",
     "integrations.example.subtract",
     "integrations.example.complex_example",
     "integrations.example.join",


### PR DESCRIPTION
# Changes
- Allow secrets to be declared in the `@registry.register()` decorator
- The key-value pairs inside each secret (that's added from the frontend) are loaded dynamically into each integration function call.
- See secrets/README.md for more details