### PR TITLE
feat(engine+ui): Add Datadog security signals actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,5 @@ NEXT_PUBLIC_DISABLE_SESSION_RECORDING=true
 # Integrations env vars (optional)
 OPENAI_API_KEY=your-openai-api-key
 RESEND_API_KEY=your-resend-api-key
+DD_API_KEY=your-datadog-api-key
+DD_APP_KEY=your-datadog-app-key

--- a/frontend/src/types/schemas.ts
+++ b/frontend/src/types/schemas.ts
@@ -45,7 +45,9 @@ const integrationTypes = [
   // Material Security
   "integrations.sublime_security.test",
   // Datadog
-  "integrations.datadog.test",
+  "integrations.datadog.list_security_signals",
+  "integrations.datadog.update_security_signal_state",
+  "integrations.datadog.list_detection_rules",
 ] as const
 export type IntegrationType = (typeof integrationTypes)[number]
 

--- a/tracecat/integrations/datadog.py
+++ b/tracecat/integrations/datadog.py
@@ -25,11 +25,11 @@ logger = standard_logger(__name__)
 
 
 DD_REGION_TO_URL = {
-    "us1": "https://app.datadoghq.com",
-    "us3": "https://us3.datadoghq.com",
-    "us2": "https://us2.datadoghq.com",
-    "eu1": "https://app.datadoghq.eu",
-    "ap1": "https://app.datadoghq.com",
+    "ap1": "https://api.ap1.datadoghq.com",
+    "eu1": "https://api.datadoghq.eu",
+    "us1": "https://api.datadoghq.com",
+    "us3": "https://api.us3.datadoghq.com",
+    "us5": "https://api.us5.datadoghq.com",
 }
 
 

