### PR TITLE
fix(engine+ui): Fix unable to update secrets

### DIFF
--- a/frontend/src/components/workspaces/edit-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/edit-workspace-secret.tsx
@@ -23,7 +23,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -12,6 +12,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import Secret
+from tracecat.identifiers import SecretID
 from tracecat.logging import logger
 from tracecat.secrets.encryption import decrypt_keyvalues, encrypt_keyvalues
 from tracecat.secrets.models import (
@@ -76,7 +77,7 @@ class SecretsService:
     ) -> Secret | None: ...
 
     async def get_secret_by_id(
-        self, secret_id: str, raise_on_none: bool = False
+        self, secret_id: SecretID, raise_on_none: bool = False
     ) -> Secret | None:
         statement = select(Secret).where(
             Secret.owner_id == self.role.workspace_id, Secret.id == secret_id
@@ -128,16 +129,16 @@ class SecretsService:
         await self._update_secret(secret=secret, params=params)
 
     async def update_secret_by_id(
-        self, secret_id: str, params: UpdateSecretParams
+        self, secret_id: SecretID, params: UpdateSecretParams
     ) -> None:
-        secret = await self.get_secret_by_name(secret_id, raise_on_none=True)
+        secret = await self.get_secret_by_id(secret_id, raise_on_none=True)
         await self._update_secret(secret=secret, params=params)
 
     async def delete_secret_by_name(self, secret_name: str) -> None:
         secret = await self.get_secret_by_name(secret_name, raise_on_none=True)
         await self._delete_secret(secret)
 
-    async def delete_secret_by_id(self, secret_id: str) -> None:
+    async def delete_secret_by_id(self, secret_id: SecretID) -> None:
         secret = await self.get_secret_by_id(secret_id, raise_on_none=True)
         await self._delete_secret(secret)
 


### PR DESCRIPTION
# Changes
- Fixed issue where `AuthSandbox` with `context` target doesn't load all secrets
- Fixed issue where form validation occured message would appear on editing a secret
- Simplify update secret form logic. Make the form mirror the update secret endpoint as closely as possible - omitted fields are not changed, only update fields that are specified  
- Add info text to indicate whether a field will be changed

# Testing
Manual QA, confirm that able to edit secrets and use in workflows correctly

# Screens

https://github.com/user-attachments/assets/55e82545-0a64-413b-9c45-77c91c3c8d79

