### PR TITLE
ci: Add ui to ghcr and entrypoint to cli

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ TRACECAT__API_URL=http://api:8000
 TRACECAT__PUBLIC_RUNNER_URL=http://localhost:8000
 
 # --- CLI env vars ---
-TRACECAT__EXTERNAL_API_URL=http://localhost:8000
+TRACECAT__PUBLIC_API_URL=http://localhost:8000
 
 # --- Postgres ---
 TRACECAT__POSTGRES_USER=postgres

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ TRACECAT__API_URL=http://api:8000
 # to start ngrok and update this with the forwarding URL
 TRACECAT__PUBLIC_RUNNER_URL=http://localhost:8000
 
+# --- CLI env vars ---
+TRACECAT__EXTERNAL_API_URL=http://localhost:8000
+
 # --- Postgres ---
 TRACECAT__POSTGRES_USER=postgres
 TRACECAT__POSTGRES_PASSWORD=postgres

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -38,6 +44,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tracecathq/tracecat:latest' || '' }}
@@ -48,6 +55,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -68,6 +81,7 @@ jobs:
           context: frontend
           file: Dockerfile.prod
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tracecathq/tracecat-ui:latest' || '' }}

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -14,7 +14,7 @@ permissions:
   packages: write
 
 jobs:
-  push-to-ghcr:
+  push-api-to-ghcr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -41,4 +41,34 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tracecathq/tracecat:latest' || '' }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  push-ui-to-ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tracecathq/tracecat-ui
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend
+          file: Dockerfile.prod
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tracecathq/tracecat-ui:latest' || '' }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,4 +114,4 @@ jobs:
       - name: Run tests (headless mode)
         env:
           TRACECAT__IMAGE_TAG: ${{ env.TRACECAT__IMAGE_TAG }}
-        run: pytest tests/unit --temporal-no-restart --tracecat-no-restart
+        run: pytest tests/unit --temporal-no-restart --tracecat-no-restart --capture=all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,13 +95,15 @@ jobs:
         run: |
           docker compose -f docker-compose.yml up --no-deps api worker postgres_db -d
 
-      - name: Verify Tracecat CLI installation
-        run: |
-          tracecat --help
-          docker run --rm ghcr.io/tracecathq/tracecat:latest --help
-
       - name: Verify Tracecat API is running
         run: curl -s http://localhost:8000/health | jq -e '.status == "ok"'
+
+      - name: Verify Tracecat CLI installation
+        env:
+          TRACECAT__IMAGE_TAG: ${{ env.TRACECAT__IMAGE_TAG }}
+        run: |
+          tracecat --help
+          docker run --rm ghcr.io/tracecathq/tracecat:$TRACECAT__IMAGE_TAG --help
 
       - name: Start Temporal server
         run: nohup temporal server start-dev > temporal.log 2>&1 &

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,9 @@ jobs:
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Download Temporal CLI
         run: |
           # Download the Temporal CLI archive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,15 +91,22 @@ jobs:
             echo "TRACECAT__IMAGE_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           fi
 
+      - name: Start Docker Compose services
+        run: |
+          docker compose -f docker-compose.yml up --no-deps api worker postgres_db -d
+
+      - name: Verify Tracecat CLI installation
+        run: |
+          tracecat --help
+          docker run --rm ghcr.io/tracecathq/tracecat:latest --help
+
+      - name: Verify Tracecat API is running
+        run: curl -s http://localhost:8000/health | jq -e '.status == "ok"'
+
+      - name: Start Temporal server
+        run: nohup temporal server start-dev > temporal.log 2>&1 &
+
       - name: Run tests (headless mode)
         env:
           TRACECAT__IMAGE_TAG: ${{ env.TRACECAT__IMAGE_TAG }}
-        run: |
-          # Start Tracecat services (without frontend)
-          docker compose -f docker-compose.yml up --no-deps api worker postgres_db -d
-
-          # Start Temporal lite server in detached mode
-          nohup temporal server start-dev > temporal.log 2>&1 &
-
-          # Run Tracecat tests
-          pytest tests/unit --temporal-no-restart --tracecat-no-restart
+        run: pytest tests/unit --temporal-no-restart --tracecat-no-restart

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,9 +57,6 @@ jobs:
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Download Temporal CLI
         run: |
           # Download the Temporal CLI archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,12 @@ COPY --chown=apiuser:apiuser ./requirements.txt /app/requirements.txt
 COPY --chown=apiuser:apiuser ./README.md /app/README.md
 COPY --chown=apiuser:apiuser ./LICENSE /app/LICENSE
 
