### PR TITLE
feat: Update Datadog extract emails to slack playbook + add new transform actions

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,12 +8,16 @@ services:
     volumes:
       - ./tracecat:/app/tracecat
       - core-app:/var/lib/tracecat
+    environment:
+      DUMP_TRACECAT_RESULT: 1
 
   worker:
     build: .
     volumes:
       - ./tracecat:/app/tracecat
       - core-app:/var/lib/tracecat
+    environment:
+      DUMP_TRACECAT_RESULT: 1
 
   ui:
     build:

--- a/playbooks/alert_management/aws-guardduty-to-slack.yml
+++ b/playbooks/alert_management/aws-guardduty-to-slack.yml
@@ -29,7 +29,7 @@ actions:
       - pull_aws_guardduty_findings
     run_if: ${{ FN.is_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
     args:
-      url: ${{ SECRETS.slack_chatops.SLACK_WEBHOOK }}
+      url: ${{ SECRETS.slack.SLACK_WEBHOOK }}
       method: POST
       headers:
         Content-Type: application/json
@@ -67,7 +67,7 @@ actions:
     # Assign each SMAC finding to a variable named `smac`
     for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
     args:
-      channel: ${{ SECRETS.slack_chatops.SLACK_CHANNEL }}
+      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
       text: GuardDuty findings
       blocks:
         - type: header

--- a/playbooks/alert_management/datadog-extract-email-to-slack.yml
+++ b/playbooks/alert_management/datadog-extract-email-to-slack.yml
@@ -5,6 +5,10 @@ description: |
   Requires `datadog` and `slack` secrets.
 entrypoint:
   ref: pull_datadog_signals
+  expects:
+    start_time: datetime
+    end_time: datetime
+
 inputs:
   dd_region: us5
   dd_api_url: https://api.us5.datadoghq.com
@@ -12,7 +16,7 @@ inputs:
 triggers:
   - type: webhook
     ref: datadog_webhook
-    entrypoint: pull_datadog_siem_signals
+    entrypoint: pull_datadog_signals
 
 actions:
   - ref: pull_datadog_signals
@@ -22,12 +26,32 @@ actions:
       end_time: ${{ TRIGGER.end_time }}
       limit: 10
 
+  - ref: no_signals_message
+    action: integrations.chat.slack.post_slack_message
+    depends_on:
+      - pull_datadog_signals
+    run_if: ${{ FN.is_empty(ACTIONS.pull_datadog_signals.result) }}
+    args:
+      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+      text: No Datadog signals found
+      blocks:
+        - type: header
+          text:
+            type: plain_text
+            text: No Datadog signals found
+            emoji: true
+        - type: section
+          text:
+            type: mrkdwn
+            text: No signals between ${{ TRIGGER.start_time }} and ${{ TRIGGER.end_time }}.
+
   - ref: reshape_signals
+    # Reshape incoming signals into a list of flat json objects
     action: core.transform.forward
     depends_on:
-      - pull_datadog_siem_signals
-    run_if: ${{ FN.not_empty(ACTIONS.pull_datadog_siem_signals.result) }}
-    for_each: ${{ for var.signal in ACTIONS.pull_datadog_siem_signals.result }}
+      - pull_datadog_signals
+    run_if: ${{ FN.not_empty(ACTIONS.pull_datadog_signals.result) }}
+    for_each: ${{ for var.signal in ACTIONS.pull_datadog_signals.result }}
     args:
       value:
         title: ${{ var.signal.attributes.attributes.title }}
@@ -36,44 +60,98 @@ actions:
         first_seen: ${{ var.signal.attributes.attributes.workflow.first_seen }}
         last_seen: ${{ var.signal.attributes.attributes.workflow.last_seen }}
         samples: ${{ var.signal.attributes.attributes.samples }}
-        link_to_signal: ${{ INPUTS.dd_api_url }}/security?event=${{ var.signal.EventID }}
+        link_to_signal: ${{ INPUTS.dd_api_url }}/security?event=${{ var.signal.id }}
+    # Returns: list[signal]
+    # Each signal can produce multiple emails
+    # We need to associate each email back to the signal
 
-  - ref: extract_emails
-    # Returns a list of list of emails per alert
+  - ref: extract_emails_from_signals
     action: core.extraction.extract_emails
     depends_on:
       - reshape_signals
+    # Iterate over the list[signal]
     for_each: ${{ for var.signal in ACTIONS.reshape_signals.result }}
     args:
-      text: ${{ FN.serialize_json(var.signal.samples) }}
+      texts: ${{ FN.serialize_json.map(var.signal.samples) }}
+      normalize: true # user+test@domain -> user@domain
+    # Returns: list[list[email]]
 
-  - ref: find_slack_users
-    # Returns a list of list of Slack users per alert
-    action: integrations.slack.find_slack_users
-    depends_on:
-      - extract_emails
-    for_each: ${{ for var.emails in ACTIONS.extract_emails.result }}
-    args:
-      emails: ${{ var.emails }}
-
-  - ref: extract_slack_user_ids
-    # Returns a list of list of Slack user IDs per alert
+  - ref: enrich_with_emails
     action: core.transform.forward
     depends_on:
-      - find_slack_users
-    for_each: ${{ for var.user_ids in ACTIONS.find_slack_users.result }}
+      - extract_emails_from_signals
+    for_each: # Zip the signals with the emails
+      - ${{ for var.signal in ACTIONS.reshape_signals.result }}
+      - ${{ for var.email_list in ACTIONS.extract_emails_from_signals.result }}
     args:
-      tags: ${{ FN.format.map('<@{}>', var.user_ids) }}
+      value:
+        signal: ${{ var.signal }}
+        emails: ${{ FN.unique(var.email_list) }} # Internal order doesn't matter
+
+  - ref: drop_signals_with_empty_emails
+    action: core.transform.filter
+    depends_on:
+      - enrich_with_emails
+    args:
+      # Filter out only relevant emails
+      items: ${{ ACTIONS.enrich_with_emails.result }}
+      constraint:
+        jsonpath: $.emails
+        function: not_empty
+    # Returns: list[slack_user]h
+
+  - ref: find_slack_users
+    action: integrations.chat.slack.list_slack_users
+    depends_on:
+      - drop_signals_with_empty_emails
+    args:
+      # Filter out only relevant emails
+      emails: ${{ FN.flatten(ACTIONS.extract_emails_from_signals.result) }}
+    # Returns: list[slack_user]
+
+  - ref: slack_user_mapping
+    action: core.transform.build_reference_table
+    depends_on:
+      - find_slack_users
+    args:
+      items: ${{ ACTIONS.find_slack_users.result }}
+      key: $.profile.email
+    # Returns a mapping of email to slack_user object at ACTIONS.slack_user_mapping.result
+
+  - ref: enrich_with_slack_info
+    action: core.transform.forward
+    depends_on:
+      - drop_signals_with_empty_emails
+      - slack_user_mapping
+    for_each:
+      - ${{ for var.combined in ACTIONS.drop_signals_with_empty_emails.result }}
+    args:
+      value:
+        signal: ${{ var.combined.signal }}
+        emails: ${{ var.combined.emails }}
+        # Lookup the slack user ref table with a list of emails
+        slack_info: ${{ FN.lookup.map(ACTIONS.slack_user_mapping.result, var.combined.emails) }}
+
+  # Need to get the user ids from the slack users
+  - ref: extract_slack_tags
+    action: core.transform.forward
+    depends_on:
+      - enrich_with_slack_info
+    # This is now a list[slack_user]
+    for_each: ${{ for var.enriched_signal in ACTIONS.enrich_with_slack_info.result }}
+    args:
+      # Use jsonpath to pull the id fields as a list of ids
+      value: ${{ FN.format.map('<@{}>', var.enriched_signal.slack_info[*].id) }}
 
   - ref: send_slack_notification
     action: integrations.chat.slack.post_slack_message
     depends_on:
-      - find_slack_users
-      - reshape_signals
+      - extract_slack_tags
+      - enrich_with_slack_info
     run_if: ${{ FN.not_empty(ACTIONS.find_slack_users.result) }}
     for_each:
-      - ${{ for var.signal in ACTIONS.reshape_signals.result }}
-      - ${{ for var.user_ids in ACTIONS.extract_slack_user_ids.result }}
+      - ${{ for var.enriched_signal in ACTIONS.enrich_with_slack_info.result }}
+      - ${{ for var.user_tags in ACTIONS.extract_slack_tags.result }}
     args:
       channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
       text: Datadog alerts
@@ -81,28 +159,28 @@ actions:
         - type: header
           text:
             type: plain_text
-            text: ${{ var.signal.title }}
+            text: ${{ var.enriched_signal.signal.title }}
             emoji: true
         - type: context
           elements:
             - type: plain_text
-              text: "*Link to signal:* ${{ var.signal.link_to_signal }}"
+              text: "*Link to signal:* ${{ var.enriched_signal.signal.link_to_signal }}"
         # Tag Slack users
         - type: context
           elements:
             - type: plain_text
-              text: "*Tagged users:* ${{ var.user_ids.tags }}"
+              text: "*Tagged users:* ${{ FN.join(var.user_tags, ', ') }}"
         - type: context
           elements:
             - type: plain_text
-              text: "*Status:* ${{ var.signal.status }}"
+              text: "*Status:* ${{ var.enriched_signal.signal.status }}"
         - type: context
           elements:
             - type: plain_text
-              text: "*First seen:* ${{ FN.from_timestamp(var.signal.first_seen, 'ms') }}"
+              text: "*First seen:* ${{ FN.from_timestamp(var.enriched_signal.signal.first_seen, 'ms') }}"
             - type: plain_text
-              text: "*Last seen:* ${{ FN.from_timestamp(var.signal.last_seen, 'ms') }}"
+              text: "*Last seen:* ${{ FN.from_timestamp(var.enriched_signal.signal.last_seen, 'ms') }}"
         - type: section
           text:
             type: mrkdwn
-            text: ${{ var.signal.description }}
+            text: ${{ var.enriched_signal.signal.description }}

--- a/tests/data/workflows/integration_send_slack.yml
+++ b/tests/data/workflows/integration_send_slack.yml
@@ -16,7 +16,7 @@ actions:
   - ref: send_slack_notifications
     action: integrations.chat.slack.post_slack_message
     args:
-      channel: ${{ SECRETS.slack_chatops.SLACK_CHANNEL }}
+      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
       text: Integration Test
       blocks:
         - type: header

--- a/tests/data/workflows/unit_transform_filter_dict.yml
+++ b/tests/data/workflows/unit_transform_filter_dict.yml
@@ -1,0 +1,28 @@
+title: Reshape data
+description: Test that we can use a forwarder to reshape data
+entrypoint:
+  ref: filter_empty
+inputs: #2D list
+  matrix:
+    - signal: a
+      data: [1, 2, 3]
+    - signal: b
+      data: [4, 5, 6]
+    - signal: c
+      data: []
+    - signal: d
+      data: [7, 8, 9]
+    - signal: e
+      data: [10, 11, 12]
+    - signal: f
+      data: []
+
+actions:
+  - ref: filter_empty
+    action: core.transform.filter
+    args:
+      # List of objects to filter
+      items: ${{ INPUTS.matrix }}
+      constraint:
+        jsonpath: $.data
+        function: not_empty

--- a/tests/data/workflows/unit_transform_filter_dict_expected.yml
+++ b/tests/data/workflows/unit_transform_filter_dict_expected.yml
@@ -1,0 +1,28 @@
+ACTIONS:
+  filter_empty:
+    result:
+      - signal: a
+        data: [1, 2, 3]
+      - signal: b
+        data: [4, 5, 6]
+      - signal: d
+        data: [7, 8, 9]
+      - signal: e
+        data: [10, 11, 12]
+    result_typename: list
+
+INPUTS:
+  matrix:
+    - signal: a
+      data: [1, 2, 3]
+    - signal: b
+      data: [4, 5, 6]
+    - signal: c
+      data: []
+    - signal: d
+      data: [7, 8, 9]
+    - signal: e
+      data: [10, 11, 12]
+    - signal: f
+      data: []
+TRIGGER:

--- a/tests/data/workflows/unit_transform_filter_function.yml
+++ b/tests/data/workflows/unit_transform_filter_function.yml
@@ -1,0 +1,18 @@
+title: Reshape data
+description: Test that we can use a forwarder to reshape data
+entrypoint:
+  ref: filter_empty
+inputs: #2D list
+  matrix:
+    - [1, 2, 3]
+    - [4, 5, 6]
+    - []
+    - [7, 8, 9]
+    - [10, 11, 12]
+    - []
+
+actions:
+  - ref: filter_empty
+    action: core.transform.forward
+    args:
+      value: ${{ FN.filter(INPUTS.matrix, 'len(x) > 0') }}

--- a/tests/data/workflows/unit_transform_filter_function_expected.yml
+++ b/tests/data/workflows/unit_transform_filter_function_expected.yml
@@ -1,0 +1,14 @@
+ACTIONS:
+  filter_empty:
+    result: [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
+    result_typename: list
+
+INPUTS:
+  matrix:
+    - [1, 2, 3]
+    - [4, 5, 6]
+    - []
+    - [7, 8, 9]
+    - [10, 11, 12]
+    - []
+TRIGGER:

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -399,6 +399,10 @@ def test_eval_templated_object_inline_fails_if_not_str():
                 "Hello, Charlie! You are happy.",
             ],
         ),
+        (
+            "FN.flatten([[1, 2, 3], [4, 5, 6], [7, 8, 9]])",
+            [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        ),
         # Ternary expressions
         (
             "'It contains 1' if FN.contains(1, INPUTS.list) else 'it does not contain 1'",
@@ -438,6 +442,7 @@ def test_eval_templated_object_inline_fails_if_not_str():
         ("INPUTS.people[*].age", [30, 40, 50]),
         ("INPUTS.people[*].name", ["Alice", "Bob", "Charlie"]),
         ("INPUTS.people[*].gender", ["female", "male"]),
+        ('INPUTS.["user@tracecat.com"].name', "Bob"),
         # Combination
         ("'a' if FN.is_equal(var.y, '100') else 'b'", "a"),
         ("'a' if var.y == '100' else 'b'", "a"),
@@ -493,6 +498,9 @@ def test_expression_parser(expr, expected):
                     "age": 50,
                 },
             ],
+            "user@tracecat.com": {
+                "name": "Bob",
+            },
         },
         ExprContext.ENV: {
             "item": "ITEM",

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -62,8 +62,11 @@ def test_eval_jsonpath():
     assert eval_jsonpath("$.webhook.data.name", operand) == "John"
     assert eval_jsonpath("$.webhook.data.age", operand) == 30
     with pytest.raises(TracecatExpressionError) as e:
-        _ = eval_jsonpath("$.webhook.data.nonexistent", operand) is None
+        _ = eval_jsonpath("$.webhook.data.nonexistent", operand=operand, strict=True)
         assert "Operand has no path" in str(e.value)
+    assert (
+        eval_jsonpath("$.webhook.data.nonexistent", operand=operand, strict=False) == []
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -444,7 +444,7 @@ def test_eval_templated_object_inline_fails_if_not_str():
         ("INPUTS.people[*].age", [30, 40, 50]),
         ("INPUTS.people[*].name", ["Alice", "Bob", "Charlie"]),
         ("INPUTS.people[*].gender", ["female", "male"]),
-        ('INPUTS.["user@tracecat.com"].name', "Bob"),
+        # ('INPUTS.["user@tracecat.com"].name', "Bob"), TODO: Add support for object key indexing
         # Combination
         ("'a' if FN.is_equal(var.y, '100') else 'b'", "a"),
         ("'a' if var.y == '100' else 'b'", "a"),

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,0 +1,60 @@
+import pytest
+
+from tracecat.expressions.functions import lambda_filter
+
+
+def test_lambda_filter_success():
+    items = [1, 2, 3, 4, 5, 6, 7]
+
+    expr = "x > 2"
+    assert lambda_filter(items, expr) == [3, 4, 5, 6, 7]
+
+    expr = "x > 2 and x < 6"
+    assert lambda_filter(items, expr) == [3, 4, 5]
+
+    expr = "x in [1,2,3]"
+    assert lambda_filter(items, expr) == [1, 2, 3]
+
+    listoflists = [[1, 2, 3], [4, 5, 6, 7, 8, 9], [10, 11], []]
+
+    expr = "2 in x or 11 in x"
+    assert lambda_filter(listoflists, expr) == [[1, 2, 3], [10, 11]]
+
+    expr = "len(x) > 0"
+    assert lambda_filter(listoflists, expr) == [[1, 2, 3], [4, 5, 6, 7, 8, 9], [10, 11]]
+
+    expr = "len(x) < 3"
+    assert lambda_filter(listoflists, expr) == [[10, 11], []]
+
+    strlist = ["test@tracecat.com", "user@tracecat.com", "user@other.com"]
+    expr = "'tracecat.com' in x"
+    assert lambda_filter(strlist, expr) == ["test@tracecat.com", "user@tracecat.com"]
+
+
+def test_lambda_filter_fails():
+    items = [1, 2, 3, 4, 5, 6, 7]
+    with pytest.raises(ValueError):
+        lambda_filter(items, "sum(x)")
+
+    listoflists = [[1, 2, 3], [4, 5, 6, 7, 8, 9], [10, 11], []]
+    with pytest.raises(ValueError):
+        lambda_filter(listoflists, "sum(x) > 1")
+
+    with pytest.raises(ValueError):
+        lambda_filter(items, "x + 1")
+    with pytest.raises(ValueError):
+        lambda_filter(items, "y + 1")
+    with pytest.raises(ValueError):
+        lambda_filter(items, "y > 1")
+
+    with pytest.raises(ValueError):
+        lambda_filter(items, "x > 2 and x < 6 and x + 1")
+
+    with pytest.raises(ValueError):
+        lambda_filter(items, "lambda x: x > 2")
+
+    with pytest.raises(ValueError):
+        lambda_filter(items, "eval()")
+
+    with pytest.raises(ValueError):
+        lambda_filter(items, "import os")

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -230,6 +230,8 @@ correctness_test_cases = [
     "unit_conditional_adder_tree_continues",
     "unit_conditional_adder_tree_skip_propagates",
     "unit_conditional_adder_diamond_skip_with_join_weak_dep",
+    "unit_transform_filter",
+    "unit_transform_filter_dict",
     "unit_transform_forwarder_loop",
     "unit_transform_forwarder_loop_chained",
     "unit_transform_forwarder_arrange",
@@ -238,6 +240,7 @@ correctness_test_cases = [
     "unit_transform_forwarder_map_loop",
     "unit_runtime_test_adder_tree",
     "unit_runtime_test_chain",
+    "unit_transform_filter",
 ]
 
 
@@ -269,7 +272,13 @@ async def test_workflow_completes_and_correct(
             DSLRunArgs(dsl=dsl, role=ctx_role.get(), wf_id=TEST_WF_ID),
             id=wf_exec_id,
             task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-            retry_policy=RetryPolicy(maximum_attempts=1),
+            retry_policy=RetryPolicy(
+                maximum_attempts=1,
+                non_retryable_error_types=[
+                    "tracecat.types.exceptions.TracecatExpressionError"
+                    "TracecatValidationError"
+                ],
+            ),
         )
     assert result == expected
 

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -230,8 +230,6 @@ correctness_test_cases = [
     "unit_conditional_adder_tree_continues",
     "unit_conditional_adder_tree_skip_propagates",
     "unit_conditional_adder_diamond_skip_with_join_weak_dep",
-    "unit_transform_filter",
-    "unit_transform_filter_dict",
     "unit_transform_forwarder_loop",
     "unit_transform_forwarder_loop_chained",
     "unit_transform_forwarder_arrange",
@@ -240,7 +238,8 @@ correctness_test_cases = [
     "unit_transform_forwarder_map_loop",
     "unit_runtime_test_adder_tree",
     "unit_runtime_test_chain",
-    "unit_transform_filter",
+    "unit_transform_filter_dict",
+    "unit_transform_filter_function",
 ]
 
 

--- a/tracecat/actions/core/transform.py
+++ b/tracecat/actions/core/transform.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from tracecat.expressions.functions import custom_filter
 from tracecat.registry import registry
 
 
@@ -20,3 +21,28 @@ def forward(
     value: Annotated[Any, Field(..., description="The value to forward")],
 ) -> Any:
     return value
+
+
+@registry.register(
+    namespace="core.transform",
+    version="0.1.0",
+    description="Filter a collection based on a condition.",
+    default_title="Filter",
+    display_group="Data Transform",
+)
+def filter(
+    items: Annotated[list[Any], Field(..., description="A collection of items.")],
+    constraint: Annotated[
+        str | list[Any],
+        Field(
+            ...,
+            description=(
+                "A constraint to filter the collection."
+                "If a list is provided, it will be used as a set filter."
+                "If a string is provided, it will be evaluated as a restricted conditional expression."
+                " Container items are refereneced by `x` e.g. 'x > 2 and x < 6'"
+            ),
+        ),
+    ],
+) -> Any:
+    return custom_filter(items, constraint)

--- a/tracecat/actions/integrations/chat/slack.py
+++ b/tracecat/actions/integrations/chat/slack.py
@@ -39,10 +39,10 @@ from slack_sdk.web.async_client import AsyncWebClient
 from tracecat.registry import Field, RegistrySecret, registry
 from tracecat.types.exceptions import TracecatCredentialsError
 
-slack_chatops_secret = RegistrySecret(name="slack_chatops", keys=["SLACK_BOT_TOKEN"])
-"""Slack ChatOps secret.
+slack_secret = RegistrySecret(name="slack", keys=["SLACK_BOT_TOKEN"])
+"""Slack secret.
 
-- name: `slack_chatops`
+- name: `slack`
 - keys:
     - `SLACK_BOT_TOKEN`
 """
@@ -54,7 +54,7 @@ slack_chatops_secret = RegistrySecret(name="slack_chatops", keys=["SLACK_BOT_TOK
     description="Send Slack message to channel.",
     display_group="ChatOps",
     namespace="integrations.chat.slack",
-    secrets=[slack_chatops_secret],
+    secrets=[slack_secret],
 )
 async def post_slack_message(
     channel: Annotated[
@@ -84,7 +84,7 @@ async def post_slack_message(
     description="Fetch Slack users by team ID or list of emails.",
     display_group="ChatOps",
     namespace="integrations.chat.slack",
-    secrets=[slack_chatops_secret],
+    secrets=[slack_secret],
 )
 async def list_slack_users(
     team_id: Annotated[

--- a/tracecat/actions/integrations/chat/slack.py
+++ b/tracecat/actions/integrations/chat/slack.py
@@ -107,6 +107,6 @@ async def list_slack_users(
 
     if emails:
         # Filter for users with matching email
-        users = [user for user in users if user["profile"]["email"] in emails]
-
+        filter_by = set(emails)
+        users = [user for user in users if user["profile"].get("email") in filter_by]
     return users

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -24,6 +24,8 @@ TRACECAT__DB_URI = os.environ.get(
 TRACECAT__TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
 TRACECAT__TRIAGE_DIR = TRACECAT_DIR / "triage"
 TRACECAT__TRIAGE_DIR.mkdir(parents=True, exist_ok=True)
+TRACECAT__EXECUTIONS_DIR = TRACECAT_DIR / "executions"
+TRACECAT__EXECUTIONS_DIR.mkdir(parents=True, exist_ok=True)
 
 # TODO: Set this as an environment variable
 TRACECAT__SERVICE_ROLES_WHITELIST = ["tracecat-runner", "tracecat-api", "tracecat-cli"]

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -85,6 +85,15 @@ class DSLInput(BaseModel):
         invalid_refs = {t.ref for t in self.tests} - valid_actions
         if invalid_refs:
             raise TracecatDSLError(f"Invalid action refs in tests: {invalid_refs}")
+
+        # Validate that all the refs in depends_on are valid actions
+        dependencies = {dep for a in self.actions for dep in a.depends_on}
+        invalid_deps = dependencies - valid_actions
+        if invalid_deps:
+            raise TracecatDSLError(
+                f"Invalid depends_on refs in actions: {invalid_deps}."
+                f" Valid actions: {valid_actions}"
+            )
         return self
 
     @field_validator("inputs")

--- a/tracecat/dsl/dispatcher.py
+++ b/tracecat/dsl/dispatcher.py
@@ -41,10 +41,8 @@ async def dispatch_workflow(
     )
     # Write result to file for debugging
     if os.getenv("DUMP_TRACECAT_RESULT", "0") in ("1", "true"):
-        from pathlib import Path
-
-        path = Path(os.getenv("TRACECAT_DIR")) / f"{wf_exec_id}.json"
-        path.touch(mode=0o666)
+        path = config.TRACECAT__EXECUTIONS_DIR / f"{wf_exec_id}.json"
+        path.touch()
         with path.open("w") as f:
             json.dump(result, f, indent=2)
     else:

--- a/tracecat/dsl/dispatcher.py
+++ b/tracecat/dsl/dispatcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -38,5 +39,14 @@ async def dispatch_workflow(
         task_queue=config.TEMPORAL__CLUSTER_QUEUE,
         **kwargs,
     )
-    logger.debug(f"Workflow result:\n{json.dumps(result, indent=2)}")
+    # Write result to file for debugging
+    if os.getenv("DUMP_TRACECAT_RESULT", "0") in ("1", "true"):
+        from pathlib import Path
+
+        path = Path(os.getenv("TRACECAT_DIR")) / f"{wf_exec_id}.json"
+        path.touch(mode=0o666)
+        with path.open("w") as f:
+            json.dump(result, f, indent=2)
+    else:
+        logger.debug(f"Workflow result:\n{json.dumps(result, indent=2)}")
     return DispatchResult(wf_id=wf_id, final_context=result)

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -216,6 +216,8 @@ class DSLWorkflow:
         await self.scheduler.start()
 
         self.logger.info("DSL workflow completed")
+        # XXX: Don't return ENV context for now
+        self.context.pop(ExprContext.ENV, None)
         return self.context
 
     async def execute_task(self, task: ActionStatement) -> None:

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -154,7 +154,11 @@ def _expr_with_context(expr: str, context_type: ExprContext | None) -> str:
 
 
 def eval_jsonpath(
-    expr: str, operand: dict[str, Any], *, context_type: ExprContext | None = None
+    expr: str,
+    operand: dict[str, Any],
+    *,
+    context_type: ExprContext | None = None,
+    strict: bool = False,
 ) -> Any:
     if operand is None or not isinstance(operand, dict | list):
         logger.error("Invalid operand for jsonpath", operand=operand)
@@ -173,7 +177,7 @@ def eval_jsonpath(
     matches = [found.value for found in jsonpath_expr.find(operand)]
     if len(matches) == 1:
         return matches[0]
-    elif len(matches) > 1:
+    if not strict or matches:
         return matches
     else:
         # We know that if this function is called, there was a templated field.

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -6,7 +6,7 @@ import itertools
 import operator
 import re
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import wraps
 from typing import Any, ParamSpec, TypedDict, TypeVar
 
@@ -295,8 +295,10 @@ _FUNCTION_MAPPING = {
     # Convert JSON to string
     "serialize_json": lambda x: orjson.dumps(x).decode(),
     "deserialize_json": lambda x: orjson.loads(x),
-    # Convert timestamp to datetime
+    # Time related
     "from_timestamp": lambda x, unit,: _from_timestamp(x, unit),
+    "now": lambda: datetime.now(),
+    "minutes": lambda minutes: timedelta(minutes=minutes),
     # Base64
     "to_base64": _str_to_b64,
     "from_base64": _b64_to_str,

--- a/tracecat/expressions/parser/evaluator.py
+++ b/tracecat/expressions/parser/evaluator.py
@@ -27,8 +27,9 @@ class TracecatTransformer(Transformer):
 class ExprEvaluator(TracecatTransformer):
     _visitor_name = "ExprEvaluator"
 
-    def __init__(self, context: ExprContextType) -> None:
+    def __init__(self, context: ExprContextType, strict: bool = True) -> None:
         self._context = context
+        self._strict = strict
         self.logger = logger.bind(visitor=self._visitor_name)
 
     @v_args(inline=True)
@@ -98,27 +99,37 @@ class ExprEvaluator(TracecatTransformer):
     @v_args(inline=True)
     def actions(self, jsonpath: str):
         logger.trace("Visiting actions:", args=jsonpath)
-        return functions.eval_jsonpath(ExprContext.ACTIONS + jsonpath, self._context)
+        return functions.eval_jsonpath(
+            ExprContext.ACTIONS + jsonpath, self._context, strict=self._strict
+        )
 
     @v_args(inline=True)
     def secrets(self, jsonpath: str):
         logger.trace("Visiting secrets:", jsonpath=jsonpath)
-        return functions.eval_jsonpath(ExprContext.SECRETS + jsonpath, self._context)
+        return functions.eval_jsonpath(
+            ExprContext.SECRETS + jsonpath, self._context, strict=self._strict
+        )
 
     @v_args(inline=True)
     def inputs(self, jsonpath: str):
         logger.trace("Visiting inputs:", args=jsonpath)
-        return functions.eval_jsonpath(ExprContext.INPUTS + jsonpath, self._context)
+        return functions.eval_jsonpath(
+            ExprContext.INPUTS + jsonpath, self._context, strict=self._strict
+        )
 
     @v_args(inline=True)
     def env(self, jsonpath: str):
         logger.trace("Visiting env:", args=jsonpath)
-        return functions.eval_jsonpath(ExprContext.ENV + jsonpath, self._context)
+        return functions.eval_jsonpath(
+            ExprContext.ENV + jsonpath, self._context, strict=self._strict
+        )
 
     @v_args(inline=True)
     def local_vars(self, jsonpath: str):
         logger.trace("Visiting local_vars:", args=jsonpath)
-        return functions.eval_jsonpath(ExprContext.LOCAL_VARS + jsonpath, self._context)
+        return functions.eval_jsonpath(
+            ExprContext.LOCAL_VARS + jsonpath, self._context, strict=self._strict
+        )
 
     @v_args(inline=True)
     def local_vars_assignment(self, jsonpath: str):
@@ -128,7 +139,9 @@ class ExprEvaluator(TracecatTransformer):
     @v_args(inline=True)
     def trigger(self, jsonpath: str):
         logger.trace("Visiting trigger:", args=jsonpath)
-        return functions.eval_jsonpath(ExprContext.TRIGGER + jsonpath, self._context)
+        return functions.eval_jsonpath(
+            ExprContext.TRIGGER + jsonpath, self._context, strict=self._strict
+        )
 
     @v_args(inline=True)
     def function(self, fn_name: str, fn_args: Sequence[Any]):

--- a/tracecat/expressions/parser/grammar.py
+++ b/tracecat/expressions/parser/grammar.py
@@ -57,7 +57,7 @@ JSONPATH: ( "." CNAME ("[" JSONPATH_INDEX "]")?  )+
 JSONPATH_INDEX: /\d+/ | "*"
 OPERATOR: "+" | "-" | "*" | "/" | "%" | "==" | "!=" | ">" | "<" | ">=" | "<=" | "&&" | "||" | "in"
 TYPE_SPECIFIER: "int" | "float" | "str" | "bool"
-STRING_LITERAL: /'[^']*'/
+STRING_LITERAL: /'(?:[^'\\]|\\.)*'/ | /"(?:[^"\\]|\\.)*"/
 BOOL_LITERAL: "True" | "False"
 NUMERIC_LITERAL: /\d+(\.\d+)?/
 NONE_LITERAL: "None"

--- a/tracecat/expressions/parser/validator.py
+++ b/tracecat/expressions/parser/validator.py
@@ -36,11 +36,14 @@ class ExprValidator(Visitor):
         task_group: GatheringTaskGroup,
         validation_context: ExprValidationContext,
         validators: dict[ExprType, Awaitable[ExprValidationResult]] | None = None,
+        *,
+        strict: bool = True,
     ) -> None:
         self._task_group = task_group
         # Contextual information
         self._context = validation_context
         self._results: list[ExprValidationResult] = []
+        self._strict = strict
 
         # External validators
         self._validators = validators or {}
@@ -145,7 +148,10 @@ class ExprValidator(Visitor):
         self.logger.trace("Visit input expression", jsonpath=jsonpath)
         try:
             functions.eval_jsonpath(
-                jsonpath, self._context.inputs_context, context_type=ExprContext.INPUTS
+                jsonpath,
+                self._context.inputs_context,
+                context_type=ExprContext.INPUTS,
+                strict=self._strict,
             )
             self.add(status="success", type=ExprType.INPUT)
         except TracecatExpressionError as e:

--- a/tracecat/expressions/parser/validator.py
+++ b/tracecat/expressions/parser/validator.py
@@ -101,6 +101,7 @@ class ExprValidator(Visitor):
     def actions(self, node: Tree):
         self.logger.trace("Visit action expression", expr=node)
         jsonpath = node.children[0].lstrip(".")
+        # ACTIONS.<ref>.<prop> [INDEX] [ATTRIBUTE ACCESS]
         ref, prop, *_ = jsonpath.split(".")
         if ref not in self._context.action_refs:
             self.add(
@@ -108,12 +109,14 @@ class ExprValidator(Visitor):
                 msg=f"Invalid action reference {ref!r} in ACTION expression {jsonpath!r}",
                 type=ExprType.ACTION,
             )
-        elif prop not in DSLNodeResult.__annotations__:
-            valid = list(DSLNodeResult.__annotations__.keys())
+        # Check prop
+        valid_properties = "|".join(DSLNodeResult.__annotations__.keys())
+        pattern = rf"({valid_properties})(\[(\d+|\*)\])?"  # e.g. "result[0], result[*], result"
+        if not re.match(pattern, prop):
             self.add(
                 status="error",
                 msg=f"Invalid property {prop!r} for action reference {ref!r} in ACTION expression {jsonpath!r}."
-                f" Use one of {valid}, e.g. `{ref}.{valid[0]}`",
+                f" Use one of {valid_properties}, e.g. `{ref}.{valid_properties[0]}`",
                 type=ExprType.ACTION,
             )
         else:

--- a/tracecat/expressions/shared.py
+++ b/tracecat/expressions/shared.py
@@ -4,7 +4,12 @@ from enum import StrEnum, auto
 from typing import Any
 
 
-class ExprContext(StrEnum):
+class TracecatEnum(StrEnum):
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class ExprContext(TracecatEnum):
     ACTIONS = "ACTIONS"
     SECRETS = "SECRETS"
     FN = "FN"
@@ -14,7 +19,7 @@ class ExprContext(StrEnum):
     LOCAL_VARS = "var"  # Action-local variables
 
 
-class ExprType(StrEnum):
+class ExprType(TracecatEnum):
     GENERIC = auto()
     ACTION = auto()
     SECRET = auto()
@@ -27,9 +32,6 @@ class ExprType(StrEnum):
     ITERATOR = auto()
     TERNARY = auto()
     TRIGGER = auto()
-
-    def __repr__(self) -> str:
-        return str(self)
 
 
 ExprContextType = dict[ExprContext, Any]

--- a/tracecat/expressions/validation.py
+++ b/tracecat/expressions/validation.py
@@ -14,6 +14,9 @@ def is_full_template(template: str) -> bool:
 def is_iterable(value: Any, *, container_only: bool = True) -> bool:
     try:
         iter(value)
+        if isinstance(value, dict):
+            # We don't consider dictionaries as iterables
+            return False
         if container_only:
             return not isinstance(value, str | bytes)
         return True


### PR DESCRIPTION
# Features
- Add depends_on validity checks
- dd strict flag for eval_jsonpath, defaults to false
- Add custom filter function as action and function expression. 
    - This allows you to do more complex filtering, for example you can express these kinds of filtering semantics: 
        - "filter a collection of items using a jsonpath pointing to a field in this item, and use a function/operator for evaluation/comparison" 
- You can use double quotes for string literals
- Add dump run results to fs for debugging
- New actions
    - `core.transfrom.filter`: wrapper around `custom_filter`
    - `core.transform.build_reference_table`: Allows you to convert a list of objects into a dict, where you choose the key using a jsonpath
- Add time related function expressions: FN.now, FN.minutes
- Add workflow start_time into ENV context

# Changes
- Allow validation to pass for jsonpath array syntax e.g. `path[9]`
- Updated DD playbook
- Rename `slack_chatops` secret back to `slack`


# Testing
- All unit tests passing
- DD emails slack pb working live
