### PR TITLE
feat: Webhook API changes

### DIFF
--- a/docs/api-reference/reference/triggers/create-webhook.mdx
+++ b/docs/api-reference/reference/triggers/create-webhook.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: post /workflows/{workflow_id}/webhooks
+openapi: post /workflows/{workflow_id}/webhook
 ---

--- a/docs/api-reference/reference/triggers/delete-webhook.mdx
+++ b/docs/api-reference/reference/triggers/delete-webhook.mdx
@@ -1,3 +1,0 @@
----
-openapi: delete /workflows/{workflow_id}/webhooks/{webhook_id}
----

--- a/docs/api-reference/reference/triggers/get-webhook.mdx
+++ b/docs/api-reference/reference/triggers/get-webhook.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /workflows/{workflow_id}/webhooks/{webhook_id}
+openapi: get /workflows/{workflow_id}/webhook
 ---

--- a/docs/api-reference/reference/triggers/list-webhooks.mdx
+++ b/docs/api-reference/reference/triggers/list-webhooks.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /workflows/{workflow_id}/webhooks
----

--- a/docs/api-reference/reference/triggers/update-webhook.mdx
+++ b/docs/api-reference/reference/triggers/update-webhook.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: patch /workflows/{workflow_id}/webhooks/{webhook_id}
+openapi: patch /workflows/{workflow_id}/webhook
 ---

--- a/docs/api-reference/reference/udfs/get-udf.mdx
+++ b/docs/api-reference/reference/udfs/get-udf.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /udfs/{key}
+openapi: get /udfs/{udf_key}
 ---

--- a/docs/api-reference/reference/udfs/validate-udf-args.mdx
+++ b/docs/api-reference/reference/udfs/validate-udf-args.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: post /udfs/{key}/validate
+openapi: post /udfs/{udf_key}/validate
 ---

--- a/docs/api-reference/reference/workflows/update-workflow.mdx
+++ b/docs/api-reference/reference/workflows/update-workflow.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: post /workflows/{workflow_id}
+openapi: patch /workflows/{workflow_id}
 ---

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -102,8 +102,8 @@
                 "api-reference/reference/workflows/list-workflows",
                 "api-reference/reference/workflows/create-workflow",
                 "api-reference/reference/workflows/get-workflow",
-                "api-reference/reference/workflows/update-workflow",
                 "api-reference/reference/workflows/delete-workflow",
+                "api-reference/reference/workflows/update-workflow",
                 "api-reference/reference/workflows/copy-workflow",
                 "api-reference/reference/workflows/commit-workflow",
                 "api-reference/reference/workflows/get-workflow-definition",
