### PR TITLE
ci(infra): Add Caddy as reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,6 @@ TRACECAT__API_URL=http://api:8000
 # to start ngrok and update this with the forwarding URL
 TRACECAT__PUBLIC_RUNNER_URL=http://localhost:8000
 # CORS (comman separated string of allowed origins)
-# NOTE: Defaults to `http://localhost:3000` for local development
 TRACECAT__ALLOW_ORIGINS=http://localhost:3000
 
 # --- CLI env vars ---

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 LOG_LEVEL=INFO
 COMPOSE_PROJECT_NAME=tracecat
 
+# -- Caddy env vars ---
+TRACECAT__API_DOMAIN=localhost:8000
+TRACECAT__UI_DOMAIN=localhost:3000
+
 # --- App and DB env vars ---
 # One of `development`, `staging`, or `production`
 TRACECAT__APP_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,9 @@ LOG_LEVEL=INFO
 COMPOSE_PROJECT_NAME=tracecat
 
 # -- Caddy env vars ---
-TRACECAT__API_DOMAIN=localhost:8000
-TRACECAT__UI_DOMAIN=localhost:3000
+BASE_DOMAIN=:80
+# Note: replace with your server's IP address
+ADDRESS=0.0.0.0
 
 # --- App and DB env vars ---
 # One of `development`, `staging`, or `production`
@@ -27,10 +28,10 @@ TRACECAT__API_URL=http://api:8000
 # to start ngrok and update this with the forwarding URL
 TRACECAT__PUBLIC_RUNNER_URL=http://localhost:8000
 # CORS (comman separated string of allowed origins)
-TRACECAT__ALLOW_ORIGINS=http://localhost:3000
+TRACECAT__ALLOW_ORIGINS=http://localhost:3000,http://localhost
 
 # --- CLI env vars ---
-TRACECAT__PUBLIC_API_URL=http://localhost:8000
+TRACECAT__PUBLIC_API_URL=http://localhost/api/
 
 # --- Postgres ---
 TRACECAT__POSTGRES_USER=postgres
