### PR TITLE
feat(engine): Improve user facing error when workflow is committed without any actions

### DIFF
--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -160,10 +160,11 @@ class DSLInput(BaseModel):
         # Check that we're inside an open
         if not workflow.object:
             raise ValueError("Empty workflow graph object. Is `workflow.object` set?")
+        # XXX: Invoking workflow.actions instantiates the actions relationship
+        # If it still falsy, raise a user facing error
         if not workflow.actions:
-            raise ValueError(
-                "Empty actions list. Please hydrate the workflow by "
-                "calling `workflow.actions` inside an open db session."
+            raise TracecatValidationError(
+                "Workflow has no actions. Please add an action to the workflow before committing."
             )
         graph = RFGraph.from_workflow(workflow)
         return DSLInput(


### PR DESCRIPTION
# Changes
- Raise `TracecatValidationError` when workflow is committed without error. This gets shown on the UI nicely.

# Screens
<img width="1549" alt="Screenshot 2024-08-08 at 12 50 51" src="https://github.com/user-attachments/assets/a59754ca-4ea5-4c0a-bca1-8e40f4b7da71">