--- a/tracecat/integrations/datadog.py
+++ b/tracecat/integrations/datadog.py
@@ -99,7 +99,7 @@ def update_security_signal_state(
     archive_comment: str | None = None,
     archive_reason: str | None = None,
     region: str = "us1",
-) -> dict:
+) -> dict[str, Any]:
     """Return updated security signal object."""
     with create_datadog_client(region=region) as client:
         rsp = client.patch(

--- a/tracecat/integrations/datadog.py
+++ b/tracecat/integrations/datadog.py
@@ -1,4 +1,11 @@
-"""Datadog integrations."""
+"""Integrations with Datadog security monitoring API.
+
+Inputs and outputs are denoised and normalized.
+The interface is an opintionated take on the request / responses most relevant for high-fidelity alert management.
+This is not a 1-to-1 mapping to the Datadog API.
+
+API reference: https://docs.datadoghq.com/api/latest/security-monitoring
+"""
 
 from tracecat.integrations._registry import registry
 from tracecat.logger import standard_logger
@@ -6,8 +13,25 @@ from tracecat.logger import standard_logger
 logger = standard_logger(__name__)
 
 
-@registry.register(description="Test datadog integration. Do not use in production.")
-def test() -> str:
-    """Test datadog integration."""
-    logger.info("Testing datadog integration. Woof")
-    return "test_datadog"
+DD_SITE_TO_URL = {
+    "us1": "app.datadoghq.com",
+    "us3": "us3.datadoghq.com",
+    "us2": "us2.datadoghq.com",
+    "eu1": "app.datadoghq.eu",
+    "ap1": "app.datadoghq.com",
+}
+
+
+@registry.register(description="Get Datadog SIEM security signals.")
+def list_security_signals(datadog_site: str = "us1"):
+    pass
+
+
+@registry.register(description="Update Datadog SIEM security signal.")
+def update_security_signal(datadog_site: str = "us1"):
+    pass
+
+
+@registry.register(description="List Datadog SIEM detection rules.")
+def list_detection_rules(datadog_site: str = "us1"):
+    pass

--- a/tracecat/integrations/datadog.py
+++ b/tracecat/integrations/datadog.py
@@ -56,7 +56,7 @@ def list_security_signals(
     end: datetime | None = None,
     limit: int = 100,
     region: str = "us1",
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """Return list of security signals."""
     body = {
         "filter": {

--- a/tracecat/integrations/datadog.py
+++ b/tracecat/integrations/datadog.py
@@ -4,8 +4,19 @@ Inputs and outputs are denoised and normalized.
 The interface is an opintionated take on the request / responses most relevant for high-fidelity alert management.
 This is not a 1-to-1 mapping to the Datadog API.
 
+Required credentials: `datadog-security-monitoring` secret with `DD_API_KEY` and `DD_APP_KEY` keys.
+
 API reference: https://docs.datadoghq.com/api/latest/security-monitoring
 """
+
+import os
+from datetime import datetime
+from typing import Literal
+
+import httpx
+import orjson
+import polars as pl
+import polars.selectors as cs
 
 from tracecat.integrations._registry import registry
 from tracecat.logger import standard_logger
@@ -13,25 +24,155 @@ from tracecat.logger import standard_logger
 logger = standard_logger(__name__)
 
 
-DD_SITE_TO_URL = {
-    "us1": "app.datadoghq.com",
-    "us3": "us3.datadoghq.com",
-    "us2": "us2.datadoghq.com",
-    "eu1": "app.datadoghq.eu",
-    "ap1": "app.datadoghq.com",
+DD_REGION_TO_URL = {
+    "us1": "https://app.datadoghq.com",
+    "us3": "https://us3.datadoghq.com",
+    "us2": "https://us2.datadoghq.com",
+    "eu1": "https://app.datadoghq.eu",
+    "ap1": "https://app.datadoghq.com",
 }
 
 
-@registry.register(description="Get Datadog SIEM security signals.")
-def list_security_signals(datadog_site: str = "us1"):
-    pass
+def create_datadog_client(region: str):
+    base_url = DD_REGION_TO_URL.get(region, "https://app.datadoghq.com")
+    dd_api_key = os.environ["DD_API_KEY"]
+    dd_app_key = os.environ["DD_APP_KEY"]
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "DD-API-KEY": dd_api_key,
+        "DD-APPLICATION-KEY": dd_app_key,
+    }
+    return httpx.Client(base_url=base_url, headers=headers)
 
 
-@registry.register(description="Update Datadog SIEM security signal.")
-def update_security_signal(datadog_site: str = "us1"):
-    pass
+@registry.register(
+    description="Get Datadog SIEM security signals. Requires `security_monitoring_signals_read` scope.",
+    secrets=["datadog-security-monitoring"],
+)
+def list_security_signals(
+    query: str | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    limit: int = 100,
+    region: str = "us1",
+) -> list[dict]:
+    """Return list of security signals."""
+    body = {
+        "filter": {
+            # Assume UTC
+            "from": start.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+            "to": end.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+            "query": query,
+        },
+        "page": {"limit": limit},
+    }
+    with create_datadog_client(region=region) as client:
+        rsp = client.post(
+            "/api/v2/security_monitoring/signals", data=orjson.dumps(body)
+        )
+        rsp.raise_for_status()
+
+    events = rsp.json().get("data", [])
+    signals = (
+        pl.from_dicts(events)
+        .unnest("attributes")
+        # TODO: Select relevant columns
+        # .select([])
+        .to_dicts()
+    )
+    return signals
 
 
-@registry.register(description="List Datadog SIEM detection rules.")
-def list_detection_rules(datadog_site: str = "us1"):
-    pass
+@registry.register(
+    description="Update Datadog SIEM security signal's triage state. Requires `security_monitoring_signals_write` scope.",
+    secrets=["datadog-security-monitoring"],
+)
+def update_security_signal_state(
+    state: Literal[
+        "none",
+        "false_positive",
+        "testing_or_maintenance",
+        "investigated_case_opened",
+        "other",
+    ],
+    archive_comment: str | None = None,
+    archive_reason: str | None = None,
+    region: str = "us1",
+) -> dict:
+    """Return updated security signal object."""
+    with create_datadog_client(region=region) as client:
+        rsp = client.patch(
+            "/api/v2/security_monitoring/signals/{signal_id}/state",
+            data=orjson.dumps(
+                {
+                    "state": state,
+                    "archive_comment": archive_comment,
+                    "archive_reason": archive_reason,
+                }
+            ),
+        )
+        rsp.raise_for_status()
+    return rsp.json()
+
+
+@registry.register(
+    description="List Datadog SIEM detection rules. Requires `security_monitoring_rules_read` scope.",
+    secrets=["datadog-security-monitoring"],
+)
+def list_detection_rules(region: str = "us1") -> list[dict]:
+    """Return list of detection rules."""
+    page_size = 100
+    max_pages = 20  # In reality ~10-15 pages only, but this is a safety net
+
+    rules = []
+    for i in range(max_pages):
+        with create_datadog_client(region=region) as client:
+            rsp = client.get(
+                "/api/v2/security_monitoring/rules",
+                params={"page[size]": page_size, "page[number]": i},
+            )
+            rsp.raise_for_status()
+            obj = rsp.json()
+        # Unpack rules
+        listed_rules = obj["data"]
+        rules.extend(listed_rules)
+        if len(listed_rules) < page_size:
+            break
+
+    # NOTE: Not all rules are log detections
+    detection_rules = (
+        pl.LazyFrame(rules)
+        .unique("id")
+        .explode("tags")
+        .with_columns(
+            tag_key=pl.col("tags").str.split(":").get(0),
+            tag_value=pl.col("tags").str.split(":").get(1),
+        )
+        .collect()
+        .pivot(
+            index=cs.all().exclude("tag_value", "tag_key", "tags"),
+            values="tag_value",
+            columns="tag_key",
+        )
+        # Select and normalize column names
+        .select(
+            [
+                pl.col("id").alias("rule_id"),
+                pl.col("name").alias("rule_name"),
+                pl.col("source").alias("log_source"),
+                pl.col("tactic"),
+                pl.col("technique"),
+                pl.col("queries"),
+                pl.col("options"),
+                pl.col("cases"),
+                pl.col("message"),
+                pl.col("isDefault").alias("is_default"),
+                pl.col("isEnabled").alias("is_enabled"),
+                pl.col("isDeleted").alias("is_deleted"),
+            ]
+        )
+        .sort(["source", "tactic", "technique"])
+        .to_dicts()
+    )
+    return detection_rules

--- a/tracecat/integrations/datadog.py
+++ b/tracecat/integrations/datadog.py
@@ -11,7 +11,7 @@ API reference: https://docs.datadoghq.com/api/latest/security-monitoring
 
 import os
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 import httpx
 import orjson

--- a/tracecat/integrations/datadog.py
+++ b/tracecat/integrations/datadog.py
@@ -34,7 +34,7 @@ DD_REGION_TO_URL = {
 
 
 def create_datadog_client(region: str):
-    base_url = DD_REGION_TO_URL.get(region, "https://app.datadoghq.com")
+    base_url = DD_REGION_TO_URL.get(region, DD_REGION_TO_URL["us1"])
     dd_api_key = os.environ["DD_API_KEY"]
     dd_app_key = os.environ["DD_APP_KEY"]
     headers = {

--- a/tracecat/types/actions.py
+++ b/tracecat/types/actions.py
@@ -25,5 +25,7 @@ ActionType = Literal[
     ## Material Security
     "integrations.sublime_security.test",
     ## Datadog
-    "integrations.datadog.test",
+    "integrations.datadog.list_security_signals",
+    "integrations.datadog.update_security_signal_state",
+    "integrations.datadog.list_detection_rules",
 ]


### PR DESCRIPTION
Closes part of tracker issue #67

Note: still untested. Requires an AWS-Datadog lab environment (with stratus-red-team to generator signals).

- [x] Integration and action form shows up correctly in frontend
<img width="1047" alt="dd_integrations" src="https://github.com/TracecatHQ/tracecat/assets/46541035/034825fb-a43a-4e57-a218-a84f70af12cf">

- [x] Confirmed type hints to UI works

<img width="533" alt="image" src="https://github.com/TracecatHQ/tracecat/assets/46541035/90b957f0-84cc-4f8e-96f9-a6cdab4d325f">

- [x] Confirm form saves and state shows up in JSON viewer
