### PR TITLE
feat+refactor(engine): Pull based workflows for schedules + general schedule improvements

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -185,6 +185,73 @@ export const $ActionStatement = {
     title: 'ActionStatement'
 } as const;
 
+export const $ActionStatement_Any_ = {
+    properties: {
+        ref: {
+            type: 'string',
+            pattern: '^[a-z0-9_]+$',
+            title: 'Ref',
+            description: 'Unique reference for the task'
+        },
+        description: {
+            type: 'string',
+            title: 'Description',
+            default: ''
+        },
+        action: {
+            type: 'string',
+            pattern: '^[a-z0-9_.]+$',
+            title: 'Action',
+            description: 'Action type. Equivalent to the UDF key.'
+        },
+        args: {
+            title: 'Args',
+            description: 'Arguments for the action'
+        },
+        depends_on: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Depends On',
+            description: 'Task dependencies'
+        },
+        run_if: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Run If',
+            description: 'Condition to run the task'
+        },
+        for_each: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'For Each',
+            description: 'Iterate over a list of items and run the task for each item.'
+        }
+    },
+    type: 'object',
+    required: ['ref', 'action'],
+    title: 'ActionStatement[Any]'
+} as const;
+
 export const $ActionTest = {
     properties: {
         ref: {
@@ -1036,7 +1103,14 @@ export const $DSLRunArgs = {
             '$ref': '#/components/schemas/Role'
         },
         dsl: {
-            '$ref': '#/components/schemas/DSLInput'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/DSLInput'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         wf_id: {
             type: 'string',
@@ -1077,10 +1151,23 @@ export const $DSLRunArgs = {
             format: 'duration',
             title: 'Timeout',
             description: 'The maximum time to wait for the workflow to complete.'
+        },
+        schedule_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: 'sch-[0-9a-f]{32}'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Schedule Id',
+            description: 'The schedule ID that triggered this workflow, if any.'
         }
     },
     type: 'object',
-    required: ['role', 'dsl', 'wf_id'],
+    required: ['role', 'wf_id'],
     title: 'DSLRunArgs'
 } as const;
 
@@ -1283,9 +1370,6 @@ export const $GetWorkflowDefinitionActivityInputs = {
         role: {
             '$ref': '#/components/schemas/Role'
         },
-        task: {
-            '$ref': '#/components/schemas/ActionStatement'
-        },
         workflow_id: {
             type: 'string',
             pattern: 'wf-[0-9a-f]{32}',
@@ -1301,10 +1385,20 @@ export const $GetWorkflowDefinitionActivityInputs = {
                 }
             ],
             title: 'Version'
+        },
+        task: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/ActionStatement_Any_'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',
-    required: ['role', 'task', 'workflow_id'],
+    required: ['role', 'workflow_id'],
     title: 'GetWorkflowDefinitionActivityInputs'
 } as const;
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -63,6 +63,34 @@ export type ActionStatement = {
     for_each?: string | Array<(string)> | null;
 };
 
