### PR TITLE
feat(engine): Implement JIT secrets for template secret expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "pytest",
     "python-dotenv",
     "pytest-asyncio",
+    "pytest-mock==3.14.0",
     "minio",
     "mypy",
     "boto3-stubs[cloudtrail,guardduty,s3]",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def monkeysession(request):
 # NOTE: Don't auto-use this fixture unless necessary
 @pytest.fixture(scope="session")
 def auth_sandbox():
-    from tracecat.auth import Role
+    from tracecat.auth.credentials import Role
     from tracecat.contexts import ctx_role
 
     service_role = Role(

--- a/tests/integration/test_workflows.py
+++ b/tests/integration/test_workflows.py
@@ -20,8 +20,8 @@ from pathlib import Path
 import pytest
 from temporalio.common import RetryPolicy
 
+from tracecat.dsl.common import DSLInput
 from tracecat.dsl.dispatcher import dispatch_workflow
-from tracecat.dsl.workflow import DSLInput
 
 DATA_PATH = Path(__file__).parent.parent.joinpath("data/workflows")
 SHARED_TEST_DEFNS = list(DATA_PATH.glob("shared_*.yml"))

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -3,10 +3,12 @@ import os
 import pytest
 from httpx import AsyncClient
 
-from tracecat.auth import (
+from tracecat.auth.clients import (
     AuthenticatedAPIClient,
     AuthenticatedRunnerClient,
     AuthenticatedServiceClient,
+)
+from tracecat.auth.credentials import (
     Role,
     decrypt,
     decrypt_object,

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -3,11 +3,7 @@ import os
 import pytest
 from httpx import AsyncClient
 
-from tracecat.auth.clients import (
-    AuthenticatedAPIClient,
-    AuthenticatedRunnerClient,
-    AuthenticatedServiceClient,
-)
+from tracecat.auth.clients import AuthenticatedAPIClient, AuthenticatedServiceClient
 from tracecat.auth.credentials import (
     Role,
     decrypt,
@@ -15,7 +11,7 @@ from tracecat.auth.credentials import (
     encrypt,
     encrypt_object,
 )
-from tracecat.config import TRACECAT__API_URL, TRACECAT__RUNNER_URL
+from tracecat.config import TRACECAT__API_URL
 from tracecat.contexts import ctx_role
 
 
@@ -115,56 +111,7 @@ async def test_authenticated_service_client_init_role_from_context():
 
 
 @pytest.mark.asyncio
-async def test_authenticated_runner_client_init_no_role():
-    # Test initialization of AuthenticatedAPIClient without role
-    default_role = Role(type="service", service_id="tracecat-service")
-    async with AuthenticatedRunnerClient() as client:
-        assert client.role == default_role
-        assert client.headers["Service-Role"] == "tracecat-service"
-        assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
-        assert "Service-User-ID" not in client.headers
-        assert client.base_url == TRACECAT__RUNNER_URL
-
-
-@pytest.mark.asyncio
-async def test_authenticated_runner_client_init_with_role():
-    # Test initialization of AuthenticatedServiceClient
-    role = Role(type="service", user_id="mock_user_id", service_id="mock_service_id")
-    async with AuthenticatedRunnerClient(role=role) as client:
-        assert isinstance(client, AsyncClient)
-        assert client.role == role
-        assert client.headers["Service-Role"] == "mock_service_id"
-        assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
-        assert client.headers["Service-User-ID"] == "mock_user_id"
-        assert client.base_url == TRACECAT__RUNNER_URL
-
-    role = Role(type="service", service_id="mock_service_id")
-    async with AuthenticatedRunnerClient(role=role) as client:
-        assert client.role == role
-        assert client.headers["Service-Role"] == "mock_service_id"
-        assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
-        assert "Service-User-ID" not in client.headers
-        assert client.base_url == TRACECAT__RUNNER_URL
-
-    role = Role(type="service")
-    async with AuthenticatedRunnerClient(role=role) as client:
-        assert client.role == role
-        assert client.headers["Service-Role"] == "tracecat-service"
-        assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
-        assert "Service-User-ID" not in client.headers
-        assert client.base_url == TRACECAT__RUNNER_URL
-
-    role = Role(type="service", user_id="mock_user_id")
-    async with AuthenticatedRunnerClient(role=role) as client:
-        assert client.role == role
-        assert client.headers["Service-Role"] == "tracecat-service"
-        assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
-        assert client.headers["Service-User-ID"] == "mock_user_id"
-        assert client.base_url == TRACECAT__RUNNER_URL
-
-
-@pytest.mark.asyncio
-async def test_authenticated_runner_client_init_role_from_context():
+async def test_authenticated_api_client_init_role_from_context():
     # Test initialization of AuthenticatedAPIClient without role
     mock_ctx_role = Role(
         type="service",
@@ -173,12 +120,12 @@ async def test_authenticated_runner_client_init_role_from_context():
     )
     ctx_role.set(mock_ctx_role)
 
-    async with AuthenticatedRunnerClient() as client:
+    async with AuthenticatedAPIClient() as client:
         assert client.role == mock_ctx_role
         assert client.headers["Service-Role"] == "mock_ctx_service_id"
         assert client.headers["X-API-Key"] == os.environ["TRACECAT__SERVICE_KEY"]
         assert client.headers["Service-User-ID"] == "mock_ctx_user_id"
-        assert client.base_url == TRACECAT__RUNNER_URL
+        assert client.base_url == TRACECAT__API_URL
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -1,5 +1,5 @@
+from tracecat.dsl.common import ActionStatement, DSLInput
 from tracecat.dsl.graph import RFGraph
-from tracecat.dsl.workflow import ActionStatement, DSLInput
 
 metadata = {
     "title": "TEST_WORKFLOW",

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,0 +1,46 @@
+import httpx
+import pytest
+import pytest_mock
+
+from tracecat.auth.credentials import Role
+from tracecat.auth.sandbox import AuthSandbox
+from tracecat.contexts import ctx_role
+from tracecat.db.schemas import Secret
+from tracecat.types.secrets import SecretKeyValue
+
+
+@pytest.mark.asyncio
+async def test_auth_sandbox_with_secrets(mocker: pytest_mock.MockFixture, auth_sandbox):
+    role = ctx_role.get()
+    assert role is not None
+
+    mock_secret_keys = [SecretKeyValue(key="SECRET_KEY", value="my_secret_key")]
+    mock_secret = Secret(name="my_secret", owner_id=role.user_id)
+    mock_secret.keys = mock_secret_keys
+
+    mock_client = mocker.AsyncMock()
+    mock_client.get.return_value = httpx.Response(
+        200, content=mock_secret.model_dump_json().encode()
+    )
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    # Patch the AuthenticatedAPIClient to return the mock client
+    mocker.patch(
+        "tracecat.auth.sandbox.AuthenticatedAPIClient", return_value=mock_client
+    )
+
+    async with AuthSandbox(secrets=["my_secret"], target="context") as sandbox:
+        assert sandbox.secrets == {"my_secret": {"SECRET_KEY": "my_secret_key"}}
+
+    # Assert that the secrets API was called with the correct parameters
+    mock_client.get.assert_called_once_with("/secrets/my_secret")
+
+
+@pytest.mark.asyncio
+async def test_auth_sandbox_without_secrets(auth_sandbox):
+    async with AuthSandbox() as sandbox:
+        assert sandbox.secrets == {}
+        assert sandbox._role == Role(
+            type="service", user_id="test-tracecat-user", service_id="tracecat-testing"
+        )

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -21,11 +21,10 @@ from temporalio.common import RetryPolicy
 from temporalio.worker import Worker
 
 from tracecat.contexts import ctx_role
-from tracecat.dsl.common import get_temporal_client
+from tracecat.dsl.common import DSLInput, get_temporal_client
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import (
     DSLContext,
-    DSLInput,
     DSLRunArgs,
     DSLWorkflow,
     dsl_activities,

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -20,7 +20,7 @@ from tracecat.api.completions import (
     FieldCons,
     stream_case_completions,
 )
-from tracecat.auth import (
+from tracecat.auth.credentials import (
     Role,
     authenticate_service,
     authenticate_user,

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -44,11 +44,11 @@ from tracecat.db.schemas import (
     WorkflowDefinition,
     WorkflowRun,
 )
+from tracecat.dsl.common import DSLInput
 
 # TODO: Clean up API params / response "zoo"
 # lots of repetition and inconsistency
 from tracecat.dsl.dispatcher import dispatch_workflow
-from tracecat.dsl.workflow import DSLInput
 
 # from loguru import logger
 from tracecat.logging import logger

--- a/tracecat/auth/clients.py
+++ b/tracecat/auth/clients.py
@@ -1,0 +1,72 @@
+"""Tracecat authn clients."""
+
+import os
+
+import httpx
+
+from tracecat import config
+from tracecat.auth.credentials import Role
+from tracecat.contexts import ctx_role
+
+
+class AuthenticatedServiceClient(httpx.AsyncClient):
+    """An authenticated service client. Typically used by internal services.
+
+    Role precedence
+    ---------------
+    1. Role passed to the client
+    2. Role set in the session role context
+    3. Default role Role(type="service", service_id="tracecat-service")
+    """
+
+    __default_service_id = "tracecat-service"
+
+    def __init__(
+        self,
+        role: Role | None = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        # Precedence: role > ctx_role > default role. Role is always set.
+        self.role = role or ctx_role.get(
+            Role(type="service", service_id="tracecat-service")
+        )
+        if self.role.type != "service":
+            raise ValueError("AuthenticatedServiceClient can only be used by services")
+        self.headers["Service-Role"] = self.role.service_id or self.__default_service_id
+        self.headers["X-API-Key"] = os.environ["TRACECAT__SERVICE_KEY"]
+        if self.role.user_id:
+            self.headers["Service-User-ID"] = self.role.user_id
+
+
+class AuthenticatedAPIClient(AuthenticatedServiceClient):
+    """An authenticated httpx client to hit main API endpoints.
+
+     Role precedence
+    ---------------
+    1. Role passed to the client
+    2. Role set in the session role context
+    3. Default role Role(type="service", service_id="tracecat-service")
+    """
+
+    def __init__(self, role: Role | None = None, *args, **kwargs):
+        kwargs["role"] = role
+        kwargs["base_url"] = config.TRACECAT__API_URL
+        super().__init__(*args, **kwargs)
+
+
+class AuthenticatedRunnerClient(AuthenticatedServiceClient):
+    """An authenticated httpx client to hit runner endpoints.
+
+     Role precedence
+    ---------------
+    1. Role passed to the client
+    2. Role set in the session role context
+    3. Default role Role(type="service", service_id="tracecat-service")
+    """
+
+    def __init__(self, role: Role | None = None, *args, **kwargs):
+        kwargs["role"] = role
+        kwargs["base_url"] = config.TRACECAT__RUNNER_URL
+        super().__init__(*args, **kwargs)

--- a/tracecat/auth/clients.py
+++ b/tracecat/auth/clients.py
@@ -54,19 +54,3 @@ class AuthenticatedAPIClient(AuthenticatedServiceClient):
         kwargs["role"] = role
         kwargs["base_url"] = config.TRACECAT__API_URL
         super().__init__(*args, **kwargs)
-
-
-class AuthenticatedRunnerClient(AuthenticatedServiceClient):
-    """An authenticated httpx client to hit runner endpoints.
-
-     Role precedence
-    ---------------
-    1. Role passed to the client
-    2. Role set in the session role context
-    3. Default role Role(type="service", service_id="tracecat-service")
-    """
-
-    def __init__(self, role: Role | None = None, *args, **kwargs):
-        kwargs["role"] = role
-        kwargs["base_url"] = config.TRACECAT__RUNNER_URL
-        super().__init__(*args, **kwargs)

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -1,0 +1,111 @@
+"""Tracecat authn sandbox."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING, Literal, Self
+
+from loguru import logger
+
+from tracecat.auth.clients import AuthenticatedAPIClient
+from tracecat.auth.credentials import Role
+from tracecat.contexts import ctx_role
+
+if TYPE_CHECKING:
+    from tracecat.db.schemas import Secret
+
+
+class AuthSandbox:
+    """Context manager to temporarily set secrets in the environment as env vars.
+
+    Motivation
+    ----------
+    - This allows use of `os.environ` to access secrets in the environment in UDFs.
+    - We wrap the execution of a UDF with this context manager to set secrets in the environment.
+    """
+
+    def __init__(
+        self,
+        role: Role | None = None,
+        secrets: list[str] | None = None,
+        target: Literal["env", "context"] = "env",
+    ):
+        self._role = role or ctx_role.get()
+        self._secret_paths: list[str] = secrets
+        self._secret_objs: list[Secret] = []
+        self._target = target
+        self._context = {}
+
+    def __enter__(self) -> Self:
+        if self._secret_paths:
+            self._secret_objs = asyncio.run(self._get_secrets())
+            self._set_secrets()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self._unset_secrets()
+        if exc_type is not None:
+            logger.error("An error occurred", exc_info=(exc_type, exc_value, traceback))
+
+    async def __aenter__(self):
+        if self._secret_paths:
+            self._secret_objs = await self._get_secrets()
+            self._set_secrets()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return self.__exit__(exc_type, exc_value, traceback)
+
+    @property
+    def secrets(self) -> dict[str, str]:
+        """Return secret names mapped to their secret key value pairs."""
+        return self._context
+
+    def _set_secrets(self):
+        """Set secrets in the target."""
+        if self._target == "context":
+            logger.info(
+                "Setting secrets in the context",
+                paths=self._secret_paths,
+                objs=self._secret_objs,
+            )
+            for secret in self._secret_objs:
+                self._context[secret.name] = {kv.key: kv.value for kv in secret.keys}
+        else:
+            logger.info("Setting secrets in the environment", paths=self._secret_paths)
+            for secret in self._secret_objs:
+                for kv in secret.keys:
+                    os.environ[kv.key] = kv.value
+
+    def _unset_secrets(self):
+        if self._target == "context":
+            for secret in self._secret_objs:
+                del self._context[secret.name]
+        else:
+            for secret in self._secret_objs:
+                for kv in secret.keys:
+                    del os.environ[kv.key]
+
+    async def _get_secrets(self) -> list[Secret]:
+        """Retrieve secrets from the secrets API."""
+
+        # XXX: This import is necessary to avoid horrendous circular import errors
+        from tracecat.db.schemas import Secret
+
+        logger.info(
+            "Retrieving secrets from the secrets API",
+            secret_names=self._secret_paths,
+            role=self._role,
+        )
+        secret_names = (path.split(".")[0] for path in self._secret_paths)
+
+        async with AuthenticatedAPIClient(role=self._role) as client:
+            # NOTE(perf): This is not really batched - room for improvement
+            secret_responses = await asyncio.gather(
+                *[client.get(f"/secrets/{secret_name}") for secret_name in secret_names]
+            )
+            return [
+                Secret.model_validate_json(secret_bytes.content)
+                for secret_bytes in secret_responses
+            ]

--- a/tracecat/cli/config.py
+++ b/tracecat/cli/config.py
@@ -1,6 +1,6 @@
 from dotenv import find_dotenv, load_dotenv
 
-from tracecat.auth import Role
+from tracecat.auth.credentials import Role
 
 load_dotenv(find_dotenv())
 

--- a/tracecat/cli/dev.py
+++ b/tracecat/cli/dev.py
@@ -5,7 +5,7 @@ import orjson
 import rich
 import typer
 
-from tracecat.auth import AuthenticatedAPIClient
+from tracecat.auth.clients import AuthenticatedAPIClient
 
 from . import config
 

--- a/tracecat/cli/workflow.py
+++ b/tracecat/cli/workflow.py
@@ -7,7 +7,7 @@ import rich
 import typer
 
 from tracecat.auth.clients import AuthenticatedAPIClient
-from tracecat.dsl.workflow import DSLInput
+from tracecat.dsl.common import DSLInput
 from tracecat.types.api import WebhookResponse
 
 from . import config

--- a/tracecat/cli/workflow.py
+++ b/tracecat/cli/workflow.py
@@ -6,7 +6,7 @@ import orjson
 import rich
 import typer
 
-from tracecat.auth import AuthenticatedAPIClient
+from tracecat.auth.clients import AuthenticatedAPIClient
 from tracecat.dsl.workflow import DSLInput
 from tracecat.types.api import WebhookResponse
 

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
-    from tracecat.auth import Role
+    from tracecat.auth.credentials import Role
 
 
 class RunContext(BaseModel):

--- a/tracecat/db/converters.py
+++ b/tracecat/db/converters.py
@@ -1,6 +1,6 @@
 from tracecat.db.schemas import Workflow
+from tracecat.dsl.common import DSLInput
 from tracecat.dsl.graph import RFGraph
-from tracecat.dsl.workflow import DSLInput
 
 
 def workflow_to_dsl(workflow: Workflow) -> DSLInput:

--- a/tracecat/db/helpers.py
+++ b/tracecat/db/helpers.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 
-from tracecat.auth import AuthenticatedAPIClient, Role
+from tracecat.auth.clients import AuthenticatedAPIClient
+from tracecat.auth.credentials import Role
 from tracecat.db.schemas import Secret
 
 

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -85,7 +85,7 @@ class Secret(Resource, table=True):
     id: str = Field(
         default_factory=gen_id("secret"), nullable=False, unique=True, index=True
     )
-    type: str  # "custom", "token", "oauth2"
+    type: str = "custom"  # "custom", "token", "oauth2"
     name: str = Field(..., max_length=255, index=True, nullable=False)
     description: str | None = Field(default=None, max_length=255)
     # We store this object as encrypted bytes, but first validate that it's the correct type

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -12,7 +12,7 @@ from sqlmodel import Field, Relationship, SQLModel
 
 from tracecat import config, registry
 from tracecat.auth.credentials import compute_hash, decrypt_object, encrypt_object
-from tracecat.dsl.workflow import DSLInput
+from tracecat.dsl.common import DSLInput
 from tracecat.types.secrets import SECRET_FACTORY, SecretBase, SecretKeyValue
 
 DEFAULT_CASE_ACTIONS = [

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -1,10 +1,102 @@
+"""Tracecat DSL Common Module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any, Literal, Self
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from temporalio.client import Client
 
 from tracecat import config
 from tracecat.dsl._converter import pydantic_data_converter
+from tracecat.templates import TemplateValidator
+
+SLUG_PATTERN = r"^[a-z0-9_]+$"
+ACTION_TYPE_PATTERN = r"^[a-z0-9_.]+$"
 
 
 async def get_temporal_client() -> Client:
     return await Client.connect(
         config.TEMPORAL__CLUSTER_URL, data_converter=pydantic_data_converter
     )
+
+
+class DSLError(ValueError):
+    pass
+
+
+class ActionStatement(BaseModel):
+    ref: str = Field(pattern=SLUG_PATTERN)
+    """Unique reference for the task"""
+
+    action: str = Field(pattern=ACTION_TYPE_PATTERN)
+    """Namespaced action type"""
+
+    args: dict[str, Any] = Field(default_factory=dict)
+    """Arguments for the action"""
+
+    depends_on: list[str] = Field(default_factory=list)
+    """Task dependencies"""
+
+    run_if: Annotated[str | None, Field(default=None), TemplateValidator()]
+
+
+class DSLConfig(BaseModel):
+    scheduler: Literal["static", "dynamic"] = "dynamic"
+
+
+class Trigger(BaseModel):
+    type: Literal["schedule", "webhook"]
+    ref: str = Field(pattern=SLUG_PATTERN)
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class DSLInput(BaseModel):
+    """DSL definition for a workflow.
+
+    The difference between this and a normal workflow engine is that here,
+    our workflow execution order is defined by the DSL itself, independent
+    of a workflow scheduler.
+
+    With a traditional
+    This allows the execution of the workflow to be fully deterministic.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    title: str
+    description: str
+    entrypoint: str
+    actions: list[ActionStatement]
+    config: DSLConfig = Field(default_factory=DSLConfig)
+    triggers: list[Trigger] = Field(default_factory=list)
+    inputs: dict[str, Any] = Field(default_factory=dict)
+
+    @staticmethod
+    def from_yaml(path: str | Path) -> DSLInput:
+        with Path(path).open("r") as f:
+            yaml_str = f.read()
+        dsl_dict = yaml.safe_load(yaml_str)
+        return DSLInput.model_validate(dsl_dict)
+
+    def to_yaml(self, path: str | Path) -> None:
+        with Path(path).expanduser().resolve().open("w") as f:
+            yaml.dump(self.model_dump(), f)
+
+    def dump_yaml(self) -> str:
+        return yaml.dump(self.model_dump())
+
+    @model_validator(mode="after")
+    def validate_input(self) -> Self:
+        if not self.actions:
+            raise DSLError("At least one action must be defined")
+        if len({action.ref for action in self.actions}) != len(self.actions):
+            raise DSLError("All task.ref must be unique")
+        valid_actions = tuple(action.ref for action in self.actions)
+        if self.entrypoint not in valid_actions:
+            raise DSLError(f"Entrypoint must be one of the actions {valid_actions!r}")
+        n_entrypoints = sum(1 for action in self.actions if not action.depends_on)
+        if n_entrypoints != 1:
+            raise DSLError(f"Expected 1 entrypoint, got {n_entrypoints}")
+        return self

--- a/tracecat/dsl/dispatcher.py
+++ b/tracecat/dsl/dispatcher.py
@@ -8,8 +8,8 @@ from loguru import logger
 from pydantic import BaseModel
 
 from tracecat.contexts import ctx_role
-from tracecat.dsl.common import get_temporal_client
-from tracecat.dsl.workflow import DSLContext, DSLInput, DSLRunArgs, DSLWorkflow
+from tracecat.dsl.common import DSLInput, get_temporal_client
+from tracecat.dsl.workflow import DSLContext, DSLRunArgs, DSLWorkflow
 
 # logger = standard_logger("tracecat.dsl.dispatcher")
 

--- a/tracecat/dsl/graph.py
+++ b/tracecat/dsl/graph.py
@@ -8,7 +8,7 @@ from loguru import logger
 from pydantic import BaseModel, Field, model_validator
 from slugify import slugify
 
-from tracecat.dsl.workflow import ActionStatement
+from tracecat.dsl.common import ActionStatement
 from tracecat.types.exceptions import TracecatValidationError
 
 if TYPE_CHECKING:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -16,6 +16,8 @@ from tracecat.contexts import RunContext
 with workflow.unsafe.imports_passed_through():
     import jsonpath_ng.lexer  # noqa
     import jsonpath_ng.parser  # noqa
+    from tracecat.auth.credentials import Role
+    from tracecat.auth.sandbox import AuthSandbox
     from tracecat.logging import logger
     from pydantic import BaseModel, ConfigDict, Field, model_validator
 

--- a/tracecat/registry.py
+++ b/tracecat/registry.py
@@ -13,7 +13,7 @@ from pydantic_core import ValidationError
 from typing_extensions import Doc
 
 from tracecat import templates
-from tracecat.auth import AuthSandbox
+from tracecat.auth.sandbox import AuthSandbox
 from tracecat.types.exceptions import TracecatException
 
 DEFAULT_NAMESPACE = "core"
@@ -291,3 +291,8 @@ def _get_signature_docs(fn: FunctionType) -> dict[str, str]:
                 if isinstance(meta, Doc):
                     param_docs[name] = meta.documentation
     return param_docs
+
+
+def init() -> None:
+    """Initialize the registry."""
+    registry.init()

--- a/tracecat/templates/__init__.py
+++ b/tracecat/templates/__init__.py
@@ -1,5 +1,10 @@
-from .eval import eval_templated_object
+from .eval import eval_templated_object, extract_templated_secrets
 from .expressions import TemplateExpression
 from .validators import TemplateValidator
 
-__all__ = ["TemplateValidator", "TemplateExpression", "eval_templated_object"]
+__all__ = [
+    "TemplateValidator",
+    "TemplateExpression",
+    "eval_templated_object",
+    "extract_templated_secrets",
+]

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict
 
 from tracecat.db.schemas import ActionRun, Resource, Schedule, WorkflowRun
-from tracecat.dsl.workflow import DSLInput
+from tracecat.dsl.common import DSLInput
 from tracecat.types.generics import ListModel
 from tracecat.types.secrets import SecretKeyValue
 

--- a/tracecat/types/cases.py
+++ b/tracecat/types/cases.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
 from typing import Any, Literal, Self
+from uuid import uuid4
 
 import orjson
 from pydantic import BaseModel, Field
 
-from tracecat.db.schemas import gen_id
 from tracecat.types.api import CaseContext, CaseParams, ListModel, Suppression, Tag
 
 CaseEvent = Literal[
@@ -16,11 +18,20 @@ CaseEvent = Literal[
 ]
 
 
+def _gen_id(prefix: str):
+    separator = "-"
+
+    def wrapper():
+        return prefix + separator + uuid4().hex
+
+    return wrapper
+
+
 class Case(BaseModel):
     """Case model used in the API and runner."""
 
     # Required inputs
-    id: str = Field(default_factory=gen_id("case"))  # Action run id
+    id: str = Field(default_factory=_gen_id("case"))  # Action run id
     owner_id: str  # NOTE: Ideally this would inherit form db.Resource
     workflow_id: str
     case_title: str
@@ -65,7 +76,7 @@ class Case(BaseModel):
     @classmethod
     def from_params(
         cls, params: CaseParams, *, owner_id: str, id: str | None = None
-    ) -> "Case":
+    ) -> Case:
         """Constructs from API params."""
         kwargs = {"owner_id": owner_id}
         kwargs.update(params.model_dump())


### PR DESCRIPTION
# Features
- You can now use templated secret expressions `${{ SECRETS.my_secret.SECRET_KEY }}` just as you would regular template expressions. These are now compatible with the Temporal backend. 
- Extend `AuthSandbox` to allow the sandbox target to be either 'env' or 'context', the first is standard behavior which loads secrets into the environment, the latter loads it into a dictionary

# Changes
- Removed `AuthenticatedRunnerClient`
- Refactor auth module
- Refactor DSL module

# Testing
- Added `pytest-mock` and unit tests