### PR TITLE
feat(engine): Implement FN.func.map

### DIFF
--- a/tests/data/workflows/unit_transform_forwarder_map_loop.yml
+++ b/tests/data/workflows/unit_transform_forwarder_map_loop.yml
@@ -1,0 +1,17 @@
+title: Forwarder with map in loop
+description: Test that we can loop and map inside
+entrypoint: a
+inputs:
+  nested:
+    - ["user_1", "user_2", "user_3"]
+    - ["user_4", "user_5", "user_6"]
+    - ["user_7", "user_8", "user_9"]
+
+actions:
+  - ref: a
+    action: core.transform.forward
+    for_each: ${{ for var.list in INPUTS.nested }}
+    args:
+      # We map the list into the template. the `map` function automatically
+      # broadcasts the template to each element of the list.
+      value: ${{ FN.format.map('Got {}!', var.list) }}

--- a/tests/data/workflows/unit_transform_forwarder_map_loop_expected.yml
+++ b/tests/data/workflows/unit_transform_forwarder_map_loop_expected.yml
@@ -1,0 +1,14 @@
+ACTIONS:
+  a:
+    result:
+      - ["Got user_1!", "Got user_2!", "Got user_3!"]
+      - ["Got user_4!", "Got user_5!", "Got user_6!"]
+      - ["Got user_7!", "Got user_8!", "Got user_9!"]
+    result_typename: list
+
+INPUTS:
+  nested:
+    - ["user_1", "user_2", "user_3"]
+    - ["user_4", "user_5", "user_6"]
+    - ["user_7", "user_8", "user_9"]
+TRIGGER:

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -426,6 +426,19 @@ def test_eval_templated_object_inline_fails_if_not_str():
         ("FN.join(['A', 'B', 'C'], ',')", "A,B,C"),
         ("FN.join(['A', 'B', 'C'], '@')", "A@B@C"),
         ("FN.contains('A', ['A', 'B', 'C'])", True),
+        ("FN.format('Formatted: {} !', 'yay')", "Formatted: yay !"),
+        (
+            "FN.format.map('Hey {}!', ['Alice', 'Bob', 'Charlie'])",
+            ["Hey Alice!", "Hey Bob!", "Hey Charlie!"],
+        ),
+        (
+            "FN.format.map('Hello, {}! You are {}.', ['Alice', 'Bob', 'Charlie'], INPUTS.adjectives)",
+            [
+                "Hello, Alice! You are cool.",
+                "Hello, Bob! You are awesome.",
+                "Hello, Charlie! You are happy.",
+            ],
+        ),
         # Ternary expressions
         (
             "'It contains 1' if FN.contains(1, INPUTS.list) else 'it does not contain 1'",
@@ -469,6 +482,7 @@ def test_expression_parser(expr, expected):
                     "items": ["a", "b", "c"],
                 },
             },
+            "adjectives": ["cool", "awesome", "happy"],
         },
         ExprContext.ENV: {
             "item": "ITEM",

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -422,6 +422,10 @@ def test_eval_templated_object_inline_fails_if_not_str():
         ("FN.add(5, 2)", 7),
         ("  FN.is_null(None)   ", True),
         ("FN.contains('a', INPUTS.my.module.items)", True),
+        ("FN.length([1, 2, 3])", 3),
+        ("FN.join(['A', 'B', 'C'], ',')", "A,B,C"),
+        ("FN.join(['A', 'B', 'C'], '@')", "A@B@C"),
+        ("FN.contains('A', ['A', 'B', 'C'])", True),
         # Ternary expressions
         (
             "'It contains 1' if FN.contains(1, INPUTS.list) else 'it does not contain 1'",
@@ -442,6 +446,7 @@ def test_eval_templated_object_inline_fails_if_not_str():
         ("'500'", "500"),
         ("bool(True)", True),
         ("bool(1)", True),
+        ("[1, 2, 3]", [1, 2, 3]),
     ],
 )
 def test_expression_parser(expr, expected):

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -227,6 +227,7 @@ correctness_test_cases = [
     "unit_transform_forwarder_arrange",
     "unit_transform_forwarder_arrange_loop",
     "unit_transform_forwarder_zip",
+    "unit_transform_forwarder_map_loop",
 ]
 
 

--- a/tracecat/expressions/engine.py
+++ b/tracecat/expressions/engine.py
@@ -339,8 +339,11 @@ class ExpressionParser:
         if ExprContext.FN in self._exclude_contexts:
             return expr
         resolved_args = self._parse_parameter_pack(args, depth + 1)
