### PR TITLE
feat(engine): More input validation

### DIFF
--- a/cli/tracecat_cli/workflow.py
+++ b/cli/tracecat_cli/workflow.py
@@ -151,7 +151,7 @@ def _commit_workflow(yaml_path: Path, workflow_id: str):
             rich.print(f"Successfully committed to workflow {workflow_id!r}!")
     except httpx.HTTPStatusError as e:
         rich.print(f"[red]Failed to commit to workflow {workflow_id!r}![/red]")
-        rich.print(e.response.json())
+        rich.print(orjson.dumps(e.response.json(), option=orjson.OPT_INDENT_2).decode())
 
 
 def _run_workflow(

--- a/playbooks/alert_management/aws-guardduty-to-cases.yml
+++ b/playbooks/alert_management/aws-guardduty-to-cases.yml
@@ -2,7 +2,8 @@ title: Open cases for GuardDuty findings
 description: |
   Pulls GuardDuty findings from AWS and opens cases.
   Also sends a message if no findings available.
-entrypoint: pull_aws_guardduty_findings
+entrypoint:
+  ref: pull_aws_guardduty_findings
 triggers:
   - type: webhook
     ref: guardduty_findings_webhook

--- a/playbooks/alert_management/aws-guardduty-to-slack.yml
+++ b/playbooks/alert_management/aws-guardduty-to-slack.yml
@@ -2,7 +2,8 @@ title: Send Slack notifications for GuardDuty findings
 description: |
   Pulls GuardDuty findings from AWS and sends them to Slack.
   Also sends a message if no findings available.
-entrypoint: pull_aws_guardduty_findings
+entrypoint:
+  ref: pull_aws_guardduty_findings
 triggers:
   - type: webhook
     ref: guardduty_findings_webhook

--- a/playbooks/alert_management/crowdstrike-to-cases-no-slack.yml
+++ b/playbooks/alert_management/crowdstrike-to-cases-no-slack.yml
@@ -22,7 +22,13 @@ config:
   # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
   # runtime configuration for this flag i.e. tracecat workflow run --test flag).
   enable_runtime_tests: true
-entrypoint: pull_crowdstrike_alerts
+
+entrypoint:
+  ref: pull_crowdstrike_alerts
+  expects:
+    start_time: str
+    end_time: str
+
 triggers:
   - type: webhook
     ref: crowdstrike_alerts_webhook
@@ -48,7 +54,7 @@ actions:
         payload:
           rule: ${{ var.alert.id }} # Identifier associated with the alert
           severity: ${{ var.alert.severity }} # Severity level associated with the detection
-        status: ${{ 'closed' if FN.equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
+        status: ${{ 'closed' if FN.is_equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
         malice: ${{ 'malicious' if FN.greater_than(var.alert.severity, 0) else 'benign' }} # Determines malice based on severity
         action: quarantine
         context:

--- a/playbooks/alert_management/crowdstrike-to-cases.yml
+++ b/playbooks/alert_management/crowdstrike-to-cases.yml
@@ -25,7 +25,8 @@ config:
   # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
   # runtime configuration for this flag i.e. tracecat workflow run --test flag).
   enable_runtime_tests: true
-entrypoint: pull_crowdstrike_alerts
+entrypoint:
+  ref: pull_crowdstrike_alerts
 triggers:
   - type: webhook
     ref: crowdstrike_alerts_webhook
@@ -51,7 +52,7 @@ actions:
         payload:
           rule: ${{ var.alert.id }} # Identifier associated with the alert
           severity: ${{ var.alert.severity }} # Severity level associated with the detection
-        status: ${{ 'closed' if FN.equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
+        status: ${{ 'closed' if FN.is_equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
         malice: ${{ 'malicious' if FN.greater_than(var.alert.severity, 0) else 'benign' }} # Determines malice based on severity
         action: quarantine
         context:

--- a/playbooks/alert_management/datadog-extract-email-to-slack.yml
+++ b/playbooks/alert_management/datadog-extract-email-to-slack.yml
@@ -3,7 +3,8 @@ description: |
   Pulls Datadog SIEM signals (alerts), extracts emails contains within the signal,
   finds Slack users associated with the emails, and tags the Slack users in a notification.
   Requires `datadog` and `slack` secrets.
-entrypoint: pull_datadog_signals
+entrypoint:
+  ref: pull_datadog_signals
 inputs:
   dd_region: us5
   dd_api_url: https://api.us5.datadoghq.com

--- a/playbooks/alert_management/datadog-to-cases.yml
+++ b/playbooks/alert_management/datadog-to-cases.yml
@@ -3,7 +3,8 @@ description: |
   This playbook pulls Datadog signals, sends them to Slack and
   opens cases in Tracecat's case management system.
 
-entrypoint: pull_datadog_signals
+entrypoint:
+  ref: pull_datadog_signals
 inputs:
   dd_region: us5
   dd_api_url: https://api.us5.datadoghq.com

--- a/playbooks/alert_management/sentinel-one-to-slack.yml
+++ b/playbooks/alert_management/sentinel-one-to-slack.yml
@@ -2,7 +2,8 @@ title: Send Slack notifications for SentinelOne alerts
 description: |
   Pulls SentinelOne alerts and sends them to Slack.
   Also sends a message if no alerts available.
-entrypoint: pull_sentinelone_alerts
+entrypoint:
+  ref: pull_sentinelone_alerts
 triggers:
   - type: webhook
     ref: sentinelone_alerts_webhook

--- a/playbooks/alert_management/slack-to-crowdstrike-update.yml
+++ b/playbooks/alert_management/slack-to-crowdstrike-update.yml
@@ -4,7 +4,8 @@ description: |
   `alert_ids` and `status` provided in the Slack action payload.
 config:
   enable_runtime_tests: true
-entrypoint: extract_slack_payload
+entrypoint:
+  ref: extract_slack_payload
 triggers:
   - type: webhook
     ref: slack_actions_webhook

--- a/playbooks/alert_management/slack-to-sentinel-one-update.yml
+++ b/playbooks/alert_management/slack-to-sentinel-one-update.yml
@@ -2,7 +2,8 @@ title: Update SentinelOne alerts via Slack
 description: |
   Receives a Slack action and updates SentinelOne alerts based on
   `alert_ids` and `status` provided in the Slack action payload.
-entrypoint: extract_slack_payload
+entrypoint:
+  ref: extract_slack_payload
 triggers:
   - type: webhook
     ref: slack_actions_webhook
@@ -12,7 +13,7 @@ actions:
   - ref: extract_slack_payload
     action: core.transform.forward
     # Check if action received is as expected
-    run_if: ${{ FN.equal(TRIGGER.action.action_id, 'update_sentinelone_alert') }}
+    run_if: ${{ FN.is_equal(TRIGGER.action.action_id, 'update_sentinelone_alert') }}
     args:
       value:
         username: ${{ TRIGGER.user.username }}

--- a/playbooks/enrichment/triage-using-llms.yml
+++ b/playbooks/enrichment/triage-using-llms.yml
@@ -3,7 +3,8 @@ description: |
   Given a security alert, this playbook extracts URLs and IP addresses from the alert
   enriches them using VirusTotal, and provides triage advice for further investigation.
 
-entrypoint: enrich_iocs
+entrypoint:
+  ref: receive_alert
 triggers:
   - type: webhook
     ref: alert_webhook

--- a/playbooks/threat_intel/virustotal-to-email.yml
+++ b/playbooks/threat_intel/virustotal-to-email.yml
@@ -1,7 +1,8 @@
 title: Send Virustotal report to email using the builtin integration
 description: Scan a malicious hash on Virustotal and send the results to an email address
 
-entrypoint: call_virustotal
+entrypoint:
+  ref: call_virustotal
 triggers:
   - type: webhook
     ref: virustotal_webhook

--- a/tests/data/workflows/integration_core_ai_action.yml
+++ b/tests/data/workflows/integration_core_ai_action.yml
@@ -2,7 +2,8 @@ title: Core AI Action Integration Test
 description: |
   Test that the core.ai_action UDF works as expected.
   Requires `openai.OPENAI_API_KEY` secret.
-entrypoint: tell_me_something_intereesting
+entrypoint:
+  ref: tell_me_something_intereesting
 inputs:
   prompt: "Please tell me something interesting"
 

--- a/tests/data/workflows/integration_io_linear_http.yml
+++ b/tests/data/workflows/integration_io_linear_http.yml
@@ -2,7 +2,8 @@ title: Send Slack notifications for GuardDuty findings
 description: Tests that we can wait on external IO.
 config:
   scheduler: dynamic
-entrypoint: pull_aws_guardduty_findings
+entrypoint:
+  ref: pull_aws_guardduty_findings
 inputs:
   uim_url: http://host.docker.internal:8005
   num_days: 1

--- a/tests/data/workflows/integration_webhook_concat.yml
+++ b/tests/data/workflows/integration_webhook_concat.yml
@@ -3,7 +3,8 @@ title: Concat tree Workflow with webhook
 #    /\
 #   B  c
 description: Use this for testing webhook correctness
-entrypoint: a
+entrypoint:
+  ref: a
 
 triggers:
   - type: webhook

--- a/tests/data/workflows/playbook_virustotal_email.yml
+++ b/tests/data/workflows/playbook_virustotal_email.yml
@@ -1,7 +1,8 @@
 title: Send Virustotal report to email
 description: Scan a malicious hash on Virustotal and send the results to an email address
 
-entrypoint: call_virustotal
+entrypoint:
+  ref: call_virustotal
 triggers:
   - type: webhook
     ref: my_webhook

--- a/tests/data/workflows/shared_adder_tree.yml
+++ b/tests/data/workflows/shared_adder_tree.yml
@@ -7,7 +7,8 @@ title: Adder tree Workflow
 description: Tests correctness, templates + type casting, context passing.
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: "http://api:8000"
   value: 1

--- a/tests/data/workflows/shared_kite.yml
+++ b/tests/data/workflows/shared_kite.yml
@@ -4,7 +4,8 @@ config:
   # Static -> node execution order is fixed, less performant
   # Dynamic -> node execution order is not fixed
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: "http://api:8000"
   value: 1

--- a/tests/data/workflows/shared_tree.yml
+++ b/tests/data/workflows/shared_tree.yml
@@ -7,7 +7,8 @@ title: Tree Workflow
 description: Mainly tests correctness, templates, and context passing
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: "http://api:8000"
   value: 1

--- a/tests/data/workflows/stress_adder_tree.yml
+++ b/tests/data/workflows/stress_adder_tree.yml
@@ -7,7 +7,8 @@ title: Adder tree Workflow
 description: Use this for stress testing the workflow engine.
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   value: 1
 

--- a/tests/data/workflows/unit_conditional_adder_diamond_skip_with_join_strong_dep_fails.yml
+++ b/tests/data/workflows/unit_conditional_adder_diamond_skip_with_join_strong_dep_fails.yml
@@ -15,7 +15,8 @@ description: |
   - D fails
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: http://api:8000
   value: 1

--- a/tests/data/workflows/unit_conditional_adder_diamond_skip_with_join_weak_dep.yml
+++ b/tests/data/workflows/unit_conditional_adder_diamond_skip_with_join_weak_dep.yml
@@ -15,7 +15,8 @@ description: |
   - D still runs
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: http://api:8000
   value: 1

--- a/tests/data/workflows/unit_conditional_adder_tree_continues.yml
+++ b/tests/data/workflows/unit_conditional_adder_tree_continues.yml
@@ -5,7 +5,8 @@ title: Adder tree continues
 description: Test that the condition returns true and C runs
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: http://api:8000
   value: 1

--- a/tests/data/workflows/unit_conditional_adder_tree_skip_propagates.yml
+++ b/tests/data/workflows/unit_conditional_adder_tree_skip_propagates.yml
@@ -7,7 +7,8 @@ title: Adder tree skips with propagation
 description: Test that the condition returns false and C, D does not run
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: http://api:8000
   value: 1

--- a/tests/data/workflows/unit_conditional_adder_tree_skips.yml
+++ b/tests/data/workflows/unit_conditional_adder_tree_skips.yml
@@ -5,7 +5,8 @@ title: Adder tree skips
 description: Test that the condition returns false and C does not run
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: http://api:8000
   value: 1

--- a/tests/data/workflows/unit_error_fatal.yml
+++ b/tests/data/workflows/unit_error_fatal.yml
@@ -1,0 +1,39 @@
+title: Fatal error Workflow
+#    A
+#    |
+#    B
+description: Use this to test error handling
+config:
+  scheduler: dynamic
+entrypoint:
+  ref: a
+  # Expect a json object
+  expects:
+    value: int
+    another_invalid: str
+    invalid: int
+
+inputs:
+  invalid: 1
+  value:
+    another_invalid: ${{ACTIONS.a.result -> int}}
+
+triggers:
+  - type: webhook
+    ref: my_webhook
+    entrypoint: a # This can be any
+
+actions:
+  - ref: a
+    action: core.transform.forward
+    args:
+      # This will throw because no result is available
+      value: ${{ INPUTS.invalid }}
+
+  - ref: b
+    action: example.add
+    args:
+      lhs: ${{ ACTIONS.a.result -> int }}
+      rhs: ${{ INPUTS.value.another_invalid }}
+    depends_on:
+      - a

--- a/tests/data/workflows/unit_ordering_kite.yml
+++ b/tests/data/workflows/unit_ordering_kite.yml
@@ -2,7 +2,8 @@ title: Test kite order
 description: Tests execution order correctness
 config:
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: "http://api:8000"
   value: 1

--- a/tests/data/workflows/unit_ordering_kite2.yml
+++ b/tests/data/workflows/unit_ordering_kite2.yml
@@ -4,7 +4,8 @@ config:
   # Static -> node execution order is fixed, less performant
   # Dynamic -> node execution order is not fixed
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: "http://api:8000"
   value: 1
@@ -13,7 +14,7 @@ triggers:
   - type: webhook
     ref: my_webhook
     id: wh-XXXXXX
-    entrypoint: a # This can be any
+
     args:
       url: http://api:8000/test/items/1
       method: GET

--- a/tests/data/workflows/unit_runtime_test_adder_tree.yml
+++ b/tests/data/workflows/unit_runtime_test_adder_tree.yml
@@ -5,7 +5,8 @@ title: Adder tree Workflow with runtime tests
 description: |
   Tests correctness, templates + type casting, context passing, tests.
   B gets overridden by a test, but C's override is disabled.
-entrypoint: a
+entrypoint:
+  ref: a
 actions:
   - ref: a
     action: core.transform.forward

--- a/tests/data/workflows/unit_runtime_test_chain.yml
+++ b/tests/data/workflows/unit_runtime_test_chain.yml
@@ -3,7 +3,8 @@ title: Forward chain with runtime tests
 description: |
   Tests correctness, templates + type casting, context passing, tests.
   A and C get overridden by tests
-entrypoint: a
+entrypoint:
+  ref: a
 actions:
   - ref: a
     action: core.transform.forward

--- a/tests/data/workflows/unit_secrets.yml
+++ b/tests/data/workflows/unit_secrets.yml
@@ -4,7 +4,8 @@ config:
   # Static -> node execution order is fixed, less performant
   # Dynamic -> node execution order is not fixed
   scheduler: dynamic
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   another_url: "http://api:8000"
   value: 1

--- a/tests/data/workflows/unit_transform_forwarder_arrange.yml
+++ b/tests/data/workflows/unit_transform_forwarder_arrange.yml
@@ -1,6 +1,7 @@
 title: Reshape data
 description: Test that we can use a forwarder to reshape data
-entrypoint: flatten
+entrypoint:
+  ref: flatten
 inputs:
   details:
     name: John Doe

--- a/tests/data/workflows/unit_transform_forwarder_arrange_loop.yml
+++ b/tests/data/workflows/unit_transform_forwarder_arrange_loop.yml
@@ -1,6 +1,7 @@
 title: Reshape data in a loop
 description: Test that we can use a forwarder to reshape data from a list of mappings to a list of key-value pairs
-entrypoint: flatten
+entrypoint:
+  ref: flatten
 inputs:
   contacts:
     - name: John Doe

--- a/tests/data/workflows/unit_transform_forwarder_loop.yml
+++ b/tests/data/workflows/unit_transform_forwarder_loop.yml
@@ -1,6 +1,7 @@
 title: Forwarder loop
 description: Test that we can loop
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   first: 1
   second: 2

--- a/tests/data/workflows/unit_transform_forwarder_loop_chained.yml
+++ b/tests/data/workflows/unit_transform_forwarder_loop_chained.yml
@@ -1,6 +1,7 @@
 title: Chained forwarder loop
 description: Test that we can chain for loops back to back
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   first: 1
   second: 2

--- a/tests/data/workflows/unit_transform_forwarder_map_loop.yml
+++ b/tests/data/workflows/unit_transform_forwarder_map_loop.yml
@@ -1,6 +1,7 @@
 title: Forwarder with map in loop
 description: Test that we can loop and map inside
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   nested:
     - ["user_1", "user_2", "user_3"]

--- a/tests/data/workflows/unit_transform_forwarder_zip.yml
+++ b/tests/data/workflows/unit_transform_forwarder_zip.yml
@@ -1,6 +1,7 @@
 title: Forwarder loop with a list of iterables (zip)
 description: Test that we can loop
-entrypoint: a
+entrypoint:
+  ref: a
 inputs:
   first: 1
   second: 2

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -24,7 +24,7 @@ from tracecat.expressions.visitors import ExprEvaluatorVisitor
 from tracecat.expressions.visitors.validator import ExprValidationContext
 from tracecat.types.exceptions import TracecatExpressionError
 from tracecat.types.secrets import SecretKeyValue
-from tracecat.types.validation import ValidationResult
+from tracecat.types.validation import ExprValidationResult
 from tracecat.validation import default_validator_visitor
 
 
@@ -546,14 +546,14 @@ def test_expression_parser(expr, expected):
 
 
 def assert_validation_result(
-    res: ValidationResult,
+    res: ExprValidationResult,
     *,
     type: ExprType,
     status: Literal["success", "error"],
     contains_msg: str | None = None,
     contains_detail: str | None = None,
 ):
-    assert res.type == type
+    assert res.exprssion_type == type
     assert res.status == status
     if contains_msg:
         assert contains_msg in res.msg
@@ -670,7 +670,7 @@ def assert_validation_result(
                 {
                     "type": ExprType.INPUT,
                     "status": "error",
-                    "contains_msg": "'invalid'",
+                    "contains_msg": "invalid",
                 },
             ],
         ),

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -1,20 +1,20 @@
 from pydantic import BaseModel
 
-from tracecat.dsl.common import ActionStatement, DSLInput
+from tracecat.dsl.common import ActionStatement, DSLEntrypoint, DSLInput
 from tracecat.dsl.graph import RFGraph, TriggerNode
 
 
 class TestMetadata(BaseModel):
     title: str
     description: str
-    entrypoint: str
+    entrypoint: DSLEntrypoint
     trigger: TriggerNode
 
 
 metadata = TestMetadata(
     title="TEST_WORKFLOW",
     description="TEST_DESCRIPTION",
-    entrypoint="action_a",
+    entrypoint={"ref": "action_a"},
     trigger={
         "id": "trigger-TEST_WORKFLOW_ID",
         "type": "trigger",

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -1,0 +1,45 @@
+from tracecat.expressions.functions import eval_jsonpath
+from tracecat.parse import traverse_leaves
+
+
+def test_iter_dict_leaves():
+    # Test case 1: Nested dictionary
+    obj1 = d = {
+        "a": {"b": {"c": 1}, "d": 2},
+        "e": 3,
+        "f": [{"g": 4}, {"h": 5}],
+        "i": [6, 7],
+    }
+    expected1 = [
+        ("a.b.c", 1),
+        ("a.d", 2),
+        ("e", 3),
+        ("f[0].g", 4),
+        ("f[1].h", 5),
+        ("i[0]", 6),
+        ("i[1]", 7),
+    ]
+    actual = list(traverse_leaves(obj1))
+    assert actual == expected1
+
+    # Test that the jsonpath expressions are valid
+    for path, expected_value in actual:
+        actual_value = eval_jsonpath(path, d)
+        assert actual_value == expected_value
+
+
+def test_more_iter_dict_leaves():
+    # Test case 2: Empty dictionary
+    obj2 = {}
+    expected2 = []
+    assert list(traverse_leaves(obj2)) == expected2
+
+    # Test case 3: Dictionary with empty values
+    obj3 = {"a": {}, "b": {"c": {}}, "d": []}
+    expected3 = []
+    assert list(traverse_leaves(obj3)) == expected3
+
+    # Test case 4: Dictionary with non-dict values
+    obj4 = {"a": 1, "b": [2, 3], "c": "hello"}
+    expected4 = [("a", 1), ("b[0]", 2), ("b[1]", 3), ("c", "hello")]
+    assert list(traverse_leaves(obj4)) == expected4

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -784,10 +784,10 @@ async def commit_workflow(
                 return CommitWorkflowResponse(
                     workflow_id=workflow_id,
                     status="failure",
-                    message=f"{len(val_errors)} validation errors",
+                    message=f"{len(val_errors)} validation error(s)",
                     errors=[
-                        UDFArgsValidationResponse.from_validation_result(e)
-                        for e in val_errors
+                        UDFArgsValidationResponse.from_validation_result(val_res)
+                        for val_res in val_errors
                     ],
                     metadata={"filename": yaml_file.filename} if yaml_file else None,
                 ).to_orjson(status.HTTP_400_BAD_REQUEST)

--- a/tracecat/db/converters.py
+++ b/tracecat/db/converters.py
@@ -23,7 +23,11 @@ def workflow_to_dsl(workflow: Workflow) -> DSLInput:
     return DSLInput(
         title=workflow.title,
         description=workflow.description,
-        entrypoint=graph.logical_entrypoint.ref,
+        entrypoint={
+            "ref": graph.logical_entrypoint.ref,
+            # TODO: Add expects for UI -> DSL
+            "expects": {},
+        },
         actions=graph.action_statements(workflow),
         # config=workflow.config,
         # triggers=workflow.triggers,
@@ -67,7 +71,7 @@ def dsl_to_graph(workflow: Workflow, dsl: DSLInput) -> RFGraph:
                 src_key = identifiers.action.key(wf_id, src_ref)
                 edges.append(RFEdge(source=src_key, target=dst_key))
 
-        entrypoint_id = identifiers.action.key(wf_id, dsl.entrypoint)
+        entrypoint_id = identifiers.action.key(wf_id, dsl.entrypoint.ref)
         # Add trigger edge
         edges.append(
             RFEdge(source=trigger.id, target=entrypoint_id, label="⚡ Trigger")

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -154,7 +154,7 @@ class DSLInput(BaseModel):
 
     title: str
     description: str
-    entrypoint = DSLEntrypoint
+    entrypoint: DSLEntrypoint
     actions: list[ActionStatement]
     config: DSLConfig = Field(default_factory=DSLConfig)
     triggers: list[Trigger] = Field(default_factory=list)

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -136,6 +136,11 @@ def resolve_string_or_uri(string_or_uri: str) -> Any:
         return string_or_uri
 
 
+class DSLEntrypoint(BaseModel):
+    ref: str = Field(..., description="The entrypoint action ref")
+    expects: dict[str, Any] = Field(default_factory=dict, description="Expected input")
+
+
 class DSLInput(BaseModel):
     """DSL definition for a workflow.
 
@@ -149,7 +154,7 @@ class DSLInput(BaseModel):
 
     title: str
     description: str
-    entrypoint: str = Field(..., description="The entrypoint action ref")
+    entrypoint = DSLEntrypoint
     actions: list[ActionStatement]
     config: DSLConfig = Field(default_factory=DSLConfig)
     triggers: list[Trigger] = Field(default_factory=list)
@@ -193,7 +198,7 @@ class DSLInput(BaseModel):
         if len({action.ref for action in self.actions}) != len(self.actions):
             raise TracecatDSLError("All task.ref must be unique")
         valid_actions = tuple(action.ref for action in self.actions)
-        if self.entrypoint not in valid_actions:
+        if self.entrypoint.ref not in valid_actions:
             raise TracecatDSLError(
                 f"Entrypoint must be one of the actions {valid_actions!r}"
             )

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -137,7 +137,7 @@ class DSLScheduler:
 
     async def dynamic_start(self) -> None:
         """Run the scheduler in dynamic mode."""
-        self.queue.put_nowait(self.dsl.entrypoint)
+        self.queue.put_nowait(self.dsl.entrypoint.ref)
         while not self.queue.empty() or len(self.completed_tasks) < len(self.tasks):
             try:
                 task_ref = await asyncio.wait_for(

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -1,6 +1,5 @@
 import base64
 import itertools
-import json
 import operator
 import re
 from collections.abc import Callable
@@ -9,6 +8,7 @@ from functools import wraps
 from typing import Any, ParamSpec, TypeVar
 
 import jsonpath_ng
+import orjson
 from jsonpath_ng.exceptions import JsonPathParserError
 
 from tracecat.expressions.validators import is_iterable
@@ -92,8 +92,8 @@ _FUNCTION_MAPPING = {
     "not": lambda a: not a,
     # Type conversion
     # Convert JSON to string
-    "serialize_json": json.dumps,
-    "deserialize_json": json.loads,
+    "serialize_json": lambda x: orjson.dumps(x).decode(),
+    "deserialize_json": lambda x: orjson.loads(x),
     # Convert timestamp to datetime
     "from_timestamp": lambda x, unit,: _from_timestamp(x, unit),
     # Base64

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -132,9 +132,9 @@ def cast(x: Any, typename: str) -> Any:
 
 
 def eval_jsonpath(expr: str, operand: dict[str, Any]) -> Any:
-    if operand is None or not isinstance(operand, dict):
+    if operand is None or not isinstance(operand, dict | list):
         raise TracecatExpressionError(
-            "A dict-type operand is required for templated jsonpath."
+            "A dict or list operand is required for templated jsonpath."
         )
     try:
         # Try to evaluate the expression

--- a/tracecat/parse.py
+++ b/tracecat/parse.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -44,3 +45,20 @@ def parse_child_webhook(
         "path": path,
         "secret": secret,
     }
+
+
+def traverse_leaves(obj: Any, parent_key: str = "") -> Iterator[tuple[str, Any]]:
+    """Iterate through the leaves of a nested dictionary.
+
+    Each iterations returns the location (jsonpath) and the value.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            new_key = f"{parent_key}.{key}" if parent_key else key
+            yield from traverse_leaves(value, new_key)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            new_key = f"{parent_key}[{i}]"
+            yield from traverse_leaves(item, new_key)
+    else:
+        yield parent_key, obj

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from typing import Any, Literal
 
 from fastapi.responses import ORJSONResponse
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from tracecat import identifiers
 from tracecat.db.schemas import ActionRun, Resource, Schedule, WorkflowRun
@@ -349,8 +349,16 @@ class UDFArgsValidationResponse(BaseModel):
         )
 
     @staticmethod
-    def from_validation_exc(exc: TracecatValidationError):
+    def from_dsl_validation_error(exc: TracecatValidationError):
         return UDFArgsValidationResponse(ok=False, message=str(exc), detail=exc.detail)
+
+    @staticmethod
+    def from_pydantic_validation_error(exc: ValidationError):
+        return UDFArgsValidationResponse(
+            ok=False,
+            message=f"Schema validation error: {exc.title}",
+            detail=exc.errors(),
+        )
 
 
 class CommitWorkflowResponse(BaseModel):

--- a/tracecat/types/exceptions.py
+++ b/tracecat/types/exceptions.py
@@ -11,6 +11,10 @@ through FastAPI exception handlers, which match the exception type.
 class TracecatException(Exception):
     """Tracecat generic user-facing exception"""
 
+    def __init__(self, *args, detail=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.detail = detail
+
 
 class TracecatValidationError(TracecatException):
     """Tracecat user-facting validation error"""

--- a/tracecat/types/validation.py
+++ b/tracecat/types/validation.py
@@ -22,7 +22,7 @@ class RegistryValidationResult(ValidationResult):
 class ExprValidationResult(ValidationResult):
     """Result of visiting an expression node."""
 
-    type: ExprType
+    exprssion_type: ExprType
 
 
 class SecretValidationResult(ValidationResult):

--- a/tracecat/validation.py
+++ b/tracecat/validation.py
@@ -23,7 +23,7 @@ Advanced
 
 ## INPUTS
 Note that static inputs are defined at the top of the file
-[ ] Check that there are no templated expressions in the inputs
+[x] Check that there are no templated expressions in the inputs
 [x] Check that input expressions are all valid (i.e. attempt to evaluate it, since it's static)
  - for now, performing checks on static inputs are redundant as they can be evlauted immediately
 


### PR DESCRIPTION
# Features
- Validate `INPUTS` context
    - Check that any `INPUTS` context invocation matches what's been defined in the `inputs` top level key
    - Ensure that `inputs` don't contain templates, as these are static inputs.
- Adjust `DSLInput.entrypoint` API
    - Add `entrypoint.expects` to allow the user to define a schema to which the trigger input must conform
    - Move `entrypoint` to `entrypoint.ref`
    
e.g.
old
```yaml
entrypoint: my_action
```
new
```yaml
entrypoint:
    ref: my_action
    expects: <WIP>
    ...
```
# Changes
- Update all playbooks to reflect new `entrypoint` top level key shape
    
    
# Tests
- All unit tests passing
    