### PR TITLE
feat(engine): Template actions first version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /app
 
 # Copy the application files into the container and set ownership
 COPY --chown=apiuser:apiuser ./tracecat /app/tracecat
+COPY --chown=apiuser:apiuser ./templates /app/templates
 COPY --chown=apiuser:apiuser ./pyproject.toml /app/pyproject.toml
 COPY --chown=apiuser:apiuser ./README.md /app/README.md
 COPY --chown=apiuser:apiuser ./LICENSE /app/LICENSE

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,7 @@ WORKDIR /app
 
 # Copy the application files into the container
 COPY ./tracecat /app/tracecat
+COPY ./templates /app/templates
 COPY ./pyproject.toml /app/pyproject.toml
 COPY ./README.md /app/README.md
 COPY ./LICENSE /app/LICENSE

--- a/templates/_example_hit_localhost_server.yml
+++ b/templates/_example_hit_localhost_server.yml
@@ -1,0 +1,29 @@
+# Template actions are used to define a reusable set of arguments
+type: action
+definition:
+  title: Hit localhost server
+  description: Make a http request to a localhost server
+  action: integrations.test.localhost
+  namespace: integrations.test
+  display_group: Testing
+  expects:
+    domain:
+      type: str
+      description: The domain to hit
+      default: host.docker.internal
+    port:
+      type: int
+      description: The port to hit
+      default: 8005
+  # Layers are used to define a sequence of operations
+  layers:
+    - ref: base
+      action: core.http_request
+      args:
+        url: http://${{ inputs.domain }}:${{ inputs.port }}
+        method: GET
+        headers:
+          Content-Type: application/json
+        payload:
+          data: 100
+  returns: ${{ layers.base.result }}

--- a/templates/_example_template_action.yml
+++ b/templates/_example_template_action.yml
@@ -1,0 +1,35 @@
+# Template actions are used to define a reusable set of arguments
+type: action
+definition:
+  title: Example Template Action
+  description: This is just an example template action
+  action: integrations.test.wrapper
+  namespace: integrations.test
+  display_group: Testing
+  secrets:
+    - name: test_secret
+      keys: ["KEY"]
+
+  expects:
+    service_source:
+      type: str
+      description: The service source
+      default: elastic
+    limit:
+      type: int | None
+      description: The limit
+  # Layers are used to define a sequence of operations
+  layers:
+    - ref: base
+      action: core.transform.reshape
+      args:
+        value:
+          service_source: ${{ inputs.service_source }}
+          data: 100
+    - ref: final
+      action: core.transform.reshape
+      args:
+        value:
+          - ${{ layers.base.result.data + 100 }}
+          - ${{ layers.base.result.service_source }}
+  returns: ${{ layers.final.result }}

--- a/tests/unit/test_template_actions.py
+++ b/tests/unit/test_template_actions.py
@@ -1,0 +1,147 @@
+import pytest
+
+from tracecat.expressions.expectations import ExpectedField
+from tracecat.registry import ActionLayer, RegistrySecret, TemplateAction
+
+
+def test_construct_template_action():
+    data = {
+        "type": "action",
+        "definition": {
+            "title": "Test Action",
+            "description": "This is just a test",
+            "action": "integrations.test.wrapper",
+            "namespace": "integrations.test",
+            "display_group": "Testing",
+            "secrets": [{"name": "test_secret", "keys": ["KEY"]}],
+            "expects": {
+                "service_source": {
+                    "type": "str",
+                    "description": "The service source",
+                    "default": "elastic",
+                },
+                "limit": {"type": "int | None", "description": "The limit"},
+            },
+            "layers": [
+                {
+                    "ref": "base",
+                    "action": "core.transform.reshape",
+                    "args": {
+                        "value": {
+                            "service_source": "${{ inputs.service_source }}",
+                            "data": 100,
+                        }
+                    },
+                },
+                {
+                    "ref": "final",
+                    "action": "core.transform.reshape",
+                    "args": {
+                        "value": [
+                            "${{ layers.base.result.data + 100 }}",
+                            "${{ layers.base.result.service_source }}",
+                        ]
+                    },
+                },
+            ],
+            "returns": "${{ layers.final.result }}",
+        },
+    }
+
+    try:
+        action = TemplateAction.model_validate(data)
+    except Exception as e:
+        pytest.fail(f"Failed to construct template action: {e}")
+    else:
+        assert action.definition.title == "Test Action"
+        assert action.definition.description == "This is just a test"
+        assert action.definition.action == "integrations.test.wrapper"
+        assert action.definition.namespace == "integrations.test"
+        assert action.definition.display_group == "Testing"
+        assert action.definition.secrets == [
+            RegistrySecret(name="test_secret", keys=["KEY"])
+        ]
+        assert action.definition.expects == {
+            "service_source": ExpectedField(
+                type="str",
+                description="The service source",
+                default="elastic",
+            ),
+            "limit": ExpectedField(
+                type="int | None",
+                description="The limit",
+            ),
+        }
+        assert action.definition.layers == [
+            ActionLayer(
+                ref="base",
+                action="core.transform.reshape",
+                args={
+                    "value": {
+                        "service_source": "${{ inputs.service_source }}",
+                        "data": 100,
+                    }
+                },
+            ),
+            ActionLayer(
+                ref="final",
+                action="core.transform.reshape",
+                args={
+                    "value": [
+                        "${{ layers.base.result.data + 100 }}",
+                        "${{ layers.base.result.service_source }}",
+                    ]
+                },
+            ),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_template_action_run():
+    action = TemplateAction(
+        **{
+            "type": "action",
+            "definition": {
+                "title": "Test Action",
+                "description": "This is just a test",
+                "action": "integrations.test.wrapper",
+                "namespace": "integrations.test",
+                "display_group": "Testing",
+                "secrets": [{"name": "test_secret", "keys": ["KEY"]}],
+                "expects": {
+                    "service_source": {
+                        "type": "str",
+                        "description": "The service source",
+                        "default": "elastic",
+                    },
+                    "limit": {"type": "int | None", "description": "The limit"},
+                },
+                "layers": [
+                    {
+                        "ref": "base",
+                        "action": "core.transform.reshape",
+                        "args": {
+                            "value": {
+                                "service_source": "${{ inputs.service_source }}",
+                                "data": 100,
+                            }
+                        },
+                    },
+                    {
+                        "ref": "final",
+                        "action": "core.transform.reshape",
+                        "args": {
+                            "value": [
+                                "${{ layers.base.result.data + 100 }}",
+                                "${{ layers.base.result.service_source }}",
+                            ]
+                        },
+                    },
+                ],
+                "returns": "${{ layers.final.result }}",
+            },
+        }
+    )
+
+    result = await action.run(args={"service_source": "elastic"}, base_context={})
+    assert result == [200, "elastic"]

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -978,7 +978,11 @@ class DSLActivities:
                 try:
                     async with GatheringTaskGroup() as tg:
                         for patched_args in iterator:
-                            tg.create_task(udf.run_async(patched_args))
+                            tg.create_task(
+                                udf.run_async(
+                                    args=patched_args, context=context_with_secrets
+                                )
+                            )
 
                     result = tg.results()
                 except* Exception as eg:
@@ -994,8 +998,8 @@ class DSLActivities:
                     ) from eg
 
             else:
