### PR TITLE
Fix/more fixes

### DIFF
--- a/cli/tracecat_cli/workflow.py
+++ b/cli/tracecat_cli/workflow.py
@@ -24,9 +24,6 @@ def create(
     activate_webhook: bool = typer.Option(
         False, "--webhook", help="Activate the webhook"
     ),
-    defn_file: Path = typer.Option(
-        None, "--commit", "-c", help="Create with workflow definition"
-    ),
 ):
     """Create a new workflow."""
 
@@ -34,8 +31,6 @@ def create(
     rich.print(result)
     if activate_workflow:
         _activate_workflow(result["id"], activate_webhook)
-    if defn_file:
-        _commit_workflow(defn_file, result["id"])
 
 
 @app.command(help="Commit a workflow definition")
@@ -205,7 +200,7 @@ def _create_workflow(title: str | None = None, description: str | None = None):
             params["title"] = title
         if description:
             params["description"] = description
-        res = client.post("/workflows", content=orjson.dumps(params))
+        res = client.post("/workflows", data=params)
         result = Client.handle_response(res)
     rich.print("Created workflow")
     return result

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -190,9 +190,31 @@ export const $Body_validate_workflow = {
     title: 'Body_validate_workflow'
 } as const;
 
-export const $Body_workflows_commit_workflow = {
+export const $Body_workflows_create_workflow = {
     properties: {
-        yaml_file: {
+        title: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Title'
+        },
+        description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Description'
+        },
+        file: {
             anyOf: [
                 {
                     type: 'string',
@@ -202,11 +224,11 @@ export const $Body_workflows_commit_workflow = {
                     type: 'null'
                 }
             ],
-            title: 'Yaml File'
+            title: 'File'
         }
     },
     type: 'object',
-    title: 'Body_workflows-commit_workflow'
+    title: 'Body_workflows-create_workflow'
 } as const;
 
 export const $CaseAction = {
@@ -839,35 +861,6 @@ export const $CreateWorkflowExecutionResponse = {
     type: 'object',
     required: ['message', 'wf_id', 'wf_exec_id'],
     title: 'CreateWorkflowExecutionResponse'
-} as const;
-
-export const $CreateWorkflowParams = {
-    properties: {
-        title: {
-            anyOf: [
-                {
-                    type: 'string'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Title'
-        },
-        description: {
-            anyOf: [
-                {
-                    type: 'string'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Description'
-        }
-    },
-    type: 'object',
-    title: 'CreateWorkflowParams'
 } as const;
 
 export const $DSLConfig = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -96,15 +96,15 @@ export const workflowsListWorkflows = (data: WorkflowsListWorkflowsData = {}): C
  * Create Workflow
  * Create new Workflow with title and description.
  * @param data The data for the request.
- * @param data.requestBody
+ * @param data.formData
  * @returns WorkflowMetadataResponse Successful Response
  * @throws ApiError
  */
-export const workflowsCreateWorkflow = (data: WorkflowsCreateWorkflowData): CancelablePromise<WorkflowsCreateWorkflowResponse> => { return __request(OpenAPI, {
+export const workflowsCreateWorkflow = (data: WorkflowsCreateWorkflowData = {}): CancelablePromise<WorkflowsCreateWorkflowResponse> => { return __request(OpenAPI, {
     method: 'POST',
     url: '/workflows',
-    body: data.requestBody,
-    mediaType: 'application/json',
+    formData: data.formData,
+    mediaType: 'multipart/form-data',
     errors: {
         422: 'Validation Error'
     }
@@ -196,12 +196,9 @@ export const workflowsCopyWorkflow = (data: WorkflowsCopyWorkflowData): Cancelab
  * Commit Workflow
  * Commit a workflow.
  *
- * XXX: This is actually creating a workflow definition
- *
  * This deploys the workflow and updates its version. If a YAML file is provided, it will override the workflow in the database.
  * @param data The data for the request.
  * @param data.workflowId
- * @param data.formData
  * @returns CommitWorkflowResponse Successful Response
  * @throws ApiError
  */
@@ -211,8 +208,6 @@ export const workflowsCommitWorkflow = (data: WorkflowsCommitWorkflowData): Canc
     path: {
         workflow_id: data.workflowId
     },
-    formData: data.formData,
-    mediaType: 'multipart/form-data',
     errors: {
         422: 'Validation Error'
     }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -74,8 +74,10 @@ export type Body_validate_workflow = {
     payload?: (Blob | File);
 };
 
-export type Body_workflows_commit_workflow = {
-    yaml_file?: (Blob | File) | null;
+export type Body_workflows_create_workflow = {
+    title?: string | null;
+    description?: string | null;
+    file?: (Blob | File) | null;
 };
 
 export type CaseAction = {
@@ -257,11 +259,6 @@ export type CreateWorkflowExecutionResponse = {
     message: string;
     wf_id: string;
     wf_exec_id: string;
-};
-
-export type CreateWorkflowParams = {
-    title?: string | null;
-    description?: string | null;
 };
 
 export type DSLConfig = {
@@ -811,7 +808,7 @@ export type WorkflowsListWorkflowsData = {
 export type WorkflowsListWorkflowsResponse = Array<WorkflowMetadataResponse>;
 
 export type WorkflowsCreateWorkflowData = {
-    requestBody: CreateWorkflowParams;
+    formData?: Body_workflows_create_workflow;
 };
 
 export type WorkflowsCreateWorkflowResponse = WorkflowMetadataResponse;
@@ -843,7 +840,6 @@ export type WorkflowsCopyWorkflowData = {
 export type WorkflowsCopyWorkflowResponse = void;
 
 export type WorkflowsCommitWorkflowData = {
-    formData?: Body_workflows_commit_workflow;
     workflowId: string;
 };
 

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -5,7 +5,7 @@ import { ConeIcon } from "lucide-react"
 
 import { useWorkflows } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
-import CreateWorkflowButton from "@/components/dashboard/create-workflow-button"
+import { CreateWorkflowButton } from "@/components/dashboard/create-workflow-button"
 import { WorkflowItem } from "@/components/dashboard/workflows-dashboard-item"
 import { AlertNotification } from "@/components/notifications"
 import { ListItemSkeletion } from "@/components/skeletons"
@@ -21,14 +21,14 @@ export function WorkflowsDashboard() {
               Your workflows dashboard.
             </p>
           </div>
-          <div className="ml-auto space-x-2">
-            <CreateWorkflowButton />
+          <div className="ml-auto flex items-center space-x-2">
             <Link href="/playbooks">
               <Button variant="outline" role="combobox" className="space-x-2">
                 <ConeIcon className="size-4 text-emerald-600" />
                 <span>Find playbook</span>
               </Button>
             </Link>
+            <CreateWorkflowButton />
           </div>
         </div>
         <WorkflowList />

--- a/frontend/src/components/nav/workflow-nav.tsx
+++ b/frontend/src/components/nav/workflow-nav.tsx
@@ -127,7 +127,7 @@ export default function WorkflowNav() {
             >
               {manualTriggerDisabled
                 ? "Please commit changes to enable manual trigger."
-                : "Run the workflow manually without a webhook."}
+                : "Run the workflow manually without a webhook. Click to configure inputs."}
             </TooltipContent>
             <PopoverContent className="p-3">
               <WorkflowExecutionControls workflowId={workflow.id} />

--- a/tracecat/workflow/management.py
+++ b/tracecat/workflow/management.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ValidationError
+from sqlmodel import Session
+
+from tracecat import validation
+from tracecat.contexts import ctx_role
+from tracecat.db.schemas import Action, Webhook, Workflow
+from tracecat.dsl.common import DSLInput
+from tracecat.dsl.graph import RFGraph
+from tracecat.logging import logger
+from tracecat.types.api import UDFArgsValidationResponse
+from tracecat.types.auth import Role
+from tracecat.types.exceptions import TracecatValidationError
+from tracecat.workflow.models import CreateWorkflowFromDSLResponse
+
+
+class WorkflowsManagementService:
+    """Manages CRUD operations for Workflows."""
+
+    def __init__(self, session: Session, role: Role | None = None):
+        self.role = role or ctx_role.get()
+        self.session = session
+        self.logger = logger.bind(service="workflows")
+
+    async def create_workflow(title: str, description: str) -> Workflow:
+        """Create a new workflow."""
+        workflow = Workflow(
+            title=title,
+            description=description,
+        )
+        return workflow
+
+    async def create_workflow_from_dsl(
+        self, data: dict[str, Any], *, skip_secret_validation: bool = False
+    ) -> CreateWorkflowFromDSLResponse:
+        """Create a new workflow from a file."""
+
+        construction_errors = []
+        try:
+            # Convert the workflow into a WorkflowDefinition
+            # XXX: When we commit from the workflow, we have action IDs
+            dsl = DSLInput.model_validate(data)
+            logger.info("Commiting workflow from database")
+        except* TracecatValidationError as eg:
+            logger.error(eg.message, error=eg.exceptions)
+            construction_errors.extend(
+                UDFArgsValidationResponse.from_dsl_validation_error(e)
+                for e in eg.exceptions
+            )
+        except* ValidationError as eg:
+            logger.error(eg.message, error=eg.exceptions)
+            construction_errors.extend(
+                UDFArgsValidationResponse.from_pydantic_validation_error(e)
+                for e in eg.exceptions
+            )
+        if construction_errors:
+            return CreateWorkflowFromDSLResponse(errors=construction_errors)
+
+        if not skip_secret_validation:
+            if val_errors := await validation.validate_dsl(
+                session=self.session, dsl=dsl
+            ):
+                logger.warning("Validation errors", errors=val_errors)
+                return CreateWorkflowFromDSLResponse(
+                    errors=[
+                        UDFArgsValidationResponse.from_validation_result(val_res)
+                        for val_res in val_errors
+                    ]
+                )
+
+        logger.warning("Creating workflow from DSL", dsl=dsl)
+        try:
+            workflow = Workflow(
+                title=dsl.title,
+                description=dsl.description,
+                owner_id=self.role.user_id,
+            )
+
+            # Add the Workflow to the session first to generate an ID
+            self.session.add(workflow)
+            self.session.flush()  # Flush to generate workflow.id
+
+            # Create and associate Webhook with the Workflow
+            webhook = Webhook(
+                owner_id=self.role.user_id,
+                workflow_id=workflow.id,
+            )
+            self.session.add(webhook)
+            workflow.webhook = webhook
+
+            # Create and associate Actions with the Workflow
+            actions: list[Action] = []
+            for act_stmt in dsl.actions:
+                new_action = Action(
+                    owner_id=self.role.user_id,
+                    workflow_id=workflow.id,
+                    type=act_stmt.action,
+                    inputs=act_stmt.args,
+                    title=act_stmt.title,
+                    description=act_stmt.description,
+                )
+                actions.append(new_action)
+                self.session.add(new_action)
+
+            workflow.actions = actions  # Associate actions with the workflow
+
+            # Create and set the graph for the Workflow
+            base_graph = RFGraph.with_defaults(workflow)
+            logger.info("Creating graph for workflow", graph=base_graph)
+
+            # Add DSL contents to the Workflow
+            ref2id = {act.ref: act.id for act in actions}
+            updated_graph = dsl.to_graph(trigger_node=base_graph.trigger, ref2id=ref2id)
+            workflow.object = updated_graph.model_dump(by_alias=True, mode="json")
+            workflow.entrypoint = (
+                updated_graph.entrypoint.id if updated_graph.entrypoint else None
+            )
+
+            # Commit the transaction
+            self.session.commit()
+            self.session.refresh(workflow)
+
+            return CreateWorkflowFromDSLResponse(workflow=workflow)
+
+        except Exception as e:
+            # Rollback the transaction on error
+            logger.error(f"Error creating workflow: {e}")
+            self.session.rollback()
+            raise e

--- a/tracecat/workflow/models.py
+++ b/tracecat/workflow/models.py
@@ -18,8 +18,10 @@ from pydantic import (
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 
 from tracecat import identifiers
+from tracecat.db.schemas import Workflow
 from tracecat.dsl.common import DSLRunArgs
 from tracecat.dsl.workflow import DSLContext, UDFActionInput
+from tracecat.types.api import UDFArgsValidationResponse
 from tracecat.types.auth import Role
 from tracecat.workflow.definitions import GetWorkflowDefinitionActivityInputs
 
@@ -251,3 +253,8 @@ class CreateWorkflowExecutionResponse(TypedDict):
 class DispatchWorkflowResult(TypedDict):
     wf_id: identifiers.WorkflowID
     final_context: DSLContext
+
+
+class CreateWorkflowFromDSLResponse(BaseModel):
+    workflow: Workflow | None = None
+    errors: list[UDFArgsValidationResponse] | None = None


### PR DESCRIPTION
# Features
- Upgrade create workflow button:
    - Upload yaml file
    - Create as usual
- Update how we commit workflows - we only allow committing workflows from the database, no longer allowing direct yaml commits. YAML should only be used to create workflows.
- Update workflow creation endpoints to support file upload 
- Updated cli
- Added barebones workflow management service (wip)

# Todos
Deprecate `tracecat workflow commit`