### PR TITLE
fix: Remove multiprocessing for run integration action

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
-"""Set up shared environment variables and S3 proxy server (MinIO) for integration tests.
-"""
+"""Set up shared environment variables and S3 proxy server (MinIO) for integration tests."""
 
 import logging
 import os
@@ -7,9 +6,6 @@ from uuid import uuid4
 
 import pytest
 from cryptography.fernet import Fernet
-
-from tracecat.db import Secret
-from tracecat.types.secrets import SecretKeyValue
 
 # MinIO settings
 MINIO_CONTAINER_NAME = "minio_test_server"
@@ -31,6 +27,7 @@ def setup_shared_env():
     os.environ["TRACECAT__DB_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
     os.environ["TRACECAT__API_URL"] = "http://api:8000"
     os.environ["TRACECAT__RUNNER_URL"] = "http://runner:8000"
+    os.environ["TRACECAT__PUBLIC_RUNNER_URL"] = "http://localhost:8001"
     os.environ["TRACECAT__SERVICE_KEY"] = "test-service-key"
 
     # AWS
@@ -55,6 +52,9 @@ def setup_shared_env():
 
 @pytest.fixture(scope="session")
 def create_mock_secret():
+    from tracecat.db import Secret
+    from tracecat.types.secrets import SecretKeyValue
+
     def _get_secret(secret_name: str, secrets: dict[str, str]) -> list[Secret]:
         keys = [SecretKeyValue(key=k, value=v) for k, v in secrets.items()]
         new_secret = Secret(

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -33,18 +33,18 @@ def test_simple_integration():
     @registry.register(
         description="Test description",
     )
-    def add(nums: list[int]) -> int:
+    def add1(nums: list[int]) -> int:
         """Adds integers together."""
         return sum(nums)
 
     input_data = [1, 2]
     # Key format is "integrations.<module_name>.<function_name>"
     # The module name would be 'test_integrations' (current file) in this case
-    expected_key = "integrations.test_integrations.add"
-    assert add(input_data) == 3
-    assert expected_key in registry.integrations
-    assert registry.integrations[expected_key](input_data) == 3
-    assert registry.metadata[expected_key]["description"] == "Test description"
+    expected_qualifier = "integrations.test_integrations.add1"
+    assert add1(input_data) == 3
+    assert expected_qualifier in registry.integrations
+    assert registry.integrations[expected_qualifier](input_data) == 3
+    assert registry.metadata[expected_qualifier]["description"] == "Test description"
 
 
 @pytest.mark.asyncio
@@ -56,21 +56,19 @@ async def test_run_integration_action_no_secrets():
     @registry.register(
         description="Test description",
     )
-    def add(nums: list[int]) -> int:
+    def add2(nums: list[int]) -> int:
         """Adds integers together."""
         return sum(nums)
 
     input_data = [1, 2]
     # Key format is "integrations.<module_name>.<function_name>"
     # The module name would be 'test_integrations' (current file) in this case
-    expected_key = "integrations.test_integrations.add"
+    expected_qualifier = "integrations.test_integrations.add2"
     expected = 3
-
-    # assert add(input_data) == expected
 
     # Rune the integration action
     actual_output = await run_integration_action(
-        qualname=expected_key,
+        qualname=expected_qualifier,
         params={"nums": input_data},
     )
     actual = actual_output["output"]

--- a/tracecat/concurrency.py
+++ b/tracecat/concurrency.py
@@ -12,6 +12,8 @@ _P = ParamSpec("_P")
 
 logger = Logger("executor.cloudpickle")
 
+# TODO: Do something about these functions
+
 
 def _run_serialized_fn(serialized_wrapped_fn: bytes, role: Role, /, *args, **kwargs):
     # NOTE: This is not the raw function - it is still wrapped by the `wrapper` decorator

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -4,7 +4,9 @@ from pathlib import Path
 HTTP_MAX_RETRIES = 10
 LLM_MAX_RETRIES = 3
 
-TRACECAT_DIR = Path(os.environ["TRACECAT_DIR"]).expanduser().resolve()
+TRACECAT_DIR = (
+    Path(os.environ.get("TRACECAT_DIR", "~/.tracecat")).expanduser().resolve()
+)
 TRACECAT__SCHEDULE_INTERVAL_SECONDS = os.environ.get(
     "TRACECAT__SCHEDULE_INTERVAL_SECONDS", 60
 )
@@ -12,7 +14,9 @@ TRACECAT__SCHEDULE_MAX_CONNECTIONS = 6
 TRACECAT__APP_ENV = os.environ.get("TRACECAT__APP_ENV", "dev")
 TRACECAT__API_URL = os.environ.get("TRACECAT__API_URL", "http://api:8000")
 TRACECAT__RUNNER_URL = os.environ.get("TRACECAT__RUNNER_URL", "http://runner:8000")
-TRACECAT__PUBLIC_RUNNER_URL = os.environ["TRACECAT__PUBLIC_RUNNER_URL"]
+TRACECAT__PUBLIC_RUNNER_URL = os.environ.get(
+    "TRACECAT__PUBLIC_RUNNER_URL", "http://localhost:8001"
+)
 
 TRACECAT__TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
 TRACECAT__TRIAGE_DIR = TRACECAT_DIR / "triage"


### PR DESCRIPTION
# Motivation
After upgrading to loguru, integration would throw an error regarding `multiprocessing.SimpleQueue` when the execution is offloaded to a child process. 

Realizations: when using cloudpickle, it captures the function + imported modules. This also captures the loguru logger, which (most likely) has a queue object it uses for async writes. 

# Solution
Remove multiprocessing