### PR TITLE
feat: Implement child workflow core functionality

### DIFF
--- a/frontend/src/app/workflows/[workflowId]/executions/event-details.tsx
+++ b/frontend/src/app/workflows/[workflowId]/executions/event-details.tsx
@@ -131,26 +131,28 @@ export function WorkflowExecutionEventDetailView({
         )}
 
         {isUDFActionInput(event.event_group?.action_input) && (
-          <AccordionItem value="execution-context">
-            <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-              <div className="flex items-center">
-                <span>Execution Context</span>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="my-4 flex flex-col space-y-8 px-4">
-                <div className="rounded-md border p-4 shadow-md">
-                  <JsonView
-                    displaySize
-                    enableClipboard
-                    src={event.event_group.action_input.exec_context}
-                    className="text-sm"
-                    theme="atom"
-                  />
+          <>
+            <AccordionItem value="result">
+              <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                <div className="flex items-end">
+                  <span>Input</span>
                 </div>
-              </div>
-            </AccordionContent>
-          </AccordionItem>
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="my-4 flex flex-col space-y-8 px-4">
+                  <div className="rounded-md border p-4 shadow-md">
+                    <JsonView
+                      displaySize
+                      enableClipboard
+                      src={event.event_group.action_input}
+                      className="text-sm"
+                      theme="atom"
+                    />
+                  </div>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </>
         )}
       </Accordion>
     </div>
@@ -261,10 +263,10 @@ export function EventGeneralInfo({ event }: { event: EventHistoryResponse }) {
       </div>
 
       {isUDFActionInput(event_group?.action_input) && (
-        <ActionEvent input={event_group.action_input} />
+        <ActionEventGeneralInfo input={event_group.action_input} />
       )}
       {isDSLRunArgs(event_group?.action_input) && (
-        <ChildWorkflowEvent input={event_group.action_input} />
+        <ChildWorkflowEventGeneralInfo input={event_group.action_input} />
       )}
     </div>
   )
@@ -283,10 +285,12 @@ export function DescriptorBadge({
     </Badge>
   )
 }
