### PR TITLE
feat(engine): Implement schedules

### DIFF
--- a/frontend/src/components/workspace/canvas/trigger-node.tsx
+++ b/frontend/src/components/workspace/canvas/trigger-node.tsx
@@ -127,7 +127,7 @@ export default React.memo(function TriggerNode({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="h-8 text-center text-xs">
+                  <TableHead className="h-8 text-center text-xs" colSpan={2}>
                     <div className="flex items-center justify-center gap-1">
                       <CalendarCheck className="size-3" />
                       <span>Schedules</span>
@@ -136,9 +136,31 @@ export default React.memo(function TriggerNode({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {workflow.schedules.map(({ id, cron }) => (
-                  <TableRow key={id}>
-                    <TableCell>{cron}</TableCell>
+                {workflow.schedules.map(({ status, every }, idx) => (
+                  <TableRow
+                    key={idx}
+                    className="items-center text-center text-xs text-muted-foreground"
+                  >
+                    <TableCell>
+                      <div className="flex w-full items-center justify-center">
+                        <span
+                          className={cn(
+                            status !== "online" &&
+                              "bg-muted-foreground/5 text-muted-foreground/50"
+                          )}
+                        >
+                          {every}
+                        </span>
+                        <span
+                          className={cn(
+                            "ml-2 inline-block size-2 rounded-full ",
+                            workflow.webhook.status === "online"
+                              ? "bg-emerald-500"
+                              : "bg-gray-300"
+                          )}
+                        />
+                      </div>
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/frontend/src/components/workspace/panel/trigger-panel.tsx
+++ b/frontend/src/components/workspace/panel/trigger-panel.tsx
@@ -265,30 +265,42 @@ export function ScheduleControls({ schedules }: { schedules: Schedule[] }) {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="h-8 text-center text-xs">
+            <TableHead className="h-8 text-center text-xs" colSpan={4}>
               <div className="flex items-center justify-center gap-1">
                 <WebhookIcon className="size-3" />
                 <span>Schedules</span>
               </div>
             </TableHead>
           </TableRow>
+          <TableRow>
+            <TableHead className="h-8 text-center text-xs">ID</TableHead>
+            <TableHead className="h-8 text-center text-xs">Status</TableHead>
+            <TableHead className="h-8 text-center text-xs">Inputs</TableHead>
+            <TableHead className="h-8 text-center text-xs">Every</TableHead>
+          </TableRow>
         </TableHeader>
         <TableBody>
-          {schedules.map(({ id, cron }) => (
-            <TableRow key={id}>
-              <TableCell>{cron}</TableCell>
+          {schedules.map(({ id, status, inputs, every }) => (
+            <TableRow key={id} className="text-xs text-muted-foreground">
+              <TableCell>{id}</TableCell>
+              <TableCell>{status}</TableCell>
+              <TableCell>{JSON.stringify(inputs)}</TableCell>
+              <TableCell>{every}</TableCell>
             </TableRow>
           ))}
         </TableBody>
-        <TableFooter className="flex w-full justify-center text-muted-foreground">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="flex w-full items-center justify-center gap-2"
-          >
-            <PlusCircleIcon className="size-4" />
-            <span>Add Schedule</span>
-          </Button>
+        <TableFooter>
+          <TableCell colSpan={4}>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex h-4 w-full items-center justify-center gap-2 text-muted-foreground/90"
+              disabled
+            >
+              <PlusCircleIcon className="size-4" />
+              <span>Add Schedule</span>
+            </Button>
+          </TableCell>
         </TableFooter>
       </Table>
     </div>

--- a/frontend/src/types/schemas.ts
+++ b/frontend/src/types/schemas.ts
@@ -39,8 +39,13 @@ export type Webhook = z.infer<typeof webhookSchema>
 export const scheduleSchema = z
   .object({
     status: z.enum(["online", "offline"]),
-    entrypoint_payload: z.record(z.any()),
-    cron: z.string(),
+    inputs: z.record(z.any()),
+    cron: z.string().nullish(),
+    every: z.string(),
+    offset: z.string().nullable(),
+    start_at: strAsDate.nullable(),
+    end_at: strAsDate.nullable(),
+    workflow_id: z.string(),
   })
   .and(resourceSchema)
 export type Schedule = z.infer<typeof scheduleSchema>

--- a/playbooks/alert_management/aws-guardduty-to-slack.yml
+++ b/playbooks/alert_management/aws-guardduty-to-slack.yml
@@ -23,7 +23,7 @@ actions:
       - pull_aws_guardduty_findings
     run_if: ${{ FN.is_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
     args:
-      url: ${{ SECRETS.slack_channel.SLACK_WEBHOOK }}
+      url: ${{ SECRETS.slack.SLACK_WEBHOOK }}
       method: POST
       headers:
         Content-Type: application/json
@@ -61,7 +61,7 @@ actions:
     # Assign each SMAC finding to a variable named `smac`
     for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
     args:
-      channel: ${{ SECRETS.slack_channel.SLACK_CHANNEL }}
+      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
       text: GuardDuty findings
       blocks:
         - type: header

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1191,7 +1191,7 @@ async def create_schedule(
     role: Annotated[Role, Depends(authenticate_user)],
     params: CreateScheduleParams,
 ) -> Schedule:
-    """**[WORK IN PROGRESS]** Create a schedule for a workflow."""
+    """Create a schedule for a workflow."""
 
     with Session(engine) as session, logger.contextualize(role=role):
         result = session.exec(
@@ -1282,7 +1282,7 @@ def update_schedule(
     schedule_id: identifiers.ScheduleID,
     params: UpdateScheduleParams,
 ) -> Schedule:
-    """**[WORK IN PROGRESS]** Get a schedule from a workflow."""
+    """Get a schedule from a workflow."""
     with Session(engine) as session:
         statement = select(Schedule).where(
             Schedule.owner_id == role.user_id, Schedule.id == schedule_id

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1210,9 +1210,7 @@ async def create_schedule(
 
         schedule = Schedule(
             owner_id=role.user_id,
-            cron=params.cron,
-            inputs=params.inputs,
-            workflow_id=params.workflow_id,
+            **params.model_dump(exclude_unset=True),
         )
         session.refresh(defn_data)
         defn = WorkflowDefinition.model_validate(defn_data)

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -17,6 +17,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.params import Body
 from fastapi.responses import ORJSONResponse, StreamingResponse
@@ -210,6 +211,16 @@ async def tracecat_exception_handler(request: Request, exc: TracecatException):
     return ORJSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={"type": type(exc).__name__, "message": msg},
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    """Improves visiblity of 422 errors."""
+    exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
+    logger.error(f"{request}: {exc_str}")
+    return ORJSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content=exc_str
     )
 
 

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import os
+from contextlib import contextmanager
 from functools import partial
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import httpx
 import orjson
@@ -242,3 +243,19 @@ async def authenticate_user_or_service(
     if api_key:
         return await _get_role_from_service_key(request, api_key)
     raise HTTP_EXC("Could not validate credentials")
+
+
+@contextmanager
+def TemporaryRole(
+    type: Literal["user", "service"] = "service",
+    user_id: str | None = None,
+    service_id: str | None = None,
+):
+    """An async context manager to authenticate a user or service."""
+    prev_role = ctx_role.get()
+    temp_role = Role(type=type, user_id=user_id, service_id=service_id)
+    ctx_role.set(temp_role)
+    try:
+        yield temp_role
+    finally:
+        ctx_role.set(prev_role)

--- a/tracecat/cli/_utils.py
+++ b/tracecat/cli/_utils.py
@@ -1,11 +1,25 @@
+from pathlib import Path
+
 import httpx
+import orjson
+import rich
+import typer
 from rich.table import Table
 
 from ._config import config
 
 
 def user_client() -> httpx.AsyncClient:
+    """Returns an asynchronous httpx client with the user's JWT token."""
     return httpx.AsyncClient(
+        headers={"Authorization": f"Bearer {config.jwt_token}"},
+        base_url=config.api_url,
+    )
+
+
+def user_client_sync() -> httpx.Client:
+    """Returns a synchronous httpx client with the user's JWT token."""
+    return httpx.Client(
         headers={"Authorization": f"Bearer {config.jwt_token}"},
         base_url=config.api_url,
     )
@@ -22,3 +36,32 @@ def dynamic_table(data: list[dict[str, str]], title: str) -> Table:
         for item in data:
             table.add_row(*[str(value) for value in item.values()])
     return table
+
+
+def read_input(data: str) -> dict[str, str]:
+    """Read data from a file or JSON string.
+
+    If the data starts with '@', it is treated as a file path.
+    Else it is treated as a JSON string.
+    """
+    if data[0] == "@":
+        p = Path(data[1:])
+        if not p.exists():
+            raise typer.BadParameter(f"File {p} does not exist")
+        if p.suffix != ".json":
+            raise typer.BadParameter(f"File {p} is not a JSON file")
+        with p.open() as f:
+            data = f.read()
+    try:
+        return orjson.loads(data)
+    except orjson.JSONDecodeError as e:
+        raise typer.BadParameter(f"Invalid JSON: {e}") from e
+
+
+def handle_response(res: httpx.Response) -> httpx.Response:
+    if res.status_code == 422:
+        rich.print("[red]Validation error[/red]")
+        rich.print(res.json())
+        raise typer.Exit()
+    res.raise_for_status()
+    return res

--- a/tracecat/cli/dev.py
+++ b/tracecat/cli/dev.py
@@ -15,7 +15,7 @@ import yaml
 from pydantic import BaseModel
 
 from ._config import config
-from ._utils import user_client
+from ._utils import read_input, user_client
 
 app = typer.Typer(no_args_is_help=True, help="Dev tools.")
 
@@ -37,7 +37,8 @@ def api(
     data: str = typer.Option(None, "--data", "-d", help="JSON Payload to send"),
 ):
     """Commit a workflow definition to the database."""
-    payload = orjson.loads(data) if data else None
+
+    payload = read_input(data) if data else None
     result = asyncio.run(hit_api_endpoint(method, endpoint, payload))
     rich.print("Hit the endpoint successfully!")
     rich.print(result, len(result))

--- a/tracecat/cli/main.py
+++ b/tracecat/cli/main.py
@@ -1,7 +1,7 @@
 import typer
 from dotenv import find_dotenv, load_dotenv
 
-from . import dev, secret, workflow
+from . import dev, schedule, secret, workflow
 
 load_dotenv(find_dotenv())
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
@@ -26,6 +26,7 @@ def tracecat(
 app.add_typer(workflow.app, name="workflow")
 app.add_typer(dev.app, name="dev")
 app.add_typer(secret.app, name="secret")
+app.add_typer(schedule.app, name="schedule")
 
 if __name__ == "__main__":
     typer.run(app)

--- a/tracecat/cli/schedule.py
+++ b/tracecat/cli/schedule.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import asyncio
+
+import rich
+import typer
+from rich.console import Console
+
+from tracecat.types.api import CreateScheduleParams, UpdateScheduleParams
+
+from ._utils import (
+    dynamic_table,
+    handle_response,
+    read_input,
+    user_client,
+    user_client_sync,
+)
+
+app = typer.Typer(no_args_is_help=True, help="Manage schedules.")
+
+
+@app.command(help="Create a schedule", no_args_is_help=True)
+def create(
+    workflow_id: str = typer.Argument(..., help="Workflow ID"),
+    data: str = typer.Option(
+        None, "--data", "-d", help="JSON Payload to send (trigger context)"
+    ),
+    every: str = typer.Option(
+        None, "--every", "-e", help="Interval at which the schedule should run"
+    ),
+    offset: str = typer.Option(
+        None, "--offset", "-o", help="Offset from the start of the interval"
+    ),
+):
+    """Create a new schedule."""
+
+    inputs = read_input(data) if data else None
+
+    params = CreateScheduleParams(
+        workflow_id=workflow_id,
+        every=every,
+        offset=offset,
+        inputs=inputs,
+    )
+
+    with user_client_sync() as client:
+        res = client.post(
+            "/schedules",
+            json=params.model_dump(exclude_unset=True, exclude_none=True, mode="json"),
+        )
+        handle_response(res)
+
+    rich.print(res.json())
+
+
+@app.command(name="list", help="List all schedules")
+def list_schedules(
+    workflow_id: str = typer.Argument(None, help="Workflow ID"),
+    as_table: bool = typer.Option(False, "--table", "-t", help="Display as table"),
+):
+    """List all schedules."""
+
+    params = {}
+    if workflow_id:
+        params["workflow_id"] = workflow_id
+    with user_client_sync() as client:
+        res = client.get("/schedules", params=params)
+        handle_response(res)
+
+    result = res.json()
+    if as_table:
+        table = dynamic_table(result, "Schedules")
+        Console().print(table)
+    else:
+        rich.print(result)
+
+
+@app.command(help="Delete schedules", no_args_is_help=True)
+def delete(
+    schedule_ids: list[str] = typer.Argument(
+        ..., help="IDs of the schedules to delete"
+    ),
+):
+    """Delete schedules"""
+
+    delete = typer.confirm(f"Are you sure you want to delete {schedule_ids!r}")
+    if not delete:
+        rich.print("Aborted")
+        return
+
+    async def _delete():
+        async with user_client() as client, asyncio.TaskGroup() as tg:
+            for sch_id in schedule_ids:
+                tg.create_task(client.delete(f"/schedules/{sch_id}"))
+
+    asyncio.run(_delete())
+
+
+@app.command(help="Update a schedule", no_args_is_help=True)
+def update(
+    schedule_id: str = typer.Argument(..., help="ID of the schedule to update."),
+    inputs: str = typer.Option(
+        None, "--data", "-d", help="JSON Payload to send (trigger context)"
+    ),
+    every: str = typer.Option(
+        None, "--every", "-e", help="Interval at which the schedule should run"
+    ),
+    offset: str = typer.Option(
+        None, "--offset", "-o", help="Offset from the start of the interval"
+    ),
+):
+    """Update a schedule"""
+
+    params = UpdateScheduleParams(
+        inputs=read_input(inputs) if inputs else None,
+        every=every,
+        offset=offset,
+    )
+    with user_client_sync() as client:
+        res = client.post(
+            f"/schedules/{schedule_id}",
+            json=params.model_dump(exclude_unset=True, exclude_none=True),
+        )
+        handle_response(res)
+    rich.print(res.json())
+
+
+@app.command(help="Inspect a schedule", no_args_is_help=True)
+def inspect(
+    schedule_id: str = typer.Argument(..., help="ID of the schedule to inspect"),
+):
+    """Inspect a schedule"""
+
+    with user_client_sync() as client:
+        res = client.get(f"/schedules/{schedule_id}")
+        handle_response(res)
+    rich.print(res.json())

--- a/tracecat/cli/schedule.py
+++ b/tracecat/cli/schedule.py
@@ -103,23 +103,28 @@ def update(
         None, "--data", "-d", help="JSON Payload to send (trigger context)"
     ),
     every: str = typer.Option(
-        None, "--every", "-e", help="Interval at which the schedule should run"
+        None, "--every", help="Interval at which the schedule should run"
     ),
     offset: str = typer.Option(
-        None, "--offset", "-o", help="Offset from the start of the interval"
+        None, "--offset", help="Offset from the start of the interval"
     ),
+    online: bool = typer.Option(None, "--online", help="Set the schedule to online"),
+    offline: bool = typer.Option(None, "--offline", help="Set the schedule to offline"),
 ):
     """Update a schedule"""
+    if online and offline:
+        raise typer.BadParameter("Cannot set both online and offline")
 
     params = UpdateScheduleParams(
         inputs=read_input(inputs) if inputs else None,
         every=every,
         offset=offset,
+        status="online" if online else "offline",
     )
     with user_client_sync() as client:
         res = client.post(
             f"/schedules/{schedule_id}",
-            json=params.model_dump(exclude_unset=True, exclude_none=True),
+            json=params.model_dump(exclude_unset=True, exclude_none=True, mode="json"),
         )
         handle_response(res)
     rich.print(res.json())

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -34,6 +34,9 @@ TEMPORAL__CLUSTER_URL = os.environ.get(
 TEMPORAL__CLUSTER_NAMESPACE = os.environ.get(
     "TEMPORAL__CLUSTER_NAMESPACE", "default"
 )  # Temporal namespace
+TEMPORAL__CLUSTER_QUEUE = os.environ.get(
+    "TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"
+)  # Temporal task queue
 TEMPORAL__TLS_ENABLED = os.environ.get("TEMPORAL__TLS_ENABLED", False)
 TEMPORAL__TLS_ENABLED = os.environ.get("TEMPORAL__TLS_ENABLED", False)
 TEMPORAL__TLS_CLIENT_CERT = os.environ.get("TEMPORAL__TLS_CLIENT_CERT")

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
 
 
 class RunContext(BaseModel):
-    wf_id: identifiers.workflow.WorkflowID
-    wf_exec_id: identifiers.workflow.WorkflowExecutionID
-    wf_run_id: identifiers.workflow.WorkflowRunID
+    wf_id: identifiers.WorkflowID
+    wf_exec_id: identifiers.WorkflowExecutionID | identifiers.WorkflowScheduleID
+    wf_run_id: identifiers.WorkflowRunID
 
 
 ctx_run: ContextVar[RunContext] = ContextVar("run", default=None)

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -314,10 +314,8 @@ class Schedule(Resource, table=True):
         default_factory=id_factory("sch"), nullable=False, unique=True, index=True
     )
     status: str = "offline"  # "online" or "offline"
-    cron: str
-    entrypoint_payload: dict[str, Any] = Field(
-        default_factory=dict, sa_column=Column(JSON)
-    )
+    cron: str | None = None
+    inputs: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
 
     # Relationships
     workflow_id: str | None = Field(

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -313,7 +313,7 @@ class Schedule(Resource, table=True):
     id: str = Field(
         default_factory=id_factory("sch"), nullable=False, unique=True, index=True
     )
-    status: str = "offline"  # "online" or "offline"
+    status: str = "online"  # "online" or "offline"
     cron: str | None = None
     inputs: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
     every: timedelta = Field(..., description="ISO 8601 duration string")

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -1,6 +1,6 @@
 """Database schemas for Tracecat."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Self
 
 import pyarrow as pa
@@ -316,7 +316,10 @@ class Schedule(Resource, table=True):
     status: str = "offline"  # "online" or "offline"
     cron: str | None = None
     inputs: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
-
+    every: timedelta = Field(..., description="ISO 8601 duration string")
+    offset: timedelta | None = Field(None, description="ISO 8601 duration string")
+    start_at: datetime | None = Field(None, description="ISO 8601 datetime string")
+    end_at: datetime | None = Field(None, description="ISO 8601 datetime string")
     # Relationships
     workflow_id: str | None = Field(
         sa_column=Column(String, ForeignKey("workflow.id", ondelete="CASCADE"))

--- a/tracecat/dsl/dispatcher.py
+++ b/tracecat/dsl/dispatcher.py
@@ -1,13 +1,12 @@
 import asyncio
 import json
-import os
 import sys
 from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel
 
-from tracecat import identifiers
+from tracecat import config, identifiers
 from tracecat.contexts import ctx_role
 from tracecat.dsl.common import DSLInput, get_temporal_client
 from tracecat.dsl.workflow import DSLContext, DSLRunArgs, DSLWorkflow
@@ -33,7 +32,7 @@ async def dispatch_workflow(
         DSLWorkflow.run,
         DSLRunArgs(dsl=dsl, role=role, wf_id=wf_id),
         id=wf_exec_id,
-        task_queue=os.environ.get("TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"),
+        task_queue=config.TEMPORAL__CLUSTER_QUEUE,
         **kwargs,
     )
     logger.debug(f"Workflow result:\n{json.dumps(result, indent=2)}")

--- a/tracecat/dsl/schedules.py
+++ b/tracecat/dsl/schedules.py
@@ -1,0 +1,155 @@
+import re
+from datetime import datetime, timedelta
+from typing import Any, TypeVar
+
+from pydantic import ValidationInfo, ValidatorFunctionWrapHandler, WrapValidator
+from temporalio.client import (
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleDescription,
+    ScheduleHandle,
+    ScheduleIntervalSpec,
+    ScheduleListDescription,
+    ScheduleSpec,
+    ScheduleState,
+    ScheduleUpdate,
+    ScheduleUpdateInput,
+)
+
+from tracecat import config, identifiers
+from tracecat.contexts import ctx_role
+from tracecat.dsl.common import DSLInput, get_temporal_client
+from tracecat.dsl.workflow import DSLRunArgs, DSLWorkflow
+
+T = TypeVar("T")
+
+EASY_TD_PATTERN = (
+    r"^"  # Start of string
+    r"(?:(?P<weeks>\d+)w)?"  # Match weeks
+    r"(?:(?P<days>\d+)d)?"  # Match days
+    r"(?:(?P<hours>\d+)h)?"  # Match hours
+    r"(?:(?P<minutes>\d+)m)?"  # Match minutes
+    r"(?:(?P<seconds>\d+)s)?"  # Match seconds
+    r"$"  # End of string
+)
+
+
+class EasyTimedelta:
+    def __new__(cls):
+        return WrapValidator(cls.maybe_str2timedelta)
+
+    @classmethod
+    def maybe_str2timedelta(
+        cls, v: T, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
+    ) -> T:
+        if isinstance(v, str):
+            # If it's a string, try to parse it as a timedelta
+            try:
+                return string_to_timedelta(v)
+            except ValueError:
+                pass
+        # Otherwise, handle as normal
+        return handler(v, info)
+
+
+def string_to_timedelta(time_str: str) -> timedelta:
+    # Regular expressions to match different time units with named capture groups
+    pattern = re.compile(
+        r"^"  # Start of string
+        r"(?:(?P<weeks>\d+)w)?"  # Match weeks
+        r"(?:(?P<days>\d+)d)?"  # Match days
+        r"(?:(?P<hours>\d+)h)?"  # Match hours
+        r"(?:(?P<minutes>\d+)m)?"  # Match minutes
+        r"(?:(?P<seconds>\d+)s)?"  # Match seconds
+        r"$"  # End of string
+    )
+    match = pattern.match(time_str)
+
+    if not match:
+        raise ValueError("Invalid time format")
+
+    # Extracting the values, defaulting to 0 if not present
+    weeks = int(match.group("weeks") or 0)
+    days = int(match.group("days") or 0)
+    hours = int(match.group("hours") or 0)
+    minutes = int(match.group("minutes") or 0)
+    seconds = int(match.group("seconds") or 0)
+
+    # Check if all values are zero
+    if all(v == 0 for v in (weeks, days, hours, minutes, seconds)):
+        raise ValueError("Invalid time format. All values are zero.")
+
+    # Creating a timedelta object
+    return timedelta(
+        days=days, weeks=weeks, hours=hours, minutes=minutes, seconds=seconds
+    )
+
+
+async def create_schedule(
+    workflow_id: identifiers.WorkflowID,
+    schedule_id: str,
+    dsl: DSLInput,
+    # Schedule config
+    every: timedelta,
+    offset: timedelta | None = None,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    **kwargs: Any,
+) -> ScheduleHandle:
+    client = await get_temporal_client()
+
+    exec_id = identifiers.workflow.exec_id(workflow_id)
+    return await client.create_schedule(
+        schedule_id,
+        Schedule(
+            action=ScheduleActionStartWorkflow(
+                DSLWorkflow.run,
+                # The args that should run in the scheduled workflow
+                DSLRunArgs(dsl=dsl, role=ctx_role.get(), wf_id=workflow_id),
+                id=exec_id,
+                task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+            ),
+            spec=ScheduleSpec(
+                intervals=[ScheduleIntervalSpec(every=every, offset=offset)],
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            state=ScheduleState(note="Here's a note on my Schedule."),
+        ),
+        **kwargs,
+    )
+
+
+async def delete_schedule(sch_id: str) -> ScheduleHandle:
+    client = await get_temporal_client()
+    handle = client.get_schedule_handle(sch_id)
+    return await handle.delete()
+
+
+async def update_schedule(input: ScheduleUpdateInput) -> ScheduleUpdate:
+    schedule_action = input.description.schedule.action
+
+    if isinstance(schedule_action, ScheduleActionStartWorkflow):
+        schedule_action.args = [
+            DSLRunArgs(dsl=input.description.schedule.action.args.dsl)
+        ]
+    ScheduleUpdate(schedule=input.description.schedule)
+
+
+async def get_schedule() -> ScheduleDescription:
+    client = await get_temporal_client()
+    handle = client.get_schedule_handle(
+        "workflow-schedule-id",
+    )
+
+    desc = await handle.describe()
+
+    print(f"Returns the note: {desc.schedule.state.note}")
+
+
+async def list_schedules() -> list[ScheduleListDescription]:
+    client = await get_temporal_client()
+    res = []
+    async for schedule in await client.list_schedules():
+        res.append(schedule)
+    return res

--- a/tracecat/dsl/schedules.py
+++ b/tracecat/dsl/schedules.py
@@ -87,7 +87,7 @@ def string_to_timedelta(time_str: str) -> timedelta:
 
 async def create_schedule(
     workflow_id: identifiers.WorkflowID,
-    schedule_id: str,
+    schedule_id: identifiers.ScheduleID,
     dsl: DSLInput,
     # Schedule config
     every: timedelta,
@@ -120,10 +120,16 @@ async def create_schedule(
     )
 
 
-async def delete_schedule(sch_id: str) -> ScheduleHandle:
+async def delete_schedule(sch_id: identifiers.ScheduleID) -> ScheduleHandle:
     client = await get_temporal_client()
     handle = client.get_schedule_handle(sch_id)
-    return await handle.delete()
+    try:
+        return await handle.delete()
+    except Exception as e:
+        if "workflow execution already completed" in str(e):
+            # This is fine, we can ignore this error
+            return
+        raise e
 
 
 async def update_schedule(input: ScheduleUpdateInput) -> ScheduleUpdate:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -428,7 +428,7 @@ class DSLActivities:
         else:
             result = await udf.run_async(args)
 
-        act_logger.info("Result", result=result)
+        act_logger.debug("Result", result=result)
         return result
 
 

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -38,9 +38,10 @@ e.g. wf-77932a0b140a4465a1a25a5c95edcfb8:run-b140a425a577932a0c95edcfb8465a1a
 
 """
 
-from tracecat.identifiers import action, workflow
+from tracecat.identifiers import action, schedules, workflow
 from tracecat.identifiers.action import ActionID, ActionKey, ActionRef
 from tracecat.identifiers.resource import id_factory
+from tracecat.identifiers.schedules import ScheduleID
 from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowID, WorkflowRunID
 
 __all__ = [
@@ -50,7 +51,9 @@ __all__ = [
     "WorkflowID",
     "WorkflowExecutionID",
     "WorkflowRunID",
+    "ScheduleID",
     "id_factory",
     "action",
     "workflow",
+    "schedules",
 ]

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -42,7 +42,12 @@ from tracecat.identifiers import action, schedules, workflow
 from tracecat.identifiers.action import ActionID, ActionKey, ActionRef
 from tracecat.identifiers.resource import id_factory
 from tracecat.identifiers.schedules import ScheduleID
-from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowID, WorkflowRunID
+from tracecat.identifiers.workflow import (
+    WorkflowExecutionID,
+    WorkflowID,
+    WorkflowRunID,
+    WorkflowScheduleID,
+)
 
 __all__ = [
     "ActionID",
@@ -50,6 +55,7 @@ __all__ = [
     "ActionRef",
     "WorkflowID",
     "WorkflowExecutionID",
+    "WorkflowScheduleID",
     "WorkflowRunID",
     "ScheduleID",
     "id_factory",

--- a/tracecat/identifiers/schedules.py
+++ b/tracecat/identifiers/schedules.py
@@ -1,0 +1,15 @@
+"""Schedule identifiers."""
+
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+ScheduleID = Annotated[str, StringConstraints(pattern=r"sch-[0-9a-f]{32}")]
+"""A unique ID for a schedule.
+
+This is the equivalent of a Schedule ID in Temporal.
+
+Exapmles
+--------
+- 'sch-77932a0b140a4465a1a25a5c95edcfb8'
+"""

--- a/tracecat/identifiers/workflow.py
+++ b/tracecat/identifiers/workflow.py
@@ -6,6 +6,11 @@ from pydantic import UUID4, StringConstraints
 
 from tracecat.identifiers.resource import ResourcePrefix, generate_resource_id
 
+WorkflowScheduleID = Annotated[
+    str, StringConstraints(pattern=r"wf-[0-9a-f]{32}:sch-[0-9a-f]{32}")
+]
+"""A unique ID for a scheduled workflow."""
+
 WorkflowID = Annotated[str, StringConstraints(pattern=r"wf-[0-9a-f]{32}")]
 """A unique ID for a workflow.
 

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from tracecat import identifiers
 from tracecat.db.schemas import ActionRun, Resource, Schedule, WorkflowRun
 from tracecat.dsl.common import DSLInput
 from tracecat.types.generics import ListModel
@@ -334,15 +335,6 @@ class UDFArgsValidationResponse(BaseModel):
     detail: Any | None = None
 
 
-class CreateScheduleParams(BaseModel):
-    inputs: dict[str, Any] | None = None
-    cron: str | None = None
-    every: timedelta = Field(..., description="ISO 8601 duration string")
-    offset: timedelta | None = Field(None, description="ISO 8601 duration string")
-    start_at: datetime | None = Field(None, description="ISO 8601 datetime string")
-    end_at: datetime | None = Field(None, description="ISO 8601 datetime string")
-
-
 class CommitWorkflowResponse(BaseModel):
     workflow_id: str
     status: Literal["success", "failure"]
@@ -355,3 +347,33 @@ class ServiceCallbackAction(BaseModel):
     action: Literal["webhook"]
     payload: dict[str, Any]
     metadata: dict[str, Any]
+
+
+class CreateScheduleParams(BaseModel):
+    workflow_id: identifiers.WorkflowID
+    inputs: dict[str, Any] | None = None
+    cron: str | None = None
+    every: timedelta = Field(..., description="ISO 8601 duration string")
+    offset: timedelta | None = Field(None, description="ISO 8601 duration string")
+    start_at: datetime | None = Field(None, description="ISO 8601 datetime string")
+    end_at: datetime | None = Field(None, description="ISO 8601 datetime string")
+    status: Literal["online", "offline"] = "online"
+
+
+class UpdateScheduleParams(BaseModel):
+    inputs: dict[str, Any] | None = None
+    cron: str | None = None
+    every: timedelta | None = Field(None, description="ISO 8601 duration string")
+    offset: timedelta | None = Field(None, description="ISO 8601 duration string")
+    start_at: datetime | None = Field(None, description="ISO 8601 datetime string")
+    end_at: datetime | None = Field(None, description="ISO 8601 datetime string")
+    status: Literal["online", "offline"] | None = None
+
+
+class SearchScheduleParams(BaseModel):
+    workflow_id: str | None = None
+    limit: int = 100
+    order_by: str = "created_at"
+    query: str | None = None
+    group_by: list[str] | None = None
+    agg: str | None = None

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from tracecat.db.schemas import ActionRun, Resource, Schedule, WorkflowRun
 from tracecat.dsl.common import DSLInput
@@ -335,9 +335,12 @@ class UDFArgsValidationResponse(BaseModel):
 
 
 class CreateScheduleParams(BaseModel):
-    entrypoint_ref: str
-    entrypoint_payload: dict[str, Any] | None = None
-    cron: str
+    inputs: dict[str, Any] | None = None
+    cron: str | None = None
+    every: timedelta = Field(..., description="ISO 8601 duration string")
+    offset: timedelta | None = Field(None, description="ISO 8601 duration string")
+    start_at: datetime | None = Field(None, description="ISO 8601 datetime string")
+    end_at: datetime | None = Field(None, description="ISO 8601 datetime string")
 
 
 class CommitWorkflowResponse(BaseModel):


### PR DESCRIPTION
# Features
- Implement Schedule CRUD operations for API
- Schedule implemented as a top-level entity in our schema
- Implement Schedule CRUD operations for CLI
- Schedules are backed by Temporal schedules under the hood, and CRUD operations are coordinated between our and Temporal's systems
- Update schedules UI

# Changes
- Added more utility functions the CLI
- Set `TEMPORAL__CLUSTER_QUEUE` inside `tracecat.config`
- Add better visibility for 422 errors with a FastAPI exception handler
- Use `slack` instead of `slack_channel` for aws GD playhbook

# Testing
- Manual QA for schedules
    - Verified that crud works and syncs with Tamporal