### PR TITLE
feat(integrations): Capture ReadTimeout exceptions in httpx as "expected" errors

### DIFF
--- a/tracecat/actions/core/http.py
+++ b/tracecat/actions/core/http.py
@@ -79,6 +79,9 @@ async def http_request(
         logger.error(f"HTTP request failed with status {e.response.status_code}.")
         logger.error(e.response.text)
         raise e
+    except httpx.ReadTimeout as e:
+        logger.error(f"HTTP request timed out after {timeout} seconds.")
+        raise e
 
     # Handle 204 No Content
     if response.status_code == 204:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -914,6 +914,13 @@ class DSLActivities:
                 non_retryable=True,
                 type=e.__class__.__name__,
             ) from e
+        except httpx.ReadTimeout as e:
+            act_logger.error("HTTP read timeout occurred", error=e)
+            raise ApplicationError(
+                _contextualize_message(task, "HTTP read timeout"),
+                non_retryable=True,
+                type=e.__class__.__name__,
+            ) from e
         except ApplicationError as e:
             act_logger.error("ApplicationError occurred", error=e)
             raise ApplicationError(


### PR DESCRIPTION
As per title
<img width="720" alt="Screenshot 2024-09-10 at 1 00 03 PM" src="https://github.com/user-attachments/assets/5dcb9e72-11a3-4a8e-ae32-9888ee3d21cd">

