### PR TITLE
fix: Run context propagation

### DIFF
--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -4,9 +4,17 @@ import logging
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel
+
 if TYPE_CHECKING:
     from tracecat.auth import Role
 
 
+class RunContext(BaseModel):
+    wf_id: str
+    wf_run_id: str
+
+
+ctx_run: ContextVar[RunContext] = ContextVar("run", default=None)
 ctx_role: ContextVar[Role] = ContextVar("role", default=None)
 ctx_logger: ContextVar[logging.Logger] = ContextVar("logger", default=None)

--- a/tracecat/dsl/dispatcher.py
+++ b/tracecat/dsl/dispatcher.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from tracecat.contexts import ctx_role
 from tracecat.dsl.common import get_temporal_client
-from tracecat.dsl.workflow import DSLContext, DSLInput, DSLWorkflow
+from tracecat.dsl.workflow import DSLContext, DSLInput, DSLRunArgs, DSLWorkflow
 
 # logger = standard_logger("tracecat.dsl.dispatcher")
 
@@ -28,7 +28,7 @@ async def dispatch_workflow(dsl: DSLInput, **kwargs) -> DispatchResult:
     # Run workflow
     result = await client.execute_workflow(
         DSLWorkflow.run,
-        dsl,
+        DSLRunArgs(dsl=dsl, role=role),
         id=wf_id,
         task_queue=os.environ.get("TEMPORAL__CLUSTER_QUEUE", "dsl-task-queue"),
         **kwargs,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -15,7 +15,7 @@ from tracecat.contexts import RunContext
 with workflow.unsafe.imports_passed_through():
     import jsonpath_ng.lexer  # noqa
     import jsonpath_ng.parser  # noqa
-    from loguru import logger
+    from tracecat.logging import logger
     from pydantic import BaseModel, ConfigDict, Field, model_validator
 
     from tracecat.auth import Role

--- a/tracecat/logging/_logger.py
+++ b/tracecat/logging/_logger.py
@@ -1,10 +1,19 @@
 """Loggers to override default FastAPI uvicorn logger behavior."""
 
+import sys
+
 from loguru import logger as base_logger
 
-from .config import LOG_CONFIG
+try:
+    base_logger.remove(0)
+except ValueError:
+    pass
 
-base_logger.remove(0)
-base_logger.add(**LOG_CONFIG["stderr:log"])
+base_logger.add(
+    sink=sys.stderr,
+    colorize=True,
+    level="INFO",
+    format="{time} | <level>{level: <8}</level> <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level> | {extra}",
+)
 
 logger = base_logger

--- a/tracecat/registry.py
+++ b/tracecat/registry.py
@@ -14,7 +14,8 @@ from pydantic_core import ValidationError
 from typing_extensions import Doc
 
 from tracecat import templates
-from tracecat.auth import AuthSandbox, Role
+from tracecat.auth import AuthSandbox
+from tracecat.contexts import ctx_role
 from tracecat.types.exceptions import TracecatException
 
 DEFAULT_NAMESPACE = "core"
@@ -171,7 +172,7 @@ class _Registry:
                     """
                     self[key].validate_args(*args, **kwargs)
 
-                    role: Role = kwargs.pop("__role", Role(type="service"))
+                    role = ctx_role.get()
                     with logger.contextualize(user_id=role.user_id, pid=os.getpid()):
                         async with AuthSandbox(role=role, secrets=secrets):
                             return await fn(**kwargs)
@@ -183,7 +184,7 @@ class _Registry:
 
                     self[key].validate_args(*args, **kwargs)
 
-                    role: Role = kwargs.pop("__role", Role(type="service"))
+                    role = ctx_role.get()
                     with logger.contextualize(user_id=role.user_id, pid=os.getpid()):
                         with AuthSandbox(role=role, secrets=secrets):
                             return fn(**kwargs)

--- a/tracecat/registry.py
+++ b/tracecat/registry.py
@@ -6,7 +6,7 @@ import os
 import re
 from collections.abc import Callable
 from types import FunctionType, GenericAlias
-from typing import Annotated, Any, Self, TypedDict
+from typing import Annotated, Any, Generic, Self, TypedDict, TypeVar
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, create_model
@@ -31,7 +31,10 @@ class UDFSchema(TypedDict):
     secrets: list[str] | None
 
 
-class RegisteredUDF(BaseModel):
+ArgsT = TypeVar("ArgsT", bound=type[BaseModel])
+
+
+class RegisteredUDF(BaseModel, Generic[ArgsT]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     fn: FunctionType
     key: str
@@ -39,7 +42,7 @@ class RegisteredUDF(BaseModel):
     namespace: str
     version: str | None = None
     secrets: list[str] | None = None
-    args_cls: type[BaseModel]
+    args_cls: ArgsT
     args_docs: dict[str, str] = Field(default_factory=dict)
     rtype_cls: Any | None = None
     rtype_adapter: TypeAdapter | None = None

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -29,7 +29,7 @@ class ActionResponse(BaseModel):
     title: str
     description: str
     status: str
-    inputs: dict[str, Any] = {}
+    inputs: dict[str, Any]
     key: str  # Computed field
 
 

--- a/tracecat/types/cases.py
+++ b/tracecat/types/cases.py
@@ -1,10 +1,10 @@
 from datetime import UTC, datetime
 from typing import Any, Literal, Self
-from uuid import uuid4
 
 import orjson
 from pydantic import BaseModel, Field
 
+from tracecat.db.schemas import gen_id
 from tracecat.types.api import CaseContext, CaseParams, ListModel, Suppression, Tag
 
 CaseEvent = Literal[
@@ -20,7 +20,7 @@ class Case(BaseModel):
     """Case model used in the API and runner."""
 
     # Required inputs
-    id: str = Field(default_factory=lambda: uuid4().hex)  # Action run id
+    id: str = Field(default_factory=gen_id("case"))  # Action run id
     owner_id: str  # NOTE: Ideally this would inherit form db.Resource
     workflow_id: str
     case_title: str
@@ -28,10 +28,10 @@ class Case(BaseModel):
     malice: Literal["malicious", "benign"]
     status: Literal["open", "closed", "in_progress", "reported", "escalated"]
     priority: Literal["low", "medium", "high", "critical"]
-    context: ListModel[CaseContext]  # JSON serialized
     action: Literal[
         "ignore", "quarantine", "informational", "sinkhole", "active_compromise"
     ]
+    context: ListModel[CaseContext]  # JSON serialized
     suppression: ListModel[Suppression]  # JSON serialized
     tags: ListModel[Tag]  # JSON serialized
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))


### PR DESCRIPTION
# Features
- Added `tracecat.contexts.ctx_run` 
- Pass contextvars through `workflow` and `activity` args, as activities may be run on different workers (no longer threadlocal). The alternative is passing context through Temporal header interceptors, but appears to be more work.

# Improvements
- Revived case management
- Fix propagation of `ContextVars` throughout Temporal workflows and workers (tested using case management)

![Screenshot 2024-06-05 at 21 23 24](https://github.com/TracecatHQ/tracecat/assets/5508348/00f65fdb-b2e0-4752-aefe-3b0592c5feba)

