### PR TITLE
feat(engine): Add asyncpg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "polars-lts-cpu==1.2.0",
     "psycopg[binary]==3.1.19",
     "psycopg2-binary==2.9.9",
+    "asyncpg==0.29.0",
     "pyarrow==16.1.0",
     "pydantic==2.6.1",
     "python-jose[cryptography]",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import subprocess
 import time
@@ -33,6 +34,13 @@ def pytest_addoption(parser: pytest.Parser):
         default=False,
         help="Do not restart the Tracecat stack if it is already running",
     )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -728,15 +728,13 @@ def assert_validation_result(
         ),
     ],
 )
-async def test_extract_expressions_errors(
-    expr, expected, auth_sandbox, env_sandbox, mock_secrets_service
-):
+async def test_extract_expressions_errors(expr, expected, auth_sandbox, env_sandbox):
     # The only defined action reference is "my_action"
     validation_context = ExprValidationContext(
         action_refs={"my_action"},
         inputs_context={"arg": 2},
     )
-    validators = get_validators(secrets_service=mock_secrets_service)
+    validators = get_validators()
     async with GatheringTaskGroup() as tg:
         visitor = ExprValidator(
             task_group=tg, validation_context=validation_context, validators=validators

--- a/tracecat/actions/core/cases.py
+++ b/tracecat/actions/core/cases.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Literal
 from pydantic import Field
 
 from tracecat.contexts import ctx_role, ctx_run
-from tracecat.db.engine import get_session_context_manager
+from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import Case
 from tracecat.registry import registry
 from tracecat.types.api import CaseContext, Tag
@@ -61,7 +61,7 @@ async def open_case(
     context = context or []
     if isinstance(context, dict):
         context = [CaseContext(key=key, value=value) for key, value in context.items()]
-    with get_session_context_manager() as session:
+    async with get_async_session_context_manager() as session:
         case = Case(
             owner_id=role.user_id,
             workflow_id=run.wf_id,
@@ -75,7 +75,7 @@ async def open_case(
             tags=tags,
         )
         session.add(case)
-        session.commit()
-        session.refresh(case)
+        await session.commit()
+        await session.refresh(case)
 
     return case.model_dump()

--- a/tracecat/api/routers/cases/actions.py
+++ b/tracecat/api/routers/cases/actions.py
@@ -2,10 +2,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import or_
-from sqlmodel import Session, select
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat.auth.credentials import authenticate_user
-from tracecat.db.engine import get_session
+from tracecat.db.engine import get_async_session
 from tracecat.db.schemas import CaseAction
 from tracecat.types.api import CaseActionParams
 from tracecat.types.auth import Role
@@ -14,9 +15,9 @@ router = APIRouter(prefix="/case-actions")
 
 
 @router.get("", tags=["cases"])
-def list_case_actions(
+async def list_case_actions(
     role: Annotated[Role, Depends(authenticate_user)],
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> list[CaseAction]:
     """List all case actions."""
     statement = select(CaseAction).where(
@@ -25,41 +26,42 @@ def list_case_actions(
             CaseAction.owner_id == role.user_id,
         )
     )
-    actions = session.exec(statement).all()
+    result = await session.exec(statement)
+    actions = result.all()
     return actions
 
 
 @router.post("", tags=["cases"])
-def create_case_action(
+async def create_case_action(
     role: Annotated[Role, Depends(authenticate_user)],
     params: CaseActionParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> CaseAction:
     """Create a new case action."""
     case_action = CaseAction(owner_id=role.user_id, **params.model_dump())
     session.add(case_action)
-    session.commit()
-    session.refresh(case_action)
+    await session.commit()
+    await session.refresh(case_action)
     return case_action
 
 
 @router.delete("/{case_action_id}", tags=["cases"])
-def delete_case_action(
+async def delete_case_action(
     role: Annotated[Role, Depends(authenticate_user)],
     case_action_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ):
     """Delete a case action."""
     statement = select(CaseAction).where(
         CaseAction.owner_id == role.user_id,
         CaseAction.id == case_action_id,
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         action = result.one()
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
         ) from e
-    session.delete(action)
-    session.commit()
+    await session.delete(action)
+    await session.commit()

--- a/tracecat/api/routers/cases/management.py
+++ b/tracecat/api/routers/cases/management.py
@@ -2,10 +2,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import NoResultFound
-from sqlmodel import Session, select
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat.auth.credentials import authenticate_service, authenticate_user
-from tracecat.db.engine import get_session
+from tracecat.db.engine import get_async_session
 from tracecat.db.schemas import Case, CaseEvent
 from tracecat.types.api import CaseEventParams, CaseParams, CaseResponse
 from tracecat.types.auth import Role
@@ -18,11 +19,11 @@ router = APIRouter()
     status_code=status.HTTP_201_CREATED,
     tags=["cases"],
 )
-def create_case(
+async def create_case(
     role: Annotated[Role, Depends(authenticate_service)],  # M2M
     workflow_id: str,
     cases: list[CaseParams],
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> CaseResponse:
     """Create a new case for a workflow."""
     case = Case(
@@ -31,8 +32,8 @@ def create_case(
         **cases.model_dump(),
     )
     session.add(case)
-    session.commit()
-    session.refresh(case)
+    await session.commit()
+    await session.refresh(case)
 
     return CaseResponse(
         id=case.id,
@@ -52,17 +53,17 @@ def create_case(
 
 
 @router.get("/workflows/{workflow_id}/cases", tags=["cases"])
-def list_cases(
+async def list_cases(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     limit: int = 100,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> list[CaseResponse]:
     """List all cases for a workflow."""
     query = select(Case).where(
         Case.owner_id == role.user_id, Case.workflow_id == workflow_id
     )
-    result = session.exec(query)
+    result = await session.exec(query)
     try:
         cases = result.fetchmany(size=limit)
     except NoResultFound as e:
@@ -91,11 +92,11 @@ def list_cases(
 
 
 @router.get("/workflows/{workflow_id}/cases/{case_id}", tags=["cases"])
-def get_case(
+async def get_case(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     case_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> CaseResponse:
     """Get a specific case for a workflow."""
     query = select(Case).where(
@@ -103,7 +104,8 @@ def get_case(
         Case.workflow_id == workflow_id,
         Case.id == case_id,
     )
-    case = session.exec(query).one_or_none()
+    result = await session.exec(query)
+    case = result.one_or_none()
     if case is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
@@ -126,12 +128,12 @@ def get_case(
 
 
 @router.post("/workflows/{workflow_id}/cases/{case_id}", tags=["cases"])
-def update_case(
+async def update_case(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     case_id: str,
     params: CaseParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> CaseResponse:
     """Update a specific case for a workflow."""
     query = select(Case).where(
@@ -139,7 +141,8 @@ def update_case(
         Case.workflow_id == workflow_id,
         Case.id == case_id,
     )
-    case = session.exec(query).one_or_none()
+    result = await session.exec(query)
+    case = result.one_or_none()
     if case is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
@@ -150,8 +153,8 @@ def update_case(
         setattr(case, key, value)
 
     session.add(case)
-    session.commit()
-    session.refresh(case)
+    await session.commit()
+    await session.refresh(case)
     return CaseResponse(
         id=case.id,
         owner_id=case.owner_id,
@@ -174,12 +177,12 @@ def update_case(
     status_code=status.HTTP_201_CREATED,
     tags=["cases"],
 )
-def create_case_event(
+async def create_case_event(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     case_id: str,
     params: CaseEventParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Create a new Case Event."""
     case_event = CaseEvent(
@@ -190,17 +193,17 @@ def create_case_event(
         **params.model_dump(),
     )
     session.add(case_event)
-    session.commit()
-    session.refresh(case_event)
+    await session.commit()
+    await session.refresh(case_event)
     return case_event
 
 
 @router.get("/workflows/{workflow_id}/cases/{case_id}/events", tags=["cases"])
-def list_case_events(
+async def list_case_events(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     case_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> list[CaseEvent]:
     """List all Case Events."""
     query = select(CaseEvent).where(
@@ -208,19 +211,20 @@ def list_case_events(
         CaseEvent.workflow_id == workflow_id,
         CaseEvent.case_id == case_id,
     )
-    case_events = session.exec(query).all()
+    result = await session.exec(query)
+    case_events = result.all()
     return case_events
 
 
 @router.get(
     "/workflows/{workflow_id}/cases/{case_id}/events/{event_id}", tags=["cases"]
 )
-def get_case_event(
+async def get_case_event(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     case_id: str,
     event_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ):
     """Get a specific case event."""
     query = select(CaseEvent).where(
@@ -229,7 +233,8 @@ def get_case_event(
         CaseEvent.case_id == case_id,
         CaseEvent.id == event_id,
     )
-    case_event = session.exec(query).one_or_none()
+    result = await session.exec(query)
+    case_event = result.one_or_none()
     if case_event is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"

--- a/tracecat/api/routers/public/callbacks.py
+++ b/tracecat/api/routers/public/callbacks.py
@@ -3,8 +3,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from tracecat.api.routers.public.dependencies import (
-    handle_incoming_webhook,
     handle_service_callback,
+    validate_incoming_webhook,
 )
 from tracecat.contexts import ctx_role
 from tracecat.dsl.common import DSLInput
@@ -35,8 +35,8 @@ async def webhook_callback(
             metadata={"path": path, "secret": secret},
         ):
             # Don't validate method because callback is always POST
-            defn = await handle_incoming_webhook(
-                request, path, secret, validate_method=False
+            defn = await validate_incoming_webhook(
+                path=path, secret=secret, request=request, validate_method=False
             )
             logger.info(
                 "Received Webhook in callback",

--- a/tracecat/api/routers/public/webhooks.py
+++ b/tracecat/api/routers/public/webhooks.py
@@ -2,7 +2,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Header
 
-from tracecat.api.routers.public.dependencies import handle_incoming_webhook
+from tracecat.api.routers.public.dependencies import validate_incoming_webhook
 from tracecat.contexts import ctx_role
 from tracecat.db.schemas import WorkflowDefinition
 from tracecat.dsl.common import DSLInput
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/webhooks")
 
 @router.post("/{path}/{secret}", tags=["public"])
 async def incoming_webhook(
-    defn: Annotated[WorkflowDefinition, Depends(handle_incoming_webhook)],
+    defn: Annotated[WorkflowDefinition, Depends(validate_incoming_webhook)],
     path: str,
     payload: dict[str, Any] | None = None,
     x_tracecat_enable_runtime_tests: Annotated[str | None, Header()] = None,
@@ -26,12 +26,7 @@ async def incoming_webhook(
     This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
     The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
     """
-    logger.info(
-        "Webhook hit",
-        path=path,
-        payload=payload,
-        role=ctx_role.get(),
-    )
+    logger.info("Webhook hit", path=path, payload=payload, role=ctx_role.get())
 
     dsl_input = DSLInput(**defn.content)
 

--- a/tracecat/api/routers/schedules.py
+++ b/tracecat/api/routers/schedules.py
@@ -2,11 +2,12 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import NoResultFound
-from sqlmodel import Session, select
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat import identifiers
 from tracecat.auth.credentials import TemporaryRole, authenticate_user
-from tracecat.db.engine import get_session
+from tracecat.db.engine import get_async_session
 from tracecat.db.schemas import Schedule, WorkflowDefinition
 from tracecat.dsl import schedules
 from tracecat.dsl.common import DSLInput
@@ -25,31 +26,27 @@ router = APIRouter(prefix="/schedules")
 async def list_schedules(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: identifiers.WorkflowID | None = None,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> list[Schedule]:
     """List all schedules for a workflow."""
     statement = select(Schedule).where(Schedule.owner_id == role.user_id)
     if workflow_id:
         statement = statement.where(Schedule.workflow_id == workflow_id)
-    result = session.exec(statement)
-    try:
-        return result.all()
-    except NoResultFound as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
-        ) from e
+    result = await session.exec(statement)
+    schedules = result.all()
+    return schedules
 
 
 @router.post("", tags=["schedules"])
 async def create_schedule(
     role: Annotated[Role, Depends(authenticate_user)],
     params: CreateScheduleParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> Schedule:
     """Create a schedule for a workflow."""
 
     with logger.contextualize(role=role):
-        result = session.exec(
+        result = await session.exec(
             select(WorkflowDefinition)
             .where(WorkflowDefinition.workflow_id == params.workflow_id)
             .order_by(WorkflowDefinition.version.desc())
@@ -66,7 +63,7 @@ async def create_schedule(
         schedule = Schedule(
             owner_id=role.user_id, **params.model_dump(exclude_unset=True)
         )
-        session.refresh(defn_data)
+        await session.refresh(defn_data)
         defn = WorkflowDefinition.model_validate(defn_data)
         dsl = DSLInput(**defn.content)
         if params.inputs:
@@ -97,8 +94,8 @@ async def create_schedule(
                 )
 
             session.add(schedule)
-            session.commit()
-            session.refresh(schedule)
+            await session.commit()
+            await session.refresh(schedule)
             return schedule
         except Exception as e:
             session.rollback()
@@ -110,22 +107,23 @@ async def create_schedule(
 
 
 @router.get("/{schedule_id}", tags=["schedules"])
-def get_schedule(
+async def get_schedule(
     role: Annotated[Role, Depends(authenticate_user)],
     schedule_id: identifiers.ScheduleID,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> Schedule:
     """Get a schedule from a workflow."""
     statement = select(Schedule).where(
         Schedule.owner_id == role.user_id, Schedule.id == schedule_id
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
-        return result.one()
+        schedule = result.one()
     except NoResultFound as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
         ) from e
+    return schedule
 
 
 @router.post("/{schedule_id}", tags=["schedules"])
@@ -133,13 +131,13 @@ async def update_schedule(
     role: Annotated[Role, Depends(authenticate_user)],
     schedule_id: identifiers.ScheduleID,
     params: UpdateScheduleParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> Schedule:
     """Update a schedule from a workflow. You cannot update the Workflow Definition, but you can update other fields."""
     statement = select(Schedule).where(
         Schedule.owner_id == role.user_id, Schedule.id == schedule_id
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         schedule = result.one()
     except NoResultFound as e:
@@ -157,8 +155,8 @@ async def update_schedule(
             setattr(schedule, key, value)
 
         session.add(schedule)
-        session.commit()
-        session.refresh(schedule)
+        await session.commit()
+        await session.refresh(schedule)
         return schedule
     except Exception as e:
         session.rollback()
@@ -177,13 +175,13 @@ async def update_schedule(
 async def delete_schedule(
     role: Annotated[Role, Depends(authenticate_user)],
     schedule_id: identifiers.ScheduleID,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Delete a schedule from a workflow."""
     statement = select(Schedule).where(
         Schedule.owner_id == role.user_id, Schedule.id == schedule_id
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     schedule = result.one_or_none()
     if not schedule:
         logger.warning(
@@ -197,8 +195,8 @@ async def delete_schedule(
 
         # If successful, delete the schedule from the database
         if schedule:
-            session.delete(schedule)
-            session.commit()
+            await session.delete(schedule)
+            await session.commit()
         else:
             logger.warning(
                 "Schedule was already deleted from the database",
@@ -213,13 +211,13 @@ async def delete_schedule(
 
 
 @router.get("/search", tags=["schedules"])
-def search_schedules(
+async def search_schedules(
     role: Annotated[Role, Depends(authenticate_user)],
     params: SearchScheduleParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> list[Schedule]:
     """**[WORK IN PROGRESS]** Search for schedules."""
     statement = select(Schedule).where(Schedule.owner_id == role.user_id)
-    results = session.exec(statement)
+    results = await session.exec(statement)
     schedules = results.all()
     return schedules

--- a/tracecat/api/routers/users.py
+++ b/tracecat/api/routers/users.py
@@ -2,10 +2,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import NoResultFound
-from sqlmodel import Session, select
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat.auth.credentials import authenticate_user
-from tracecat.db.engine import get_session
+from tracecat.db.engine import get_async_session
 from tracecat.db.schemas import User
 from tracecat.types.api import UpdateUserParams
 from tracecat.types.auth import Role
@@ -14,15 +15,15 @@ router = APIRouter(prefix="/users")
 
 
 @router.post("", status_code=status.HTTP_201_CREATED, tags=["users"])
-def create_user(
+async def create_user(
     role: Annotated[Role, Depends(authenticate_user)],
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> User:
     """Create new user."""
 
     # Check if user exists
     statement = select(User).where(User.id == role.user_id).limit(1)
-    result = session.exec(statement)
+    result = await session.exec(statement)
 
     user = result.one_or_none()
     if user is not None:
@@ -32,40 +33,40 @@ def create_user(
     user = User(owner_id="tracecat", id=role.user_id)
 
     session.add(user)
-    session.commit()
-    session.refresh(user)
+    await session.commit()
+    await session.refresh(user)
     return user
 
 
 @router.get("", tags=["users"])
-def get_user(
+async def get_user(
     role: Annotated[Role, Depends(authenticate_user)],
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> User:
     """Get a user."""
 
     # Get user given user_id
     statement = select(User).where(User.id == role.user_id)
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         user = result.one()
-        return user
     except NoResultFound as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         ) from e
+    return user
 
 
 @router.post("", status_code=status.HTTP_204_NO_CONTENT, tags=["users"])
-def update_user(
+async def update_user(
     role: Annotated[Role, Depends(authenticate_user)],
     params: UpdateUserParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Update a user."""
 
     statement = select(User).where(User.id == role.user_id)
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         user = result.one()
     except NoResultFound as e:
@@ -79,23 +80,23 @@ def update_user(
         user.settings = params.settings
 
     session.add(user)
-    session.commit()
+    await session.commit()
 
 
 @router.delete("", status_code=status.HTTP_204_NO_CONTENT, tags=["users"])
-def delete_user(
+async def delete_user(
     role: Annotated[Role, Depends(authenticate_user)],
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Delete a user."""
 
     statement = select(User).where(User.id == role.user_id)
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         user = result.one()
     except NoResultFound as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         ) from e
-    session.delete(user)
-    session.commit()
+    await session.delete(user)
+    await session.commit()

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -65,8 +65,10 @@ def _create_db_engine() -> Engine:
 def _create_async_db_engine() -> AsyncEngine:
     # Postgres as default
     engine_kwargs = {
-        "pool_size": 20,
+        "pool_size": 50,
         "max_overflow": 10,
+        "future": True,
+        "pool_recycle": 3600,
     }
 
     uri = _get_db_uri(driver="asyncpg")

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -1,10 +1,13 @@
 import contextlib
 import os
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
+from typing import Literal
 
 from loguru import logger
 from sqlalchemy import Engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlmodel import Session, SQLModel, create_engine, delete, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat import config
 from tracecat.db.schemas import DEFAULT_CASE_ACTIONS, CaseAction, UDFSpec, User
@@ -14,6 +17,22 @@ from tracecat.registry import registry
 # Outside of being best practice, this is needed so we can properly pool
 # connections and not create a new pool on every request
 _engine: Engine | None = None
+_async_engine: AsyncEngine | None = None
+
+
+def _get_db_uri(driver: Literal["psycopg", "asyncpg"] = "psycopg") -> str:
+    if config.TRACECAT__DB_USER and config.TRACECAT__DB_PASS:
+        uri = get_connection_string(
+            username=config.TRACECAT__DB_USER,
+            password=config.TRACECAT__DB_PASS,
+            host=config.TRACECAT__DB_ENDPOINT,
+            port=config.TRACECAT__DB_PORT,
+            database=config.TRACECAT__DB_NAME,
+            driver=driver,
+        )
+    else:
+        uri = config.TRACECAT__DB_URI
+    return uri
 
 
 def _create_db_engine() -> Engine:
@@ -35,17 +54,28 @@ def _create_db_engine() -> Engine:
             "pool_recycle": 3600,
             "connect_args": {"sslmode": "disable"},
         }
-    if config.TRACECAT__DB_USER and config.TRACECAT__DB_PASS:
-        db_name = config.TRACECAT__DB_NAME
-        username = config.TRACECAT__DB_USER
-        password = config.TRACECAT__DB_PASS
-        address = f"{config.TRACECAT__DB_ENDPOINT}:{config.TRACECAT__DB_PORT}"
-        uri = f"postgresql+psycopg://{username}:{password}@{address}/{db_name}"
-    else:
-        uri = config.TRACECAT__DB_URI
 
-    engine = create_engine(uri, **engine_kwargs)
-    return engine
+    uri = _get_db_uri(driver="psycopg")
+    return create_engine(uri, **engine_kwargs)
+
+
+def _create_async_db_engine() -> AsyncEngine:
+    # Postgres as default
+    engine_kwargs = {
+        "pool_timeout": 30,
+        "pool_recycle": 3600,
+    }
+
+    # Add common async-specific configurations
+    engine_kwargs.update(
+        {
+            "echo": True,  # Set to False in production
+            "future": True,
+            "pool_pre_ping": True,
+        }
+    )
+    uri = _get_db_uri(driver="asyncpg")
+    return create_async_engine(uri, **engine_kwargs)
 
 
 def initialize_db() -> Engine:
@@ -81,11 +111,43 @@ def initialize_db() -> Engine:
     return engine
 
 
+async def async_initialize_db() -> AsyncEngine:
+    engine = get_async_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    registry.init()
+    async with AsyncSession(engine) as session:
+        await session.exec(delete(UDFSpec))
+        udfs = [udf.to_udf_spec() for _, udf in registry]
+        logger.info("Initializing UDF registry with default UDFs.", n=len(udfs))
+        session.add_all(udfs)
+        await session.commit()
+
+        user_id = "default-tracecat-user"
+        result = await session.exec(select(User).where(User.id == user_id).limit(1))
+        if not result.one_or_none():
+            # Create a default user if it doesn't exist
+            user = User(owner_id="tracecat", id=user_id)
+            session.add(user)
+            await session.commit()
+    return engine
+
+
 def get_engine() -> Engine:
+    """Get the db sync connection pool."""
     global _engine
     if _engine is None:
         _engine = _create_db_engine()
     return _engine
+
+
+def get_async_engine() -> AsyncEngine:
+    """Get the db async connection pool."""
+    global _async_engine
+    if _async_engine is None:
+        _async_engine = _create_async_db_engine()
+    return _async_engine
 
 
 def get_session() -> Generator[Session, None, None]:
@@ -93,5 +155,29 @@ def get_session() -> Generator[Session, None, None]:
         yield session
 
 
+async def get_async_session() -> AsyncGenerator[AsyncSession, None, None]:
+    async with AsyncSession(get_async_engine()) as session:
+        yield session
+
+
 def get_session_context_manager() -> contextlib.AbstractContextManager[Session]:
     return contextlib.contextmanager(get_session)()
+
+
+def get_async_session_context_manager() -> (
+    contextlib.AbstractAsyncContextManager[AsyncSession]
+):
+    return contextlib.asynccontextmanager(get_async_session)()
+
+
+def get_connection_string(
+    *,
+    username: str,
+    password: str,
+    host: str = "postgres_db",
+    port: int | str = 5432,
+    database: str = "postgres",
+    scheme: str = "postgresql",
+    driver: Literal["asyncpg", "psycopg"] = "asyncpg",
+) -> str:
+    return f"{scheme}+{driver}://{username}:{password}@{host}:{port!s}/{database}"

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -22,6 +22,10 @@ DEFAULT_CASE_ACTIONS = [
     "Sinkholed",
 ]
 
+DEFAULT_SA_RELATIONSHIP_KWARGS = {
+    "lazy": "selectin",
+}
+
 
 class Resource(SQLModel):
     """Base class for all resources in the system."""
@@ -54,13 +58,19 @@ class User(Resource, table=True):
     settings: str | None = None  # JSON-serialized String of settings
     owned_workflows: list["Workflow"] = Relationship(
         back_populates="owner",
-        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
+        sa_relationship_kwargs={
+            "cascade": "all, delete",
+            **DEFAULT_SA_RELATIONSHIP_KWARGS,
+        },
     )
     case_actions: list["CaseAction"] = Relationship(back_populates="user")
     case_contexts: list["CaseContext"] = Relationship(back_populates="user")
     secrets: list["Secret"] = Relationship(
         back_populates="owner",
-        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
+        sa_relationship_kwargs={
+            "cascade": "all, delete",
+            **DEFAULT_SA_RELATIONSHIP_KWARGS,
+        },
     )
 
 
@@ -195,7 +205,10 @@ class WorkflowDefinition(Resource, table=True):
 
     # DSL content
     content: dict[str, Any] = Field(sa_column=Column(JSONB))
-    workflow: "Workflow" = Relationship(back_populates="definitions")
+    workflow: "Workflow" = Relationship(
+        back_populates="definitions",
+        sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS,
+    )
 
 
 class Workflow(Resource, table=True):
@@ -251,20 +264,32 @@ class Workflow(Resource, table=True):
     owner: User | None = Relationship(back_populates="owned_workflows")
     actions: list["Action"] | None = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
+        sa_relationship_kwargs={
+            "cascade": "all, delete",
+            **DEFAULT_SA_RELATIONSHIP_KWARGS,
+        },
     )
     definitions: list["WorkflowDefinition"] | None = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
+        sa_relationship_kwargs={
+            "cascade": "all, delete",
+            **DEFAULT_SA_RELATIONSHIP_KWARGS,
+        },
     )
     # Triggers
     webhook: "Webhook" = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
+        sa_relationship_kwargs={
+            "cascade": "all, delete",
+            **DEFAULT_SA_RELATIONSHIP_KWARGS,
+        },
     )
     schedules: list["Schedule"] | None = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
+        sa_relationship_kwargs={
+            "cascade": "all, delete",
+            **DEFAULT_SA_RELATIONSHIP_KWARGS,
+        },
     )
 
 
@@ -280,7 +305,9 @@ class Webhook(Resource, table=True):
     workflow_id: str | None = Field(
         sa_column=Column(String, ForeignKey("workflow.id", ondelete="CASCADE"))
     )
-    workflow: Workflow | None = Relationship(back_populates="webhook")
+    workflow: Workflow | None = Relationship(
+        back_populates="webhook", sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS
+    )
 
     @computed_field
     @property
@@ -311,7 +338,10 @@ class Schedule(Resource, table=True):
     workflow_id: str | None = Field(
         sa_column=Column(String, ForeignKey("workflow.id", ondelete="CASCADE"))
     )
-    workflow: Workflow | None = Relationship(back_populates="schedules")
+    workflow: Workflow | None = Relationship(
+        back_populates="schedules",
+        sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS,
+    )
 
     # Custom validator for the cron field
     @field_validator("cron")
@@ -339,7 +369,9 @@ class Action(Resource, table=True):
     workflow_id: str | None = Field(
         sa_column=Column(String, ForeignKey("workflow.id", ondelete="CASCADE"))
     )
-    workflow: Workflow | None = Relationship(back_populates="actions")
+    workflow: Workflow | None = Relationship(
+        back_populates="actions", sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS
+    )
 
     @computed_field
     @property

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -54,13 +54,13 @@ class User(Resource, table=True):
     settings: str | None = None  # JSON-serialized String of settings
     owned_workflows: list["Workflow"] = Relationship(
         back_populates="owner",
-        sa_relationship_kwargs={"cascade": "all, delete"},
+        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
     )
     case_actions: list["CaseAction"] = Relationship(back_populates="user")
     case_contexts: list["CaseContext"] = Relationship(back_populates="user")
     secrets: list["Secret"] = Relationship(
         back_populates="owner",
-        sa_relationship_kwargs={"cascade": "all, delete"},
+        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
     )
 
 
@@ -251,20 +251,20 @@ class Workflow(Resource, table=True):
     owner: User | None = Relationship(back_populates="owned_workflows")
     actions: list["Action"] | None = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete"},
+        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
     )
     definitions: list["WorkflowDefinition"] | None = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete"},
+        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
     )
     # Triggers
     webhook: "Webhook" = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete"},
+        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
     )
     schedules: list["Schedule"] | None = Relationship(
         back_populates="workflow",
-        sa_relationship_kwargs={"cascade": "all, delete"},
+        sa_relationship_kwargs={"cascade": "all, delete", "lazy": "selectin"},
     )
 
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -27,12 +27,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat import identifiers
     from tracecat.auth.sandbox import AuthSandbox
     from tracecat.concurrency import GatheringTaskGroup
-    from tracecat.contexts import (
-        RunContext,
-        ctx_logger,
-        ctx_role,
-        ctx_run,
-    )
+    from tracecat.contexts import RunContext, ctx_logger, ctx_role, ctx_run
     from tracecat.dsl.common import DSLInput, DSLRunArgs
     from tracecat.dsl.io import resolve_success_output
     from tracecat.dsl.models import ActionStatement, ActionTest, DSLNodeResult
@@ -54,9 +49,9 @@ with workflow.unsafe.imports_passed_through():
         TracecatValidationError,
     )
     from tracecat.workflow.management.definitions import (
-        GetWorkflowDefinitionActivityInputs,
         get_workflow_definition_activity,
     )
+    from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
 
 
 class DSLContext(TypedDict, total=False):

--- a/tracecat/types/validation.py
+++ b/tracecat/types/validation.py
@@ -13,6 +13,9 @@ class ValidationResult(BaseModel):
     msg: str = ""
     detail: Any | None = None
 
+    def __hash__(self) -> int:
+        return hash((self.status, self.msg, self.detail))
+
 
 class RegistryValidationResult(ValidationResult):
     """Result of validating a UDF args."""

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -21,7 +21,7 @@ from tracecat import identifiers
 from tracecat.dsl.common import DSLRunArgs
 from tracecat.dsl.workflow import DSLContext, UDFActionInput
 from tracecat.types.auth import Role
-from tracecat.workflow.management.definitions import GetWorkflowDefinitionActivityInputs
+from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
 
 WorkflowExecutionStatusLiteral = Literal[
     "RUNNING",

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -414,7 +414,7 @@ class WorkflowExecutionsService:
     def cancel_workflow_execution(
         self,
         wf_exec_id: identifiers.WorkflowExecutionID | identifiers.WorkflowScheduleID,
-    ) -> None:
+    ) -> Awaitable[None]:
         """Cancel a workflow execution."""
         return self.handle(wf_exec_id).cancel()
 
@@ -422,6 +422,6 @@ class WorkflowExecutionsService:
         self,
         wf_exec_id: identifiers.WorkflowExecutionID | identifiers.WorkflowScheduleID,
         reason: str | None = None,
-    ) -> None:
+    ) -> Awaitable[None]:
         """Terminate a workflow execution."""
         return self.handle(wf_exec_id).terminate(reason=reason)

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -27,7 +27,7 @@ class WorkflowDefinitionsService:
 
     @asynccontextmanager
     @staticmethod
-    async def get_session(
+    async def with_session(
         role: Role,
     ) -> AsyncGenerator[WorkflowDefinitionsService, None, None]:
         async with get_async_session_context_manager() as session:
@@ -134,7 +134,7 @@ async def get_workflow_definition_activity(
     input: GetWorkflowDefinitionActivityInputs,
 ) -> DSLRunArgs:
     logger.trace("Getting workflow definition", workflow_id=input.workflow_id)
-    async with WorkflowDefinitionsService.get_session(role=input.role) as service:
+    async with WorkflowDefinitionsService.with_session(role=input.role) as service:
         defn = await service.get_definition_by_workflow_id(
             input.workflow_id, version=input.version
         )

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -5,12 +5,16 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
+from tracecat import identifiers
+from tracecat.contexts import RunContext
 from tracecat.db.schemas import Schedule, Workflow
+from tracecat.dsl.models import ActionStatement
 from tracecat.types.api import (
     ActionResponse,
     UDFArgsValidationResponse,
     WebhookResponse,
 )
+from tracecat.types.auth import Role
 
 
 class CreateWorkflowFromDSLResponse(BaseModel):
@@ -61,3 +65,12 @@ class WorkflowMetadataResponse(BaseModel):
 class CreateWorkflowParams(BaseModel):
     title: str | None = None
     description: str | None = None
+
+
+class GetWorkflowDefinitionActivityInputs(BaseModel):
+    role: Role
+    task: ActionStatement
+    workflow_id: identifiers.WorkflowID
+    trigger_inputs: dict[str, Any]
+    version: int | None = None
+    run_context: RunContext

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -313,7 +313,7 @@ async def commit_workflow(
         # When we're here, we've verified that the workflow DSL is structurally sound
         # Now, we have to ensure that the arguments are sound
 
-        if val_errors := await validation.validate_dsl(session=session, dsl=dsl):
+        if val_errors := await validation.validate_dsl(dsl):
             logger.warning("Validation errors", errors=val_errors)
             return CommitWorkflowResponse(
                 workflow_id=workflow_id,

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -15,10 +15,11 @@ from fastapi import (
 from pydantic import ValidationError
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat import identifiers, validation
 from tracecat.auth.credentials import authenticate_user
-from tracecat.db.engine import get_session
+from tracecat.db.engine import get_async_session, get_session
 from tracecat.db.schemas import Webhook, Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.graph import RFGraph
@@ -44,10 +45,10 @@ router = APIRouter(prefix="/workflows")
 
 
 @router.get("", tags=["workflows"])
-def list_workflows(
+async def list_workflows(
     role: Annotated[Role, Depends(authenticate_user)],
     library: bool = False,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> list[WorkflowMetadataResponse]:
     """
     List workflows.
@@ -56,7 +57,7 @@ def list_workflows(
     """
     query_user_id = role.user_id if not library else "tracecat"
     statement = select(Workflow).where(Workflow.owner_id == query_user_id)
-    results = session.exec(statement)
+    results = await session.exec(statement)
     workflows = results.all()
     workflow_metadata = [
         WorkflowMetadataResponse(
@@ -80,7 +81,7 @@ async def create_workflow(
     title: str | None = Form(None),
     description: str | None = Form(None),
     file: UploadFile | None = File(None),
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> WorkflowMetadataResponse:
     """Create a new Workflow.
 
@@ -128,7 +129,8 @@ async def create_workflow(
         # When we create a workflow, we automatically create a webhook
         # Add the Workflow to the session first to generate an ID
         session.add(workflow)
-        session.flush()  # Flush to generate workflow.id
+        await session.flush()  # Flush to generate workflow.id
+        await session.refresh(workflow)
 
         # Create and associate Webhook with the Workflow
         webhook = Webhook(
@@ -142,8 +144,8 @@ async def create_workflow(
         workflow.object = graph.model_dump(by_alias=True, mode="json")
         workflow.entrypoint = graph.entrypoint.id if graph.entrypoint else None
         session.add(workflow)
-        session.commit()
-        session.refresh(workflow)
+        await session.commit()
+        await session.refresh(workflow)
 
     return WorkflowMetadataResponse(
         id=workflow.id,
@@ -158,18 +160,17 @@ async def create_workflow(
 
 
 @router.get("/{workflow_id}", tags=["workflows"])
-def get_workflow(
+async def get_workflow(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> WorkflowResponse:
     """Return Workflow as title, description, list of Action JSONs, adjacency list of Action IDs."""
     # Get Workflow given workflow_id
     statement = select(Workflow).where(
-        Workflow.owner_id == role.user_id,
-        Workflow.id == workflow_id,
+        Workflow.owner_id == role.user_id, Workflow.id == workflow_id
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         workflow = result.one()
     except NoResultFound as e:
@@ -177,9 +178,9 @@ def get_workflow(
             status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
         ) from e
 
+    actions = workflow.actions or []
     actions_responses = {
-        action.id: ActionResponse(**action.model_dump())
-        for action in workflow.actions or []
+        action.id: ActionResponse(**action.model_dump()) for action in actions
     }
     # Add webhook/schedules
     return WorkflowResponse(
@@ -195,18 +196,18 @@ def get_workflow(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["workflows"],
 )
-def update_workflow(
+async def update_workflow(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     params: UpdateWorkflowParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Update a workflow."""
     statement = select(Workflow).where(
         Workflow.owner_id == role.user_id,
         Workflow.id == workflow_id,
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         workflow = result.one()
     except NoResultFound as e:
@@ -219,7 +220,7 @@ def update_workflow(
         setattr(workflow, key, value)
 
     session.add(workflow)
-    session.commit()
+    await session.commit()
 
 
 @router.delete(
@@ -227,10 +228,10 @@ def update_workflow(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["workflows"],
 )
-def delete_workflow(
+async def delete_workflow(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Delete a workflow."""
 
@@ -238,22 +239,22 @@ def delete_workflow(
         Workflow.owner_id == role.user_id,
         Workflow.id == workflow_id,
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         workflow = result.one()
     except NoResultFound as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
         ) from e
-    session.delete(workflow)
-    session.commit()
+    await session.delete(workflow)
+    await session.commit()
 
 
 @router.post("/{workflow_id}/commit", tags=["workflows"])
 async def commit_workflow(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> CommitWorkflowResponse:
     """Commit a workflow.
 
@@ -268,7 +269,7 @@ async def commit_workflow(
         statement = select(Workflow).where(
             Workflow.owner_id == role.user_id, Workflow.id == workflow_id
         )
-        result = session.exec(statement)
+        result = await session.exec(statement)
         try:
             workflow = result.one()
         except NoResultFound as e:
@@ -355,7 +356,7 @@ async def commit_workflow(
 
 
 @router.get("/{workflow_id}/definition", tags=["workflows"])
-async def list_workflow_definitions(
+def list_workflow_definitions(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: identifiers.WorkflowID,
     session: Session = Depends(get_session),
@@ -401,11 +402,11 @@ def create_workflow_definition(
     status_code=status.HTTP_201_CREATED,
     tags=["triggers"],
 )
-def create_webhook(
+async def create_webhook(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     params: UpsertWebhookParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Create a webhook for a workflow."""
 
@@ -416,22 +417,22 @@ def create_webhook(
         workflow_id=workflow_id,
     )
     session.add(webhook)
-    session.commit()
-    session.refresh(webhook)
+    await session.commit()
+    await session.refresh(webhook)
 
 
 @router.get("/{workflow_id}/webhook", tags=["triggers"])
-def get_webhook(
+async def get_webhook(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> WebhookResponse:
     """Get the webhook from a workflow."""
     statement = select(Webhook).where(
         Webhook.owner_id == role.user_id,
         Webhook.workflow_id == workflow_id,
     )
-    result = session.exec(statement)
+    result = await session.exec(statement)
     try:
         webhook = result.one()
         return WebhookResponse(**webhook.model_dump())
@@ -446,14 +447,14 @@ def get_webhook(
     tags=["triggers"],
     status_code=status.HTTP_204_NO_CONTENT,
 )
-def update_webhook(
+async def update_webhook(
     role: Annotated[Role, Depends(authenticate_user)],
     workflow_id: str,
     params: UpsertWebhookParams,
-    session: Session = Depends(get_session),
+    session: AsyncSession = Depends(get_async_session),
 ) -> None:
     """Update the webhook for a workflow. We currently supprt only one webhook per workflow."""
-    result = session.exec(
+    result = await session.exec(
         select(Workflow).where(
             Workflow.owner_id == role.user_id, Workflow.id == workflow_id
         )
@@ -472,5 +473,5 @@ def update_webhook(
         setattr(webhook, key, value)
 
     session.add(webhook)
-    session.commit()
-    session.refresh(webhook)
+    await session.commit()
+    await session.refresh(webhook)


### PR DESCRIPTION
# Features
- Add `asyncpg` postgresdb driver. Better synergy with fastapi and has better performance (see the benchmark on `asyncpg` 's readme)
- We're maintaining backward compatibility by keeping the sync sqlmodel engine
- Adopted async db sessions across all services and routers
- Add pytest fixture to share single event loop across a test session. This was causing a bug where a future was awaited on a different event loop (i.e. the event loop changed)
- Added deduplication for `ValidationResult` objects


# Known issues
- DB connection and session is sensitive to the event loop, as the connection pool is a global var.
- There are issues with how pytest handles async-marked tests. We've used the fixture to share the same event loop over all the tests, however in the FastAPI lifespan we cannot switch out the sync initialization to async. This breaks pytest. I suspect that its because initializing the engine async creates the db connection pool thread-locally to some event loop that's different from the one pytest creates.
# Testing
- Manual QA of each service, appears to be working