-        result = FUNCTION_MAPPING[qualname](*resolved_args)
-        return result
+        if qualname.endswith(".map"):
+            qualname = qualname.rsplit(".", 1)[0]
+            fn = FUNCTION_MAPPING[qualname]
+            return fn.map(*resolved_args)
+        return FUNCTION_MAPPING[qualname](*resolved_args)
 
     def _parse_parameter_pack(self, expr: str, depth: int = 0) -> tuple:
         parts = _split_arguments(expr)

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import operator
+import re
+from datetime import datetime
+from typing import Any
+
+
+def _bool(x: Any) -> bool:
+    if isinstance(x, bool):
+        return x
+    if isinstance(x, str):
+        return x.lower() in ("true", "1")
+    # Use default bool for everything else
+    return bool(x)
+
+
+def _from_timestamp(x: int, unit: str) -> datetime:
+    if unit == "ms":
+        dt = datetime.fromtimestamp(x / 1000)
+    else:
+        dt = datetime.fromtimestamp(x)
+    return dt
+
+
+def _format_string(template: str, *args: Any) -> str:
+    """Format a string with the given arguments."""
+    return template.format(*args)
+
+
+BUILTIN_TYPE_NAPPING = {
+    "int": int,
+    "float": float,
+    "str": str,
+    "bool": _bool,
+    # TODO: Perhaps support for URLs for files?
+}
+
+# Supported Formulas / Functions
+FUNCTION_MAPPING = {
+    # Comparison
+    "less_than": operator.lt,
+    "less_than_or_equal": operator.le,
+    "greater_than": operator.gt,
+    "greater_than_or_equal": operator.ge,
+    "not_equal": operator.ne,
+    "is_equal": operator.eq,
+    "not_null": lambda x: x is not None,
+    "is_null": lambda x: x is None,
+    # Regex
+    "regex_extract": lambda pattern, text: re.search(pattern, text).group(0),
+    "regex_match": lambda pattern, text: bool(re.match(pattern, text)),
+    "regex_not_match": lambda pattern, text: not bool(re.match(pattern, text)),
+    # Collections
+    "contains": lambda item, container: item in container,
+    "does_not_contain": lambda item, container: item not in container,
+    "length": len,
+    "is_empty": lambda x: len(x) == 0,
+    "not_empty": lambda x: len(x) > 0,
+    # Math
+    "add": operator.add,
+    "sub": operator.sub,
+    "mul": operator.mul,
+    "div": operator.truediv,
+    "mod": operator.mod,
+    "pow": operator.pow,
+    # Transform
+    "join": lambda items, sep: sep.join(items),
+    "concat": lambda *items: "".join(items),
+    "format": _format_string,
+    # Logical
+    "and": lambda a, b: a and b,
+    "or": lambda a, b: a or b,
+    "not": lambda a: not a,
+    # Type conversion
+    # Convert JSON to string
+    "serialize_json": json.dumps,
+    # Convert timestamp to datetime
+    "from_timestamp": lambda x, unit,: _from_timestamp(x, unit),
+}

--- a/tracecat/expressions/patterns.py
+++ b/tracecat/expressions/patterns.py
@@ -1,6 +1,4 @@
-import functools
 import re
-from typing import Literal
 
 
 # Function to create the base pattern with optional type specifier
@@ -32,34 +30,6 @@ SECRET_SCAN_TEMPLATE = re.compile(r"\${{\s*SECRETS\.(?P<secret>.+?)\s*}}")
 FULL_TEMPLATE = re.compile(r"^\${{\s*[^{}]*\s*}}$")
 
 
-_DEFAULT_CONTEXTS = ("INPUTS", "ACTIONS", "SECRETS", "FN", "ENV", "TRIGGER")
-_ExprContext = Literal["INPUTS", "ACTIONS", "SECRETS", "FN", "ENV", "TRIGGER"]
-
-
-@functools.lru_cache
-def EXPR_CONTEXT_PATTERN(*contexts: _ExprContext):
-    """Create a pattern that matches a subset of expressions.
-
-    Default contexts are `INPUTS`, `ACTIONS`, `SECRETS`, `FN`, `ENV`, `TRIGGER`.
-
-    If no contexts are provided, the pattern will match all contexts.
-    """
-    if any(context not in _DEFAULT_CONTEXTS for context in contexts):
-        raise ValueError(f"Invalid context. Must be one of {_DEFAULT_CONTEXTS}")
-    if len(contexts) == 0:
-        contexts = _DEFAULT_CONTEXTS
-    combined = "|".join(contexts)
-    return (
-        r"^\s*"
-        r"(?P<full>"  # Full expression start
-        rf"(?P<context>{combined}?)"
-        r"\.(?P<expr>.+?)"
-        r"(\s*->\s*(?P<rtype>\bint\b|\bfloat\b|\bstr\b|\bbool\b))?"
-        r")"  # Full expression end
-        r"(?=\s*$)"  # Negative lookahead for optional whitespace and end of string
-    )
-
-
 TYPE_SPECIFIERS = ("int", "float", "str", "bool")
 
 TYPE_SPECIFIER_PATTERN = "|".join(rf"\b{type}\b" for type in TYPE_SPECIFIERS)