@@ -118,10 +118,8 @@
             {
               "group": "triggers",
               "pages": [
-                "api-reference/reference/triggers/list-webhooks",
-                "api-reference/reference/triggers/create-webhook",
                 "api-reference/reference/triggers/get-webhook",
-                "api-reference/reference/triggers/delete-webhook",
+                "api-reference/reference/triggers/create-webhook",
                 "api-reference/reference/triggers/update-webhook",
                 "api-reference/reference/triggers/list-schedules",
                 "api-reference/reference/triggers/create-schedule",

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -177,12 +177,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-    post:
+    patch:
       tags:
       - workflows
       summary: Update Workflow
       description: Update a workflow.
-      operationId: update_workflow_workflows__workflow_id__post
+      operationId: update_workflow_workflows__workflow_id__patch
       security:
       - OAuth2PasswordBearer: []
       parameters:
@@ -273,7 +273,8 @@ paths:
       description: 'Commit a workflow.
 
 
-        This deploys the workflow and updates its version.'
+        This deploys the workflow and updates its version. If a YAML file is provided,
+        it will override the workflow in the database.'
       operationId: commit_workflow_workflows__workflow_id__commit_post
       security:
       - OAuth2PasswordBearer: []
@@ -284,6 +285,13 @@ paths:
         schema:
           type: string
           title: Workflow Id
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/Body_commit_workflow_workflows__workflow_id__commit_post'
+              title: Body
       responses:
         '204':
           description: Successful Response
@@ -541,46 +549,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /workflows/{workflow_id}/webhooks:
-    get:
-      tags:
-      - triggers
-      summary: List Webhooks
-      description: List all webhooks for a workflow. Wrokflows only have one webhook
-        at the moment but this may change in the future.
-      operationId: list_webhooks_workflows__workflow_id__webhooks_get
-      security:
-      - OAuth2PasswordBearer: []
-      - APIKeyHeader: []
-      parameters:
-      - name: workflow_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Workflow Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/WebhookResponse'
-                title: Response List Webhooks Workflows  Workflow Id  Webhooks Get
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+  /workflows/{workflow_id}/webhook:
     post:
       tags:
       - triggers
       summary: Create Webhook
       description: Create a webhook for a workflow.
-      operationId: create_webhook_workflows__workflow_id__webhooks_post
+      operationId: create_webhook_workflows__workflow_id__webhook_post
       security:
       - OAuth2PasswordBearer: []
       - APIKeyHeader: []
@@ -609,23 +584,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /workflows/{workflow_id}/webhooks/{webhook_id}:
     get:
       tags:
       - triggers
       summary: Get Webhook
       description: Get the webhook from a workflow.
-      operationId: get_webhook_workflows__workflow_id__webhooks__webhook_id__get
+      operationId: get_webhook_workflows__workflow_id__webhook_get
       security:
       - OAuth2PasswordBearer: []
-      - APIKeyHeader: []
       parameters:
-      - name: webhook_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Webhook Id
       - name: workflow_id
         in: path
         required: true
@@ -645,56 +612,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-    delete:
-      tags:
-      - triggers
-      summary: Delete Webhook
-      description: Delete the webhook from a workflow.
-      operationId: delete_webhook_workflows__workflow_id__webhooks__webhook_id__delete
-      security:
-      - OAuth2PasswordBearer: []
-      - APIKeyHeader: []
-      parameters:
-      - name: workflow_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Workflow Id
-      - name: webhook_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Webhook Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
     patch:
       tags:
       - triggers
       summary: Update Webhook
-      description: Update a webhook for a workflow.
-      operationId: update_webhook_workflows__workflow_id__webhooks__webhook_id__patch
+      description: Update the webhook for a workflow. We currently supprt only one
+        webhook per workflow.
+      operationId: update_webhook_workflows__workflow_id__webhook_patch
       security:
       - OAuth2PasswordBearer: []
-      - APIKeyHeader: []
       parameters:
-      - name: webhook_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Webhook Id
       - name: workflow_id
         in: path
         required: true
@@ -708,11 +635,8 @@ paths:
             schema:
               $ref: '#/components/schemas/UpsertWebhookParams'
       responses:
-        '200':
+        '204':
           description: Successful Response
-          content:
-            application/json:
-              schema: {}
         '422':
           description: Validation Error
           content:
@@ -2272,6 +2196,14 @@ components:
       - ref
       - action
       title: ActionStatement
+    Body_commit_workflow_workflows__workflow_id__commit_post:
+      properties:
+        yaml_file:
+          type: string
+          format: binary
+          title: Yaml File
+      type: object
+      title: Body_commit_workflow_workflows__workflow_id__commit_post
     Body_streaming_autofill_case_fields_completions_cases_stream_post:
       properties:
         cases:

--- a/frontend/src/components/workspace/canvas/canvas.tsx
+++ b/frontend/src/components/workspace/canvas/canvas.tsx
@@ -26,7 +26,7 @@ import {
   createAction,
   deleteAction,
   fetchWorkflow,
-  updateDndFlow,
+  updateWorkflowGraphObject,
 } from "@/lib/workflow"
 import { useToast } from "@/components/ui/use-toast"
 import triggerNode, {
@@ -272,7 +272,7 @@ export function WorkflowCanvas() {
       setNodes((nds) =>
         nds.filter((n) => !nodesToDelete.map((nd) => nd.id).includes(n.id))
       )
-      await updateDndFlow(workflowId, reactFlowInstance)
+      await updateWorkflowGraphObject(workflowId, reactFlowInstance)
       console.log("Nodes deleted successfully")
     } catch (error) {
       console.error("An error occurred while deleting Action nodes:", error)
@@ -338,7 +338,7 @@ export function WorkflowCanvas() {
   // Saving react flow instance state
   useEffect(() => {
     if (workflowId && reactFlowInstance) {
-      updateDndFlow(workflowId, reactFlowInstance)
+      updateWorkflowGraphObject(workflowId, reactFlowInstance)
     }
   }, [edges])
 
@@ -348,7 +348,7 @@ export function WorkflowCanvas() {
     nodes: UDFNodeType[]
   ) => {
     if (workflowId && reactFlowInstance) {
-      updateDndFlow(workflowId, reactFlowInstance)
+      updateWorkflowGraphObject(workflowId, reactFlowInstance)
     }
   }
 

--- a/frontend/src/components/workspace/panel/trigger-panel.tsx
+++ b/frontend/src/components/workspace/panel/trigger-panel.tsx
@@ -183,13 +183,13 @@ export function GeneralControls({ entrypointRef }: { entrypointRef?: string }) {
 }
 
 export function WebhookControls({
-  webhook: { id, url, status },
+  webhook: { url, status },
   workflowId,
 }: {
   webhook: Webhook
   workflowId: string
 }) {
-  const { mutateAsync } = useUpdateWebhook(workflowId, id)
+  const { mutateAsync } = useUpdateWebhook(workflowId)
   const onCheckedChange = async (checked: boolean) => {
     await mutateAsync({
       status: checked ? "online" : "offline",

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -63,8 +63,8 @@ const __clerk = authConfig.disabled
  */
 export async function getAuthToken() {
   if (authConfig.disabled) {
-    console.warn("Auth is disabled, using test token.")
-    return "super-secret-token-32-characters-long"
+    console.warn("Auth is disabled, using test token `super-secret-jwt-token`")
+    return "super-secret-jwt-token"
   }
   let token: string | null | undefined
   if (isServer()) {

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -203,14 +203,14 @@ export function useActionInputs(action?: Action) {
   return { actionInputs, setActionInputs }
 }
 
-export function useUpdateWebhook(workflowId: string, webhookId: string) {
+export function useUpdateWebhook(workflowId: string) {
   const queryClient = useQueryClient()
   const mutation = useMutation({
     mutationFn: async (params: {
       entrypointRef?: string
       method?: "GET" | "POST"
       status?: "online" | "offline"
-    }) => await updateWebhook(workflowId, webhookId, params),
+    }) => await updateWebhook(workflowId, params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
     },

--- a/frontend/src/lib/trigger.ts
+++ b/frontend/src/lib/trigger.ts
@@ -2,7 +2,6 @@ import { client } from "@/lib/api"
 
 export async function updateWebhook(
   workflowId: string,
-  webhookId: string,
   params: {
     entrypointRef?: string | null
     method?: "GET" | "POST"
@@ -10,7 +9,7 @@ export async function updateWebhook(
   }
 ) {
   const response = await client.patch(
-    `/workflows/${workflowId}/webhooks/${webhookId}`,
+    `/workflows/${workflowId}/webhook`,
     params
   )
   return response.data

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -20,17 +20,9 @@ export async function updateDndFlow(
   reactFlowInstance: ReactFlowInstance | null
 ) {
   try {
-    const objectContent = reactFlowInstance
-      ? reactFlowInstance.toObject()
-      : null
-    const updateFlowObjectParams = {
-      object: objectContent,
-    }
-
-    await client.post(`/workflows/${workflowId}`, updateFlowObjectParams, {
-      headers: {
-        "Content-Type": "application/json",
-      },
+    const object = reactFlowInstance ? reactFlowInstance.toObject() : null
+    await client.patch(`/workflows/${workflowId}`, {
+      object,
     })
     console.log("Updated DnD flow object")
   } catch (error) {

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -15,7 +15,7 @@ import {
 } from "@/types/schemas"
 import { client } from "@/lib/api"
 
-export async function updateDndFlow(
+export async function updateWorkflowGraphObject(
   workflowId: string,
   reactFlowInstance: ReactFlowInstance | null
 ) {

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -84,7 +84,7 @@ export async function updateWorkflow(
   values: Record<string, any>
 ) {
   try {
-    const response = await client.post(`/workflows/${workflowId}`, values)
+    const response = await client.patch(`/workflows/${workflowId}`, values)
     return response.data
   } catch (error) {
     console.error("Error updating workflow:", error)

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -18,7 +18,7 @@ import {
 } from "reactflow"
 
 import { slugify } from "@/lib/utils"
-import { updateDndFlow } from "@/lib/workflow"
+import { updateWorkflowGraphObject } from "@/lib/workflow"
 import { NodeType } from "@/components/workspace/canvas/canvas"
 
 interface ReactFlowContextType {
@@ -53,14 +53,14 @@ export const WorkflowBuilderProvider: React.FC<
   const setReactFlowNodes = useCallback(
     (nodes: NodeType[] | ((nodes: NodeType[]) => NodeType[])) => {
       reactFlowInstance.setNodes(nodes)
-      updateDndFlow(workflowId, reactFlowInstance)
+      updateWorkflowGraphObject(workflowId, reactFlowInstance)
     },
     [workflowId, reactFlowInstance]
   )
   const setReactFlowEdges = useCallback(
     (edges: Edge[] | ((edges: Edge[]) => Edge[])) => {
       reactFlowInstance.setEdges(edges)
-      updateDndFlow(workflowId, reactFlowInstance)
+      updateWorkflowGraphObject(workflowId, reactFlowInstance)
     },
     [workflowId, reactFlowInstance]
   )

--- a/tests/unit/test_template_expressions.py
+++ b/tests/unit/test_template_expressions.py
@@ -18,6 +18,7 @@ from tracecat.templates.expressions import (
     eval_jsonpath,
 )
 from tracecat.templates.patterns import FULL_TEMPLATE
+from tracecat.types.exceptions import TracecatExpressionError
 from tracecat.types.secrets import SecretKeyValue
 
 
@@ -52,7 +53,7 @@ def test_eval_jsonpath():
     assert eval_jsonpath("$.webhook.result", operand) == 42
     assert eval_jsonpath("$.webhook.data.name", operand) == "John"
     assert eval_jsonpath("$.webhook.data.age", operand) == 30
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(TracecatExpressionError) as e:
         _ = eval_jsonpath("$.webhook.data.nonexistent", operand) is None
         assert "Operand has no path" in str(e.value)
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -365,14 +365,11 @@ def create_workflow(
 ) -> WorkflowMetadataResponse:
     """Create new Workflow with title and description."""
 
-    title = (
-        datetime.now().strftime("%b %d, %Y, %H:%M:%S")
-        if params.title is None
-        else params.title
-    )
+    now = datetime.now().strftime("%b %d, %Y, %H:%M:%S")
+    title = now if params.title is None else params.title
     # Create the message
     description = (
-        f"New workflow created {title}"
+        f"New workflow created {now}"
         if params.description is None
         else params.description
     )

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -437,7 +437,7 @@ def get_workflow(
         )
 
 
-@app.post(
+@app.patch(
     "/workflows/{workflow_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["workflows"],

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -163,8 +163,11 @@ if IS_AUTH_DISABLED:
     # Override the authentication functions with a dummy function
     logger.warning("User authentication is disabled, using default user.")
     _DEFAULT_TRACECAT_USER_ID = "default-tracecat-user"
+    _DEFAULT_TRACECAT_JWT = "super-secret-jwt-token"
 
     async def _get_role_from_jwt(token: str | bytes) -> Role:
+        if token != _DEFAULT_TRACECAT_JWT:
+            raise HTTP_EXC(f"Auth disabled, please use {_DEFAULT_TRACECAT_JWT!r}.")
         role = Role(type="user", user_id=_DEFAULT_TRACECAT_USER_ID)
         ctx_role.set(role)
         return role

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -71,12 +71,14 @@ class AuthSandbox:
                 objs=self._secret_objs,
             )
             for secret in self._secret_objs:
-                self._context[secret.name] = {kv.key: kv.value for kv in secret.keys}
+                self._context[secret.name] = {
+                    kv.key: kv.value.get_secret_value() for kv in secret.keys
+                }
         else:
             logger.info("Setting secrets in the environment", paths=self._secret_paths)
             for secret in self._secret_objs:
                 for kv in secret.keys:
-                    os.environ[kv.key] = kv.value
+                    os.environ[kv.key] = kv.value.get_secret_value()
 
     def _unset_secrets(self):
         if self._target == "context":

--- a/tracecat/cli/_config.py
+++ b/tracecat/cli/_config.py
@@ -16,10 +16,9 @@ if not load_dotenv(find_dotenv()):
 @dataclass(frozen=True)
 class Config:
     role: Role = field(
-        default_factory=lambda: Role(
-            type="service", user_id="default-tracecat-user", service_id="tracecat-cli"
-        )
+        default_factory=lambda: Role(type="service", user_id="default-tracecat-user")
     )
+    jwt_token: str = field(default="super-secret-jwt-token")
     docs_path: Path = field(default_factory=lambda: Path("docs"))
     docs_api_group: str = field(default="API Documentation")
     docs_api_pages_group: str = field(default="Reference")

--- a/tracecat/cli/_config.py
+++ b/tracecat/cli/_config.py
@@ -5,6 +5,7 @@ import rich
 import typer
 from dotenv import find_dotenv, load_dotenv
 
+from tracecat import config
 from tracecat.auth.credentials import Role
 
 if not load_dotenv(find_dotenv()):
@@ -22,6 +23,7 @@ class Config:
     docs_path: Path = field(default_factory=lambda: Path("docs"))
     docs_api_group: str = field(default="API Documentation")
     docs_api_pages_group: str = field(default="Reference")
+    api_url: str = field(default=config.TRACECAT__API_URL)
 
 
 config = Config()

--- a/tracecat/cli/workflow.py
+++ b/tracecat/cli/workflow.py
@@ -28,10 +28,9 @@ async def _upsert_workflow_definition(yaml_path: Path, workflow_id: str):
 async def _run_workflow(workflow_id: str, content: dict[str, str] | None = None):
     async with AuthenticatedAPIClient(role=config.role) as client:
         # Get the webhook url
-        res = await client.get(f"/workflows/{workflow_id}/webhooks")
+        res = await client.get(f"/workflows/{workflow_id}/webhook")
         res.raise_for_status()
-        # There's only 1 webhook
-        webhooks = WebhookResponse.model_validate(res.json()[0])
+        webhooks = WebhookResponse.model_validate(res.json())
     async with httpx.AsyncClient() as client:
         res = await client.post(webhooks.url, content=content)
         res.raise_for_status()

--- a/tracecat/db/helpers.py
+++ b/tracecat/db/helpers.py
@@ -25,5 +25,7 @@ def format_secrets_as_json(secrets: list[Secret]) -> dict[str, str]:
     """Format secrets as a dict."""
     secret_dict = {}
     for secret in secrets:
-        secret_dict[secret.name] = {kv.key: kv.value for kv in secret.keys}
+        secret_dict[secret.name] = {
+            kv.key: kv.value.get_secret_value() for kv in secret.keys
+        }
     return secret_dict

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from tempfile import SpooledTemporaryFile
 from typing import Annotated, Any, Literal, Self
 
 import yaml
@@ -74,9 +75,16 @@ class DSLInput(BaseModel):
     inputs: dict[str, Any] = Field(default_factory=dict)
 
     @staticmethod
-    def from_yaml(path: str | Path) -> DSLInput:
-        with Path(path).open("r") as f:
-            yaml_str = f.read()
+    def from_yaml(path: str | Path | SpooledTemporaryFile) -> DSLInput:
+        """Read a DSL definition from a YAML file."""
+        # Handle binaryIO
+        if isinstance(path, str | Path):
+            with Path(path).open("r") as f:
+                yaml_str = f.read()
+        elif isinstance(path, SpooledTemporaryFile):
+            yaml_str = path.read().decode()
+        else:
+            raise ValueError(f"Invalid file/path type {type(path)}")
         dsl_dict = yaml.safe_load(yaml_str)
         return DSLInput.model_validate(dsl_dict)
 


### PR DESCRIPTION
# Features
- `workflows/{wfid}/commit` now accepts a yaml file in the request body
# Changes
- Since we only have 1 webhook we use `/webhook` instead of `/webhooks` and just return the object instead of a list of webhooks
- Use PATCH to update workflows
- Removed delete webhook endpoint as webhook cannot be deleted manually, only when workflow gets deleted.
- Remove list webhooks accordingly
- Update CLI to use `workflows/{wfid}/commit` instead creating the workflow definition direcly -- aligned with how you would do it with pure api calls
- Changed no-auth mode to use hardcoded secret token instead of service key
- Rename updateDndFlow to udpateWorkflowGraphObject
- Add missing changes for `pydantic.SecretStr` usage + update tests

# Testing
- Ran commands in terminal
- Triggered kite workflow with slack, works