### PR TITLE
ci: Setup basic nginx reverse proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,5 @@
-# Base compose file
+version: '3.8'
+
 services:
   api:
     build: .
@@ -10,7 +11,6 @@ services:
       - app-storage:/var/lib/tracecat
     environment:
       API_MODULE: "tracecat.api.app:app"
-      # Shared
       LOG_LEVEL: ${LOG_LEVEL}
       RABBITMQ_URI: ${RABBITMQ_URI}
       TRACECAT__APP_ENV: ${TRACECAT__APP_ENV}
@@ -21,17 +21,13 @@ services:
       TRACECAT__API_URL: ${TRACECAT__API_URL}
       TRACECAT__RUNNER_URL: ${TRACECAT__RUNNER_URL}
       TRACECAT__PUBLIC_RUNNER_URL: ${TRACECAT__PUBLIC_RUNNER_URL}
-      # Auth
       CLERK_FRONTEND_API_URL: ${CLERK_FRONTEND_API_URL}
       TRACECAT__DISABLE_AUTH: ${TRACECAT__DISABLE_AUTH}
-      # Integrations
       OPENAI_API_KEY: ${OPENAI_API_KEY}
     restart: unless-stopped
     depends_on:
       rabbitmq:
         condition: service_healthy
-    networks:
-      - internal-network
 
   runner:
     build: .
@@ -43,7 +39,6 @@ services:
       - app-storage:/var/lib/tracecat
     environment:
       API_MODULE: "tracecat.runner.app:app"
-      # Shared
       LOG_LEVEL: ${LOG_LEVEL}
       RABBITMQ_URI: ${RABBITMQ_URI}
       TRACECAT__APP_ENV: ${TRACECAT__APP_ENV}
@@ -54,16 +49,12 @@ services:
       TRACECAT__API_URL: ${TRACECAT__API_URL}
       TRACECAT__RUNNER_URL: ${TRACECAT__RUNNER_URL}
       TRACECAT__PUBLIC_RUNNER_URL: ${TRACECAT__PUBLIC_RUNNER_URL}
-      # Integrations
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       RESEND_API_KEY: ${RESEND_API_KEY}
-
     restart: unless-stopped
     depends_on:
       rabbitmq:
         condition: service_healthy
-    networks:
-      - internal-network
 
   frontend:
     build:
@@ -85,8 +76,7 @@ services:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
       NEXT_PUBLIC_APP_ENV: ${NEXT_PUBLIC_APP_ENV}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL}
-      # Auth
-      NEXT_PUBLIC_DISABLE_AUTH: ${TRACECAT__DISABLE_AUTH} # Prefix with NEXT_PUBLIC_ to expose to client
+      NEXT_PUBLIC_DISABLE_AUTH: ${TRACECAT__DISABLE_AUTH}
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY}
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       NEXT_PUBLIC_CLERK_SIGN_IN_URL: ${NEXT_PUBLIC_CLERK_SIGN_IN_URL}
@@ -95,15 +85,13 @@ services:
     depends_on:
       - api
       - runner
-    networks:
-      - internal-network
 
   rabbitmq:
     image: rabbitmq:3.13-management
     container_name: rabbitmq
     ports:
-      - "5672:5672" # RabbitMQ server
-      - "15672:15672" # Management UI
+      - "5672:5672"
+      - "15672:15672"
     environment:
       RABBITMQ_USER: ${RABBITMQ_USER}
       RABBITMQ_PASS: ${RABBITMQ_PASS}
@@ -115,8 +103,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    networks:
-      - internal-network
 
   postgres_db:
     image: postgres:16.2-bullseye
@@ -130,11 +116,18 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    networks:
-      - internal-network
 
-networks:
-  internal-network:
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - api
+      - runner
+      - frontend
 
 volumes:
   app-storage:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,43 @@
+events {}
+
+http {
+    upstream api {
+        server api:8000;
+    }
+
+    upstream runner {
+        server runner:8000;
+    }
+
+    upstream frontend {
+        server frontend:3000;
+    }
+
+    server {
+        listen 80;
+
+        location /api/ {
+            proxy_pass http://api;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /runner/ {
+            proxy_pass http://runner;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
**Motivation:** the behavior out-of-the-box docker networking is inconsistent. We are getting reports from Linux box users being unable to connect frontend to the API service.

**Changes**
- nginx reverse proxy to avoid host.docker.internal
- Remove the internal docker network
- Get rid of `host.docker.internal`
- Fixes the CORS issue in #118 

Closes #138 #118 