### PR TITLE
build: Split dev and prod into separate run options

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,12 @@
+# Overrides for dev environment
+# This should automatically override the docker-compose.yaml file
+# `docker-compose -f docker-compose.yaml -f docker-compose.prod.yaml up`
+services:
+  frontend:
+    build:
+      context: ./frontend
+    container_name: frontend
+    volumes:
+      - ./frontend/src:/app/src
+      - ./frontend/.next:/app/.next
+      - ./frontend/node_modules:/app/node_modules

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,10 @@
+# Overrides for prod environment
+# Merge this into the main docker-compose.yaml file using
+# `docker-compose -f docker-compose.yaml -f docker-compose.prod.yaml up`
+services:
+  frontend:
+    build:
+      context: ./frontend
+    container_name: frontend
+    volumes:
+      - ./frontend/src:/app/src

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,4 @@
+# Base compose file
 version: "3.8"
 services:
   api:
@@ -106,10 +107,6 @@ services:
     env_file: .env
     ports:
       - "3000:3000"
-    volumes:
-      - ./frontend/src:/app/src
-      - ./frontend/.next:/app/.next
-      - ./frontend/node_modules:/app/node_modules
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
       NEXT_PUBLIC_APP_ENV: ${NEXT_PUBLIC_APP_ENV}

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -31,12 +31,12 @@ Run the command below to start Tracecat and all related services.
 git clone git@github.com:TracecatHQ/tracecat.git
 cd tracecat
 chmod +x services.sh
-bash services.sh start
+bash services.sh start --env prod
 ```
 
 <Note>
-  You can run `bash services.sh start --tail` to view the logs of all services
-  in real-time.
+  You can run `bash services.sh start --env prod --tail` to view the logs of all
+  services in real-time.
 </Note>
 
 You'll be prompted to enter your public facing Runner URL (you can set one up using ngrok), OpenAI API key, and Resend API key.
@@ -95,7 +95,7 @@ You can view the API docs at `http://localhost:8000/docs` and the runner docs at
 To spin down all services, run the following command:
 
 ```bash
-bash services.sh stop
+bash services.sh stop --env prod
 ```
 
 If you'd like to spin down specific services, you can pass additional options as such:
@@ -108,6 +108,11 @@ bash services.sh stop --supabase # or -s, Stops Supabase services
 ## Restarting services
 
 Running `bash services.sh start` will restart all services if they are already running.
+
+## Runtime environment configuration
+
+Note that we've been passing `--env prod` flag to the `services.sh` script. This is to avoid having to install `npm` and `pnpm` on the host machine.
+If you'd like to make code contributions or run the services in development mode, use `--env dev` instead or don't pass an environment flag (runs as `dev` by default).
 
 ## Troubldshooting
 

--- a/services.sh
+++ b/services.sh
@@ -15,10 +15,17 @@ else
     NC='\033[0m' # No Color
 fi
 
-# Initial COMMAND setup for docker compose
-DOCKER_COMPOSE_UP_FLAGS=""
+# Start services flags
+DOCKER_COMPOSE_UP_FLAGS=
+DOCKER_COMPOSE_COMMAND=
 TAIL_LOGS=false
 BUILD_SERVICES=false
