### PR TITLE
fix: Check API_URL against the placeholder string instead of nullish

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,10 +19,13 @@ export function getBaseUrl() {
   }
 
   // Client side
-  return (
+  // @ts-expect-error Reason: Suppressing TypeScript error for the following code block
+  if (global.API_URL === "__PLACEHOLDER_API_URL__") {
+    return process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000"
+  } else {
     // @ts-expect-error Reason: Suppressing TypeScript error for the following code block
-    global.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000"
-  )
+    return global.API_URL
+  }
 }
 
 // Legacy axiosclient


### PR DESCRIPTION
# Changes
- Previously when the `__PLACEHOLDER_API_URL__` string doesn't get replaced, axios would think that this is a string path and direct api calls to `localhost:3000/__PLACEHOLDER_API_URL__`