### PR TITLE
feat(ui): Add more checks before initializing posthog

### DIFF
--- a/frontend/src/providers/posthog.tsx
+++ b/frontend/src/providers/posthog.tsx
@@ -3,25 +3,43 @@
 import posthog from "posthog-js"
 import { PostHogProvider } from "posthog-js/react"
 
-if (typeof window !== "undefined") {
-  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY || "" // Ensure that the variable is defined
-  posthog.init(posthogKey, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_INGEST_HOST,
-    ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-    persistence: "memory", // We don't use cookies for analytics!
-    capture_pageview: false,
-    // Disable session recording by default
-    disable_session_recording:
-      process.env.NEXT_PUBLIC_DISABLE_SESSION_RECORDING === "true",
-    session_recording: {
-      // If even session recording is enabled,
-      // we mask all inputs and text for maximum privacy
-      maskAllInputs: true,
-      maskTextSelector: "*",
-    },
-  })
+export const initPostHog = () => {
+  // @ts-ignore
+  console.log("Initializing PostHog 👋")
+  try {
+    if (typeof window !== "undefined") {
+      // @ts-ignore
+      const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
+      if (
+        process.env.NODE_ENV === "production" &&
+        process.env.ENABLE_TELEMETRY === "true" &&
+        posthogKey
+      ) {
+        posthog.init(posthogKey, {
+          api_host: process.env.NEXT_PUBLIC_POSTHOG_INGEST_HOST,
+          ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+          persistence: "memory", // We don't use cookies for analytics!
+          capture_pageview: false,
+          // Disable session recording by default
+          disable_session_recording:
+            process.env.NEXT_PUBLIC_DISABLE_SESSION_RECORDING === "true",
+          session_recording: {
+            // If even session recording is enabled,
+            // we mask all inputs and text for maximum privacy
+            maskAllInputs: true,
+            maskTextSelector: "*",
+          },
+        })
+      }
+    }
+    return posthog
+  } catch (e) {
+    console.log("posthog err", e)
+  }
+  return undefined
 }
 
 export function PHProvider({ children }: { children: React.ReactNode }) {
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+  const ph = initPostHog()
+  return <PostHogProvider client={ph}>{children}</PostHogProvider>
 }


### PR DESCRIPTION
## Reference Issues/PRs
Inspired by the way Infisical does their posthog init.


## What does this implement/fix? Explain your changes.
- Performs additional checks before initializing posthog. Was facing an error when using `pnpm start` with Docker and using NODE_ENV=production -- I suspect that doing so has some less-documented effect on posthog/supabase. 
- Add explicit ENABLE_TELEMETRY env var.

## Any other comments?
- Currently just completely circumventing this issue by using `pnpm dev`