### PR TITLE
feat: Add and improve triggers UI

### DIFF
--- a/frontend/src/components/console/control-panel.tsx
+++ b/frontend/src/components/console/control-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useEventFeedContext } from "@/providers/event-feed-stream"
-import { useWorkflowMetadata } from "@/providers/workflow"
+import { useWorkflow } from "@/providers/workflow"
 import { FileJson, FileType, Sheet } from "lucide-react"
 import { useFormContext } from "react-hook-form"
 
@@ -53,7 +53,7 @@ export function ConsolePanel({
   className,
 }: React.HTMLAttributes<HTMLDivElement>) {
   const { control } = useFormContext<WorkflowControlsForm>()
-  const { workflow } = useWorkflowMetadata()
+  const { workflow } = useWorkflow()
   const [actions, setActions] = useState<Action[]>([])
   const { isStreaming, clearEvents } = useEventFeedContext()
   useEffect(() => {
@@ -199,11 +199,7 @@ export function ConsolePanel({
             description="You are about to clear all console events from your local browser storage. This action cannot be undone."
             onConfirm={handleClearEvents}
           >
-            <Button
-              className={cn("w-full")}
-              type="button"
-              variant="outline"
-            >
+            <Button className={cn("w-full")} type="button" variant="outline">
               Clear Events
             </Button>
           </ConfirmationDialog>

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -17,6 +17,7 @@ import {
   Sparkles,
   Tags,
   Webhook,
+  ZapIcon,
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -202,15 +203,16 @@ export const UDFIcons: Record<
       <BoxesIcon {...rest} />
     </div>
   ),
+  // Triggers namespace
+  trigger: ({ className, ...rest }) => (
+    <div className={cn("bg-indigo-100", basicIconsCommon, className)}>
+      <ZapIcon {...rest} />
+    </div>
+  ),
   // Core namespace
   core: ({ className, ...rest }) => (
     <div className={cn("bg-slate-200/50", basicIconsCommon, className)}>
       <Cpu {...rest} />
-    </div>
-  ),
-  "core.webhook": ({ className, ...rest }) => (
-    <div className={cn("bg-indigo-100", basicIconsCommon, className)}>
-      <Webhook {...rest} />
     </div>
   ),
   "core.http_request": ({ className, ...rest }) => (

--- a/frontend/src/components/nav/workflow-nav.tsx
+++ b/frontend/src/components/nav/workflow-nav.tsx
@@ -3,7 +3,7 @@
 import React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useWorkflowMetadata } from "@/providers/workflow"
+import { useWorkflow } from "@/providers/workflow"
 import {
   GitPullRequestCreateArrowIcon,
   RadioIcon,
@@ -11,7 +11,7 @@ import {
   WorkflowIcon,
 } from "lucide-react"
 
-import { useCommitWorkflow } from "@/lib/hooks"
+import { Badge } from "@/components/ui/badge"
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -25,63 +25,62 @@ import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export default function WorkflowNav() {
-  const { workflow, workflowId, isLoading, isOnline, setIsOnline } =
-    useWorkflowMetadata()
-  const { mutateAsync: commitAsync } = useCommitWorkflow(workflowId!)
+  const { workflow, isLoading, isOnline, setIsOnline, commit } = useWorkflow()
+
+  const handleCommit = async () => {
+    console.log("Committing changes...")
+    await commit()
+  }
 
   if (!workflow || isLoading) {
     return null
   }
 
-  const handleCommit = async () => {
-    console.log("Committing changes...")
-    await commitAsync()
-  }
   return (
-    workflowId && (
-      <div className="flex w-full items-center space-x-8">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/workflows">Workflows</BreadcrumbLink>
-            </BreadcrumbItem>
-            {workflow && (
-              <>
-                <BreadcrumbSeparator className="font-semibold">
-                  {"/"}
-                </BreadcrumbSeparator>
-                <BreadcrumbItem>{workflow.title}</BreadcrumbItem>
-              </>
-            )}
-          </BreadcrumbList>
-        </Breadcrumb>
-        <TabSwitcher workflowId={workflowId} />
-        <div className="flex flex-1 items-center justify-end space-x-3">
-          <Button
-            variant="outline"
-            onClick={handleCommit}
-            className="delay-50 h-7 text-xs text-muted-foreground transition duration-200 ease-in-out hover:-translate-y-0.5 hover:scale-105 hover:bg-emerald-500 hover:text-white"
-          >
-            <GitPullRequestCreateArrowIcon className="mr-2 size-4" />
-            Commit
-          </Button>
+    <div className="flex w-full items-center space-x-8">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/workflows">Workflows</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator className="font-semibold">
+            {"/"}
+          </BreadcrumbSeparator>
+          <BreadcrumbItem>{workflow.title}</BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <TabSwitcher workflowId={workflow.id} />
+      <div className="flex flex-1 items-center justify-end space-x-3">
+        <Button
+          variant="outline"
+          onClick={handleCommit}
+          className="delay-50 h-7 text-xs text-muted-foreground transition duration-200 ease-in-out hover:-translate-y-0.5 hover:scale-105 hover:bg-emerald-500 hover:text-white"
+        >
+          <GitPullRequestCreateArrowIcon className="mr-2 size-4" />
+          Commit
+        </Button>
+        <Badge
+          variant="outline"
+          className="text-xs font-normal text-muted-foreground hover:cursor-default"
+        >
+          {workflow.version ? `v${workflow.version}` : "Not Committed"}
+        </Badge>
 
-          <Switch
-            id="enable-workflow"
-            checked={isOnline}
-            onCheckedChange={setIsOnline}
-            className="data-[state=checked]:bg-emerald-500"
-          />
-          <Label
-            className="flex text-xs text-muted-foreground"
-            htmlFor="enable-workflow"
-          >
-            <RadioIcon className="mr-2 h-4 w-4" />
-            <span>Enable workflow</span>
-          </Label>
-        </div>
+        <Switch
+          id="enable-workflow"
+          checked={isOnline}
+          onCheckedChange={setIsOnline}
+          className="data-[state=checked]:bg-emerald-500"
+        />
+        <Label
+          className="flex text-xs text-muted-foreground"
+          htmlFor="enable-workflow"
+        >
+          <RadioIcon className="mr-2 h-4 w-4" />
+          <span>Enable workflow</span>
+        </Label>
       </div>
-    )
+    </div>
   )
 }
 

--- a/frontend/src/components/workspace/canvas/canvas.tsx
+++ b/frontend/src/components/workspace/canvas/canvas.tsx
@@ -6,17 +6,22 @@ import ReactFlow, {
   Controls,
   Edge,
   MarkerType,
+  NodeChange,
   ReactFlowInstance,
   useEdgesState,
   useNodesState,
   useReactFlow,
+  XYPosition,
+  type Node,
   type ReactFlowJsonObject,
 } from "reactflow"
 
 import "reactflow/dist/style.css"
 
 import { useParams } from "next/navigation"
+import { useWorkflow } from "@/providers/workflow"
 
+import { Workflow } from "@/types/schemas"
 import {
   createAction,
   deleteAction,
@@ -24,13 +29,25 @@ import {
   updateDndFlow,
 } from "@/lib/workflow"
 import { useToast } from "@/components/ui/use-toast"
+import triggerNode, {
+  TriggerNodeData,
+  TriggerNodeType,
+  TriggerTypename,
+} from "@/components/workspace/canvas/trigger-node"
 import udfNode, {
   UDFNodeData,
   UDFNodeType,
 } from "@/components/workspace/canvas/udf-node"
 
+export type NodeTypename = "udf" | "trigger"
+export type NodeType = UDFNodeType | TriggerNodeType
+export type NodeData = UDFNodeData | TriggerNodeData
+
+export const invincibleNodeTypes: readonly string[] = [TriggerTypename]
+
 const nodeTypes = {
   udf: udfNode,
+  trigger: triggerNode,
 }
 
 const defaultEdgeOptions = {
@@ -39,24 +56,98 @@ const defaultEdgeOptions = {
   },
   style: { strokeWidth: 2 },
 }
-const WorkflowCanvas: React.FC = () => {
-  const reactFlowWrapper = useRef<HTMLDivElement>(null)
+
+function isInvincible<T>(node: Node<T>): boolean {
+  return invincibleNodeTypes.includes(node?.type as string)
+}
+
+async function createNewNode(
+  type: NodeTypename,
+  workflowId: string,
+  nodeData: NodeData,
+  newPosition: XYPosition
+): Promise<NodeType> {
+  const common = {
+    type,
+    position: newPosition,
+    data: nodeData,
+  }
+  let newNode: NodeType
+  switch (type) {
+    case "udf":
+      const actionId = await createAction(
+        nodeData.type,
+        nodeData.title,
+        workflowId
+      )
+      // Then create Action node in React Flow
+      newNode = {
+        id: actionId,
+        ...common,
+      } as UDFNodeType
+
+      return newNode
+    default:
+      console.error("Invalid node type")
+      throw new Error("Invalid node type")
+  }
+}
+
+function getInitialState(
+  workflow: Workflow,
+  containerRef: React.RefObject<HTMLDivElement>
+) {
+  const rect = containerRef.current?.getBoundingClientRect()
+  const width = rect?.width || 0
+  const height = rect?.height || 0
+  const graphInitialState = {
+    nodes: [
+      {
+        id: `trigger-${workflow.id}`,
+        type: "trigger",
+        position: { x: width / 2, y: height / 2 },
+        data: {
+          type: "trigger",
+          title: "Trigger",
+          status: "online",
+          isConfigured: true,
+          webhook: workflow.webhook,
+          schedules: workflow.schedules,
+        },
+      },
+    ],
+    edges: [],
+    viewport: {
+      x: 0,
+      y: 0,
+      zoom: 1,
+    },
+  }
+  return graphInitialState
+}
+
+export function WorkflowCanvas() {
+  const containerRef = useRef<HTMLDivElement>(null)
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance | null>(null)
-  const { setViewport } = useReactFlow()
+  const { setViewport, getNode } = useReactFlow()
   const { workflowId } = useParams<{ workflowId: string }>()
   const { toast } = useToast()
+  const { update } = useWorkflow()
 
+  /**
+   * Load the saved workflow
+   */
   useEffect(() => {
     async function initializeReactFlowInstance() {
       if (!workflowId) {
         return
       }
       try {
-        const response = await fetchWorkflow(workflowId)
-        const flow = response.object as ReactFlowJsonObject
+        const workflow = await fetchWorkflow(workflowId)
+        const flow = workflow.object as ReactFlowJsonObject
         if (flow) {
           // If there is a saved React Flow configuration, load it
           setNodes(flow.nodes || [])
@@ -66,6 +157,12 @@ const WorkflowCanvas: React.FC = () => {
             y: flow.viewport.y,
             zoom: flow.viewport.zoom,
           })
+        } else {
+          // Otherwise, load the default nodes
+          const initialState = getInitialState(workflow, containerRef)
+          setNodes(initialState.nodes)
+          setEdges(initialState.edges)
+          setViewport(initialState.viewport)
         }
       } catch (error) {
         console.error("Failed to fetch workflow data:", error)
@@ -76,10 +173,31 @@ const WorkflowCanvas: React.FC = () => {
 
   // React Flow callbacks
   const onConnect = useCallback(
-    (params: Edge | Connection) => {
+    async (params: Edge | Connection) => {
+      console.log("Edge connected:", params)
+      if (params.source?.startsWith("trigger")) {
+        params = {
+          ...params,
+          label: "⚡ Trigger",
+        }
+        // 1. Find the trigger node
+        let triggerNode = nodes.find(
+          (node) => node.type === "trigger"
+        ) as TriggerNodeType
+        // 2. Find the entrypoint node
+        let entrypointNode = getNode(
+          params.target! /* Target is non-null as we are in a connect callback */
+        )
+        if (!triggerNode || !entrypointNode) {
+          throw new Error("Could not find trigger or entrypoint node")
+        }
+
+        // 3. Set the workflow entrypoint
+        await update({ entrypoint: entrypointNode.id })
+      }
       setEdges((eds) => addEdge(params, eds))
     },
-    [edges, setEdges]
+    [edges, setEdges, getNode, setNodes]
   )
 
   const onDragOver = useCallback(
@@ -104,44 +222,53 @@ const WorkflowCanvas: React.FC = () => {
       return
     }
 
-    const reactFlowNodeType = event.dataTransfer.getData(
+    const nodeTypename = event.dataTransfer.getData(
       "application/reactflow"
-    )
-    console.log("React Flow Node Type:", reactFlowNodeType)
+    ) as NodeTypename
+    console.log("Node Typename:", nodeTypename)
 
     const rawNodeData = event.dataTransfer.getData("application/json")
-    const nodeData = JSON.parse(rawNodeData) as UDFNodeData
+    const nodeData = JSON.parse(rawNodeData) as NodeData
 
     console.log("Action Node Data:", nodeData)
 
-    // Create Action in database
-    const actionId = await createAction(
-      nodeData.type,
-      nodeData.title,
-      workflowId
-    )
     const reactFlowNodePosition = reactFlowInstance.screenToFlowPosition({
       x: event.clientX,
       y: event.clientY,
     })
-    // Then create Action node in React Flow
-    const newNode = {
-      id: actionId,
-      type: reactFlowNodeType,
-      position: reactFlowNodePosition,
-      data: nodeData,
-    } as UDFNodeType
-
-    setNodes((prevNodes) =>
-      prevNodes
-        .map((n) => ({ ...n, selected: false }))
-        .concat({ ...newNode, selected: true })
-    )
+    try {
+      const newNode = await createNewNode(
+        nodeTypename,
+        workflowId,
+        nodeData,
+        reactFlowNodePosition
+      )
+      // Create Action in database
+      setNodes((prevNodes) =>
+        prevNodes
+          .map((n) => ({ ...n, selected: false }))
+          .concat({ ...newNode, selected: true })
+      )
+    } catch (error) {
+      console.error("An error occurred while creating a new node:", error)
+      toast({
+        title: "Failed to create new node",
+        description: "Could not create new node.",
+      })
+    }
   }
 
-  const onNodesDelete = async (nodesToDelete: UDFNodeType[]) => {
+  const onNodesDelete = async <T,>(nodesToDelete: Node<T>[]) => {
     try {
-      await Promise.all(nodesToDelete.map((node) => deleteAction(node.id)))
+      const filteredNodes = nodesToDelete.filter((node) => !isInvincible(node))
+      if (filteredNodes.length === 0) {
+        toast({
+          title: "Invalid action",
+          description: "Cannot delete invincible node",
+        })
+        return
+      }
+      await Promise.all(filteredNodes.map((node) => deleteAction(node.id)))
       setNodes((nds) =>
         nds.filter((n) => !nodesToDelete.map((nd) => nd.id).includes(n.id))
       )
@@ -153,12 +280,59 @@ const WorkflowCanvas: React.FC = () => {
   }
 
   const onEdgesDelete = useCallback(
-    (edgesToDelete: Edge[]) => {
+    async (edgesToDelete: Edge[]) => {
+      edgesToDelete.forEach(async (params: Edge) => {
+        if (params.source?.startsWith("trigger")) {
+          // 1. Find the trigger node
+          let triggerNode = nodes.find(
+            (node) => node.type === "trigger"
+          ) as TriggerNodeType
+          // 2. Find the entrypoint node
+          let entrypointNode = getNode(
+            params.target! /* Target is non-null as we are in a connect callback */
+          )
+          if (!triggerNode || !entrypointNode) {
+            throw new Error("Could not find trigger or entrypoint node")
+          }
+
+          // 3. Update the trigger node UI state with the entrypoint id
+          // We'll persist this through the trigger panel
+          await update({ entrypoint: null })
+        }
+      })
       setEdges((eds) =>
         eds.filter((e) => !edgesToDelete.map((ed) => ed.id).includes(e.id))
       )
     },
-    [edges, setEdges]
+    [edges, setEdges, getNode, setNodes]
+  )
+
+  const handleNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      const nextChanges = changes.reduce((acc, change) => {
+        // if this change is supposed to remove a node we want to validate it first
+        if (change.type === "remove") {
+          const node = getNode(change.id)
+
+          // if the node can be removed, keep the change, otherwise we skip the change and keep the node
+          if (node && !isInvincible(node)) {
+            console.log("Node is not invincible, removing it")
+            return [...acc, change]
+          }
+
+          // change is skipped, node is kept
+          console.log("Node is invincible, keeping it")
+          return acc
+        }
+
+        // all other change types are just put into the next changes arr
+        return [...acc, change]
+      }, [] as NodeChange[])
+
+      // apply the changes we kept
+      onNodesChange(nextChanges)
+    },
+    [nodes, setNodes]
   )
 
   // Saving react flow instance state
@@ -179,7 +353,7 @@ const WorkflowCanvas: React.FC = () => {
   }
 
   return (
-    <div ref={reactFlowWrapper} style={{ height: "100%" }}>
+    <div ref={containerRef} style={{ height: "100%" }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -189,7 +363,7 @@ const WorkflowCanvas: React.FC = () => {
         onEdgesChange={onEdgesChange}
         onEdgesDelete={onEdgesDelete}
         onInit={setReactFlowInstance}
-        onNodesChange={onNodesChange}
+        onNodesChange={handleNodesChange}
         onNodesDelete={onNodesDelete}
         onNodeDragStop={onNodesDragStop}
         defaultEdgeOptions={defaultEdgeOptions}
@@ -204,5 +378,3 @@ const WorkflowCanvas: React.FC = () => {
     </div>
   )
 }
-
-export { WorkflowCanvas }

--- a/frontend/src/components/workspace/canvas/custom-handle.tsx
+++ b/frontend/src/components/workspace/canvas/custom-handle.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from "react"
+import {
+  Edge,
+  getConnectedEdges,
+  Handle,
+  Node,
+  useNodeId,
+  useStore,
+  type HandleProps,
+} from "reactflow"
+
+interface CustomHandleProps
+  extends Omit<HandleProps, "isConnectable">,
+    React.HTMLAttributes<HTMLDivElement> {
+  isConnectable?:
+    | number
+    | boolean
+    | ((args: { node: Node; connectedEdges: Edge[] }) => boolean)
+}
+export function CustomHandle(props: CustomHandleProps) {
+  const { nodeInternals, edges } = useStore((s: any) => ({
+    nodeInternals: s.nodeInternals,
+    edges: s.edges,
+  }))
+  const nodeId = useNodeId()
+
+  const isHandleConnectable = useMemo(() => {
+    if (typeof props.isConnectable === "function") {
+      const node = nodeInternals.get(nodeId)
+      const connectedEdges = getConnectedEdges([node], edges)
+
+      return props.isConnectable({ node, connectedEdges })
+    }
+
+    if (typeof props.isConnectable === "number") {
+      const node = nodeInternals.get(nodeId)
+      const connectedEdges = getConnectedEdges([node], edges)
+
+      return connectedEdges.length < props.isConnectable
+    }
+
+    return props.isConnectable
+  }, [nodeInternals, edges, nodeId, props.isConnectable])
+
+  return <Handle {...props} isConnectable={isHandleConnectable}></Handle>
+}

--- a/frontend/src/components/workspace/canvas/trigger-node.tsx
+++ b/frontend/src/components/workspace/canvas/trigger-node.tsx
@@ -1,0 +1,185 @@
+import React from "react"
+import { useWorkflowBuilder } from "@/providers/builder"
+import { useWorkflow } from "@/providers/workflow"
+import {
+  BellDotIcon,
+  CalendarCheck,
+  ChevronDownIcon,
+  CircleCheckBigIcon,
+  EyeIcon,
+  LayoutListIcon,
+  ScanSearchIcon,
+  WebhookIcon,
+} from "lucide-react"
+import { Node, NodeProps, Position, useNodeId } from "reactflow"
+
+import { Schedule, Webhook } from "@/types/schemas"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Separator } from "@/components/ui/separator"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { getIcon } from "@/components/icons"
+import NoContent from "@/components/no-content"
+import { CustomHandle } from "@/components/workspace/canvas/custom-handle"
+
+export interface TriggerNodeData {
+  type: "trigger"
+  title: string
+  status: "online" | "offline"
+  isConfigured: boolean
+  entrypointId?: string
+  webhook: Webhook
+  schedules: Schedule[]
+}
+export type TriggerNodeType = Node<TriggerNodeData>
+export const TriggerTypename = "trigger" as const
+
+export default React.memo(function TriggerNode({
+  data: { title, isConfigured, type },
+  selected,
+}: NodeProps<TriggerNodeData>) {
+  const id = useNodeId()
+  const { workflowId, getNode, reactFlow } = useWorkflowBuilder()
+  const { workflow } = useWorkflow()
+
+  if (!workflow) {
+    return null
+  }
+
+  return (
+    <Card className={cn("min-w-72", selected && "shadow-xl drop-shadow-xl")}>
+      <CardHeader className="p-4 px-4">
+        <div className="flex w-full items-center space-x-4">
+          {getIcon(type, {
+            className: "size-10 p-2",
+          })}
+
+          <div className="flex w-full flex-1 justify-between space-x-12">
+            <div className="flex flex-col">
+              <CardTitle className="flex w-full items-center justify-between text-xs font-medium leading-none">
+                <div className="flex w-full">{title}</div>
+              </CardTitle>
+              <CardDescription className="mt-2 text-xs text-muted-foreground">
+                Workflow triggers
+              </CardDescription>
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="m-0 h-6 w-6 p-0">
+                  <ChevronDownIcon className="m-1 h-4 w-4 text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem disabled>
+                  <ScanSearchIcon className="mr-2 h-4 w-4" />
+                  <span className="text-xs">Search events</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem disabled>
+                  <EyeIcon className="mr-2 h-4 w-4" />
+                  <span className="text-xs">View logs</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </CardHeader>
+      <Separator />
+      <div className="p-4">
+        <div className="space-y-4">
+          <div
+            className={cn(
+              "flex h-8 items-center justify-center gap-1 rounded-lg border text-xs text-muted-foreground",
+              workflow?.webhook.status === "offline"
+                ? "bg-muted-foreground/5 text-muted-foreground/50"
+                : "bg-background text-emerald-500"
+            )}
+          >
+            <WebhookIcon className="size-3" />
+            <span>Webhook</span>
+            <span
+              className={cn(
+                "ml-2 inline-block size-2 rounded-full ",
+                workflow.webhook.status === "online"
+                  ? "bg-emerald-500"
+                  : "bg-gray-300"
+              )}
+            />
+          </div>
+
+          <div className="rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="h-8 text-center text-xs">
+                    <div className="flex items-center justify-center gap-1">
+                      <CalendarCheck className="size-3" />
+                      <span>Schedules</span>
+                    </div>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {workflow.schedules.map(({ id, cron }) => (
+                  <TableRow key={id}>
+                    <TableCell>{cron}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              <TableFooter>
+                <NoContent
+                  className="min-h-8 text-xs text-muted-foreground/70"
+                  message="No schedules"
+                />
+              </TableFooter>
+            </Table>
+          </div>
+        </div>
+      </div>
+      <Separator />
+      <CardContent className="p-4 py-3">
+        <div className="grid grid-cols-2 space-x-4 text-xs text-muted-foreground">
+          <div className="flex items-center space-x-2">
+            {isConfigured ? (
+              <CircleCheckBigIcon className="size-4 text-emerald-500" />
+            ) : (
+              <LayoutListIcon className="size-4 text-gray-400" />
+            )}
+            <span className="text-xs capitalize">{"Not configured"}</span>
+          </div>
+          <div className="flex items-center justify-end">
+            <BellDotIcon className="mr-2 h-3 w-3" />0
+          </div>
+        </div>
+      </CardContent>
+
+      <CustomHandle
+        type="source"
+        position={Position.Bottom}
+        className="w-16 !bg-gray-500"
+        style={{ width: 8, height: 8 }}
+        isConnectable={1}
+      />
+    </Card>
+  )
+})

--- a/frontend/src/components/workspace/catalog/catalog.tsx
+++ b/frontend/src/components/workspace/catalog/catalog.tsx
@@ -1,0 +1,11 @@
+import { TriggerCatalog } from "@/components/workspace/catalog/trigger-catalog"
+import { UDFCatalog } from "@/components/workspace/catalog/udf-catalog"
+
+export function WorkflowCatalog({ isCollapsed }: { isCollapsed: boolean }) {
+  return (
+    <div className="flex flex-col space-y-2">
+      <TriggerCatalog isCollapsed={isCollapsed} />
+      <UDFCatalog isCollapsed={isCollapsed} />
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/catalog/trigger-catalog.tsx
+++ b/frontend/src/components/workspace/catalog/trigger-catalog.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { DragEvent } from "react"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { getIcon } from "@/components/icons"
+import { TriggerTypename } from "@/components/workspace/canvas/trigger-node"
+
+const onDragStart = (event: DragEvent<HTMLDivElement>) => {
+  event.dataTransfer.setData("application/reactflow", TriggerTypename)
+  event.dataTransfer.setData(
+    "application/json",
+    JSON.stringify({
+      type: TriggerTypename,
+      title: "Trigger",
+      status: "offline",
+      isConfigured: false,
+      webhooks: [],
+      schedules: [],
+    })
+  )
+  event.dataTransfer.effectAllowed = "move"
+}
+
+export function TriggerCatalog({ isCollapsed }: { isCollapsed: boolean }) {
+  return (
+    <div
+      data-collapsed={isCollapsed}
+      className="group flex flex-col gap-4 p-2 data-[collapsed=true]:py-2"
+    >
+      <nav className="grid px-2 group-[[data-collapsed=true]]:justify-center group-[[data-collapsed=true]]:px-2">
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <div
+              className={cn(
+                buttonVariants({
+                  variant: "ghost",
+                  size: isCollapsed ? "icon" : "sm",
+                }),
+                "hover:cursor-default hover:bg-transparent",
+                isCollapsed ? "size-9" : "w-full justify-start gap-2"
+              )}
+              onDragStart={(event) => onDragStart(event)}
+            >
+              {getIcon(TriggerTypename, { className: "size-5" })}
+              {!isCollapsed && <span>Trigger</span>}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent
+            side="right"
+            className={cn(
+              "flex items-center gap-4 rounded-lg p-2 shadow-lg",
+              !isCollapsed && "hidden"
+            )}
+          >
+            Trigger
+          </TooltipContent>
+        </Tooltip>
+      </nav>
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/panel/trigger-panel.tsx
+++ b/frontend/src/components/workspace/panel/trigger-panel.tsx
@@ -1,0 +1,310 @@
+"use client"
+
+import "react18-json-view/src/style.css"
+
+import React from "react"
+import {
+  BanIcon,
+  CalendarClockIcon,
+  CheckCheckIcon,
+  CopyIcon,
+  PlusCircleIcon,
+  SaveIcon,
+  SettingsIcon,
+  WebhookIcon,
+} from "lucide-react"
+
+import { Schedule, Webhook, Workflow } from "@/types/schemas"
+import { useUpdateWebhook } from "@/lib/hooks"
+import { copyToClipboard } from "@/lib/utils"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { getIcon } from "@/components/icons"
+import {
+  TriggerNodeData,
+  TriggerTypename,
+} from "@/components/workspace/canvas/trigger-node"
+
+export function TriggerPanel({
+  nodeData,
+  workflow,
+}: {
+  nodeData: TriggerNodeData
+  workflow: Workflow
+}) {
+  return (
+    <div className="size-full overflow-auto">
+      <div className="grid grid-cols-3">
+        <div className="col-span-2 overflow-hidden">
+          <h3 className="p-4 px-4">
+            <div className="flex w-full items-center space-x-4">
+              {getIcon(TriggerTypename, {
+                className: "size-10 p-2",
+                flairSize: "md",
+              })}
+              <div className="flex w-full flex-1 justify-between space-x-12">
+                <div className="flex flex-col">
+                  <div className="flex w-full items-center justify-between text-xs font-medium leading-none">
+                    <div className="flex w-full">Trigger</div>
+                  </div>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Workflow Triggers
+                  </p>
+                </div>
+              </div>
+            </div>
+          </h3>
+        </div>
+        <div className="flex justify-end space-x-2 p-4">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="icon" disabled>
+                <SaveIcon className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Save</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+      <Separator />
+      {/* Metadata */}
+      <Accordion
+        type="multiple"
+        defaultValue={[
+          "trigger-settings",
+          "trigger-webhooks",
+          "trigger-schedules",
+        ]}
+      >
+        {/* General */}
+        <AccordionItem value="trigger-settings">
+          <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+            <div className="flex items-center">
+              <SettingsIcon className="mr-3 size-4" />
+              <span>General</span>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className="my-4 space-y-2 px-4">
+              <GeneralControls
+                entrypointRef={workflow.entrypoint ?? undefined}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Webhooks */}
+        <AccordionItem value="trigger-webhooks">
+          <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+            <div className="flex items-center">
+              <WebhookIcon className="mr-3 size-4" />
+              <span>Webhook</span>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className="my-4 space-y-2 px-4">
+              <WebhookControls
+                webhook={workflow.webhook}
+                workflowId={workflow.id}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Schedules */}
+        <AccordionItem value="trigger-schedules">
+          <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+            <div className="flex items-center">
+              <CalendarClockIcon className="mr-3 size-4" />
+              <span>Schedules</span>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className="my-4 space-y-2 px-4">
+              <ScheduleControls schedules={workflow.schedules} />
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  )
+}
+
+export function GeneralControls({ entrypointRef }: { entrypointRef?: string }) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Entrypoint</span>
+          {entrypointRef ? (
+            <CopyButton
+              value={entrypointRef}
+              toastMessage="Copied entrypoint ID to clipboard"
+            />
+          ) : (
+            <BanIcon className="size-3 text-muted-foreground" />
+          )}
+        </Label>
+        <div className="rounded-md border shadow-sm">
+          <Input
+            name="entrypointId"
+            className="rounded-md border-none text-xs shadow-none"
+            value={entrypointRef || "No entrypoint"}
+            readOnly
+            disabled
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function WebhookControls({
+  webhook: { id, url, status },
+  workflowId,
+}: {
+  webhook: Webhook
+  workflowId: string
+}) {
+  const { mutateAsync } = useUpdateWebhook(workflowId, id)
+  const onCheckedChange = async (checked: boolean) => {
+    await mutateAsync({
+      status: checked ? "online" : "offline",
+    })
+  }
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Toggle Webhook</span>
+        </Label>
+        <Switch
+          checked={status === "online"}
+          onCheckedChange={onCheckedChange}
+          className="data-[state=checked]:bg-emerald-500"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>URL</span>
+          <CopyButton value={url} toastMessage="Copied URL to clipboard" />
+        </Label>
+        <div className="rounded-md border shadow-sm">
+          <Input
+            name="url"
+            defaultValue={url}
+            className="rounded-md border-none text-xs shadow-none"
+            readOnly
+            disabled
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+function CopyButton({
+  value,
+  toastMessage,
+}: {
+  value: string
+  toastMessage: string
+}) {
+  const [copied, setCopied] = React.useState(false)
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          className="group m-0 size-4 p-0"
+          onClick={() => {
+            copyToClipboard({
+              value,
+              message: toastMessage,
+            })
+            setCopied(true)
+            setTimeout(() => setCopied(false), 2000)
+          }}
+        >
+          {copied ? (
+            <CheckCheckIcon className="size-3 text-muted-foreground" />
+          ) : (
+            <CopyIcon className="size-3 text-muted-foreground" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Copy</TooltipContent>
+    </Tooltip>
+  )
+}
+export function ScheduleControls({ schedules }: { schedules: Schedule[] }) {
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="h-8 text-center text-xs">
+              <div className="flex items-center justify-center gap-1">
+                <WebhookIcon className="size-3" />
+                <span>Schedules</span>
+              </div>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {schedules.map(({ id, cron }) => (
+            <TableRow key={id}>
+              <TableCell>{cron}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter className="flex w-full justify-center text-muted-foreground">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="flex w-full items-center justify-center gap-2"
+          >
+            <PlusCircleIcon className="size-4" />
+            <span>Add Schedule</span>
+          </Button>
+        </TableFooter>
+      </Table>
+    </div>
+  )
+}
+
+// ;<div className="flex w-full max-w-sm items-center rounded-md border">
+//   <Input
+//     name="url"
+//     defaultValue={url}
+//     className="rounded-r-none border-none pr-0"
+//     readOnly
+//     disabled
+//   />
+//   <Button variant="ghost" className="group rounded-l-none border-l shadow-sm">
+//     <CopyIcon className="size-4 text-muted-foreground/50 group-hover:text-foreground" />
+//   </Button>
+// </div>

--- a/frontend/src/components/workspace/panel/workflow/controls.tsx
+++ b/frontend/src/components/workspace/panel/workflow/controls.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react"
 import * as React from "react"
-import { useWorkflowMetadata } from "@/providers/workflow"
+import { useWorkflow } from "@/providers/workflow"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { PlayIcon, ZapIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
@@ -36,7 +36,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { Separator } from "@/components/ui/separator"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Tooltip,
@@ -171,7 +170,7 @@ export default function EntrypointSelector({
 }: {
   setSelectedAction: React.Dispatch<React.SetStateAction<Action | null>>
 }) {
-  const { workflow } = useWorkflowMetadata()
+  const { workflow } = useWorkflow()
   const [actions, setActions] = useState<Action[]>([])
 
   useEffect(() => {

--- a/frontend/src/components/workspace/panel/workflow/form.tsx
+++ b/frontend/src/components/workspace/panel/workflow/form.tsx
@@ -5,12 +5,12 @@ import { zodResolver } from "@hookform/resolvers/zod"
 
 import "@radix-ui/react-dialog"
 
+import { useWorkflow } from "@/providers/workflow"
 import { SaveIcon, Settings2Icon } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
 import { Workflow } from "@/types/schemas"
-import { useSaveWorkflow } from "@/lib/hooks"
 import {
   Accordion,
   AccordionContent,
@@ -43,30 +43,23 @@ const workflowFormSchema = z.object({
 
 type TWorkflowForm = z.infer<typeof workflowFormSchema>
 
-interface WorkflowFormProps {
-  workflow: Workflow
-}
-
 export function WorkflowForm({
   workflow,
-}: WorkflowFormProps): React.JSX.Element {
-  const {
-    id: workflowId,
-    title: workflowTitle,
-    description: workflowDescription,
-  } = workflow
+}: {
+  workflow: Workflow
+}): React.JSX.Element {
+  const { update } = useWorkflow()
   const form = useForm<TWorkflowForm>({
     resolver: zodResolver(workflowFormSchema),
     defaultValues: {
-      title: workflowTitle || "",
-      description: workflowDescription || "",
+      title: workflow.title || "",
+      description: workflow.description || "",
     },
   })
-  const { mutateAsync: saveAsync } = useSaveWorkflow(workflowId)
 
   const onSubmit = async (values: TWorkflowForm) => {
     console.log("Saving changes...")
-    await saveAsync(values)
+    await update(values)
   }
 
   return (

--- a/frontend/src/components/workspace/workspace.tsx
+++ b/frontend/src/components/workspace/workspace.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/resizable"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { WorkflowCanvas } from "@/components/workspace/canvas/canvas"
-import { UDFCatalog } from "@/components/workspace/catalog/udf-catalog"
+import { WorkflowCatalog } from "@/components/workspace/catalog/catalog"
 import { WorkspacePanel } from "@/components/workspace/panel/workspace-panel"
 
 interface WorkspaceProps {
@@ -90,7 +90,7 @@ export function Workspace({
                   "min-w-14 transition-all duration-300 ease-in-out"
               )}
             >
-              <UDFCatalog isCollapsed={isCollapsed} />
+              <WorkflowCatalog isCollapsed={isCollapsed} />
               {/* For items that should align at the end of the side nav */}
             </ResizablePanel>
             <CustomResizableHandle>

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -10,12 +10,8 @@ import {
   fetchCaseEvents,
   updateCase,
 } from "@/lib/cases"
-import {
-  commitWorkflow,
-  getActionById,
-  updateAction,
-  updateWorkflow,
-} from "@/lib/workflow"
+import { updateWebhook } from "@/lib/trigger"
+import { getActionById, updateAction } from "@/lib/workflow"
 import { toast } from "@/components/ui/use-toast"
 import { UDFNodeType } from "@/components/workspace/canvas/udf-node"
 
@@ -207,45 +203,23 @@ export function useActionInputs(action?: Action) {
   return { actionInputs, setActionInputs }
 }
 
-export function useSaveWorkflow<T extends Object>(workflowId: string) {
+export function useUpdateWebhook(workflowId: string, webhookId: string) {
   const queryClient = useQueryClient()
   const mutation = useMutation({
-    mutationFn: async (values: T) => await updateWorkflow(workflowId, values),
+    mutationFn: async (params: {
+      entrypointRef?: string
+      method?: "GET" | "POST"
+      status?: "online" | "offline"
+    }) => await updateWebhook(workflowId, webhookId, params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
-      toast({
-        title: "Saved workflow changes",
-        description: "Workflow changes saved successfully.",
-      })
     },
     onError: (error) => {
-      console.error("Failed to save workflow:", error)
+      console.error("Failed to update webhook:", error)
       toast({
-        title: "Error saving workflow",
-        description: "Could not save workflow. Please try again.",
-      })
-    },
-  })
-
-  return mutation
-}
-
-export function useCommitWorkflow(workflowId: string) {
-  const queryClient = useQueryClient()
-  const mutation = useMutation({
-    mutationFn: async () => await commitWorkflow(workflowId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
-      toast({
-        title: "Commited changes to workflow",
-        description: "New workflow deployment created successfully.",
-      })
-    },
-    onError: (error) => {
-      console.error("Failed to commit workflow:", error)
-      toast({
-        title: "Error commiting workflow",
-        description: "Could not commit workflow. Please try again.",
+        title: "Error updating webhook",
+        description: "Could not update webhook. Please try again.",
+        variant: "destructive",
       })
     },
   })

--- a/frontend/src/lib/trigger.ts
+++ b/frontend/src/lib/trigger.ts
@@ -1,0 +1,17 @@
+import { client } from "@/lib/api"
+
+export async function updateWebhook(
+  workflowId: string,
+  webhookId: string,
+  params: {
+    entrypointRef?: string | null
+    method?: "GET" | "POST"
+    status?: "online" | "offline"
+  }
+) {
+  const response = await client.patch(
+    `/workflows/${workflowId}/webhooks/${webhookId}`,
+    params
+  )
+  return response.data
+}

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -4,7 +4,6 @@ import { z } from "zod"
 import {
   actionMetadataSchema,
   actionSchema,
-  NodeType,
   workflowMetadataSchema,
   WorkflowRun,
   workflowRunSchema,
@@ -80,9 +79,17 @@ export async function fetchAllWorkflows(): Promise<WorkflowMetadata[]> {
   }
 }
 
-export async function updateWorkflow(workflowId: string, values: Object) {
-  const response = await client.post(`/workflows/${workflowId}`, values)
-  return response.data
+export async function updateWorkflow(
+  workflowId: string,
+  values: Record<string, any>
+) {
+  try {
+    const response = await client.post(`/workflows/${workflowId}`, values)
+    return response.data
+  } catch (error) {
+    console.error("Error updating workflow:", error)
+    throw error
+  }
 }
 
 export async function deleteWorkflow(workflowId: string): Promise<void> {
@@ -143,7 +150,7 @@ export async function deleteAction(actionId: string): Promise<void> {
 }
 
 export async function createAction(
-  type: NodeType,
+  type: string,
   title: string,
   workflowId: string
 ): Promise<string> {
@@ -179,7 +186,7 @@ export async function triggerWorkflow(
 ) {
   try {
     const response = await client.post(
-      `/workflows/${workflowId}/trigger`,
+      `/workflows/${workflowId}/controls/trigger`,
       JSON.stringify({
         action_key: actionKey,
         payload,

--- a/frontend/src/providers/cases.tsx
+++ b/frontend/src/providers/cases.tsx
@@ -8,7 +8,7 @@ import React, {
   useEffect,
   useState,
 } from "react"
-import { useWorkflowMetadata } from "@/providers/workflow"
+import { useWorkflow } from "@/providers/workflow"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { type Case } from "@/types/schemas"
@@ -31,7 +31,7 @@ export default function CasesProvider({
   children,
 }: PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) {
   const [cases, setCases] = useState<Case[]>([])
-  const { workflowId } = useWorkflowMetadata()
+  const { workflowId } = useWorkflow()
   const [isCommitable, setIsCommitable] = useState(false)
   const [isCommitting, setIsCommitting] = useState(false)
   const queryClient = useQueryClient()

--- a/frontend/src/providers/event-feed-stream.tsx
+++ b/frontend/src/providers/event-feed-stream.tsx
@@ -9,7 +9,7 @@ import React, {
   useEffect,
   useState,
 } from "react"
-import { useWorkflowMetadata } from "@/providers/workflow"
+import { useWorkflow } from "@/providers/workflow"
 
 import { streamGenerator } from "@/lib/api"
 import {
@@ -40,7 +40,7 @@ interface EventFeedProviderProps {
 export const EventFeedProvider: React.FC<EventFeedProviderProps> = ({
   children,
 }) => {
-  const { workflowId } = useWorkflowMetadata()
+  const { workflowId } = useWorkflow()
   const [events, setEvents] = useState<GenericConsoleEvent[] | null>(null)
   const [isStreaming, setIsStreaming] = useState(false)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
+    "croniter==2.0.5",
     "boto3==1.34.69",
     "diskcache==5.6.3",
     "cryptography==42.0.7",

--- a/tracecat/db/converters.py
+++ b/tracecat/db/converters.py
@@ -4,6 +4,7 @@ from tracecat.dsl.workflow import DSLInput
 
 
 def workflow_to_dsl(workflow: Workflow) -> DSLInput:
+    """Connector to convert an AppState workflow to a DSLInput."""
     # NOTE: Must only call inside a db session
     # Check that we're inside an open
     if not workflow.object:
@@ -14,16 +15,6 @@ def workflow_to_dsl(workflow: Workflow) -> DSLInput:
             "calling `workflow.actions` inside an open db session."
         )
     graph = RFGraph.from_workflow(workflow)
-    actions = []
-    for action in workflow.actions:
-        action_inputs = action.inputs
-        actions.append(
-            {
-                "ref": action.ref,
-                "action": action.type,
-                "args": action_inputs,
-            }
-        )
     return DSLInput(
         title=workflow.title,
         description=workflow.description,

--- a/tracecat/dsl/graph.py
+++ b/tracecat/dsl/graph.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Literal, Self
 
-from pydantic import BaseModel, Field
+from loguru import logger
+from pydantic import BaseModel, Field, model_validator
 from slugify import slugify
 
 from tracecat.dsl.workflow import ActionStatement
+from tracecat.types.exceptions import TracecatValidationError
 
 if TYPE_CHECKING:
     from tracecat.db.schemas import Workflow
@@ -36,10 +38,33 @@ class RFNode(BaseModel):
     id: str
     """RF Graph Node ID. Different from action ref."""
 
-    type: str
-    """Namespaced action type."""
+    type: Literal["udf"]
+    """UDF type."""
 
     data: RFNodeData
+
+    @property
+    def ref(self) -> str:
+        return get_ref(self.data.title)
+
+
+class RFTriggerNodeData(BaseModel):
+    """React Flow Trigger Node Data."""
+
+    title: str
+    """Node title. Used to generate the action ref."""
+
+
+class RFTriggerNode(BaseModel):
+    """React Flow Trigger Node."""
+
+    id: str
+    """RF Graph Node ID. Different from action ref."""
+
+    type: Literal["trigger"]
+    """Namespaced action type."""
+
+    data: RFTriggerNodeData
 
     @property
     def ref(self) -> str:
@@ -69,6 +94,34 @@ class RFGraph(BaseModel):
 
     nodes: list[RFNode]
     edges: list[RFEdge]
+    trigger: RFTriggerNode
+    entrypoint_id: str
+
+    @model_validator(mode="after")
+    def validate_graph(self) -> Self:
+        # The graph may have 0 inner edges if it only is a single node
+        if not self.nodes:
+            raise TracecatValidationError(
+                "Graph must have at least one node excluding trigger"
+            )
+        if not self.trigger:
+            raise TracecatValidationError("Graph must have a trigger node")
+
+        # Complex validations
+        # No trigger edges in the main graph
+        if not all(
+            self.trigger.id not in (edge.source, edge.target) for edge in self.edges
+        ):
+            raise TracecatValidationError(
+                "Trigger node should not have edges in the main graph"
+            )
+
+        if self.entrypoint != self.node_map[self.entrypoint_id].ref:
+            lhs = self.entrypoint
+            rhs = self.node_map[self.entrypoint_id].ref
+            logger.error(f"Entrypoint doesn't match: {lhs!r} != {rhs!r}")
+            raise TracecatValidationError("Entrypoint doesn't match")
+        return self
 
     @cached_property
     def node_map(self) -> dict[str, RFNode]:
@@ -99,7 +152,7 @@ class RFGraph(BaseModel):
     def entrypoint(self) -> str:
         entrypoints = [node.ref for node in self.nodes if self.indegree[node.id] == 0]
         if len(entrypoints) != 1:
-            raise ValueError(
+            raise TracecatValidationError(
                 f"Expected 1 entrypoint, got {len(entrypoints)}: {entrypoints!r}"
             )
         return entrypoints[0]
@@ -129,7 +182,41 @@ class RFGraph(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: dict[str, Any], /) -> Self:
-        return cls(nodes=obj["nodes"], edges=obj["edges"])
+        triggers, nodes = [], []
+        for node in obj["nodes"]:
+            t = node["type"]
+            if t == "trigger":
+                triggers.append(RFTriggerNode(**node))
+            elif t == "udf":
+                nodes.append(RFNode(**node))
+            else:
+                raise ValueError(f"Unknown node type: {t!r}")
+
+        if len(triggers) != 1:
+            raise TracecatValidationError(
+                f"Expected 1 trigger node, got {len(triggers)}"
+            )
+
+        trigger = triggers[0]
+        entrypoint = []
+        edges = []
+        for edge in obj["edges"]:
+            if trigger.id in (edge["source"], edge["target"]):
+                entrypoint.append(edge)
+            else:
+                edges.append(RFEdge(**edge))
+
+        if len(entrypoint) != 1:
+            raise TracecatValidationError(
+                f"Expected 1 trigger edge, got {len(entrypoint)}"
+            )
+
+        return cls(
+            nodes=nodes,
+            edges=edges,
+            trigger=trigger,
+            entrypoint_id=entrypoint[0]["target"],
+        )
 
     @classmethod
     def from_workflow(cls, workflow: Workflow) -> Self:

--- a/tracecat/logging/__init__.py
+++ b/tracecat/logging/__init__.py
@@ -1,4 +1,4 @@
 from tracecat.logging._default import file_logger, standard_logger
-from tracecat.logging._logger import Logger, logger
+from tracecat.logging._logger import logger
 
-__all__ = ["Logger", "logger", "standard_logger", "file_logger"]
+__all__ = ["logger", "standard_logger", "file_logger"]

--- a/tracecat/logging/_logger.py
+++ b/tracecat/logging/_logger.py
@@ -2,4 +2,9 @@
 
 from loguru import logger as base_logger
 
+from .config import LOG_CONFIG
+
+base_logger.remove(0)
+base_logger.add(**LOG_CONFIG["stderr:log"])
+
 logger = base_logger

--- a/tracecat/logging/config.py
+++ b/tracecat/logging/config.py
@@ -34,7 +34,7 @@ LOG_CONFIG = {
         "level": "INFO",
         "colorize": True,
         "backtrace": True,
-        "enqueue": True,
+        # "enqueue": True,  # Causes pickling errors if enabled
         "format": "{time} | <level>{level: <8}</level> <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level> | {extra}",
     },
     "file:log": {

--- a/tracecat/types/exceptions.py
+++ b/tracecat/types/exceptions.py
@@ -1,2 +1,20 @@
+"""Tracecat exceptions
+
+Note
+----
+This module contains exceptions that are user-facing, meaning they are
+meant to be displayed to the user in a user-friendly way. We expose these
+through FastAPI exception handlers, which match the exception type.
+"""
+
+
 class TracecatException(Exception):
+    """Tracecat generic user-facing exception"""
+
+    pass
+
+
+class TracecatValidationError(TracecatException):
+    """Tracecat user-facting validation error"""
+
     pass


### PR DESCRIPTION
# Features
- `Workflow`s now come with only one `Webhook` by default
- Introduce concept of `Trigger`, which include 1 `Webhook` and N `Schedules`
- Added version badge to nav bar
- Added new node type `trigger` with panel
    - Each `trigger` node can only have one outgoing edge
    - `trigger` node is created on workflow creation and cannot be deleted
- Reinstate proper webhook authentication
- Implement scaffolding for `Schedule` triggers


# Improvements
- Webhook copy button shows double tick for 2s after click
- Improved data model for workflow source of truth reasoning
- Better graph validation on commit (RFGraph)
- Improved and cleaned up FE hooks
- Imroved and cleaned up `useWorkflow` context
- Improved BE incoming webhook validation
- Improved user facing exceptions]
- Reduce usage of `toast` across the app
- Cleanup and simplify logic across the FE

# Todo
- Select the version and only execute the checked out version. Currently we just execute the latest version

# Testing
- Tested diamond pattern with slack with ngrok

![Screenshot 2024-06-05 at 03 07 56](https://github.com/TracecatHQ/tracecat/assets/5508348/6f83e92c-8600-45c4-a23d-dbbabe090078)
