### PR TITLE
feat(engine): Generate graph from headless mode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@clerk/clerk-js": "^5.4.0",
     "@clerk/nextjs": "^5.0.12",
+    "@dagrejs/dagre": "^1.1.2",
     "@hookform/resolvers": "^3.4.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@clerk/nextjs':
         specifier: ^5.0.12
         version: 5.0.12(next@14.1.1(@babel/core@7.24.5)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dagrejs/dagre':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@hookform/resolvers':
         specifier: ^3.4.0
         version: 3.4.0(react-hook-form@7.51.4(react@18.3.1))
@@ -473,6 +476,13 @@ packages:
   '@clerk/types@4.4.0':
     resolution: {integrity: sha512-OaT02uLG1P/jBFNyoPM3n9nLdV4H0etTpa/l3iTW4IgOLiAINToLpMOvEpWzKWUq9nvmOouZlBzPVMozu7dwDg==}
     engines: {node: '>=18.17.0'}
+
+  '@dagrejs/dagre@1.1.2':
+    resolution: {integrity: sha512-F09dphqvHsbe/6C2t2unbmpr5q41BNPEfJCdn8Z7aEBpVSy/zFQ/b4SWsweQjWNsYMDvE2ffNUN8X0CeFsEGNw==}
+
+  '@dagrejs/graphlib@2.2.2':
+    resolution: {integrity: sha512-CbyGpCDKsiTg/wuk79S7Muoj8mghDGAESWGxcSyhHX5jD35vYMBZochYVFzlHxynpE9unpu6O+4ZuhrLxASsOg==}
+    engines: {node: '>17.0.0'}
 
   '@emnapi/runtime@1.1.1':
     resolution: {integrity: sha512-3bfqkzuR1KLx57nZfjr2NLnFOobvyS0aTszaEGCGqmYMVDRaGvgIZbjGSV/MHSSmLgQ/b9JFHQ5xm5WRZYd+XQ==}
@@ -4813,6 +4823,12 @@ snapshots:
   '@clerk/types@4.4.0':
     dependencies:
       csstype: 3.1.1
+
+  '@dagrejs/dagre@1.1.2':
+    dependencies:
+      '@dagrejs/graphlib': 2.2.2
+
+  '@dagrejs/graphlib@2.2.2': {}
 
   '@emnapi/runtime@1.1.1':
     dependencies:

--- a/frontend/src/components/workspace/canvas/canvas.tsx
+++ b/frontend/src/components/workspace/canvas/canvas.tsx
@@ -7,6 +7,7 @@ import ReactFlow, {
   Edge,
   MarkerType,
   NodeChange,
+  Panel,
   ReactFlowInstance,
   useEdgesState,
   useNodesState,
@@ -20,14 +21,17 @@ import "reactflow/dist/style.css"
 
 import { useParams } from "next/navigation"
 import { useWorkflow } from "@/providers/workflow"
+import Dagre, { type GraphLabel, type Label } from "@dagrejs/dagre"
+import { MoveHorizontalIcon, MoveVerticalIcon } from "lucide-react"
 
-import { Workflow } from "@/types/schemas"
 import {
   createAction,
   deleteAction,
   fetchWorkflow,
   updateWorkflowGraphObject,
 } from "@/lib/workflow"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { useToast } from "@/components/ui/use-toast"
 import triggerNode, {
   TriggerNodeData,
@@ -38,6 +42,42 @@ import udfNode, {
   UDFNodeData,
   UDFNodeType,
 } from "@/components/workspace/canvas/udf-node"
+
+const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
+
+/**
+ * Taken from https://reactflow.dev/learn/layouting/layouting#dagre
+ * @param nodes
+ * @param edges
+ * @param options
+ * @returns
+ */
+const getLayoutedElements = (
+  nodes: Node[],
+  edges: Edge[],
+  options: GraphLabel
+) => {
+  g.setGraph({ ...options, ranksep: 75, nodesep: 100 })
+
+  edges.forEach((edge) => g.setEdge(edge.source, edge.target))
+  nodes.forEach((node) => g.setNode(node.id, node as Label))
+
+  Dagre.layout(g)
+  console.log(nodes)
+
+  return {
+    nodes: nodes.map((node) => {
+      const position = g.node(node.id)
+      // We are shifting the dagre node position (anchor=center center) to the top left
+      // so it matches the React Flow node anchor point (top left).
+      const x = position.x - node.width! / 2
+      const y = position.y - node.height! / 2
+
+      return { ...node, position: { x, y } }
+    }),
+    edges,
+  }
+}
 
 export type NodeTypename = "udf" | "trigger"
 export type NodeType = UDFNodeType | TriggerNodeType
@@ -294,6 +334,15 @@ export function WorkflowCanvas() {
     [nodes, setNodes]
   )
 
+  const onLayout = useCallback(
+    (direction: "TB" | "LR") => {
+      const layouted = getLayoutedElements(nodes, edges, { rankdir: direction })
+      setNodes([...layouted.nodes])
+      setEdges([...layouted.edges])
+    },
+    [nodes, edges]
+  )
+
   // Saving react flow instance state
   useEffect(() => {
     if (workflowId && reactFlowInstance) {
@@ -332,7 +381,29 @@ export function WorkflowCanvas() {
         deleteKeyCode={["Backspace", "Delete"]}
       >
         <Background />
-        <Controls />
+        <Controls className="rounded-sm" />
+        <Panel position="bottom-right" className="flex items-center gap-1">
+          <Badge
+            variant="outline"
+            className="select-none bg-background text-xs font-extralight hover:cursor-default"
+          >
+            Layout
+          </Badge>
+          <Button
+            variant="outline"
+            className="m-0 size-6 p-0 text-xs"
+            onClick={() => onLayout("TB")}
+          >
+            <MoveVerticalIcon className="size-3" strokeWidth={2} />
+          </Button>
+          <Button
+            variant="outline"
+            className="m-0 size-6 p-0 text-xs"
+            onClick={() => onLayout("LR")}
+          >
+            <MoveHorizontalIcon className="size-3" strokeWidth={2} />
+          </Button>
+        </Panel>
       </ReactFlow>
     </div>
   )

--- a/frontend/src/components/workspace/canvas/canvas.tsx
+++ b/frontend/src/components/workspace/canvas/canvas.tsx
@@ -93,39 +93,6 @@ async function createNewNode(
   }
 }
 
-function getInitialState(
-  workflow: Workflow,
-  containerRef: React.RefObject<HTMLDivElement>
-) {
-  const rect = containerRef.current?.getBoundingClientRect()
-  const width = rect?.width || 0
-  const height = rect?.height || 0
-  const graphInitialState = {
-    nodes: [
-      {
-        id: `trigger-${workflow.id}`,
-        type: "trigger",
-        position: { x: width / 2, y: height / 2 },
-        data: {
-          type: "trigger",
-          title: "Trigger",
-          status: "online",
-          isConfigured: true,
-          webhook: workflow.webhook,
-          schedules: workflow.schedules,
-        },
-      },
-    ],
-    edges: [],
-    viewport: {
-      x: 0,
-      y: 0,
-      zoom: 1,
-    },
-  }
-  return graphInitialState
-}
-
 export function WorkflowCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
   const [nodes, setNodes, onNodesChange] = useNodesState([])
@@ -148,22 +115,14 @@ export function WorkflowCanvas() {
       try {
         const workflow = await fetchWorkflow(workflowId)
         const flow = workflow.object as ReactFlowJsonObject
-        if (flow) {
-          // If there is a saved React Flow configuration, load it
-          setNodes(flow.nodes || [])
-          setEdges(flow.edges || [])
-          setViewport({
-            x: flow.viewport.x,
-            y: flow.viewport.y,
-            zoom: flow.viewport.zoom,
-          })
-        } else {
-          // Otherwise, load the default nodes
-          const initialState = getInitialState(workflow, containerRef)
-          setNodes(initialState.nodes)
-          setEdges(initialState.edges)
-          setViewport(initialState.viewport)
-        }
+        if (!flow) throw new Error("No workflow data found")
+        setNodes(flow.nodes || [])
+        setEdges(flow.edges || [])
+        setViewport({
+          x: flow.viewport.x,
+          y: flow.viewport.y,
+          zoom: flow.viewport.zoom,
+        })
       } catch (error) {
         console.error("Failed to fetch workflow data:", error)
       }

--- a/frontend/src/components/workspace/catalog/udf-catalog.tsx
+++ b/frontend/src/components/workspace/catalog/udf-catalog.tsx
@@ -34,7 +34,6 @@ const groupByDisplayGroup = (udfs: UDF[]): Record<string, UDF[]> => {
     }
     groups[displayGroup].push(udf)
   })
-  console.log("groups", groups)
   return groups
 }
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -61,6 +61,7 @@ from tracecat.dsl.common import DSLInput
 from tracecat.dsl.dispatcher import dispatch_workflow
 
 # from loguru import logger
+from tracecat.dsl.graph import RFGraph
 from tracecat.logging import logger
 from tracecat.middleware import RequestLoggingMiddleware
 from tracecat.registry import registry
@@ -396,6 +397,8 @@ def create_workflow(
             owner_id=role.user_id,
             workflow_id=workflow.id,
         )
+        graph = RFGraph.with_defaults(workflow, webhook)
+        workflow.object = graph.model_dump(by_alias=True)
         session.add(workflow)
         session.add(webhook)
         session.commit()

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -616,6 +616,9 @@ def commit_workflow(
             workflow.version = defn.version
             workflow.title = dsl.title
             workflow.description = dsl.description
+            workflow.entrypoint = (
+                new_graph.entrypoint.id if new_graph.entrypoint else None
+            )
 
             session.add(workflow)
             session.add(defn)

--- a/tracecat/db/converters.py
+++ b/tracecat/db/converters.py
@@ -1,10 +1,15 @@
 from tracecat.db.schemas import Workflow
 from tracecat.dsl.common import DSLInput
-from tracecat.dsl.graph import RFGraph
+from tracecat.dsl.graph import RFEdge, RFGraph, UDFNode, UDFNodeData
+from tracecat.logging import logger
+from tracecat.utils import action_key
 
 
 def workflow_to_dsl(workflow: Workflow) -> DSLInput:
-    """Connector to convert an AppState workflow to a DSLInput."""
+    """Converter for Workflow to DSLInput.
+
+    Use Case: Committing a Workflow into a Workflow Definition
+    """
     # NOTE: Must only call inside a db session
     # Check that we're inside an open
     if not workflow.object:
@@ -18,9 +23,71 @@ def workflow_to_dsl(workflow: Workflow) -> DSLInput:
     return DSLInput(
         title=workflow.title,
         description=workflow.description,
-        entrypoint=graph.entrypoint,
+        entrypoint=graph.logical_entrypoint.ref,
         actions=graph.action_statements(workflow),
         # config=workflow.config,
         # triggers=workflow.triggers,
         # inputs=workflow.inputs,
     )
+
+
+# For syncing headless to the frontend, we need to convert the DSLInput into an RFGraph that we can then convert to a Workflow object.
+# We need DSLInputs (yaml) to show changes in the frontend graph object
+
+
+def dsl_to_graph(workflow: Workflow, dsl: DSLInput) -> RFGraph:
+    """Converter for DSLInput to Workflow.
+
+    Use Case: Syncing headless to the frontend.
+    Call this only
+    """
+    if not dsl.actions:
+        raise ValueError("Empty actions list")
+    wf_id = workflow.id
+    graph = RFGraph.from_workflow(workflow)
+    trigger = graph.trigger
+
+    # Create nodes and edges
+    nodes: list[RFEdge] = [trigger]
+    edges: list[RFEdge] = []
+    try:
+        for action in dsl.actions:
+            # Get updated nodes
+            dst_key = action_key(wf_id, action.ref)
+            node = UDFNode(
+                id=dst_key,
+                data=UDFNodeData(
+                    title=action.title,
+                    type=action.action,
+                ),
+            )
+            nodes.append(node)
+
+            for src_ref in action.depends_on:
+                src_key = action_key(wf_id, src_ref)
+                edges.append(RFEdge(source=src_key, target=dst_key))
+
+        entrypoint_id = action_key(wf_id, dsl.entrypoint)
+        # Add trigger edge
+        edges.append(
+            RFEdge(source=trigger.id, target=entrypoint_id, label="⚡ Trigger")
+        )
+        return RFGraph(nodes=nodes, edges=edges)
+    except Exception as e:
+        logger.opt(exception=e).error("Error creating graph")
+        raise e
+
+
+# Since a Workflow object always has a graph now, we really only need to have an update function.
+
+if __name__ == "__main__":
+    from pydantic import BaseModel
+
+    class Test(BaseModel):
+        a: int
+
+        def asdf(self):
+            return self.a
+
+    t = Test.model_construct(a="zxcm,nxcmvn")
+    print(t.asdf())

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -144,7 +144,7 @@ class CaseEvent(Resource, table=True):
         default_factory=gen_id("case-evt"), nullable=False, unique=True, index=True
     )
     type: str  # The CaseEvent type
-    workflow_id: str | None = Field(foreign_key="workflow.id")
+    workflow_id: str
     case_id: str
     # Tells us what kind of role modified the case
     initiator_role: str  # "user", "service"

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -39,25 +39,47 @@ class DSLError(ValueError):
 
 
 class ActionStatement(BaseModel):
-    ref: str = Field(pattern=SLUG_PATTERN)
-    """Unique reference for the task"""
+    id: str | None = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "The action ID. If this is populated means there is a corresponding action"
+            "in the database `Action` table."
+        ),
+    )
 
-    action: str = Field(pattern=ACTION_TYPE_PATTERN)
-    """Namespaced action type"""
+    ref: str = Field(pattern=SLUG_PATTERN, description="Unique reference for the task")
 
-    args: dict[str, Any] = Field(default_factory=dict)
-    """Arguments for the action"""
+    description: str = ""
 
-    depends_on: list[str] = Field(default_factory=list)
-    """Task dependencies"""
+    action: str = Field(
+        pattern=ACTION_TYPE_PATTERN, description="Action type / UDF key"
+    )
 
-    run_if: Annotated[str | None, Field(default=None), TemplateValidator()]
-    """Condition to run the task"""
+    args: dict[str, Any] = Field(
+        default_factory=dict, description="Arguments for the action"
+    )
+
+    depends_on: list[str] = Field(default_factory=list, description="Task dependencies")
+
+    run_if: Annotated[
+        str | None,
+        Field(default=None, description="Condition to run the task"),
+        TemplateValidator(),
+    ]
 
     for_each: Annotated[
-        str | list[str] | None, Field(default=None), TemplateValidator()
+        str | list[str] | None,
+        Field(
+            default=None,
+            description="Iterate over a list of items and run the task for each item.",
+        ),
+        TemplateValidator(),
     ]
-    """Run the task over an iterable"""
+
+    @property
+    def title(self) -> str:
+        return self.ref.capitalize().replace("_", " ")
 
 
 class DSLConfig(BaseModel):

--- a/tracecat/dsl/graph.py
+++ b/tracecat/dsl/graph.py
@@ -306,8 +306,8 @@ class RFGraph(TSObject):
                     "data": {
                         "type": "trigger",
                         "title": "Trigger",
-                        "status": "online",
-                        "isConfigured": True,
+                        "status": "offline",
+                        "isConfigured": False,
                         "webhook": webhook,
                         "schedules": workflow.schedules or [],
                     },

--- a/tracecat/types/cases.py
+++ b/tracecat/types/cases.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any, Literal, Self
-from uuid import uuid4
 
 import orjson
 from pydantic import BaseModel, Field
 
 from tracecat.types.api import CaseContext, CaseParams, ListModel, Suppression, Tag
+from tracecat.utils import gen_id
 
 CaseEvent = Literal[
     "changed_status",
@@ -18,20 +18,11 @@ CaseEvent = Literal[
 ]
 
 
-def _gen_id(prefix: str):
-    separator = "-"
-
-    def wrapper():
-        return prefix + separator + uuid4().hex
-
-    return wrapper
-
-
 class Case(BaseModel):
     """Case model used in the API and runner."""
 
     # Required inputs
-    id: str = Field(default_factory=_gen_id("case"))  # Action run id
+    id: str = Field(default_factory=gen_id("case"))  # Action run id
     owner_id: str  # NOTE: Ideally this would inherit form db.Resource
     workflow_id: str
     case_title: str

--- a/tracecat/utils.py
+++ b/tracecat/utils.py
@@ -1,0 +1,24 @@
+"""Tracecat utility functions."""
+
+from uuid import uuid4
+
+from slugify import slugify
+
+
+def gen_id(prefix: str):
+    separator = "-"
+
+    def wrapper():
+        return prefix + separator + uuid4().hex
+
+    return wrapper
+
+
+def get_ref(text: str) -> str:
+    """Return a slugified version of the text."""
+    return slugify(text, separator="_")
+
+
+def action_key(wfid: str, ref: str) -> str:
+    """Inner workflow ID for an action, using the workflow ID and action ref."""
+    return f"{wfid}:{ref}"


### PR DESCRIPTION
# Features
- Move initla graph construction to server side
- Workflow commit endpoint now performs graph object construction
- Add layouting using dagre

# Changes
- Clean up `RFGraph API`, prepare to take on more server side logic

# Testing
- Unit tests all passing

