### PR TITLE
ci: add publishing glasskube manifest on tag

### DIFF
--- a/.github/workflows/release-glasskube.yml
+++ b/.github/workflows/release-glasskube.yml
@@ -1,0 +1,23 @@
+name: Publish Glasskube Manifest
+on:
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  publish-manifest:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: "v1.30.5"
+      - name: Build Manifest
+        run: kubectl kustomize deployments/glasskube > deployments/glasskube/glasskube-manifest.yaml
+      - name: Upload Release Artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.ref_name }} deployments/glasskube/glasskube-manifest.yaml


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR adds a new GitHub workflow that builds the Glasskube deployment manifest and uploads it as release artifact. 

**Important:** Requires #396

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Related to: #375
Requires: #396

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

Difficult, but in a fork you can create a new release (with a tag like "a.a.a") and check the actions tab (you can cancel any other workflows, they are not needed).

## [optional] What gif best describes this PR?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
