### PR TITLE
Okta enhancement/fix

### DIFF
--- a/tracecat/actions/integrations/iam/__init__.py
+++ b/tracecat/actions/integrations/iam/__init__.py
@@ -1,7 +1,13 @@
-from .okta import expire_okta_sessions, suspend_okta_user, unsuspend_okta_user
+from .okta import (
+    expire_okta_sessions,
+    find_okta_user,
+    suspend_okta_user,
+    unsuspend_okta_user,
+)
 
 __all__ = [
     "suspend_okta_user",
     "unsuspend_okta_user",
     "expire_okta_sessions",
+    "find_okta_user",
 ]

--- a/tracecat/actions/integrations/iam/okta.py
+++ b/tracecat/actions/integrations/iam/okta.py
@@ -27,6 +27,7 @@ okta_secret = RegistrySecret(
     - `OKTA_API_TOKEN`
 """
 
+
 @registry.register(
     default_title="Find Okta User",
     description="Find an Okta user by login username or email",
@@ -49,12 +50,13 @@ async def find_okta_user(
     }
 
     async with httpx.AsyncClient() as client:
-        response = await client.post(
+        response = await client.get(
             f"{base_url}/api/v1/users?search=profile.login%20eq%20%22{username_or_email}%22%20or%20profile.email%20eq%20%22{username_or_email}%22",
             headers=headers,
         )
         response.raise_for_status()
         return response.json()
+
 
 @registry.register(
     default_title="Suspend Okta user",

--- a/tracecat/actions/integrations/iam/okta.py
+++ b/tracecat/actions/integrations/iam/okta.py
@@ -33,7 +33,7 @@ def create_okta_client() -> httpx.AsyncClient:
     if OKTA_API_TOKEN is None:
         raise ValueError("OKTA_API_TOKEN is not set")
     client = httpx.AsyncClient(
-        base_url=f"{os.getenv("OKTA_BASE_URL")}/api/v1",
+        base_url=f'{os.getenv("OKTA_BASE_URL")}/api/v1',
         headers={
             "Authorization": f"SSWS {OKTA_API_TOKEN}",
             "Accept": "application/json",

--- a/tracecat/actions/integrations/iam/okta.py
+++ b/tracecat/actions/integrations/iam/okta.py
@@ -57,13 +57,13 @@ async def find_okta_user(
     ],
 ) -> list:
     async with create_okta_client() as client:
-        params = [
-            "search",
-            f'profile.login eq "{username_or_email}" or profile.email eq "{username_or_email}"',
-        ]
+        params = {
+            "search": (
+                f'profile.login eq "{username_or_email}" or profile.email eq "{username_or_email}"'
+            )
+        }
         response = await client.get(
-            f"{client.base_url}/api/v1/users?search=profile.login%20eq%20%22{username_or_email}%22%20or%20profile.email%20eq%20%22{username_or_email}%22",
-            headers=client.headers,
+            "/api/v1/users",
             params=params,
         )
 
@@ -86,8 +86,7 @@ async def suspend_okta_user(
 ) -> bool:
     async with create_okta_client() as client:
         response = await client.post(
-            f"{client.base_url}/api/v1/users/{okta_user_id}/lifecycle/suspend",
-            headers=client.headers,
+            f"/api/v1/users/{okta_user_id}/lifecycle/suspend",
         )
         response.raise_for_status()
         return True
@@ -108,8 +107,7 @@ async def unsuspend_okta_user(
 ) -> bool:
     async with create_okta_client() as client:
         response = await client.post(
-            f"{client.base_url}/api/v1/users/{okta_user_id}/lifecycle/unsuspend",
-            headers=client.headers,
+            f"/api/v1/users/{okta_user_id}/lifecycle/unsuspend",
         )
         response.raise_for_status()
         return True
@@ -130,8 +128,7 @@ async def expire_okta_sessions(
 ) -> bool:
     async with create_okta_client() as client:
         response = await client.delete(
-            f"{client.base_url}/api/v1/users/{okta_user_id}/sessions",
-            headers=client.headers,
+            f"/api/v1/users/{okta_user_id}/sessions",
         )
         response.raise_for_status()
         return True

--- a/tracecat/actions/integrations/iam/okta.py
+++ b/tracecat/actions/integrations/iam/okta.py
@@ -33,7 +33,7 @@ def create_okta_client() -> httpx.AsyncClient:
     if OKTA_API_TOKEN is None:
         raise ValueError("OKTA_API_TOKEN is not set")
     client = httpx.AsyncClient(
-        base_url=os.getenv("OKTA_BASE_URL"),
+        base_url=f"{os.getenv("OKTA_BASE_URL")}/api/v1",
         headers={
             "Authorization": f"SSWS {OKTA_API_TOKEN}",
             "Accept": "application/json",
@@ -63,7 +63,7 @@ async def find_okta_user(
             )
         }
         response = await client.get(
-            "/api/v1/users",
+            "/users",
             params=params,
         )
 
@@ -86,7 +86,7 @@ async def suspend_okta_user(
 ) -> bool:
     async with create_okta_client() as client:
         response = await client.post(
-            f"/api/v1/users/{okta_user_id}/lifecycle/suspend",
+            f"/users/{okta_user_id}/lifecycle/suspend",
         )
         response.raise_for_status()
         return True
@@ -107,7 +107,7 @@ async def unsuspend_okta_user(
 ) -> bool:
     async with create_okta_client() as client:
         response = await client.post(
-            f"/api/v1/users/{okta_user_id}/lifecycle/unsuspend",
+            f"/users/{okta_user_id}/lifecycle/unsuspend",
         )
         response.raise_for_status()
         return True
@@ -128,7 +128,7 @@ async def expire_okta_sessions(
 ) -> bool:
     async with create_okta_client() as client:
         response = await client.delete(
-            f"/api/v1/users/{okta_user_id}/sessions",
+            f"/users/{okta_user_id}/sessions",
         )
         response.raise_for_status()
         return True

--- a/tracecat/actions/integrations/iam/okta.py
+++ b/tracecat/actions/integrations/iam/okta.py
@@ -59,7 +59,7 @@ async def find_okta_user(
     async with create_okta_client() as client:
         params = [
             "search",
-            f"profile.login%20eq%20%22{username_or_email}%22%20or%20profile.email%20eq%20%22{username_or_email}%22",
+            f'profile.login eq "{username_or_email}" or profile.email eq "{username_or_email}"',
         ]
         response = await client.get(
             f"{client.base_url}/api/v1/users?search=profile.login%20eq%20%22{username_or_email}%22%20or%20profile.email%20eq%20%22{username_or_email}%22",


### PR DESCRIPTION
## Description

Okta API calls do not always accept supplying the user's ID using the profile.login value.  Added a new action to lookup user(s) by login/email and modified other actions to take Okta user id as input.

## Related Tickets & Documents



## Screenshots/Recordings



## Steps to QA

Tested against live Okta environment

## [optional] What gif best describes this PR?


