### PR TITLE
refactor(engine): Standardize db access + clean up api

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,7 +38,7 @@ services:
       - ./tracecat:/app/tracecat
       - core-app:/var/lib/tracecat
     environment:
-      DUMP_TRACECAT_RESULT: 1
+      DUMP_TRACECAT_RESULT: 0
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__API_URL: ${TRACECAT__API_URL}
       TRACECAT__APP_ENV: ${TRACECAT__APP_ENV}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - 3000:3000
     environment:
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY} # Sensitive
+      API_URL: ${API_URL}
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
       NEXT_PUBLIC_APP_ENV: ${NEXT_PUBLIC_APP_ENV}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL}

--- a/tracecat/actions/core/cases.py
+++ b/tracecat/actions/core/cases.py
@@ -3,10 +3,9 @@
 from typing import Annotated, Any, Literal
 
 from pydantic import Field
-from sqlmodel import Session
 
 from tracecat.contexts import ctx_role, ctx_run
-from tracecat.db.engine import create_db_engine
+from tracecat.db.engine import get_session
 from tracecat.db.schemas import Case
 from tracecat.registry import registry
 from tracecat.types.api import CaseContext, Tag
@@ -56,14 +55,13 @@ async def open_case(
     ] = None,
 ) -> dict[str, Any]:
     """Open a new case in the case management system."""
-    engine = create_db_engine()
     run = ctx_run.get()
     role = ctx_role.get()
     tags = tags or []
     context = context or []
     if isinstance(context, dict):
         context = [CaseContext(key=key, value=value) for key, value in context.items()]
