### PR TITLE
fix: Remove host.docker.internal dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ TRACECAT__PUBLIC_RUNNER_URL=https://your-ngrok-runner-url
 # --- Postgres ---
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-TRACECAT__DB_URI=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@host.docker.internal:5432/postgres
+TRACECAT__DB_URI=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres_db:5432/postgres
 
 # --- Shared frontend env vars ---
 # Important: environment variables prefixed with `NEXT_PUBLIC_` are exposed to the browser client

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # --- Shared env vars ---
 LOG_LEVEL=INFO
+# Static docker0 network interface IP
+DOCKER_HOST_IP=172.17.0.1
 
 # --- App and DB env vars ---
 # One of `development`, `staging`, or `production`
@@ -36,7 +38,7 @@ NEXT_PUBLIC_APP_ENV=development
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Allows the browser to communicate with the backend
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_SERVER_API_URL=http://api:8000
+NEXT_SERVER_API_URL=http://${DOCKER_HOST_IP}:8000
 
 # --- Authentication + Clerk ---
 # Controls auth for both the API and the frontend server + client
@@ -54,7 +56,7 @@ NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 
 # --- Temporal ---
-TEMPORAL__CLUSTER_URL=http://host.docker.internal:7233
+TEMPORAL__CLUSTER_URL=http://${DOCKER_HOST_IP}:7233
 TEMPORAL__CLUSTER_QUEUE=tracecat-task-queue
 
 # --- Cloud only ---

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,5 @@
+{$BASE_URL} {
+        bind {$ADDRESS} # Binds to all available network interfaces if not specified
+        reverse_proxy /* http://api:8000
+        # tls /certs/cert.pem /certs/key.pem
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
     networks:
       - internal-network
-    entrypoint: [ "python", "tracecat/dsl/worker.py" ]
+    entrypoint: ["python", "tracecat/dsl/worker.py"]
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL} # Sensitive
       TEMPORAL__CLUSTER_QUEUE: ${TEMPORAL__CLUSTER_QUEUE} # Sensitive
     restart: unless-stopped
+    depends_on:
+      - postgres_db
     networks:
       - internal-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,25 @@ services:
       - internal-network
     volumes:
       - db-storage:/var/lib/postgresql/data
+  caddy:
+    image: caddy:2.8.4-alpine
+    restart: unless-stopped
 
+    # Configure the mounted Caddyfile and the exposed ports or use another reverse proxy if needed
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      # - ./certs:/certs # Provide custom certificate files like cert.pem and key.pem to enable HTTPS - See the corresponding section in the Caddyfile
+    ports:
+      # To change the exposed port, simply change 80:80 to <desired_port>:80. No other changes needed
+      - 80:80
+      # - 443:443 # Uncomment to enable HTTPS handling by Caddy
+    environment:
+      - BASE_URL=":80"
+      # - BASE_URL=":443" # uncomment and comment line above to enable HTTPS via custom certificate and key files
+      # - BASE_URL=mydomain.com # Uncomment and comment line above to enable HTTPS handling by Caddy
+      - ADDRESS=${ADDRESS}
+    networks:
+      - internal-network
 networks:
   internal-network:
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,14 +4,9 @@ import { getAuthToken } from "@/lib/auth"
 import { isServer } from "@/lib/utils"
 
 // Determine the base URL based on the execution environment
-let baseURL = process.env.NEXT_PUBLIC_API_URL
-
-// Use different base url for server-side
-if (process.env.NODE_ENV === "development" && isServer()) {
-  baseURL = "http://host.docker.internal:8000"
-} else if (process.env.NODE_ENV === "production" && isServer()) {
-  baseURL = process.env.NEXT_SERVER_API_URL
-}
+let baseURL = isServer()
+  ? process.env.NEXT_SERVER_API_URL
+  : process.env.NEXT_PUBLIC_API_URL
 
 export const client = axios.create({
   baseURL,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@ import { getAuthToken } from "@/lib/auth"
 import { isServer } from "@/lib/utils"
 
 // Determine the base URL based on the execution environment
-let baseURL = isServer()
+const baseURL = isServer()
   ? process.env.NEXT_SERVER_API_URL
   : process.env.NEXT_PUBLIC_API_URL
 


### PR DESCRIPTION
# Changes
- Use the static IP address `1172.17.0.1` from [this stackoverflow thread](https://stackoverflow.com/a/48547074) and set this as `DOCKER_HOST_IP`
- Replace all instances of `host.docker.internal` with this
- Updated .env.example
- Updated FE api.ts

# Testing
This was tested on an ubuntu github codespcaes machine
```
(tracecat) @daryllimyt ➜ /workspaces/tracecat (fix/docker-host-internal) $ cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.6 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

which has the following /etc/hosts:

```
(tracecat) @daryllimyt ➜ /workspaces/tracecat (fix/docker-host-internal) $ cat /etc/hosts
127.0.0.1       localhost
::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
127.0.0.1       codespaces-2d4037
```

Ran `docker compose up caddy frontend postgres_db api` (no temporal worker) and forward ports 8000, 3000.
Able to access frontend and create the default tracecat user. 
Able to create a workflow and add nodes.
