### PR TITLE
feat(engine): Mask secrets

### DIFF
--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -74,11 +74,34 @@ def test_apply_masks_object_with_string():
     )
 
 
-def test_apply_masks_object_with_list():
+def test_apply_masks_object_with_tuple():
+    """
+    Test apply_masks_object with a tuple.
+    """
     masks = ["secret", "password"]
-    input_list = ["This is a secret message", "No sensitive data here"]
-    expected_list = ["This is a *** message", "No sensitive data here"]
-    assert apply_masks_object(input_list, masks) == expected_list
+    input_tuple = ("This is a secret message", "No sensitive data here")
+    expected_tuple = ("This is a *** message", "No sensitive data here")
+    assert apply_masks_object(input_tuple, masks) == expected_tuple
+
+
+def test_apply_masks_object_with_mixed_types():
+    """
+    Test apply_masks_object with mixed types.
+    """
+    masks = ["secret", "password"]
+    input_data = [
+        "This is a secret message",
+        {"key": "password123"},
+        ("No sensitive data here", "Another secret"),
+        ["No sensitive data here", "Another secret in a list"],
+    ]
+    expected_data = [
+        "This is a *** message",
+        {"key": "***123"},
+        ("No sensitive data here", "Another ***"),
+        ["No sensitive data here", "Another *** in a list"],
+    ]
+    assert apply_masks_object(input_data, masks) == expected_data
 
 
 def test_apply_masks_object_with_dict():

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -20,6 +20,7 @@ from temporalio.common import RetryPolicy
 from temporalio.worker import Worker
 
 from tests.shared import TEST_WF_ID, generate_test_exec_id
+from tracecat import config
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import Workflow
@@ -1119,8 +1120,9 @@ async def test_multiple_child_workflow_environments_have_correct_defaults(
 
 @pytest.mark.asyncio
 async def test_single_child_workflow_get_correct_secret_environment(
-    temporal_cluster, test_role, temporal_client
+    temporal_cluster, test_role, temporal_client, monkeysession: pytest.MonkeyPatch
 ):
+    monkeysession.setattr(config, "TRACECAT__UNSAFE_DISABLE_SM_MASKING", True)
     test_name = f"{test_single_child_workflow_get_correct_secret_environment.__name__}"
     test_description = "Test that a single child workflow can get a secret from the correect environment"
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -120,6 +120,17 @@ SMTP_IGNORE_CERT_ERRORS = os.environ.get("SMTP_IGNORE_CERT_ERRORS", "0").lower()
     "1",
     "true",
 )
-SMTP_AUTH_ENABLED = os.environ.get("SMTP_AUTH_ENABLED", "0").lower() in (1, "true")
+SMTP_AUTH_ENABLED = os.environ.get("SMTP_AUTH_ENABLED", "0").lower() in ("1", "true")
 SMTP_USER = os.environ.get("SMTP_USER", "")
 SMTP_PASS = os.environ.get("SMTP_PASS", "")
+
+
+# Secrets manager config
+TRACECAT__UNSAFE_DISABLE_SM_MASKING = os.environ.get(
+    "TRACECAT__UNSAFE_DISABLE_SM_MASKING",
+    "0",  # Default to False
+).lower() in ("1", "true")
+"""Disable masking of secrets in the secrets manager.
+    WARNING: This is only be used for testing and debugging purposes during
+    development and should never be enabled in production.
+"""

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -112,12 +112,12 @@ RETRY_STOP_AFTER_ATTEMPT = 5
 SMTP_HOST = os.environ.get("SMTP_HOST", "")
 SMTP_PORT = os.environ.get("SMTP_PORT", 25)
 SMTP_STARTTLS_ENABLED = os.environ.get("SMTP_STARTTLS_ENABLED", "0").lower() in (
-    1,
+    "1",
     "true",
 )
-SMTP_SSL_ENABLED = os.environ.get("SMTP_SSL_ENABLED", "0").lower() in (1, "true")
+SMTP_SSL_ENABLED = os.environ.get("SMTP_SSL_ENABLED", "0").lower() in ("1", "true")
 SMTP_IGNORE_CERT_ERRORS = os.environ.get("SMTP_IGNORE_CERT_ERRORS", "0").lower() in (
-    1,
+    "1",
     "true",
 )
 SMTP_AUTH_ENABLED = os.environ.get("SMTP_AUTH_ENABLED", "0").lower() in (1, "true")

--- a/tracecat/secrets/common.py
+++ b/tracecat/secrets/common.py
@@ -1,0 +1,25 @@
+import re
+from collections.abc import Iterable
+
+from tracecat.secrets.constants import MASK_VALUE
+
+
+def apply_masks(value: str, masks: Iterable[str]) -> str:
+    if not masks:
+        return value
+
+    pattern = "|".join(map(re.escape, masks))
+    return re.sub(pattern, MASK_VALUE, value)
+
+
+def apply_masks_object[T](obj: T, masks: Iterable[str]) -> T:
+    """Process jsonpaths in strings, lists, and dictionaries."""
+    match obj:
+        case str():
+            return apply_masks(obj, masks)
+        case list():
+            return [apply_masks_object(item, masks) for item in obj]
+        case dict():
+            return {k: apply_masks_object(v, masks) for k, v in obj.items()}
+        case _:
+            return obj

--- a/tracecat/secrets/common.py
+++ b/tracecat/secrets/common.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
 
 from tracecat.secrets.constants import MASK_VALUE
 
@@ -13,13 +13,13 @@ def apply_masks(value: str, masks: Iterable[str]) -> str:
 
 
 def apply_masks_object[T](obj: T, masks: Iterable[str]) -> T:
-    """Process jsonpaths in strings, lists, and dictionaries."""
+    """Process jsonpaths in strings, sequences, and mappings."""
     match obj:
         case str():
             return apply_masks(obj, masks)
-        case list():
-            return [apply_masks_object(item, masks) for item in obj]
-        case dict():
-            return {k: apply_masks_object(v, masks) for k, v in obj.items()}
+        case Sequence():
+            return type(obj)(apply_masks_object(item, masks) for item in obj)
+        case Mapping():
+            return type(obj)((k, apply_masks_object(v, masks)) for k, v in obj.items())
         case _:
             return obj

--- a/tracecat/secrets/constants.py
+++ b/tracecat/secrets/constants.py
@@ -1,1 +1,2 @@
 DEFAULT_SECRETS_ENVIRONMENT = "default"
+MASK_VALUE = "***"


### PR DESCRIPTION
# Changes
- Fix JSONDecodeError in run history
- Add secret masking in udf inputs/outputs
- Add environment variable `TRACECAT__UNSAFE_DISABLE_SM_MASKING` to toggle masking secrets. We don't expose this in .env.example.

Invariants or non-negotiables
- Any secret values returned by UDFs will be fully masked
   - If you try to use a result that involves a secret value, you will receive the masked value
    - This is intentional, as otherwise we are crossing a security boundary
    - The only secure method of retrieving secrets is using the SM inside an integration or secret expression.