### PR TITLE
feat(engine): Implement runtime action tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "cryptography==42.0.7",
     "diskcache==5.6.3",
     "fastapi==0.111.0",
+    "fsspec==2024.6.0",
     "httpx==0.27.0",
     "jsonpath_ng==1.6.1",
     "lancedb==0.6.3",

--- a/tests/data/workflows/unit_runtime_test_adder_tree.yml
+++ b/tests/data/workflows/unit_runtime_test_adder_tree.yml
@@ -35,6 +35,8 @@ tests:
     success: 999
 
   - ref: c
-    enable: false
     validate_args: true
     success: 1000
+
+config:
+  enable_runtime_tests: true

--- a/tests/data/workflows/unit_runtime_test_adder_tree.yml
+++ b/tests/data/workflows/unit_runtime_test_adder_tree.yml
@@ -31,11 +31,9 @@ actions:
 
 tests:
   - ref: b
-    validate_args: true
     success: 999
 
   - ref: c
-    validate_args: true
     success: 1000
 
 config:

--- a/tests/data/workflows/unit_runtime_test_adder_tree.yml
+++ b/tests/data/workflows/unit_runtime_test_adder_tree.yml
@@ -1,0 +1,40 @@
+title: Adder tree Workflow with runtime tests
+#    A
+#    /\
+#   B  c
+description: |
+  Tests correctness, templates + type casting, context passing, tests.
+  B gets overridden by a test, but C's override is disabled.
+entrypoint: a
+actions:
+  - ref: a
+    action: core.transform.forward
+    args:
+      value: "1"
+
+  - ref: b
+    action: example.add
+    depends_on:
+      - a
+    args:
+      # Demonstrate casting
+      lhs: ${{ ACTIONS.a.result -> int }}
+      rhs: 1
+
+  - ref: c
+    action: example.add
+    depends_on:
+      - a
+    args:
+      lhs: 3
+      rhs: ${{ ACTIONS.a.result -> int }}
+
+tests:
+  - ref: b
+    validate_args: true
+    success: 999
+
+  - ref: c
+    enable: false
+    validate_args: true
+    success: 1000

--- a/tests/data/workflows/unit_runtime_test_adder_tree_expected.yml
+++ b/tests/data/workflows/unit_runtime_test_adder_tree_expected.yml
@@ -1,0 +1,13 @@
+ACTIONS:
+  a:
+    result: "1"
+    result_typename: "str"
+  b:
+    result: 999
+    result_typename: "int"
+  c:
+    result: 4
+    result_typename: "int"
+INPUTS:
+
+TRIGGER:

--- a/tests/data/workflows/unit_runtime_test_adder_tree_expected.yml
+++ b/tests/data/workflows/unit_runtime_test_adder_tree_expected.yml
@@ -6,7 +6,7 @@ ACTIONS:
     result: 999
     result_typename: "int"
   c:
-    result: 4
+    result: 1000
     result_typename: "int"
 INPUTS:
 

--- a/tests/data/workflows/unit_runtime_test_chain.yml
+++ b/tests/data/workflows/unit_runtime_test_chain.yml
@@ -42,4 +42,7 @@ tests:
 
   - ref: c
     # NOTE: REturn type consistency not enforced
-    success: tests/data/workflows/unit_runtime_test_chain_data.json
+    success: file://tests/data/workflows/unit_runtime_test_chain_data.json
+
+config:
+  enable_runtime_tests: true

--- a/tests/data/workflows/unit_runtime_test_chain.yml
+++ b/tests/data/workflows/unit_runtime_test_chain.yml
@@ -1,0 +1,45 @@
+title: Forward chain with runtime tests
+#    A -> B -> C
+description: |
+  Tests correctness, templates + type casting, context passing, tests.
+  A and C get overridden by tests
+entrypoint: a
+actions:
+  - ref: a
+    action: core.transform.forward
+    args:
+      value:
+        one: 1
+        two: 2
+        three: 3
+
+  - ref: b
+    action: core.transform.forward
+    depends_on:
+      - a
+    args:
+      value:
+        one: ${{ ACTIONS.a.result.one -> int }}
+        two: ${{ ACTIONS.a.result.two -> int }}
+        three: ${{ ACTIONS.a.result.three -> int }}
+
+  - ref: c
+    action: core.transform.forward
+    depends_on:
+      - b
+    args:
+      value:
+        one: ${{ ACTIONS.b.result.one }}
+        two: ${{ ACTIONS.b.result.two }}
+        three: ${{ ACTIONS.b.result.three }}
+
+tests:
+  - ref: a
+    success:
+      one: 111
+      two: 222
+      three: 333
+
+  - ref: c
+    # NOTE: REturn type consistency not enforced
+    success: tests/data/workflows/unit_runtime_test_chain_data.json

--- a/tests/data/workflows/unit_runtime_test_chain_data.json
+++ b/tests/data/workflows/unit_runtime_test_chain_data.json
@@ -1,0 +1,4 @@
+{
+    "hello": "world",
+    "foo": "bar"
+}