+export type ActionStatement_Any_ = {
+    /**
+     * Unique reference for the task
+     */
+    ref: string;
+    description?: string;
+    /**
+     * Action type. Equivalent to the UDF key.
+     */
+    action: string;
+    /**
+     * Arguments for the action
+     */
+    args?: unknown;
+    /**
+     * Task dependencies
+     */
+    depends_on?: Array<(string)>;
+    /**
+     * Condition to run the task
+     */
+    run_if?: string | null;
+    /**
+     * Iterate over a list of items and run the task for each item.
+     */
+    for_each?: string | Array<(string)> | null;
+};
+
 export type ActionTest = {
     /**
      * Action reference
@@ -350,7 +378,7 @@ export type DSLInput = {
 
 export type DSLRunArgs = {
     role: Role;
-    dsl: DSLInput;
+    dsl?: DSLInput | null;
     wf_id: string;
     trigger_inputs?: {
     [key: string]: unknown;
@@ -364,6 +392,10 @@ export type DSLRunArgs = {
      * The maximum time to wait for the workflow to complete.
      */
     timeout?: string;
+    /**
+     * The schedule ID that triggered this workflow, if any.
+     */
+    schedule_id?: string | null;
 };
 
 export type ErrorModel = {
@@ -417,9 +449,9 @@ export type EventHistoryType = 'WORKFLOW_EXECUTION_STARTED' | 'WORKFLOW_EXECUTIO
 
 export type GetWorkflowDefinitionActivityInputs = {
     role: Role;
-    task: ActionStatement;
     workflow_id: string;
     version?: number | null;
+    task?: ActionStatement_Any_ | null;
 };
 
 export type HTTPValidationError = {

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -267,7 +267,7 @@ function ChildWorkflowEventGeneralInfo({ input }: { input: DSLRunArgs }) {
         Workflow Title
       </Label>
       <DescriptorBadge
-        text={input.dsl.title}
+        text={input.dsl?.title || "No title"}
         className="font-mono font-semibold"
       />
     </div>

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -551,27 +551,27 @@ async def test_workflow_default_environment_correct(
 """Child workflow"""
 
 
-async def _setup_child_workflow(dsl: DSLInput, role: Role) -> Workflow:
+async def _create_and_commit_workflow(dsl: DSLInput, role: Role) -> Workflow:
     async with get_async_session_context_manager() as session:
         # Create the child workflow
         mgmt_service = WorkflowsManagementService(session, role=role)
-        child_res = await mgmt_service.create_workflow_from_dsl(
+        res = await mgmt_service.create_workflow_from_dsl(
             dsl.model_dump(), skip_secret_validation=True
         )
-        child_workflow = child_res.workflow
-        if not child_workflow:
-            return pytest.fail("Child workflow not created")
-        constructed_dsl = await mgmt_service.build_dsl_from_workflow(child_workflow)
+        workflow = res.workflow
+        if not workflow:
+            return pytest.fail("Workflow wasn't created")
+        constructed_dsl = await mgmt_service.build_dsl_from_workflow(workflow)
 
         # Commit the child workflow
         defn_service = WorkflowDefinitionsService(session, role=role)
         await defn_service.create_workflow_definition(
-            workflow_id=child_workflow.id, dsl=constructed_dsl
+            workflow_id=workflow.id, dsl=constructed_dsl
         )
-        return child_workflow
+        return workflow
 
 
-async def _run_parent_workflow(client: Client, wf_exec_id: str, run_args: DSLRunArgs):
+async def _run_workflow(client: Client, wf_exec_id: str, run_args: DSLRunArgs):
     queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
     async with Worker(
         client,
@@ -620,7 +620,7 @@ async def test_child_workflow_success(temporal_cluster, test_role, temporal_clie
     )
     logger.info("child dsl", child_dsl=child_dsl)
 
-    child_workflow = await _setup_child_workflow(child_dsl, test_role)
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
     # Parent
     parent_dsl = DSLInput(
         **{
@@ -657,7 +657,7 @@ async def test_child_workflow_success(temporal_cluster, test_role, temporal_clie
         role=test_role,
         wf_id=TEST_WF_ID,
     )
-    result = await _run_parent_workflow(temporal_client, wf_exec_id, run_args)
+    result = await _run_workflow(temporal_client, wf_exec_id, run_args)
 
     expected = {
         "ACTIONS": {
@@ -707,7 +707,7 @@ async def test_child_workflow_context_passing(
         }
     )
 
-    child_workflow = await _setup_child_workflow(child_dsl, test_role)
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
 
     # Parent
     parent_workflow_id = "wf-00000000000000000000000000000002"
@@ -758,7 +758,7 @@ async def test_child_workflow_context_passing(
         },
     )
 
-    result = await _run_parent_workflow(temporal_client, wf_exec_id, run_args)
+    result = await _run_workflow(temporal_client, wf_exec_id, run_args)
     # Parent expected
     expected = {
         "ACTIONS": {
@@ -823,7 +823,7 @@ async def test_single_child_workflow_override_environment_correct(
             "triggers": [],
         }
     )
-    child_workflow = await _setup_child_workflow(child_dsl, test_role)
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
 
     parent_dsl = DSLInput(
         **{
@@ -857,7 +857,7 @@ async def test_single_child_workflow_override_environment_correct(
         wf_id=TEST_WF_ID,
     )
 
-    result = await _run_parent_workflow(temporal_client, wf_exec_id, run_args)
+    result = await _run_workflow(temporal_client, wf_exec_id, run_args)
     expected = {
         "ACTIONS": {
             "parent": {
@@ -902,7 +902,7 @@ async def test_multiple_child_workflow_override_environment_correct(
             "triggers": [],
         }
     )
-    child_workflow = await _setup_child_workflow(child_dsl, test_role)
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
     parent_dsl = DSLInput(
         **{
             "title": f"{test_name}:parent",
@@ -936,7 +936,7 @@ async def test_multiple_child_workflow_override_environment_correct(
         wf_id=TEST_WF_ID,
     )
 
-    result = await _run_parent_workflow(temporal_client, wf_exec_id, run_args)
+    result = await _run_workflow(temporal_client, wf_exec_id, run_args)
     expected = {
         "ACTIONS": {
             "parent": {
@@ -982,7 +982,7 @@ async def test_single_child_workflow_environment_has_correct_default(
             "triggers": [],
         }
     )
-    child_workflow = await _setup_child_workflow(child_dsl, test_role)
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
     parent_dsl = DSLInput(
         **{
             "title": f"{test_name}:parent",
@@ -1015,7 +1015,7 @@ async def test_single_child_workflow_environment_has_correct_default(
         wf_id=TEST_WF_ID,
     )
 
-    result = await _run_parent_workflow(temporal_client, wf_exec_id, run_args)
+    result = await _run_workflow(temporal_client, wf_exec_id, run_args)
     expected = {
         "ACTIONS": {
             "parent": {
@@ -1063,7 +1063,7 @@ async def test_multiple_child_workflow_environments_have_correct_defaults(
             "triggers": [],
         }
     )
-    child_workflow = await _setup_child_workflow(child_dsl, test_role)
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
 
     parent_dsl = DSLInput(
         **{
@@ -1100,7 +1100,7 @@ async def test_multiple_child_workflow_environments_have_correct_defaults(
         wf_id=TEST_WF_ID,
     )
 
-    result = await _run_parent_workflow(temporal_client, wf_exec_id, run_args)
+    result = await _run_workflow(temporal_client, wf_exec_id, run_args)
     expected = {
         "ACTIONS": {
             "parent": {
@@ -1169,7 +1169,7 @@ async def test_single_child_workflow_get_correct_secret_environment(
             "triggers": [],
         }
     )
-    child_workflow = await _setup_child_workflow(child_dsl, test_role)
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
     parent_dsl = DSLInput(
         **{
             "title": f"{test_name}:parent",
@@ -1203,7 +1203,7 @@ async def test_single_child_workflow_get_correct_secret_environment(
         wf_id=TEST_WF_ID,
     )
 
-    result = await _run_parent_workflow(temporal_client, wf_exec_id, run_args)
+    result = await _run_workflow(temporal_client, wf_exec_id, run_args)
     expected = {
         "ACTIONS": {
             "parent": {

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -16,7 +16,7 @@ from tracecat.dsl.graph import RFEdge, RFGraph, TriggerNode, UDFNode, UDFNodeDat
 from tracecat.dsl.models import ActionStatement, ActionTest, DSLConfig, Trigger
 from tracecat.dsl.validation import SchemaValidatorFactory
 from tracecat.expressions import patterns
-from tracecat.identifiers import WorkflowID
+from tracecat.identifiers import ScheduleID, WorkflowID
 from tracecat.logging import logger
 from tracecat.parse import traverse_leaves
 from tracecat.types.auth import Role
@@ -190,7 +190,7 @@ class DSLInput(BaseModel):
 
 class DSLRunArgs(BaseModel):
     role: Role
-    dsl: DSLInput
+    dsl: DSLInput | None = None
     wf_id: WorkflowID
     trigger_inputs: dict[str, Any] | None = None
     parent_run_context: RunContext | None = None
@@ -204,6 +204,10 @@ class DSLRunArgs(BaseModel):
     timeout: timedelta = Field(
         default_factory=lambda: timedelta(minutes=5),
         description="The maximum time to wait for the workflow to complete.",
+    )
+    schedule_id: ScheduleID | None = Field(
+        None,
+        description="The schedule ID that triggered this workflow, if any.",
     )
 
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -356,6 +356,7 @@ class DSLWorkflow:
             # Use the provided DSL
             self.logger.debug("Using provided workflow definition")
             self.dsl = args.dsl
+            self.dispatch_type = "push"
         else:
             # Otherwise, fetch the latest workflow definition
             self.logger.debug("Fetching latest workflow definition")
@@ -368,6 +369,7 @@ class DSLWorkflow:
                     non_retryable=True,
                     type=e.__class__.__name__,
                 ) from e
+            self.dispatch_type = "pull"
 
         if "runtime_config" in args.model_fields_set:
             # Use the override runtime config if it's set
@@ -398,7 +400,10 @@ class DSLWorkflow:
             INPUTS=self.dsl.inputs,
             TRIGGER=trigger_inputs,
             ENV=DSLEnvironment(
-                workflow={"start_time": wf_info.start_time},
+                workflow={
+                    "start_time": wf_info.start_time,
+                    "dispatch_type": self.dispatch_type,
+                },
                 environment=self.runtime_config.environment,
                 variables={},
             ),

--- a/tracecat/types/exceptions.py
+++ b/tracecat/types/exceptions.py
@@ -40,3 +40,11 @@ class TracecatAuthorizationError(TracecatException):
 
 class TracecatManagementError(TracecatException):
     """Tracecat user-facing management error"""
+
+
+class TracecatNotFoundError(TracecatException):
+    """Raised when a resource is not found in the Tracecat database."""
+
+
+class TracecatServiceError(TracecatException):
+    """Tracecat generic user-facing service error"""

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -230,7 +230,8 @@ class WorkflowExecutionsService:
                         )
                     )
                 case EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
-                    group = EventGroup.from_scheduled_activity(event)
+                    if not (group := EventGroup.from_scheduled_activity(event)):
+                        continue
                     event_group_names[event.event_id] = group
                     events.append(
                         EventHistoryResponse(
@@ -246,7 +247,8 @@ class WorkflowExecutionsService:
                     parent_event_id = (
                         event.activity_task_started_event_attributes.scheduled_event_id
                     )
-                    group = event_group_names.get(parent_event_id)
+                    if not (group := event_group_names.get(parent_event_id)):
+                        continue
                     event_group_names[event.event_id] = group
                     events.append(
                         EventHistoryResponse(
@@ -260,7 +262,8 @@ class WorkflowExecutionsService:
                 case EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
                     # The task completiong comes with the scheduled event ID and the started event id
                     gparent_event_id = event.activity_task_completed_event_attributes.scheduled_event_id
-                    group = event_group_names.get(gparent_event_id)
+                    if not (group := event_group_names.get(gparent_event_id)):
+                        continue
                     event_group_names[event.event_id] = group
                     result = _extract_first(
                         event.activity_task_completed_event_attributes.result
@@ -279,7 +282,8 @@ class WorkflowExecutionsService:
                     gparent_event_id = (
                         event.activity_task_failed_event_attributes.scheduled_event_id
                     )
-                    group = event_group_names.get(gparent_event_id)
+                    if not (group := event_group_names.get(gparent_event_id)):
+                        continue
                     event_group_names[event.event_id] = group
                     events.append(
                         EventHistoryResponse(

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -70,9 +70,9 @@ class CreateWorkflowParams(BaseModel):
 
 class GetWorkflowDefinitionActivityInputs(BaseModel):
     role: Role
-    task: ActionStatement
     workflow_id: WorkflowID
     version: int | None = None
+    task: ActionStatement[Any] | None = None
 
 
 WorkflowExportFormat = Literal["json", "yaml"]

--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -62,9 +62,9 @@ async def create_schedule(
 async def delete_schedule(schedule_id: ScheduleID) -> None:
     handle = await _get_handle(schedule_id)
     try:
-        return await handle.delete()
+        await handle.delete()
     except Exception as e:
-        if "workflow execution already completed" not in str(e):
+        if "workflow execution already completed" not in str(e).lower():
             raise RuntimeError(f"Error deleting schedule: {e}") from e
     return None
 

--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -1,13 +1,11 @@
 from datetime import datetime, timedelta
-from typing import Any
 
 import temporalio.client
 
 from tracecat import config
 from tracecat.contexts import ctx_role
 from tracecat.dsl.client import get_temporal_client
-from tracecat.dsl.common import DSLInput, DSLRunArgs
-from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.dsl.common import DSLRunArgs
 from tracecat.identifiers import ScheduleID, WorkflowID
 from tracecat.workflow.schedules.models import ScheduleUpdate
 
@@ -20,29 +18,32 @@ async def _get_handle(schedule_id: ScheduleID) -> temporalio.client.ScheduleHand
 async def create_schedule(
     workflow_id: WorkflowID,
     schedule_id: ScheduleID,
-    dsl: DSLInput,
-    # Schedule config
+    *,
     every: timedelta,
     offset: timedelta | None = None,
     start_at: datetime | None = None,
     end_at: datetime | None = None,
-    trigger_inputs: dict[str, Any] | None = None,
-    **kwargs: Any,
 ) -> temporalio.client.ScheduleHandle:
+    # Importing here to avoid circular imports...
+    from tracecat.dsl.workflow import DSLWorkflow
+
     client = await get_temporal_client()
 
     workflow_schedule_id = f"{workflow_id}:{schedule_id}"
+
     return await client.create_schedule(
         schedule_id,
         temporalio.client.Schedule(
             action=temporalio.client.ScheduleActionStartWorkflow(
                 DSLWorkflow.run,
-                # The args that should run in the scheduled workflow
+                # Scheduled workflow only needs to know the workflow ID
+                # and the role of the user who scheduled it. Everything else
+                # is pulled inside the workflow itself.
                 DSLRunArgs(
-                    dsl=dsl,
                     role=ctx_role.get(),
                     wf_id=workflow_id,
-                    trigger_inputs=trigger_inputs,
+                    schedule_id=schedule_id,
+                    timeout=timedelta(minutes=5),
                 ),
                 id=workflow_schedule_id,
                 task_queue=config.TEMPORAL__CLUSTER_QUEUE,
@@ -55,7 +56,6 @@ async def create_schedule(
                 end_at=end_at,
             ),
         ),
-        **kwargs,
     )
 
 

--- a/tracecat/workflow/schedules/models.py
+++ b/tracecat/workflow/schedules/models.py
@@ -3,7 +3,23 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from tracecat.identifiers import WorkflowID
+from tracecat.identifiers import OwnerID, ScheduleID, WorkflowID
+from tracecat.types.auth import Role
+
+
+class ScheduleRead(BaseModel):
+    id: ScheduleID
+    owner_id: OwnerID
+    created_at: datetime
+    updated_at: datetime
+    workflow_id: WorkflowID
+    inputs: dict[str, Any] = Field(..., default_factory=dict)
+    cron: str | None = None
+    every: timedelta | None = None
+    offset: timedelta | None = None
+    start_at: datetime | None = None
+    end_at: datetime | None = None
+    status: Literal["online", "offline"]
 
 
 class ScheduleCreate(BaseModel):
@@ -34,3 +50,9 @@ class ScheduleSearch(BaseModel):
     query: str | None = None
     group_by: list[str] | None = None
     agg: str | None = None
+
+
+class GetScheduleActivityInputs(BaseModel):
+    role: Role
+    schedule_id: ScheduleID
+    workflow_id: WorkflowID

--- a/tracecat/workflow/schedules/router.py
+++ b/tracecat/workflow/schedules/router.py
@@ -38,10 +38,10 @@ async def create_schedule(
     try:
         return await service.create_schedule(params)
     except TracecatServiceError as e:
-        logger.exception("Error creating schedule")
+        logger.error("Error creating schedule", error=e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error creating schedule: {e}",
+            detail=f"Error creating schedule: {e}. Please try again or contact support.",
         ) from e
 
 
@@ -54,8 +54,10 @@ async def get_schedule(
     try:
         return await service.get_schedule(schedule_id)
     except TracecatNotFoundError as e:
+        logger.error("Error getting schedule", error=e)
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Schedule {schedule_id} not found. Please check whether this schedule exists and try again.",
         ) from e
 
 
@@ -72,12 +74,14 @@ async def update_schedule(
         return await service.update_schedule(schedule_id, params)
     except TracecatNotFoundError as e:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Schedule {schedule_id} not found. Please check whether this schedule exists and try again.",
         ) from e
     except TracecatServiceError as e:
+        logger.error("Error updating schedule", error=e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error updating schedule: {e}",
+            detail=f"Failed to update schedule: {e}. Please try again or contact support.",
         ) from e
 
 
@@ -93,19 +97,11 @@ async def delete_schedule(
     service = WorkflowSchedulesService(session, role=role)
     try:
         await service.delete_schedule(schedule_id)
-    except TracecatNotFoundError as e:
-        logger.warning(
-            "Schedule not found, attempt to delete underlying Temporal schedule...",
-            schedule_id=schedule_id,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found"
-        ) from e
     except TracecatServiceError as e:
         logger.error("Error deleting schedule", error=e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error deleting schedule",
+            detail=f"Failed to delete schedule: {e}. Please try again or contact support.",
         ) from e
 
 

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -1,22 +1,29 @@
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
+from typing import Any
 
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from temporalio import activity
 
 from tracecat.auth.credentials import TemporaryRole
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.db.schemas import Schedule, WorkflowDefinition
-from tracecat.dsl.common import DSLInput
+from tracecat.db.schemas import Schedule
 from tracecat.identifiers import ScheduleID, WorkflowID
 from tracecat.logging import logger
 from tracecat.types.auth import Role
+from tracecat.types.exceptions import TracecatNotFoundError, TracecatServiceError
 from tracecat.workflow.schedules import bridge
-from tracecat.workflow.schedules.models import ScheduleCreate, ScheduleUpdate
+from tracecat.workflow.schedules.models import (
+    GetScheduleActivityInputs,
+    ScheduleCreate,
+    ScheduleRead,
+    ScheduleUpdate,
+)
 
 
 class WorkflowSchedulesService:
@@ -74,44 +81,38 @@ class WorkflowSchedulesService:
 
         Raises
         ------
-        NoResultFound
-            If no workflow definition is found for the given workflow ID.
-        RuntimeError
+        TracecatServiceError
             If there is an error creating the schedule.
 
         """
-        result = await self.session.exec(
-            select(WorkflowDefinition)
-            .where(WorkflowDefinition.workflow_id == params.workflow_id)
-            .order_by(WorkflowDefinition.version.desc())  # type: ignore
-        )
-        defn_data = result.first()
-        if not defn_data:
-            raise NoResultFound("No workflow definition found for workflow ID")
-
+        owner_id = self.role.workspace_id
         schedule = Schedule(
-            owner_id=self.role.workspace_id, **params.model_dump(exclude_unset=True)
+            owner_id=owner_id,
+            workflow_id=params.workflow_id,
+            inputs=params.inputs,
+            every=params.every,
+            offset=params.offset,
+            start_at=params.start_at,
+            end_at=params.end_at,
+            cron=params.cron,
+            status="online",
         )
-        await self.session.refresh(defn_data)
-        defn = WorkflowDefinition.model_validate(defn_data)
-        dsl = DSLInput(**defn.content)
+        self.session.add(schedule)
 
         # Set the role for the schedule as the tracecat-runner
         with TemporaryRole(
             type="service",
-            user_id=defn.owner_id,
+            user_id=owner_id,
             service_id="tracecat-schedule-runner",
         ) as sch_role:
             try:
                 handle = await bridge.create_schedule(
                     workflow_id=params.workflow_id,
                     schedule_id=schedule.id,
-                    dsl=dsl,
                     every=params.every,
                     offset=params.offset,
                     start_at=params.start_at,
                     end_at=params.end_at,
-                    trigger_inputs=params.inputs,
                 )
             except Exception as e:
                 # If we fail to create the schedule in temporal
@@ -124,7 +125,7 @@ class WorkflowSchedulesService:
                     schedule_id=schedule.id,
                     sch_role=sch_role,
                 )
-                raise RuntimeError("Error creating schedule") from e
+                raise TracecatServiceError("Error creating schedule") from e
             logger.info(
                 "Created schedule",
                 handle_id=handle.id,
@@ -133,7 +134,6 @@ class WorkflowSchedulesService:
                 sch_role=sch_role,
             )
 
-        self.session.add(schedule)
         await self.session.commit()
         await self.session.refresh(schedule)
         return schedule
@@ -154,7 +154,8 @@ class WorkflowSchedulesService:
 
         Raises
         ------
-        None
+        TracecatNotFoundError
+            If the schedule is not found
 
         """
         result = await self.session.exec(
@@ -163,7 +164,10 @@ class WorkflowSchedulesService:
                 Schedule.id == schedule_id,
             )
         )
-        return result.one()
+        try:
+            return result.one()
+        except NoResultFound as e:
+            raise TracecatNotFoundError(f"Schedule {schedule_id} not found") from e
 
     async def update_schedule(
         self, schedule_id: ScheduleID, params: ScheduleUpdate
@@ -185,7 +189,7 @@ class WorkflowSchedulesService:
 
         Raises
         ------
-        RuntimeError
+        TracecatNotFoundError
             If there is an error updating the schedule.
         """
         schedule = await self.get_schedule(schedule_id)
@@ -196,7 +200,7 @@ class WorkflowSchedulesService:
         except Exception as e:
             await self.session.rollback()
             logger.error("Error updating schedule", error=e)
-            raise RuntimeError("Error updating schedule") from e
+            raise TracecatNotFoundError("Error updating schedule") from e
 
         # Update the schedule
         for key, value in params.model_dump(exclude_unset=True).items():
@@ -219,7 +223,7 @@ class WorkflowSchedulesService:
 
         Raises
         ------
-        RuntimeError
+        TracecatNotFoundError
             If an error occurs while deleting the schedule from Temporal.
 
         """
@@ -234,8 +238,8 @@ class WorkflowSchedulesService:
         try:
             # Delete the schedule from Temporal first
             await bridge.delete_schedule(schedule_id)
-        except RuntimeError as e:
-            raise e
+        except TracecatNotFoundError:
+            raise
 
         # If successful, delete the schedule from the database
         if schedule:
@@ -246,3 +250,52 @@ class WorkflowSchedulesService:
                 "Schedule was already deleted from the database",
                 schedule_id=schedule_id,
             )
+
+    @classmethod
+    def get_activities(cls) -> list[Callable[..., Any]]:
+        """Get all loaded activities in the class."""
+        return [
+            getattr(cls, method_name)
+            for method_name in dir(cls)
+            if hasattr(getattr(cls, method_name), "__temporal_activity_definition")
+        ]
+
+    @staticmethod
+    @activity.defn
+    async def get_schedule_activity(input: GetScheduleActivityInputs) -> ScheduleRead:
+        """Temporal activity to get a schedule.
+
+        Parameters
+        ----------
+        input : GetScheduleActivityInputs
+            The input parameters for retrieving the schedule.
+
+        Returns
+        -------
+        ScheduleRead
+            The schedule information.
+
+        Raises
+        ------
+        TracecatNotFoundError
+            If the schedule is not found.
+        """
+        async with WorkflowSchedulesService.with_session(role=input.role) as service:
+            try:
+                schedule = await service.get_schedule(input.schedule_id)
+                return ScheduleRead(
+                    id=schedule.id,
+                    owner_id=schedule.owner_id,
+                    created_at=schedule.created_at,
+                    updated_at=schedule.updated_at,
+                    workflow_id=schedule.workflow_id,
+                    inputs=schedule.inputs,
+                    every=schedule.every,
+                    offset=schedule.offset,
+                    start_at=schedule.start_at,
+                    end_at=schedule.end_at,
+                    cron=schedule.cron,
+                    status=schedule.status,
+                )
+            except TracecatNotFoundError:
+                raise


### PR DESCRIPTION
# Features
- Introduce concepts of `pull` and `push` based dispatch types for workflows
- What we have right now are push based workflows. We pass a `DSLInput` into the `DSLWorkflow` args, and the workflow executes it. 
- We introduce pull based workflows - we don't pass `DSLInput` or trigger inputs into workflow args. The workflow then makes a call to find the latest workflow definition and latest trigger inputs in `Schedule` table.
- All new schedules created will be `pull` based. Existing schedules are unchanged.

# Changes
- Make schedules pull based
  - They pull the latest workflow defintion
  - They pull the latest trigger input payload  in `Schedule.inputs`
- Add `TracecatNotFoundError` and `TracecatServiceError` for abstraction of 

# Todos
- Add UI to update the current trigger inputs. I've tested that the schedule correctly pulls trigger inputs from the `Schedule` table, but needs a UI.
- Add UI to update schedule interval


# Screens
https://github.com/user-attachments/assets/e94f43f1-8c11-480f-b6a6-ac543ed7bf17