-    with Session(engine) as session:
+    with get_session() as session:
         case = Case(
             owner_id=role.user_id,
             workflow_id=run.wf_id,

--- a/tracecat/actions/core/cases.py
+++ b/tracecat/actions/core/cases.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Literal
 from pydantic import Field
 
 from tracecat.contexts import ctx_role, ctx_run
-from tracecat.db.engine import get_session
+from tracecat.db.engine import get_session_context_manager
 from tracecat.db.schemas import Case
 from tracecat.registry import registry
 from tracecat.types.api import CaseContext, Tag
@@ -61,7 +61,7 @@ async def open_case(
     context = context or []
     if isinstance(context, dict):
         context = [CaseContext(key=key, value=value) for key, value in context.items()]
-    with get_session() as session:
+    with get_session_context_manager() as session:
         case = Case(
             owner_id=role.user_id,
             workflow_id=run.wf_id,

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -35,7 +35,7 @@ from tracecat.auth.credentials import (
     authenticate_user_or_service,
 )
 from tracecat.contexts import ctx_role
-from tracecat.db.engine import get_engine
+from tracecat.db.engine import get_session, initialize_db
 from tracecat.db.schemas import (
     Action,
     Case,
@@ -107,7 +107,7 @@ engine: Engine
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global engine
-    engine = get_engine()
+    engine = initialize_db()
     yield
 
 
@@ -229,12 +229,6 @@ def root() -> dict[str, str]:
 @app.get("/health")
 def check_health() -> dict[str, str]:
     return {"message": "Hello world. I am the API. This is the health endpoint."}
-
-
-# ----- Dependencies ----- #
-def get_session():
-    with Session(engine) as session:
-        yield session
 
 
 # ----- Trigger handlers ----- #

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -35,7 +35,7 @@ from tracecat.auth.credentials import (
     authenticate_user_or_service,
 )
 from tracecat.contexts import ctx_role
-from tracecat.db.engine import get_session, initialize_db
+from tracecat.db.engine import get_session, get_session_context_manager, initialize_db
 from tracecat.db.schemas import (
     Action,
     Case,
@@ -242,7 +242,7 @@ def validate_incoming_webhook(
 
     NOte: The webhook ID here is the workflow ID.
     """
-    with get_session() as session:
+    with get_session_context_manager() as session:
         result = session.exec(select(Webhook).where(Webhook.workflow_id == webhook_id))
         try:
             # One webhook per workflow

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from loguru import logger
@@ -12,18 +11,10 @@ from sqlmodel import (
 )
 
 from tracecat import config
-from tracecat.db.schemas import (
-    DEFAULT_CASE_ACTIONS,
-    Action,
-    CaseAction,
-    UDFSpec,
-    User,
-    Webhook,
-    Workflow,
-)
+from tracecat.db.schemas import DEFAULT_CASE_ACTIONS, CaseAction, UDFSpec, User
 from tracecat.registry import registry
 
-_engine: Engine = None
+_engine: Engine | None = None
 
 
 def create_db_engine() -> Engine:
@@ -97,72 +88,3 @@ def get_engine() -> Engine:
     if _engine is None:
         _engine = initialize_db()
     return _engine
-
-
-def clone_workflow(
-    workflow: Workflow,
-    session: Session,
-    new_owner_id: str,
-) -> Workflow:
-    """
-    Clones a Resource, including its relationships (up to a certain depth).
-
-    :param model_instance: The SQLModel instance to clone.
-    :param session: The SQLModel session.
-    :param _depth: Current depth level, used to limit recursive depth.
-    :return: The cloned instance.
-    """
-
-    # Create a new instance of the same model without the primary key
-    cloned_workflow = Workflow(
-        **workflow.model_dump(
-            exclude={"id", "created_at", "updated_at", "owner_id", "object", "status"}
-        ),
-        owner_id=new_owner_id,
-        status="offline",
-    )
-
-    # Iterate over relationships and clone them
-    action_replacements = {}
-    for action in workflow.actions:
-        # Special treatment for webhook actions:
-        # Need to update the action.path
-
-        cloned_action = Action(
-            owner_id=new_owner_id,
-            workflow_id=cloned_workflow.id,
-            **action.model_dump(
-                exclude={"id", "created_at", "updated_at", "owner_id", "workflow_id"}
-            ),
-        )
-
-        action_inputs: dict[str, str] = json.loads(cloned_action.inputs)
-        if action.type == "webhook":
-            cloned_webhook = Webhook(
-                owner_id=new_owner_id,
-                action_id=cloned_action.id,
-                workflow_id=cloned_workflow.id,
-            )
-            # Update the action inputs to point to the new webhook path
-            action_inputs.update(path=cloned_webhook.id, secret=cloned_webhook.secret)
-
-            # Assert that there's a new computed secret
-            session.add(cloned_webhook)
-        cloned_action.inputs = json.dumps(action_inputs)
-        action_replacements[action.id] = (cloned_action.id, action_inputs)
-        session.add(cloned_action)
-
-    # For each action in the workflow, update the workflow object
-    graph = json.loads(workflow.object)
-    for edge in graph["edges"]:
-        edge["source"] = action_replacements[edge["source"]][0]
-        edge["target"] = action_replacements[edge["target"]][0]
-        edge["id"] = f"{edge['source']}-{edge['target']}"
-    for node in graph["nodes"]:
-        new_id, new_inputs = action_replacements[node["id"]]
-        node["id"] = new_id
-        node["data"].update(id=new_id, inputs=new_inputs, selected=False)
-    cloned_workflow.object = json.dumps(graph)
-
-    session.add(cloned_workflow)
-    return cloned_workflow

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -1,15 +1,10 @@
+import contextlib
 import os
 from collections.abc import Generator
 
 from loguru import logger
 from sqlalchemy import Engine
-from sqlmodel import (
-    Session,
-    SQLModel,
-    create_engine,
-    delete,
-    select,
-)
+from sqlmodel import Session, SQLModel, create_engine, delete, select
 
 from tracecat import config
 from tracecat.db.schemas import DEFAULT_CASE_ACTIONS, CaseAction, UDFSpec, User
@@ -96,3 +91,7 @@ def get_engine() -> Engine:
 def get_session() -> Generator[Session, None, None]:
     with Session(get_engine()) as session:
         yield session
+
+
+def get_session_context_manager() -> contextlib.AbstractContextManager[Session]:
+    return contextlib.contextmanager(get_session)()

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -226,10 +226,6 @@ class StartWorkflowResponse(BaseModel):
     id: str
 
 
-class CopyWorkflowParams(BaseModel):
-    owner_id: str
-
-
 class SecretResponse(BaseModel):
     id: str
     type: Literal["custom"]  # Support other types later

--- a/tracecat/workflow/definitions.py
+++ b/tracecat/workflow/definitions.py
@@ -12,7 +12,7 @@ from temporalio import activity
 
 from tracecat import identifiers
 from tracecat.contexts import RunContext, ctx_role, ctx_run
-from tracecat.db.engine import create_db_engine
+from tracecat.db.engine import get_engine
 from tracecat.db.schemas import Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput, DSLRunArgs
 from tracecat.dsl.models import ActionStatement
@@ -30,7 +30,7 @@ class WorkflowDefinitionsService:
     @contextmanager
     @staticmethod
     def get_session(role: Role) -> Generator[WorkflowDefinitionsService, None, None]:
-        engine = create_db_engine()
+        engine = get_engine()
         with Session(engine) as session:
             yield WorkflowDefinitionsService(session, role)
 

--- a/tracecat/workflow/executions.py
+++ b/tracecat/workflow/executions.py
@@ -8,7 +8,6 @@ from collections.abc import AsyncGenerator, Awaitable
 from typing import Any
 
 import orjson
-from sqlmodel import Session
 from temporalio.api.enums.v1 import EventType
 from temporalio.client import (
     Client,
@@ -30,7 +29,6 @@ from tracecat.dsl.workflow import DSLWorkflow, retry_policies
 from tracecat.logging import logger
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatValidationError
-from tracecat.workflow.definitions import WorkflowDefinitionsService
 from tracecat.workflow.models import (
     CreateWorkflowExecutionResponse,
     DispatchWorkflowResult,
@@ -427,25 +425,3 @@ class WorkflowExecutionsService:
     ) -> None:
         """Terminate a workflow execution."""
         return self.handle(wf_exec_id).terminate(reason=reason)
-
-
-if __name__ == "__main__":
-    from dotenv import find_dotenv, load_dotenv
-
-    from tracecat.db.engine import create_db_engine
-
-    load_dotenv(find_dotenv())
-
-    engine = create_db_engine()
-
-    with Session(engine) as session:
-        service = WorkflowDefinitionsService(
-            session,
-            role=Role(
-                type="user",
-                user_id="default-tracecat-user",
-                service_id="tracecat-service",
-            ),
-        )
-        res = service.get_definition_by_workflow_title("Child workflow")
-        service.logger.warning("Result", res=res)


### PR DESCRIPTION
# Changes
- Move fastapi exception handlers to app creation
- Remove clone workflow
- Remove global db `engine` variable in app router. We instead use the global variable inside the `db.engine` module and use methods to access the connection pool
- Make all api router usage of db session through fastapi's dependency injection subsystem
- Added `API_URL` to `docker-compose.yml`

# Remarks
- This is in preparation for introducing `asyncpg` and to break up the app router into smaller routers.
- Also tested that the exception handlers can catch errors in sub-routers (which apparently couldn't do before)