### PR TITLE
feat(integration): Add list crowdstrike detections summary

### DIFF
--- a/tracecat/actions/integrations/edr/crowdstrike.py
+++ b/tracecat/actions/integrations/edr/crowdstrike.py
@@ -193,3 +193,21 @@ async def update_crowdstrike_detect_status(
     )
 
     return response
+
+@registry.register(
+    default_title="Get Crowdstrike detect summaries",
+    description="Fetch the summaries of specific Crowdstrike detections by their IDs.",
+    display_group="Crowdstrike",
+    namespace="integrations.crowdstrike",
+    secrets=[crowdstrike_secret],
+)
+async def get_crowdstrike_detect_summaries(
+    detection_ids: Annotated[
+        list[str], Field(..., description="List of detection IDs to fetch summaries for")
+    ],
+) -> dict[str, Any]:
+    falcon = Detects(**get_crowdstrike_credentials())
+    
+    response = falcon.get_detect_summaries(ids=detection_ids)
+    
+    return response

--- a/tracecat/actions/integrations/edr/crowdstrike.py
+++ b/tracecat/actions/integrations/edr/crowdstrike.py
@@ -194,6 +194,7 @@ async def update_crowdstrike_detect_status(
 
     return response
 
+
 @registry.register(
     default_title="Get Crowdstrike detect summaries",
     description="Fetch the summaries of specific Crowdstrike detections by their IDs.",
@@ -203,11 +204,12 @@ async def update_crowdstrike_detect_status(
 )
 async def get_crowdstrike_detect_summaries(
     detection_ids: Annotated[
-        list[str], Field(..., description="List of detection IDs to fetch summaries for")
+        list[str],
+        Field(..., description="List of detection IDs to fetch summaries for"),
     ],
 ) -> dict[str, Any]:
     falcon = Detects(**get_crowdstrike_credentials())
-    
+
     response = falcon.get_detect_summaries(ids=detection_ids)
-    
+
     return response


### PR DESCRIPTION
Added a new integration which can fetch detection details by passing in the detection IDs.

## Description


When querying for CrowdStrike detections, an array of detection IDs are returned. Currently, there is no integration which allows you to use these IDs and query for detection details. This integration simply takes the array of IDs and returns the full detection details.


## Related Tickets & Documents

<!--
N/A
-->

## Screenshots/Recordings

Sample Use Case:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6c487ec4-7305-4503-ae83-821f6382f489">


Sample Configuration:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/cb672aac-78d1-43de-91db-8adce03cc5c0">


## Steps to QA

1. Verify the code is valid
2. Create a workflow using the List CrowdStrike Detects and the new Get CrowdStrike Detect Summaries integrations
3. Validate that an array of detection details is returned


<!--  ## [optional] What gif best describes this PR? -->

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
