### PR TITLE
build(engine): Add basic Caddy reverse proxy for API requests

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,5 @@
+{$BASE_URL} {
+        bind {$ADDRESS} # Binds to all available network interfaces if not specified
+        reverse_proxy /* http://api:8000
+        # tls /certs/cert.pem /certs/key.pem
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
     networks:
       - internal-network
-    entrypoint: [ "python", "tracecat/dsl/worker.py" ]
+    entrypoint: ["python", "tracecat/dsl/worker.py"]
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,25 @@ services:
       - internal-network
     volumes:
       - db-storage:/var/lib/postgresql/data
+  caddy:
+    image: caddy:2.8.4-alpine
+    restart: unless-stopped
 
+    # Configure the mounted Caddyfile and the exposed ports or use another reverse proxy if needed
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      # - ./certs:/certs # Provide custom certificate files like cert.pem and key.pem to enable HTTPS - See the corresponding section in the Caddyfile
+    ports:
+      # To change the exposed port, simply change 80:80 to <desired_port>:80. No other changes needed
+      - 80:80
+      # - 443:443 # Uncomment to enable HTTPS handling by Caddy
+    environment:
+      - BASE_URL=":80"
+      # - BASE_URL=":443" # uncomment and comment line above to enable HTTPS via custom certificate and key files
+      # - BASE_URL=mydomain.com # Uncomment and comment line above to enable HTTPS handling by Caddy
+      - ADDRESS=${ADDRESS}
+    networks:
+      - internal-network
 networks:
   internal-network:
 


### PR DESCRIPTION
# Motivations
- Remove ngrok from default install path

# Changes
- We'll still suggest ngrok as an optional tool (if users can and wish to hit APIs external data sources)
- Include Caddy as a simple rev proxy
- Hit `localhost` to access the API


<img width="1548" alt="Screenshot 2024-06-20 at 14 00 58" src="https://github.com/TracecatHQ/tracecat/assets/5508348/9f19602b-fb15-4de6-8fe0-2f6516681608">