+ENVIRONMENT="dev"
+
+# Stop services flags
+# Remove all by default
+REMOVE_INTERNAL=true
+REMOVE_SUPABASE=true
 
 dotenv_replace() {
     local env_var_name=$1
@@ -38,6 +45,22 @@ dotenv_replace() {
     eval sed $sed_option "s$delimiter^${env_var_name}=.*$delimiter${env_var_name}=${new_value}$delimiter" $file_path
 }
 
+set_docker_compose_command() {
+    case $ENVIRONMENT in
+        dev)
+            DOCKER_COMPOSE_COMMAND="docker compose"
+            ;;
+        prod)
+            DOCKER_COMPOSE_COMMAND="docker compose -f docker-compose.yaml -f docker-compose.prod.yaml"
+            ;;
+        *)
+            echo -e "${RED}Invalid environment '${ENVIRONMENT}' specified. Please use 'dev' or 'prod'.${NC}"
+            exit 1
+            ;;
+    esac
+    echo -e "${YELLOW}Using command '$DOCKER_COMPOSE_COMMAND'.${NC}"
+}
+
 # Function to handle start command
 start_services() {
     # Check for --tail flag in subsequent arguments. If not present, start services in detached mode.
@@ -49,7 +72,6 @@ start_services() {
     if $BUILD_SERVICES; then
         DOCKER_COMPOSE_UP_FLAGS+=" --build"
     fi
-
 
     echo -e "${YELLOW}Starting Tracecat application setup...${NC}"
 
@@ -150,7 +172,7 @@ start_services() {
 
 
     echo -e "${YELLOW}Starting Tracecat services with docker compose flags '$DOCKER_COMPOSE_UP_FLAGS'.${NC}"
-    if docker compose down --remove-orphans && docker compose up $DOCKER_COMPOSE_UP_FLAGS; then
+    if $DOCKER_COMPOSE_COMMAND down --remove-orphans && $DOCKER_COMPOSE_COMMAND up $DOCKER_COMPOSE_UP_FLAGS; then
         echo -e "${GREEN}Tracecat local development setup started successfully.${NC}"
         echo -e "${BLUE}API URL:${NC} http://localhost:8000"
         echo -e "${BLUE}Runner URL:${NC} http://localhost:8001"
@@ -162,9 +184,7 @@ start_services() {
     echo -e "${GREEN}Tracecat local development setup is complete.${NC}"
 }
 
-# Remove all by default
-REMOVE_INTERNAL=true
-REMOVE_SUPABASE=true
+
 # Function to handle stop command
 stop_services() {
     if [ $REMOVE_INTERNAL = true ]; then
@@ -194,36 +214,29 @@ shift # Remove the first argument, leaving any additional arguments
 # Execute based on the action
 case $ACTION in
     start)
-        # Parse additional arguments
-        for arg in "$@"
-        do
-            case $arg in
-                --tail|-t)
-                TAIL_LOGS=true
-                ;;
-            esac
-            case $arg in
-                --build|-b)
-                BUILD_SERVICES=true
-                ;;
+        while true; do
+            case "$1" in
+                -t | --tail ) TAIL_LOGS=true; shift ;;
+                -b | --build ) BUILD_SERVICES=true; shift ;;
+                -e | --env ) ENVIRONMENT="$2"; shift 2 ;;
+                * ) break ;;
             esac
         done
+        echo -e "${YELLOW}Environment: $ENVIRONMENT${NC}"
+        set_docker_compose_command
         start_services
         ;;
     stop)
-        for arg in "$@"
-        do
-            case $arg in
-                --supabase|-s)
-                REMOVE_INTERNAL=false
-                ;;
-            esac
-            case $arg in
-                --internal|-i)
-                REMOVE_SUPABASE=false
-                ;;
+        while true; do
+            case "$1" in
+                -s | --supabase ) REMOVE_INTERNAL=false; shift ;;
+                -i | --internal ) REMOVE_SUPABASE=false; shift ;;
+                -e | --env ) ENVIRONMENT="$2"; shift 2 ;;
+                * ) break ;;
             esac
         done
+        echo -e "${YELLOW}Environment: $ENVIRONMENT${NC}"
+        set_docker_compose_command
         stop_services
         ;;
     *)


### PR DESCRIPTION
# Description
Closes #47. Updated `services.sh` to parse the desired runtime environment.

`dev` mode uses bind mounts with your host machine `frontend/node_modules` and `frontend/.next` to sync host/container. This requires running `pnpm install` inside of `/frontend`, then using the commands below:
- Start `./services.sh start ...` 
- Stop `./services.sh stop ...` 

This is suitable for local development.

`prod` mode bypasses running `pnpm install` on the host, suitable for quick preview use cases.
- Start `./services.sh start --env prod ...`
- Stop `./services.sh stop --env prod ...`

## Additional changes
- Add option to force rebuild images using `--no-cache` flag.

# Remarks
I would rather have used `pnpm start` to override the start command, but doing so seems to change some hidden config inside of posthog and supabase that isn't very clear...