### PR TITLE
fix(engine): Hash unhashable types using json dumps during validation

### DIFF
--- a/frontend/src/components/nav/workbench-nav.tsx
+++ b/frontend/src/components/nav/workbench-nav.tsx
@@ -101,12 +101,16 @@ export function WorkbenchNav() {
 
   const handleCommit = async () => {
     console.log("Committing changes...")
-    const response = await commitWorkflow()
-    const { status, errors } = response
-    if (status === "failure") {
-      setCommitErrors(errors || null)
-    } else {
-      setCommitErrors(null)
+    try {
+      const response = await commitWorkflow()
+      const { status, errors } = response
+      if (status === "failure") {
+        setCommitErrors(errors || null)
+      } else {
+        setCommitErrors(null)
+      }
+    } catch (error) {
+      console.error("Failed to commit workflow:", error)
     }
   }
 

--- a/tracecat/types/validation.py
+++ b/tracecat/types/validation.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
@@ -14,7 +15,8 @@ class ValidationResult(BaseModel):
     detail: Any | None = None
 
     def __hash__(self) -> int:
-        return hash((self.status, self.msg, self.detail))
+        detail = json.dumps(self.detail, sort_keys=True)
+        return hash((self.status, self.msg, detail))
 
 
 class RegistryValidationResult(ValidationResult):


### PR DESCRIPTION
# Fixes
- Issue where passing lists and dicts cause this to fail. Band aid fix just by stringifying using json.dumps 
    - The above error occurred when i tried to commit a playbook i imported from yaml, and we try to deduplicate the validation errors returned to the user