### PR TITLE
ci: Add draft GH workflow to test all playbooks

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,14 @@ replacers:
     replace: "- "
 
 autolabeler:
+  - label: playbook
+    title:
+      - "/^playbook/"
+
+  - label: integration
+    title:
+      - "/^integration/"
+
   - label: frontend
     title:
       # Example: feat(ui): ...
@@ -82,6 +90,12 @@ categories:
 
   - title: ⚠️ Deprecations
     labels: deprecation
+
+  - title: 📘 Playbooks
+    labels: playbook
+
+  - title: 🧩 Integrations
+    labels: integration
 
   - title: 🚀 Performance improvements
     labels: performance

--- a/.github/workflows/playbooks.yml
+++ b/.github/workflows/playbooks.yml
@@ -1,0 +1,94 @@
+name: Playbooks
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  run-playbooks:
+    runs-on: ubuntu-latest-8-cores
+    environment: QA
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download Temporal CLI
+        run: |
+          curl -L -o temporal.tar.gz "https://temporal.download/cli/archive/latest?platform=linux&arch=amd64"
+          mkdir -p temporal-cli
+          tar -xzf temporal.tar.gz -C temporal-cli
+          echo "${GITHUB_WORKSPACE}/temporal-cli" >> $GITHUB_PATH
+
+      - name: Verify Temporal CLI installation
+        run: temporal --version
+
+      - name: Install Tracecat CLI
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[cli]"
+
+      - name: Run environment setup script
+        run: bash env.sh
+
+      - name: Get image tag
+        id: set-image-tag
+        run: |
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            echo "TRACECAT__IMAGE_TAG=latest" >> $GITHUB_ENV
+          else
+            echo "TRACECAT__IMAGE_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          fi
+
+      - name: Mask sensitive data
+        run: |
+          echo "::add-mask::${{ secrets.INTEGRATION__ABUSECH_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__ABUSEIPDB_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__AWS_GUARDDUTY__ACCESS_KEY_ID }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__AWS_GUARDDUTY__SECRET_ACCESS_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__DD_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__DD_APP_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__HYBRID_ANALYSIS_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__OPENAI_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__PULSEDRIVE_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__RESEND_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__SLACK_BOT_TOKEN }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__SLACK_CHANNEL }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__URLSCAN_API_KEY }}"
+          echo "::add-mask::${{ secrets.INTEGRATION__VT_API_KEY }}"
+
+      - name: Run playbooks
+        env:
+          TRACECAT__IMAGE_TAG: ${{ env.TRACECAT__IMAGE_TAG }}
+          ABUSECH_API_KEY: ${{ secrets.INTEGRATION__ABUSECH_API_KEY }}
+          ABUSEIPDB_API_KEY: ${{ secrets.INTEGRATION__ABUSEIPDB_API_KEY }}
+          AWS_GUARDDUTY__ACCESS_KEY_ID: ${{ secrets.INTEGRATION__AWS_GUARDDUTY__ACCESS_KEY_ID }}
+          AWS_GUARDDUTY__SECRET_ACCESS_KEY: ${{ secrets.INTEGRATION__AWS_GUARDDUTY__SECRET_ACCESS_KEY }}
+          DD_API_KEY: ${{ secrets.INTEGRATION__DD_API_KEY }}
+          DD_APP_KEY: ${{ secrets.INTEGRATION__DD_APP_KEY }}
+          HYBRID_ANALYSIS_API_KEY: ${{ secrets.INTEGRATION__HYBRID_ANALYSIS_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.INTEGRATION__OPENAI_API_KEY }}
+          PULSEDRIVE_API_KEY: ${{ secrets.INTEGRATION__PULSEDRIVE_API_KEY }}
+          RESEND_API_KEY: ${{ secrets.INTEGRATION__RESEND_API_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.INTEGRATION__SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.INTEGRATION__SLACK_CHANNEL }}
+          URLSCAN_API_KEY: ${{ secrets.INTEGRATION__URLSCAN_API_KEY }}
+          VT_API_KEY: ${{ secrets.INTEGRATION__VT_API_KEY }}
+        run: |
+          docker compose -f docker-compose.yml up --no-deps api worker postgres_db -d
+          nohup temporal server start-dev > temporal.log 2>&1 &
+          pytest -k "test_playbooks" --temporal-no-restart --tracecat-no-restart

