### PR TITLE
Synchronous calling of webhooks

### DIFF
--- a/tracecat/api/routers/public/webhooks.py
+++ b/tracecat/api/routers/public/webhooks.py
@@ -46,7 +46,7 @@ async def incoming_webhook(
 
 
 @router.post("/{path}/{secret}/wait", tags=["public"])
-async def incoming_webhook_sync(
+async def incoming_webhook_wait(
     defn: Annotated[WorkflowDefinition, Depends(validate_incoming_webhook)],
     path: str,
     payload: dict[str, Any] | None = None,

--- a/tracecat/api/routers/public/webhooks.py
+++ b/tracecat/api/routers/public/webhooks.py
@@ -75,4 +75,4 @@ async def incoming_webhook_sync(
         enable_runtime_tests=enable_runtime_tests,
     )
 
-    return response.final_context
+    return response["final_context"]

--- a/tracecat/api/routers/public/webhooks.py
+++ b/tracecat/api/routers/public/webhooks.py
@@ -43,3 +43,36 @@ async def incoming_webhook(
         enable_runtime_tests=enable_runtime_tests,
     )
     return response
+
+
+@router.post("/{path}/{secret}/wait", tags=["public"])
+async def incoming_webhook_sync(
+    defn: Annotated[WorkflowDefinition, Depends(validate_incoming_webhook)],
+    path: str,
+    payload: dict[str, Any] | None = None,
+    x_tracecat_enable_runtime_tests: Annotated[str | None, Header()] = None,
+) -> dict[str, Any]:
+    """
+    Webhook endpoint to trigger a workflow.
+
+    This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
+    The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
+    """
+    logger.info("Webhook hit", path=path, payload=payload, role=ctx_role.get())
+
+    dsl_input = DSLInput(**defn.content)
+
+    enable_runtime_tests = (x_tracecat_enable_runtime_tests or "false").lower() in (
+        "1",
+        "true",
+    )
+
+    service = await WorkflowExecutionsService.connect()
+    response = await service.create_workflow_execution(
+        dsl=dsl_input,
+        wf_id=path,
+        payload=payload,
+        enable_runtime_tests=enable_runtime_tests,
+    )
+
+    return response.final_context


### PR DESCRIPTION
## Description

Append /wait to a standard webhook to wait for the response of the workflow to return.  The final_context of the workflow will be returned as the response to the initial POST.

## Related Tickets & Documents

N/A

## Screenshots/Recordings

N/A

## Steps to QA

Call a webhook by appending /wait and the response should be the final_context of the workflow you called.

## [optional] What gif best describes this PR?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