@@ -45,9 +46,9 @@ TRACECAT__DB_URI=postgresql+psycopg://${TRACECAT__POSTGRES_USER}:${TRACECAT__POS
 NODE_ENV=development
 NEXT_PUBLIC_APP_ENV=development
 # The frontend app URL
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost
 # Allows the browser to communicate with the backend
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=http://localhost/api/
 # Allows the frontend server (inside docker) to communicate with the backend server (inside docker)
 NEXT_SERVER_API_URL=http://api:8000
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,25 @@
+# {
+#     email {$ACME_EMAIL}
+# }
+
+# Public facing API with automatic HTTP to HTTPS redirection
+{$API_DOMAIN} {
+	redir https://{host}{uri}
+	reverse_proxy api:8000
+}
+
+# Public facing UI with automatic HTTP to HTTPS redirection
+{$UI_DOMAIN} {
+	redir https://{host}{uri}
+	reverse_proxy ui:3000
+}
+
+# Internal API for UI server-side calls
+http://api:8000 {
+	reverse_proxy api:8000
+}
+
+# Internal Temporal server for worker gRPC calls
+temporal:7233 {
+	reverse_proxy temporal:7233
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,25 +1,15 @@
-# {
-#     email {$ACME_EMAIL}
-# }
-
-# Public facing API with automatic HTTP to HTTPS redirection
-{$API_DOMAIN} {
-	redir https://{host}{uri}
-	reverse_proxy api:8000
+{$BASE_DOMAIN} {
+	bind {$ADDRESS} # Binds to all available network interfaces if not specified
+	handle_path /api/* {
+		reverse_proxy http://api:8000
+	}
+	reverse_proxy http://ui:3000
 }
 
-# Public facing UI with automatic HTTP to HTTPS redirection
-{$UI_DOMAIN} {
-	redir https://{host}{uri}
-	reverse_proxy ui:3000
-}
-
-# Internal API for UI server-side calls
 http://api:8000 {
 	reverse_proxy api:8000
 }
 
-# Internal Temporal server for worker gRPC calls
 temporal:7233 {
 	reverse_proxy temporal:7233
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,7 +44,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: worker
     restart: unless-stopped
     environment:
       DUMP_TRACECAT_RESULT: 0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,20 +5,18 @@ services:
     restart: unless-stopped
     ports:
       - 80:80
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
     environment:
       - BASE_DOMAIN=${BASE_DOMAIN}
       - ADDRESS=${ADDRESS}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
 
   api:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    volumes:
-      - ./tracecat:/app/tracecat
-      - core-app:/var/lib/tracecat
     container_name: tracecat_api
+    restart: unless-stopped
     ports:
       - 8000:8000
     environment:
@@ -38,17 +36,16 @@ services:
       # Temporal
       TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
       TEMPORAL__CLUSTER_QUEUE: ${TEMPORAL__CLUSTER_QUEUE}
-    restart: unless-stopped
-    networks:
-      - core
-      - temporal
+    volumes:
+      - ./tracecat:/app/tracecat
+      - core-app:/var/lib/tracecat
+
   worker:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    volumes:
-      - ./tracecat:/app/tracecat
-      - core-app:/var/lib/tracecat
+    container_name: tracecat_worker
+    restart: unless-stopped
     environment:
       DUMP_TRACECAT_RESULT: 0
       LOG_LEVEL: ${LOG_LEVEL}
@@ -63,10 +60,9 @@ services:
       # Temporal
       TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
       TEMPORAL__CLUSTER_QUEUE: ${TEMPORAL__CLUSTER_QUEUE}
-    restart: unless-stopped
-    networks:
-      - core
-      - temporal
+    volumes:
+      - ./tracecat:/app/tracecat
+      - core-app:/var/lib/tracecat
     entrypoint: ["python", "tracecat/dsl/worker.py"]
 
   ui:
@@ -80,11 +76,8 @@ services:
         NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY} # Sensitive
         NEXT_SERVER_API_URL: ${NEXT_SERVER_API_URL}
         NODE_ENV: ${NODE_ENV}
-    volumes:
-      - ./frontend/src:/app/src
-      - ./frontend/.next:/app/.next
-      - ./frontend/node_modules:/app/node_modules
     container_name: tracecat_ui
+    restart: unless-stopped
     ports:
       - 3000:3000
     environment:
@@ -98,24 +91,23 @@ services:
       NEXT_PUBLIC_DISABLE_AUTH: ${TRACECAT__DISABLE_AUTH}
       NEXT_SERVER_API_URL: ${NEXT_SERVER_API_URL}
       NODE_ENV: ${NODE_ENV}
-    restart: unless-stopped
     depends_on:
       - api
-    networks:
-      - core
+    volumes:
+      - ./frontend/src:/app/src
+      - ./frontend/.next:/app/.next
+      - ./frontend/node_modules:/app/node_modules
 
   postgres_db:
     image: postgres:16
     container_name: tracecat_postgres_db
+    restart: always
     ports:
       - 5432:5432
-    restart: always
     shm_size: 128mb
     environment:
       POSTGRES_USER: ${TRACECAT__POSTGRES_USER}
       POSTGRES_PASSWORD: ${TRACECAT__POSTGRES_PASSWORD}
-    networks:
-      - core
     volumes:
       - core-db:/var/lib/postgresql/data
 
@@ -126,29 +118,15 @@ services:
     environment:
       POSTGRES_USER: ${TEMPORAL__POSTGRES_USER}
       POSTGRES_PASSWORD: ${TEMPORAL__POSTGRES_PASSWORD}
-    networks:
-      - temporal
     volumes:
       - temporal-db:/var/lib/postgresql/data
-
-  temporal_ui:
-    image: temporalio/ui:${TEMPORAL__UI_VERSION}
-    container_name: tracecat_temporal_ui
-    environment:
-      - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
-    depends_on:
-      - temporal
-    networks:
-      - temporal
-    ports:
-      - 8080:8080
-    attach: false
 
   temporal:
     image: temporalio/auto-setup:${TEMPORAL__VERSION}
     container_name: tracecat_temporal
     restart: always
+    ports:
+      - 7233:7233
     environment:
       - DB=postgres12
       - DB_PORT=5432
@@ -156,16 +134,23 @@ services:
       - POSTGRES_PWD=${TEMPORAL__POSTGRES_PASSWORD}
       - POSTGRES_SEEDS=temporal_postgres_db
       - LOG_LEVEL=warn
-    ports:
-      - 7233:7233
     depends_on:
       - temporal_postgres_db
     networks:
       - temporal
 
-networks:
-  core:
-  temporal:
+  temporal_ui:
+    image: temporalio/ui:${TEMPORAL__UI_VERSION}
+    container_name: tracecat_temporal_ui
+    ports:
+      - 8080:8080
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+    depends_on:
+      - temporal
+    networks:
+      - temporal
 
 volumes:
   core-app:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: tracecat_api
+    container_name: api
     restart: unless-stopped
     ports:
       - 8000:8000
@@ -44,7 +44,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: tracecat_worker
+    container_name: worker
     restart: unless-stopped
     environment:
       DUMP_TRACECAT_RESULT: 0
@@ -76,7 +76,7 @@ services:
         NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY} # Sensitive
         NEXT_SERVER_API_URL: ${NEXT_SERVER_API_URL}
         NODE_ENV: ${NODE_ENV}
-    container_name: tracecat_ui
+    container_name: ui
     restart: unless-stopped
     ports:
       - 3000:3000
@@ -100,7 +100,7 @@ services:
 
   postgres_db:
     image: postgres:16
-    container_name: tracecat_postgres_db
+    container_name: postgres_db
     restart: always
     ports:
       - 5432:5432
@@ -113,7 +113,7 @@ services:
 
   temporal_postgres_db:
     image: postgres:13
-    container_name: tracecat_temporal_postgres_db
+    container_name: temporal_postgres_db
     restart: always
     environment:
       POSTGRES_USER: ${TEMPORAL__POSTGRES_USER}
@@ -123,7 +123,7 @@ services:
 
   temporal:
     image: temporalio/auto-setup:${TEMPORAL__VERSION}
-    container_name: tracecat_temporal
+    container_name: temporal
     restart: always
     ports:
       - 7233:7233
@@ -136,8 +136,6 @@ services:
       - LOG_LEVEL=warn
     depends_on:
       - temporal_postgres_db
-    networks:
-      - temporal
 
   temporal_ui:
     image: temporalio/ui:${TEMPORAL__UI_VERSION}
@@ -148,8 +146,6 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000
     depends_on:
-      - temporal
-    networks:
       - temporal
 
 volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,16 @@
 services:
+  caddy:
+    image: caddy:2.8.4-alpine
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - 80:80
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+    environment:
+      - BASE_DOMAIN=${BASE_DOMAIN}
+      - ADDRESS=${ADDRESS}
+
   api:
     build:
       context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -139,7 +139,7 @@ services:
 
   temporal_ui:
     image: temporalio/ui:${TEMPORAL__UI_VERSION}
-    container_name: tracecat_temporal_ui
+    container_name: temporal_ui
     ports:
       - 8080:8080
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,16 @@ services:
     restart: unless-stopped
     ports:
       - 80:80
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
     environment:
       - BASE_DOMAIN=${BASE_DOMAIN}
       - ADDRESS=${ADDRESS}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
 
   api:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.5.2}
     container_name: api
+    restart: unless-stopped
     ports:
       - 8000:8000
     environment:
@@ -32,12 +33,13 @@ services:
       # Temporal
       TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
       TEMPORAL__CLUSTER_QUEUE: ${TEMPORAL__CLUSTER_QUEUE}
-    restart: unless-stopped
     volumes:
       - core-app:/var/lib/tracecat
 
   worker:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.5.2}
+    container_name: worker
+    restart: unless-stopped
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__API_URL: ${TRACECAT__API_URL}
@@ -58,7 +60,6 @@ services:
       SMTP_AUTH: ${SMTP_AUTH}
       SMTP_USER: ${SMTP_USER}
       SMTP_PASS: ${SMTP_PASS}
-    restart: unless-stopped
     volumes:
       - core-app:/var/lib/tracecat
     command: ["python", "tracecat/dsl/worker.py"]
@@ -66,6 +67,7 @@ services:
   ui:
     image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-0.5.2}
     container_name: ui
+    restart: unless-stopped
     ports:
       - 3000:3000
     environment:
@@ -79,16 +81,15 @@ services:
       NEXT_PUBLIC_DISABLE_AUTH: ${TRACECAT__DISABLE_AUTH}
       NEXT_SERVER_API_URL: ${NEXT_SERVER_API_URL}
       NODE_ENV: ${NODE_ENV}
-    restart: unless-stopped
     depends_on:
       - api
 
   postgres_db:
     image: postgres:16
     container_name: postgres_db
+    restart: always
     ports:
       - 5432:5432
-    restart: always
     shm_size: 128mb
     environment:
       POSTGRES_USER: ${TRACECAT__POSTGRES_USER}
@@ -106,21 +107,12 @@ services:
     volumes:
       - temporal-db:/var/lib/postgresql/data
 
-  temporal_ui:
-    image: temporalio/ui:${TEMPORAL__UI_VERSION}
-    container_name: temporal_ui
-    environment:
-      - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
-    depends_on:
-      - temporal
-    ports:
-      - 8080:8080
-
   temporal:
     image: temporalio/auto-setup:${TEMPORAL__VERSION}
     container_name: temporal
     restart: always
+    ports:
+      - 7233:7233
     environment:
       - DB=postgres12
       - DB_PORT=5432
@@ -128,14 +120,21 @@ services:
       - POSTGRES_PWD=${TEMPORAL__POSTGRES_PASSWORD}
       - POSTGRES_SEEDS=temporal_postgres_db
       - LOG_LEVEL=warn
-    ports:
-      - 7233:7233
     depends_on:
       - temporal_postgres_db
+
+  temporal_ui:
+    image: temporalio/ui:${TEMPORAL__UI_VERSION}
+    container_name: temporal_ui
+    ports:
+      - 8080:8080
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+    depends_on:
+      - temporal
 
 volumes:
   core-app:
   core-db:
   temporal-db:
-  caddy_data:
-  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,18 @@
 services:
+  caddy:
+    image: caddy:2.8.4-alpine
+    container_name: caddy
+    ports:
+      - 80:80
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+    environment:
+      - API_DOMAIN=${TRACECAT__API_DOMAIN}
+      - UI_DOMAIN=${TRACECAT__UI_DOMAIN}
+
   api:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.5.2}
-    container_name: tracecat_api
+    container_name: api
     ports:
       - 8000:8000
     environment:
@@ -23,13 +34,9 @@ services:
     restart: unless-stopped
     volumes:
       - core-app:/var/lib/tracecat
-    networks:
-      - core
-      - temporal
 
   worker:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.5.2}
-    # container_name: tracecat_worker
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__API_URL: ${TRACECAT__API_URL}
@@ -53,14 +60,11 @@ services:
     restart: unless-stopped
     volumes:
       - core-app:/var/lib/tracecat
-    networks:
-      - core
-      - temporal
     command: ["python", "tracecat/dsl/worker.py"]
 
   ui:
     image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-0.5.2}
-    container_name: tracecat_ui
+    container_name: ui
     ports:
       - 3000:3000
     environment:
@@ -77,12 +81,10 @@ services:
     restart: unless-stopped
     depends_on:
       - api
-    networks:
-      - core
 
   postgres_db:
     image: postgres:16
-    container_name: tracecat_postgres_db
+    container_name: postgres_db
     ports:
       - 5432:5432
     restart: always
@@ -90,39 +92,33 @@ services:
     environment:
       POSTGRES_USER: ${TRACECAT__POSTGRES_USER}
       POSTGRES_PASSWORD: ${TRACECAT__POSTGRES_PASSWORD}
-    networks:
-      - core
     volumes:
       - core-db:/var/lib/postgresql/data
 
   temporal_postgres_db:
     image: postgres:13
-    container_name: tracecat_temporal_postgres_db
+    container_name: temporal_postgres_db
     restart: always
     environment:
       POSTGRES_USER: ${TEMPORAL__POSTGRES_USER}
       POSTGRES_PASSWORD: ${TEMPORAL__POSTGRES_PASSWORD}
-    networks:
-      - temporal
     volumes:
       - temporal-db:/var/lib/postgresql/data
 
   temporal_ui:
     image: temporalio/ui:${TEMPORAL__UI_VERSION}
-    container_name: tracecat_temporal_ui
+    container_name: temporal_ui
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000
     depends_on:
-      - temporal
-    networks:
       - temporal
     ports:
       - 8080:8080
 
   temporal:
     image: temporalio/auto-setup:${TEMPORAL__VERSION}
-    container_name: tracecat_temporal
+    container_name: temporal
     restart: always
     environment:
       - DB=postgres12
@@ -135,14 +131,10 @@ services:
       - 7233:7233
     depends_on:
       - temporal_postgres_db
-    networks:
-      - temporal
-
-networks:
-  core:
-  temporal:
 
 volumes:
   core-app:
   core-db:
   temporal-db:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,14 @@ services:
   caddy:
     image: caddy:2.8.4-alpine
     container_name: caddy
+    restart: unless-stopped
     ports:
       - 80:80
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
     environment:
-      - API_DOMAIN=${TRACECAT__API_DOMAIN}
-      - UI_DOMAIN=${TRACECAT__UI_DOMAIN}
+      - BASE_DOMAIN=${BASE_DOMAIN}
+      - ADDRESS=${ADDRESS}
 
   api:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.5.2}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
 
   worker:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.5.2}
-    container_name: worker
     restart: unless-stopped
     environment:
       LOG_LEVEL: ${LOG_LEVEL}


### PR DESCRIPTION
## What changed
- Add Caddyfile to point http://localhost to UI service and http://localhost/api/ (with prefix stripping via handle path directive) to API service
- Add `BASE_DOMAIN` and `ADDRESS` env vars to docker-compose and .env.example
- Update public URLs in .env.example to the Caddy exposed URLs
- Specified internal routes for temporal and API in caddy
- Removed docker network configs in docker compose
- Style: just rearranged docker fields to be consistent between services (e.g. `restart` after `container_name`)
- !!! Removed overly verbose `tracecat_` prefix from container names

## QA
- Test on both `docker compose up` and `docker compose -f docker-compose.dev.yml up`
- Go to http://localhost (UI)
- Go to http://localhost/api/ (API)
- QA loop:
   1. Retrieve workflows
   2. Create new workflow
   3. Add case action to workflow
   4. Enable / commit workflow
   5. Trigger workflow from form in UI
   6. Check workflow runs success
   7. Check case is created
   8. Create schedule
   9. Wait for schedule to run
   10. Check workflow runs success
   11. Check case is created

## Screenshots

<img width="742" alt="Screenshot 2024-08-01 at 1 18 12 PM" src="https://github.com/user-attachments/assets/8f9886e1-8cc2-40fd-b475-5b832c425724">

<img width="454" alt="Screenshot 2024-08-01 at 1 35 28 PM" src="https://github.com/user-attachments/assets/2226ad73-c2cc-4624-befc-0831bc2fc874">
