### PR TITLE
feat(integration): Support OAuth2 flows in http core action

### DIFF
--- a/playbooks/tutorials/limacharlie/list_tags.yml
+++ b/playbooks/tutorials/limacharlie/list_tags.yml
@@ -8,6 +8,7 @@ definition:
   inputs:
     api_url: https://api.limacharlie.io/v1
     jwt_url: https://jwt.limacharlie.io
+    token_response_key: token
   returns:
     tags: ${{ ACTIONS.list_tags.result.tags }}
     sensors: ${{ ACTIONS.list_sensors_by_tags.result.sensors }}
@@ -17,6 +18,7 @@ definition:
       ref: list_tags
       args:
         url: "${{ INPUTS.api_url }}/tags/${{ SECRETS.limacharlie.LIMACHARLIE_OID }}"
+        token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         method: GET
 
@@ -26,5 +28,6 @@ definition:
         - list_tags
       args:
         url: "${{ INPUTS.api_url }}/sensors/${{ SECRETS.limacharlie.LIMACHARLIE_OID }}"
+        token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         method: GET

--- a/playbooks/tutorials/limacharlie/run_investigation.yml
+++ b/playbooks/tutorials/limacharlie/run_investigation.yml
@@ -12,6 +12,7 @@ definition:
   inputs:
     api_url: https://api.limacharlie.io/v1
     jwt_url: https://jwt.limacharlie.io
+    token_response_key: token
     payload_dir_path: "C:\\F0"
     child_workflow_id:
     batch_size: 10

--- a/playbooks/tutorials/limacharlie/run_investigation.yml
+++ b/playbooks/tutorials/limacharlie/run_investigation.yml
@@ -21,6 +21,7 @@ definition:
       ref: list_sensors_by_tags
       args:
         url: "{{ INPUTS.api_url }}/tags/{{ SECRETS.limacharlie.LIMACHARLIE_OID }}/{ TRIGGER.tags }"
+        token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "{{ INPUTS.jwt_url }}?oid={{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret={{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         method: GET
 
@@ -39,6 +40,7 @@ definition:
       for_each: ${{ for var.sensor_id in ACTIONS.extract_sensor_ids.result.sensor_ids }}
       args:
         url: "${{ INPUTS.api_url }}/${{ var.sensor_id }}/"
+        token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         payload:
           tasks: ["run --shell-command 'del ${{ INPUTS.payload_dir_path }}\\*.exe'"]

--- a/playbooks/tutorials/limacharlie/run_tests.yml
+++ b/playbooks/tutorials/limacharlie/run_tests.yml
@@ -22,6 +22,7 @@ definition:
       for_each: ${{ for var.test_id in TRIGGER.test_ids }}
       args:
         url: "${{ INPUTS.api_url }}/${{ TRIGGER.sensor_id }}/"
+        token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         payload:
           tasks: ["put --payload-name ${{ var.test_id }} --payload-path ${{ TRIGGER.payload_dir_path }}\\${{ var.test_id }}.exe"]
@@ -36,6 +37,7 @@ definition:
       for_each: ${{ for var.test_id in TRIGGER.test_ids }}
       args:
         url: "${{ INPUTS.api_url }}/${{ TRIGGER.sensor_id }}/"
+        token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         payload:
           tasks: ["run --shell-command '${{ TRIGGER.payload_dir_path }}\\${{ var.test_id }}.exe'"]

--- a/playbooks/tutorials/limacharlie/run_tests.yml
+++ b/playbooks/tutorials/limacharlie/run_tests.yml
@@ -13,6 +13,7 @@ definition:
   inputs:
     api_url: https://api.limacharlie.io/v1
     jwt_url: https://jwt.limacharlie.io
+    token_response_key: token
     datetime_format: "%Y-%m-%d %H:%M:%S"
     event_type: RECEIPT
 

--- a/tracecat/actions/core/http.py
+++ b/tracecat/actions/core/http.py
@@ -151,13 +151,13 @@ async def http_request(
         Field(description="Key to access the token in the JWT / OAuth2 response JSON"),
     ] = "access_token",
     auth_header_key: Annotated[
-        dict[str, str],
+        str,
         Field(
             description="Authorization header key to pass into HTTP headers. If None, defaults to 'Authorization'}"
         ),
     ] = None,
     auth_header_value: Annotated[
-        dict[str, str],
+        str,
         Field(
             description="Authorization header value (must contain `{token}` in the string) to pass into HTTP headers. If None, defaults to 'Bearer {token}'}"
         ),

--- a/tracecat/actions/core/http.py
+++ b/tracecat/actions/core/http.py
@@ -150,15 +150,20 @@ async def http_request(
         str,
         Field(description="Key to access the token in the JWT / OAuth2 response JSON"),
     ] = "access_token",
-    authorization_header: Annotated[
+    auth_header_key: Annotated[
         dict[str, str],
         Field(
-            description='Additional authorization header to pass into HTTP headers. If None, defaults to {"Authorization": "Bearer {token}"}'
+            description="Authorization header key to pass into HTTP headers. If None, defaults to 'Authorization'}"
+        ),
+    ] = None,
+    auth_header_value: Annotated[
+        dict[str, str],
+        Field(
+            description="Authorization header value (must contain `{token}` in the string) to pass into HTTP headers. If None, defaults to 'Bearer {token}'}"
         ),
     ] = None,
 ) -> HTTPResponse:
     access_token = None
-    auth_header = authorization_header or {"Authorization": "Bearer {token}"}
     if jwt_url is not None:
         access_token = get_jwt_token(
             url=jwt_url,
@@ -180,9 +185,7 @@ async def http_request(
         )
 
     if access_token is not None:
-        key = auth_header.keys()[0]
-        auth_header[key] = auth_header[key].format(access_token)
-        headers = {**headers, **auth_header}
+        headers[auth_header_key] = auth_header_value.format(token=access_token)
 
     try:
         async with httpx.AsyncClient(


### PR DESCRIPTION
## What changed
- Support passing OAuth parameters into http core action
- API design inspired by Cribl collector templates and Tines OAuth2 credentials type
- Updated Limacharlie playbooks (set `token_response_key` to `token`)