### PR TITLE
feat(udf): Improve registry secrets api

### DIFF
--- a/tracecat/actions/core/email.py
+++ b/tracecat/actions/core/email.py
@@ -11,9 +11,20 @@ import httpx
 from loguru import logger
 from tenacity import retry, stop_after_attempt, wait_exponential
 
-from tracecat.registry import registry
+from tracecat.registry import RegistrySecret, registry
 
 SAFE_EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+
+resend_secret = RegistrySecret(
+    name="resend_api_key",
+    keys=["RESEND_API_KEY"],
+)
+"""Resend secret.
+
+- name: `resend_api_key`
+- keys:
+    - `RESEND_API_KEY`
+"""
 
 
 class EmailBouncedError(Exception):
@@ -136,7 +147,7 @@ class ResendMailProvider(AsyncMailProvider):
     namespace="core",
     version="0.1.0",
     description="Perform a send email action",
-    secrets=["resend_api_key"],
+    secrets=[resend_secret],
     default_title="Send Email",
 )
 async def send_email(

--- a/tracecat/actions/core/llm.py
+++ b/tracecat/actions/core/llm.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 from pydantic import Field
 
 from tracecat.llm import DEFAULT_MODEL_TYPE, ModelType, async_openai_call
-from tracecat.registry import registry
+from tracecat.registry import RegistrySecret, registry
 
 
 def _event_context_instructions(event_context: dict[str, Any]) -> str:
@@ -26,13 +26,24 @@ def _event_context_instructions(event_context: dict[str, Any]) -> str:
 
 DEFAULT_SYSTEM_CONTEXT = "You will be provided with a body of text and your task is to do exactly as instructed."
 
+openai_secret = RegistrySecret(
+    name="openai",
+    keys=["OPENAI_API_KEY"],
+)
+"""OpenAI secret.
+
+- name: `openai`
+- keys:
+    - `OPENAI_API_KEY`
+"""
+
 
 @registry.register(
     namespace="core",
     version="0.1.0",
     description="Call an LLM.",
     default_title="AI Action",
-    secrets=["openai"],
+    secrets=[openai_secret],
 )
 async def ai_action(
     prompt: Annotated[str, Field(description="The prompt to send to the LLM")],

--- a/tracecat/actions/integrations/cdr/amazon_guardduty.py
+++ b/tracecat/actions/integrations/cdr/amazon_guardduty.py
@@ -83,9 +83,32 @@ from types_aiobotocore_guardduty.client import GuardDutyClient
 
 from tracecat.actions.io import retry
 from tracecat.logging import logger
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 GUARDDUTY_MAX_RESULTS = 50
+
+aws_guardduty_secret = RegistrySecret(
+    name="aws_guardduty",
+    keys=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"],
+)
+"""AWS GuardDuty secret.
+
+Secret
+------
+- name: `aws_guardduty`
+- keys:
+    - `AWS_ACCESS_KEY_ID`
+    - `AWS_SECRET_ACCESS_KEY`
+    - `AWS_REGION`
+
+Example Usage
+-------------
+Environment variables:
+>>> os.environ["AWS_ACCESS_KEY_ID"]
+
+Expression:
+>>> ${{ SECRETS.aws_guardduty.AWS_ACCESS_KEY_ID }}
+"""
 
 
 @retry()
@@ -140,7 +163,7 @@ async def _get_findings(
     description="Fetch Amazon GuardDuty alerts and filter by time range.",
     display_group="Amazon GuardDuty",
     namespace="integrations.aws.guardduty",
-    secrets=["aws_guardduty"],
+    secrets=[aws_guardduty_secret],
 )
 async def list_guardduty_alerts(
     start_time: Annotated[

--- a/tracecat/actions/integrations/cdr/microsoft_defender.py
+++ b/tracecat/actions/integrations/cdr/microsoft_defender.py
@@ -11,9 +11,27 @@ from datetime import datetime
 from typing import Annotated
 
 from tracecat.actions.integrations.common import list_microsoft_graph_alerts
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 MICROSOFT_GRAPH_SERVICE_SOURCE = "microsoftDefenderForCloud"
+
+
+microsoft_defender_cloud_secret = RegistrySecret(
+    name="microsoft_defender_cloud",
+    keys=[
+        "MICROSOFT_GRAPH_CLIENT_ID",
+        "MICROSOFT_GRAPH_CLIENT_SECRET",
+        "MICROSOFT_GRAPH_TENANT_ID",
+    ],
+)
+"""Microsoft Defender for Cloud secret.
+
+- name: `microsoft_defender_cloud`
+- keys:
+    - `MICROSOFT_GRAPH_CLIENT_ID`
+    - `MICROSOFT_GRAPH_CLIENT_SECRET`
+    - `MICROSOFT_GRAPH_TENANT_ID`
+"""
 
 
 @registry.register(
@@ -21,7 +39,7 @@ MICROSOFT_GRAPH_SERVICE_SOURCE = "microsoftDefenderForCloud"
     description="Fetch Microsoft Defender for Cloud alerts and filter by time range.",
     display_group="Microsoft Defender",
     namespace="integrations.microsoft_defender",
-    secrets=["microsoft_defender_cloud"],
+    secrets=[microsoft_defender_cloud_secret],
 )
 async def list_defender_cloud_alerts(
     start_time: Annotated[

--- a/tracecat/actions/integrations/cdr/wiz.py
+++ b/tracecat/actions/integrations/cdr/wiz.py
@@ -27,7 +27,7 @@ from typing import Annotated, Any
 import httpx
 
 from tracecat.actions.io import retry
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 QUERY_STRING = """
 query IssuesTable($filterBy: IssueFilters, $first: Int, $after: String, $orderBy: IssueOrder) {
@@ -113,6 +113,25 @@ query IssuesTable($filterBy: IssueFilters, $first: Int, $after: String, $orderBy
 }
 """
 
+wiz_secret = RegistrySecret(
+    name="wiz",
+    keys=[
+        "WIZ_API_URL",
+        "WIZ_AUTH_URL",
+        "WIZ_CLIENT_ID",
+        "WIZ_CLIENT_SECRET",
+    ],
+)
+"""Wiz secret.
+
+- name: `wiz`
+- keys:
+    - `WIZ_API_URL`
+    - `WIZ_AUTH_URL`
+    - `WIZ_CLIENT_ID`
+    - `WIZ_CLIENT_SECRET`
+"""
+
 
 async def _get_access_token(client_id: str, client_secret: str, auth_url: str) -> str:
     payload = {
@@ -152,7 +171,7 @@ async def _query_wiz_alerts(
     description="Fetch Wiz detection findings and filter by time range.",
     display_group="Wiz",
     namespace="integrations.wiz",
-    secrets=["wiz"],
+    secrets=[wiz_secret],
 )
 async def list_wiz_alerts(
     start_time: Annotated[

--- a/tracecat/actions/integrations/chat/slack.py
+++ b/tracecat/actions/integrations/chat/slack.py
@@ -36,8 +36,16 @@ from typing import Annotated, Any
 
 from slack_sdk.web.async_client import AsyncWebClient
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 from tracecat.types.exceptions import TracecatCredentialsError
+
+slack_chatops_secret = RegistrySecret(name="slack_chatops", keys=["SLACK_BOT_TOKEN"])
+"""Slack ChatOps secret.
+
+- name: `slack_chatops`
+- keys:
+    - `SLACK_BOT_TOKEN`
+"""
 
 
 # MESSAGES API
@@ -46,7 +54,7 @@ from tracecat.types.exceptions import TracecatCredentialsError
     description="Send Slack message to channel.",
     display_group="ChatOps",
     namespace="integrations.chat.slack",
-    secrets=["slack"],
+    secrets=[slack_chatops_secret],
 )
 async def post_slack_message(
     channel: Annotated[
@@ -76,7 +84,7 @@ async def post_slack_message(
     description="Fetch Slack users by team ID or list of emails.",
     display_group="ChatOps",
     namespace="integrations.chat.slack",
-    secrets=["slack"],
+    secrets=[slack_chatops_secret],
 )
 async def list_slack_users(
     team_id: Annotated[

--- a/tracecat/actions/integrations/edr/crowdstrike.py
+++ b/tracecat/actions/integrations/edr/crowdstrike.py
@@ -36,7 +36,7 @@ from typing import Annotated, Any, Literal
 
 from falconpy import Alerts, Detects
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 TOKEN_ENDPOINT = "/oauth2/token"
 ALERTS_ENDPOINT = "/alerts/queries/alerts/v2"
@@ -47,6 +47,18 @@ AlertStatus = Literal[
     "ignored", "new", "in_progress", "true_positive", "false_positive"
 ]
 DetectStatus = Literal["ignored", "new", "in_progress", "resolved", "false_positive"]
+
+crowdstrike_secret = RegistrySecret(
+    name="crowdstrike",
+    keys=["CROWDSTRIKE_CLIENT_ID", "CROWDSTRIKE_CLIENT_SECRET"],
+)
+"""Crowdstrike secret.
+
+- name: `crowdstrike`
+- keys:
+    - `CROWDSTRIKE_CLIENT_ID`
+    - `CROWDSTRIKE_CLIENT_SECRET`
+"""
 
 
 def get_crowdstrike_credentials():
@@ -62,7 +74,7 @@ def get_crowdstrike_credentials():
     description="Fetch all Crowdstrike alerts from Falcon SIEM.",
     display_group="Crowdstrike",
     namespace="integrations.crowdstrike",
-    secrets=["crowdstrike"],
+    secrets=[crowdstrike_secret],
 )
 async def list_crowdstrike_alerts(
     start_time: Annotated[
@@ -90,7 +102,7 @@ async def list_crowdstrike_alerts(
     description="Fetch all Crowdstrike detections from Falcon SIEM.",
     display_group="Crowdstrike",
     namespace="integrations.crowdstrike",
-    secrets=["crowdstrike"],
+    secrets=[crowdstrike_secret],
 )
 async def list_crowdstrike_detects(
     start_time: Annotated[
@@ -118,7 +130,7 @@ async def list_crowdstrike_detects(
     description="Update the status of Crowdstrike alerts.",
     display_group="Crowdstrike",
     namespace="integrations.crowdstrike",
-    secrets=["crowdstrike"],
+    secrets=[crowdstrike_secret],
 )
 async def update_crowdstrike_alert_status(
     alert_ids: Annotated[
@@ -142,7 +154,7 @@ async def update_crowdstrike_alert_status(
     description="Update the status of Crowdstrike detects.",
     display_group="Crowdstrike",
     namespace="integrations.crowdstrike",
-    secrets=["crowdstrike"],
+    secrets=[crowdstrike_secret],
 )
 async def update_crowdstrike_detect_status(
     detection_ids: Annotated[

--- a/tracecat/actions/integrations/edr/microsoft_defender.py
+++ b/tracecat/actions/integrations/edr/microsoft_defender.py
@@ -11,9 +11,26 @@ from datetime import datetime
 from typing import Annotated
 
 from tracecat.actions.integrations.common import list_microsoft_graph_alerts
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 MICROSOFT_GRAPH_SERVICE_SOURCE = "microsoftDefenderForEndpoint"
+
+microsoft_defender_endpoint_secret = RegistrySecret(
+    name="microsoft_defender_endpoint",
+    keys=[
+        "MICROSOFT_GRAPH_CLIENT_ID",
+        "MICROSOFT_GRAPH_CLIENT_SECRET",
+        "MICROSOFT_GRAPH_TENANT_ID",
+    ],
+)
+"""Microsoft Defender for Endpoint secret.
+
+- name: `microsoft_defender_endpoint`
+- keys:
+    - `MICROSOFT_GRAPH_CLIENT_ID`
+    - `MICROSOFT_GRAPH_CLIENT_SECRET`
+    - `MICROSOFT_GRAPH_TENANT_ID`
+"""
 
 
 @registry.register(
@@ -23,12 +40,12 @@ MICROSOFT_GRAPH_SERVICE_SOURCE = "microsoftDefenderForEndpoint"
     # description="Fetch all Sentinel One alerts.",
     # display_group="Endpoint Detection & Response",
     # namespace="integrations.sentinel_one",
-    # secrets=["sentinel_one"],
+    # secrets=[sentinel_one_secret],
     default_title="List Microsoft Defender for Endpoint alerts",
     description="Fetch all Microsoft Defender for Endpoint alerts and filter by time range.",
     display_group="Microsoft Defender",
     namespace="integrations.microsoft_defender",
-    secrets=["microsoft_defender_endpoint"],
+    secrets=[microsoft_defender_endpoint_secret],
 )
 async def list_defender_endpoint_alerts(
     start_time: Annotated[

--- a/tracecat/actions/integrations/edr/sentinel_one.py
+++ b/tracecat/actions/integrations/edr/sentinel_one.py
@@ -26,12 +26,24 @@ from typing import Annotated, Any, Literal
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 ALERTS_ENDPOINT = "/web/api/v2.1/cloud-detection/alerts"
 ANALYST_VERDICT_ENDPOINT = "/web/api/v2.1/cloud-detection/alerts/analyst-verdict"
 
 AnalystVerdict = Literal["FALSE_POSITIVE", "SUSPICIOUS", "TRUE_POSITIVE", "UNDEFINED"]
+
+sentinel_one_secret = RegistrySecret(
+    name="sentinel_one",
+    keys=["SENTINEL_ONE_BASE_URL", "SENTINEL_ONE_API_TOKEN"],
+)
+"""Sentinel One secret.
+
+- name: `sentinel_one`
+- keys:
+    - `SENTINEL_ONE_BASE_URL`
+    - `SENTINEL_ONE_API_TOKEN`
+"""
 
 
 @registry.register(
@@ -39,7 +51,7 @@ AnalystVerdict = Literal["FALSE_POSITIVE", "SUSPICIOUS", "TRUE_POSITIVE", "UNDEF
     description="Fetch all Sentinel One alerts and filter by time range.",
     display_group="Sentinel One",
     namespace="integrations.sentinel_one",
-    secrets=["sentinel_one"],
+    secrets=[sentinel_one_secret],
 )
 async def list_sentinelone_alerts(
     start_time: Annotated[
@@ -83,6 +95,7 @@ async def list_sentinelone_alerts(
     description="Update the analyst verdict of Sentinel One alerts.",
     display_group="Sentinel One",
     namespace="integrations.sentinel_one",
+    secrets=[sentinel_one_secret],
 )
 async def update_sentinelone_alert_status(
     alert_ids: Annotated[

--- a/tracecat/actions/integrations/enrichment/abuseipdb.py
+++ b/tracecat/actions/integrations/enrichment/abuseipdb.py
@@ -23,9 +23,18 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 ABUSEIPDB_BASE_URL = "https://api.abuseipdb.com/api"
+
+# Secret
+abuseipdb_secret = RegistrySecret(name="abuseipdb", keys=["ABUSEIPDB_API_KEY"])
+"""AbuseIPDB secret.
+
+- name: `abuseipdb`
+- keys:
+    - `ABUSEIPDB_API_KEY`
+"""
 
 
 @registry.register(
@@ -33,7 +42,7 @@ ABUSEIPDB_BASE_URL = "https://api.abuseipdb.com/api"
     description="Analyze an IP address using AbuseIPDB.",
     display_group="AbuseIPDB",
     namespace="integrations.abuseipdb",
-    secrets=["abuseipdb"],
+    secrets=[abuseipdb_secret],
 )
 async def analyze_ip_address(
     ip_address: Annotated[str, Field(..., description="The IP address to analyze")],

--- a/tracecat/actions/integrations/enrichment/alienvault.py
+++ b/tracecat/actions/integrations/enrichment/alienvault.py
@@ -36,10 +36,28 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 # Base URL for AlienVault OTX API
 OTX_BASE_URL = "https://otx.alienvault.com/api"
+
+alienvault_secret = RegistrySecret(name="alienvault", keys=["OTX_API_KEY"])
+"""AlienVault OTX secret.
+
+Secret
+------
+- name: `alienvault`
+- keys:
+    - `OTX_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["OTX_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.alienvault.OTX_API_KEY }}
+"""
 
 
 # Function to create an HTTPX async client for AlienVault OTX
@@ -59,7 +77,7 @@ def create_alienvault_client() -> httpx.AsyncClient:
     description="Analyze a URL using AlienVault OTX.",
     display_group="AlienVault OTX",
     namespace="integrations.alienvault",
-    secrets=["alienvault"],
+    secrets=[alienvault_secret],
 )
 async def analyze_url(
     url: Annotated[str, Field(..., description="The URL to analyze")],
@@ -73,6 +91,7 @@ async def analyze_url(
 @registry.register(
     description="Analyze an IP address using AlienVault OTX.",
     namespace="alienvault",
+    secrets=[alienvault_secret],
 )
 async def analyze_ip_address(
     ip_address: Annotated[str, Field(..., description="The IP address to analyze")],
@@ -94,7 +113,7 @@ async def analyze_ip_address(
     description="Analyze a malware sample using AlienVault OTX.",
     display_group="AlienVault OTX",
     namespace="integrations.alienvault",
-    secrets=["alienvault"],
+    secrets=[alienvault_secret],
 )
 async def analyze_malware_sample(
     file_hash: Annotated[

--- a/tracecat/actions/integrations/enrichment/censys.py
+++ b/tracecat/actions/integrations/enrichment/censys.py
@@ -6,9 +6,27 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 CENSYS_BASE_URL = "https://search.censys.io/api/v2"
+
+censys_secret = RegistrySecret(name="censys", keys=["CENSYS_API_KEY"])
+"""Censys secret.
+
+Secret
+------
+- name: `censys`
+- keys:
+    - `CENSYS_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["CENSYS_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.censys.CENSYS_API_KEY }}
+"""
 
 
 def create_censys_client() -> httpx.AsyncClient:
@@ -27,7 +45,7 @@ def create_censys_client() -> httpx.AsyncClient:
     description="Analyze an IP address using Censys.",
     display_group="Censys",
     namespace="censys",
-    secrets=["censys"],
+    secrets=[censys_secret],
 )
 async def analyze_ip_address(
     ip_address: Annotated[str, Field(..., description="The IP address to analyze")],

--- a/tracecat/actions/integrations/enrichment/emailrep.py
+++ b/tracecat/actions/integrations/enrichment/emailrep.py
@@ -22,9 +22,28 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 EMAILREP_BASE_URL = "https://emailrep.io"
+
+
+emailrep_secret = RegistrySecret(name="emailrep", keys=["EMAILREP_API_KEY"])
+"""Emailrep secret.
+
+Secret
+------
+- name: `emailrep`
+- keys:
+    - `EMAILREP_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["EMAILREP_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.emailrep.EMAILREP_API_KEY }}
+"""
 
 
 def create_emailrep_client() -> httpx.AsyncClient:
@@ -40,7 +59,7 @@ def create_emailrep_client() -> httpx.AsyncClient:
     description="Analyze an email address using Emailrep.",
     display_group="Emailrep",
     namespace="integrations.emailrep",
-    secrets=["emailrep"],
+    secrets=[emailrep_secret],
 )
 async def analyze_email(
     email: Annotated[str, Field(..., description="The email address to analyze")],

--- a/tracecat/actions/integrations/enrichment/hybrid_analysis.py
+++ b/tracecat/actions/integrations/enrichment/hybrid_analysis.py
@@ -23,9 +23,27 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 HA_BASE_URL = "https://www.hybrid-analysis.com/api/v2/"
+
+hybrid_analysis_secret = RegistrySecret(name="hybrid_analysis", keys=["HA_API_KEY"])
+"""Hybrid Analysis secret.
+
+Secret
+------
+- name: `hybrid_analysis`
+- keys:
+    - `HA_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["HA_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.hybrid_analysis.HA_API_KEY }}
+"""
 
 
 def create_hybrid_analysis_client() -> httpx.AsyncClient:
@@ -44,7 +62,7 @@ def create_hybrid_analysis_client() -> httpx.AsyncClient:
     description="Analyze a malware sample using Hybrid Analysis.",
     display_group="Hybrid Analysis",
     namespace="integrations.hybrid_analysis",
-    secrets=["hybrid_analysis"],
+    secrets=[hybrid_analysis_secret],
 )
 async def analyze_malware_sample(
     file_hash: Annotated[

--- a/tracecat/actions/integrations/enrichment/malwarebazaar.py
+++ b/tracecat/actions/integrations/enrichment/malwarebazaar.py
@@ -23,9 +23,29 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 MALWAREBAZAAR_BASE_URL = "https://mb-api.abuse.ch/api"
+
+malwarebazaar_secret = RegistrySecret(
+    name="malwarebazaar", keys=["MALWAREBAZAAR_API_KEY"]
+)
+"""MalwareBazaar secret.
+
+Secret
+------
+- name: `malwarebazaar`
+- keys:
+    - `MALWAREBAZAAR_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["MALWAREBAZAAR_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.malwarebazaar.MALWAREBAZAAR_API_KEY }}
+"""
 
 
 @registry.register(
@@ -33,7 +53,7 @@ MALWAREBAZAAR_BASE_URL = "https://mb-api.abuse.ch/api"
     description="Analyze a malware sample using Malwarebazaar.",
     display_group="Malwarebazaar",
     namespace="integrations.malwarebazaar",
-    secrets=["malwarebazaar"],
+    secrets=[malwarebazaar_secret],
 )
 async def analyze_malware_sample(
     file_hash: Annotated[

--- a/tracecat/actions/integrations/enrichment/pulsedive.py
+++ b/tracecat/actions/integrations/enrichment/pulsedive.py
@@ -34,9 +34,28 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 PULSEDIVE_BASE_URL = "https://pulsedive.com/api/"
+
+pulsedive_secret = RegistrySecret(name="pulsedive", keys=["PULSEDIVE_API_KEY"])
+"""Pulsedive secret.
+
+Secret
+------
+- name: `pulsedive`
+
+- keys:
+    - `PULSEDIVE_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["PULSEDIVE_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.pulsedive.PULSEDIVE_API_KEY }}
+"""
 
 
 def create_pulsedive_client() -> httpx.AsyncClient:
@@ -54,7 +73,7 @@ def create_pulsedive_client() -> httpx.AsyncClient:
     description="Analyze a URL using Pulsedive.",
     display_group="Pulsedive",
     namespace="integrations.pulsedive",
-    secrets=["pulsedive"],
+    secrets=[pulsedive_secret],
 )
 async def analyze_url(
     url: Annotated[str, Field(..., description="The URL to analyze")],
@@ -71,7 +90,7 @@ async def analyze_url(
     description="Analyze an IP address using Pulsedive.",
     display_group="Pulsedive",
     namespace="integrations.pulsedive",
-    secrets=["pulsedive"],
+    secrets=[pulsedive_secret],
 )
 async def analyze_ip_address(
     ip_address: Annotated[str, Field(..., description="The IP address to analyze")],

--- a/tracecat/actions/integrations/enrichment/shodan.py
+++ b/tracecat/actions/integrations/enrichment/shodan.py
@@ -5,7 +5,25 @@ from typing import Annotated, Any
 
 import shodan
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
+
+shodan_secret = RegistrySecret(name="shodan", keys=["SHODAN_API_KEY"])
+"""Shodan secret.
+
+Secret
+------
+- name: `shodan`
+- keys:
+    - `SHODAN_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["SHODAN_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.shodan.SHODAN_API_KEY }}
+"""
 
 
 def create_shodan_client():
@@ -21,7 +39,7 @@ def create_shodan_client():
     description="Analyze a URL using Shodan.",
     display_group="Shodan",
     namespace="integrations.shodan",
-    secrets=["shodan"],
+    secrets=[shodan_secret],
 )
 async def analyze_url(
     url: Annotated[str, Field(..., description="The URL to analyze")],
@@ -42,7 +60,7 @@ async def analyze_url(
     description="Analyze an IP address using Shodan.",
     display_group="Shodan",
     namespace="integrations.shodan",
-    secrets=["shodan"],
+    secrets=[shodan_secret],
 )
 async def analyze_ip_address(
     ip_address: Annotated[str, Field(..., description="The IP address to analyze")],

--- a/tracecat/actions/integrations/enrichment/urlscan.py
+++ b/tracecat/actions/integrations/enrichment/urlscan.py
@@ -27,9 +27,27 @@ from typing import Annotated, Any, Literal
 import httpx
 from tenacity import retry, stop_after_delay, wait_combine, wait_fixed
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 URLSCAN_BASE_URL = "https://urlscan.io/api/"
+
+urlscan_secret = RegistrySecret(name="urlscan", keys=["URLSCAN_API_KEY"])
+"""URLScan secret.
+
+Secret
+------
+- name: `urlscan`
+- keys:
+    - `URLSCAN_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["URLSCAN_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.urlscan.URLSCAN_API_KEY }}
+"""
 
 
 def create_urlscan_client() -> httpx.AsyncClient:
@@ -52,7 +70,7 @@ async def _get_scan_result(scan_id: str) -> dict[str, Any]:
     description="Get the scan result from URLScan by scan ID.",
     display_group="URLScan",
     namespace="integrations.urlscan",
-    secrets=["urlscan"],
+    secrets=[urlscan_secret],
 )
 async def get_scan_result(
     scan_id: Annotated[
@@ -68,7 +86,7 @@ async def get_scan_result(
     description="Analyze a URL using URLScan.",
     display_group="URLScan",
     namespace="integrations.urlscan",
-    secrets=["urlscan"],
+    secrets=[urlscan_secret],
 )
 async def analyze_url(
     url: Annotated[str, Field(..., description="The URL to analyze")],

--- a/tracecat/actions/integrations/enrichment/virustotal.py
+++ b/tracecat/actions/integrations/enrichment/virustotal.py
@@ -36,9 +36,27 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 VT_BASE_URL = "https://www.virustotal.com/api/"
+
+virustotal_secret = RegistrySecret(name="virustotal", keys=["VIRUSTOTAL_API_KEY"])
+"""VirusTotal secret.
+
+Secret
+------
+- name: `virustotal`
+- keys:
+    - `VIRUSTOTAL_API_KEY`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["VIRUSTOTAL_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.virustotal.VIRUSTOTAL_API_KEY }}
+"""
 
 
 def create_virustotal_client() -> httpx.AsyncClient:
@@ -57,7 +75,7 @@ def create_virustotal_client() -> httpx.AsyncClient:
     description="Analyze a URL using VirusTotal.",
     display_group="VirusTotal",
     namespace="integrations.virustotal",
-    secrets=["virustotal"],
+    secrets=[virustotal_secret],
 )
 async def analyze_url(
     url: Annotated[str, Field(..., description="The URL to analyze")],
@@ -74,7 +92,7 @@ async def analyze_url(
     description="Analyze an IP address using VirusTotal.",
     display_group="VirusTotal",
     namespace="integrations.virustotal",
-    secrets=["virustotal"],
+    secrets=[virustotal_secret],
 )
 async def analyze_ip_address(
     ip_address: Annotated[str, Field(..., description="The IP address to analyze")],
@@ -90,7 +108,7 @@ async def analyze_ip_address(
     description="Analyze a malware sample using VirusTotal.",
     display_group="VirusTotal",
     namespace="integrations.virustotal",
-    secrets=["virustotal"],
+    secrets=[virustotal_secret],
 )
 async def analyze_malware_sample(
     file_hash: Annotated[

--- a/tracecat/actions/integrations/siem/datadog.py
+++ b/tracecat/actions/integrations/siem/datadog.py
@@ -32,7 +32,7 @@ from typing import Annotated, Any
 import httpx
 from fastapi.exceptions import HTTPException
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
 
 DD_REGION_TO_API_URL = {
     "us1": "https://api.datadoghq.com/api",
@@ -42,13 +42,36 @@ DD_REGION_TO_API_URL = {
     "ap1": "https://api.ap1.datadoghq.com/api",
 }
 
+datadog_secret = RegistrySecret(
+    name="datadog",
+    keys=["DD_APP_KEY", "DD_API_KEY", "DD_REGION"],
+)
+"""Datadog secret.
+
+Secret
+------
+- name: `datadog`
+- keys:
+    - `DD_APP_KEY`
+    - `DD_API_KEY`
+    - `DD_REGION`
+
+Example Usage
+-------------
+Environment variables:
+>>> os.environ["DD_APP_KEY"]
+
+Expression:
+>>> ${{ SECRETS.datadog.DD_APP_KEY }}
+"""
+
 
 @registry.register(
     default_title="List Datadog SIEM alerts",
     description="Fetch Datadog SIEM alerts (signals) and filter by time range.",
     display_group="Datadog",
     namespace="integrations.datadog",
-    secrets=["datadog"],
+    secrets=[datadog_secret],
 )
 async def list_datadog_alerts(
     start_time: Annotated[

--- a/tracecat/actions/integrations/siem/elastic.py
+++ b/tracecat/actions/integrations/siem/elastic.py
@@ -24,7 +24,29 @@ from typing import Annotated, Any
 
 import httpx
 
-from tracecat.registry import Field, registry
+from tracecat.registry import Field, RegistrySecret, registry
+
+elastic_secret = RegistrySecret(
+    name="elastic",
+    keys=["ELASTIC_API_KEY", "ELASTIC_API_URL"],
+)
+"""Elastic secret.
+
+Secret
+------
+- name: `elastic`
+- keys:
+    - `ELASTIC_API_KEY`
+    - `ELASTIC_API_URL`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["ELASTIC_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.elastic.ELASTIC_API_KEY }}
+"""
 
 
 @registry.register(
@@ -32,7 +54,7 @@ from tracecat.registry import Field, registry
     description="Fetch all alerts from Elastic Security and filter by time range.",
     display_group="Elastic",
     namespace="integrations.elastic",
-    secrets=["elastic"],
+    secrets=[elastic_secret],
 )
 async def list_elastic_alerts(
     start_time: Annotated[

--- a/tracecat/types/secrets.py
+++ b/tracecat/types/secrets.py
@@ -1,6 +1,12 @@
-from typing import Self
+from typing import Annotated, Self
 
-from pydantic import BaseModel, ConfigDict, SecretStr
+from pydantic import BaseModel, ConfigDict, SecretStr, StringConstraints
+
+SecretName = Annotated[str, StringConstraints(pattern=r"[a-z0-9_]+")]
+"""Validator for a secret name. e.g. 'aws_access_key_id'"""
+
+SecretKey = Annotated[str, StringConstraints(pattern=r"[a-zA-Z0-9_]+")]
+"""Validator for a secret key. e.g. 'access_key_id'"""
 
 
 class SecretKeyValue(BaseModel):


### PR DESCRIPTION
# Features
- Implement and use `RegistrySecret` in place of a `list[str]` for registry secrets
- Add `SecretName` and `SecretKey` patterns for runtime pattern validation
- Add docstrings with example usage

# Impact
- ⁠Single source of truth for what secrets are required
- ⁠⁠Solves documentation: colocates it directly with the UDF, and is easier to automate updating docs
- ⁠⁠Declarative and obvious to the user
- ⁠⁠Better for validation as it’s all contained in the udf registry, no need to parse the actual funciton body to look for env vars
- Enforce secret name and key patterns

# Screens
<img width="596" alt="Screenshot 2024-06-29 at 17 02 34" src="https://github.com/TracecatHQ/tracecat/assets/5508348/de98a8fc-f15b-482a-8889-fbacb54a400d">