-function ChildWorkflowEvent({ input }: { input: DSLRunArgs }) {
+function ChildWorkflowEventGeneralInfo({ input }: { input: DSLRunArgs }) {
   return (
     <div className="space-x-2">
-      <Label className="w-24 text-xs text-muted-foreground">DSL</Label>
+      <Label className="w-24 text-xs text-muted-foreground">
+        Workflow Title
+      </Label>
       <DescriptorBadge
         text={input.dsl.title}
         className="font-mono font-semibold"
@@ -295,7 +299,7 @@ function ChildWorkflowEvent({ input }: { input: DSLRunArgs }) {
   )
 }
 
-function ActionEvent({ input }: { input: UDFActionInput }) {
+function ActionEventGeneralInfo({ input }: { input: UDFActionInput }) {
   return (
     <div>
       <div className="space-x-2">

--- a/frontend/src/app/workflows/[workflowId]/executions/event-details.tsx
+++ b/frontend/src/app/workflows/[workflowId]/executions/event-details.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { EventHistoryResponse } from "@/client"
+import { DSLRunArgs, EventHistoryResponse, UDFActionInput } from "@/client"
 import JsonView from "react18-json-view"
 
 import {
@@ -107,7 +107,30 @@ export function WorkflowExecutionEventDetailView({
           </AccordionItem>
         )}
 
-        {event.event_group?.action_input.exec_context && (
+        {isDSLRunArgs(event.event_group?.action_input) && (
+          <AccordionItem value="result">
+            <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+              <div className="flex items-end">
+                <span>Input</span>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className="my-4 flex flex-col space-y-8 px-4">
+                <div className="rounded-md border p-4 shadow-md">
+                  <JsonView
+                    displaySize
+                    enableClipboard
+                    src={event?.event_group?.action_input}
+                    className="text-sm"
+                    theme="atom"
+                  />
+                </div>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        )}
+
+        {isUDFActionInput(event.event_group?.action_input) && (
           <AccordionItem value="execution-context">
             <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
               <div className="flex items-center">
@@ -120,7 +143,7 @@ export function WorkflowExecutionEventDetailView({
                   <JsonView
                     displaySize
                     enableClipboard
-                    src={event.event_group?.action_input.exec_context}
+                    src={event.event_group.action_input.exec_context}
                     className="text-sm"
                     theme="atom"
                   />
@@ -168,11 +191,19 @@ export function EventGeneralInfo({ event }: { event: EventHistoryResponse }) {
             ERROR_EVENT_TYPES.includes(event.event_type) && "bg-rose-100",
             event.event_type == "WORKFLOW_EXECUTION_STARTED" &&
               "bg-emerald-100",
-            event.event_type == "ACTIVITY_TASK_SCHEDULED" && "bg-amber-100",
-            event.event_type == "ACTIVITY_TASK_STARTED" && "bg-violet-200/70",
-            event.event_type == "ACTIVITY_TASK_COMPLETED" && "bg-sky-200/70",
             event.event_type == "WORKFLOW_EXECUTION_COMPLETED" &&
-              "bg-emerald-200"
+              "bg-emerald-200",
+            event.event_type == "ACTIVITY_TASK_SCHEDULED" && "bg-amber-100",
+            event.event_type == "ACTIVITY_TASK_STARTED" && "bg-sky-200/70",
+            event.event_type == "ACTIVITY_TASK_COMPLETED" && "bg-sky-200/70",
+            event.event_type == "START_CHILD_WORKFLOW_EXECUTION_INITIATED" &&
+              "bg-amber-100",
+            event.event_type == "CHILD_WORKFLOW_EXECUTION_STARTED" &&
+              "bg-violet-200/70",
+            event.event_type == "CHILD_WORKFLOW_EXECUTION_COMPLETED" &&
+              "bg-violet-200/70",
+            event.event_type == "CHILD_WORKFLOW_EXECUTION_FAILED" &&
+              "bg-rose-200"
           )}
         />
       </div>
@@ -228,52 +259,13 @@ export function EventGeneralInfo({ event }: { event: EventHistoryResponse }) {
           </>
         )}
       </div>
-      <div className="space-x-2">
-        {event_group?.action_input.task.depends_on && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">
-              Dependencies
-            </Label>
-            {event_group.action_input.task.depends_on.map((dep) => (
-              <DescriptorBadge
-                key={dep}
-                text={dep}
-                className="font-mono font-semibold"
-              />
-            ))}
-          </>
-        )}
-      </div>
-      <div className="space-x-2">
-        {event_group?.action_input.task.run_if && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">Run If</Label>
-            <DescriptorBadge
-              text={event_group.action_input.task.run_if}
-              className="font-mono font-semibold tracking-tight"
-            />
-          </>
-        )}
-      </div>
-      <div className="space-x-2">
-        {event_group?.action_input.task.for_each && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">
-              For Each
-            </Label>
-            {(Array.isArray(event_group.action_input.task.for_each)
-              ? event_group.action_input.task.for_each
-              : [event_group.action_input.task.for_each ?? []]
-            ).map((dep, index) => (
-              <DescriptorBadge
-                key={`${dep}-${index}`}
-                text={dep}
-                className="font-mono font-semibold"
-              />
-            ))}
-          </>
-        )}
-      </div>
+
+      {isUDFActionInput(event_group?.action_input) && (
+        <ActionEvent input={event_group.action_input} />
+      )}
+      {isDSLRunArgs(event_group?.action_input) && (
+        <ChildWorkflowEvent input={event_group.action_input} />
+      )}
     </div>
   )
 }
@@ -289,5 +281,89 @@ export function DescriptorBadge({
     >
       {text}
     </Badge>
+  )
+}
+function ChildWorkflowEvent({ input }: { input: DSLRunArgs }) {
+  return (
+    <div className="space-x-2">
+      <Label className="w-24 text-xs text-muted-foreground">DSL</Label>
+      <DescriptorBadge
+        text={input.dsl.title}
+        className="font-mono font-semibold"
+      />
+    </div>
+  )
+}
+
+function ActionEvent({ input }: { input: UDFActionInput }) {
+  return (
+    <div>
+      <div className="space-x-2">
+        {input.task.depends_on && (
+          <>
+            <Label className="w-24 text-xs text-muted-foreground">
+              Dependencies
+            </Label>
+            {input.task.depends_on?.map((dep) => (
+              <DescriptorBadge
+                key={dep}
+                text={dep}
+                className="font-mono font-semibold"
+              />
+            ))}
+          </>
+        )}
+      </div>
+      <div className="space-x-2">
+        {input.task.run_if && (
+          <>
+            <Label className="w-24 text-xs text-muted-foreground">Run If</Label>
+            <DescriptorBadge
+              text={input.task.run_if}
+              className="font-mono font-semibold tracking-tight"
+            />
+          </>
+        )}
+      </div>
+      <div className="space-x-2">
+        {input.task.for_each && (
+          <>
+            <Label className="w-24 text-xs text-muted-foreground">
+              For Each
+            </Label>
+            {(Array.isArray(input.task.for_each)
+              ? input.task.for_each
+              : [input.task.for_each ?? []]
+            ).map((dep, index) => (
+              <DescriptorBadge
+                key={`${dep}-${index}`}
+                text={dep}
+                className="font-mono font-semibold"
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function isUDFActionInput(actionInput: unknown): actionInput is UDFActionInput {
+  return (
+    typeof actionInput === "object" &&
+    actionInput !== null &&
+    "task" in actionInput &&
+    typeof (actionInput as UDFActionInput).task === "object"
+  )
+}
+
+function isDSLRunArgs(actionInput: unknown): actionInput is DSLRunArgs {
+  // Define the conditions to check for DSLRunArgs
+  return (
+    typeof actionInput === "object" &&
+    actionInput !== null &&
+    // Check specific properties of DSLRunArgs
+    typeof (actionInput as DSLRunArgs).dsl === "object" &&
+    (actionInput as DSLRunArgs).wf_id !== undefined
   )
 }

--- a/frontend/src/app/workflows/[workflowId]/executions/event-history.tsx
+++ b/frontend/src/app/workflows/[workflowId]/executions/event-history.tsx
@@ -8,6 +8,7 @@ import {
   CircleX,
   GlobeIcon,
   Play,
+  WorkflowIcon,
 } from "lucide-react"
 
 import { useWorkflowExecutionEventHistory } from "@/lib/hooks"
@@ -107,6 +108,13 @@ export function EventDescriptor({
       </span>
     )
   }
+  if (event.event_type.includes("CHILD_WORKFLOW_EXECUTION")) {
+    return (
+      <span className="flex items-center space-x-2 text-xs">
+        <span>{event.event_group?.action_title ?? "Unnamed action"}</span>
+      </span>
+    )
+  }
   return <span className="capitalize">{parseEventType(event.event_type)}</span>
 }
 export function EventHistoryItemIcon({
@@ -142,6 +150,26 @@ function getEventHistoryIcon(
       )
     case "WORKFLOW_EXECUTION_FAILED":
       return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
+    case "START_CHILD_WORKFLOW_EXECUTION_INITIATED":
+      return (
+        <WorkflowIcon
+          className={cn("fill-orange-200/50 stroke-orange-500/70", className)}
+        />
+      )
+    case "CHILD_WORKFLOW_EXECUTION_STARTED":
+      return (
+        <Play
+          className={cn("fill-violet-400/80 stroke-violet-400/80", className)}
+        />
+      )
+    case "CHILD_WORKFLOW_EXECUTION_COMPLETED":
+      return (
+        <CircleCheck
+          className={cn("fill-violet-400/80 stroke-white", className)}
+        />
+      )
+    case "CHILD_WORKFLOW_EXECUTION_FAILED":
+      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
     case "ACTIVITY_TASK_SCHEDULED":
       return (
         <CalendarCheck
@@ -150,9 +178,7 @@ function getEventHistoryIcon(
       )
     case "ACTIVITY_TASK_STARTED":
       return (
-        <Play
-          className={cn("fill-violet-400/80 stroke-violet-400/80", className)}
-        />
+        <Play className={cn("fill-sky-500/80 stroke-sky-500/80", className)} />
       )
     case "ACTIVITY_TASK_COMPLETED":
       return (
@@ -163,6 +189,6 @@ function getEventHistoryIcon(
     case "ACTIVITY_TASK_FAILED":
       return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
     default:
-      throw new Error("Invalid event type")
+      throw new Error(`Invalid event type ${eventType}`)
   }
 }

--- a/frontend/src/app/workflows/[workflowId]/executions/nav.tsx
+++ b/frontend/src/app/workflows/[workflowId]/executions/nav.tsx
@@ -96,7 +96,11 @@ export function WorkflowExecutionNav({
                   <Label className="text-xs text-muted-foreground">
                     End Time
                   </Label>
-                  <span>{new Date(execution.close_time).toLocaleString()}</span>
+                  <span>
+                    {execution.close_time
+                      ? new Date(execution.close_time).toLocaleString()
+                      : "-"}
+                  </span>
                 </div>
               </div>
             </HoverCardContent>

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -172,28 +172,6 @@ export const $ActionTest = {
     title: 'ActionTest'
 } as const;
 
-export const $Body_cases_streaming_autofill_case_fields = {
-    properties: {
-        cases: {
-            items: {
-                '$ref': '#/components/schemas/Case-Input'
-            },
-            type: 'array',
-            title: 'Cases'
-        },
-        fields: {
-            items: {
-                type: 'string'
-            },
-            type: 'array',
-            title: 'Fields'
-        }
-    },
-    type: 'object',
-    required: ['cases', 'fields'],
-    title: 'Body_cases-streaming_autofill_case_fields'
-} as const;
-
 export const $Body_validate_workflow = {
     properties: {
         definition: {
@@ -222,136 +200,6 @@ export const $Body_workflows_commit_workflow = {
     },
     type: 'object',
     title: 'Body_workflows-commit_workflow'
-} as const;
-
-export const $Case_Input = {
-    properties: {
-        id: {
-            type: 'string',
-            title: 'Id'
-        },
-        owner_id: {
-            type: 'string',
-            title: 'Owner Id'
-        },
-        workflow_id: {
-            type: 'string',
-            title: 'Workflow Id'
-        },
-        case_title: {
-            type: 'string',
-            title: 'Case Title'
-        },
-        payload: {
-            type: 'object',
-            title: 'Payload'
-        },
-        malice: {
-            type: 'string',
-            enum: ['malicious', 'benign'],
-            title: 'Malice'
-        },
-        status: {
-            type: 'string',
-            enum: ['open', 'closed', 'in_progress', 'reported', 'escalated'],
-            title: 'Status'
-        },
-        priority: {
-            type: 'string',
-            enum: ['low', 'medium', 'high', 'critical'],
-            title: 'Priority'
-        },
-        action: {
-            type: 'string',
-            enum: ['ignore', 'quarantine', 'informational', 'sinkhole', 'active_compromise'],
-            title: 'Action'
-        },
-        context: {
-            '$ref': '#/components/schemas/ListModel_CaseContext_-Input'
-        },
-        tags: {
-            '$ref': '#/components/schemas/ListModel_Tag_'
-        },
-        created_at: {
-            type: 'string',
-            format: 'date-time',
-            title: 'Created At'
-        },
-        updated_at: {
-            type: 'string',
-            format: 'date-time',
-            title: 'Updated At'
-        }
-    },
-    type: 'object',
-    required: ['owner_id', 'workflow_id', 'case_title', 'payload', 'malice', 'status', 'priority', 'action', 'context', 'tags'],
-    title: 'Case',
-    description: 'Case model used in the API and runner.'
-} as const;
-
-export const $Case_Output = {
-    properties: {
-        id: {
-            type: 'string',
-            title: 'Id'
-        },
-        owner_id: {
-            type: 'string',
-            title: 'Owner Id'
-        },
-        workflow_id: {
-            type: 'string',
-            title: 'Workflow Id'
-        },
-        case_title: {
-            type: 'string',
-            title: 'Case Title'
-        },
-        payload: {
-            type: 'object',
-            title: 'Payload'
-        },
-        malice: {
-            type: 'string',
-            enum: ['malicious', 'benign'],
-            title: 'Malice'
-        },
-        status: {
-            type: 'string',
-            enum: ['open', 'closed', 'in_progress', 'reported', 'escalated'],
-            title: 'Status'
-        },
-        priority: {
-            type: 'string',
-            enum: ['low', 'medium', 'high', 'critical'],
-            title: 'Priority'
-        },
-        action: {
-            type: 'string',
-            enum: ['ignore', 'quarantine', 'informational', 'sinkhole', 'active_compromise'],
-            title: 'Action'
-        },
-        context: {
-            '$ref': '#/components/schemas/ListModel_CaseContext_-Output'
-        },
-        tags: {
-            '$ref': '#/components/schemas/ListModel_Tag_'
-        },
-        created_at: {
-            type: 'string',
-            format: 'date-time',
-            title: 'Created At'
-        },
-        updated_at: {
-            type: 'string',
-            format: 'date-time',
-            title: 'Updated At'
-        }
-    },
-    type: 'object',
-    required: ['owner_id', 'workflow_id', 'case_title', 'payload', 'malice', 'status', 'priority', 'action', 'context', 'tags'],
-    title: 'Case',
-    description: 'Case model used in the API and runner.'
 } as const;
 
 export const $CaseAction = {
@@ -565,66 +413,6 @@ export const $CaseEventParams = {
     title: 'CaseEventParams'
 } as const;
 
-export const $CaseMetrics = {
-    properties: {
-        statues: {
-            items: {
-                additionalProperties: {
-                    anyOf: [
-                        {
-                            type: 'integer'
-                        },
-                        {
-                            type: 'number'
-                        }
-                    ]
-                },
-                type: 'object'
-            },
-            type: 'array',
-            title: 'Statues'
-        },
-        priority: {
-            items: {
-                additionalProperties: {
-                    anyOf: [
-                        {
-                            type: 'integer'
-                        },
-                        {
-                            type: 'number'
-                        }
-                    ]
-                },
-                type: 'object'
-            },
-            type: 'array',
-            title: 'Priority'
-        },
-        malice: {
-            items: {
-                additionalProperties: {
-                    anyOf: [
-                        {
-                            type: 'integer'
-                        },
-                        {
-                            type: 'number'
-                        }
-                    ]
-                },
-                type: 'object'
-            },
-            type: 'array',
-            title: 'Malice'
-        }
-    },
-    type: 'object',
-    required: ['statues', 'priority', 'malice'],
-    title: 'CaseMetrics',
-    description: 'Summary statistics for cases over a time period.'
-} as const;
-
 export const $CaseParams = {
     properties: {
         id: {
@@ -670,21 +458,85 @@ export const $CaseParams = {
             enum: ['low', 'medium', 'high', 'critical'],
             title: 'Priority'
         },
-        context: {
-            '$ref': '#/components/schemas/ListModel_CaseContext_-Input'
-        },
         action: {
             type: 'string',
             enum: ['ignore', 'quarantine', 'informational', 'sinkhole', 'active_compromise'],
             title: 'Action'
+        },
+        context: {
+            '$ref': '#/components/schemas/ListModel_CaseContext_-Input'
         },
         tags: {
             '$ref': '#/components/schemas/ListModel_Tag_'
         }
     },
     type: 'object',
-    required: ['id', 'owner_id', 'created_at', 'updated_at', 'workflow_id', 'case_title', 'payload', 'malice', 'status', 'priority', 'context', 'action', 'tags'],
+    required: ['id', 'owner_id', 'created_at', 'updated_at', 'workflow_id', 'case_title', 'payload', 'malice', 'status', 'priority', 'action', 'context', 'tags'],
     title: 'CaseParams'
+} as const;
+
+export const $CaseResponse = {
+    properties: {
+        id: {
+            type: 'string',
+            title: 'Id'
+        },
+        owner_id: {
+            type: 'string',
+            title: 'Owner Id'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        updated_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Updated At'
+        },
+        workflow_id: {
+            type: 'string',
+            title: 'Workflow Id'
+        },
+        case_title: {
+            type: 'string',
+            title: 'Case Title'
+        },
+        payload: {
+            type: 'object',
+            title: 'Payload'
+        },
+        malice: {
+            type: 'string',
+            enum: ['malicious', 'benign'],
+            title: 'Malice'
+        },
+        status: {
+            type: 'string',
+            enum: ['open', 'closed', 'in_progress', 'reported', 'escalated'],
+            title: 'Status'
+        },
+        priority: {
+            type: 'string',
+            enum: ['low', 'medium', 'high', 'critical'],
+            title: 'Priority'
+        },
+        action: {
+            type: 'string',
+            enum: ['ignore', 'quarantine', 'informational', 'sinkhole', 'active_compromise'],
+            title: 'Action'
+        },
+        context: {
+            '$ref': '#/components/schemas/ListModel_CaseContext_-Output'
+        },
+        tags: {
+            '$ref': '#/components/schemas/ListModel_Tag_'
+        }
+    },
+    type: 'object',
+    required: ['id', 'owner_id', 'created_at', 'updated_at', 'workflow_id', 'case_title', 'payload', 'malice', 'status', 'priority', 'action', 'context', 'tags'],
+    title: 'CaseResponse'
 } as const;
 
 export const $CopyWorkflowParams = {
@@ -927,7 +779,7 @@ export const $CreateWorkflowExecutionResponse = {
         },
         wf_exec_id: {
             type: 'string',
-            pattern: 'wf-[0-9a-f]{32}:exec-[0-9a-f]{32}',
+            pattern: 'wf-[0-9a-f]{32}:exec-[\\w-]+',
             title: 'Wf Exec Id'
         }
     },
@@ -963,6 +815,149 @@ export const $CreateWorkflowParams = {
     },
     type: 'object',
     title: 'CreateWorkflowParams'
+} as const;
+
+export const $DSLConfig = {
+    properties: {
+        scheduler: {
+            type: 'string',
+            enum: ['static', 'dynamic'],
+            title: 'Scheduler',
+            default: 'dynamic'
+        },
+        enable_runtime_tests: {
+            type: 'boolean',
+            title: 'Enable Runtime Tests',
+            description: 'Enable runtime action tests. This is dynamically set on workflow entry.',
+            default: false
+        }
+    },
+    type: 'object',
+    title: 'DSLConfig'
+} as const;
+
+export const $DSLEntrypoint = {
+    properties: {
+        ref: {
+            type: 'string',
+            title: 'Ref',
+            description: 'The entrypoint action ref'
+        },
+        expects: {
+            anyOf: [
+                {},
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expects',
+            description: 'Expected trigger input shape'
+        }
+    },
+    type: 'object',
+    required: ['ref'],
+    title: 'DSLEntrypoint'
+} as const;
+
+export const $DSLInput = {
+    properties: {
+        title: {
+            type: 'string',
+            title: 'Title'
+        },
+        description: {
+            type: 'string',
+            title: 'Description'
+        },
+        entrypoint: {
+            '$ref': '#/components/schemas/DSLEntrypoint'
+        },
+        actions: {
+            items: {
+                '$ref': '#/components/schemas/ActionStatement'
+            },
+            type: 'array',
+            title: 'Actions'
+        },
+        config: {
+            '$ref': '#/components/schemas/DSLConfig'
+        },
+        triggers: {
+            items: {
+                '$ref': '#/components/schemas/Trigger'
+            },
+            type: 'array',
+            title: 'Triggers'
+        },
+        inputs: {
+            type: 'object',
+            title: 'Inputs',
+            description: 'Static input parameters'
+        },
+        tests: {
+            items: {
+                '$ref': '#/components/schemas/ActionTest'
+            },
+            type: 'array',
+            title: 'Tests',
+            description: 'Action tests'
+        }
+    },
+    type: 'object',
+    required: ['title', 'description', 'entrypoint', 'actions'],
+    title: 'DSLInput',
+    description: `DSL definition for a workflow.
+
+The difference between this and a normal workflow engine is that here,
+our workflow execution order is defined by the DSL itself, independent
+of a workflow scheduler.
+
+With a traditional
+This allows the execution of the workflow to be fully deterministic.`
+} as const;
+
+export const $DSLRunArgs = {
+    properties: {
+        role: {
+            '$ref': '#/components/schemas/Role'
+        },
+        dsl: {
+            '$ref': '#/components/schemas/DSLInput'
+        },
+        wf_id: {
+            type: 'string',
+            pattern: 'wf-[0-9a-f]{32}',
+            title: 'Wf Id'
+        },
+        trigger_inputs: {
+            anyOf: [
+                {
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Trigger Inputs'
+        },
+        parent_run_context: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/RunContext'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        },
+        run_config: {
+            type: 'object',
+            title: 'Run Config'
+        }
+    },
+    type: 'object',
+    required: ['role', 'dsl', 'wf_id'],
+    title: 'DSLRunArgs'
 } as const;
 
 export const $EventFailure = {
@@ -1038,7 +1033,15 @@ export const $EventGroup = {
             title: 'Action Description'
         },
         action_input: {
-            '$ref': '#/components/schemas/UDFActionInput'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/UDFActionInput'
+                },
+                {
+                    '$ref': '#/components/schemas/DSLRunArgs'
+                }
+            ],
+            title: 'Action Input'
         },
         action_result: {
             anyOf: [
@@ -1121,7 +1124,7 @@ export const $EventHistoryResponse = {
 
 export const $EventHistoryType = {
     type: 'string',
-    enum: ['WORKFLOW_EXECUTION_STARTED', 'WORKFLOW_EXECUTION_COMPLETED', 'WORKFLOW_EXECUTION_FAILED', 'ACTIVITY_TASK_SCHEDULED', 'ACTIVITY_TASK_STARTED', 'ACTIVITY_TASK_COMPLETED', 'ACTIVITY_TASK_FAILED'],
+    enum: ['WORKFLOW_EXECUTION_STARTED', 'WORKFLOW_EXECUTION_COMPLETED', 'WORKFLOW_EXECUTION_FAILED', 'ACTIVITY_TASK_SCHEDULED', 'ACTIVITY_TASK_STARTED', 'ACTIVITY_TASK_COMPLETED', 'ACTIVITY_TASK_FAILED', 'CHILD_WORKFLOW_EXECUTION_STARTED', 'CHILD_WORKFLOW_EXECUTION_COMPLETED', 'CHILD_WORKFLOW_EXECUTION_FAILED', 'START_CHILD_WORKFLOW_EXECUTION_INITIATED'],
     title: 'EventHistoryType',
     description: 'The event types we care about.'
 } as const;
@@ -1233,7 +1236,7 @@ export const $RunContext = {
             anyOf: [
                 {
                     type: 'string',
-                    pattern: 'wf-[0-9a-f]{32}:exec-[0-9a-f]{32}'
+                    pattern: 'wf-[0-9a-f]{32}:exec-[\\w-]+'
                 },
                 {
                     type: 'string',
@@ -1567,16 +1570,33 @@ export const $Tag = {
         value: {
             type: 'string',
             title: 'Value'
-        },
-        is_ai_generated: {
-            type: 'boolean',
-            title: 'Is Ai Generated',
-            default: false
         }
     },
     type: 'object',
     required: ['tag', 'value'],
     title: 'Tag'
+} as const;
+
+export const $Trigger = {
+    properties: {
+        type: {
+            type: 'string',
+            enum: ['schedule', 'webhook'],
+            title: 'Type'
+        },
+        ref: {
+            type: 'string',
+            pattern: '^[a-z0-9_]+$',
+            title: 'Ref'
+        },
+        args: {
+            type: 'object',
+            title: 'Args'
+        }
+    },
+    type: 'object',
+    required: ['type', 'ref'],
+    title: 'Trigger'
 } as const;
 
 export const $UDFActionInput = {
@@ -2277,8 +2297,15 @@ export const $WorkflowExecutionResponse = {
             description: 'When this workflow run started or should start.'
         },
         close_time: {
-            type: 'string',
-            format: 'date-time',
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Close Time',
             description: 'When the workflow was closed if closed.'
         },
@@ -2301,7 +2328,7 @@ export const $WorkflowExecutionResponse = {
         }
     },
     type: 'object',
-    required: ['id', 'run_id', 'start_time', 'execution_time', 'close_time', 'status', 'workflow_type', 'task_queue', 'history_length'],
+    required: ['id', 'run_id', 'start_time', 'execution_time', 'status', 'workflow_type', 'task_queue', 'history_length'],
     title: 'WorkflowExecutionResponse'
 } as const;
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1039,6 +1039,9 @@ export const $EventGroup = {
                 },
                 {
                     '$ref': '#/components/schemas/DSLRunArgs'
+                },
+                {
+                    '$ref': '#/components/schemas/GetWorkflowDefinitionActivityInputs'
                 }
             ],
             title: 'Action Input'
@@ -1133,6 +1136,42 @@ export const $ExprContext = {
     type: 'string',
     enum: ['ACTIONS', 'SECRETS', 'FN', 'INPUTS', 'ENV', 'TRIGGER', 'var'],
     title: 'ExprContext'
+} as const;
+
+export const $GetWorkflowDefinitionActivityInputs = {
+    properties: {
+        role: {
+            '$ref': '#/components/schemas/Role'
+        },
+        task: {
+            '$ref': '#/components/schemas/ActionStatement'
+        },
+        workflow_title: {
+            type: 'string',
+            title: 'Workflow Title'
+        },
+        trigger_inputs: {
+            type: 'object',
+            title: 'Trigger Inputs'
+        },
+        version: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Version'
+        },
+        run_context: {
+            '$ref': '#/components/schemas/RunContext'
+        }
+    },
+    type: 'object',
+    required: ['role', 'task', 'workflow_title', 'trigger_inputs', 'run_context'],
+    title: 'GetWorkflowDefinitionActivityInputs'
 } as const;
 
 export const $HTTPValidationError = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { CheckHealthResponse, PublicIncomingWebhookData, PublicIncomingWebhookResponse, PublicWebhookCallbackData, PublicWebhookCallbackResponse, WorkflowsListWorkflowsData, WorkflowsListWorkflowsResponse, WorkflowsCreateWorkflowData, WorkflowsCreateWorkflowResponse, WorkflowsGetWorkflowData, WorkflowsGetWorkflowResponse, WorkflowsUpdateWorkflowData, WorkflowsUpdateWorkflowResponse, WorkflowsDeleteWorkflowData, WorkflowsDeleteWorkflowResponse, WorkflowsCopyWorkflowData, WorkflowsCopyWorkflowResponse, WorkflowsCommitWorkflowData, WorkflowsCommitWorkflowResponse, WorkflowsGetWorkflowDefinitionData, WorkflowsGetWorkflowDefinitionResponse, WorkflowExecutionsListWorkflowExecutionsData, WorkflowExecutionsListWorkflowExecutionsResponse, WorkflowExecutionsCreateWorkflowExecutionData, WorkflowExecutionsCreateWorkflowExecutionResponse, WorkflowExecutionsGetWorkflowExecutionData, WorkflowExecutionsGetWorkflowExecutionResponse, WorkflowExecutionsListWorkflowExecutionEventHistoryData, WorkflowExecutionsListWorkflowExecutionEventHistoryResponse, TriggersCreateWebhookData, TriggersCreateWebhookResponse, TriggersGetWebhookData, TriggersGetWebhookResponse, TriggersUpdateWebhookData, TriggersUpdateWebhookResponse, SchedulesListSchedulesData, SchedulesListSchedulesResponse, SchedulesCreateScheduleData, SchedulesCreateScheduleResponse, SchedulesGetScheduleData, SchedulesGetScheduleResponse, SchedulesUpdateScheduleData, SchedulesUpdateScheduleResponse, SchedulesDeleteScheduleData, SchedulesDeleteScheduleResponse, SchedulesSearchSchedulesData, SchedulesSearchSchedulesResponse, ActionsListActionsData, ActionsListActionsResponse, ActionsCreateActionData, ActionsCreateActionResponse, ActionsGetActionData, ActionsGetActionResponse, ActionsUpdateActionData, ActionsUpdateActionResponse, ActionsDeleteActionData, ActionsDeleteActionResponse, CasesCreateCaseData, CasesCreateCaseResponse, CasesListCasesData, CasesListCasesResponse, CasesGetCaseData, CasesGetCaseResponse, CasesUpdateCaseData, CasesUpdateCaseResponse, CasesCreateCaseEventData, CasesCreateCaseEventResponse, CasesListCaseEventsData, CasesListCaseEventsResponse, CasesGetCaseEventData, CasesGetCaseEventResponse, CasesGetCaseMetricsData, CasesGetCaseMetricsResponse, CasesListCaseActionsResponse, CasesCreateCaseActionData, CasesCreateCaseActionResponse, CasesDeleteCaseActionData, CasesDeleteCaseActionResponse, CasesListCaseContextsResponse, CasesCreateCaseContextData, CasesCreateCaseContextResponse, CasesDeleteCaseContextData, CasesDeleteCaseContextResponse, CasesStreamingAutofillCaseFieldsData, CasesStreamingAutofillCaseFieldsResponse, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserResponse, SecretsListSecretsResponse, SecretsCreateSecretData, SecretsCreateSecretResponse, SecretsGetSecretData, SecretsGetSecretResponse, SecretsUpdateSecretData, SecretsUpdateSecretResponse, SecretsDeleteSecretData, SecretsDeleteSecretResponse, SecretsSearchSecretsData, SecretsSearchSecretsResponse, UdfsListUdfsData, UdfsListUdfsResponse, UdfsGetUdfData, UdfsGetUdfResponse, UdfsCreateUdfData, UdfsCreateUdfResponse, UdfsValidateUdfArgsData, UdfsValidateUdfArgsResponse, ValidateWorkflowData, ValidateWorkflowResponse } from './types.gen';
+import type { CheckHealthResponse, PublicIncomingWebhookData, PublicIncomingWebhookResponse, PublicWebhookCallbackData, PublicWebhookCallbackResponse, WorkflowsListWorkflowsData, WorkflowsListWorkflowsResponse, WorkflowsCreateWorkflowData, WorkflowsCreateWorkflowResponse, WorkflowsGetWorkflowData, WorkflowsGetWorkflowResponse, WorkflowsUpdateWorkflowData, WorkflowsUpdateWorkflowResponse, WorkflowsDeleteWorkflowData, WorkflowsDeleteWorkflowResponse, WorkflowsCopyWorkflowData, WorkflowsCopyWorkflowResponse, WorkflowsCommitWorkflowData, WorkflowsCommitWorkflowResponse, WorkflowsGetWorkflowDefinitionData, WorkflowsGetWorkflowDefinitionResponse, WorkflowExecutionsListWorkflowExecutionsData, WorkflowExecutionsListWorkflowExecutionsResponse, WorkflowExecutionsCreateWorkflowExecutionData, WorkflowExecutionsCreateWorkflowExecutionResponse, WorkflowExecutionsGetWorkflowExecutionData, WorkflowExecutionsGetWorkflowExecutionResponse, WorkflowExecutionsListWorkflowExecutionEventHistoryData, WorkflowExecutionsListWorkflowExecutionEventHistoryResponse, TriggersCreateWebhookData, TriggersCreateWebhookResponse, TriggersGetWebhookData, TriggersGetWebhookResponse, TriggersUpdateWebhookData, TriggersUpdateWebhookResponse, SchedulesListSchedulesData, SchedulesListSchedulesResponse, SchedulesCreateScheduleData, SchedulesCreateScheduleResponse, SchedulesGetScheduleData, SchedulesGetScheduleResponse, SchedulesUpdateScheduleData, SchedulesUpdateScheduleResponse, SchedulesDeleteScheduleData, SchedulesDeleteScheduleResponse, SchedulesSearchSchedulesData, SchedulesSearchSchedulesResponse, ActionsListActionsData, ActionsListActionsResponse, ActionsCreateActionData, ActionsCreateActionResponse, ActionsGetActionData, ActionsGetActionResponse, ActionsUpdateActionData, ActionsUpdateActionResponse, ActionsDeleteActionData, ActionsDeleteActionResponse, CasesCreateCaseData, CasesCreateCaseResponse, CasesListCasesData, CasesListCasesResponse, CasesGetCaseData, CasesGetCaseResponse, CasesUpdateCaseData, CasesUpdateCaseResponse, CasesCreateCaseEventData, CasesCreateCaseEventResponse, CasesListCaseEventsData, CasesListCaseEventsResponse, CasesGetCaseEventData, CasesGetCaseEventResponse, CasesListCaseActionsResponse, CasesCreateCaseActionData, CasesCreateCaseActionResponse, CasesDeleteCaseActionData, CasesDeleteCaseActionResponse, CasesListCaseContextsResponse, CasesCreateCaseContextData, CasesCreateCaseContextResponse, CasesDeleteCaseContextData, CasesDeleteCaseContextResponse, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserResponse, SecretsListSecretsResponse, SecretsCreateSecretData, SecretsCreateSecretResponse, SecretsGetSecretData, SecretsGetSecretResponse, SecretsUpdateSecretData, SecretsUpdateSecretResponse, SecretsDeleteSecretData, SecretsDeleteSecretResponse, SecretsSearchSecretsData, SecretsSearchSecretsResponse, UdfsListUdfsData, UdfsListUdfsResponse, UdfsGetUdfData, UdfsGetUdfResponse, UdfsCreateUdfData, UdfsCreateUdfResponse, UdfsValidateUdfArgsData, UdfsValidateUdfArgsResponse, ValidateWorkflowData, ValidateWorkflowResponse } from './types.gen';
 
 /**
  * Check Health
@@ -599,7 +599,7 @@ export const actionsDeleteAction = (data: ActionsDeleteActionData): CancelablePr
  * @param data The data for the request.
  * @param data.workflowId
  * @param data.requestBody
- * @returns unknown Successful Response
+ * @returns CaseResponse Successful Response
  * @throws ApiError
  */
 export const casesCreateCase = (data: CasesCreateCaseData): CancelablePromise<CasesCreateCaseResponse> => { return __request(OpenAPI, {
@@ -621,7 +621,7 @@ export const casesCreateCase = (data: CasesCreateCaseData): CancelablePromise<Ca
  * @param data The data for the request.
  * @param data.workflowId
  * @param data.limit
- * @returns Case_Output Successful Response
+ * @returns CaseResponse Successful Response
  * @throws ApiError
  */
 export const casesListCases = (data: CasesListCasesData): CancelablePromise<CasesListCasesResponse> => { return __request(OpenAPI, {
@@ -644,7 +644,7 @@ export const casesListCases = (data: CasesListCasesData): CancelablePromise<Case
  * @param data The data for the request.
  * @param data.workflowId
  * @param data.caseId
- * @returns Case_Output Successful Response
+ * @returns CaseResponse Successful Response
  * @throws ApiError
  */
 export const casesGetCase = (data: CasesGetCaseData): CancelablePromise<CasesGetCaseResponse> => { return __request(OpenAPI, {
@@ -666,7 +666,7 @@ export const casesGetCase = (data: CasesGetCaseData): CancelablePromise<CasesGet
  * @param data.workflowId
  * @param data.caseId
  * @param data.requestBody
- * @returns unknown Successful Response
+ * @returns CaseResponse Successful Response
  * @throws ApiError
  */
 export const casesUpdateCase = (data: CasesUpdateCaseData): CancelablePromise<CasesUpdateCaseResponse> => { return __request(OpenAPI, {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -69,11 +69,6 @@ export type ActionTest = {
     failure?: unknown;
 };
 
-export type Body_cases_streaming_autofill_case_fields = {
-    cases: Array<Case_Input>;
-    fields: Array<(string)>;
-};
-
 export type Body_validate_workflow = {
     definition: (Blob | File);
     payload?: (Blob | File);
@@ -81,56 +76,6 @@ export type Body_validate_workflow = {
 
 export type Body_workflows_commit_workflow = {
     yaml_file?: (Blob | File);
-};
-
-/**
- * Case model used in the API and runner.
- */
-export type Case_Input = {
-    id?: string;
-    owner_id: string;
-    workflow_id: string;
-    case_title: string;
-    payload: {
-        [key: string]: unknown;
-    };
-    malice: 'malicious' | 'benign';
-    status: 'open' | 'closed' | 'in_progress' | 'reported' | 'escalated';
-    priority: 'low' | 'medium' | 'high' | 'critical';
-    action: 'ignore' | 'quarantine' | 'informational' | 'sinkhole' | 'active_compromise';
-    context: ListModel_CaseContext__Input;
-    tags: ListModel_Tag_;
-    created_at?: string;
-    updated_at?: string;
-};
-
-export type malice = 'malicious' | 'benign';
-
-export type status = 'open' | 'closed' | 'in_progress' | 'reported' | 'escalated';
-
-export type priority = 'low' | 'medium' | 'high' | 'critical';
-
-export type action = 'ignore' | 'quarantine' | 'informational' | 'sinkhole' | 'active_compromise';
-
-/**
- * Case model used in the API and runner.
- */
-export type Case_Output = {
-    id?: string;
-    owner_id: string;
-    workflow_id: string;
-    case_title: string;
-    payload: {
-        [key: string]: unknown;
-    };
-    malice: 'malicious' | 'benign';
-    status: 'open' | 'closed' | 'in_progress' | 'reported' | 'escalated';
-    priority: 'low' | 'medium' | 'high' | 'critical';
-    action: 'ignore' | 'quarantine' | 'informational' | 'sinkhole' | 'active_compromise';
-    context: ListModel_CaseContext__Output;
-    tags: ListModel_Tag_;
-    created_at?: string;
-    updated_at?: string;
 };
 
 export type CaseAction = {
@@ -181,21 +126,6 @@ export type CaseEventParams = {
 } | null;
 };
 
-/**
- * Summary statistics for cases over a time period.
- */
-export type CaseMetrics = {
-    statues: Array<{
-        [key: string]: (number);
-    }>;
-    priority: Array<{
-        [key: string]: (number);
-    }>;
-    malice: Array<{
-        [key: string]: (number);
-    }>;
-};
-
 export type CaseParams = {
     id: string;
     owner_id: string;
@@ -209,8 +139,34 @@ export type CaseParams = {
     malice: 'malicious' | 'benign';
     status: 'open' | 'closed' | 'in_progress' | 'reported' | 'escalated';
     priority: 'low' | 'medium' | 'high' | 'critical';
-    context: ListModel_CaseContext__Input;
     action: 'ignore' | 'quarantine' | 'informational' | 'sinkhole' | 'active_compromise';
+    context: ListModel_CaseContext__Input;
+    tags: ListModel_Tag_;
+};
+
+export type malice = 'malicious' | 'benign';
+
+export type status = 'open' | 'closed' | 'in_progress' | 'reported' | 'escalated';
+
+export type priority = 'low' | 'medium' | 'high' | 'critical';
+
+export type action = 'ignore' | 'quarantine' | 'informational' | 'sinkhole' | 'active_compromise';
+
+export type CaseResponse = {
+    id: string;
+    owner_id: string;
+    created_at: string;
+    updated_at: string;
+    workflow_id: string;
+    case_title: string;
+    payload: {
+        [key: string]: unknown;
+    };
+    malice: 'malicious' | 'benign';
+    status: 'open' | 'closed' | 'in_progress' | 'reported' | 'escalated';
+    priority: 'low' | 'medium' | 'high' | 'critical';
+    action: 'ignore' | 'quarantine' | 'informational' | 'sinkhole' | 'active_compromise';
+    context: ListModel_CaseContext__Output;
     tags: ListModel_Tag_;
 };
 
@@ -296,6 +252,69 @@ export type CreateWorkflowParams = {
     description?: string | null;
 };
 
+export type DSLConfig = {
+    scheduler?: 'static' | 'dynamic';
+    /**
+     * Enable runtime action tests. This is dynamically set on workflow entry.
+     */
+    enable_runtime_tests?: boolean;
+};
+
+export type scheduler = 'static' | 'dynamic';
+
+export type DSLEntrypoint = {
+    /**
+     * The entrypoint action ref
+     */
+    ref: string;
+    /**
+     * Expected trigger input shape
+     */
+    expects?: unknown | null;
+};
+
+/**
+ * DSL definition for a workflow.
+ *
+ * The difference between this and a normal workflow engine is that here,
+ * our workflow execution order is defined by the DSL itself, independent
+ * of a workflow scheduler.
+ *
+ * With a traditional
+ * This allows the execution of the workflow to be fully deterministic.
+ */
+export type DSLInput = {
+    title: string;
+    description: string;
+    entrypoint: DSLEntrypoint;
+    actions: Array<ActionStatement>;
+    config?: DSLConfig;
+    triggers?: Array<Trigger>;
+    /**
+     * Static input parameters
+     */
+    inputs?: {
+        [key: string]: unknown;
+    };
+    /**
+     * Action tests
+     */
+    tests?: Array<ActionTest>;
+};
+
+export type DSLRunArgs = {
+    role: Role;
+    dsl: DSLInput;
+    wf_id: string;
+    trigger_inputs?: {
+    [key: string]: unknown;
+} | null;
+    parent_run_context?: RunContext | null;
+    run_config?: {
+        [key: string]: unknown;
+    };
+};
+
 export type EventFailure = {
     message: string;
     stack_trace: string;
@@ -316,7 +335,7 @@ export type EventGroup = {
     action_ref: string;
     action_title: string;
     action_description: string;
-    action_input: UDFActionInput;
+    action_input: UDFActionInput | DSLRunArgs;
     action_result?: unknown | null;
 };
 
@@ -337,7 +356,7 @@ export type EventHistoryResponse = {
 /**
  * The event types we care about.
  */
-export type EventHistoryType = 'WORKFLOW_EXECUTION_STARTED' | 'WORKFLOW_EXECUTION_COMPLETED' | 'WORKFLOW_EXECUTION_FAILED' | 'ACTIVITY_TASK_SCHEDULED' | 'ACTIVITY_TASK_STARTED' | 'ACTIVITY_TASK_COMPLETED' | 'ACTIVITY_TASK_FAILED';
+export type EventHistoryType = 'WORKFLOW_EXECUTION_STARTED' | 'WORKFLOW_EXECUTION_COMPLETED' | 'WORKFLOW_EXECUTION_FAILED' | 'ACTIVITY_TASK_SCHEDULED' | 'ACTIVITY_TASK_STARTED' | 'ACTIVITY_TASK_COMPLETED' | 'ACTIVITY_TASK_FAILED' | 'CHILD_WORKFLOW_EXECUTION_STARTED' | 'CHILD_WORKFLOW_EXECUTION_COMPLETED' | 'CHILD_WORKFLOW_EXECUTION_FAILED' | 'START_CHILD_WORKFLOW_EXECUTION_INITIATED';
 
 export type ExprContext = 'ACTIONS' | 'SECRETS' | 'FN' | 'INPUTS' | 'ENV' | 'TRIGGER' | 'var';
 
@@ -466,8 +485,17 @@ export type SecretResponse = {
 export type Tag = {
     tag: string;
     value: string;
-    is_ai_generated?: boolean;
 };
+
+export type Trigger = {
+    type: 'schedule' | 'webhook';
+    ref: string;
+    args?: {
+        [key: string]: unknown;
+    };
+};
+
+export type type2 = 'schedule' | 'webhook';
 
 export type UDFActionInput = {
     task: ActionStatement;
@@ -669,7 +697,7 @@ export type WorkflowExecutionResponse = {
     /**
      * When the workflow was closed if closed.
      */
-    close_time: string;
+    close_time?: string | null;
     status: 'RUNNING' | 'COMPLETED' | 'FAILED' | 'CANCELED' | 'TERMINATED' | 'CONTINUED_AS_NEW' | 'TIMED_OUT';
     workflow_type: string;
     task_queue: string;
@@ -919,21 +947,21 @@ export type CasesCreateCaseData = {
     workflowId: string;
 };
 
-export type CasesCreateCaseResponse = unknown;
+export type CasesCreateCaseResponse = CaseResponse;
 
 export type CasesListCasesData = {
     limit?: number;
     workflowId: string;
 };
 
-export type CasesListCasesResponse = Array<Case_Output>;
+export type CasesListCasesResponse = Array<CaseResponse>;
 
 export type CasesGetCaseData = {
     caseId: string;
     workflowId: string;
 };
 
-export type CasesGetCaseResponse = Case_Output;
+export type CasesGetCaseResponse = CaseResponse;
 
 export type CasesUpdateCaseData = {
     caseId: string;
@@ -941,7 +969,7 @@ export type CasesUpdateCaseData = {
     workflowId: string;
 };
 
-export type CasesUpdateCaseResponse = unknown;
+export type CasesUpdateCaseResponse = CaseResponse;
 
 export type CasesCreateCaseEventData = {
     caseId: string;
@@ -965,13 +993,6 @@ export type CasesGetCaseEventData = {
 };
 
 export type CasesGetCaseEventResponse = unknown;
-
-export type CasesGetCaseMetricsData = {
-    caseId: string;
-    workflowId: string;
-};
-
-export type CasesGetCaseMetricsResponse = CaseMetrics;
 
 export type CasesListCaseActionsResponse = Array<CaseAction>;
 
@@ -1000,14 +1021,6 @@ export type CasesDeleteCaseContextData = {
 };
 
 export type CasesDeleteCaseContextResponse = unknown;
-
-export type CasesStreamingAutofillCaseFieldsData = {
-    requestBody: Body_cases_streaming_autofill_case_fields;
-};
-
-export type CasesStreamingAutofillCaseFieldsResponse = {
-    [key: string]: (string);
-};
 
 export type UsersGetUserResponse = User;
 
@@ -1505,7 +1518,7 @@ export type $OpenApiTs = {
                 /**
                  * Successful Response
                  */
-                201: unknown;
+                201: CaseResponse;
                 /**
                  * Validation Error
                  */
@@ -1518,7 +1531,7 @@ export type $OpenApiTs = {
                 /**
                  * Successful Response
                  */
-                200: Array<Case_Output>;
+                200: Array<CaseResponse>;
                 /**
                  * Validation Error
                  */
@@ -1533,7 +1546,7 @@ export type $OpenApiTs = {
                 /**
                  * Successful Response
                  */
-                200: Case_Output;
+                200: CaseResponse;
                 /**
                  * Validation Error
                  */
@@ -1546,7 +1559,7 @@ export type $OpenApiTs = {
                 /**
                  * Successful Response
                  */
-                200: unknown;
+                200: CaseResponse;
                 /**
                  * Validation Error
                  */
@@ -1666,23 +1679,6 @@ export type $OpenApiTs = {
                  * Successful Response
                  */
                 200: unknown;
-                /**
-                 * Validation Error
-                 */
-                422: HTTPValidationError;
-            };
-        };
-    };
-    '/completions/cases/stream': {
-        post: {
-            req: CasesStreamingAutofillCaseFieldsData;
-            res: {
-                /**
-                 * Successful Response
-                 */
-                200: {
-                    [key: string]: (string);
-                };
                 /**
                  * Validation Error
                  */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type EventGroup = {
     action_ref: string;
     action_title: string;
     action_description: string;
-    action_input: UDFActionInput | DSLRunArgs;
+    action_input: UDFActionInput | DSLRunArgs | GetWorkflowDefinitionActivityInputs;
     action_result?: unknown | null;
 };
 
@@ -359,6 +359,17 @@ export type EventHistoryResponse = {
 export type EventHistoryType = 'WORKFLOW_EXECUTION_STARTED' | 'WORKFLOW_EXECUTION_COMPLETED' | 'WORKFLOW_EXECUTION_FAILED' | 'ACTIVITY_TASK_SCHEDULED' | 'ACTIVITY_TASK_STARTED' | 'ACTIVITY_TASK_COMPLETED' | 'ACTIVITY_TASK_FAILED' | 'CHILD_WORKFLOW_EXECUTION_STARTED' | 'CHILD_WORKFLOW_EXECUTION_COMPLETED' | 'CHILD_WORKFLOW_EXECUTION_FAILED' | 'START_CHILD_WORKFLOW_EXECUTION_INITIATED';
 
 export type ExprContext = 'ACTIONS' | 'SECRETS' | 'FN' | 'INPUTS' | 'ENV' | 'TRIGGER' | 'var';
+
+export type GetWorkflowDefinitionActivityInputs = {
+    role: Role;
+    task: ActionStatement;
+    workflow_title: string;
+    trigger_inputs: {
+        [key: string]: unknown;
+    };
+    version?: number | null;
+    run_context: RunContext;
+};
 
 export type HTTPValidationError = {
     detail?: Array<ValidationError>;

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -277,6 +277,11 @@ export const UDFIcons: Record<string, (props: CustomIconProps) => JSX.Element> =
         />
       </div>
     ),
+    "core.workflow": ({ className, ...rest }) => (
+      <div className={cn("bg-violet-200/70", basicIconsCommon, className)}>
+        <WorkflowIcon {...rest} />
+      </div>
+    ),
     // AWS namespace
     aws_cloudtrail: ({ className, ...rest }: IconProps) => (
       <svg

--- a/frontend/src/lib/event-history.ts
+++ b/frontend/src/lib/event-history.ts
@@ -9,14 +9,17 @@ export const encode = (str: string): string =>
 export const ERROR_EVENT_TYPES: EventHistoryResponse["event_type"][] = [
   "WORKFLOW_EXECUTION_FAILED",
   "ACTIVITY_TASK_FAILED",
+  "CHILD_WORKFLOW_EXECUTION_FAILED",
 ] as const
 export const SUCCESS_EVENT_TYPES: EventHistoryResponse["event_type"][] = [
   "ACTIVITY_TASK_COMPLETED",
   "WORKFLOW_EXECUTION_COMPLETED",
+  "CHILD_WORKFLOW_EXECUTION_COMPLETED",
 ] as const
 export const STARTED_EVENT_TYPES: EventHistoryResponse["event_type"][] = [
   "ACTIVITY_TASK_STARTED",
   "WORKFLOW_EXECUTION_STARTED",
+  "CHILD_WORKFLOW_EXECUTION_STARTED",
 ] as const
 
 export type Input = {
@@ -47,43 +50,6 @@ export type ActivityTaskStartedEvent = Omit<EventHistoryResponse, "details"> & {
   details: ActivityTaskScheduledEventDetails
 }
 
-export function getEventDetails(event: EventHistoryResponse) {
-  switch (event.event_type) {
-    case "WORKFLOW_EXECUTION_STARTED":
-      return getWorkflowExecutionStartedDetails(
-        event as WorkflowExecutionStartedEvent
-      )
-    case "WORKFLOW_EXECUTION_COMPLETED":
-      return "Workflow Execution Completed"
-    case "WORKFLOW_EXECUTION_FAILED":
-      return "Workflow Execution Failed"
-    // case "ACTIVITY_TASK_SCHEDULED":
-    //   return (event.details as ActivityTaskScheduledEventDetails).input
-    case "ACTIVITY_TASK_STARTED":
-      return "Activity Task Started"
-    case "ACTIVITY_TASK_COMPLETED":
-      return "Activity Task Completed"
-    case "ACTIVITY_TASK_FAILED":
-      return "Activity Task Failed"
-    default:
-      return "Unknown event history type, please check the logs"
-  }
-}
-
-export function getWorkflowExecutionStartedDetails(
-  event: WorkflowExecutionStartedEvent
-) {
-  // Get the details from the event
-  event.details.input.payloads.forEach((payload) => {
-    // Decode the data
-    const decodedData = decode(payload.data)
-    // Parse the data
-    const parsedData = JSON.parse(decodedData)
-    console.log(parsedData)
-  })
-  return "Workflow Execution Started"
-}
-
 export function parseEventType(eventType: EventHistoryResponse["event_type"]) {
   return eventType
     .toString()
@@ -111,18 +77,4 @@ export function getRelativeTime(date: Date) {
   if (minutes > 0) return `about ${minutes} minute${minutes > 1 ? "s" : ""} ago`
   if (seconds > 0) return `${seconds} second${seconds > 1 ? "s" : ""} ago`
   return "just now"
-}
-
-export function getColorScheme(eventType: EventHistoryResponse["event_type"]) {
-  if (ERROR_EVENT_TYPES.includes(eventType)) return "bg-rose-100"
-  if (STARTED_EVENT_TYPES.includes(eventType)) return "bg-sky-100"
-
-  switch (eventType) {
-    case "ACTIVITY_TASK_COMPLETED":
-      return "bg-sky-100"
-    case "WORKFLOW_EXECUTION_COMPLETED":
-      return "bg-emerald-100"
-    default:
-      return "bg-gray-100"
-  }
 }

--- a/frontend/src/lib/jsonschema.ts
+++ b/frontend/src/lib/jsonschema.ts
@@ -88,7 +88,7 @@ export function getType(value: JSONSchema7): string {
       .join(" | ")
   }
   if (value.enum) {
-    return value.enum.join(" | ")
+    return value.enum.map((v) => `'${v}'`).join(" | ")
   }
   return (value.type || "unknown") as string
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def auth_sandbox():
     from tracecat.types.auth import Role
 
     service_role = Role(
-        type="service", user_id="test-tracecat-user", service_id="tracecat-runner"
+        type="service", user_id="default-tracecat-user", service_id="tracecat-runner"
     )
     ctx_role.set(service_role)
     yield

--- a/tests/data/workflows/unit_child_workflow_child.yml
+++ b/tests/data/workflows/unit_child_workflow_child.yml
@@ -1,0 +1,12 @@
+title: Child workflow
+description: Test child workflow
+entrypoint:
+  ref: a
+  expects:
+    number: int
+
+actions:
+  - ref: a
+    action: core.transform.forward
+    args:
+      value: ${{ TRIGGER.number + 1000 }}

--- a/tests/data/workflows/unit_child_workflow_child.yml
+++ b/tests/data/workflows/unit_child_workflow_child.yml
@@ -1,4 +1,4 @@
-title: Child workflow
+title: __test__child_workflow
 description: Test child workflow
 entrypoint:
   ref: a
@@ -10,3 +10,5 @@ actions:
     action: core.transform.forward
     args:
       value: ${{ TRIGGER.number + 1000 }}
+
+returns: ${{ ACTIONS.a.result }}

--- a/tests/data/workflows/unit_child_workflow_parent.yml
+++ b/tests/data/workflows/unit_child_workflow_parent.yml
@@ -3,14 +3,14 @@ description: Test child workflow
 entrypoint:
   ref: parent
 inputs:
-  data: [777, 888, 999, 1000, 2000, 3000, 4000]
+  data: [1, 2, 3, 4, 5, 6, 7]
 
 actions:
   - ref: parent
     for_each: ${{ for var.x in INPUTS.data }}
     action: core.workflow.execute
     args:
-      workflow_title: Child workflow
+      workflow_title: __test__child_workflow
       loop_strategy: parallel
       fail_strategy: isolated
       batch_size: 3

--- a/tests/data/workflows/unit_child_workflow_parent.yml
+++ b/tests/data/workflows/unit_child_workflow_parent.yml
@@ -1,0 +1,18 @@
+title: Parent workflow
+description: Test child workflow
+entrypoint:
+  ref: parent
+inputs:
+  data: [777, 888, 999, 1000, 2000, 3000, 4000]
+
+actions:
+  - ref: parent
+    for_each: ${{ for var.x in INPUTS.data }}
+    action: core.workflow.execute
+    args:
+      workflow_title: Child workflow
+      loop_strategy: parallel
+      fail_strategy: isolated
+      batch_size: 3
+      trigger_inputs:
+        number: ${{ var.x }}

--- a/tests/data/workflows/unit_child_workflow_parent.yml
+++ b/tests/data/workflows/unit_child_workflow_parent.yml
@@ -10,7 +10,7 @@ actions:
     for_each: ${{ for var.x in INPUTS.data }}
     action: core.workflow.execute
     args:
-      workflow_title: __test__child_workflow
+      workflow_id: <<child_workflow_id>>
       loop_strategy: parallel
       fail_strategy: isolated
       batch_size: 3

--- a/tests/data/workflows/unit_child_workflow_parent_expected.yml
+++ b/tests/data/workflows/unit_child_workflow_parent_expected.yml
@@ -1,0 +1,8 @@
+ACTIONS:
+  parent:
+    result: [1001, 1002, 1003, 1004, 1005, 1006, 1007]
+    result_typename: "list"
+
+INPUTS:
+  data: [1, 2, 3, 4, 5, 6, 7]
+TRIGGER:

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -23,12 +23,11 @@ from temporalio.worker import Worker
 
 from tracecat.contexts import ctx_role
 from tracecat.dsl.client import get_temporal_client
-from tracecat.dsl.common import DSLInput
+from tracecat.dsl.common import DSLInput, DSLRunArgs
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import (
     DSLActivities,
     DSLContext,
-    DSLRunArgs,
     DSLWorkflow,
     retry_policies,
 )

--- a/tracecat/actions/__init__.py
+++ b/tracecat/actions/__init__.py
@@ -7,7 +7,16 @@ Do not add `from __future__ import annotations` to any action module. This will 
 # Bring all actions into the namespace to be registered
 
 from tracecat.actions import integrations
-from tracecat.actions.core import cases, condition, email, example, http, llm, transform
+from tracecat.actions.core import (
+    cases,
+    condition,
+    email,
+    example,
+    http,
+    llm,
+    transform,
+    workflow,
+)
 
 __all__ = [
     # Core
@@ -19,4 +28,5 @@ __all__ = [
     "cases",
     "transform",
     "integrations",
+    "workflow",
 ]

--- a/tracecat/actions/core/workflow.py
+++ b/tracecat/actions/core/workflow.py
@@ -2,6 +2,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
+from tracecat import identifiers
 from tracecat.dsl.common import DSLRunArgs
 from tracecat.registry import RegistryUDFError, registry
 
@@ -20,8 +21,8 @@ class ChildWorkflowExecutionOptions(BaseModel):
     display_group="Workflows",
 )
 async def execute(
-    workflow_title: Annotated[
-        str,
+    workflow_id: Annotated[
+        identifiers.WorkflowID,
         Field(
             ...,
             description=("The title of the child workflow. "),

--- a/tracecat/actions/core/workflow.py
+++ b/tracecat/actions/core/workflow.py
@@ -1,14 +1,15 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
-from pydantic import Field
-from sqlmodel import Session
+from pydantic import BaseModel, Field
 
-from tracecat.contexts import ctx_role, ctx_run
-from tracecat.db.engine import create_db_engine
-from tracecat.dsl.common import DSLInput
-from tracecat.dsl.workflow import DSLRunArgs
-from tracecat.registry import registry
-from tracecat.workflow.service import WorkflowDefinitionsService
+from tracecat.dsl.common import DSLRunArgs
+from tracecat.registry import RegistryUDFError, registry
+
+
+class ChildWorkflowExecutionOptions(BaseModel):
+    loop_strategy: Literal["sequential", "parallel", "batch"] = "parallel"
+    batch_size: int = 16
+    fail_strategy: Literal["strict", "skip"] = "strict"
 
 
 @registry.register(
@@ -27,7 +28,7 @@ async def execute(
         ),
     ],
     trigger_inputs: Annotated[
-        Any,
+        dict[str, Any],
         Field(
             ...,
             description="The inputs to pass to the child workflow.",
@@ -37,22 +38,29 @@ async def execute(
         int | None,
         Field(..., description="The version of the child workflow definition, if any."),
     ] = None,
+    loop_strategy: Annotated[
+        Literal["parallel", "batch", "sequential"],
+        Field(
+            ...,
+            description="The execution strategy to use for the child workflow.",
+        ),
+    ] = "parallel",
+    batch_size: Annotated[
+        int,
+        Field(
+            ...,
+            description="The number of child workflows to execute in parallel.",
+        ),
+    ] = 16,
+    fail_strategy: Annotated[
+        Literal["isolated", "all"],
+        Field(
+            ...,
+            description="Fail strategy to use when a child workflow fails.",
+        ),
+    ] = "isolated",
 ) -> DSLRunArgs:
-    # 1. Grab the child workflow DSL
-    engine = create_db_engine()
-    role = ctx_role.get()
-    with Session(engine) as session:
-        service = WorkflowDefinitionsService(session, role=role)
-        defn = service.get_definition_by_workflow_title(workflow_title, version=version)
-
-    # 2. Set inputs in the DSL (TRIGGER)
-
-    dsl = DSLInput(**defn.content)
-    parent_run_context = ctx_run.get()
-    return DSLRunArgs(
-        role=role,
-        dsl=dsl,
-        wf_id=defn.workflow_id,
-        parent_run_context=parent_run_context,
-        trigger_inputs=trigger_inputs,
+    raise RegistryUDFError(
+        "This UDF only defines a controller interface and cannot be invoked directly."
+        "If you are seeing this error, please contact your administrator."
     )

--- a/tracecat/actions/core/workflow.py
+++ b/tracecat/actions/core/workflow.py
@@ -1,0 +1,58 @@
+from typing import Annotated, Any
+
+from pydantic import Field
+from sqlmodel import Session
+
+from tracecat.contexts import ctx_role, ctx_run
+from tracecat.db.engine import create_db_engine
+from tracecat.dsl.common import DSLInput
+from tracecat.dsl.workflow import DSLRunArgs
+from tracecat.registry import registry
+from tracecat.workflow.service import WorkflowDefinitionsService
+
+
+@registry.register(
+    namespace="core.workflow",
+    version="0.1.0",
+    description="Execute a child workflow. The child workflow inherits the parent's execution context.",
+    default_title="Execute Child Workflow",
+    display_group="Workflows",
+)
+async def execute(
+    workflow_title: Annotated[
+        str,
+        Field(
+            ...,
+            description=("The title of the child workflow. "),
+        ),
+    ],
+    trigger_inputs: Annotated[
+        Any,
+        Field(
+            ...,
+            description="The inputs to pass to the child workflow.",
+        ),
+    ],
+    version: Annotated[
+        int | None,
+        Field(..., description="The version of the child workflow definition, if any."),
+    ] = None,
+) -> DSLRunArgs:
+    # 1. Grab the child workflow DSL
+    engine = create_db_engine()
+    role = ctx_role.get()
+    with Session(engine) as session:
+        service = WorkflowDefinitionsService(session, role=role)
+        defn = service.get_definition_by_workflow_title(workflow_title, version=version)
+
+    # 2. Set inputs in the DSL (TRIGGER)
+
+    dsl = DSLInput(**defn.content)
+    parent_run_context = ctx_run.get()
+    return DSLRunArgs(
+        role=role,
+        dsl=dsl,
+        wf_id=defn.workflow_id,
+        parent_run_context=parent_run_context,
+        trigger_inputs=trigger_inputs,
+    )

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -90,13 +90,13 @@ from tracecat.types.api import (
 )
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatException, TracecatValidationError
+from tracecat.workflow.executions import WorkflowExecutionsService
 from tracecat.workflow.models import (
     CreateWorkflowExecutionParams,
     CreateWorkflowExecutionResponse,
     EventHistoryResponse,
     WorkflowExecutionResponse,
 )
-from tracecat.workflow.service import WorkflowExecutionsService
 
 engine: Engine
 
@@ -109,7 +109,7 @@ async def lifespan(app: FastAPI):
 
 
 def custom_generate_unique_id(route: APIRoute):
-    logger.info("Generating unique ID for route", tags=route.tags, name=route.name)
+    logger.trace("Generating unique ID for route", tags=route.tags, name=route.name)
     if route.tags:
         return f"{route.tags[0]}-{route.name}"
     return route.name

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -361,7 +361,7 @@ async def incoming_webhook(
     )
 
     service = await WorkflowExecutionsService.connect()
-    response = service.create_workflow_execution(
+    response = service.create_workflow_execution_nowait(
         dsl=dsl_input,
         wf_id=path,
         payload=payload,
@@ -487,7 +487,7 @@ async def webhook_callback(
             dsl_input = DSLInput(**defn.content)
 
             wf_exec_service = await WorkflowExecutionsService.connect()
-            response = wf_exec_service.create_workflow_execution(
+            response = wf_exec_service.create_workflow_execution_nowait(
                 dsl=dsl_input,
                 wf_id=path,
                 payload=payload,
@@ -1006,7 +1006,7 @@ async def create_workflow_execution(
             ) from e
         dsl_input = DSLInput(**defn.content)
         try:
-            response = service.create_workflow_execution(
+            response = service.create_workflow_execution_nowait(
                 dsl=dsl_input,
                 wf_id=params.workflow_id,
                 payload=params.inputs,

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -65,6 +65,7 @@ class DSLInput(BaseModel):
         default_factory=dict, description="Static input parameters"
     )
     tests: list[ActionTest] = Field(default_factory=list, description="Action tests")
+    returns: Any | None = Field(None, description="The action ref or value to return.")
 
     @model_validator(mode="after")
     def validate_structure(self) -> Self:

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -10,13 +10,16 @@ import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from tracecat import identifiers
+from tracecat.contexts import RunContext
 from tracecat.db.schemas import Workflow
 from tracecat.dsl.graph import RFEdge, RFGraph, UDFNode, UDFNodeData
 from tracecat.dsl.models import ActionStatement, ActionTest, DSLConfig, Trigger
 from tracecat.dsl.validation import SchemaValidatorFactory
 from tracecat.expressions import patterns
+from tracecat.identifiers import WorkflowID
 from tracecat.logging import logger
 from tracecat.parse import traverse_leaves
+from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatDSLError, TracecatValidationError
 
 
@@ -214,3 +217,12 @@ class DSLInput(BaseModel):
         except Exception as e:
             logger.opt(exception=e).error("Error creating graph")
             raise e
+
+
+class DSLRunArgs(BaseModel):
+    role: Role
+    dsl: DSLInput
+    wf_id: WorkflowID
+    trigger_inputs: dict[str, Any] | None = None
+    parent_run_context: RunContext | None = None
+    run_config: dict[str, Any] = Field(default_factory=dict)

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -61,9 +61,6 @@ class DSLInput(BaseModel):
     inputs: dict[str, Any] = Field(
         default_factory=dict, description="Static input parameters"
     )
-    trigger_inputs: dict[str, Any] = Field(
-        default_factory=dict, description="Dynamic input parameters"
-    )
     tests: list[ActionTest] = Field(default_factory=list, description="Action tests")
 
     @model_validator(mode="after")

--- a/tracecat/dsl/schedules.py
+++ b/tracecat/dsl/schedules.py
@@ -102,6 +102,7 @@ async def create_schedule(
     offset: timedelta | None = None,
     start_at: datetime | None = None,
     end_at: datetime | None = None,
+    trigger_inputs: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> ScheduleHandle:
     client = await get_temporal_client()
@@ -113,7 +114,12 @@ async def create_schedule(
             action=ScheduleActionStartWorkflow(
                 DSLWorkflow.run,
                 # The args that should run in the scheduled workflow
-                DSLRunArgs(dsl=dsl, role=ctx_role.get(), wf_id=workflow_id),
+                DSLRunArgs(
+                    dsl=dsl,
+                    role=ctx_role.get(),
+                    wf_id=workflow_id,
+                    trigger_inputs=trigger_inputs,
+                ),
                 id=workflow_schedule_id,
                 task_queue=config.TEMPORAL__CLUSTER_QUEUE,
             ),

--- a/tracecat/dsl/schedules.py
+++ b/tracecat/dsl/schedules.py
@@ -18,7 +18,8 @@ from temporalio.client import (
 from tracecat import config, identifiers
 from tracecat.contexts import ctx_role
 from tracecat.dsl.client import get_temporal_client
-from tracecat.dsl.workflow import DSLRunArgs, DSLWorkflow
+from tracecat.dsl.common import DSLRunArgs
+from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.types.api import UpdateScheduleParams
 
 if TYPE_CHECKING:

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -17,6 +17,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.workflow import DSLActivities, DSLWorkflow
     from tracecat.registry import registry
+    from tracecat.workflow.definitions import get_workflow_definition_activity
 
 
 # Due to known issues with Pydantic's use of issubclass and our inability to
@@ -57,7 +58,7 @@ async def main() -> None:
     async with Worker(
         client,
         task_queue=os.environ.get("TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"),
-        activities=DSLActivities.load(),
+        activities=[*DSLActivities.load(), get_workflow_definition_activity],
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
     ):

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -421,7 +421,7 @@ class DSLWorkflow:
                         else None
                     )
                     logger.trace("Running action", act_test=act_test)
-                    action_result = await self._run_action(task)
+                    action_result = await self._run_action(task, action_test=act_test)
 
                 self.context[ExprContext.ACTIONS][task.ref] = DSLNodeResult(
                     result=action_result,
@@ -478,7 +478,9 @@ class DSLWorkflow:
             retry_policy=retry_policies["activity:fail_fast"],
         )
 
-    def _run_action(self, task: ActionStatement) -> Awaitable[Any]:
+    def _run_action(
+        self, task: ActionStatement, action_test: ActionTest | None = None
+    ) -> Awaitable[Any]:
         return workflow.execute_activity(
             _udf_key_to_activity_name(task.action),
             arg=UDFActionInput(
@@ -486,6 +488,7 @@ class DSLWorkflow:
                 role=self.role,
                 run_context=self.run_ctx,
                 exec_context=self.context,
+                action_test=action_test,
             ),
             start_to_close_timeout=self.start_to_close_timeout,
             retry_policy=retry_policies["activity:fail_fast"],

--- a/tracecat/expressions/eval.py
+++ b/tracecat/expressions/eval.py
@@ -5,7 +5,7 @@ from typing import Any, TypeVar
 
 from tracecat.expressions import patterns
 from tracecat.expressions.core import Expression, TemplateExpression
-from tracecat.expressions.shared import ExprContext
+from tracecat.expressions.shared import ExprContext, IterableExpr
 
 T = TypeVar("T", str, list[Any], dict[str, Any])
 
@@ -109,3 +109,21 @@ def extract_expressions(templated_obj: Any) -> list[Expression]:
 
     _eval_templated_obj_rec(templated_obj, operator)
     return exprs
+
+
+def get_iterables_from_expression(
+    expr: str, operand: OperandType
+) -> list[IterableExpr]:
+    iterable_exprs: IterableExpr | list[IterableExpr] = eval_templated_object(
+        expr, operand=operand
+    )
+    if isinstance(iterable_exprs, IterableExpr):
+        iterable_exprs = [iterable_exprs]
+    elif not (
+        isinstance(iterable_exprs, list)
+        and all(isinstance(expr, IterableExpr) for expr in iterable_exprs)
+    ):
+        raise ValueError(
+            "Invalid for_each expression. Must be an IterableExpr or a list of IterableExprs."
+        )
+    return iterable_exprs

--- a/tracecat/registry.py
+++ b/tracecat/registry.py
@@ -29,6 +29,10 @@ class RegistrySecret(BaseModel):
     keys: list[SecretKey]
 
 
+class RegistryUDFError(TracecatException):
+    """Exception raised when a registry UDF error occurs."""
+
+
 class RegistryValidationError(TracecatException):
     """Exception raised when a registry validation error occurs."""
 

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any, Literal
 
 from fastapi.responses import ORJSONResponse
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from tracecat import identifiers
 from tracecat.db.schemas import Resource, Schedule
@@ -71,7 +71,6 @@ class CreateWorkflowParams(BaseModel):
 
 
 class UpdateWorkflowParams(BaseModel):
-    model_config: ConfigDict = ConfigDict(arbitrary_types_allowed=True)
     title: str | None = None
     description: str | None = None
     status: Literal["online", "offline"] | None = None

--- a/tracecat/workflow/definitions.py
+++ b/tracecat/workflow/definitions.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+from pydantic import BaseModel
+from sqlmodel import Session, select
+from temporalio import activity
+
+from tracecat import identifiers
+from tracecat.contexts import RunContext, ctx_role, ctx_run
+from tracecat.db.engine import create_db_engine
+from tracecat.db.schemas import Workflow, WorkflowDefinition
+from tracecat.dsl.common import DSLInput, DSLRunArgs
+from tracecat.dsl.models import ActionStatement
+from tracecat.logging import logger
+from tracecat.types.auth import Role
+from tracecat.types.exceptions import TracecatException
+
+
+class WorkflowDefinitionsService:
+    def __init__(self, session: Session, role: Role | None = None):
+        self.role = role or ctx_role.get()
+        self._session = session
+        self.logger = logger.bind(service="workflow_definitions")
+
+    @contextmanager
+    @staticmethod
+    def get_session(role: Role) -> Generator[WorkflowDefinitionsService, None, None]:
+        engine = create_db_engine()
+        with Session(engine) as session:
+            yield WorkflowDefinitionsService(session, role)
+
+    def get_definition_by_workflow_id(
+        self, workflow_id: identifiers.WorkflowID, *, version: int | None = None
+    ) -> WorkflowDefinition | None:
+        statement = select(WorkflowDefinition).where(
+            WorkflowDefinition.owner_id == self.role.user_id,
+            WorkflowDefinition.workflow_id == workflow_id,
+        )
+        if version:
+            statement = statement.where(WorkflowDefinition.version == version)
+        else:
+            # Get the latest version
+            statement = statement.order_by(WorkflowDefinition.version.desc())
+
+        return self._session.exec(statement).first()
+
+    def get_definition_by_workflow_title(
+        self, workflow_title: str, *, version: int | None = None
+    ) -> WorkflowDefinition | None:
+        self.logger.warning(
+            "Getting workflow definition by ref",
+            workflow_title=workflow_title,
+            role=self.role,
+        )
+        wf_statement = select(Workflow.id).where(
+            Workflow.owner_id == self.role.user_id,
+            Workflow.title == workflow_title,
+        )
+
+        wf_id = self._session.exec(wf_statement).one_or_none()
+        self.logger.warning("Workflow ID", wf_id=wf_id)
+        if not wf_id:
+            self.logger.error("Workflow name not found", workflow_title=workflow_title)
+            return None
+
+        wf_defn_statement = select(WorkflowDefinition).where(
+            WorkflowDefinition.owner_id == self.role.user_id,
+            WorkflowDefinition.workflow_id == wf_id,
+        )
+
+        if version:
+            wf_defn_statement = wf_defn_statement.where(
+                WorkflowDefinition.version == version
+            )
+        else:
+            # Get the latest version
+            wf_defn_statement = wf_defn_statement.order_by(
+                WorkflowDefinition.version.desc()
+            )
+
+        return self._session.exec(wf_defn_statement).first()
+
+
+class GetWorkflowDefinitionActivityInputs(BaseModel):
+    role: Role
+    task: ActionStatement
+    workflow_title: str
+    trigger_inputs: dict[str, Any]
+    version: int | None = None
+    run_context: RunContext
+
+
+@activity.defn
+async def get_workflow_definition_activity(
+    input: GetWorkflowDefinitionActivityInputs,
+) -> DSLRunArgs:
+    def _get_definition() -> WorkflowDefinition | None:
+        with WorkflowDefinitionsService.get_session(role=input.role) as service:
+            return service.get_definition_by_workflow_title(
+                input.workflow_title, version=input.version
+            )
+
+    logger.trace("Getting workflow definition", workflow_title=input.workflow_title)
+    defn = await asyncio.to_thread(_get_definition)
+    if not defn:
+        raise TracecatException(
+            f"Workflow definition not found. {input.workflow_title!r}, version={input.version}"
+        )
+    dsl = DSLInput(**defn.content)
+    parent_run_context = ctx_run.get()
+    return DSLRunArgs(
+        role=input.role,
+        dsl=dsl,
+        wf_id=defn.workflow_id,
+        parent_run_context=parent_run_context,
+        trigger_inputs=input.trigger_inputs,
+    )

--- a/tracecat/workflow/models.py
+++ b/tracecat/workflow/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal, TypedDict
+from typing import Annotated, Any, Generic, Literal, TypedDict, TypeVar
 
 import orjson
 import temporalio.api.common.v1
@@ -18,7 +18,7 @@ from pydantic import (
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 
 from tracecat import identifiers
-from tracecat.dsl.workflow import DSLContext, UDFActionInput
+from tracecat.dsl.workflow import DSLContext, DSLRunArgs, UDFActionInput
 from tracecat.types.auth import Role
 
 WorkflowExecutionStatusLiteral = Literal[
@@ -43,6 +43,12 @@ class EventHistoryType(StrEnum):
     ACTIVITY_TASK_STARTED = "ACTIVITY_TASK_STARTED"
     ACTIVITY_TASK_COMPLETED = "ACTIVITY_TASK_COMPLETED"
     ACTIVITY_TASK_FAILED = "ACTIVITY_TASK_FAILED"
+    CHILD_WORKFLOW_EXECUTION_STARTED = "CHILD_WORKFLOW_EXECUTION_STARTED"
+    CHILD_WORKFLOW_EXECUTION_COMPLETED = "CHILD_WORKFLOW_EXECUTION_COMPLETED"
+    CHILD_WORKFLOW_EXECUTION_FAILED = "CHILD_WORKFLOW_EXECUTION_FAILED"
+    START_CHILD_WORKFLOW_EXECUTION_INITIATED = (
+        "START_CHILD_WORKFLOW_EXECUTION_INITIATED"
+    )
 
 
 class WorkflowExecutionResponse(BaseModel):
@@ -90,7 +96,10 @@ def destructure_slugified_namespace(s: str, delimiter: str = "__") -> tuple[str,
     return (".".join(stem), leaf)
 
 
-class EventGroup(BaseModel):
+EventInput = TypeVar("EventInput", UDFActionInput, DSLRunArgs)
+
+
+class EventGroup(BaseModel, Generic[EventInput]):
     event_id: int
     udf_namespace: str
     udf_name: str
@@ -99,11 +108,13 @@ class EventGroup(BaseModel):
     action_ref: str
     action_title: str
     action_description: str
-    action_input: UDFActionInput
+    action_input: EventInput
     action_result: Any | None = None
 
     @staticmethod
-    def from_scheduled_activity(event: temporalio.api.history.v1.HistoryEvent):
+    def from_scheduled_activity(
+        event: temporalio.api.history.v1.HistoryEvent,
+    ) -> EventGroup[UDFActionInput]:
         if (
             event.event_type
             != temporalio.api.enums.v1.EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
@@ -128,6 +139,35 @@ class EventGroup(BaseModel):
             action_title=action_input.task.title,
             action_description=action_input.task.description,
             action_input=action_input,
+        )
+
+    @staticmethod
+    def from_initiated_child_workflow(
+        event: temporalio.api.history.v1.HistoryEvent,
+    ) -> EventGroup[DSLRunArgs]:
+        if (
+            event.event_type
+            != temporalio.api.enums.v1.EventType.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED
+        ):
+            raise ValueError("Event is not a child workflow initiated event.")
+        # Load the input data
+        input = orjson.loads(
+            event.start_child_workflow_execution_initiated_event_attributes.input.payloads[
+                0
+            ].data
+        )
+        dsl_run_args = DSLRunArgs(**input)
+        # Create an event group
+        return EventGroup(
+            event_id=event.event_id,
+            udf_namespace="core.workflow",
+            udf_name="execute",
+            udf_key="core.workflow.execute",
+            action_id=dsl_run_args.wf_id,
+            action_ref=dsl_run_args.dsl.title,
+            action_title=dsl_run_args.dsl.title,
+            action_description=dsl_run_args.dsl.description,
+            action_input=dsl_run_args,
         )
 
 
@@ -162,13 +202,13 @@ class EventFailure(BaseModel):
         )
 
 
-class EventHistoryResponse(BaseModel):
+class EventHistoryResponse(BaseModel, Generic[EventInput]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     event_id: int
     event_time: datetime
     event_type: EventHistoryType
     task_id: int
-    event_group: EventGroup | None = Field(
+    event_group: EventGroup[EventInput] | None = Field(
         default=None,
         description="The action group of the event. We use this to keep track of what events are related to each other.",
     )

--- a/tracecat/workflow/service.py
+++ b/tracecat/workflow/service.py
@@ -124,6 +124,7 @@ class WorkflowExecutionsService:
                             event_id=event.event_id,
                             event_time=event.event_time.ToDatetime(datetime.UTC),
                             event_type=EventHistoryType.START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+                            event_group=group,
                             task_id=event.task_id,
                             role=group.action_input.role,
                             input=group.action_input,
@@ -138,8 +139,8 @@ class WorkflowExecutionsService:
                             event_id=event.event_id,
                             event_time=event.event_time.ToDatetime(datetime.UTC),
                             event_type=EventHistoryType.CHILD_WORKFLOW_EXECUTION_STARTED,
-                            task_id=event.task_id,
                             event_group=group,
+                            task_id=event.task_id,
                         )
                     )
                 case EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED:
@@ -148,11 +149,14 @@ class WorkflowExecutionsService:
                             0
                         ].data
                     )
+                    initiator_event_id = event.child_workflow_execution_completed_event_attributes.initiated_event_id
+                    group = event_group_names.get(initiator_event_id)
                     events.append(
                         EventHistoryResponse(
                             event_id=event.event_id,
                             event_time=event.event_time.ToDatetime(datetime.UTC),
                             event_type=EventHistoryType.CHILD_WORKFLOW_EXECUTION_COMPLETED,
+                            event_group=group,
                             task_id=event.task_id,
                             result=result,
                         )


### PR DESCRIPTION
# Features
- Implement basic child workflow invocation
- Add event history for child workflows + UI
- Implement looping for child workflows
    - Child workflow loops run at the temporal workflow level
    - Udfs still run loop iteration inside the temporal activity
- Implement `all` and `isolated` fail strategies using `asyncio.gather` / `GatheringTaskGroup`
- Implement `parallel`, `sequential`, and `batched` loop strategies
- Implement `returns` key for `DSLInput`. Pass an expression to define the return value of the workflow.

# Changes
- Break `workflow/service.py` into `workflow/definitions.py` and `workflow/executions.py`
- Refator some models to avoid circular imports
- Standardize colors to avoid confusion

# Testing
- Added new workflow test

# Example usage
```yaml
title: Parent workflow
description: Test child workflow
entrypoint:
  ref: parent
inputs:
  data: [1, 2, 3, 4, 5, 6, 7]

actions:
  - ref: parent
    for_each: ${{ for var.x in INPUTS.data }}
    action: core.workflow.execute
    args:
      workflow_id: <<child workflow id>>
      loop_strategy: parallel
      fail_strategy: isolated
      batch_size: 3
      trigger_inputs:
        number: ${{ var.x }}

```

# Todos
- Missing subsytem to register workflows as executables, which will enable referencing workflows using unique refs instead of IDs.