### PR TITLE
feat(playbook): Crowdstrike distributed alerting in Slack

### DIFF
--- a/playbooks/alert_management/crowdstrike-to-cases.yml
+++ b/playbooks/alert_management/crowdstrike-to-cases.yml
@@ -67,6 +67,26 @@ actions:
               text: "*Action:* ${{ var.smac.action }}"
             - type: mrkdwn
               text: "*Context:* ${{ var.smac.context }}"
+        - type: section
+          text:
+            type: mrkdwn
+            text: "Select an option to update the alert:"
+          accessory:
+            type: static_select
+            action_id: update_crowdstrike_alert
+            options:
+              - text:
+                  type: plain_text
+                  text: "Ignore"
+                value: "ignored"
+              - text:
+                  type: plain_text
+                  text: "True Positive"
+                value: "true_positive"
+              - text:
+                  type: plain_text
+                  text: "False Positive"
+                value: "false_positive"
 
   - ref: open_cases
     action: core.open_case

--- a/playbooks/alert_management/crowdstrike-to-cases.yml
+++ b/playbooks/alert_management/crowdstrike-to-cases.yml
@@ -42,7 +42,8 @@ actions:
 
   - ref: send_slack_notification
     action: integrations.chat.slack.post_slack_message
-    depends_on: reshape_alerts_into_smac
+    depends_on:
+      - reshape_alerts_into_smac
     for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
     args:
       channel: ${{ SECRETS.slack.SLACK_CHANNEL }}

--- a/playbooks/alert_management/slack-to-crowdstrike-update.yml
+++ b/playbooks/alert_management/slack-to-crowdstrike-update.yml
@@ -1,0 +1,51 @@
+title: Update Crowdstrike alerts via Slack
+description: |
+  Receives a Slack action and updates Crowdstrike alerts based on
+  `alert_ids` and `status` provided in the Slack action payload.
+entrypoint:
+triggers:
+  - type: webhook
+    ref: slack_actions_webhook
+    entrypoint: receive_slack_action
+
+actions:
+  - ref: extract_slack_payload
+    action: core.transform.forward
+    # Check if action received is as expected
+    run_if: ${{ FN.equal(TRIGGER.action.action_id, 'update_crowdstrike_alert') }}
+    args:
+      username: ${{ TRIGGER.user.username }}
+      alert_id: ${{ TRIGGER.action.value.alert_id }}
+      old_status: ${{ TRIGGER.action.value.old_status }}
+      new_status: ${{ TRIGGER.action.value.new_status }}
+
+  - ref: update_crowdstrike_alerts
+    action: integrations.crowdstrike.update_crowdstrike_alerts
+    depends_on:
+      - extract_slack_payload
+    args:
+      alert_id: ${{ ACTIONS.extract_slack_payload.result.alert_id }}
+      status: ${{ ACTIONS.extract_slack_payload.result.new_status }}
+
+  # Send slack notifiaction after updating Crowdstrike alerts
+  - ref: send_slack_notification
+    action: integrations.chat.slack.post_slack_message
+    depends_on:
+      - update_crowdstrike_alerts
+    args:
+      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+      text: CrowdStrike alerts updated
+      blocks:
+        - type: header
+          text:
+            type: plain_text
+            text: ${{ ACTIONS.extract_slack_payload.result.username }} changed status of alert
+            emoji: true
+        - type: section
+          fields:
+            - type: mrkdwn
+              text: "*Alert ID:* ${{ ACTIONS.extract_slack_payload.result.alert_id }}"
+            - type: mrkdwn
+              text: "*Old status:* ${{ ACTIONS.extract_slack_payload.result.old_status }}"
+            - type: mrkdwn
+              text: "*New status:* ${{ ACTIONS.extract_slack_payload.result.new_status }}"

--- a/playbooks/alert_management/slack-to-crowdstrike-update.yml
+++ b/playbooks/alert_management/slack-to-crowdstrike-update.yml
@@ -2,7 +2,7 @@ title: Update Crowdstrike alerts via Slack
 description: |
   Receives a Slack action and updates Crowdstrike alerts based on
   `alert_ids` and `status` provided in the Slack action payload.
-entrypoint:
+entrypoint: extract_slack_payload
 triggers:
   - type: webhook
     ref: slack_actions_webhook
@@ -14,17 +14,19 @@ actions:
     # Check if action received is as expected
     run_if: ${{ FN.equal(TRIGGER.action.action_id, 'update_crowdstrike_alert') }}
     args:
-      username: ${{ TRIGGER.user.username }}
-      alert_id: ${{ TRIGGER.action.value.alert_id }}
-      old_status: ${{ TRIGGER.action.value.old_status }}
-      new_status: ${{ TRIGGER.action.value.new_status }}
+      value:
+        username: ${{ TRIGGER.user.username }}
+        alert_id: ${{ TRIGGER.action.value.alert_id }}
+        old_status: ${{ TRIGGER.action.value.old_status }}
+        new_status: ${{ TRIGGER.action.value.new_status }}
 
   - ref: update_crowdstrike_alerts
-    action: integrations.crowdstrike.update_crowdstrike_alerts
+    action: integrations.crowdstrike.update_crowdstrike_alert_status
     depends_on:
       - extract_slack_payload
     args:
-      alert_id: ${{ ACTIONS.extract_slack_payload.result.alert_id }}
+      alert_ids:
+        - ${{ ACTIONS.extract_slack_payload.result.alert_id }}
       status: ${{ ACTIONS.extract_slack_payload.result.new_status }}
 
   # Send slack notifiaction after updating Crowdstrike alerts

--- a/tracecat/actions/integrations/edr/__init__.py
+++ b/tracecat/actions/integrations/edr/__init__.py
@@ -1,4 +1,9 @@
-from .crowdstrike import list_crowdstrike_alerts, list_crowdstrike_detects
+from .crowdstrike import (
+    list_crowdstrike_alerts,
+    list_crowdstrike_detects,
+    update_crowdstrike_alert_status,
+    update_crowdstrike_detect_status,
+)
 from .microsoft_defender import list_defender_endpoint_alerts
 from .sentinel_one import list_sentinelone_alerts
 
@@ -7,4 +12,6 @@ __all__ = [
     "list_crowdstrike_detects",
     "list_sentinelone_alerts",
     "list_defender_endpoint_alerts",
+    "update_crowdstrike_alert_status",
+    "update_crowdstrike_detect_status",
 ]


### PR DESCRIPTION
## What changed
- Added playbook: CS to Slack with drop down to update status
- Added playbook: Receive Slack action and update alert status in CS

## QA
- Validated both playbooks via the cli