--- a/.github/workflows/playbooks.yml
+++ b/.github/workflows/playbooks.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Verify Temporal CLI installation
         run: temporal --version
 
-      - name: Install Tracecat CLI
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ".[cli]"
+          pip install ".[dev,cli]"
 
       - name: Run environment setup script
         run: bash env.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   push-to-ghcr:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   pytest:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     needs: push-to-ghcr
     timeout-minutes: 30
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,4 +105,4 @@ jobs:
           nohup temporal server start-dev > temporal.log 2>&1 &
 
           # Run Tracecat tests
-          pytest tests --temporal-no-restart --tracecat-no-restart
+          pytest tests/unit --temporal-no-restart --tracecat-no-restart

--- a/playbooks/alert_management/aws-guardduty-to-slack.yml
+++ b/playbooks/alert_management/aws-guardduty-to-slack.yml
@@ -9,7 +9,7 @@ inputs:
 
 triggers:
   - type: webhook
-    ref: my_webhook
+    ref: guardduty_findings_webhook
     entrypoint: pull_aws_guardduty_findings
 
 actions:
@@ -19,6 +19,20 @@ actions:
       start_time: ${{ INPUTS.start_time }}
       end_time: ${{ INPUTS.end_time }}
       limit: 10
+
+  # Short circuit the workflow if no findings are found
+  - ref: report_no_findings
+    action: core.http_request
+    depends_on:
+      - pull_aws_guardduty_findings
+    run_if: ${{ FN.is_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
+    args:
+      url: ${{ SECRETS.slack.SLACK_WEBHOOK }}
+      method: POST
+      headers:
+        Content-Type: application/json
+      payload:
+        text: Tracecat ran workflow for GuardDuty findings, but no findings were found
 
   # Transform the list of GuardDuty findings into a list of SMAC findings
   - ref: reshape_findings_into_smac

--- a/playbooks/alert_management/aws-guardduty-to-slack.yml
+++ b/playbooks/alert_management/aws-guardduty-to-slack.yml
@@ -7,7 +7,6 @@ inputs:
   slack_channel: CXXXXXXXXXXXX
   start_time: "2023-06-12T00:00:00Z"
   end_time: "2024-06-15T12:00:00Z"
-  slack_webhook: http://your-slack-webhook-url.com
 
 triggers:
   - type: webhook
@@ -21,20 +20,6 @@ actions:
       start_time: ${{ INPUTS.start_time }}
       end_time: ${{ INPUTS.end_time }}
       limit: 10
-
-  # Short circuit the workflow if no findings are found
-  - ref: report_no_findings
-    action: core.http_request
-    depends_on:
-      - pull_aws_guardduty_findings
-    run_if: ${{ FN.is_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
-    args:
-      url: ${{ INPUTS.slack_webhook }}
-      method: POST
-      headers:
-        Content-Type: application/json
-      payload:
-        text: Tracecat ran workflow for GuardDuty findings, but no findings were found
 
   # Transform the list of GuardDuty findings into a list of SMAC findings
   - ref: reshape_findings_into_smac

--- a/playbooks/alert_management/aws-guardduty-to-slack.yml
+++ b/playbooks/alert_management/aws-guardduty-to-slack.yml
@@ -4,7 +4,6 @@ description: |
   Also sends a message if no findings available.
 entrypoint: pull_aws_guardduty_findings
 inputs:
-  slack_channel: CXXXXXXXXXXXX
   start_time: "2023-06-12T00:00:00Z"
   end_time: "2024-06-15T12:00:00Z"
 
@@ -52,7 +51,7 @@ actions:
     # Assign each SMAC finding to a variable named `smac`
     for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
     args:
-      channel: ${{ INPUTS.slack_channel }}
+      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
       text: GuardDuty findings for past 24h
       blocks:
         - type: header

--- a/playbooks/alert_management/datadog-siem-to-slack.yml
+++ b/playbooks/alert_management/datadog-siem-to-slack.yml
@@ -10,7 +10,7 @@ inputs:
 
 triggers:
   - type: webhook
-    ref: my_webhook
+    ref: datadog_siem_signals_webhook
     entrypoint: pull_datadog_siem_signals
 
 actions:

--- a/playbooks/alert_management/datadog-siem-to-slack.yml
+++ b/playbooks/alert_management/datadog-siem-to-slack.yml
@@ -7,7 +7,6 @@ entrypoint: pull_datadog_signals
 inputs:
   dd_region: us5
   dd_api_url: https://api.us5.datadoghq.com
-  slack_channel: CXXXXXXXXXXXX
 
 triggers:
   - type: webhook
@@ -75,7 +74,7 @@ actions:
       - ${{ for var.signal in ACTIONS.reshape_signals.result }}
       - ${{ for var.user_ids in ACTIONS.extract_slack_user_ids.result }}
     args:
-      channel: ${{ INPUTS.slack_channel }}
+      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
       text: Datadog alerts (last )
       blocks:
         - type: header

--- a/tests/integration/test_playbooks.py
+++ b/tests/integration/test_playbooks.py
@@ -1,0 +1,71 @@
+import json
+import os
+import subprocess
+
+import pytest
+
+
+# Fixture to create Tracecat secrets
+@pytest.fixture(scope="session", autouse=True)
+def create_secrets():
+    secrets = {
+        "abusech": {"ABUSECH_API_KEY": os.getenv("ABUSECH_API_KEY")},
+        "abuseipdb": {"ABUSEIPDB_API_KEY": os.getenv("ABUSEIPDB_API_KEY")},
+        "aws-guardduty": {
+            "AWS_ACCESS_KEY_ID": os.getenv("AWS_GUARDDUTY__ACCESS_KEY_ID"),
+            "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_GUARDDUTY__SECRET_ACCESS_KEY"),
+        },
+        "datadog": {
+            "DD_API_KEY": os.getenv("DD_API_KEY"),
+            "DD_APP_KEY": os.getenv("DD_APP_KEY"),
+        },
+        "hybrid-analysis": {
+            "HYBRID_ANALYSIS_API_KEY": os.getenv("HYBRID_ANALYSIS_API_KEY")
+        },
+        "openai": {"OPENAI_API_KEY": os.getenv("OPENAI_API_KEY")},
+        "pulsedrive": {"PULSEDRIVE_API_KEY": os.getenv("PULSEDRIVE_API_KEY")},
+        "resend": {"RESEND_API_KEY": os.getenv("RESEND_API_KEY")},
+        "slack": {
+            "SLACK_BOT_TOKEN": os.getenv("SLACK_BOT_TOKEN"),
+            "SLACK_CHANNEL": os.getenv("SLACK_CHANNEL"),
+            "SLACK_WEBHOOK": os.getenv("SLACK_WEBHOOK"),
+        },
+        "urlscan": {"URLSCAN_API_KEY": os.getenv("URLSCAN_API_KEY")},
+        "virustotal": {"VT_API_KEY": os.getenv("VT_API_KEY")},
+    }
+
+    for name, env_vars in secrets.items():
+        env_vars_str = " ".join([f"{key}={value}" for key, value in env_vars.items()])
+        command = f"tracecat secret create {name} {env_vars_str}"
+        subprocess.run(command, shell=True, check=True)
+
+
+@pytest.mark.parametrize(
+    "path_to_playbook",
+    [
+        # "alert_management/aws-guardduty-to-slack.yml",
+        "alert_management/crowdstrike-to-cases.yml",
+        "alert_management/datadog-siem-to-slack.yml",
+    ],
+)
+def test_playbook(path_to_playbook):
+    # Extract the filename without extension
+    filename = os.path.basename(path_to_playbook).replace(".yml", "")
+    # 1. Create workflow
+    # Output is a JSON where the workflow ID is stored under the key "id"
+    output = subprocess.run(
+        ["tracecat", "workflow", "create", "--title", filename],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    workflow_id = json.loads(output.stdout)["id"]
+    # 2. Commit workflow definition
+    subprocess.run(
+        ["tracecat", "workflow", "commit", "--file", path_to_playbook, workflow_id],
+        check=True,
+    )
+    # 3. Activate the workflow
+    subprocess.run(["tracecat", "workflow", "up", "--webhook", workflow_id], check=True)
+    # 4. Run the workflow
+    subprocess.run(["tracecat", "workflow", "run", workflow_id], check=True)

--- a/tests/integration/test_playbooks.py
+++ b/tests/integration/test_playbooks.py
@@ -38,6 +38,7 @@ def create_secrets():
         env_vars_str = " ".join([f"{key}={value}" for key, value in env_vars.items()])
         output = subprocess.run(
             f"tracecat secret create {name} {env_vars_str}",
+            shell=True,
             capture_output=True,
             text=True,
         )
@@ -59,6 +60,7 @@ def test_playbook(path_to_playbook):
     # Output is a JSON where the workflow ID is stored under the key "id"
     output = subprocess.run(
         ["tracecat", "workflow", "create", "--title", filename],
+        shell=True,
         capture_output=True,
         text=True,
     )
@@ -66,11 +68,12 @@ def test_playbook(path_to_playbook):
     # 2. Commit workflow definition
     output = subprocess.run(
         ["tracecat", "workflow", "commit", "--file", path_to_playbook, workflow_id],
+        shell=True,
         capture_output=True,
         text=True,
     )
     assert "Successfully committed to workflow" in output.stdout
     # 3. Activate the workflow
-    subprocess.run(["tracecat", "workflow", "up", "--webhook", workflow_id])
+    subprocess.run(["tracecat", "workflow", "up", "--webhook", workflow_id], shell=True)
     # 4. Run the workflow
-    subprocess.run(["tracecat", "workflow", "run", workflow_id])
+    subprocess.run(["tracecat", "workflow", "run", workflow_id], shell=True)

--- a/tracecat/cli/_config.py
+++ b/tracecat/cli/_config.py
@@ -2,15 +2,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import rich
-import typer
 from dotenv import find_dotenv, load_dotenv
 
 from tracecat import config
 from tracecat.auth.credentials import Role
 
 if not load_dotenv(find_dotenv()):
-    rich.print("[red]No .env file found[/red]")
-    raise typer.Exit()
+    rich.print("[yellow]No .env file found[/yellow]")
 
 
 # In reality we should use the user's id from config.toml

--- a/tracecat/cli/_config.py
+++ b/tracecat/cli/_config.py
@@ -1,14 +1,12 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import rich
 from dotenv import find_dotenv, load_dotenv
 
 from tracecat import config
 from tracecat.auth.credentials import Role
 
-if not load_dotenv(find_dotenv()):
-    rich.print("[yellow]No .env file found[/yellow]")
+load_dotenv(find_dotenv())
 
 
 # In reality we should use the user's id from config.toml


### PR DESCRIPTION
## NOTE:
This is an incomplete PR. Need to deal with accessing docker / localhost from within github actions issues in a follow-up PR.

## What changed
- [x] Add workflow to run playbooks via pytest (very similar setup to #177)
- [x] Made webhooks secret
- [x] Gave each playbook trigger ref a meaningful name  

## Comments
- Assumes no data is sent to webhook
- Need to extend this test suite to support playbooks with incoming data into the trigger
- Need to extend this test suite with scheduled workflows