### PR TITLE
fix(engine): Allow object/attribute access for jsonpath

### DIFF
--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -429,6 +429,17 @@ def test_eval_templated_object_inline_fails_if_not_str():
         ("TRIGGER.data.name", "John"),
         ("TRIGGER.data.age", 30),
         ("TRIGGER.value -> int", 100),
+        ## Try more uncommon trigger expressions
+        ("TRIGGER.hits._test", "_test_ok"),
+        ("TRIGGER.hits.________test", "________test_ok"),
+        ("TRIGGER.hits._source['kibana.alert.rule.name']", "TEST"),
+        ("TRIGGER.hits._source.['kibana.alert.rule.name']", "TEST"),
+        ('TRIGGER.hits._source.["kibana.alert.rule.name"]', "TEST"),
+        ('TRIGGER.hits._source."kibana.alert.rule.name"', "TEST"),
+        ("TRIGGER.hits._source.'kibana.alert.rule.name'", "TEST"),
+        ("TRIGGER.hits.'_source'.['kibana.alert.rule.name']", "TEST"),
+        ("TRIGGER.hits.'_source'.['kibana.alert.rule.name']", "TEST"),
+        ("TRIGGER.hits.['_source']['kibana.alert.rule.name']", "TEST"),
         # Local variables
         ("var.x", 5),
         ("var.y", "100"),
@@ -509,6 +520,14 @@ def test_expression_parser(expr, expected):
                 "age": 30,
             },
             "value": "100",
+            "hits": {
+                # Leading underscore + flattened key
+                "_source": {
+                    "kibana.alert.rule.name": "TEST",
+                },
+                "_test": "_test_ok",
+                "________test": "________test_ok",
+            },
         },
         ExprContext.LOCAL_VARS: {
             "x": 5,
@@ -672,7 +691,7 @@ def assert_validation_result(
                     "url": "${{ int(100) }}",
                 },
                 "test2": "fail 1 ${{ ACTIONS.my_action.invalid }} ",
-                "test3": "fail 2 ${{ int(ACTIONS.my_action.invalid_inner) }} ",
+                "test3": "fail 2 ${{ int(INPUTS.my_action.invalid_inner) }} ",
             },
             [
                 {
@@ -686,7 +705,7 @@ def assert_validation_result(
                     "contains_msg": "invalid",
                 },
                 {
-                    "type": ExprType.ACTION,
+                    "type": ExprType.INPUT,
                     "status": "error",
                     "contains_msg": "invalid_inner",
                 },

--- a/tracecat/expressions/parser/evaluator.py
+++ b/tracecat/expressions/parser/evaluator.py
@@ -178,7 +178,18 @@ class ExprEvaluator(TracecatTransformer):
         logger.trace("Visiting binary_op:", lhs=lhs, op=op, rhs=rhs)
         return functions.OPERATORS[op](lhs, rhs)
 
-    # Terminals
+    @v_args(inline=True)
+    def jsonpath_expression(self, *args):
+        logger.trace("Visiting jsonpath expression", args=args)
+        return "".join(args)
+
+    @v_args(inline=True)
+    def jsonpath_segment(self, *args):
+        logger.trace("Visiting jsonpath segment", args=args)
+        return "".join(args)
+
+    """Terminals"""
+
     def JSONPATH(self, token: Token):
         logger.trace("Visiting jsonpath:", value=token.value)
         return token
@@ -223,4 +234,12 @@ class ExprEvaluator(TracecatTransformer):
 
     def ATTRIBUTE_PATH(self, token: Token):
         logger.trace("Visiting ATTRIBUTE_PATH:", value=token.value)
+        return token.value
+
+    def ATTRIBUTE_ACCESS(self, token: Token):
+        logger.trace("Visiting ATTRIBUTE_ACCESS:", value=token.value)
+        return token.value
+
+    def BRACKET_ACCESS(self, token: Token):
+        logger.trace("Visiting BRACKET_ACCESS:", value=token.value)
         return token.value

--- a/tracecat/expressions/parser/grammar.py
+++ b/tracecat/expressions/parser/grammar.py
@@ -29,12 +29,12 @@ binary_op: expression OPERATOR expression
 arg_list: (expression ("," expression)*)?
 
 
-actions: "ACTIONS" JSONPATH
+actions: "ACTIONS" jsonpath_expression
 secrets: "SECRETS" ATTRIBUTE_PATH
-inputs: "INPUTS" JSONPATH
-env: "ENV" JSONPATH
-local_vars: "var" JSONPATH
-trigger: "TRIGGER" JSONPATH
+inputs: "INPUTS" jsonpath_expression
+env: "ENV" jsonpath_expression
+local_vars: "var" jsonpath_expression
+trigger: "TRIGGER" jsonpath_expression
 function: "FN." FN_NAME_WITH_TRANSFORM "(" [arg_list] ")"
 local_vars_assignment: "var" ATTRIBUTE_PATH
 
@@ -53,14 +53,21 @@ kvpair : STRING_LITERAL ":" expression
 ATTRIBUTE_PATH: ("." CNAME)+
 FN_NAME_WITH_TRANSFORM: CNAME FN_TRANSFORM?
 FN_TRANSFORM: "." CNAME
-JSONPATH: ( "." CNAME ("[" JSONPATH_INDEX "]")?  )+
+
+jsonpath_expression: jsonpath_segment+
+?jsonpath_segment: ATTRIBUTE_ACCESS | BRACKET_ACCESS
 JSONPATH_INDEX: /\d+/ | "*"
+ATTRIBUTE_ACCESS: "." ( CNAME | STRING_LITERAL | BRACKET_ACCESS )
+BRACKET_ACCESS: "[" (STRING_LITERAL | JSONPATH_INDEX) "]"
+
 OPERATOR: "+" | "-" | "*" | "/" | "%" | "==" | "!=" | ">" | "<" | ">=" | "<=" | "&&" | "||" | "in"
 TYPE_SPECIFIER: "int" | "float" | "str" | "bool"
 STRING_LITERAL: /'(?:[^'\\]|\\.)*'/ | /"(?:[^"\\]|\\.)*"/
 BOOL_LITERAL: "True" | "False"
 NUMERIC_LITERAL: /\d+(\.\d+)?/
 NONE_LITERAL: "None"
+
+
 
 %import common.CNAME
 %import common.WS


### PR DESCRIPTION
# Changes
- Extend Lark grammar to use recurvie `jsonpath_expression`
- Reason aboue jsonpaths as path segments of `ATTRIBUTE_ACCESS` and `BRACKET_ACCESS`
    - attribute access: `.cname`, `.'some_key'`, `.['bracket']`
    - bracket access: `['key']`, `[*]` (array wildcard), `[\d+]` (array index)
 - These changes also allow for repeated bracket access application: `.segment['key1']['key2']` (equivalent to .segment.key1.key2 if object, if array then it will index)
   

# Tests
- Added relevant expression unit tests
- Add test to check that we can use leading underscores for attribute access