### PR TITLE
feat(engine): Dynamically register UDFs in DSLActivities

### DIFF
--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -23,12 +23,7 @@ from temporalio.worker import Worker
 from tracecat.contexts import ctx_role
 from tracecat.dsl.common import DSLInput, get_temporal_client
 from tracecat.dsl.worker import new_sandbox_runner
-from tracecat.dsl.workflow import (
-    DSLContext,
-    DSLRunArgs,
-    DSLWorkflow,
-    dsl_activities,
-)
+from tracecat.dsl.workflow import DSLActivities, DSLContext, DSLRunArgs, DSLWorkflow
 from tracecat.expressions import ExprContext
 from tracecat.identifiers.resource import ResourcePrefix
 from tracecat.types.exceptions import TracecatExpressionError
@@ -128,7 +123,7 @@ async def test_workflow_can_run_from_yaml(
     async with Worker(
         client,
         task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-        activities=dsl_activities,
+        activities=DSLActivities.load(),
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
     ):
@@ -193,7 +188,7 @@ async def test_workflow_ordering_is_correct(
     async with Worker(
         client,
         task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-        activities=dsl_activities,
+        activities=DSLActivities.load(),
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
     ):
@@ -262,7 +257,7 @@ async def test_workflow_completes_and_correct(
     async with Worker(
         client,
         task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-        activities=dsl_activities,
+        activities=DSLActivities.load(),
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
     ):
@@ -292,7 +287,7 @@ async def test_conditional_execution_fails(
     async with Worker(
         client,
         task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-        activities=dsl_activities,
+        activities=DSLActivities.load(),
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
     ):

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -14,7 +14,7 @@ from temporalio.worker.workflow_sandbox import (
 # are safe for workflow use
 with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.common import get_temporal_client
-    from tracecat.dsl.workflow import DSLWorkflow, dsl_activities
+    from tracecat.dsl.workflow import DSLActivities, DSLWorkflow
     from tracecat.registry import registry
 
 
@@ -52,10 +52,11 @@ async def main() -> None:
     client = await get_temporal_client()
 
     # Run a worker for the activities and workflow
+    DSLActivities.init()
     async with Worker(
         client,
         task_queue=os.environ.get("TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"),
-        activities=dsl_activities,
+        activities=DSLActivities.load(),
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
     ):


### PR DESCRIPTION
# Features
- Instead of displaying `run_udf` for every function, dynamically wrap each UDF in a Temporal activity and register it with workers.
    - In the UDF key we replace `.` with `__`. e.g. `ns.subns.method_name` -> `ns__subns__method_name`

# Remarks
- Improve workflow observability
- Before we start a worker, generate temporal activity wrappers for all registered UDFs so that they show up as activity types in the Temporal UI

# Screens
<img width="635" alt="image" src="https://github.com/TracecatHQ/tracecat/assets/5508348/57c2a4e0-7927-4c79-9e6d-5d0917b1b4de">

# Testing
- All workflow tests passing
