### PR TITLE
feat(integration): Normalize events to ECS

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -165,6 +165,17 @@ services:
     depends_on:
       - temporal
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    container_name: elasticsearch
+    restart: unless-stopped
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+
 volumes:
   core-db:
   temporal-db:
+  elasticsearch-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,9 +137,25 @@ services:
     depends_on:
       - temporal_postgres_db
 
+  # Tracecat uses Elasticsearch for event normalization
+  # Disable this if you don't intend to use Tracecat's ECS normalization action
+  # or have your own Elasticsearch instance
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    container_name: elasticsearch
+    restart: unless-stopped
+    networks:
+      - core
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+
 volumes:
   core-db:
   temporal-db:
+  elasticsearch-data:
 
 networks:
   core:

--- a/tracecat/actions/__init__.py
+++ b/tracecat/actions/__init__.py
@@ -7,7 +7,6 @@ Do not add `from __future__ import annotations` to any action module. This will 
 # Bring all actions into the namespace to be registered
 
 from tracecat.actions import integrations
-from tracecat.actions.etl import extraction, normalization
 from tracecat.actions.core import (
     cases,
     email,
@@ -17,6 +16,7 @@ from tracecat.actions.core import (
     transform,
     workflow,
 )
+from tracecat.actions.etl import extraction, normalization
 
 __all__ = [
     "cases",

--- a/tracecat/actions/__init__.py
+++ b/tracecat/actions/__init__.py
@@ -7,6 +7,7 @@ Do not add `from __future__ import annotations` to any action module. This will 
 # Bring all actions into the namespace to be registered
 
 from tracecat.actions import integrations
+from tracecat.actions.etl import extraction, normalization
 from tracecat.actions.core import (
     cases,
     email,
@@ -18,13 +19,14 @@ from tracecat.actions.core import (
 )
 
 __all__ = [
-    # Core
-    "example",
-    "http",
-    "email",
-    "llm",
     "cases",
-    "transform",
+    "email",
+    "example",
+    "extraction",
+    "http",
     "integrations",
+    "llm",
+    "normalization",
+    "transform",
     "workflow",
 ]

--- a/tracecat/actions/etl/normalization/__init__.py
+++ b/tracecat/actions/etl/normalization/__init__.py
@@ -1,0 +1,3 @@
+from .ecs import normalize_events_to_ecs
+
+__all__ = ["normalize_events_to_ecs"]

--- a/tracecat/actions/etl/normalization/ecs.py
+++ b/tracecat/actions/etl/normalization/ecs.py
@@ -46,13 +46,13 @@ from typing import Annotated, Any
 
 
 @registry.register(
-    default_title="Normalize outputs (ECS)",
+    default_title="Normalize events (ECS)",
     description="Normalize JSON objects into ECS format using an ingest pipeline.",
     display_group="Normalization",
     namespace="etl.normalization.ecs",
     secrets=[elastic_secret],
 )
-async def normalize_outputs(
+async def normalize_events(
     pipeline: Annotated[
         str | dict[str, Any],
         Field(..., description="Ingest pipeline definition. Can be a dictionary or URL to a YAML definition file."),

--- a/tracecat/actions/etl/normalization/ecs.py
+++ b/tracecat/actions/etl/normalization/ecs.py
@@ -12,11 +12,14 @@ References
 - https://www.elastic.co/guide/en/elasticsearch/reference/current/simulate-pipeline-api.html
 """
 
+import os
+from typing import Annotated, Any
+
 import httpx
-
+import orjson
 from yaml import safe_load
-from tracecat.registry import Field, RegistrySecret, registry
 
+from tracecat.registry import Field, RegistrySecret, registry
 
 elastic_secret = RegistrySecret(
     name="elastic",
@@ -40,10 +43,6 @@ Expression:
 >>> ${{ SECRETS.elastic.ELASTIC_API_KEY }}
 """
 
-import os
-import orjson
-from typing import Annotated, Any
-
 
 @registry.register(
     default_title="Normalize events (ECS)",
@@ -55,7 +54,10 @@ from typing import Annotated, Any
 async def normalize_events_to_ecs(
     pipeline: Annotated[
         str | dict[str, Any],
-        Field(..., description="Ingest pipeline definition. Can be a dictionary or URL to a YAML definition file."),
+        Field(
+            ...,
+            description="Ingest pipeline definition. Can be a dictionary or URL to a YAML definition file.",
+        ),
     ],
     data: Annotated[
         list[dict[str, Any]],
@@ -66,7 +68,7 @@ async def normalize_events_to_ecs(
     api_url = os.getenv("ELASTIC_API_URL", "http://elasticsearch:9200")
 
     url = f"{api_url}/_ingest/pipeline/_simulate"
-    headers={"Content-Type": "application/json"}
+    headers = {"Content-Type": "application/json"}
     if api_key is not None:
         headers["Authorization"] = f"ApiKey {api_key}"
 

--- a/tracecat/actions/etl/normalization/ecs.py
+++ b/tracecat/actions/etl/normalization/ecs.py
@@ -63,7 +63,7 @@ async def normalize_events(
     ],
 ) -> list[dict[str, Any]]:
     api_key = os.getenv("ELASTIC_API_KEY")
-    api_url = os.getenv("ELASTIC_API_URL", "http://localhost:9200")
+    api_url = os.getenv("ELASTIC_API_URL", "http://elasticsearch:9200")
 
     url = f"{api_url}/_ingest/pipeline/_simulate"
     headers={"Content-Type": "application/json"}

--- a/tracecat/actions/etl/normalization/ecs.py
+++ b/tracecat/actions/etl/normalization/ecs.py
@@ -1,0 +1,83 @@
+"""Action that uses Elasticsearch to normalize data into ECS format.
+
+We use the Elasticsearch's REST API and ingest endpoints.
+In particular, we use the `simulate` pipeline API to normalize data into ECS format without storing it.
+
+Authentication (in order of precedence):
+1. Connect to Elasticsearch in the local environment (port 9200).
+2. Connect to Elasticsearch in external environement if `ELASTIC_API_KEY` and `ELASTIC_API_URL` secrets are set in Tracecat.
+
+References
+----------
+- https://www.elastic.co/guide/en/elasticsearch/reference/current/simulate-pipeline-api.html
+"""
+
+import httpx
+
+from yaml import safe_load
+from tracecat.registry import Field, RegistrySecret, registry
+
+
+elastic_secret = RegistrySecret(
+    name="elastic",
+    keys=["ELASTIC_API_KEY", "ELASTIC_API_URL"],
+)
+"""Elastic secret.
+
+Secret
+------
+- name: `elastic`
+- keys:
+    - `ELASTIC_API_KEY`
+    - `ELASTIC_API_URL`
+
+Example Usage
+-------------
+Environment variable:
+>>> os.environ["ELASTIC_API_KEY"]
+
+Expression:
+>>> ${{ SECRETS.elastic.ELASTIC_API_KEY }}
+"""
+
+import os
+from typing import Annotated, Any
+
+
+@registry.register(
+    default_title="Normalize outputs (ECS)",
+    description="Normalize JSON objects into ECS format using an ingest pipeline.",
+    display_group="Normalization",
+    namespace="etl.normalization.ecs",
+    secrets=[elastic_secret],
+)
+async def normalize_outputs(
+    pipeline: Annotated[
+        str | dict[str, Any],
+        Field(..., description="Ingest pipeline definition. Can be a dictionary or URL to a YAML definition file."),
+    ],
+    docs: Annotated[
+        list[dict[str, Any]],
+        Field(..., description="List of JSON objects to normalize into ECS format."),
+    ],
+) -> list[dict[str, Any]]:
+    api_key = os.getenv("ELASTIC_API_KEY")
+    api_url = os.getenv("ELASTIC_API_URL", "http://localhost:9200")
+
+    url = f"{api_url}/_ingest/pipeline/_simulate"
+    headers={"Content-Type": "application/json"}
+    if api_key is not None:
+        headers["Authorization"] = f"ApiKey {api_key}"
+
+    if isinstance(pipeline, str):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(pipeline)
+            response.raise_for_status()
+            pipeline = safe_load(response.text)
+
+    query = {"pipeline": pipeline, "docs": docs}
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, headers=headers, json=query)
+        response.raise_for_status()  # Raise an exception for HTTP errors
+        return response.json()

--- a/tracecat/actions/etl/normalization/ecs.py
+++ b/tracecat/actions/etl/normalization/ecs.py
@@ -1,7 +1,7 @@
-"""Action that uses Elasticsearch to normalize data into ECS format.
+"""Action that uses Elasticsearch to normalize data to ECS format.
 
 We use the Elasticsearch's REST API and ingest endpoints.
-In particular, we use the `simulate` pipeline API to normalize data into ECS format without storing it.
+In particular, we use the `simulate` pipeline API to normalize data to ECS format without storing it.
 
 Authentication (in order of precedence):
 1. Connect to Elasticsearch in the local environment (port 9200).
@@ -47,19 +47,19 @@ from typing import Annotated, Any
 
 @registry.register(
     default_title="Normalize events (ECS)",
-    description="Normalize JSON objects into ECS format using an ingest pipeline.",
+    description="Normalize JSON objects to ECS format using an Elastic ingest pipeline.",
     display_group="Normalization",
-    namespace="etl.normalization.ecs",
+    namespace="etl.normalization",
     secrets=[elastic_secret],
 )
-async def normalize_events(
+async def normalize_events_to_ecs(
     pipeline: Annotated[
         str | dict[str, Any],
         Field(..., description="Ingest pipeline definition. Can be a dictionary or URL to a YAML definition file."),
     ],
     data: Annotated[
         list[dict[str, Any]],
-        Field(..., description="List of JSON objects to normalize into ECS format."),
+        Field(..., description="List of JSON objects."),
     ],
 ) -> list[dict[str, Any]]:
     api_key = os.getenv("ELASTIC_API_KEY")

--- a/tracecat/actions/integrations/__init__.py
+++ b/tracecat/actions/integrations/__init__.py
@@ -1,5 +1,3 @@
-from tracecat.actions.etl import extraction
-
 from . import cdr, chat, edr, email, enrichment, iam, siem, sinks
 
 __all__ = [


### PR DESCRIPTION
## What changed
- Added integration to elastic ingest pipeline REST API
- Namespaced action as `etl.normalization.normalize_events_to_ecs`
- Uses "events" as the common terminology for any JSON input / output / logs emitted or received by Tracecat actions
- Added elasticsearch (with security mode off) to docker compose stacks

## QA
- To do in: #378