--- a/tests/data/workflows/unit_runtime_test_chain_expected.yml
+++ b/tests/data/workflows/unit_runtime_test_chain_expected.yml
@@ -1,0 +1,21 @@
+ACTIONS:
+  a:
+    result:
+      one: 111
+      two: 222
+      three: 333
+    result_typename: dict
+  b:
+    result:
+      one: 111
+      two: 222
+      three: 333
+    result_typename: dict
+  c:
+    result:
+      hello: world
+      foo: bar
+    result_typename: dict
+INPUTS:
+
+TRIGGER:

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -235,6 +235,8 @@ correctness_test_cases = [
     "unit_transform_forwarder_arrange_loop",
     "unit_transform_forwarder_zip",
     "unit_transform_forwarder_map_loop",
+    "unit_runtime_test_adder_tree",
+    "unit_runtime_test_chain",
 ]
 
 

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -85,6 +85,10 @@ class ActionStatement(BaseModel):
 
 class DSLConfig(BaseModel):
     scheduler: Literal["static", "dynamic"] = "dynamic"
+    enable_runtime_tests: bool = Field(
+        default=False,
+        description="Enable runtime action tests. This is dynamically set on workflow entry.",
+    )
 
 
 class Trigger(BaseModel):
@@ -95,8 +99,8 @@ class Trigger(BaseModel):
 
 class ActionTest(BaseModel):
     ref: str = Field(..., pattern=SLUG_PATTERN, description="Action reference")
-    enable: bool = Field(default=True, description="Enable or disable the test")
-    validate_args: bool = Field(default=True, description="Validate action arguments")
+    enable: bool = True
+    validate_args: bool = True
     success: Any = Field(
         ...,
         description=(

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -127,7 +127,7 @@ def resolve_string_or_uri(string_or_uri: str) -> Any:
 
     except (FileNotFoundError, ValueError) as e:
         if "protocol not known" in str(e).lower():
-            raise DSLError(
+            raise TracecatDSLError(
                 f"Failed to read fsspec file, protocol not known: {string_or_uri}"
             ) from e
         logger.info(

--- a/tracecat/dsl/graph.py
+++ b/tracecat/dsl/graph.py
@@ -10,7 +10,6 @@ from pydantic import (
     Field,
     TypeAdapter,
     model_validator,
-    root_validator,
 )
 from pydantic.alias_generators import to_camel
 
@@ -117,7 +116,7 @@ class RFEdge(TSObject):
 
     label: str | None = Field(default=None, description="Edge label")
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
     def generate_id(cls, values):
         """Generate the ID as a concatenation of source and target with a prefix."""
         source = values.get("source")

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -229,7 +229,13 @@ class DSLWorkflow:
                 self._mark_task(task.ref, TaskMarker.SKIP)
                 return
 
-            self.logger.info("Executing task")
+            # Check for an action test
+            act_test = (
+                self.action_test_map.get(task.ref)
+                if self.dsl.config.enable_runtime_tests
+                else None
+            )
+            self.logger.info("Executing task", act_test=act_test)
             # TODO: Set a retry policy for the activity
             activity_result = await workflow.execute_activity(
                 _udf_key_to_activity_name(task.action),
@@ -238,7 +244,7 @@ class DSLWorkflow:
                     role=self.role,
                     run_context=self.run_ctx,
                     exec_context=self.context,
-                    action_test=self.action_test_map.get(task.ref),
+                    action_test=act_test,
                 ),
                 start_to_close_timeout=timedelta(minutes=1),
             )

--- a/tracecat/types/headers.py
+++ b/tracecat/types/headers.py
@@ -1,0 +1,5 @@
+from enum import StrEnum
+
+
+class CustomHeaders(StrEnum):
+    ENABLE_RUNTIME_TESTS = "X-Tracecat-Enable-Runtime-Tests"


### PR DESCRIPTION
# API
```yaml
# tracecat workflow run <wf_id> --test
tests:
  # If an action has a test, do not run the action and mock/patch the output
  - ref: pull_crowdstrike_alerts
    enable: true # default: true
    validate_args: true # default: true
    # Path (use fsspec to support both local files and http)
    # to sample JSON or YAML content (to be JSONfied)
    success: # This is the mocked/patched output for the action.
    failure: # TODO

config:
    # Statically configure this here, or omit this and pass it in at execution time
    enable_runtime_tests: true
```
# Features
- Adds new top-level workflow directive `tests`
- Define a list of `tests` that mock the output value of actions at runtime
- By default, all tests defined are enabled. You can control whether they're enabled or disabled at runtime.
- You can override any action with any data structure
- You can load mock data using `fsspec` compliant uris/paths
- Add custom headers module
- Pass `--test` (CLI) or X-Tracecat-Enable-Runtime-Tests: true` (http) to enable runtime action tests
- At execution time, for incoming webhooks we check for `X-Tracecat-Enable-Runtime-Tests` header and set `DSLConfig` in the workflow input. Otherwise, this config can be statically configured in the `config` directive.

# Testing
- Added new tests
- All unit tests passing