@@ -71,7 +41,7 @@ ACTION_BASE = r"ACTIONS\.(?P<action_expr>[a-zA-Z0-9_\-\.]+?)"
 SECRET_BASE = r"SECRETS\.(?P<secret_expr>[a-zA-Z0-9_\-\.]+?)"
 """Match `SECRETS.secret`."""
 
-FUNCTION_BASE = r"FN\.(?P<fn_expr>(?P<fn_name>[a-zA-Z0-9_]+?)\((?P<fn_args>.*?)\))"
+FUNCTION_BASE = r"FN\.(?P<fn_expr>(?P<fn_name>[a-zA-Z0-9_\.]+?)\((?P<fn_args>.*?)\))"
 """Match `FN.func(arg1, arg2)`."""
 
 INPUTS_BASE = r"INPUTS\.(?P<input_expr>[a-zA-Z0-9_\-\.]+?)"

--- a/tracecat/expressions/patterns.py
+++ b/tracecat/expressions/patterns.py
@@ -84,9 +84,14 @@ LOCAL_VARS_BASE = r"var\.(?P<vars_expr>[a-zA-Z0-9_\-\.]+?)"
 """Match the `var` action-local context. e.g.`var.some_variable` or `var.some.variable`."""
 
 STRING_LITERAL = r"'(?P<str_literal>[^']*)'"
+LIST_LITERAL = r"\[(?P<list_literal>.*?)\]"
+NUMERIC_LITERAL = r"(?P<num_literal>\d+(?:\.\d+)?)"
+BOOL_LITERAL = r"(?P<bool_literal>True|False)"
+NONE_LITERAL = r"(?P<none_literal>None)"
 
-LITERAL_BASE = r"(?P<literal_expr>('[^']*')|True|False|None|(\d+(?:\.\d+)?))"
-"""Match `'hello'` or `True` or `False` or `None` or `5` or `5.0`."""
+LITERAL_BASE = rf"(?P<literal_expr>({STRING_LITERAL})|({BOOL_LITERAL})|({NUMERIC_LITERAL})|({LIST_LITERAL})|({NONE_LITERAL}))"
+"""Match `'hello'` or `True` or `False` or `None` or `5` or `5.0` or `[1, 2, 3]` or `[]`."""
+
 
 TYPECAST_BASE = (
     rf"(?P<cast_type>{TYPE_SPECIFIER_PATTERN})"  # Match one of 'int', 'float', 'str', 'bool'

--- a/tracecat/expressions/validators.py
+++ b/tracecat/expressions/validators.py
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from pydantic import ValidationInfo, ValidatorFunctionWrapHandler
 from pydantic.functional_validators import WrapValidator
@@ -9,6 +9,16 @@ from tracecat.expressions.patterns import FULL_TEMPLATE
 def is_full_template(template: str) -> bool:
     # return template.startswith("${{") and template.endswith("}}")
     return FULL_TEMPLATE.match(template) is not None
+
+
+def is_iterable(value: Any, *, container_only: bool = True) -> bool:
+    try:
+        iter(value)
+        if container_only:
+            return not isinstance(value, str | bytes)
+        return True
+    except TypeError:
+        return False
 
 
 T = TypeVar("T")


### PR DESCRIPTION
# Features
- Implement list literals. Use square brackets with comma delimited inner expressions
-  Improve nested structure parsing
- You can now call `FN.func.map(arg1, arg2)` to call `FN.func` on the arguments.
    - If any arguments are iterable (ignoring str and bytes), take note of these.
    - Non-iterable values get applied `itertools.repeat` (broadcast).
    - The final iterables are zipped.
    - Iteration stops when the shortest iterable is exhausted
    - For examples, see the unit tests
    
# Changes
- Remove unused pattern factory

# Testing
- Added expression unit tests for map, list literal + test workflow of "nested loop" processing using `for_each` and `.map`