### PR TITLE
feat(ui): Improve node handles + add node silhouette + add selector node

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "sharp": "^0.33.4",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
+    "uuid": "^10.0.0",
     "vaul": "^0.9.1",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.3)
+      uuid:
+        specifier: ^10.0.0
+        version: 10.0.0
       vaul:
         specifier: ^0.9.1
         version: 0.9.1(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4839,6 +4842,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -10281,6 +10288,8 @@ snapshots:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@8.3.2: {}
 

--- a/frontend/src/components/workspace/canvas/canvas.tsx
+++ b/frontend/src/components/workspace/canvas/canvas.tsx
@@ -68,7 +68,7 @@ function getLayoutedElements(
   edges: Edge[]
 } {
   const isHorizontal = direction === "LR"
-  dagreGraph.setGraph({ rankdir: direction })
+  dagreGraph.setGraph({ rankdir: direction, nodesep: 100, ranksep: 100 })
 
   nodes.forEach((node) => {
     dagreGraph.setNode(node.id, {

--- a/frontend/src/components/workspace/canvas/canvas.tsx
+++ b/frontend/src/components/workspace/canvas/canvas.tsx
@@ -417,6 +417,9 @@ export function WorkflowCanvas() {
         fitView
         fitViewOptions={fitViewOptions}
         nodeDragThreshold={4}
+        maxZoom={1}
+        minZoom={0.75}
+        panOnScroll
       >
         <Background />
         <Controls className="rounded-sm" fitViewOptions={fitViewOptions} />

--- a/frontend/src/components/workspace/canvas/canvas.tsx
+++ b/frontend/src/components/workspace/canvas/canvas.tsx
@@ -439,8 +439,9 @@ export function WorkflowCanvas() {
           </Button>
           <Button
             variant="outline"
-            className="m-0 size-6 p-0 text-xs"
+            className="m-0 hidden size-6 p-0 text-xs"
             onClick={() => onLayout("LR")}
+            disabled
           >
             <MoveHorizontalIcon className="size-3" strokeWidth={2} />
           </Button>

--- a/frontend/src/components/workspace/canvas/custom-handle.tsx
+++ b/frontend/src/components/workspace/canvas/custom-handle.tsx
@@ -5,10 +5,13 @@ import {
   Handle,
   Node,
   NodeInternals,
+  Position,
   useNodeId,
   useStore,
   type HandleProps,
 } from "reactflow"
+
+import { cn } from "@/lib/utils"
 
 interface CustomHandleProps
   extends Omit<HandleProps, "isConnectable">,
@@ -66,5 +69,33 @@ export function CustomHandle(props: CustomHandleProps) {
     return null
   }
 
-  return <Handle {...props} isConnectable={isHandleConnectable}></Handle>
+  return (
+    <CustomFloatingHandle
+      {...props}
+      isConnectable={isHandleConnectable}
+    ></CustomFloatingHandle>
+  )
+}
+
+export function CustomFloatingHandle({
+  type,
+  position,
+  className,
+}: HandleProps & React.HTMLProps<HTMLDivElement>) {
+  return (
+    <Handle
+      type={type}
+      position={position}
+      className={cn(
+        "group left-1/2 !size-10 !-translate-x-1/2 !border-none !bg-transparent",
+        position === Position.Top && "!-top-8",
+        position === Position.Bottom && "!-bottom-8",
+        position === Position.Left && "!-left-8",
+        position === Position.Right && "!-right-8",
+        className
+      )}
+    >
+      <div className="absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/50 transition-all group-hover:size-3 group-hover:bg-emerald-400 group-hover:shadow-lg" />
+    </Handle>
+  )
 }

--- a/frontend/src/components/workspace/canvas/custom-handle.tsx
+++ b/frontend/src/components/workspace/canvas/custom-handle.tsx
@@ -87,7 +87,7 @@ export function CustomFloatingHandle({
       type={type}
       position={position}
       className={cn(
-        "group left-1/2 !size-10 !-translate-x-1/2 !border-none !bg-transparent",
+        "group left-1/2 !size-8 !-translate-x-1/2 !border-none !bg-transparent",
         position === Position.Top && "!-top-8",
         position === Position.Bottom && "!-bottom-8",
         position === Position.Left && "!-left-8",
@@ -95,7 +95,7 @@ export function CustomFloatingHandle({
         className
       )}
     >
-      <div className="absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/50 transition-all group-hover:size-3 group-hover:bg-emerald-400 group-hover:shadow-lg" />
+      <div className="pointer-events-none absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/50 transition-all group-hover:size-4 group-hover:bg-emerald-400 group-hover:shadow-lg" />
     </Handle>
   )
 }

--- a/frontend/src/components/workspace/canvas/selector-node.tsx
+++ b/frontend/src/components/workspace/canvas/selector-node.tsx
@@ -1,0 +1,251 @@
+import React, { useCallback, useEffect, useRef } from "react"
+import { useWorkflowBuilder } from "@/providers/builder"
+import { useWorkflow } from "@/providers/workflow"
+import { CloudOffIcon, XIcon } from "lucide-react"
+import {
+  Handle,
+  Node,
+  NodeProps,
+  Position,
+  useKeyPress,
+  useNodeId,
+  useReactFlow,
+} from "reactflow"
+
+import { udfConfig } from "@/config/udfs"
+import { UDF, useUDFs } from "@/lib/udf"
+import { cn } from "@/lib/utils"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Label } from "@/components/ui/label"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { toast } from "@/components/ui/use-toast"
+import { getIcon } from "@/components/icons"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import {
+  createNewNode,
+  isEphemeral,
+} from "@/components/workspace/canvas/canvas"
+import { UDFNodeData } from "@/components/workspace/canvas/udf-node"
+import {
+  groupByDisplayGroup,
+  TOP_LEVEL_GROUP,
+} from "@/components/workspace/catalog/udf-catalog"
+
+export const SelectorTypename = "selector" as const
+
+export interface SelectorNodeData {
+  type: "selector"
+}
+export type SelectorNodeType = Node<SelectorNodeData>
+
+export default React.memo(function SelectorNode({
+  targetPosition,
+}: NodeProps<SelectorNodeData>) {
+  const id = useNodeId()
+  const { workflow } = useWorkflow()
+  const { setNodes, setEdges } = useReactFlow()
+  const escapePressed = useKeyPress("Escape")
+
+  const removeSelectorNode = () => {
+    setNodes((nodes) => nodes.filter((node) => !isEphemeral(node)))
+    setEdges((edges) => edges.filter((edge) => edge.target !== id))
+  }
+
+  useEffect(() => {
+    if (escapePressed) {
+      removeSelectorNode()
+    }
+  }, [escapePressed])
+
+  if (!workflow || !id) {
+    console.error("Workflow or node ID not found")
+    return null
+  }
+
+  return (
+    <div>
+      <Command className="h-96 w-72 rounded-lg border shadow-sm">
+        <div className="w-full bg-muted-foreground/5 px-3 py-[2px]">
+          <Label className="flex items-center text-xs text-muted-foreground">
+            <span className="font-medium">Add a node</span>
+            <span className="my-[1px] ml-auto flex items-center space-x-2">
+              <p className="my-0 inline-block rounded-sm border border-muted-foreground/20 bg-muted-foreground/10 px-[1px] py-0 font-mono text-xs">
+                Esc
+              </p>
+              <XIcon
+                className="mr-1 size-3 stroke-muted-foreground/70 transition-all hover:cursor-pointer"
+                strokeWidth={3}
+                onClick={removeSelectorNode}
+              />
+            </span>
+          </Label>
+        </div>
+        <Separator />
+        <CommandInput
+          className="!py-0 text-xs"
+          placeholder="Start typing to search for an action..."
+        />
+        <CommandList className="border-b">
+          <CommandEmpty>
+            <span className="text-xs text-muted-foreground/70">
+              No results found.
+            </span>
+          </CommandEmpty>
+          <UDFCommandSelector nodeId={id} />
+        </CommandList>
+      </Command>
+      <Handle
+        type="target"
+        position={targetPosition ?? Position.Top}
+        isConnectable={false} // Prevent initiating a connection from the selector node
+        className={cn(
+          "left-1/2 !size-8 !-translate-x-1/2 !border-none !bg-transparent"
+        )}
+      />
+    </div>
+  )
+})
+
+function UDFCommandSelector({ nodeId }: { nodeId: string }) {
+  const { udfs, isLoading: udfsLoading, error } = useUDFs(udfConfig.namespaces)
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleScroll = (event: Event) => {
+      event.stopPropagation()
+    }
+
+    const scrollArea = scrollAreaRef.current
+    if (scrollArea) {
+      scrollArea.addEventListener("wheel", handleScroll)
+    }
+
+    return () => {
+      if (scrollArea) {
+        scrollArea.removeEventListener("wheel", handleScroll)
+      }
+    }
+  }, [])
+
+  if (!udfs || udfsLoading) {
+    return <CenteredSpinner />
+  }
+  if (error) {
+    console.error("Failed to load UDFs", error)
+    return (
+      <div className="flex size-full items-center justify-center">
+        <CloudOffIcon className="size-8 text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <ScrollArea ref={scrollAreaRef} className="h-full">
+      {Object.entries(groupByDisplayGroup(udfs))
+        .sort(([groupA], [groupB]) => groupA.localeCompare(groupB))
+        .map(([group, udfs], idx) => (
+          <UDFCommandGroup
+            key={`${group}-${idx}`}
+            group={group === TOP_LEVEL_GROUP ? "Core" : group}
+            udfs={udfs}
+            nodeId={nodeId}
+          />
+        ))}
+    </ScrollArea>
+  )
+}
+
+function UDFCommandGroup({
+  group,
+  udfs,
+  nodeId,
+}: {
+  group: string
+  udfs: UDF[]
+  nodeId: string
+}) {
+  const { workflowId } = useWorkflowBuilder()
+  const { getNode, setNodes, setEdges } = useReactFlow()
+
+  const handleSelect = useCallback(
+    async (udf: UDF) => {
+      if (!workflowId) {
+        return
+      }
+      console.log("Selected UDF:", udf)
+      const { position: currPosition } = getNode(
+        nodeId
+      ) as Node<SelectorNodeData>
+      const nodeData = {
+        type: udf.key,
+        title: udf.metadata?.default_title || udf.key,
+        namespace: udf.namespace,
+        status: "offline",
+        isConfigured: false,
+        numberOfEvents: 0,
+      } as UDFNodeData
+      try {
+        const newNode = await createNewNode(
+          "udf",
+          workflowId,
+          nodeData,
+          currPosition
+        )
+        // Given successful creation, we can now remove the selector node
+        // Find the current "selector" node and replace it with the new node
+        // XXX: Actually just filter all ephemeral nodes
+        // Create Action in database
+        setNodes((prevNodes) =>
+          prevNodes
+            .filter((n) => !isEphemeral(n))
+            .map((n) => ({ ...n, selected: false }))
+            .concat({ ...newNode, selected: true })
+        )
+        // At this point, we have an edge between some other node and the selector node
+        // We need to create an edge between the new node and the other node
+        setEdges((prevEdges) =>
+          prevEdges.map((edge) =>
+            edge.target === nodeId
+              ? {
+                  ...edge,
+                  target: newNode.id,
+                }
+              : edge
+          )
+        )
+      } catch (error) {
+        console.error("An error occurred while creating a new node:", error)
+        toast({
+          title: "Failed to create new node",
+          description: "Could not create new node.",
+        })
+        return // Abort
+      }
+    },
+    [getNode, nodeId]
+  )
+  return (
+    <CommandGroup heading={group} className="text-xs">
+      {udfs.map((udf) => (
+        <CommandItem
+          key={udf.key}
+          className="text-xs"
+          onSelect={async () => await handleSelect(udf)}
+        >
+          {getIcon(udf.key, {
+            className: "size-5 mr-2",
+          })}
+          <span className="text-xs">{udf.metadata?.default_title}</span>
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  )
+}

--- a/frontend/src/components/workspace/canvas/trigger-node.tsx
+++ b/frontend/src/components/workspace/canvas/trigger-node.tsx
@@ -154,8 +154,6 @@ export default React.memo(function TriggerNode({
       <CustomHandle
         type="source"
         position={sourcePosition ?? Position.Bottom}
-        className="w-16 !bg-gray-500"
-        style={{ width: 8, height: 8 }}
         isConnectable={1}
       />
     </Card>

--- a/frontend/src/components/workspace/canvas/udf-node.tsx
+++ b/frontend/src/components/workspace/canvas/udf-node.tsx
@@ -30,6 +30,7 @@ import {
 import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/components/ui/use-toast"
 import { getIcon } from "@/components/icons"
+import { CustomFloatingHandle } from "@/components/workspace/canvas/custom-handle"
 
 export interface UDFNodeData {
   type: string // alias for key
@@ -42,7 +43,6 @@ export interface UDFNodeData {
 export type UDFNodeType = Node<UDFNodeData>
 export const RFGraphUDFNodeType = "udf" as const
 
-const handleStyle = { width: 8, height: 8 }
 export default React.memo(function UDFNode({
   data: { title, isConfigured, numberOfEvents, type: key },
   selected,
@@ -151,17 +151,13 @@ export default React.memo(function UDFNode({
         </div>
       </CardContent>
 
-      <Handle
+      <CustomFloatingHandle
         type="target"
         position={targetPosition ?? Position.Top}
-        className="w-16 !bg-gray-500"
-        style={handleStyle}
       />
-      <Handle
+      <CustomFloatingHandle
         type="source"
         position={sourcePosition ?? Position.Bottom}
-        className="w-16 !bg-gray-500"
-        style={handleStyle}
       />
     </Card>
   )

--- a/frontend/src/components/workspace/canvas/udf-node.tsx
+++ b/frontend/src/components/workspace/canvas/udf-node.tsx
@@ -10,7 +10,7 @@ import {
   LayoutListIcon,
   ScanSearchIcon,
 } from "lucide-react"
-import { Handle, Node, NodeProps, Position, useNodeId } from "reactflow"
+import { Node, NodeProps, Position, useNodeId } from "reactflow"
 
 import { cn, copyToClipboard, slugify } from "@/lib/utils"
 import { Button } from "@/components/ui/button"

--- a/frontend/src/components/workspace/catalog/udf-catalog.tsx
+++ b/frontend/src/components/workspace/catalog/udf-catalog.tsx
@@ -22,9 +22,9 @@ import {
   UDFNodeType,
 } from "@/components/workspace/canvas/udf-node"
 
-const TOP_LEVEL_GROUP = "__TOP_LEVEL__" as const
+export const TOP_LEVEL_GROUP = "__TOP_LEVEL__" as const
 
-const groupByDisplayGroup = (udfs: UDF[]): Record<string, UDF[]> => {
+export const groupByDisplayGroup = (udfs: UDF[]): Record<string, UDF[]> => {
   const groups = {} as Record<string, UDF[]>
   udfs.forEach((udf) => {
     const displayGroup = (

--- a/frontend/src/components/workspace/panel/workspace-panel.tsx
+++ b/frontend/src/components/workspace/panel/workspace-panel.tsx
@@ -65,6 +65,9 @@ function NodePanel({ node, workflow }: { node: NodeType; workflow: Workflow }) {
           workflow={workflow}
         />
       )
+    case "selector":
+      // XXX: Unreachable, as we never select the selector node
+      return <></>
     default:
       return <AlertNotification level="error" message="Unknown node type" />
   }

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -14,6 +14,7 @@ import {
   type WorkflowMetadata,
 } from "@/types/schemas"
 import { client } from "@/lib/api"
+import { isEphemeral } from "@/components/workspace/canvas/canvas"
 
 export async function updateWorkflowGraphObject(
   workflowId: string,
@@ -21,6 +22,24 @@ export async function updateWorkflowGraphObject(
 ) {
   try {
     const object = reactFlowInstance.toObject()
+
+    // Filter out non-ephemeral nodes and their associated edges
+    const ephemeralNodeIds = new Set(
+      object.nodes.filter(isEphemeral).map((node) => node.id)
+    )
+
+    // Keep nodes that are NOT ephemeral
+    object.nodes = object.nodes.filter((node) => !ephemeralNodeIds.has(node.id))
+    // Keep edges that are NOT connected to ephemeral nodes
+    object.edges = object.edges.filter(
+      (edge) => !ephemeralNodeIds.has(edge.target)
+    )
+
+    // Check that the object at least contains the trigger node
+    if (!object.nodes.some((node) => node.type === "trigger")) {
+      throw new Error("Workflow cannot be saved without a trigger node")
+    }
+
     await client.patch(`/workflows/${workflowId}`, {
       object,
     })

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -66,8 +66,11 @@ export const WorkflowBuilderProvider: React.FC<
   )
   useOnSelectionChange({
     onChange: ({ nodes }: { nodes: NodeType[] }) => {
-      const actionNodeSelected = nodes[0]
-      setSelectedNodeId(actionNodeSelected?.id ?? null)
+      const nodeSelected = nodes[0]
+      if (nodeSelected?.type === "selector") {
+        return
+      }
+      setSelectedNodeId(nodeSelected?.id ?? null)
     },
   })
   if (error) {


### PR DESCRIPTION
# Features
- Make node handles larger, but visually the same size (transparent body with dot). Easier to grab and drag, also nice because it looks like its floating.
- Add node silhouette when dragging out from an edge
- When the above completes, react flow fires the `onConnectEnd` event. We capture this and drop a selector (placeholder) node in which you can browse UDFs. On selection (click/hit enter), the selector node then replaces itself with the selected node type
- Add esc keybind to remove ephemeral nodes

# Remarks
- I call these kinds of non-concrete nodes "ephemeral nodes". We do not persist their state, and whenever we update the backend graph we defensively filter out any ephermeral nodes.
- The backend doesn't need to know about the existence of ephermeral nodes