### PR TITLE
feat(playbook): Sentinel One distributed alerting in Slack

### DIFF
--- a/playbooks/alert_management/sentinel-one-to-slack.yml
+++ b/playbooks/alert_management/sentinel-one-to-slack.yml
@@ -1,0 +1,104 @@
+title: Send Slack notifications for SentinelOne alerts
+description: |
+  Pulls SentinelOne alerts and sends them to Slack.
+  Also sends a message if no alerts available.
+entrypoint: pull_sentinelone_alerts
+triggers:
+  - type: webhook
+    ref: sentinelone_alerts_webhook
+    entrypoint: pull_sentinelone_alerts
+
+actions:
+  - ref: pull_sentinelone_alerts
+    action: integrations.sentinelone.list_sentinelone_alerts
+    args:
+      start_time: ${{ TRIGGER.start_time }}
+      end_time: ${{ TRIGGER.end_time }}
+      limit: 10
+
+  - ref: report_no_alerts
+    action: core.http_request
+    depends_on:
+      - pull_sentinelone_alerts
+    run_if: ${{ FN.is_empty(ACTIONS.pull_sentinelone_alerts.result) }}
+    args:
+      url: ${{ SECRETS.slack_channel.SLACK_WEBHOOK }}
+      method: POST
+      headers:
+        Content-Type: application/json
+      payload:
+        text: Tracecat ran workflow for SentinelOne alerts, but no alerts were found
+
+  - ref: reshape_alerts_into_smac
+    action: core.transform.forward
+    depends_on:
+      - pull_sentinelone_alerts
+    run_if: ${{ FN.not_empty(ACTIONS.pull_sentinelone_alerts.result) }}
+    for_each: ${{ for var.alert in ACTIONS.pull_sentinelone_alerts.result }}
+    args:
+      value:
+        title: ${{ var.alert.info.event_type }}
+        description: ${{ var.alert.info.hit.type }}
+        payload:
+          rule: ${{ var.alert.rule.scope_level }}
+          severity: ${{ var.alert.rule.severity }}
+        status: ${{ var.alert.info.status }}
+        malice: ${{ 'malicious' if FN.greater_than(var.alert.rule.severity, 0) else 'benign' }}
+        action: Investigate and remediate
+        context:
+          account_id: ${{ var.alert.agent.site_id }}
+          updated_at: ${{ var.alert.info.updated_at }}
+          created_at: ${{ var.alert.info.reported_at }}
+
+  - ref: send_slack_notifications
+    action: integrations.chat.slack.post_slack_message
+    depends_on:
+      - reshape_alerts_into_smac
+    for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
+    args:
+      channel: ${{ SECRETS.slack_channel.SLACK_CHANNEL }}
+      text: SentinelOne alerts
+      blocks:
+        - type: header
+          text:
+            type: plain_text
+            text: ${{ var.smac.title }}
+            emoji: true
+        - type: section
+          text:
+            type: mrkdwn
+            text: ${{ var.smac.description }}
+        - type: section
+          fields:
+            - type: mrkdwn
+              text: "*Status:* ${{ var.smac.status }}"
+            - type: mrkdwn
+              text: "*Malice:* ${{ var.smac.malice }}"
+            - type: mrkdwn
+              text: "*Action:* ${{ var.smac.action }}"
+            - type: mrkdwn
+              text: "*Context:* ${{ var.smac.context }}"
+        - type: section
+          text:
+            type: mrkdwn
+            text: "Select an option to update the alert:"
+          accessory:
+            type: static_select
+            action_id: update_sentinelone_alert
+            options:
+              - text:
+                  type: plain_text
+                  text: "False Positive"
+                value: "FALSE_POSITIVE"
+              - text:
+                  type: plain_text
+                  text: "Suspicious"
+                value: "SUSPICIOUS"
+              - text:
+                  type: plain_text
+                  text: "True Positive"
+                value: "TRUE_POSITIVE"
+              - text:
+                  type: plain_text
+                  text: "Undefined"
+                value: "UNDEFINED"

--- a/playbooks/alert_management/slack-to-sentinel-one-update.yml
+++ b/playbooks/alert_management/slack-to-sentinel-one-update.yml
@@ -1,0 +1,53 @@
+title: Update SentinelOne alerts via Slack
+description: |
+  Receives a Slack action and updates SentinelOne alerts based on
+  `alert_ids` and `status` provided in the Slack action payload.
+entrypoint: extract_slack_payload
+triggers:
+  - type: webhook
+    ref: slack_actions_webhook
+    entrypoint: receive_slack_action
+
+actions:
+  - ref: extract_slack_payload
+    action: core.transform.forward
+    # Check if action received is as expected
+    run_if: ${{ FN.equal(TRIGGER.action.action_id, 'update_sentinelone_alert') }}
+    args:
+      value:
+        username: ${{ TRIGGER.user.username }}
+        alert_id: ${{ TRIGGER.action.value.alert_id }}
+        old_status: ${{ TRIGGER.action.value.old_status }}
+        new_status: ${{ TRIGGER.action.value.new_status }}
+
+  - ref: update_sentinelone_alerts
+    action: integrations.sentinelone.update_sentinelone_alert_status
+    depends_on:
+      - extract_slack_payload
+    args:
+      alert_ids:
+        - ${{ ACTIONS.extract_slack_payload.result.alert_id }}
+      status: ${{ ACTIONS.extract_slack_payload.result.new_status }}
+
+  # Send Slack notification after updating SentinelOne alerts
+  - ref: send_slack_notification
+    action: integrations.chat.slack.post_slack_message
+    depends_on:
+      - update_sentinelone_alerts
+    args:
+      channel: ${{ SECRETS.slack_channel.SLACK_CHANNEL }}
+      text: SentinelOne alerts updated
+      blocks:
+        - type: header
+          text:
+            type: plain_text
+            text: ${{ ACTIONS.extract_slack_payload.result.username }} changed status of alert
+            emoji: true
+        - type: section
+          fields:
+            - type: mrkdwn
+              text: "*Alert ID:* ${{ ACTIONS.extract_slack_payload.result.alert_id }}"
+            - type: mrkdwn
+              text: "*Old status:* ${{ ACTIONS.extract_slack_payload.result.old_status }}"
+            - type: mrkdwn
+              text: "*New status:* ${{ ACTIONS.extract_slack_payload.result.new_status }}"


### PR DESCRIPTION
## What changed
- Added playbook: S1 to Slack with drop down to update status
- Added playbook: Receive Slack action and update alert status in S1

## QA
- Validated both playbooks via the cli