### PR TITLE
test: Fix flaky `workflow_id` parse in playbooks test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: "pip"
@@ -122,14 +122,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Run environment setup script
         run: bash env.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,14 @@ on:
     branches: ["main"]
     paths-ignore:
       - "frontend/**"
+      - "docs/**"
+      - "README.md"
   pull_request:
     branches: ["main"]
     paths-ignore:
       - "frontend/**"
+      - "docs/**"
+      - "README.md"
 
 permissions:
   contents: read

--- a/playbooks/alert_management/aws-guardduty-to-cases.yml
+++ b/playbooks/alert_management/aws-guardduty-to-cases.yml
@@ -3,10 +3,6 @@ description: |
   Pulls GuardDuty findings from AWS and opens cases.
   Also sends a message if no findings available.
 entrypoint: pull_aws_guardduty_findings
-inputs:
-  start_time: "2023-06-12T00:00:00Z"
-  end_time: "2024-06-15T12:00:00Z"
-
 triggers:
   - type: webhook
     ref: guardduty_findings_webhook
@@ -16,8 +12,8 @@ actions:
   - ref: pull_aws_guardduty_findings
     action: integrations.aws.guardduty.list_guardduty_alerts
     args:
-      start_time: ${{ INPUTS.start_time }}
-      end_time: ${{ INPUTS.end_time }}
+      start_time: ${{ TRIGGER.start_time }}
+      end_time: ${{ TRIGGER.end_time }}
       limit: 10
 
   # Transform the list of GuardDuty findings into a list of SMAC findings

--- a/tests/integration/test_playbooks.py
+++ b/tests/integration/test_playbooks.py
@@ -6,7 +6,7 @@ import pytest
 from dotenv import load_dotenv
 from loguru import logger
 
-from tracecat.cli.workflow import _create_activate_workflow
+from tracecat.cli.workflow import _activate_workflow, _create_workflow
 
 load_dotenv()
 
@@ -93,9 +93,10 @@ async def test_playbook(path_to_playbook, trigger_data):
     filename = os.path.basename(path_to_playbook).replace(".yml", "")
     # 1. Create an commit workflow
     # Output is a JSON where the workflow ID is stored under the key "id"
-    workflow_id = await _create_activate_workflow(
-        title=filename, description=f"Test workflow: {filename}"
-    )
+    description = f"Test playbook: {filename}"
+    workflow = await _create_workflow(filename, description)
+    workflow_id = workflow["id"]
+    await _activate_workflow(workflow_id, with_webhook=True)
     # 2. Run the workflow
     output = subprocess.run(
         [

--- a/tests/integration/test_playbooks.py
+++ b/tests/integration/test_playbooks.py
@@ -1,9 +1,10 @@
 import os
-import re
 import subprocess
 
 import pytest
 from dotenv import load_dotenv
+
+from tracecat.cli.workflow import _create_activate_workflow
 
 load_dotenv()
 
@@ -72,25 +73,9 @@ def test_playbook(path_to_playbook, trigger_data):
     filename = os.path.basename(path_to_playbook).replace(".yml", "")
     # 1. Create an commit workflow
     # Output is a JSON where the workflow ID is stored under the key "id"
-    output = subprocess.run(
-        [
-            "tracecat",
-            "workflow",
-            "create",
-            "--title",
-            filename,
-            "--commit",
-            path_to_playbook,
-        ],
-        shell=True,
-        capture_output=True,
-        text=True,
+    workflow_id = _create_activate_workflow(
+        title=filename, description=f"Test workflow: {filename}"
     )
-    # Use regex to extract the workflow ID
-    # Example output: {"id":"wf-60f4b1b1d4b3b00001f3b3b1"}
-    assert "Successfully created workflow" in output.stdout
-    assert output.returncode == 0
-    workflow_id = re.search(r'{"id":"(wf-[0-9a-f]+)"}', output.stdout).group(1)
     # 2. Activate the workflow
     output = subprocess.run(
         ["tracecat", "workflow", "up", "--webhook", workflow_id],

--- a/tests/integration/test_playbooks.py
+++ b/tests/integration/test_playbooks.py
@@ -58,7 +58,21 @@ def create_secrets():
     "path_to_playbook, trigger_data",
     [
         (
+            "playbooks/alert_management/aws-guardduty-to-cases.yml",
+            {
+                "start_time": "2024-05-01T00:00:00Z",
+                "end_time": "2024-07-01T12:00:00Z",
+            },
+        ),
+        (
             "playbooks/alert_management/aws-guardduty-to-slack.yml",
+            {
+                "start_time": "2024-05-01T00:00:00Z",
+                "end_time": "2024-07-01T12:00:00Z",
+            },
+        ),
+        (
+            "playbooks/alert_management/datadog-extract-email-to-slack.yml",
             {
                 "start_time": "2024-05-01T00:00:00Z",
                 "end_time": "2024-07-01T12:00:00Z",

--- a/tests/integration/test_playbooks.py
+++ b/tests/integration/test_playbooks.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 
@@ -76,17 +77,16 @@ def test_playbook(path_to_playbook, trigger_data):
     workflow_id = _create_activate_workflow(
         title=filename, description=f"Test workflow: {filename}"
     )
-    # 2. Activate the workflow
+    # 2. Run the workflow
     output = subprocess.run(
-        ["tracecat", "workflow", "up", "--webhook", workflow_id],
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
-    assert output.returncode == 0
-    # 3. Run the workflow
-    output = subprocess.run(
-        ["tracecat", "workflow", "run", workflow_id],
+        [
+            "tracecat",
+            "workflow",
+            "run",
+            workflow_id,
+            "--data",
+            json.dumps(trigger_data),
+        ],
         shell=True,
         capture_output=True,
         text=True,

--- a/tracecat/cli/workflow.py
+++ b/tracecat/cli/workflow.py
@@ -123,20 +123,6 @@ async def _get_cases(workflow_id: str):
     return res.json()
 
 
-async def _create_activate_workflow(
-    title: str | None = None,
-    description: str | None = None,
-) -> str:
-    """Create and activate a workflow with a webhook.
-
-    Mainly used for testing.
-    """
-    workflow = await _create_workflow(title, description)
-    workflow_id = workflow["id"]
-    await _activate_workflow(workflow_id, with_webhook=True)
-    return workflow_id
-
-
 @app.command(help="Create a workflow")
 def create(
     title: str = typer.Option(None, "--title", "-t", help="Title of the workflow"),

--- a/tracecat/cli/workflow.py
+++ b/tracecat/cli/workflow.py
@@ -123,6 +123,20 @@ async def _get_cases(workflow_id: str):
     return res.json()
 
 
+async def _create_activate_workflow(
+    title: str | None = None,
+    description: str | None = None,
+) -> str:
+    """Create and activate a workflow with a webhook.
+
+    Mainly used for testing.
+    """
+    workflow = await _create_workflow(title, description)
+    workflow_id = workflow["id"]
+    await _activate_workflow(workflow_id, with_webhook=True)
+    return workflow_id
+
+
 @app.command(help="Create a workflow")
 def create(
     title: str = typer.Option(None, "--title", "-t", help="Title of the workflow"),


### PR DESCRIPTION
## What changed
- Ignore secrets creation fixture errors (to deal with local development case when secrets have already been created and clash)
- Replaced create workflows CLI commands in test with direct calls to the REST API via the private create and activate workflow functions
- That function returns a json with workflow ID under the id field
- Replaced inputs with triggers in AWS guardduty to slack playbook