-# Install the Python dependencies
-RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+# Install package
+RUN pip install --upgrade pip && pip install ".[cli]"
+ENV PATH="/home/apiuser/.local/bin:$PATH"
+
+# Entrypoint for CLI
+ENTRYPOINT [ "tracecat" ]
 
 # Command to run the application
 CMD ["sh", "-c", "python3 -m uvicorn $API_MODULE --host $HOST --port $PORT --reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,14 @@ COPY --chown=apiuser:apiuser ./README.md /app/README.md
 COPY --chown=apiuser:apiuser ./LICENSE /app/LICENSE
 
 # Install package
-RUN pip install --upgrade pip && pip install ".[cli]"
+# Split into multiple layers to cache dependencies
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+RUN pip install --no-deps ".[cli]"
 ENV PATH="/home/apiuser/.local/bin:$PATH"
 
 # Entrypoint for CLI
-ENTRYPOINT [ "tracecat" ]
+ENTRYPOINT [ "python", "-c", "import requests; requests.get('http://localhost:8000')" ]
 
 # Command to run the application
 CMD ["sh", "-c", "python3 -m uvicorn $API_MODULE --host $HOST --port $PORT --reload"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,6 +8,7 @@ DOCKER_RUN_CMD = [
     "docker",
     "run",
     "--rm",  # Automatically remove the container when it exits
+    "--network=host",  # Use the host's network stack to call localhost
     f"ghcr.io/tracecathq/tracecat:{IMAGE_TAG}",
 ]
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,167 @@
+"""Test CLI commands."""
+
+import os
+import subprocess
+
+IMAGE_TAG = os.environ["TRACECAT__IMAGE_TAG"]
+DOCKER_RUN_CMD = [
+    "docker",
+    "run",
+    "--rm",  # Automatically remove the container when it exits
+    f"ghcr.io/tracecathq/tracecat/{IMAGE_TAG}",
+]
+
+
+def test_create_secret():
+    secret_name = "test_secret"
+    keyvalues = ["KEY1=VAL1", "KEY2=VAL2"]
+    cmd = [
+        *DOCKER_RUN_CMD,
+        "secret",
+        "create",
+        secret_name,
+        *keyvalues,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Secret created successfully!" in result.stdout
+
+
+def test_delete_secret():
+    secret_name = "test_secret_to_delete"
+    keyvalues = ["KEY1=VAL1", "KEY2=VAL2"]
+
+    # Create the secret first
+    create_cmd = [
+        *DOCKER_RUN_CMD,
+        "secret",
+        "create",
+        secret_name,
+        *keyvalues,
+    ]
+    create_result = subprocess.run(create_cmd, capture_output=True, text=True)
+    assert create_result.returncode == 0
+    assert "Secret created successfully!" in create_result.stdout
+
+    # Now delete the secret
+    delete_cmd = [
+        *DOCKER_RUN_CMD,
+        "secret",
+        "delete",
+        secret_name,
+    ]
+    delete_result = subprocess.run(delete_cmd, capture_output=True, text=True)
+    assert delete_result.returncode == 0
+    assert "Secret deleted successfully!" in delete_result.stdout
+
+
+def test_list_secrets():
+    secret_name1 = "test_secret1"
+    secret_name2 = "test_secret2"
+    keyvalues1 = ["KEY1=VAL1"]
+    keyvalues2 = ["KEY2=VAL2"]
+
+    # Create the first secret
+    create_cmd1 = [
+        *DOCKER_RUN_CMD,
+        "secret",
+        "create",
+        secret_name1,
+        *keyvalues1,
+    ]
+    create_result1 = subprocess.run(create_cmd1, capture_output=True, text=True)
+    assert create_result1.returncode == 0
+    assert "Secret created successfully!" in create_result1.stdout
+
+    # Create the second secret
+    create_cmd2 = [
+        *DOCKER_RUN_CMD,
+        "secret",
+        "create",
+        secret_name2,
+        *keyvalues2,
+    ]
+    create_result2 = subprocess.run(create_cmd2, capture_output=True, text=True)
+    assert create_result2.returncode == 0
+    assert "Secret created successfully!" in create_result2.stdout
+
+    # Now list the secrets
+    list_cmd = [
+        *DOCKER_RUN_CMD,
+        "secret",
+        "list",
+    ]
+    list_result = subprocess.run(list_cmd, capture_output=True, text=True)
+    assert list_result.returncode == 0
+    assert (
+        "Secrets" in list_result.stdout
+    )  # Check if the table title "Secrets" is in the output
+    assert secret_name1 in list_result.stdout  # Check if the created secrets are listed
+    assert secret_name2 in list_result.stdout
+
+
+def test_create_workflow():
+    title = "Test Workflow"
+    description = "This is a test workflow"
+    cmd = [
+        *DOCKER_RUN_CMD,
+        "workflow",
+        "create",
+        "--title",
+        title,
+        "--description",
+        description,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Created workflow" in result.stdout
+
+
+def test_list_workflows():
+    # Create first workflow
+    title1 = "Test Workflow 1"
+    description1 = "This is the first test workflow"
+    create_cmd1 = [
+        *DOCKER_RUN_CMD,
+        "workflow",
+        "create",
+        "--title",
+        title1,
+        "--description",
+        description1,
+    ]
+    create_result1 = subprocess.run(create_cmd1, capture_output=True, text=True)
+    assert create_result1.returncode == 0
+    assert "Created workflow" in create_result1.stdout
+
+    # Create second workflow
+    title2 = "Test Workflow 2"
+    description2 = "This is the second test workflow"
+    create_cmd2 = [
+        *DOCKER_RUN_CMD,
+        "workflow",
+        "create",
+        "--title",
+        title2,
+        "--description",
+        description2,
+    ]
+    create_result2 = subprocess.run(create_cmd2, capture_output=True, text=True)
+    assert create_result2.returncode == 0
+    assert "Created workflow" in create_result2.stdout
+
+    # List workflows
+    list_cmd = [
+        *DOCKER_RUN_CMD,
+        "workflow",
+        "list",
+    ]
+    list_result = subprocess.run(list_cmd, capture_output=True, text=True)
+    assert list_result.returncode == 0
+    assert (
+        "Workfows" in list_result.stdout
+    )  # Assuming the dynamic_table has a title "Workfows"
+    assert title1 in list_result.stdout  # Check if the first created workflow is listed
+    assert (
+        title2 in list_result.stdout
+    )  # Check if the second created workflow is listed

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,7 +8,7 @@ DOCKER_RUN_CMD = [
     "docker",
     "run",
     "--rm",  # Automatically remove the container when it exits
-    f"ghcr.io/tracecathq/tracecat/{IMAGE_TAG}",
+    f"ghcr.io/tracecathq/tracecat:{IMAGE_TAG}",
 ]
 
 

--- a/tracecat/cli/_config.py
+++ b/tracecat/cli/_config.py
@@ -19,7 +19,7 @@ class Config:
     docs_path: Path = field(default_factory=lambda: Path("docs"))
     docs_api_group: str = field(default="API Documentation")
     docs_api_pages_group: str = field(default="Reference")
-    api_url: str = field(default=config.TRACECAT__API_URL)
+    api_url: str = field(default=config.TRACECAT__EXTERNAL_API_URL)
 
 
 config = Config()

--- a/tracecat/cli/_config.py
+++ b/tracecat/cli/_config.py
@@ -1,9 +1,9 @@
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
 
-from tracecat import config
 from tracecat.auth.credentials import Role
 
 load_dotenv(find_dotenv())
@@ -19,7 +19,9 @@ class Config:
     docs_path: Path = field(default_factory=lambda: Path("docs"))
     docs_api_group: str = field(default="API Documentation")
     docs_api_pages_group: str = field(default="Reference")
-    api_url: str = field(default=config.TRACECAT__EXTERNAL_API_URL)
+    api_url: str = field(
+        default=os.getenv("TRACECAT__PUBLIC_API_URL", "http://localhost:8000")
+    )
 
 
 config = Config()


### PR DESCRIPTION
## What changed
- [x] Added entrypoint to Tracecat API image which allows you to run the CLI via `docker run` (see screenshots)
- [x] Added CLI (via `docker run`) tests
- [x] Separate Tracecat API url env var for CLI (`TRACECAT__PUBLIC_API_URL=localhost:8000`) vs internal services (docker `TRACECAT__API_URL=http://api`)
- [x] Added job in GH actions to push tracecat-ui image to ghcr

## Note
The Tracecat API image is big (~1.2gb). Don't use it just for the CLI. You need the server to use the CLI anyway.

## Screens
<img width="678" alt="Screenshot 2024-06-21 at 10 41 43 AM" src="https://github.com/TracecatHQ/tracecat/assets/46541035/e38b95c9-84ef-4237-9926-aa48a8a234ee">

