### PR TITLE
feat(engine+ui): Import/export from json/yaml

### DIFF
--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -131,7 +131,7 @@ export function CreateWorkflowButton() {
             </DropdownMenuItem>
             <DialogTrigger asChild>
               <DropdownMenuItem>
-                Import from file
+                From YAML / JSON
                 <DropdownMenuShortcut>
                   <BracesIcon className="size-4" />
                 </DropdownMenuShortcut>

--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -131,7 +131,7 @@ export function CreateWorkflowButton() {
             </DropdownMenuItem>
             <DialogTrigger asChild>
               <DropdownMenuItem>
-                Upload Definition File
+                Import from file
                 <DropdownMenuShortcut>
                   <BracesIcon className="size-4" />
                 </DropdownMenuShortcut>

--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -142,7 +142,7 @@ export function CreateWorkflowButton() {
       </DropdownMenu>
       <DialogContent className="sm:max-w-[600px]">
         <DialogHeader>
-          <DialogTitle>Import workflow from definition file</DialogTitle>
+          <DialogTitle>Import workflow from file</DialogTitle>
           <DialogDescription>
             Import a workflow from either a YAML or JSON file.
           </DialogDescription>

--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -144,7 +144,7 @@ export function CreateWorkflowButton() {
         <DialogHeader>
           <DialogTitle>Import workflow from definition file</DialogTitle>
           <DialogDescription>
-            Import a workflow from either a YAML or JSON definition file.
+            Import a workflow from either a YAML or JSON file.
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -84,7 +84,7 @@ export function CreateWorkflowButton() {
           case 400:
             console.error("Bad request:", apiError)
             form.setError("file", {
-              message: "The uploaded workflow Definition is invalid.",
+              message: "The uploaded workflow YAML / JSON is invalid.",
             })
 
             setValidationErrors(

--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -1,13 +1,17 @@
 "use client"
 
+import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { workflowsCreateWorkflow } from "@/client"
+import { ApiError } from "@/client"
 import { useWorkspace } from "@/providers/workspace"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { BracesIcon, ChevronDownIcon, PlusCircleIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
+import YAML from "yaml"
 import { z } from "zod"
 
+import { TracecatApiError } from "@/lib/errors"
+import { useWorkflowManager } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -35,6 +39,7 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
 
 const formSchema = z.object({
   file: z.instanceof(File).refine((file) => file.size <= 5000000, {
@@ -46,13 +51,15 @@ type FormValues = z.infer<typeof formSchema>
 export function CreateWorkflowButton() {
   const router = useRouter()
   const { workspaceId } = useWorkspace()
+  const { createWorkflow } = useWorkflowManager()
+  const [validationErrors, setValidationErrors] = useState<string | null>(null)
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
   })
   const workspaceUrl = `/workspaces/${workspaceId}/workflows`
   const handleCreateWorkflow = async () => {
     try {
-      const response = await workflowsCreateWorkflow({ workspaceId })
+      const response = await createWorkflow({ workspaceId })
       router.push(`${workspaceUrl}/${response.id}`)
     } catch (error) {
       console.error("Error creating workflow:", error)
@@ -61,15 +68,42 @@ export function CreateWorkflowButton() {
 
   const onSubmit = async (data: FormValues) => {
     try {
-      const response = await workflowsCreateWorkflow({
+      const { file } = data
+      const contentType = file.type
+      const response = await createWorkflow({
         workspaceId,
         formData: {
-          file: new Blob([data.file], { type: "application/yaml" }),
+          file: new Blob([file], { type: contentType }),
         },
       })
       router.push(`${workspaceUrl}/${response.id}`)
     } catch (error) {
-      console.error("Error creating workflow:", error)
+      if (error instanceof ApiError) {
+        const apiError = error as TracecatApiError
+        switch (apiError.status) {
+          case 400:
+            console.error("Bad request:", apiError)
+            form.setError("file", {
+              message: "The uploaded workflow Definition is invalid.",
+            })
+
+            setValidationErrors(
+              YAML.stringify(YAML.parse(apiError.body.detail))
+            )
+            break
+          case 409:
+            console.error("Conflict:", apiError)
+            form.setError("file", {
+              message: `A workflow with this workflow ID already exists.
+              Please either delete the existing workflow, remove the ID from the file, or upload a file with a different ID.`,
+            })
+            break
+          default:
+            console.error("Unexpected error:", apiError)
+        }
+      } else {
+        console.error("Unexpected error:", error)
+      }
     }
   }
 
@@ -85,7 +119,7 @@ export function CreateWorkflowButton() {
             <ChevronDownIcon className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-48 text-xs" align="end">
+        <DropdownMenuContent className="w-48" align="end">
           <DropdownMenuGroup>
             <DropdownMenuItem
               onClick={async () => await handleCreateWorkflow()}
@@ -97,7 +131,7 @@ export function CreateWorkflowButton() {
             </DropdownMenuItem>
             <DialogTrigger asChild>
               <DropdownMenuItem>
-                From YAML
+                Upload Definition File
                 <DropdownMenuShortcut>
                   <BracesIcon className="size-4" />
                 </DropdownMenuShortcut>
@@ -106,11 +140,11 @@ export function CreateWorkflowButton() {
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[600px]">
         <DialogHeader>
-          <DialogTitle>Import workflow from file</DialogTitle>
+          <DialogTitle>Import workflow from definition file</DialogTitle>
           <DialogDescription>
-            Import a workflow from either a YAML file.
+            Import a workflow from either a YAML or JSON definition file.
           </DialogDescription>
         </DialogHeader>
 
@@ -121,7 +155,7 @@ export function CreateWorkflowButton() {
               name="file"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>File</FormLabel>
+                  <FormLabel>File Upload</FormLabel>
                   <FormControl>
                     <Input
                       type="file"
@@ -141,6 +175,13 @@ export function CreateWorkflowButton() {
             <Button type="submit">Upload</Button>
           </form>
         </Form>
+        {validationErrors && (
+          <div className="flex h-72 flex-col space-y-2 overflow-auto rounded-md border border-rose-500 bg-rose-100 p-2 font-mono text-xs text-rose-600">
+            <span className="font-semibold">Validation errors</span>
+            <Separator className="bg-rose-400" />
+            <pre>{validationErrors}</pre>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/components/dashboard/dashboard-table.tsx
+++ b/frontend/src/components/dashboard/dashboard-table.tsx
@@ -7,7 +7,7 @@ import { useWorkspace } from "@/providers/workspace"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import { Row } from "@tanstack/react-table"
 
-import { exportWorkflow } from "@/lib/export"
+import { exportWorkflow, handleExportError } from "@/lib/export"
 import { useWorkflowManager } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -180,11 +180,7 @@ export function WorkflowsDashboardTable() {
                             "Failed to download workflow definition:",
                             error
                           )
-                          toast({
-                            title: "Error exporting workflow",
-                            description:
-                              "Could not export workflow to JSON. Please try again.",
-                          })
+                          toast(handleExportError(error as Error))
                         }
                       }}
                     >
@@ -206,11 +202,7 @@ export function WorkflowsDashboardTable() {
                             "Failed to download workflow definition:",
                             error
                           )
-                          toast({
-                            title: "Error exporting workflow",
-                            description:
-                              "Could not export workflow to YAML. Please try again.",
-                          })
+                          toast(handleExportError(error as Error))
                         }
                       }}
                     >

--- a/frontend/src/components/dashboard/dashboard-table.tsx
+++ b/frontend/src/components/dashboard/dashboard-table.tsx
@@ -7,7 +7,7 @@ import { useWorkspace } from "@/providers/workspace"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import { Row } from "@tanstack/react-table"
 
-import { exportWorkflowJson } from "@/lib/export"
+import { exportWorkflow } from "@/lib/export"
 import { useWorkflowManager } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -170,7 +170,7 @@ export function WorkflowsDashboardTable() {
                         e.stopPropagation() // Prevent row click
 
                         try {
-                          await exportWorkflowJson({
+                          await exportWorkflow({
                             workspaceId,
                             workflowId: row.original.id,
                             format: "json",
@@ -183,12 +183,38 @@ export function WorkflowsDashboardTable() {
                           toast({
                             title: "Error exporting workflow",
                             description:
-                              "Could not export workflow. Please try again.",
+                              "Could not export workflow to JSON. Please try again.",
                           })
                         }
                       }}
                     >
                       Export to JSON
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-xs"
+                      onClick={async (e) => {
+                        e.stopPropagation() // Prevent row click
+
+                        try {
+                          await exportWorkflow({
+                            workspaceId,
+                            workflowId: row.original.id,
+                            format: "yaml",
+                          })
+                        } catch (error) {
+                          console.error(
+                            "Failed to download workflow definition:",
+                            error
+                          )
+                          toast({
+                            title: "Error exporting workflow",
+                            description:
+                              "Could not export workflow to YAML. Please try again.",
+                          })
+                        }
+                      }}
+                    >
+                      Export to YAML
                     </DropdownMenuItem>
 
                     <DeleteWorkflowAlertDialogTrigger asChild>

--- a/frontend/src/components/nav/workbench-nav.tsx
+++ b/frontend/src/components/nav/workbench-nav.tsx
@@ -24,7 +24,7 @@ import {
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
-import { exportWorkflowJson } from "@/lib/export"
+import { exportWorkflow } from "@/lib/export"
 import { useWorkflowManager } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import {
@@ -446,25 +446,51 @@ function WorkbenchNavOptions({
               className="text-xs text-foreground/70"
               onClick={async () => {
                 try {
-                  await exportWorkflowJson({
+                  await exportWorkflow({
                     workspaceId,
                     workflowId,
                     format: "json",
                   })
                 } catch (error) {
                   console.error(
-                    "Failed to download workflow definition:",
+                    "Failed to download JSON workflow definition:",
                     error
                   )
                   toast({
                     title: "Error exporting workflow",
-                    description: "Could not export workflow. Please try again.",
+                    description:
+                      "Could not export workflow to JSON. Please try again.",
                   })
                 }
               }}
             >
               <DownloadIcon className="mr-2 size-4" />
               <span>Export as JSON</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-xs text-foreground/70"
+              onClick={async () => {
+                try {
+                  await exportWorkflow({
+                    workspaceId,
+                    workflowId,
+                    format: "yaml",
+                  })
+                } catch (error) {
+                  console.error(
+                    "Failed to download YAML workflow definition:",
+                    error
+                  )
+                  toast({
+                    title: "Error exporting workflow",
+                    description:
+                      "Could not export workflow to YAML. Please try again.",
+                  })
+                }
+              }}
+            >
+              <DownloadIcon className="mr-2 size-4" />
+              <span>Export as YAML</span>
             </DropdownMenuItem>
             <DialogTrigger asChild>
               <DropdownMenuItem className="text-xs text-red-600">

--- a/frontend/src/components/nav/workbench-nav.tsx
+++ b/frontend/src/components/nav/workbench-nav.tsx
@@ -24,7 +24,7 @@ import {
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
-import { exportWorkflow } from "@/lib/export"
+import { exportWorkflow, handleExportError } from "@/lib/export"
 import { useWorkflowManager } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import {
@@ -456,11 +456,7 @@ function WorkbenchNavOptions({
                     "Failed to download JSON workflow definition:",
                     error
                   )
-                  toast({
-                    title: "Error exporting workflow",
-                    description:
-                      "Could not export workflow to JSON. Please try again.",
-                  })
+                  toast(handleExportError(error as Error))
                 }
               }}
             >
@@ -481,11 +477,7 @@ function WorkbenchNavOptions({
                     "Failed to download YAML workflow definition:",
                     error
                   )
-                  toast({
-                    title: "Error exporting workflow",
-                    description:
-                      "Could not export workflow to YAML. Please try again.",
-                  })
+                  toast(handleExportError(error as Error))
                 }
               }}
             >

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -52,7 +52,7 @@ function filenameFromHeader(contentDisposition: string): string | null {
 }
 
 export function handleExportError(error: Error) {
-  console.error("Failed to download workflow definition:", error)
+  console.error("Failed to download workflow YAML / JSON:", error)
   const toastData = {
     title: "Error exporting workflow",
     description: "Could not export workflow. Please try again.",

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -1,4 +1,5 @@
 import { WorkflowsExportWorkflowData } from "@/client"
+import { AxiosError } from "axios"
 
 import { client } from "@/lib/api"
 
@@ -11,6 +12,7 @@ export async function exportWorkflow({
   const response = await client.get(`/workflows/${workflowId}/export`, {
     params: { version, format, workspace_id: workspaceId },
   })
+
   // Extract the filename from the Content-Disposition header
   const contentDisposition = response.headers["content-disposition"]
 
@@ -47,4 +49,21 @@ function filenameFromHeader(contentDisposition: string): string | null {
     return filenameMatch[1]
   }
   return null
+}
+
+export function handleExportError(error: Error) {
+  console.error("Failed to download workflow definition:", error)
+  const toastData = {
+    title: "Error exporting workflow",
+    description: "Could not export workflow. Please try again.",
+  }
+
+  if (error instanceof AxiosError && error.response?.status === 404) {
+    toastData.title = "No workflow definition"
+    toastData.description =
+      "Cannot export workflow without a definition. Please commit changes to create a definition."
+  } else {
+    toastData.description += ` ${error.message}`
+  }
+  return toastData
 }

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -59,7 +59,7 @@ export function handleExportError(error: Error) {
   }
 
   if (error instanceof AxiosError && error.response?.status === 404) {
-    toastData.title = "No workflow definition"
+    toastData.title = "No workflow version found"
     toastData.description =
       "Cannot export workflow without a definition. Please commit changes to create a definition."
   } else {

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -61,7 +61,7 @@ export function handleExportError(error: Error) {
   if (error instanceof AxiosError && error.response?.status === 404) {
     toastData.title = "No workflow version found"
     toastData.description =
-      "Cannot export workflow without a definition. Please commit changes to create a definition."
+      "Cannot export uncommitted workflow. Please commit changes to create a versioned workflow."
   } else {
     toastData.description += ` ${error.message}`
   }

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -39,6 +39,8 @@ import {
   workflowExecutionsListWorkflowExecutionEventHistory,
   workflowExecutionsListWorkflowExecutions,
   WorkflowMetadataResponse,
+  workflowsCreateWorkflow,
+  WorkflowsCreateWorkflowData,
   workflowsDeleteWorkflow,
   workflowsListWorkflows,
   workspacesCreateWorkspace,
@@ -297,6 +299,42 @@ export function useWorkflowManager() {
     retry: retryHandler,
   })
 
+  // Create workflow
+  const { mutateAsync: createWorkflow } = useMutation({
+    mutationFn: async (params: WorkflowsCreateWorkflowData) =>
+      await workflowsCreateWorkflow(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["workflows", workspaceId] })
+      toast({
+        title: "Created workflow",
+        description: "Your workflow has been created successfully.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      switch (error.status) {
+        case 400:
+          toast({
+            title: "Cannot create workflow",
+            description: "The uploaded workflow definition is invalid.",
+          })
+          break
+        case 409:
+          toast({
+            title: "Workflow already exists",
+            description: "A workflow with the same ID already exists.",
+          })
+          break
+        default:
+          console.error("Failed to create workflow:", error)
+          toast({
+            title: "Error creating workflow",
+            description: error.body.detail + ". Please try again.",
+            variant: "destructive",
+          })
+      }
+    },
+  })
+
   // Delete workflow
   const { mutateAsync: deleteWorkflow } = useMutation({
     mutationFn: async (workflowId: string) =>
@@ -333,6 +371,7 @@ export function useWorkflowManager() {
     workflows,
     workflowsLoading,
     workflowsError,
+    createWorkflow,
     deleteWorkflow,
   }
 }
@@ -401,7 +440,7 @@ export function useWorkspaceManager() {
         case 400:
           toast({
             title: "Cannot delete workspace",
-            description: error.body.detail,
+            description: JSON.stringify(error.body.detail),
           })
           break
         default:

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -315,7 +315,7 @@ export function useWorkflowManager() {
         case 400:
           toast({
             title: "Cannot create workflow",
-            description: "The uploaded workflow definition is invalid.",
+            description: "The uploaded workflow YAML / JSON is invalid.",
           })
           break
         case 409:

--- a/playbooks/alert_management/aws-guardduty-to-cases.yml
+++ b/playbooks/alert_management/aws-guardduty-to-cases.yml
@@ -1,67 +1,68 @@
-title: Open cases for GuardDuty findings
-description: |
-  Pulls GuardDuty findings from AWS and opens cases.
-  Also sends a message if no findings available.
-entrypoint:
-  ref: pull_aws_guardduty_findings
-triggers:
-  - type: webhook
-    ref: guardduty_findings_webhook
-    entrypoint: pull_aws_guardduty_findings
+definition:
+  title: Open cases for GuardDuty findings
+  description: |
+    Pulls GuardDuty findings from AWS and opens cases.
+    Also sends a message if no findings available.
+  entrypoint:
+    ref: pull_aws_guardduty_findings
+  triggers:
+    - type: webhook
+      ref: guardduty_findings_webhook
+      entrypoint: pull_aws_guardduty_findings
 
-actions:
-  - ref: pull_aws_guardduty_findings
-    action: integrations.aws.guardduty.list_guardduty_alerts
-    args:
-      start_time: ${{ TRIGGER.start_time }}
-      end_time: ${{ TRIGGER.end_time }}
-      limit: 10
+  actions:
+    - ref: pull_aws_guardduty_findings
+      action: integrations.aws.guardduty.list_guardduty_alerts
+      args:
+        start_time: ${{ TRIGGER.start_time }}
+        end_time: ${{ TRIGGER.end_time }}
+        limit: 10
 
-  # Transform the list of GuardDuty findings into a list of SMAC findings
-  - ref: reshape_findings_into_smac
-    action: core.transform.reshape
-    depends_on:
-      - pull_aws_guardduty_findings
-    run_if: ${{ FN.not_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
-    for_each: ${{ for var.finding in ACTIONS.pull_aws_guardduty_findings.result }}
-    args:
-      value:
-        title: ${{ var.finding.Title }}
-        description: ${{ var.finding.Description }}
-        payload:
-          rule: ${{ var.finding.Type }}
-          severity: ${{ var.finding.Severity }}
-        status: ${{ 'closed' if var.finding.Service.Archived else 'open' }}
-        malice: ${{ 'malicious' if FN.greater_than(var.finding.Severity, 0) else 'benign' }}
-        action: quarantine
+    # Transform the list of GuardDuty findings into a list of SMAC findings
+    - ref: reshape_findings_into_smac
+      action: core.transform.reshape
+      depends_on:
+        - pull_aws_guardduty_findings
+      run_if: ${{ FN.not_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
+      for_each: ${{ for var.finding in ACTIONS.pull_aws_guardduty_findings.result }}
+      args:
+        value:
+          title: ${{ var.finding.Title }}
+          description: ${{ var.finding.Description }}
+          payload:
+            rule: ${{ var.finding.Type }}
+            severity: ${{ var.finding.Severity }}
+          status: ${{ 'closed' if var.finding.Service.Archived else 'open' }}
+          malice: ${{ 'malicious' if FN.greater_than(var.finding.Severity, 0) else 'benign' }}
+          action: quarantine
+          context:
+            account_id: ${{ var.finding.AccountId }}
+            region: ${{ var.finding.Region }}
+            resource_type: ${{ var.finding.Resource.ResourceType }}
+            updated_at: ${{ var.finding.UpdatedAt }}
+            created_at: ${{ var.finding.CreatedAt }}
+
+    # Open cases in Tracecat's case management system
+    - ref: open_cases
+      action: core.open_case
+      depends_on:
+        - reshape_findings_into_smac
+      for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
+      args:
+        case_title: ${{ var.smac.title }}
+        status: ${{ var.smac.status }}
+        malice: ${{ var.smac.malice }}
+        action: ${{ var.smac.action }}
         context:
-          account_id: ${{ var.finding.AccountId }}
-          region: ${{ var.finding.Region }}
-          resource_type: ${{ var.finding.Resource.ResourceType }}
-          updated_at: ${{ var.finding.UpdatedAt }}
-          created_at: ${{ var.finding.CreatedAt }}
-
-  # Open cases in Tracecat's case management system
-  - ref: open_cases
-    action: core.open_case
-    depends_on:
-      - reshape_findings_into_smac
-    for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
-    args:
-      case_title: ${{ var.smac.title }}
-      status: ${{ var.smac.status }}
-      malice: ${{ var.smac.malice }}
-      action: ${{ var.smac.action }}
-      context:
-        - key: account_id
-          value: ${{ var.smac.context.account_id }}
-        - key: region
-          value: ${{ var.smac.context.region }}
-        - key: resource_type
-          value: ${{ var.smac.context.resource_type }}
-        - key: updated_at
-          value: ${{ var.smac.context.updated_at }}
-        - key: created_at
-          value: ${{ var.smac.context.created_at }}
-      payload: ${{ var.smac.payload }}
-      priority: ${{ 'high' if var.smac.payload.severity > 50 else ('medium' if var.smac.payload.severity > 20 else 'low') }}
+          - key: account_id
+            value: ${{ var.smac.context.account_id }}
+          - key: region
+            value: ${{ var.smac.context.region }}
+          - key: resource_type
+            value: ${{ var.smac.context.resource_type }}
+          - key: updated_at
+            value: ${{ var.smac.context.updated_at }}
+          - key: created_at
+            value: ${{ var.smac.context.created_at }}
+        payload: ${{ var.smac.payload }}
+        priority: ${{ 'high' if var.smac.payload.severity > 50 else ('medium' if var.smac.payload.severity > 20 else 'low') }}

--- a/playbooks/alert_management/aws-guardduty-to-slack.yml
+++ b/playbooks/alert_management/aws-guardduty-to-slack.yml
@@ -1,91 +1,92 @@
-title: Send Slack notifications for GuardDuty findings
-description: |
-  Pulls GuardDuty findings from AWS and sends them to Slack.
-  Also sends a message if no findings available.
+definition:
+  title: Send Slack notifications for GuardDuty findings
+  description: |
+    Pulls GuardDuty findings from AWS and sends them to Slack.
+    Also sends a message if no findings available.
 
-entrypoint:
-  ref: pull_aws_guardduty_findings
-  expects:
-    start_time: datetime
-    end_time: datetime
+  entrypoint:
+    ref: pull_aws_guardduty_findings
+    expects:
+      start_time: datetime
+      end_time: datetime
 
-triggers:
-  - type: webhook
-    ref: guardduty_findings_webhook
-    entrypoint: pull_aws_guardduty_findings
+  triggers:
+    - type: webhook
+      ref: guardduty_findings_webhook
+      entrypoint: pull_aws_guardduty_findings
 
-actions:
-  - ref: pull_aws_guardduty_findings
-    action: integrations.aws.guardduty.list_guardduty_alerts
-    args:
-      start_time: ${{ TRIGGER.start_time }}
-      end_time: ${{ TRIGGER.end_time }}
-      limit: 10
+  actions:
+    - ref: pull_aws_guardduty_findings
+      action: integrations.aws.guardduty.list_guardduty_alerts
+      args:
+        start_time: ${{ TRIGGER.start_time }}
+        end_time: ${{ TRIGGER.end_time }}
+        limit: 10
 
-  # Short circuit the workflow if no findings are found
-  - ref: report_no_findings
-    action: core.http_request
-    depends_on:
-      - pull_aws_guardduty_findings
-    run_if: ${{ FN.is_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
-    args:
-      url: ${{ SECRETS.slack.SLACK_WEBHOOK }}
-      method: POST
-      headers:
-        Content-Type: application/json
-      payload:
-        text: Tracecat ran workflow for GuardDuty findings, but no findings were found
-
-  # Transform the list of GuardDuty findings into a list of SMAC findings
-  - ref: reshape_findings_into_smac
-    action: core.transform.reshape
-    depends_on:
-      - pull_aws_guardduty_findings
-    run_if: ${{ FN.not_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
-    for_each: ${{ for var.finding in ACTIONS.pull_aws_guardduty_findings.result }}
-    args:
-      value:
-        title: ${{ var.finding.Title }}
-        description: ${{ var.finding.Description }}
+    # Short circuit the workflow if no findings are found
+    - ref: report_no_findings
+      action: core.http_request
+      depends_on:
+        - pull_aws_guardduty_findings
+      run_if: ${{ FN.is_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
+      args:
+        url: ${{ SECRETS.slack.SLACK_WEBHOOK }}
+        method: POST
+        headers:
+          Content-Type: application/json
         payload:
-          rule: ${{ var.finding.Type }}
-          severity: ${{ var.finding.Severity }}
-        status: ${{ 'closed' if var.finding.Service.Archived else 'open' }}
-        malice: ${{ 'malicious' if FN.greater_than(var.finding.Severity, 0) else 'benign' }}
-        action: Investigate and remediate
-        context:
-          account_id: ${{ var.finding.AccountId }}
-          region: ${{ var.finding.Region }}
-          resource_type: ${{ var.finding.Resource.ResourceType }}
-          updated_at: ${{ var.finding.UpdatedAt }}
-          created_at: ${{ var.finding.CreatedAt }}
+          text: Tracecat ran workflow for GuardDuty findings, but no findings were found
 
-  - ref: send_slack_notifications
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - reshape_findings_into_smac
-    # Assign each SMAC finding to a variable named `smac`
-    for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      text: GuardDuty findings
-      blocks:
-        - type: header
-          text:
-            type: plain_text
-            text: ${{ var.smac.title }}
-            emoji: true
-        - type: section
-          text:
-            type: mrkdwn
-            text: ${{ var.smac.description }}
-        - type: section
-          fields:
-            - type: mrkdwn
-              text: "*Status:* ${{ var.smac.status }}"
-            - type: mrkdwn
-              text: "*Malice:* ${{ var.smac.malice }}"
-            - type: mrkdwn
-              text: "*Action:* ${{ var.smac.action }}"
-            - type: mrkdwn
-              text: "*Context:* ${{ var.smac.context }}"
+    # Transform the list of GuardDuty findings into a list of SMAC findings
+    - ref: reshape_findings_into_smac
+      action: core.transform.reshape
+      depends_on:
+        - pull_aws_guardduty_findings
+      run_if: ${{ FN.not_empty(ACTIONS.pull_aws_guardduty_findings.result) }}
+      for_each: ${{ for var.finding in ACTIONS.pull_aws_guardduty_findings.result }}
+      args:
+        value:
+          title: ${{ var.finding.Title }}
+          description: ${{ var.finding.Description }}
+          payload:
+            rule: ${{ var.finding.Type }}
+            severity: ${{ var.finding.Severity }}
+          status: ${{ 'closed' if var.finding.Service.Archived else 'open' }}
+          malice: ${{ 'malicious' if FN.greater_than(var.finding.Severity, 0) else 'benign' }}
+          action: Investigate and remediate
+          context:
+            account_id: ${{ var.finding.AccountId }}
+            region: ${{ var.finding.Region }}
+            resource_type: ${{ var.finding.Resource.ResourceType }}
+            updated_at: ${{ var.finding.UpdatedAt }}
+            created_at: ${{ var.finding.CreatedAt }}
+
+    - ref: send_slack_notifications
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - reshape_findings_into_smac
+      # Assign each SMAC finding to a variable named `smac`
+      for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        text: GuardDuty findings
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: ${{ var.smac.title }}
+              emoji: true
+          - type: section
+            text:
+              type: mrkdwn
+              text: ${{ var.smac.description }}
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Status:* ${{ var.smac.status }}"
+              - type: mrkdwn
+                text: "*Malice:* ${{ var.smac.malice }}"
+              - type: mrkdwn
+                text: "*Action:* ${{ var.smac.action }}"
+              - type: mrkdwn
+                text: "*Context:* ${{ var.smac.context }}"

--- a/playbooks/alert_management/crowdstrike-to-cases-no-slack.yml
+++ b/playbooks/alert_management/crowdstrike-to-cases-no-slack.yml
@@ -16,75 +16,76 @@
 # - start_time: ISO8601 string
 # - end_time: ISO8601 string
 
-title: Fetch Crowdstrike alerts and open cases.
-description: Pulls Crowdstrike alerts and opens cases in Tracecat.
-config:
-  # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
-  # runtime configuration for this flag i.e. tracecat workflow run --test flag).
-  enable_runtime_tests: true
+definition:
+  title: Fetch Crowdstrike alerts and open cases.
+  description: Pulls Crowdstrike alerts and opens cases in Tracecat.
+  config:
+    # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
+    # runtime configuration for this flag i.e. tracecat workflow run --test flag).
+    enable_runtime_tests: true
 
-entrypoint:
-  ref: pull_crowdstrike_alerts
-  expects:
-    start_time: str
-    end_time: str
+  entrypoint:
+    ref: pull_crowdstrike_alerts
+    expects:
+      start_time: str
+      end_time: str
 
-triggers:
-  - type: webhook
-    ref: crowdstrike_alerts_webhook
-    entrypoint: pull_crowdstrike_alerts
+  triggers:
+    - type: webhook
+      ref: crowdstrike_alerts_webhook
+      entrypoint: pull_crowdstrike_alerts
 
-actions:
-  # Mocked
-  - ref: pull_crowdstrike_alerts
-    action: integrations.crowdstrike.list_crowdstrike_alerts
-    args:
-      start_time: ${{ TRIGGER.start_time }}
-      end_time: ${{ TRIGGER.end_time }}
+  actions:
+    # Mocked
+    - ref: pull_crowdstrike_alerts
+      action: integrations.crowdstrike.list_crowdstrike_alerts
+      args:
+        start_time: ${{ TRIGGER.start_time }}
+        end_time: ${{ TRIGGER.end_time }}
 
-  - ref: reshape_alerts_into_smac
-    action: core.transform.reshape
-    depends_on:
-      - pull_crowdstrike_alerts
-    for_each: ${{ for var.alert in ACTIONS.pull_crowdstrike_alerts.result }}
-    args:
-      value:
-        title: ${{ var.alert.name }} # Name of the detection
-        description: ${{ var.alert.description }} # Description of the detected file or activity
-        payload:
-          rule: ${{ var.alert.id }} # Identifier associated with the alert
-          severity: ${{ var.alert.severity }} # Severity level associated with the detection
-        status: ${{ 'closed' if FN.is_equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
-        malice: ${{ 'malicious' if FN.greater_than(var.alert.severity, 0) else 'benign' }} # Determines malice based on severity
-        action: quarantine
-        context:
-          filepath: ${{ var.alert.filepath }}
-          cid: ${{ var.alert.cid }} # CrowdStrike identifier associated with the device
-          parent_user_id: ${{ var.alert.parent_details.user_id -> str }}
-          parent_user_name: ${{ var.alert.parent_details.user_name -> str }}
-          grandparent_user_id: ${{ var.alert.grandparent_details.user_id -> str }}
-          grandparent_user_name: ${{ var.alert.grandparent_details.user_name -> str }}
-          resource_type: ${{ 'device' }} # Assuming resource type is 'device'
-          context_timestamp: ${{ var.alert.context_timestamp -> str }}
-          updated_at: ${{ var.alert.updated_timestamp -> str }} # Timestamp indicating when the alert was last updated
-          created_at: ${{ var.alert.created_timestamp -> str }} # Timestamp indicating when the alert was created
-          user_name: ${{ var.alert.user_name }}
+    - ref: reshape_alerts_into_smac
+      action: core.transform.reshape
+      depends_on:
+        - pull_crowdstrike_alerts
+      for_each: ${{ for var.alert in ACTIONS.pull_crowdstrike_alerts.result }}
+      args:
+        value:
+          title: ${{ var.alert.name }} # Name of the detection
+          description: ${{ var.alert.description }} # Description of the detected file or activity
+          payload:
+            rule: ${{ var.alert.id }} # Identifier associated with the alert
+            severity: ${{ var.alert.severity }} # Severity level associated with the detection
+          status: ${{ 'closed' if FN.is_equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
+          malice: ${{ 'malicious' if FN.greater_than(var.alert.severity, 0) else 'benign' }} # Determines malice based on severity
+          action: quarantine
+          context:
+            filepath: ${{ var.alert.filepath }}
+            cid: ${{ var.alert.cid }} # CrowdStrike identifier associated with the device
+            parent_user_id: ${{ var.alert.parent_details.user_id -> str }}
+            parent_user_name: ${{ var.alert.parent_details.user_name -> str }}
+            grandparent_user_id: ${{ var.alert.grandparent_details.user_id -> str }}
+            grandparent_user_name: ${{ var.alert.grandparent_details.user_name -> str }}
+            resource_type: ${{ 'device' }} # Assuming resource type is 'device'
+            context_timestamp: ${{ var.alert.context_timestamp -> str }}
+            updated_at: ${{ var.alert.updated_timestamp -> str }} # Timestamp indicating when the alert was last updated
+            created_at: ${{ var.alert.created_timestamp -> str }} # Timestamp indicating when the alert was created
+            user_name: ${{ var.alert.user_name }}
 
-  - ref: open_cases
-    action: core.open_case
-    depends_on:
-      - reshape_alerts_into_smac
-    for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
-    args:
-      case_title: ${{ var.smac.title }}
-      status: ${{ var.smac.status }}
-      malice: ${{ var.smac.malice }}
-      action: ${{ var.smac.action }}
-      context: ${{ var.smac.context }}
-      payload: ${{ var.smac.payload }}
-      priority: ${{ 'high' if FN.greater_than(var.smac.payload.severity, 50) else 'low' }}
+    - ref: open_cases
+      action: core.open_case
+      depends_on:
+        - reshape_alerts_into_smac
+      for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
+      args:
+        case_title: ${{ var.smac.title }}
+        status: ${{ var.smac.status }}
+        malice: ${{ var.smac.malice }}
+        action: ${{ var.smac.action }}
+        context: ${{ var.smac.context }}
+        payload: ${{ var.smac.payload }}
+        priority: ${{ 'high' if FN.greater_than(var.smac.payload.severity, 50) else 'low' }}
 
-tests:
-  - ref: pull_crowdstrike_alerts
-    success:
-      - https://raw.githubusercontent.com/TracecatHQ/tracecat/main/tests/data/log_samples/crowdstrike/alert.json
+  tests:
+    - ref: pull_crowdstrike_alerts
+      success:
+        - https://raw.githubusercontent.com/TracecatHQ/tracecat/main/tests/data/log_samples/crowdstrike/alert.json

--- a/playbooks/alert_management/crowdstrike-to-cases.yml
+++ b/playbooks/alert_management/crowdstrike-to-cases.yml
@@ -19,119 +19,120 @@
 #     This would be the Webhook URL to `playbooks/alert_management/slack-to-crowdstrike-update.yml`.
 # .   You can get the webhook URL by running `tracecat workflow inspect wf-id-for-send-slack-notification`.
 
-title: Fetch Crowdstrike alerts and open cases.
-description: Pulls Crowdstrike alerts and opens cases in Tracecat.
-config:
-  # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
-  # runtime configuration for this flag i.e. tracecat workflow run --test flag).
-  enable_runtime_tests: true
-entrypoint:
-  ref: pull_crowdstrike_alerts
-triggers:
-  - type: webhook
-    ref: crowdstrike_alerts_webhook
-    entrypoint: pull_crowdstrike_alerts
+definition:
+  title: Fetch Crowdstrike alerts and open cases.
+  description: Pulls Crowdstrike alerts and opens cases in Tracecat.
+  config:
+    # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
+    # runtime configuration for this flag i.e. tracecat workflow run --test flag).
+    enable_runtime_tests: true
+  entrypoint:
+    ref: pull_crowdstrike_alerts
+  triggers:
+    - type: webhook
+      ref: crowdstrike_alerts_webhook
+      entrypoint: pull_crowdstrike_alerts
 
-actions:
-  # Mocked
-  - ref: pull_crowdstrike_alerts
-    action: integrations.crowdstrike.list_crowdstrike_alerts
-    args:
-      start_time: ${{ TRIGGER.start_time }}
-      end_time: ${{ TRIGGER.end_time }}
+  actions:
+    # Mocked
+    - ref: pull_crowdstrike_alerts
+      action: integrations.crowdstrike.list_crowdstrike_alerts
+      args:
+        start_time: ${{ TRIGGER.start_time }}
+        end_time: ${{ TRIGGER.end_time }}
 
-  - ref: reshape_alerts_into_smac
-    action: core.transform.reshape
-    depends_on:
-      - pull_crowdstrike_alerts
-    for_each: ${{ for var.alert in ACTIONS.pull_crowdstrike_alerts.result }}
-    args:
-      value:
-        title: ${{ var.alert.name }} # Name of the detection
-        description: ${{ var.alert.description }} # Description of the detected file or activity
-        payload:
-          rule: ${{ var.alert.id }} # Identifier associated with the alert
-          severity: ${{ var.alert.severity }} # Severity level associated with the detection
-        status: ${{ 'closed' if FN.is_equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
-        malice: ${{ 'malicious' if FN.greater_than(var.alert.severity, 0) else 'benign' }} # Determines malice based on severity
-        action: quarantine
-        context:
-          filepath: ${{ var.alert.filepath }}
-          cid: ${{ var.alert.cid }} # CrowdStrike identifier associated with the device
-          parent_user_id: ${{ var.alert.parent_details.user_id -> str }}
-          parent_user_name: ${{ var.alert.parent_details.user_name -> str }}
-          grandparent_user_id: ${{ var.alert.grandparent_details.user_id -> str }}
-          grandparent_user_name: ${{ var.alert.grandparent_details.user_name -> str }}
-          resource_type: ${{ 'device' }} # Assuming resource type is 'device'
-          context_timestamp: ${{ var.alert.context_timestamp -> str }}
-          updated_at: ${{ var.alert.updated_timestamp -> str }} # Timestamp indicating when the alert was last updated
-          created_at: ${{ var.alert.created_timestamp -> str }} # Timestamp indicating when the alert was created
-          user_name: ${{ var.alert.user_name }}
+    - ref: reshape_alerts_into_smac
+      action: core.transform.reshape
+      depends_on:
+        - pull_crowdstrike_alerts
+      for_each: ${{ for var.alert in ACTIONS.pull_crowdstrike_alerts.result }}
+      args:
+        value:
+          title: ${{ var.alert.name }} # Name of the detection
+          description: ${{ var.alert.description }} # Description of the detected file or activity
+          payload:
+            rule: ${{ var.alert.id }} # Identifier associated with the alert
+            severity: ${{ var.alert.severity }} # Severity level associated with the detection
+          status: ${{ 'closed' if FN.is_equal(var.alert.status, 'resolved') else 'open' }} # Status of the alert
+          malice: ${{ 'malicious' if FN.greater_than(var.alert.severity, 0) else 'benign' }} # Determines malice based on severity
+          action: quarantine
+          context:
+            filepath: ${{ var.alert.filepath }}
+            cid: ${{ var.alert.cid }} # CrowdStrike identifier associated with the device
+            parent_user_id: ${{ var.alert.parent_details.user_id -> str }}
+            parent_user_name: ${{ var.alert.parent_details.user_name -> str }}
+            grandparent_user_id: ${{ var.alert.grandparent_details.user_id -> str }}
+            grandparent_user_name: ${{ var.alert.grandparent_details.user_name -> str }}
+            resource_type: ${{ 'device' }} # Assuming resource type is 'device'
+            context_timestamp: ${{ var.alert.context_timestamp -> str }}
+            updated_at: ${{ var.alert.updated_timestamp -> str }} # Timestamp indicating when the alert was last updated
+            created_at: ${{ var.alert.created_timestamp -> str }} # Timestamp indicating when the alert was created
+            user_name: ${{ var.alert.user_name }}
 
-  - ref: send_slack_notification
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - reshape_alerts_into_smac
-    for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      text: Crowdstrike alerts
-      blocks:
-        - type: header
-          text:
-            type: plain_text
-            text: ${{ var.smac.title }}
-            emoji: true
-        - type: section
-          text:
-            type: mrkdwn
-            text: ${{ var.smac.description }}
-        - type: section
-          fields:
-            - type: mrkdwn
-              text: "*Status:* ${{ var.smac.status }}"
-            - type: mrkdwn
-              text: "*Malice:* ${{ var.smac.malice }}"
-            - type: mrkdwn
-              text: "*Action:* ${{ var.smac.action }}"
-            - type: mrkdwn
-              text: "*Context:* ${{ var.smac.context }}"
-        - type: section
-          text:
-            type: mrkdwn
-            text: "Select an option to update the alert:"
-          accessory:
-            type: static_select
-            action_id: ${{ TRIGGER.update_crowdstrike_alert }}?action_id=update_crowdstrike_alerts&alert_id=${{ var.smac.context.cid }}&old_status=${{ var.smac.status }}&username=${{ var.smac.context.user_name }}
-            options:
-              - text:
-                  type: plain_text
-                  text: Ignore
-                value: new_status=ignored
-              - text:
-                  type: plain_text
-                  text: True Positive
-                value: new_status=true_positive
-              - text:
-                  type: plain_text
-                  text: False Positive
-                value: new_status=false_positive
+    - ref: send_slack_notification
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - reshape_alerts_into_smac
+      for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        text: Crowdstrike alerts
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: ${{ var.smac.title }}
+              emoji: true
+          - type: section
+            text:
+              type: mrkdwn
+              text: ${{ var.smac.description }}
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Status:* ${{ var.smac.status }}"
+              - type: mrkdwn
+                text: "*Malice:* ${{ var.smac.malice }}"
+              - type: mrkdwn
+                text: "*Action:* ${{ var.smac.action }}"
+              - type: mrkdwn
+                text: "*Context:* ${{ var.smac.context }}"
+          - type: section
+            text:
+              type: mrkdwn
+              text: "Select an option to update the alert:"
+            accessory:
+              type: static_select
+              action_id: ${{ TRIGGER.update_crowdstrike_alert }}?action_id=update_crowdstrike_alerts&alert_id=${{ var.smac.context.cid }}&old_status=${{ var.smac.status }}&username=${{ var.smac.context.user_name }}
+              options:
+                - text:
+                    type: plain_text
+                    text: Ignore
+                  value: new_status=ignored
+                - text:
+                    type: plain_text
+                    text: True Positive
+                  value: new_status=true_positive
+                - text:
+                    type: plain_text
+                    text: False Positive
+                  value: new_status=false_positive
 
-  - ref: open_cases
-    action: core.open_case
-    depends_on:
-      - reshape_alerts_into_smac
-    for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
-    args:
-      case_title: ${{ var.smac.title }}
-      status: ${{ var.smac.status }}
-      malice: ${{ var.smac.malice }}
-      action: ${{ var.smac.action }}
-      context: ${{ var.smac.context }}
-      payload: ${{ var.smac.payload }}
-      priority: ${{ 'high' if FN.greater_than(var.smac.payload.severity, 50) else 'low' }}
+    - ref: open_cases
+      action: core.open_case
+      depends_on:
+        - reshape_alerts_into_smac
+      for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
+      args:
+        case_title: ${{ var.smac.title }}
+        status: ${{ var.smac.status }}
+        malice: ${{ var.smac.malice }}
+        action: ${{ var.smac.action }}
+        context: ${{ var.smac.context }}
+        payload: ${{ var.smac.payload }}
+        priority: ${{ 'high' if FN.greater_than(var.smac.payload.severity, 50) else 'low' }}
 
-tests:
-  - ref: pull_crowdstrike_alerts
-    success:
-      - https://raw.githubusercontent.com/TracecatHQ/tracecat/main/tests/data/log_samples/crowdstrike/alert.json
+  tests:
+    - ref: pull_crowdstrike_alerts
+      success:
+        - https://raw.githubusercontent.com/TracecatHQ/tracecat/main/tests/data/log_samples/crowdstrike/alert.json

--- a/playbooks/alert_management/datadog-to-cases.yml
+++ b/playbooks/alert_management/datadog-to-cases.yml
@@ -1,111 +1,112 @@
-title: Pull Datadog signals, send to Slack and open cases
-description: |
-  This playbook pulls Datadog signals, sends them to Slack and
-  opens cases in Tracecat's case management system.
+definition:
+  title: Pull Datadog signals, send to Slack and open cases
+  description: |
+    This playbook pulls Datadog signals, sends them to Slack and
+    opens cases in Tracecat's case management system.
 
-entrypoint:
-  ref: pull_datadog_signals
-inputs:
-  dd_region: us5
-  dd_api_url: https://api.us5.datadoghq.com
+  entrypoint:
+    ref: pull_datadog_signals
+  inputs:
+    dd_region: us5
+    dd_api_url: https://api.us5.datadoghq.com
 
-triggers:
-  - type: webhook
-    ref: datadog_webhook
-    entrypoint: pull_datadog_siem_signals
+  triggers:
+    - type: webhook
+      ref: datadog_webhook
+      entrypoint: pull_datadog_siem_signals
 
-actions:
-  - ref: pull_datadog_signals
-    action: integrations.datadog.list_datadog_alerts
-    args:
-      start_time: ${{ TRIGGER.start_time }}
-      end_time: ${{ TRIGGER.end_time }}
-      limit: 10
+  actions:
+    - ref: pull_datadog_signals
+      action: integrations.datadog.list_datadog_alerts
+      args:
+        start_time: ${{ TRIGGER.start_time }}
+        end_time: ${{ TRIGGER.end_time }}
+        limit: 10
 
-  - ref: reshape_signals
-    action: core.transform.reshape
-    depends_on:
-      - pull_datadog_siem_signals
-    run_if: ${{ FN.not_empty(ACTIONS.pull_datadog_siem_signals.result) }}
-    for_each: ${{ for var.signal in ACTIONS.pull_datadog_siem_signals.result }}
-    args:
-      value:
-        title: ${{ var.signal.attributes.attributes.title }}
-        description: ${{ var.signal.attributes.message }}
-        status: ${{ var.signal.attributes.status }}
-        first_seen: ${{ var.signal.attributes.attributes.workflow.first_seen }}
-        last_seen: ${{ var.signal.attributes.attributes.workflow.last_seen }}
-        samples: ${{ var.signal.attributes.attributes.samples }}
-        link_to_signal: ${{ INPUTS.dd_api_url }}/security?event=${{ var.signal.id }}
-
-  - ref: send_slack_notification
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - reshape_signals
-    for_each:
-      - ${{ for var.signal in ACTIONS.reshape_signals.result }}
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      text: Datadog alerts
-      blocks:
-        - type: header
-          text:
-            type: plain_text
-            text: ${{ var.signal.title }}
-            emoji: true
-        - type: context
-          elements:
-            - type: plain_text
-              text: "*Link to signal:* ${{ var.signal.link_to_signal }}"
-        - type: context
-          elements:
-            - type: plain_text
-              text: "*Status:* ${{ var.signal.status }}"
-        - type: context
-          elements:
-            - type: plain_text
-              text: "*First seen:* ${{ FN.from_timestamp(var.signal.first_seen, 'ms') }}"
-            - type: plain_text
-              text: "*Last seen:* ${{ FN.from_timestamp(var.signal.last_seen, 'ms') }}"
-        - type: section
-          text:
-            type: mrkdwn
-            text: ${{ var.signal.description }}
-
-  - ref: reshape_findings_into_smac
-    action: core.transform.reshape
-    depends_on:
-      - pull_datadog_signals
-    run_if: ${{ FN.not_empty(ACTIONS.pull_datadog_signals.result) }}
-    for_each: ${{ for var.signal in ACTIONS.pull_datadog_signals.result }}
-    args:
-      value:
-        title: ${{ var.signal.attributes.attributes.title }}
-        description: ${{ var.signal.attributes.message }}
-        payload:
-          rule: ${{ var.signal.attributes.attributes.rule }}
-        status: ${{ var.signal.attributes.status }}
-        malice: ${{ var.signal.attributes.status }}
-        action: Investigate and remediate
-        context:
+    - ref: reshape_signals
+      action: core.transform.reshape
+      depends_on:
+        - pull_datadog_siem_signals
+      run_if: ${{ FN.not_empty(ACTIONS.pull_datadog_siem_signals.result) }}
+      for_each: ${{ for var.signal in ACTIONS.pull_datadog_siem_signals.result }}
+      args:
+        value:
+          title: ${{ var.signal.attributes.attributes.title }}
+          description: ${{ var.signal.attributes.message }}
+          status: ${{ var.signal.attributes.status }}
           first_seen: ${{ var.signal.attributes.attributes.workflow.first_seen }}
           last_seen: ${{ var.signal.attributes.attributes.workflow.last_seen }}
+          samples: ${{ var.signal.attributes.attributes.samples }}
           link_to_signal: ${{ INPUTS.dd_api_url }}/security?event=${{ var.signal.id }}
 
-  # Open cases in Tracecat's case management system
-  - ref: open_cases
-    action: core.open_case
-    depends_on:
-      - reshape_findings_into_smac
-    for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
-    args:
-      case_title: ${{ var.smac.title }}
-      status: ${{ var.smac.status }}
-      malice: ${{ var.smac.malice }}
-      action: ${{ var.smac.action }}
-      context: ${{ var.smac.context }}
-      payload: ${{ var.smac.payload }}
-      # Datadog: critical, high, medium, low, info
-      # Tracecat: critical, high, medium, low
-      # NOTE: 'info' in Datadog is considered as 'low' in Tracecat
-      priority: ${{ 'low' if FN.equals(var.smac.status, 'info') else var.smac.status }}
+    - ref: send_slack_notification
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - reshape_signals
+      for_each:
+        - ${{ for var.signal in ACTIONS.reshape_signals.result }}
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        text: Datadog alerts
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: ${{ var.signal.title }}
+              emoji: true
+          - type: context
+            elements:
+              - type: plain_text
+                text: "*Link to signal:* ${{ var.signal.link_to_signal }}"
+          - type: context
+            elements:
+              - type: plain_text
+                text: "*Status:* ${{ var.signal.status }}"
+          - type: context
+            elements:
+              - type: plain_text
+                text: "*First seen:* ${{ FN.from_timestamp(var.signal.first_seen, 'ms') }}"
+              - type: plain_text
+                text: "*Last seen:* ${{ FN.from_timestamp(var.signal.last_seen, 'ms') }}"
+          - type: section
+            text:
+              type: mrkdwn
+              text: ${{ var.signal.description }}
+
+    - ref: reshape_findings_into_smac
+      action: core.transform.reshape
+      depends_on:
+        - pull_datadog_signals
+      run_if: ${{ FN.not_empty(ACTIONS.pull_datadog_signals.result) }}
+      for_each: ${{ for var.signal in ACTIONS.pull_datadog_signals.result }}
+      args:
+        value:
+          title: ${{ var.signal.attributes.attributes.title }}
+          description: ${{ var.signal.attributes.message }}
+          payload:
+            rule: ${{ var.signal.attributes.attributes.rule }}
+          status: ${{ var.signal.attributes.status }}
+          malice: ${{ var.signal.attributes.status }}
+          action: Investigate and remediate
+          context:
+            first_seen: ${{ var.signal.attributes.attributes.workflow.first_seen }}
+            last_seen: ${{ var.signal.attributes.attributes.workflow.last_seen }}
+            link_to_signal: ${{ INPUTS.dd_api_url }}/security?event=${{ var.signal.id }}
+
+    # Open cases in Tracecat's case management system
+    - ref: open_cases
+      action: core.open_case
+      depends_on:
+        - reshape_findings_into_smac
+      for_each: ${{ for var.smac in ACTIONS.reshape_findings_into_smac.result }}
+      args:
+        case_title: ${{ var.smac.title }}
+        status: ${{ var.smac.status }}
+        malice: ${{ var.smac.malice }}
+        action: ${{ var.smac.action }}
+        context: ${{ var.smac.context }}
+        payload: ${{ var.smac.payload }}
+        # Datadog: critical, high, medium, low, info
+        # Tracecat: critical, high, medium, low
+        # NOTE: 'info' in Datadog is considered as 'low' in Tracecat
+        priority: ${{ 'low' if FN.equals(var.smac.status, 'info') else var.smac.status }}

--- a/playbooks/alert_management/sentinel-one-to-slack.yml
+++ b/playbooks/alert_management/sentinel-one-to-slack.yml
@@ -1,113 +1,114 @@
-title: Send Slack notifications for SentinelOne alerts
-description: |
-  Pulls SentinelOne alerts and sends them to Slack.
-  Also sends a message if no alerts available.
-entrypoint:
-  ref: pull_sentinelone_alerts
-triggers:
-  - type: webhook
-    ref: sentinelone_alerts_webhook
-    entrypoint: pull_sentinelone_alerts
+definition:
+  title: Send Slack notifications for SentinelOne alerts
+  description: |
+    Pulls SentinelOne alerts and sends them to Slack.
+    Also sends a message if no alerts available.
+  entrypoint:
+    ref: pull_sentinelone_alerts
+  triggers:
+    - type: webhook
+      ref: sentinelone_alerts_webhook
+      entrypoint: pull_sentinelone_alerts
 
-actions:
-  - ref: pull_sentinelone_alerts
-    action: integrations.sentinelone.list_sentinelone_alerts
-    args:
-      start_time: ${{ TRIGGER.start_time }}
-      end_time: ${{ TRIGGER.end_time }}
-      limit: 10
+  actions:
+    - ref: pull_sentinelone_alerts
+      action: integrations.sentinel_one.list_sentinelone_alerts
+      args:
+        start_time: ${{ TRIGGER.start_time }}
+        end_time: ${{ TRIGGER.end_time }}
+        limit: 10
 
-  - ref: report_no_alerts
-    action: core.http_request
-    depends_on:
-      - pull_sentinelone_alerts
-    run_if: ${{ FN.is_empty(ACTIONS.pull_sentinelone_alerts.result) }}
-    args:
-      url: ${{ SECRETS.slack_channel.SLACK_WEBHOOK }}
-      method: POST
-      headers:
-        Content-Type: application/json
-      payload:
-        text: Tracecat ran workflow for SentinelOne alerts, but no alerts were found
-
-  - ref: reshape_alerts_into_smac
-    action: core.transform.reshape
-    depends_on:
-      - pull_sentinelone_alerts
-    run_if: ${{ FN.not_empty(ACTIONS.pull_sentinelone_alerts.result) }}
-    for_each: ${{ for var.alert in ACTIONS.pull_sentinelone_alerts.result }}
-    args:
-      value:
-        title: ${{ var.alert.info.event_type }}
-        description: ${{ var.alert.info.hit.type }}
+    - ref: report_no_alerts
+      action: core.http_request
+      depends_on:
+        - pull_sentinelone_alerts
+      run_if: ${{ FN.is_empty(ACTIONS.pull_sentinelone_alerts.result) }}
+      args:
+        url: ${{ SECRETS.slack_channel.SLACK_WEBHOOK }}
+        method: POST
+        headers:
+          Content-Type: application/json
         payload:
-          rule: ${{ var.alert.rule.scope_level }}
-          severity: ${{ var.alert.rule.severity }}
-        status: ${{ var.alert.info.status }}
-        malice: ${{ 'malicious' if FN.greater_than(var.alert.rule.severity, 0) else 'benign' }}
-        action: Investigate and remediate
-        context:
-          account_id: ${{ var.alert.agent.site_id }}
-          updated_at: ${{ var.alert.info.updated_at }}
-          created_at: ${{ var.alert.info.reported_at }}
+          text: Tracecat ran workflow for SentinelOne alerts, but no alerts were found
 
-  - ref: send_slack_notifications
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - reshape_alerts_into_smac
-    for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
-    args:
-      channel: ${{ SECRETS.slack_channel.SLACK_CHANNEL }}
-      text: SentinelOne alerts
-      blocks:
-        - type: header
-          text:
-            type: plain_text
-            text: ${{ var.smac.title }}
-            emoji: true
-        - type: section
-          text:
-            type: mrkdwn
-            text: ${{ var.smac.description }}
-        - type: section
-          fields:
-            - type: mrkdwn
-              text: "*Status:* ${{ var.smac.status }}"
-            - type: mrkdwn
-              text: "*Malice:* ${{ var.smac.malice }}"
-            - type: mrkdwn
-              text: "*Action:* ${{ var.smac.action }}"
-            - type: mrkdwn
-              text: "*Context:* ${{ var.smac.context }}"
-        - type: section
-          text:
-            type: mrkdwn
-            text: "Select an option to update the alert:"
-          accessory:
-            type: static_select
-            action_id: update_sentinelone_alert
-            options:
-              - text:
-                  type: plain_text
-                  text: False Positive
-                value:
-                  old_status: ${{ var.smac.status }}
-                  new_status: FALSE_POSITIVE
-              - text:
-                  type: plain_text
-                  text: Suspicious
-                value:
-                  old_status: ${{ var.smac.status }}
-                  new_status: SUSPICIOUS
-              - text:
-                  type: plain_text
-                  text: True Positive
-                value:
-                  old_status: ${{ var.smac.status }}
-                  new_status: TRUE_POSITIVE
-              - text:
-                  type: plain_text
-                  text: Undefined
-                value:
-                  old_status: ${{ var.smac.status }}
-                  new_status: UNDEFINED
+    - ref: reshape_alerts_into_smac
+      action: core.transform.reshape
+      depends_on:
+        - pull_sentinelone_alerts
+      run_if: ${{ FN.not_empty(ACTIONS.pull_sentinelone_alerts.result) }}
+      for_each: ${{ for var.alert in ACTIONS.pull_sentinelone_alerts.result }}
+      args:
+        value:
+          title: ${{ var.alert.info.event_type }}
+          description: ${{ var.alert.info.hit.type }}
+          payload:
+            rule: ${{ var.alert.rule.scope_level }}
+            severity: ${{ var.alert.rule.severity }}
+          status: ${{ var.alert.info.status }}
+          malice: ${{ 'malicious' if FN.greater_than(var.alert.rule.severity, 0) else 'benign' }}
+          action: Investigate and remediate
+          context:
+            account_id: ${{ var.alert.agent.site_id }}
+            updated_at: ${{ var.alert.info.updated_at }}
+            created_at: ${{ var.alert.info.reported_at }}
+
+    - ref: send_slack_notifications
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - reshape_alerts_into_smac
+      for_each: ${{ for var.smac in ACTIONS.reshape_alerts_into_smac.result }}
+      args:
+        channel: ${{ SECRETS.slack_channel.SLACK_CHANNEL }}
+        text: SentinelOne alerts
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: ${{ var.smac.title }}
+              emoji: true
+          - type: section
+            text:
+              type: mrkdwn
+              text: ${{ var.smac.description }}
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Status:* ${{ var.smac.status }}"
+              - type: mrkdwn
+                text: "*Malice:* ${{ var.smac.malice }}"
+              - type: mrkdwn
+                text: "*Action:* ${{ var.smac.action }}"
+              - type: mrkdwn
+                text: "*Context:* ${{ var.smac.context }}"
+          - type: section
+            text:
+              type: mrkdwn
+              text: "Select an option to update the alert:"
+            accessory:
+              type: static_select
+              action_id: update_sentinelone_alert
+              options:
+                - text:
+                    type: plain_text
+                    text: False Positive
+                  value:
+                    old_status: ${{ var.smac.status }}
+                    new_status: FALSE_POSITIVE
+                - text:
+                    type: plain_text
+                    text: Suspicious
+                  value:
+                    old_status: ${{ var.smac.status }}
+                    new_status: SUSPICIOUS
+                - text:
+                    type: plain_text
+                    text: True Positive
+                  value:
+                    old_status: ${{ var.smac.status }}
+                    new_status: TRUE_POSITIVE
+                - text:
+                    type: plain_text
+                    text: Undefined
+                  value:
+                    old_status: ${{ var.smac.status }}
+                    new_status: UNDEFINED

--- a/playbooks/alert_management/slack-to-crowdstrike-update.yml
+++ b/playbooks/alert_management/slack-to-crowdstrike-update.yml
@@ -1,66 +1,67 @@
-title: Update Crowdstrike alerts via Slack
-description: |
-  Receives a Slack action and updates Crowdstrike alerts based on
-  `alert_ids` and `status` provided in the Slack action payload.
-config:
-  enable_runtime_tests: true
-entrypoint:
-  ref: extract_slack_payload
-triggers:
-  - type: webhook
-    ref: slack_actions_webhook
-    entrypoint: receive_slack_action
-    # shape:
-    #   - action_id: string
-    #   - alert_id: string
-    #   - old_status: string
-    #   - new_status: string
-    #   - username: string
+definition:
+  title: Update Crowdstrike alerts via Slack
+  description: |
+    Receives a Slack action and updates Crowdstrike alerts based on
+    `alert_ids` and `status` provided in the Slack action payload.
+  config:
+    enable_runtime_tests: true
+  entrypoint:
+    ref: extract_slack_payload
+  triggers:
+    - type: webhook
+      ref: slack_actions_webhook
+      entrypoint: receive_slack_action
+      # shape:
+      #   - action_id: string
+      #   - alert_id: string
+      #   - old_status: string
+      #   - new_status: string
+      #   - username: string
 
-actions:
-  - ref: extract_slack_payload
-    action: core.transform.reshape
-    args:
-      value:
-        username: ${{ TRIGGER.username }}
-        alert_id: ${{ TRIGGER.alert_id }}
-        old_status: ${{ TRIGGER.old_status }}
-        new_status: ${{ TRIGGER.new_status }}
+  actions:
+    - ref: extract_slack_payload
+      action: core.transform.reshape
+      args:
+        value:
+          username: ${{ TRIGGER.username }}
+          alert_id: ${{ TRIGGER.alert_id }}
+          old_status: ${{ TRIGGER.old_status }}
+          new_status: ${{ TRIGGER.new_status }}
 
-  - ref: update_crowdstrike_alerts
-    action: integrations.crowdstrike.update_crowdstrike_alert_status
-    depends_on:
-      - extract_slack_payload
-    args:
-      alert_ids:
-        - ${{ ACTIONS.extract_slack_payload.result.alert_id }}
-      status: ${{ ACTIONS.extract_slack_payload.result.new_status }}
+    - ref: update_crowdstrike_alerts
+      action: integrations.crowdstrike.update_crowdstrike_alert_status
+      depends_on:
+        - extract_slack_payload
+      args:
+        alert_ids:
+          - ${{ ACTIONS.extract_slack_payload.result.alert_id }}
+        status: ${{ ACTIONS.extract_slack_payload.result.new_status }}
 
-  # Send slack notifiaction after updating Crowdstrike alerts
-  - ref: send_slack_notification
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - update_crowdstrike_alerts
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      text: CrowdStrike alerts updated
-      blocks:
-        - type: header
-          text:
-            type: plain_text
-            text: ${{ ACTIONS.extract_slack_payload.result.username }} changed status of alert
-            emoji: true
-        - type: section
-          fields:
-            - type: mrkdwn
-              text: "*Alert ID:* ${{ ACTIONS.extract_slack_payload.result.alert_id }}"
-            - type: mrkdwn
-              text: "*Old status:* ${{ ACTIONS.extract_slack_payload.result.old_status }}"
-            - type: mrkdwn
-              text: "*New status:* ${{ ACTIONS.extract_slack_payload.result.new_status }}"
+    # Send slack notifiaction after updating Crowdstrike alerts
+    - ref: send_slack_notification
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - update_crowdstrike_alerts
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        text: CrowdStrike alerts updated
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: ${{ ACTIONS.extract_slack_payload.result.username }} changed status of alert
+              emoji: true
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Alert ID:* ${{ ACTIONS.extract_slack_payload.result.alert_id }}"
+              - type: mrkdwn
+                text: "*Old status:* ${{ ACTIONS.extract_slack_payload.result.old_status }}"
+              - type: mrkdwn
+                text: "*New status:* ${{ ACTIONS.extract_slack_payload.result.new_status }}"
 
-tests:
-  - ref: update_crowdstrike_alerts
-    success:
-      status: ok
-      code: 200
+  tests:
+    - ref: update_crowdstrike_alerts
+      success:
+        status: ok
+        code: 200

--- a/playbooks/alert_management/slack-to-sentinel-one-update.yml
+++ b/playbooks/alert_management/slack-to-sentinel-one-update.yml
@@ -1,54 +1,55 @@
-title: Update SentinelOne alerts via Slack
-description: |
-  Receives a Slack action and updates SentinelOne alerts based on
-  `alert_ids` and `status` provided in the Slack action payload.
-entrypoint:
-  ref: extract_slack_payload
-triggers:
-  - type: webhook
-    ref: slack_actions_webhook
-    entrypoint: receive_slack_action
+definition:
+  title: Update SentinelOne alerts via Slack
+  description: |
+    Receives a Slack action and updates SentinelOne alerts based on
+    `alert_ids` and `status` provided in the Slack action payload.
+  entrypoint:
+    ref: extract_slack_payload
+  triggers:
+    - type: webhook
+      ref: slack_actions_webhook
+      entrypoint: receive_slack_action
 
-actions:
-  - ref: extract_slack_payload
-    action: core.transform.reshape
-    # Check if action received is as expected
-    run_if: ${{ FN.is_equal(TRIGGER.action.action_id, 'update_sentinelone_alert') }}
-    args:
-      value:
-        username: ${{ TRIGGER.user.username }}
-        alert_id: ${{ TRIGGER.action.value.alert_id }}
-        old_status: ${{ TRIGGER.action.value.old_status }}
-        new_status: ${{ TRIGGER.action.value.new_status }}
+  actions:
+    - ref: extract_slack_payload
+      action: core.transform.reshape
+      # Check if action received is as expected
+      run_if: ${{ FN.is_equal(TRIGGER.action.action_id, 'update_sentinelone_alert') }}
+      args:
+        value:
+          username: ${{ TRIGGER.user.username }}
+          alert_id: ${{ TRIGGER.action.value.alert_id }}
+          old_status: ${{ TRIGGER.action.value.old_status }}
+          new_status: ${{ TRIGGER.action.value.new_status }}
 
-  - ref: update_sentinelone_alerts
-    action: integrations.sentinelone.update_sentinelone_alert_status
-    depends_on:
-      - extract_slack_payload
-    args:
-      alert_ids:
-        - ${{ ACTIONS.extract_slack_payload.result.alert_id }}
-      status: ${{ ACTIONS.extract_slack_payload.result.new_status }}
+    - ref: update_sentinelone_alerts
+      action: integrations.sentinelone.update_sentinelone_alert_status
+      depends_on:
+        - extract_slack_payload
+      args:
+        alert_ids:
+          - ${{ ACTIONS.extract_slack_payload.result.alert_id }}
+        status: ${{ ACTIONS.extract_slack_payload.result.new_status }}
 
-  # Send Slack notification after updating SentinelOne alerts
-  - ref: send_slack_notification
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - update_sentinelone_alerts
-    args:
-      channel: ${{ SECRETS.slack_channel.SLACK_CHANNEL }}
-      text: SentinelOne alerts updated
-      blocks:
-        - type: header
-          text:
-            type: plain_text
-            text: ${{ ACTIONS.extract_slack_payload.result.username }} changed status of alert
-            emoji: true
-        - type: section
-          fields:
-            - type: mrkdwn
-              text: "*Alert ID:* ${{ ACTIONS.extract_slack_payload.result.alert_id }}"
-            - type: mrkdwn
-              text: "*Old status:* ${{ ACTIONS.extract_slack_payload.result.old_status }}"
-            - type: mrkdwn
-              text: "*New status:* ${{ ACTIONS.extract_slack_payload.result.new_status }}"
+    # Send Slack notification after updating SentinelOne alerts
+    - ref: send_slack_notification
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - update_sentinelone_alerts
+      args:
+        channel: ${{ SECRETS.slack_channel.SLACK_CHANNEL }}
+        text: SentinelOne alerts updated
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: ${{ ACTIONS.extract_slack_payload.result.username }} changed status of alert
+              emoji: true
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Alert ID:* ${{ ACTIONS.extract_slack_payload.result.alert_id }}"
+              - type: mrkdwn
+                text: "*Old status:* ${{ ACTIONS.extract_slack_payload.result.old_status }}"
+              - type: mrkdwn
+                text: "*New status:* ${{ ACTIONS.extract_slack_payload.result.new_status }}"

--- a/playbooks/enrichment/tag-user-in-slack-scheduled.yml
+++ b/playbooks/enrichment/tag-user-in-slack-scheduled.yml
@@ -1,71 +1,72 @@
-title: Extract IoCs from Slack conversation message, tag Slack users, and create thread. [SCHEDULED]
-description: |
-  Given a Slack conversation message, this playbook extracts URLs and IP addresses from the message,
-  tags the users mentioned in the message, and creates a thread with the extracted IOCs.
-config:
-  # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
-  # runtime configuration for this flag i.e. tracecat workflow run --test flag).
-  enable_runtime_tests: false
-entrypoint:
-  ref: pull_slack_conversations
-  expects:
-    message_limit: int
+definition:
+  title: Extract IoCs from Slack conversation message, tag Slack users, and create thread. [SCHEDULED]
+  description: |
+    Given a Slack conversation message, this playbook extracts URLs and IP addresses from the message,
+    tags the users mentioned in the message, and creates a thread with the extracted IOCs.
+  config:
+    # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
+    # runtime configuration for this flag i.e. tracecat workflow run --test flag).
+    enable_runtime_tests: false
+  entrypoint:
+    ref: pull_slack_conversations
+    expects:
+      message_limit: int
 
-actions:
-  - ref: pull_slack_conversations
-    action: integrations.chat.slack.list_slack_conversations
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      latest: ${{ FN.to_datetime(ENV.workflow.start_time) }}
-      oldest: ${{ FN.to_datetime(ENV.workflow.start_time) - FN.minutes(15) }}
-      limit: ${{ TRIGGER.message_limit }}
+  actions:
+    - ref: pull_slack_conversations
+      action: integrations.chat.slack.list_slack_conversations
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        latest: ${{ FN.to_datetime(ENV.workflow.start_time) }}
+        oldest: ${{ FN.to_datetime(ENV.workflow.start_time) - FN.minutes(15) }}
+        limit: ${{ TRIGGER.message_limit }}
 
-  - ref: filter_datadog_messages_only
-    action: core.transform.filter
-    depends_on:
-      - pull_slack_conversations
-    run_if: ${{ FN.not_empty(ACTIONS.pull_slack_conversations.result) }}
-    args:
-      items: ${{ ACTIONS.pull_slack_conversations.result }}
-      constraint:
-        jsonpath: $.bot_profile.name
-        operator: ==
-        target: Datadog
+    - ref: filter_datadog_messages_only
+      action: core.transform.filter
+      depends_on:
+        - pull_slack_conversations
+      run_if: ${{ FN.not_empty(ACTIONS.pull_slack_conversations.result) }}
+      args:
+        items: ${{ ACTIONS.pull_slack_conversations.result }}
+        constraint:
+          jsonpath: $.bot_profile.name
+          operator: ==
+          target: Datadog
 
-  - ref: reshape_conversations
-    action: core.transform.reshape
-    depends_on:
-      - filter_datadog_messages_only
-    run_if: ${{ FN.not_empty(ACTIONS.filter_datadog_messages_only.result) }}
-    for_each: ${{ for var.conversation in ACTIONS.filter_datadog_messages_only.result }}
-    args:
-      value:
-        attachments: ${{ var.conversation.attachments }}
-        thread_ts: ${{ var.conversation.ts }}
+    - ref: reshape_conversations
+      action: core.transform.reshape
+      depends_on:
+        - filter_datadog_messages_only
+      run_if: ${{ FN.not_empty(ACTIONS.filter_datadog_messages_only.result) }}
+      for_each: ${{ for var.conversation in ACTIONS.filter_datadog_messages_only.result }}
+      args:
+        value:
+          attachments: ${{ var.conversation.attachments }}
+          thread_ts: ${{ var.conversation.ts }}
 
-  - ref: tag_slack_users
-    action: integrations.chat.slack.tag_slack_users
-    depends_on:
-      - reshape_conversations
-    args:
-      jsons: ${{ ACTIONS.reshape_conversations.result}}
+    - ref: tag_slack_users
+      action: integrations.chat.slack.tag_slack_users
+      depends_on:
+        - reshape_conversations
+      args:
+        jsons: ${{ ACTIONS.reshape_conversations.result}}
 
-  - ref: create_thread
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - tag_slack_users
-    run_if: ${{ FN.not_empty(ACTIONS.tag_slack_users.result) }}
-    for_each: ${{ for var.tagged_conversation in ACTIONS.tag_slack_users.result }}
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      thread_ts: ${{ var.tagged_conversation.json.thread_ts }}
-      text: "*Tagged users:* ${{ FN.join(var.tagged_conversation.user_tags, ', ') }}"
+    - ref: create_thread
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - tag_slack_users
+      run_if: ${{ FN.not_empty(ACTIONS.tag_slack_users.result) }}
+      for_each: ${{ for var.tagged_conversation in ACTIONS.tag_slack_users.result }}
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        thread_ts: ${{ var.tagged_conversation.json.thread_ts }}
+        text: "*Tagged users:* ${{ FN.join(var.tagged_conversation.user_tags, ', ') }}"
 
-tests:
-  - ref: pull_slack_conversations
-    success: []
-    # success: http://host.docker.internal:8005/dd_slack_tag/some_no_email_multiple.json
+  tests:
+    - ref: pull_slack_conversations
+      success: []
+      # success: http://host.docker.internal:8005/dd_slack_tag/some_no_email_multiple.json
 
-  # Could only find 1 user
-  - ref: tag_slack_users
-    success: http://host.docker.internal:8005/dd_slack_tag/email_no_slack_user.json
+    # Could only find 1 user
+    - ref: tag_slack_users
+      success: http://host.docker.internal:8005/dd_slack_tag/email_no_slack_user.json

--- a/playbooks/enrichment/tag-user-in-slack.yml
+++ b/playbooks/enrichment/tag-user-in-slack.yml
@@ -1,73 +1,74 @@
-title: Extract IoCs from Slack conversation message, tag Slack users, and create thread.
-description: |
-  Given a Slack conversation message, this playbook extracts URLs and IP addresses from the message,
-  tags the users mentioned in the message, and creates a thread with the extracted IOCs.
-config:
-  # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
-  # runtime configuration for this flag i.e. tracecat workflow run --test flag).
-  enable_runtime_tests: false
-entrypoint:
-  ref: pull_slack_conversations
-  expects:
-    latest: datetime
-    oldest: datetime
-    message_limit: int
+definition:
+  title: Extract IoCs from Slack conversation message, tag Slack users, and create thread.
+  description: |
+    Given a Slack conversation message, this playbook extracts URLs and IP addresses from the message,
+    tags the users mentioned in the message, and creates a thread with the extracted IOCs.
+  config:
+    # NOTE: Setting `enable_runtime_tests` to `true` here will override all other
+    # runtime configuration for this flag i.e. tracecat workflow run --test flag).
+    enable_runtime_tests: false
+  entrypoint:
+    ref: pull_slack_conversations
+    expects:
+      latest: datetime
+      oldest: datetime
+      message_limit: int
 
-actions:
-  - ref: pull_slack_conversations
-    action: integrations.chat.slack.list_slack_conversations
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      latest: ${{ TRIGGER.latest }}
-      oldest: ${{ TRIGGER.oldest }}
-      limit: ${{ TRIGGER.message_limit }}
+  actions:
+    - ref: pull_slack_conversations
+      action: integrations.chat.slack.list_slack_conversations
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        latest: ${{ TRIGGER.latest }}
+        oldest: ${{ TRIGGER.oldest }}
+        limit: ${{ TRIGGER.message_limit }}
 
-  - ref: filter_datadog_messages_only
-    action: core.transform.filter
-    depends_on:
-      - pull_slack_conversations
-    run_if: ${{ FN.not_empty(ACTIONS.pull_slack_conversations.result) }}
-    args:
-      items: ${{ ACTIONS.pull_slack_conversations.result }}
-      constraint:
-        jsonpath: $.bot_profile.name
-        operator: ==
-        target: Datadog
+    - ref: filter_datadog_messages_only
+      action: core.transform.filter
+      depends_on:
+        - pull_slack_conversations
+      run_if: ${{ FN.not_empty(ACTIONS.pull_slack_conversations.result) }}
+      args:
+        items: ${{ ACTIONS.pull_slack_conversations.result }}
+        constraint:
+          jsonpath: $.bot_profile.name
+          operator: ==
+          target: Datadog
 
-  - ref: reshape_conversations
-    action: core.transform.reshape
-    depends_on:
-      - filter_datadog_messages_only
-    run_if: ${{ FN.not_empty(ACTIONS.filter_datadog_messages_only.result) }}
-    for_each: ${{ for var.conversation in ACTIONS.filter_datadog_messages_only.result }}
-    args:
-      value:
-        attachments: ${{ var.conversation.attachments }}
-        thread_ts: ${{ var.conversation.ts }}
+    - ref: reshape_conversations
+      action: core.transform.reshape
+      depends_on:
+        - filter_datadog_messages_only
+      run_if: ${{ FN.not_empty(ACTIONS.filter_datadog_messages_only.result) }}
+      for_each: ${{ for var.conversation in ACTIONS.filter_datadog_messages_only.result }}
+      args:
+        value:
+          attachments: ${{ var.conversation.attachments }}
+          thread_ts: ${{ var.conversation.ts }}
 
-  - ref: tag_slack_users
-    action: integrations.chat.slack.tag_slack_users
-    depends_on:
-      - reshape_conversations
-    args:
-      jsons: ${{ ACTIONS.reshape_conversations.result}}
+    - ref: tag_slack_users
+      action: integrations.chat.slack.tag_slack_users
+      depends_on:
+        - reshape_conversations
+      args:
+        jsons: ${{ ACTIONS.reshape_conversations.result}}
 
-  - ref: create_thread
-    action: integrations.chat.slack.post_slack_message
-    depends_on:
-      - tag_slack_users
-    run_if: ${{ FN.not_empty(ACTIONS.tag_slack_users.result) }}
-    for_each: ${{ for var.tagged_conversation in ACTIONS.tag_slack_users.result }}
-    args:
-      channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
-      thread_ts: ${{ var.tagged_conversation.json.thread_ts }}
-      text: "*Tagged users:* ${{ FN.join(var.tagged_conversation.user_tags, ', ') }}"
+    - ref: create_thread
+      action: integrations.chat.slack.post_slack_message
+      depends_on:
+        - tag_slack_users
+      run_if: ${{ FN.not_empty(ACTIONS.tag_slack_users.result) }}
+      for_each: ${{ for var.tagged_conversation in ACTIONS.tag_slack_users.result }}
+      args:
+        channel: ${{ SECRETS.slack.SLACK_CHANNEL }}
+        thread_ts: ${{ var.tagged_conversation.json.thread_ts }}
+        text: "*Tagged users:* ${{ FN.join(var.tagged_conversation.user_tags, ', ') }}"
 
-tests:
-  - ref: pull_slack_conversations
-    success: []
-    # success: http://host.docker.internal:8005/dd_slack_tag/some_no_email_multiple.json
+  tests:
+    - ref: pull_slack_conversations
+      success: []
+      # success: http://host.docker.internal:8005/dd_slack_tag/some_no_email_multiple.json
 
-  # Could only find 1 user
-  - ref: tag_slack_users
-    success: http://host.docker.internal:8005/dd_slack_tag/email_no_slack_user.json
+    # Could only find 1 user
+    - ref: tag_slack_users
+      success: http://host.docker.internal:8005/dd_slack_tag/email_no_slack_user.json

--- a/playbooks/enrichment/triage-using-llms.yml
+++ b/playbooks/enrichment/triage-using-llms.yml
@@ -1,98 +1,99 @@
-title: Extract IoCs from alert, enrich using VirusTotal, and investigate using AI.
-description: |
-  Given a security alert, this playbook extracts URLs and IP addresses from the alert
-  enriches them using VirusTotal, and provides triage advice for further investigation.
+definition:
+  title: Extract IoCs from alert, enrich using VirusTotal, and investigate using AI.
+  description: |
+    Given a security alert, this playbook extracts URLs and IP addresses from the alert
+    enriches them using VirusTotal, and provides triage advice for further investigation.
 
-entrypoint:
-  ref: receive_alert
-triggers:
-  - type: webhook
-    ref: alert_webhook
-    entrypoint: receive_alert
+  entrypoint:
+    ref: receive_alert
+  triggers:
+    - type: webhook
+      ref: alert_webhook
+      entrypoint: receive_alert
 
-actions:
-  - ref: receive_alert
-    action: core.io.receive_webhook
-    args:
-      webhook: ${{ TRIGGER.webhook }}
+  actions:
+    - ref: receive_alert
+      action: core.io.receive_webhook
+      args:
+        webhook: ${{ TRIGGER.webhook }}
 
-  - ref: extract_ip_addresses
-    action: integrations.extraction.extract_ipv4_addresses
-    depends_on:
-      - receive_alert
-    args:
-      text: ${{ ACTIONS.receive_alert.result.text }}
+    - ref: extract_ip_addresses
+      action: integrations.extraction.extract_ipv4_addresses
+      depends_on:
+        - receive_alert
+      args:
+        text: ${{ ACTIONS.receive_alert.result.text }}
 
-  - ref: extract_urls
-    action: integrations.extraction.extract_urls
-    depends_on:
-      - receive_alert
-    args:
-      text: ${{ ACTIONS.receive_alert.result.text }}
+    - ref: extract_urls
+      action: integrations.extraction.extract_urls
+      depends_on:
+        - receive_alert
+      args:
+        text: ${{ ACTIONS.receive_alert.result.text }}
 
-  - ref: enrich_ip_addresses
-    action: integrations.virustotal.analyze_ip_address
-    for_each: ${{ for var.ip_address in ACTIONS.extract_iocs.result.ip_addresses }}
-    depends_on:
-      - extract_ip_addresses
-    args:
-      ip_address: ${{ var.ip_address }}
+    - ref: enrich_ip_addresses
+      action: integrations.virustotal.analyze_ip_address
+      for_each: ${{ for var.ip_address in ACTIONS.extract_iocs.result.ip_addresses }}
+      depends_on:
+        - extract_ip_addresses
+      args:
+        ip_address: ${{ var.ip_address }}
 
-  - ref: enrich_urls
-    action: integrations.virustotal.analyze_url
-    for_each: ${{ for var.url in ACTIONS.extract_iocs.result.urls }}
-    depends_on:
-      - extract_urls
-    args:
-      url: ${{ var.url }}
+    - ref: enrich_urls
+      action: integrations.virustotal.analyze_url
+      for_each: ${{ for var.url in ACTIONS.extract_iocs.result.urls }}
+      depends_on:
+        - extract_urls
+      args:
+        url: ${{ var.url }}
 
-  - ref: triage_alert
-    action: core.ai_action
-    depends_on:
-      - enrich_ip_addresses
-      - enrich_urls
-    args:
-      prompt: |
-        You are an expert security analyst. You have all the context of the alert and the enriched IOCs:
+    - ref: triage_alert
+      action: core.ai_action
+      depends_on:
+        - enrich_ip_addresses
+        - enrich_urls
+      args:
+        prompt: |
+          You are an expert security analyst. You have all the context of the alert and the enriched IOCs:
 
-        IP Addresses: ${{ ACTIONS.enrich_ip_addresses.result }}
-        URLs: ${{ ACTIONS.enrich_urls.result }}
+          IP Addresses: ${{ ACTIONS.enrich_ip_addresses.result }}
+          URLs: ${{ ACTIONS.enrich_urls.result }}
 
-        Task
-        ----
-        Answer the following questions:
-        - Are any of the provided IP addresses associated with known malicious activities or threat actors?
-        - What is the reputation of the provided URLs according to threat intelligence sources?
-        - What specific threats or vulnerabilities are associated with these IP addresses and URLs?
+          Task
+          ----
+          Answer the following questions:
+          - Are any of the provided IP addresses associated with known malicious activities or threat actors?
+          - What is the reputation of the provided URLs according to threat intelligence sources?
+          - What specific threats or vulnerabilities are associated with these IP addresses and URLs?
 
-        Give your response as a list of bullet points:
-        ```json
-        - <response 1>
-        - <response 2>
-        - <response 3>
-        ```
+          Give your response as a list of bullet points:
+          ```json
+          - <response 1>
+          - <response 2>
+          - <response 3>
+          ```
 
-  - ref: estimate_confidence
-    action: core.ai_action
-    depends_on:
-      - extract_ip_addresses
-      - extract_urls
-    args:
-      prompt: |
-        You are an expert security analyst. You have all the context of the alert and the enriched IOCs:
+    - ref: estimate_confidence
+      action: core.ai_action
+      depends_on:
+        - extract_ip_addresses
+        - extract_urls
+      args:
+        prompt: |
+          You are an expert security analyst. You have all the context of the alert and the enriched IOCs:
 
-        IP Addresses: ${{ ACTIONS.enrich_ip_addresses.result }}
-        URLs: ${{ ACTIONS.enrich_urls.result }}
+          IP Addresses: ${{ ACTIONS.enrich_ip_addresses.result }}
+          URLs: ${{ ACTIONS.enrich_urls.result }}
 
-        Task
-        ----
-        - Score this alert between 0-100 for the likelihood of this alert being a False Positive.
-        - Score this alert between 0-100 for the likelihood of this alert being a True Positive.
+          Task
+          ----
+          - Score this alert between 0-100 for the likelihood of this alert being a False Positive.
+          - Score this alert between 0-100 for the likelihood of this alert being a True Positive.
 
-        Give your response as a JSON:
-        ```json
-        {
-          "false_positive": <score>,
-          "true_legitimate": <score>
-        }
-        ```
+          Give your response as a JSON:
+          ```json
+          {
+            "false_positive": <score>,
+            "true_legitimate": <score>
+          }
+          ```

--- a/playbooks/threat_intel/virustotal-to-email.yml
+++ b/playbooks/threat_intel/virustotal-to-email.yml
@@ -1,55 +1,56 @@
-title: Send Virustotal report to email using the builtin integration
-description: Scan a malicious hash on Virustotal and send the results to an email address
+definition:
+  title: Send Virustotal report to email using the builtin integration
+  description: Scan a malicious hash on Virustotal and send the results to an email address
 
-entrypoint:
-  ref: call_virustotal
-triggers:
-  - type: webhook
-    ref: virustotal_webhook
-    entrypoint: call_virustotal
+  entrypoint:
+    ref: call_virustotal
+  triggers:
+    - type: webhook
+      ref: virustotal_webhook
+      entrypoint: call_virustotal
 
-actions:
-  # Using the hash from the webhook trigger, we'll make
-  # an API call to Virustotal
-  - ref: call_virustotal
-    action: integrations.virustotal.analyze_url
-    args:
-      url: ${{ TRIGGER.url }} # Pulls from the webhoo
+  actions:
+    # Using the hash from the webhook trigger, we'll make
+    # an API call to Virustotal
+    - ref: call_virustotal
+      action: integrations.virustotal.analyze_url
+      args:
+        url: ${{ TRIGGER.url }} # Pulls from the webhoo
 
-  # Grab the results from the Virustotal API call and send
-  # them to an email address
-  - ref: send_email_with_virustotal_results
-    action: core.send_email
-    depends_on:
-      - call_virustotal
-    args:
-      recipients:
-        - daryl@tracecat.com
-        - chris@tracecat.com
-      subject: Malware report for ${{ TRIGGER.hash }}
-      body: |
-        Dear Team,
+    # Grab the results from the Virustotal API call and send
+    # them to an email address
+    - ref: send_email_with_virustotal_results
+      action: core.send_email
+      depends_on:
+        - call_virustotal
+      args:
+        recipients:
+          - daryl@tracecat.com
+          - chris@tracecat.com
+        subject: Malware report for ${{ TRIGGER.hash }}
+        body: |
+          Dear Team,
 
-        Below is the daily malware report summary for the file.
+          Below is the daily malware report summary for the file.
 
-        1. File Identification
+          1. File Identification
 
-        SHA256: ${{ ACTIONS.call_virustotal.result.data.data.attributes.sha256 }}
-        File Names: ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.names) -> str }}
+          SHA256: ${{ ACTIONS.call_virustotal.result.data.data.attributes.sha256 }}
+          File Names: ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.names) -> str }}
 
-        2. Submission Dates
+          2. Submission Dates
 
-        First Submission: ${{ ACTIONS.call_virustotal.result.data.data.attributes.first_submission_date }}
-        Last Analysis: ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_date }}
+          First Submission: ${{ ACTIONS.call_virustotal.result.data.data.attributes.first_submission_date }}
+          Last Analysis: ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_date }}
 
-        3. Analysis Results
+          3. Analysis Results
 
-        Malicious Detections:
-        ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_results }}
+          Malicious Detections:
+          ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_results }}
 
-        4. Detection Tags
+          4. Detection Tags
 
-        ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.tags) -> str }}
-        5. File Details
+          ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.tags) -> str }}
+          5. File Details
 
-        ~Tracecat
+          ~Tracecat

--- a/tests/data/workflows/playbook_virustotal_email.yml
+++ b/tests/data/workflows/playbook_virustotal_email.yml
@@ -1,59 +1,60 @@
-title: Send Virustotal report to email
-description: Scan a malicious hash on Virustotal and send the results to an email address
+definition:
+  title: Send Virustotal report to email
+  description: Scan a malicious hash on Virustotal and send the results to an email address
 
-entrypoint:
-  ref: call_virustotal
-triggers:
-  - type: webhook
-    ref: my_webhook
-    entrypoint: call_virustotal
+  entrypoint:
+    ref: call_virustotal
+  triggers:
+    - type: webhook
+      ref: my_webhook
+      entrypoint: call_virustotal
 
-actions:
-  # Using the hash from the webhook trigger, we'll make
-  # an API call to Virustotal
-  - ref: call_virustotal
-    action: core.http_request
-    args:
-      url: https://www.virustotal.com/api/v3/files/${{ TRIGGER.hash }}
-      method: GET
-      headers:
-        # secret name: virustotal, key name: VT_API_KEY
-        x-apikey: ${{ SECRETS.virustotal.VT_API_KEY }}
+  actions:
+    # Using the hash from the webhook trigger, we'll make
+    # an API call to Virustotal
+    - ref: call_virustotal
+      action: core.http_request
+      args:
+        url: https://www.virustotal.com/api/v3/files/${{ TRIGGER.hash }}
+        method: GET
+        headers:
+          # secret name: virustotal, key name: VT_API_KEY
+          x-apikey: ${{ SECRETS.virustotal.VT_API_KEY }}
 
-  # Grab the results from the Virustotal API call and send
-  # them to an email address
-  - ref: send_email_with_virustotal_results
-    action: core.send_email
-    depends_on:
-      - call_virustotal
-    args:
-      recipients:
-        - daryl@tracecat.com
-        - chris@tracecat.com
-      subject: Malware report for ${{ TRIGGER.hash }}
-      body: |
-        Dear Team,
+    # Grab the results from the Virustotal API call and send
+    # them to an email address
+    - ref: send_email_with_virustotal_results
+      action: core.send_email
+      depends_on:
+        - call_virustotal
+      args:
+        recipients:
+          - daryl@tracecat.com
+          - chris@tracecat.com
+        subject: Malware report for ${{ TRIGGER.hash }}
+        body: |
+          Dear Team,
 
-        Below is the daily malware report summary for the file.
+          Below is the daily malware report summary for the file.
 
-        1. File Identification
+          1. File Identification
 
-        SHA256: ${{ ACTIONS.call_virustotal.result.data.data.attributes.sha256 }}
-        File Names: ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.names) -> str }}
+          SHA256: ${{ ACTIONS.call_virustotal.result.data.data.attributes.sha256 }}
+          File Names: ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.names) -> str }}
 
-        2. Submission Dates
+          2. Submission Dates
 
-        First Submission: ${{ ACTIONS.call_virustotal.result.data.data.attributes.first_submission_date }}
-        Last Analysis: ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_date }}
+          First Submission: ${{ ACTIONS.call_virustotal.result.data.data.attributes.first_submission_date }}
+          Last Analysis: ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_date }}
 
-        3. Analysis Results
+          3. Analysis Results
 
-        Malicious Detections:
-        ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_results }}
+          Malicious Detections:
+          ${{ ACTIONS.call_virustotal.result.data.data.attributes.last_analysis_results }}
 
-        4. Detection Tags
+          4. Detection Tags
 
-        ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.tags) -> str }}
-        5. File Details
+          ${{ FN.join(ACTIONS.call_virustotal.result.data.data.attributes.tags) -> str }}
+          5. File Details
 
-        ~Tracecat
+          ~Tracecat

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -223,12 +223,12 @@ def test_manage_workflows(capture_cli):
 def test_create_workflow_with_file(capture_cli):
     from cli.tracecat_cli.workflow import _create_workflow, list_workflows
 
-    expected_title = "Reshape data in a loop"
+    expected_title = "Send Virustotal report to email"
     expected_description = (
-        "Test reshaping data from a list of mappings to a list of key-value pairs"
+        "Scan a malicious hash on Virustotal and send the results to an email address"
     )
 
-    file = DATA_PATH.joinpath("unit_transform_reshape_arrange_loop.yml")
+    file = DATA_PATH.joinpath("playbook_virustotal_email.yml")
     wf = _create_workflow(file=file)
     captured_output = capture_cli()
 

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import Any
 
 from pydantic import ValidationError
@@ -14,13 +15,15 @@ from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import Action, Webhook, Workflow
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.graph import RFGraph
-from tracecat.identifiers import WorkflowID
+from tracecat.identifiers import WorkflowID, WorkspaceID
 from tracecat.logging import logger
 from tracecat.types.api import UDFArgsValidationResponse
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatValidationError
 from tracecat.workflow.management.models import (
     CreateWorkflowFromDSLResponse,
+    CreateWorkflowParams,
+    ExternalWorkflowDefinition,
     UpdateWorkflowParams,
 )
 
@@ -83,6 +86,38 @@ class WorkflowsManagementService:
         await self.session.delete(workflow)
         await self.session.commit()
 
+    async def create_workflow(self, params: CreateWorkflowParams) -> Workflow:
+        """Create a new workflow."""
+
+        now = datetime.now().strftime("%b %d, %Y, %H:%M:%S")
+        title = params.title or now
+        description = params.description or f"New workflow created {now}"
+
+        workflow = Workflow(
+            title=title, description=description, owner_id=self.role.workspace_id
+        )
+        # When we create a workflow, we automatically create a webhook
+        # Add the Workflow to the session first to generate an ID
+        self.session.add(workflow)
+        await self.session.flush()  # Flush to generate workflow.id
+        await self.session.refresh(workflow)
+
+        # Create and associate Webhook with the Workflow
+        webhook = Webhook(
+            owner_id=self.role.workspace_id,
+            workflow_id=workflow.id,
+        )
+        self.session.add(webhook)
+        workflow.webhook = webhook
+
+        graph = RFGraph.with_defaults(workflow)
+        workflow.object = graph.model_dump(by_alias=True, mode="json")
+        workflow.entrypoint = graph.entrypoint.id if graph.entrypoint else None
+        self.session.add(workflow)
+        await self.session.commit()
+        await self.session.refresh(workflow)
+        return workflow
+
     async def create_workflow_from_dsl(
         self, dsl_data: dict[str, Any], *, skip_secret_validation: bool = False
     ) -> CreateWorkflowFromDSLResponse:
@@ -121,59 +156,8 @@ class WorkflowsManagementService:
 
         logger.warning("Creating workflow from DSL", dsl=dsl)
         try:
-            workflow = Workflow(
-                title=dsl.title,
-                description=dsl.description,
-                owner_id=self.role.workspace_id,
-                static_inputs=dsl.inputs,
-                returns=dsl.returns,
-            )
-
-            # Add the Workflow to the session first to generate an ID
-            self.session.add(workflow)
-
-            # Create and associate Webhook with the Workflow
-            webhook = Webhook(
-                owner_id=self.role.workspace_id,
-                workflow_id=workflow.id,
-            )
-            self.session.add(webhook)
-            workflow.webhook = webhook
-
-            # Create and associate Actions with the Workflow
-            actions: list[Action] = []
-            for act_stmt in dsl.actions:
-                new_action = Action(
-                    owner_id=self.role.workspace_id,
-                    workflow_id=workflow.id,
-                    type=act_stmt.action,
-                    inputs=act_stmt.args,
-                    title=act_stmt.title,
-                    description=act_stmt.description,
-                )
-                actions.append(new_action)
-                self.session.add(new_action)
-
-            workflow.actions = actions  # Associate actions with the workflow
-
-            # Create and set the graph for the Workflow
-            base_graph = RFGraph.with_defaults(workflow)
-            logger.info("Creating graph for workflow", graph=base_graph)
-
-            # Add DSL contents to the Workflow
-            ref2id = {act.ref: act.id for act in actions}
-            updated_graph = dsl.to_graph(trigger_node=base_graph.trigger, ref2id=ref2id)
-            workflow.object = updated_graph.model_dump(by_alias=True, mode="json")
-            workflow.entrypoint = (
-                updated_graph.entrypoint.id if updated_graph.entrypoint else None
-            )
-
-            # Commit the transaction
-            await self.session.commit()
-            await self.session.refresh(workflow)
-
+            workflow = await self._create_db_workflow_from_dsl(dsl)
             return CreateWorkflowFromDSLResponse(workflow=workflow)
-
         except Exception as e:
             # Rollback the transaction on error
             logger.error(f"Error creating workflow: {e}")
@@ -229,6 +213,102 @@ class WorkflowsManagementService:
             returns=workflow.returns,
             # triggers=workflow.triggers,
         )
+
+    async def create_workflow_from_external_definition(
+        self, import_data: dict[str, Any]
+    ) -> Workflow:
+        """Import an external workflow definition into the current workspace.
+
+        Optionally validate the workflow definition before importing. (Default: False)
+        """
+
+        external_defn = ExternalWorkflowDefinition.model_validate(import_data)
+        # NOTE: We do not support adding invalid workflows
+
+        dsl = external_defn.definition
+        self.logger.info("Constructed DSL from external definition", dsl=dsl)
+        # We need to be able to control:
+        # 1. The workspace the workflow is imported into
+        # 2. The owner of the workflow
+        # 3. The ID of the workflow
+        workflow = await self._create_db_workflow_from_dsl(
+            dsl,
+            workspace_id=external_defn.workspace_id,
+            workflow_id=external_defn.workflow_id,
+            created_at=external_defn.created_at,
+            updated_at=external_defn.updated_at,
+        )
+        return workflow
+
+    async def _create_db_workflow_from_dsl(
+        self,
+        dsl: DSLInput,
+        *,
+        workspace_id: WorkspaceID | None = None,
+        workflow_id: WorkflowID | None = None,
+        created_at: datetime | None = None,
+        updated_at: datetime | None = None,
+    ) -> Workflow:
+        """Create a new workflow and associated actions in the database from a DSLInput."""
+        logger.info("Creating workflow from DSL", dsl=dsl)
+        workflow_kwargs = {
+            "title": dsl.title,
+            "description": dsl.description,
+            "owner_id": workspace_id or self.role.workspace_id,
+            "static_inputs": dsl.inputs,
+            "returns": dsl.returns,
+        }
+        if workflow_id:
+            workflow_kwargs["id"] = workflow_id
+        if created_at:
+            workflow_kwargs["created_at"] = created_at
+        if updated_at:
+            workflow_kwargs["updated_at"] = updated_at
+        workflow = Workflow(**workflow_kwargs)
+
+        # Add the Workflow to the session first to generate an ID
+        self.session.add(workflow)
+
+        # Create and associate Webhook with the Workflow
+        webhook = Webhook(
+            owner_id=self.role.workspace_id,
+            workflow_id=workflow.id,
+        )
+        self.session.add(webhook)
+        workflow.webhook = webhook
+
+        # Create and associate Actions with the Workflow
+        actions: list[Action] = []
+        for act_stmt in dsl.actions:
+            new_action = Action(
+                owner_id=self.role.workspace_id,
+                workflow_id=workflow.id,
+                type=act_stmt.action,
+                inputs=act_stmt.args,
+                title=act_stmt.title,
+                description=act_stmt.description,
+            )
+            actions.append(new_action)
+            self.session.add(new_action)
+
+        workflow.actions = actions  # Associate actions with the workflow
+
+        # Create and set the graph for the Workflow
+        base_graph = RFGraph.with_defaults(workflow)
+        logger.info("Creating graph for workflow", graph=base_graph)
+
+        # Add DSL contents to the Workflow
+        ref2id = {act.ref: act.id for act in actions}
+        updated_graph = dsl.to_graph(trigger_node=base_graph.trigger, ref2id=ref2id)
+        workflow.object = updated_graph.model_dump(by_alias=True, mode="json")
+        workflow.entrypoint = (
+            updated_graph.entrypoint.id if updated_graph.entrypoint else None
+        )
+
+        # Commit the transaction
+        await self.session.commit()
+        await self.session.refresh(workflow)
+        return workflow
 
     async def _synchronize_graph_with_db_actions(
         self, actions: list[Action], graph: RFGraph

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -15,7 +15,7 @@ from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import Action, Webhook, Workflow
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.graph import RFGraph
-from tracecat.identifiers import WorkflowID, WorkspaceID
+from tracecat.identifiers import WorkflowID
 from tracecat.logging import logger
 from tracecat.types.api import UDFArgsValidationResponse
 from tracecat.types.auth import Role
@@ -231,9 +231,9 @@ class WorkflowsManagementService:
         # 1. The workspace the workflow is imported into
         # 2. The owner of the workflow
         # 3. The ID of the workflow
+
         workflow = await self._create_db_workflow_from_dsl(
             dsl,
-            workspace_id=external_defn.workspace_id,
             workflow_id=external_defn.workflow_id,
             created_at=external_defn.created_at,
             updated_at=external_defn.updated_at,
@@ -244,7 +244,6 @@ class WorkflowsManagementService:
         self,
         dsl: DSLInput,
         *,
-        workspace_id: WorkspaceID | None = None,
         workflow_id: WorkflowID | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
@@ -254,7 +253,7 @@ class WorkflowsManagementService:
         workflow_kwargs = {
             "title": dsl.title,
             "description": dsl.description,
-            "owner_id": workspace_id or self.role.workspace_id,
+            "owner_id": self.role.workspace_id,
             "static_inputs": dsl.inputs,
             "returns": dsl.returns,
         }

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from tracecat.contexts import RunContext
-from tracecat.db.schemas import Schedule, Workflow
+from tracecat.db.schemas import Schedule, Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.models import ActionStatement
 from tracecat.identifiers import OwnerID, WorkflowID, WorkspaceID
@@ -80,12 +80,41 @@ class GetWorkflowDefinitionActivityInputs(BaseModel):
 WorkflowExportFormat = Literal["json", "yaml"]
 
 
-class WorkflowExport(BaseModel):
-    """External interchangable format for workflows."""
+class ExternalWorkflowDefinition(BaseModel):
+    """External interchange format for workflow definitions.
 
-    workspace_id: WorkspaceID
-    workflow_id: WorkflowID
-    created_at: datetime
-    updated_at: datetime
+    Lets you restore a workflow from a JSON or YAML file."""
+
+    workspace_id: WorkspaceID | None = Field(
+        default=None,
+        description=(
+            "If provided, can only be restored in the same workspace (TBD)."
+            "Otherwise, can be added to any workspace."
+            "This will be set to `owner_id`"
+        ),
+    )
+    workflow_id: WorkflowID | None = Field(
+        default=None,
+        description="Workflow ID. If not provided, a new workflow ID will be created.",
+    )
+    created_at: datetime | None = Field(
+        default=None,
+        description="Creation datetime of the workflow, will be set to current time if not provided.",
+    )
+    updated_at: datetime | None = Field(
+        default=None,
+        description="Last update datetime of the workflow, will be set to current time if not provided.",
+    )
     version: int = Field(gt=0)
     definition: DSLInput
+
+    @staticmethod
+    def from_database(defn: WorkflowDefinition) -> ExternalWorkflowDefinition:
+        return ExternalWorkflowDefinition(
+            workspace_id=defn.owner_id,
+            workflow_id=defn.workflow_id,
+            created_at=defn.created_at,
+            updated_at=defn.updated_at,
+            version=defn.version,
+            definition=defn.content,
+        )

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -105,7 +105,7 @@ class ExternalWorkflowDefinition(BaseModel):
         default=None,
         description="Last update datetime of the workflow, will be set to current time if not provided.",
     )
-    version: int = Field(gt=0)
+    version: int = Field(default=1, gt=0)
     definition: DSLInput
 
     @staticmethod

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from tracecat.contexts import RunContext
 from tracecat.db.schemas import Schedule, Workflow
+from tracecat.dsl.common import DSLInput
 from tracecat.dsl.models import ActionStatement
-from tracecat.identifiers import OwnerID, WorkflowID
+from tracecat.identifiers import OwnerID, WorkflowID, WorkspaceID
 from tracecat.types.api import (
     ActionResponse,
     UDFArgsValidationResponse,
@@ -74,3 +75,17 @@ class GetWorkflowDefinitionActivityInputs(BaseModel):
     trigger_inputs: dict[str, Any]
     version: int | None = None
     run_context: RunContext
+
+
+WorkflowExportFormat = Literal["json", "yaml"]
+
+
+class WorkflowExport(BaseModel):
+    """External interchangable format for workflows."""
+
+    workspace_id: WorkspaceID
+    workflow_id: WorkflowID
+    created_at: datetime
+    updated_at: datetime
+    version: int = Field(gt=0)
+    definition: DSLInput

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Annotated, Literal
 
 import orjson
@@ -15,6 +14,7 @@ from fastapi import (
     status,
 )
 from pydantic import ValidationError
+from slugify import slugify
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -23,7 +23,6 @@ from tracecat import validation
 from tracecat.auth.credentials import authenticate_user_for_workspace
 from tracecat.db.engine import get_async_session
 from tracecat.db.schemas import Webhook, Workflow, WorkflowDefinition
-from tracecat.dsl.graph import RFGraph
 from tracecat.identifiers import WorkflowID
 from tracecat.logging import logger
 from tracecat.types.api import (
@@ -38,6 +37,8 @@ from tracecat.types.exceptions import TracecatValidationError
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.models import (
+    CreateWorkflowParams,
+    ExternalWorkflowDefinition,
     UpdateWorkflowParams,
     WorkflowMetadataResponse,
     WorkflowResponse,
@@ -82,67 +83,57 @@ async def create_workflow(
     Optionally, you can provide a YAML file to create a workflow.
     You can also provide a title and description to create a blank workflow."""
 
+    service = WorkflowsManagementService(session, role=role)
     if file:
-        try:
-            data = await file.read()
-            if file.content_type in ("application/yaml", "text/yaml"):
-                dsl_data = yaml.safe_load(data)
-            elif file.content_type == "application/json":
-                dsl_data = orjson.loads(data)
-            else:
+        raw_data = await file.read()
+        match file.content_type:
+            case "application/yaml" | "text/yaml" | "application/x-yaml":
+                logger.info("Parsing YAML file", file=file.filename)
+                try:
+                    external_defn_data = yaml.safe_load(raw_data)
+                except yaml.YAMLError as e:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Error parsing YAML file: {e!r}",
+                    ) from e
+            case "application/json":
+                logger.info("Parsing JSON file", file=file.filename)
+                try:
+                    external_defn_data = orjson.loads(raw_data)
+                except orjson.JSONDecodeError as e:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Error parsing JSON file: {e!r}",
+                    ) from e
+            case None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Content-Type header is required for file uploads.",
+                )
+            case _:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Invalid file type {file.content_type}. Only YAML and JSON files are supported.",
                 )
-        except (yaml.YAMLError, orjson.JSONDecodeError) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Error parsing file: {str(e)}",
-            ) from e
 
-        service = WorkflowsManagementService(session, role=role)
-        result = await service.create_workflow_from_dsl(
-            dsl_data, skip_secret_validation=True
-        )
-        if result.errors:
+        logger.info("Importing workflow", external_defn_data=external_defn_data)
+        try:
+            workflow = await service.create_workflow_from_external_definition(
+                external_defn_data
+            )
+        except ValidationError as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail={
                     "status": "failure",
-                    "message": f"Workflow definition construction failed with {len(result.errors)} errors",
-                    "errors": [e.model_dump() for e in result.errors],
+                    "message": "Error validating external workflow definition",
+                    "errors": e.errors(),
                 },
-            )
-        workflow = result.workflow
+            ) from e
     else:
-        now = datetime.now().strftime("%b %d, %Y, %H:%M:%S")
-        title = title or now
-        description = description or f"New workflow created {now}"
-
-        workflow = Workflow(
-            title=title, description=description, owner_id=role.workspace_id
+        workflow = await service.create_workflow(
+            CreateWorkflowParams(title=title, description=description)
         )
-        # When we create a workflow, we automatically create a webhook
-        # Add the Workflow to the session first to generate an ID
-        session.add(workflow)
-        await session.flush()  # Flush to generate workflow.id
-        await session.refresh(workflow)
-
-        # Create and associate Webhook with the Workflow
-        webhook = Webhook(
-            owner_id=role.workspace_id,
-            workflow_id=workflow.id,
-        )
-        session.add(webhook)
-        workflow.webhook = webhook
-
-        graph = RFGraph.with_defaults(workflow)
-        workflow.object = graph.model_dump(by_alias=True, mode="json")
-        workflow.entrypoint = graph.entrypoint.id if graph.entrypoint else None
-        session.add(workflow)
-        await session.commit()
-        await session.refresh(workflow)
-
     return WorkflowMetadataResponse(
         id=workflow.id,
         title=workflow.title,
@@ -345,17 +336,19 @@ async def export_workflow(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Workflow definition not found",
         )
+    external_defn = ExternalWorkflowDefinition.from_database(defn)
+    filename = f"{external_defn.workflow_id}__{slugify(external_defn.definition.title)}.{format}"
     if format == "json":
         return Response(
-            content=defn.model_dump_json(indent=2),
+            content=external_defn.model_dump_json(indent=2),
             media_type="application/json",
-            headers={"Content-Disposition": f"attachment; filename={workflow_id}.json"},
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
     elif format == "yaml":
         return Response(
-            content=yaml.dump(defn.model_dump(mode="json"), indent=2),
+            content=yaml.dump(external_defn.model_dump(mode="json"), indent=2),
             media_type="application/yaml",
-            headers={"Content-Disposition": f"attachment; filename={workflow_id}.yaml"},
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
     else:
         raise HTTPException(

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -351,10 +351,16 @@ async def export_workflow(
             media_type="application/json",
             headers={"Content-Disposition": f"attachment; filename={workflow_id}.json"},
         )
+    elif format == "yaml":
+        return Response(
+            content=yaml.dump(defn.model_dump(mode="json"), indent=2),
+            media_type="application/yaml",
+            headers={"Content-Disposition": f"attachment; filename={workflow_id}.yaml"},
+        )
     else:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Only JSON format is supported",
+            detail=f"{format!r} is not a supported export format",
         )
 
 


### PR DESCRIPTION
# Features
- Add import from json
- Improve import/export logic
- Add `ExternalWorkflowDefintion`. This will serve as a portable format for workflows outside of the platform. Helps lay foundation for 2way sync (if we wish to support that in the future)
    - This class carries additional metadata alongside just the DSL workflow definition (which is what our YAMLs previously were). This lets you export out a workflow with, and restore it using the same workflow id so you can keep the run history.

# Changes
- Update workflow definitions to have a top level `definition` key

# Testing

- Can export yaml
- Can export json
- Can import yaml
    - API
    - UI
- Can import json
    - API
    - UI
- Can run imported yaml workflow
- Can run imported json workflow
- Verify that workflow ID can be overridden
- Verify that if fields not passed, are created
- Verified that when workflow id not passed, can create a copy (generates new id)
- Verify that fields can be overridden
- Verify that workflow run history is preserved when reimporting an external defn
- Catch error
    - Uploading an external definition with existing workflow ID leads to an error