### PR TITLE
fix+refactor(engine): Implement graph and db actions sync + move crea…

### DIFF
--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -422,7 +422,7 @@ async def test_child_workflow_success(temporal_cluster, test_role):
         if not child_workflow:
             raise ValueError("Child workflow not created")
         _ = child_workflow.actions
-        child_dsl = DSLInput.from_workflow(child_workflow)
+        child_dsl = await mgmt_service.build_dsl_from_workflow(child_workflow)
 
         # Commit the child workflow
         defn_service = WorkflowDefinitionsService(session, role=test_role)
@@ -497,7 +497,7 @@ async def test_child_workflow_context_passing(temporal_cluster, test_role):
         if not child_workflow:
             raise ValueError("Child workflow not created")
         _ = child_workflow.actions
-        child_dsl = DSLInput.from_workflow(child_workflow)
+        child_dsl = await mgmt_service.build_dsl_from_workflow(child_workflow)
 
         # Commit the child workflow
         defn_service = WorkflowDefinitionsService(session, role=test_role)

--- a/tracecat/dsl/graph.py
+++ b/tracecat/dsl/graph.py
@@ -13,6 +13,7 @@ from pydantic import (
 )
 from pydantic.alias_generators import to_camel
 
+from tracecat.db.schemas import Action
 from tracecat.dsl.models import ActionStatement
 from tracecat.identifiers import action
 from tracecat.logging import logger
@@ -259,17 +260,8 @@ class RFGraph(TSObject):
         """Return all `udf` (action) type nodes."""
         return [node for node in self.nodes if node.type == "udf"]
 
-    def action_statements(self, workflow: Workflow) -> list[ActionStatement]:
-        """Create ActionStatements by combining RFGraph.nodes and Workflow.actions."""
-        if len(self.action_nodes()) != len(workflow.actions):
-            logger.error(
-                f"Mismatch between graph action nodes and workflow actions: {len(self.nodes)=} != {len(workflow.actions)=}"
-            )
-            raise ValueError(
-                f"Mismatch between graph nodes and workflow actions: {len(self.nodes)=} != {len(workflow.actions)=}"
-            )
-
-        actions = workflow.actions or []
+    def build_action_statements(self, actions: list[Action]) -> list[ActionStatement]:
+        """Convert DB Actions into ActionStatements using the graph."""
         ref2action = {action.ref: action for action in actions}
 
         statements = []

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -23,7 +23,6 @@ from tracecat import validation
 from tracecat.auth.credentials import authenticate_user_for_workspace
 from tracecat.db.engine import get_async_session
 from tracecat.db.schemas import Webhook, Workflow, WorkflowDefinition
-from tracecat.dsl.common import DSLInput
 from tracecat.dsl.graph import RFGraph
 from tracecat.identifiers import WorkflowID
 from tracecat.logging import logger
@@ -246,8 +245,6 @@ async def commit_workflow(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Could not find workflow"
             )
-        # Hydrate actions
-        _ = workflow.actions
 
         # Perform Tiered Validation
         # Tier 1: DSLInput validation
@@ -256,7 +253,7 @@ async def commit_workflow(
         try:
             # Convert the workflow into a WorkflowDefinition
             # XXX: When we commit from the workflow, we have action IDs
-            dsl = DSLInput.from_workflow(workflow)
+            dsl = await mgmt_service.build_dsl_from_workflow(workflow)
         except* TracecatValidationError as eg:
             logger.error(eg.message, error=eg.exceptions)
             construction_errors.extend(


### PR DESCRIPTION
# Changes
- Add remediation step that triggers when the RFGraph (view) nodes become out of sync with the DB (model) nodes. This happens due to race conditions in reading/writing nodes to the db, mainly due to separate stores for the view and data (in Workflow.object and Action specifically
- To remediate, we check if there's a mismatch between both the lengths of both sets of nodes. If so, we take the set difference and prune the orphaned action table rows. This syncs the DB model with the graph view. 
- Moved the DSL construction step into `WorkflowManagementService` for separation of concerns. Want to keep `tracecat.dsl` close to a lib

# Testing
This was tested once, where I created a workflow with 1 node (open case). I then did the following:
1. Create an orphaned node with a different action ID (not in the graph object)
2. Commit the workflow
3. Observe that the commit succeeds
4. Observe that in the logs, I see the logger warning saying mismatched (which precedes the remediation process)
5. Observe that when I refresh tableplus, the orphaned DB entry has been removed

- I'd like to write proper tests when I get pytest working with a mock postgres setup

# Remarks
This is just a hotfix. We should consider fixing the root cause of this issue - a possible good solution would be to eliminate storing the object and just store everything in the actions table.