### PR TITLE
test(engine): Add live playbook testing infra and VT playbook

### DIFF
--- a/playbooks/virustotal-quickstart.yml
+++ b/playbooks/virustotal-quickstart.yml
@@ -1,0 +1,38 @@
+definition:
+  actions:
+    - action: integrations.virustotal.analyze_url
+      args:
+        url: ${{ TRIGGER.url_input }}
+      depends_on: []
+      description: ""
+      for_each: null
+      ref: analyze_url
+      run_if: null
+    - action: core.open_case
+      args:
+        action: informational
+        case_title: ${{ TRIGGER.url_input }}
+        malice: malicious
+        payload: ${{ ACTIONS.analyze_url.result.data }}
+        priority:
+          ${{ 'high' if ACTIONS.analyze_url.result.data.attributes.last_analysis_stats.malicious
+          > 30 else 'medium' }}
+        status: open
+      depends_on:
+        - analyze_url
+      description: ""
+      for_each: null
+      ref: open_case
+      run_if: ${{ ACTIONS.analyze_url.result.data.attributes.last_analysis_stats.malicious > 10 }}
+  config:
+    enable_runtime_tests: false
+    scheduler: dynamic
+  description: Virustotal quickstart
+  entrypoint:
+    expects: {}
+    ref: analyze_url
+  inputs: {}
+  returns: null
+  tests: []
+  title: Test virustotal
+  triggers: []


### PR DESCRIPTION
# Changes
- Add live playbook testing infra
- Added virustotal playbook from quickstart to run in the above
- Extend `AuthSandbox._get_secrets` to get db secrets through the service layer instead of making an api call
- Updated auth sandbox tests for the above change


# Testing
Manual QA 
- After the above changes, we're still able to get secrets from our SM
- Updated pytest tests passing
