### PR TITLE
ci(infra): [Part 1 / 2] Add internal ALB to direct fargate traffic to temporal

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -182,7 +182,6 @@ jobs:
           NEXT_PUBLIC_CLERK_SIGN_IN_URL: /sign-in
           NEXT_PUBLIC_CLERK_SIGN_OUT_URL: /sign-out
           # Temporal
-          TEMPORAL__CLUSTER_URL: temporal-service:7233
           TEMPORAL__CLUSTER_QUEUE: tracecat-task-queue
           TEMPORAL__CLUSTER_NAMESPACE: default
           TEMPORAL__VERSION: 1.24.2

--- a/aws/app.py
+++ b/aws/app.py
@@ -26,6 +26,7 @@ fargate = FargateStack(
     id="TracecatFargateStack",
     cluster=vpc.cluster,
     dns_namespace=vpc.dns_namespace,
+    api_hosted_zone=route53.api_hosted_zone,
     frontend_security_group=vpc.frontend_security_group,
     backend_security_group=vpc.backend_security_group,
     core_database=rds.core_database,

--- a/aws/tracecat_cdk/fargate.py
+++ b/aws/tracecat_cdk/fargate.py
@@ -57,13 +57,6 @@ class FargateStack(Stack):
             security_group=backend_security_group,
         )
 
-        # Add a listener on port 80, set open=False to restrict access
-        listener = alb.add_listener(
-            "Listener",
-            port=80,
-            open=False,
-        )
-
         ### Tracecat API / Worker
         # Execution roles
         api_execution_role = iam.Role(
@@ -519,6 +512,7 @@ class FargateStack(Stack):
         )
 
         # Temporal Target Group
+        listener = alb.add_listener("TemporalListener", port=7233)
         self.temporal_target_group = listener.add_targets(
             "TemporalTarget",
             port=7233,

--- a/aws/tracecat_cdk/fargate.py
+++ b/aws/tracecat_cdk/fargate.py
@@ -16,6 +16,7 @@ from aws_cdk import aws_servicediscovery as servicediscovery
 from constructs import Construct
 
 from .config import (
+    API_DOMAIN_NAME,
     IS_PRODUCTION,
     TEMPORAL_SERVER_CPU,
     TEMPORAL_SERVER_IMAGE,
@@ -38,6 +39,7 @@ class FargateStack(Stack):
         id: str,
         cluster: ecs.Cluster,
         dns_namespace: servicediscovery.INamespace,
+        api_hosted_zone: route53.IHostedZone,
         frontend_security_group: ec2.SecurityGroup,
         backend_security_group: ec2.SecurityGroup,
         core_database: rds.DatabaseInstance,
@@ -49,6 +51,16 @@ class FargateStack(Stack):
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
+
+        ### Internal ALB to route traffic to temporal service
+        alb = elbv2.ApplicationLoadBalancer(
+            self,
+            "FargateALB",
+            vpc=cluster.vpc,
+            http2_enabled=True,
+            internet_facing=False,
+            security_group=backend_security_group,
+        )
 
         ### Tracecat API / Worker
         # Execution roles
@@ -301,7 +313,7 @@ class FargateStack(Stack):
             "TRACECAT__DB_PORT": core_database.db_instance_endpoint_port,
             "TRACECAT__DISABLE_AUTH": os.environ["TRACECAT__DISABLE_AUTH"],
             "TRACECAT__PUBLIC_RUNNER_URL": os.environ["TRACECAT__PUBLIC_RUNNER_URL"],
-            "TEMPORAL__CLUSTER_URL": "temporal.local:443",
+            "TEMPORAL__CLUSTER_URL": f"{alb.load_balancer_dns_name}:443",
             "TEMPORAL__CLUSTER_QUEUE": os.environ["TEMPORAL__CLUSTER_QUEUE"],
         }
 
@@ -497,45 +509,29 @@ class FargateStack(Stack):
             capacity_provider_strategies=[capacity_provider_strategy],
         )
 
