### PR TITLE
feat(engine): Implement server-side UDF args validation on commit

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -287,8 +287,11 @@ paths:
               - $ref: '#/components/schemas/Body_commit_workflow_workflows__workflow_id__commit_post'
               title: Body
       responses:
-        '204':
+        '200':
           description: Successful Response
+          content:
+            application/json:
+              schema: {}
         '422':
           description: Validation Error
           content:

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -7,7 +7,7 @@ from tempfile import SpooledTemporaryFile
 from typing import Annotated, Any, Literal, Self
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 from temporalio.client import Client, TLSConfig
 
 from tracecat import config
@@ -103,7 +103,6 @@ class DSLInput(BaseModel):
     This allows the execution of the workflow to be fully deterministic.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
     title: str
     description: str
     entrypoint: str

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -338,3 +338,11 @@ class CreateScheduleParams(BaseModel):
     entrypoint_ref: str
     entrypoint_payload: dict[str, Any] | None = None
     cron: str
+
+
+class CommitWorkflowResponse(BaseModel):
+    workflow_id: str
+    status: Literal["success", "failure"]
+    message: str
+    errors: list[UDFArgsValidationResponse] | None = None
+    metadata: dict[str, Any] | None = None


### PR DESCRIPTION
# Features
- Perform UDF args validation on workflow commit
- The API returns the error details in the response

# Changes
- Updated OpenAPI docs according to commit workflow API changes

# Example output
```
❯ tracecat workflow commit wf-3ffb4a86e05d4db3a178393ac786bcf5 -f playbooks/aws/guardduty-to-slack.yml
Failed to commit to workflow 'wf-3ffb4a86e05d4db3a178393ac786bcf5'!
{
    'workflow_id': 'wf-3ffb4a86e05d4db3a178393ac786bcf5',
    'status': 'failure',
    'message': 'Validation errors',
    'errors': [
        {
            'ok': False,
            'message': 'Error validating integrations.aws.guardduty.list_guardduty_alerts',
            'detail': [
                {
                    'type': 'datetime_from_date_parsing',
                    'loc': ['start_time', "ValidationInfo(config={'title': 'IntegrationsAwsGuarddutyListGuarddutyAlerts', 'extra_fields_behavior': 'forbid'}, context=None, data={}, field_name='start_time')"],
                    'msg': 'Input should be a valid datetime or date, invalid character in year',
                    'input': 'adflhsdlkfjhasdlkfh',
                    'ctx': {'error': 'invalid character in year'},
                    'url': 'https://errors.pydantic.dev/2.6/v/datetime_from_date_parsing'
                },
                {
                    'type': 'int_parsing',
                    'loc': ['limit', "ValidationInfo(config={'title': 'IntegrationsAwsGuarddutyListGuarddutyAlerts', 'extra_fields_behavior': 'forbid'}, context=None, data={'end_time': '${{ INPUTS.end_time }}'}, field_name='limit')"],
                    'msg': 'Input should be a valid integer, unable to parse string as an integer',
                    'input': 'asdfhsdlkfh',
                    'url': 'https://errors.pydantic.dev/2.6/v/int_parsing'
                }
            ]
        }
    ],
    'metadata': {'filename': 'guardduty-to-slack.yml'}
}
```