### PR TITLE
build(engine): Replace `polars` with `polars-lts-cpu`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "loguru==0.7.2",
     "openai==1.30.3",
     "orjson==3.10.3",
-    "polars==0.20.21",
+    "polars==1.2.0",
     "psycopg[binary]==3.1.19",
     "psycopg2-binary==2.9.9",
     "pyarrow==16.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "loguru==0.7.2",
     "openai==1.30.3",
     "orjson==3.10.3",
-    "polars==1.2.0",
+    "polars-lts-cpu==1.2.0",
     "psycopg[binary]==3.1.19",
     "psycopg2-binary==2.9.9",
     "pyarrow==16.1.0",
@@ -66,15 +66,15 @@ Repository = "https://github.com/TracecatHQ/tracecat"
 
 [project.optional-dependencies]
 dev = [
-    "respx",
-    "pytest",
-    "python-dotenv",
-    "pytest-asyncio",
-    "pytest-mock==3.14.0",
+    "boto3-stubs[cloudtrail,guardduty,s3]",
     "minio",
     "mypy",
-    "boto3-stubs[cloudtrail,guardduty,s3]",
     "pre-commit",
+    "pytest-asyncio",
+    "pytest-mock",
+    "pytest",
+    "python-dotenv",
+    "respx",
 ]
 
 [tool.hatch.version]

--- a/tracecat/actions/etl/extraction/email.py
+++ b/tracecat/actions/etl/extraction/email.py
@@ -4,16 +4,9 @@ import itertools
 import re
 from typing import Annotated
 
-import polars as pl
-
 from tracecat.registry import Field, registry
 
 EMAIL_REGEX = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
-
-
-def pl_extract_emails(texts: pl.Expr) -> pl.Expr:
-    """Extract emails from a column of strings in Polars."""
-    return texts.str.extract_all(EMAIL_REGEX)
 
 
 def normalize_email_address(email: str) -> str:


### PR DESCRIPTION
Fixes #246. This sacrifices performance for SIMD heavy queries. But we have yet to fully leverage polars ETL in Tracecat (yet). Will push this temporary fix first.

## Future direction
- Build two images: one with `polars` and another with `polars-lts-cpu`
- Create docker compose extension for users without AVX