-        ### Internal ALB to route traffic to temporal service
-        alb = elbv2.ApplicationLoadBalancer(
+        # Request a new certificate for temporal.api.<domain>
+        temporal_certificate = acm.Certificate(
             self,
-            "FargateALB",
-            vpc=cluster.vpc,
-            http2_enabled=True,
-            internet_facing=False,
-            security_group=backend_security_group,
+            "TemporalApiCertificate",
+            domain_name=f"temporal.{API_DOMAIN_NAME}",
+            validation=acm.CertificateValidation.from_dns(api_hosted_zone),
         )
 
-        # Create a new private hosted zone
-        private_hosted_zone = route53.PrivateHostedZone(
+        # Create a CNAME record for the Temporal subdomain
+        route53.CnameRecord(
             self,
-            "TemporalPrivateHostedZone",
-            zone_name="temporal.local",
-            vpc=cluster.vpc,
+            "TemporalApiCnameRecord",
+            zone=api_hosted_zone,
+            record_name="temporal",
+            domain_name=alb.load_balancer_dns_name,
         )
 
-        # Create a new SSL certificate for the internal domain dynamically
-        certificate = acm.Certificate(
-            self,
-            "TemporalCertificate",
-            domain_name="temporal.local",
-            validation=acm.CertificateValidation.from_dns(),
-        )
-        validation_record = route53.TxtRecord(
-            self,
-            "CertificateValidationRecord",
-            zone=private_hosted_zone,
-            record_name=certificate.domain_validation_options[0].resource_record_name,
-            values=[certificate.domain_validation_options[0].resource_record_value],
-        )
-        validation_record.node.add_dependency(certificate)
-
-        # Create an A record to point the internal domain to the ALB
+        # Create an A record for the Temporal subdomain
         route53.ARecord(
             self,
-            "TemporalAliasRecord",
-            zone=private_hosted_zone,
+            "TemporalApiARecord",
+            zone=api_hosted_zone,
+            record_name="temporal",
             target=route53.RecordTarget.from_alias(targets.LoadBalancerTarget(alb)),
         )
 
@@ -557,7 +553,7 @@ class FargateStack(Stack):
             port=443,
             protocol=elbv2.ApplicationProtocol.HTTPS,
             open=False,
-            certificates=[certificate],
+            certificates=[temporal_certificate],
             default_target_groups=[temporal_target_group],
         )
 

--- a/aws/tracecat_cdk/fargate.py
+++ b/aws/tracecat_cdk/fargate.py
@@ -522,6 +522,7 @@ class FargateStack(Stack):
         self.temporal_target_group = listener.add_targets(
             "TemporalTarget",
             port=7233,
+            protocol=elbv2.ApplicationProtocol.HTTP,
             protocol_version=elbv2.ApplicationProtocolVersion.GRPC,
             targets=[temporal_service],
         )

--- a/aws/tracecat_cdk/fargate.py
+++ b/aws/tracecat_cdk/fargate.py
@@ -505,19 +505,24 @@ class FargateStack(Stack):
         )
 
         # Temporal Target Group
-        listener = alb.add_listener(
-            "TemporalListener",
-            port=7233,
-            protocol=elbv2.ApplicationProtocol.HTTP,
-            open=False,
-        )
-        self.temporal_target_group = listener.add_targets(
-            "TemporalTarget",
+        temporal_target_group = elbv2.ApplicationTargetGroup(
+            self,
+            "TemporalTargetGroup",
             port=7233,
             protocol=elbv2.ApplicationProtocol.HTTP,
             protocol_version=elbv2.ApplicationProtocolVersion.GRPC,
             targets=[temporal_service],
+            vpc=alb.vpc,
         )
+
+        self.listener = alb.add_listener(
+            "TemporalListener",
+            port=7233,
+            protocol=elbv2.ApplicationProtocol.HTTP,
+            open=False,
+            default_target_groups=[temporal_target_group],
+        )
+
         # Allow connections from the ALB to the target services
         backend_security_group.add_ingress_rule(
             peer=alb.connections.security_groups[0],


### PR DESCRIPTION
## NOTE: we are splitting this PR into two.

Fixes issue with worker establishing a connection to Temporal.

## What changed
- Drop service connect for worker and temporal server
- Add internal facing ALB to Fargate stack
- Added listeners and target (with protocolVersion=GRPC) for temporal service
- Update backend security group to allow traffic to internal ALB
- A Record: Created to point `temporal.{API_DOMAIN_NAME}` to the ALB.
- CNAME record: `temporal` subdomain to the API hosted zone
- Certificate: ACM certificate created for `temporal` subdomain added to the public API hosted zone
- gRPC Target Group: Configured for the Temporal service with gRPC protocol.

## Potential gotcha
- gRPC target only supports listeners with HTTPS protocol
- Can only create certificates programmatically via CDK for public hosted zones
- Even though hosted zone is public, traffic is all internal (internal ALB has `internet_facing=False`)

## Reference
- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html