### PR TITLE
ci: Configure logger verbosity

### DIFF
--- a/.github/workflows/playbooks.yml
+++ b/.github/workflows/playbooks.yml
@@ -85,4 +85,5 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.INTEGRATION__SLACK_CHANNEL }}
           URLSCAN_API_KEY: ${{ secrets.INTEGRATION__URLSCAN_API_KEY }}
           VT_API_KEY: ${{ secrets.INTEGRATION__VT_API_KEY }}
-        run: pytest -k "test_playbooks" --temporal-no-restart --tracecat-no-restart --capture=no
+          LOG_LEVEL: WARNING
+        run: pytest -k "test_playbooks" --temporal-no-restart --tracecat-no-restart

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -111,4 +111,5 @@ jobs:
       - name: Run tests (headless mode)
         env:
           TRACECAT__IMAGE_TAG: ${{ env.TRACECAT__IMAGE_TAG }}
-        run: pytest tests/unit --temporal-no-restart --tracecat-no-restart --capture=no --log-cli-level=WARNING
+          LOG_LEVEL: WARNING
+        run: pytest tests/unit --temporal-no-restart --tracecat-no-restart

--- a/tracecat/logging/_logger.py
+++ b/tracecat/logging/_logger.py
@@ -1,5 +1,6 @@
 """Loggers to override default FastAPI uvicorn logger behavior."""
 
+import os
 import sys
 
 from loguru import logger as base_logger
@@ -12,7 +13,7 @@ except ValueError:
 base_logger.add(
     sink=sys.stderr,
     colorize=True,
-    level="INFO",
+    level=os.environ.get("LOG_LEVEL", "INFO"),
     format="{time} | <level>{level: <8}</level> <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level> | {extra}",
 )
 


### PR DESCRIPTION
# Changes
- Tracecat logger reads from `LOG_LEVEL` env var
- Update CI pytests