-                args = eval_templated_object(task.args, operand=context_with_secrets)
-                result = await udf.run_async(args)
+                args = _evaluate_templated_args(task, context_with_secrets)
+                result = await udf.run_async(args=args, context=context_with_secrets)
 
             if mask_values:
                 result = apply_masks_object(result, masks=mask_values)

--- a/tracecat/expressions/parser/evaluator.py
+++ b/tracecat/expressions/parser/evaluator.py
@@ -148,6 +148,24 @@ class ExprEvaluator(Transformer):
         )
 
     @v_args(inline=True)
+    def template_action_inputs(self, jsonpath: str):
+        logger.trace("Visiting template_action_inputs:", args=jsonpath)
+        return functions.eval_jsonpath(
+            ExprContext.TEMPLATE_ACTION_INPUTS + jsonpath,
+            self._context,
+            strict=self._strict,
+        )
+
+    @v_args(inline=True)
+    def template_action_layers(self, jsonpath: str):
+        logger.trace("Visiting template_action_layers:", args=jsonpath)
+        return functions.eval_jsonpath(
+            ExprContext.TEMPLATE_ACTION_LAYERS + jsonpath,
+            self._context,
+            strict=self._strict,
+        )
+
+    @v_args(inline=True)
     def function(self, fn_name: str, fn_args: Sequence[Any]):
         is_mapped = fn_name.endswith(".map")
         fn_name = fn_name.rsplit(".", 1)[0] if is_mapped else fn_name

--- a/tracecat/expressions/parser/grammar.py
+++ b/tracecat/expressions/parser/grammar.py
@@ -25,6 +25,8 @@ binary_op: expression OPERATOR expression
         | local_vars
         | trigger
         | function
+        | template_action_inputs
+        | template_action_layers
 
 arg_list: (expression ("," expression)*)?
 
@@ -37,6 +39,9 @@ local_vars: "var" jsonpath_expression
 trigger: "TRIGGER" jsonpath_expression
 function: "FN." FN_NAME_WITH_TRANSFORM "(" [arg_list] ")"
 local_vars_assignment: "var" ATTRIBUTE_PATH
+
+template_action_inputs: "inputs" jsonpath_expression
+template_action_layers: "layers" jsonpath_expression
 
 
 

--- a/tracecat/expressions/shared.py
+++ b/tracecat/expressions/shared.py
@@ -12,13 +12,19 @@ class TracecatEnum(StrEnum):
 
 
 class ExprContext(TracecatEnum):
+    """Global contexts"""
+
     ACTIONS = "ACTIONS"
     SECRETS = "SECRETS"
     FN = "FN"
     INPUTS = "INPUTS"
     ENV = "ENV"
     TRIGGER = "TRIGGER"
-    LOCAL_VARS = "var"  # Action-local variables
+
+    """Action-local variables"""
+    LOCAL_VARS = "var"
+    TEMPLATE_ACTION_INPUTS = "inputs"
+    TEMPLATE_ACTION_LAYERS = "layers"
 
 
 class ExprType(TracecatEnum):


### PR DESCRIPTION
# Features
- Register a UDF from a templated action definition 
    - You can think of these are wrappers around UDFs, that can provide additional functionality over plain udfs
    - For example, this makes it easy to perform `reshape` after a regular UDF
- Introduce new action-local contexts (notice lowercase) `inputs` and `layers`
  - Reference the UDF argments using `inputs`
  - Action layers 
      - A template action is composed of smaller layers, that are regular UDFs
      - Layers are run sequentially, in the order it is defined in the `layers` list. The action-local context is updated with the each layer's result
      - Reference a layer is by its `ref`. e.g. `ref: my_layer` -> `${{ layers.my_layer.result }}`
- Added some examples and tests that better showcase the functionality

# Warning
- You cannot invoke the `var` context inside a template action, as it has no understanding of control flow
- You should not invoke the `INPUTS` context here, as this may not exist in the calling workflow. Think of a getting a global variable from inside a python function.

# Testing
- [x] Regular udf chaining
- [x] Run template action in for loop
- [x] Test that layer can correctly access secrets (check by disabling SM masking)