### PR TITLE
Added list_okta_user_events; Renamed find_okta_user to find_okta_users

### DIFF
--- a/tracecat/actions/integrations/iam/__init__.py
+++ b/tracecat/actions/integrations/iam/__init__.py
@@ -1,6 +1,6 @@
 from .okta import (
     expire_okta_sessions,
-    find_okta_user,
+    find_okta_users,
     suspend_okta_user,
     unsuspend_okta_user,
 )
@@ -9,5 +9,5 @@ __all__ = [
     "suspend_okta_user",
     "unsuspend_okta_user",
     "expire_okta_sessions",
-    "find_okta_user",
+    "find_okta_users",
 ]

--- a/tracecat/actions/integrations/iam/okta.py
+++ b/tracecat/actions/integrations/iam/okta.py
@@ -56,7 +56,7 @@ async def find_okta_users(
         str,
         Field(..., description="Login username or e-mail to find"),
     ],
-) -> list:
+) -> list[dict[str, Any]]:
     async with create_okta_client() as client:
         params = {
             "search": (
@@ -161,9 +161,9 @@ async def list_okta_user_events(
 ) -> list[dict[str, Any]]:
     async with create_okta_client() as client:
         params = {
-            "filter": (f'actor.id eq "{okta_user_id}"'),
-            "since": (start_time.strftime("%Y-%m-%dT%H:%M:%S")),
-            "until": (end_time.strftime("%Y-%m-%dT%H:%M:%S")),
+            "filter": f'actor.id eq "{okta_user_id}"',
+            "since": start_time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "until": end_time.strftime("%Y-%m-%dT%H:%M:%S"),
             "limit": limit,
         }
         response = await client.get(


### PR DESCRIPTION
## Description

- Added new action: list_okta_user_events
- Renamed find_okta_user to find_okta_users since we return a list, the name is more communicative of the return type

## Related Tickets & Documents

N/A

## Screenshots/Recordings

N/A

## Steps to QA

Tested against live API.

## [optional] What gif best describes this PR?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
