### PR TITLE
docs: Use `google_oauth` over `google` in docs

### DIFF
--- a/docs/self-hosting/authentication/google.mdx
+++ b/docs/self-hosting/authentication/google.mdx
@@ -8,10 +8,11 @@ description: Learn how to authenticate into Tracecat using Google OAuth.
 In your `.env` file, make sure you have the following value set.
 
 ```bash
-TRACECAT__AUTH_TYPES=google
+TRACECAT__AUTH_TYPES=google_oauth
 ```
 
 ## Prerequisites
+
 - Create a Google project. [Link here](https://console.cloud.google.com/projectcreate).
 - Enable the Google People API for the created project. [Link here.](https://console.cloud.google.com/apis/library/people.googleapis.com)
 
@@ -27,15 +28,17 @@ TRACECAT__AUTH_TYPES=google
     3. Set the **Authorized redirect URIs** to: `<your-domain>/auth/oauth/callback`.
 
     ![Google OAuth consent screen](/img/google-oauth-consent.png)
+
   </Step>
   <Step title="Set up credentials in Google">
     Go to **APIs & Services** and select the **Credentials** page.
     1. Under the **OAuth 2.0 Client IDs** section, select the app you created in the previous step.
     2. You will now see the following **Additional Information** on the right hand side of the screen.
-  
+
     ![Google OAuth client secrets](/img/google-oauth-client-secrets.png)
 
     3. Copy the **Client ID** and **Client secret** in a secure location for storing secrets.
+
   </Step>
   <Step title="Configure environment variables in Tracecat">
     Go into the `.env` file and set the following variables:
@@ -48,4 +51,3 @@ TRACECAT__AUTH_TYPES=google
     Run `docker compose up`.
   </Step>
 </Steps>
-

--- a/docs/self-hosting/authentication/introduction.mdx
+++ b/docs/self-hosting/authentication/introduction.mdx
@@ -15,6 +15,7 @@ See the following warning callout box for details:
 We cannot stress this enough. Don't forget to change the email and password of the default admin user in production!
 
 The default email is `admin@domain.com` and the default password is `password`.
+
 </Warning>
 
 ![signin-page](/img/signin-page.png)
@@ -22,16 +23,26 @@ The default email is `admin@domain.com` and the default password is `password`.
 ## Authentication Methods
 
 Tracecat currently supports the following authentication methods:
+
 - `basic`: Email and Password
 - `google`: Google OAuth
 
 Choose from a number of authentication methods listed below to get started.
 
 <CardGroup cols={2}>
-  <Card title="Basic Auth" icon="lock" href="/self-hosting/authentication/basic">
-    Email and password authentication comes preconfigured and works out-of-the-box.
+  <Card
+    title="Basic Auth"
+    icon="lock"
+    href="/self-hosting/authentication/basic"
+  >
+    Email and password authentication comes preconfigured and works
+    out-of-the-box.
   </Card>
-  <Card title="Google OAuth" icon="google" href="/self-hosting/authentication/google">
+  <Card
+    title="Google OAuth"
+    icon="google"
+    href="/self-hosting/authentication/google"
+  >
     Learn how to authenticate into Tracecat using Google OAuth.
   </Card>
 </CardGroup>
@@ -39,8 +50,8 @@ Choose from a number of authentication methods listed below to get started.
 ## Enable / Disable Authentication Methods
 
 You can enable / disable multiple authentication methods in the `.env` file by modifying the `TRACECAT__AUTH_TYPES` environment variable.
-`TRACECAT__AUTH_TYPES` is a comma separated list of auth method keys: i.e. `basic`, `google`.
+`TRACECAT__AUTH_TYPES` is a comma separated list of auth method keys: i.e. `basic`, `google_oauth`.
 
 ```bash
-TRACECAT__AUTH_TYPES=basic,google
+TRACECAT__AUTH_TYPES=basic,google_oauth
 ```


### PR DESCRIPTION
Should be `google_oauth` and not just `google` for `TRACECAT__AUTH_TYPES`. See `.env.example`