### PR TITLE
feat(engine): Implement action-local `var` context  + iterable `for_each` clause

### DIFF
--- a/tests/data/workflows/unit_transform_forwarder_loop.yml
+++ b/tests/data/workflows/unit_transform_forwarder_loop.yml
@@ -1,0 +1,14 @@
+title: Forwarder loop
+description: Test that we can loop
+entrypoint: a
+inputs:
+  first: 1
+  second: 2
+  list: [1, 2, 3]
+
+actions:
+  - ref: a
+    action: core.transform.forward
+    for_each: ${{ for var.x in INPUTS.list }}
+    args:
+      value: I received ${{ var.x }} from you

--- a/tests/data/workflows/unit_transform_forwarder_loop_expected.yml
+++ b/tests/data/workflows/unit_transform_forwarder_loop_expected.yml
@@ -1,0 +1,13 @@
+ACTIONS:
+  a:
+    result:
+      - I received 1 from you
+      - I received 2 from you
+      - I received 3 from you
+    result_typename: "list"
+
+INPUTS:
+  first: 1
+  second: 2
+  list: [1, 2, 3]
+TRIGGER:

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -219,11 +219,15 @@ async def test_workflow_ordering_is_correct(
             DATA_PATH
             / "unit_conditional_adder_diamond_skip_with_join_weak_dep_expected.yml",
         ),
+        (
+            DATA_PATH / "unit_transform_forwarder_loop.yml",
+            DATA_PATH / "unit_transform_forwarder_loop_expected.yml",
+        ),
     ],
     indirect=True,
 )
 @pytest.mark.asyncio
-async def test_conditional_execution_completes(
+async def test_workflow_completes_and_correct(
     dsl, expected, temporal_cluster, mock_registry, auth_sandbox
 ):
     """We need to test that the ordering of the workflow tasks is correct."""

--- a/tracecat/expressions/__init__.py
+++ b/tracecat/expressions/__init__.py
@@ -1,6 +1,6 @@
 """Tracecat expressions module."""
 
-from .engine import ExprContext, TemplateExpression
+from .engine import ExprContext, IterableExpr, TemplateExpression
 from .eval import eval_templated_object, extract_templated_secrets
 from .validators import TemplateValidator
 
@@ -8,6 +8,7 @@ __all__ = [
     "TemplateValidator",
     "TemplateExpression",
     "ExprContext",
+    "IterableExpr",
     "eval_templated_object",
     "extract_templated_secrets",
 ]

--- a/tracecat/registry.py
+++ b/tracecat/registry.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import functools
 import inspect
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from types import FunctionType, GenericAlias
 from typing import Annotated, Any, Generic, Self, TypedDict, TypeVar
 
@@ -78,6 +79,12 @@ class RegisteredUDF(BaseModel, Generic[ArgsT]):
             raise RegistryValidationError(
                 f"Error when validating input arguments for UDF {self.key!r}. {e}"
             ) from e
+
+    async def run_async(self, args: dict[str, Any]) -> Coroutine[Any, Any, Any]:
+        """Run a UDF async."""
+        if self.is_async:
+            return await self.fn(**args)
+        return await asyncio.to_thread(self.fn, **args)
 
 
 class _Registry:


### PR DESCRIPTION
# Features
- Add action-local context `var`. Usage: `var.my_var`. Lowercase denotes that it's action-local, meaning that no other action in the workflow can see it
- Implement for loops through the `for_each` clause. Write a generator-like expression `${{ for var.x in INPUTS.some.iterable }}`
- These features now allow any action to map over an iterable collection. Every action has a `for_each` clause, and when bound to an action-local variable like `var.x`, you can access the iterator value through `var.x`.

# Tests
- All unit tests passing
- Added action-local expression tests
- Added tests/data/workflows/unit_transform_forwarder_loop.yml