### PR TITLE
perf(engine): Use asyncio eager task factory for worker event loop

### DIFF
--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -68,6 +68,7 @@ async def main() -> None:
 
 if __name__ == "__main__":
     loop = asyncio.new_event_loop()
+    loop.set_task_factory(asyncio.eager_task_factory)
     try:
         loop.run_until_complete(main())
     except KeyboardInterrupt:


### PR DESCRIPTION
# Features
- Use asyncio eager task factory for worker event loop
- Improve asyncio performance on coroutines that can complete before being scheduled on the event loop

# References
- https://github.com/python/cpython/issues/104144
- Backed by data from Instagram: https://github.com/python/cpython/issues/97696