### PR TITLE
Add new SentinelOne actions: lookup by username, hostname, isolate, unisolate

### DIFF
--- a/tracecat/actions/integrations/edr/__init__.py
+++ b/tracecat/actions/integrations/edr/__init__.py
@@ -5,7 +5,13 @@ from .crowdstrike import (
     update_crowdstrike_detect_status,
 )
 from .microsoft_defender import list_defender_endpoint_alerts
-from .sentinel_one import list_sentinelone_alerts
+from .sentinel_one import (
+    get_sentinelone_agents_by_hostname,
+    get_sentinelone_agents_by_username,
+    isolate_sentinelone_agent,
+    list_sentinelone_alerts,
+    unisolate_sentinelone_agent,
+)
 
 __all__ = [
     "list_crowdstrike_alerts",
@@ -14,4 +20,8 @@ __all__ = [
     "list_defender_endpoint_alerts",
     "update_crowdstrike_alert_status",
     "update_crowdstrike_detect_status",
+    "get_sentinelone_agents_by_hostname",
+    "get_sentinelone_agents_by_username",
+    "isolate_sentinelone_agent",
+    "unisolate_sentinelone_agent",
 ]

--- a/tracecat/actions/integrations/edr/sentinel_one.py
+++ b/tracecat/actions/integrations/edr/sentinel_one.py
@@ -129,13 +129,13 @@ async def update_sentinelone_alert_status(
 
 
 @registry.register(
-    default_title="Get agents by username",
-    description="Find agent(s) by the last used username field",
+    default_title="Get Sentinel One agents by username",
+    description="Find Sentinel One agent(s) by the last used username field",
     display_group="Sentinel One",
     namespace="integrations.sentinel_one",
     secrets=[sentinel_one_secret],
 )
-async def get_agents_by_username(
+async def get_sentinelone_agents_by_username(
     username: Annotated[str, Field(..., description="Username to search for")],
     exact_match: Annotated[
         bool,
@@ -169,13 +169,13 @@ async def get_agents_by_username(
 
 
 @registry.register(
-    default_title="Get agents by hostname",
-    description="Find agent(s) by hostname",
+    default_title="Get Sentinel One agents by hostname",
+    description="Find Sentinel One agent(s) by hostname",
     display_group="Sentinel One",
     namespace="integrations.sentinel_one",
     secrets=[sentinel_one_secret],
 )
-async def get_agents_by_hostname(
+async def get_sentinelone_agents_by_hostname(
     hostname: Annotated[str, Field(..., description="Hostname to search for")],
     exact_match: Annotated[
         bool,
@@ -204,13 +204,13 @@ async def get_agents_by_hostname(
 
 
 @registry.register(
-    default_title="Isolate agent",
-    description="Isolate an agent from the network",
+    default_title="Isolate Sentinel One agent",
+    description="Isolate a Sentinel One agent from the network",
     display_group="Sentinel One",
     namespace="integrations.sentinel_one",
     secrets=[sentinel_one_secret],
 )
-async def isolate_agent(
+async def isolate_sentinelone_agent(
     agent_id: Annotated[str, Field(..., description="ID of the agent to isolate")],
 ) -> dict[str, Any]:
     api_token = os.getenv("SENTINEL_ONE_API_TOKEN")
@@ -231,13 +231,13 @@ async def isolate_agent(
 
 
 @registry.register(
-    default_title="Unisolate agent",
-    description="Unisolate an agent from the network",
+    default_title="Unisolate Sentinel One agent",
+    description="Unisolate a Sentinel One agent from the network",
     display_group="Sentinel One",
     namespace="integrations.sentinel_one",
     secrets=[sentinel_one_secret],
 )
-async def unisolate_agent(
+async def unisolate_sentinelone_agent(
     agent_id: Annotated[str, Field(..., description="ID of the agent to unisolate")],
 ) -> dict[str, Any]:
     api_token = os.getenv("SENTINEL_ONE_API_TOKEN")

--- a/tracecat/actions/integrations/edr/sentinel_one.py
+++ b/tracecat/actions/integrations/edr/sentinel_one.py
@@ -30,6 +30,9 @@ from tracecat.registry import Field, RegistrySecret, registry
 
 ALERTS_ENDPOINT = "/web/api/v2.1/cloud-detection/alerts"
 ANALYST_VERDICT_ENDPOINT = "/web/api/v2.1/cloud-detection/alerts/analyst-verdict"
+AGENT_ENDPOINT = "/web/api/v2.1/agents"
+DISCONNECT_ENDPOINT = "/web/api/v2.1/agents/actions/disconnect"
+CONNECT_ENDPOINT = "/web/api/v2.1/agents/actions/connect"
 
 AnalystVerdict = Literal["FALSE_POSITIVE", "SUSPICIOUS", "TRUE_POSITIVE", "UNDEFINED"]
 
@@ -120,6 +123,135 @@ async def update_sentinelone_alert_status(
                 "data": {"analystVerdict": status},
                 "filter": {"ids": alert_ids},
             },
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@registry.register(
+    default_title="Get agents by username",
+    description="Find agent(s) by the last used username field",
+    display_group="Sentinel One",
+    namespace="integrations.sentinel_one",
+    secrets=[sentinel_one_secret],
+)
+async def get_agents_by_username(
+    username: Annotated[str, Field(..., description="Username to search for")],
+    exact_match: Annotated[
+        bool,
+        Field(
+            ..., description="Exact match only, otherwise partial matches are returned"
+        ),
+    ],
+) -> list[dict[str, Any]]:
+    api_token = os.getenv("SENTINEL_ONE_API_TOKEN")
+    base_url = os.getenv("SENTINEL_ONE_BASE_URL")
+    headers = {
+        "Authorization": f"ApiToken {api_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{base_url}/{AGENT_ENDPOINT}?lastLoggedInUserName__contains={username}",
+            headers=headers,
+        )
+        response.raise_for_status()
+        results = []
+        if exact_match:
+            for agent in response.json()["data"]:
+                if agent["lastLoggedInUserName"].lower() == username.lower():
+                    results.append(agent)
+        else:
+            results = response.json()["data"]
+
+        return results
+
+
+@registry.register(
+    default_title="Get agents by hostname",
+    description="Find agent(s) by hostname",
+    display_group="Sentinel One",
+    namespace="integrations.sentinel_one",
+    secrets=[sentinel_one_secret],
+)
+async def get_agents_by_hostname(
+    hostname: Annotated[str, Field(..., description="Hostname to search for")],
+    exact_match: Annotated[
+        bool,
+        Field(
+            ..., description="Exact match only, otherwise partial matches are returned"
+        ),
+    ],
+) -> list[dict[str, Any]]:
+    api_token = os.getenv("SENTINEL_ONE_API_TOKEN")
+    base_url = os.getenv("SENTINEL_ONE_BASE_URL")
+    headers = {
+        "Authorization": f"ApiToken {api_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient() as client:
+        query_param = "computerName__contains"
+        if exact_match:
+            query_param = "computerName"
+        response = await client.get(
+            f"{base_url}/{AGENT_ENDPOINT}?{query_param}={hostname}",
+            headers=headers,
+        )
+        response.raise_for_status()
+        return response.json()["data"]
+
+
+@registry.register(
+    default_title="Isolate agent",
+    description="Isolate an agent from the network",
+    display_group="Sentinel One",
+    namespace="integrations.sentinel_one",
+    secrets=[sentinel_one_secret],
+)
+async def isolate_agent(
+    agent_id: Annotated[str, Field(..., description="ID of the agent to isolate")],
+) -> dict[str, Any]:
+    api_token = os.getenv("SENTINEL_ONE_API_TOKEN")
+    base_url = os.getenv("SENTINEL_ONE_BASE_URL")
+    headers = {
+        "Authorization": f"ApiToken {api_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{base_url}/{DISCONNECT_ENDPOINT}",
+            headers=headers,
+            json={"filter": {"ids": [agent_id]}},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@registry.register(
+    default_title="Unisolate agent",
+    description="Unisolate an agent from the network",
+    display_group="Sentinel One",
+    namespace="integrations.sentinel_one",
+    secrets=[sentinel_one_secret],
+)
+async def unisolate_agent(
+    agent_id: Annotated[str, Field(..., description="ID of the agent to unisolate")],
+) -> dict[str, Any]:
+    api_token = os.getenv("SENTINEL_ONE_API_TOKEN")
+    base_url = os.getenv("SENTINEL_ONE_BASE_URL")
+    headers = {
+        "Authorization": f"ApiToken {api_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{base_url}/{CONNECT_ENDPOINT}",
+            headers=headers,
+            json={"filter": {"ids": [agent_id]}},
         )
         response.raise_for_status()
         return response.json()


### PR DESCRIPTION
## Description

This adds additional actions to the existing Sentinel One integration:

- Agent lookup by hostname
- Agent lookup by username
- Isolate endpoint
- Unisolate endpoint

These are common response actions for an EDR product; as an example, based on an alert, you could lookup a hostname or username to find which machines they are active on, then isolate those which would block all connections except the communication channel that the EDR tool uses to communicate with it's control plane.

## Related Tickets & Documents

No open issues for this

## Screenshots/Recordings

N/A

## Steps to QA

I tested this by creating a workflow that looked up an agent, performed an isolation, and then performed an unisolation and confirmed in Sentinel One that all actions took place correctly.

## [optional] What gif best describes this PR?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
