### PR TITLE
feat(engine+ui): Prevent users from configuring registry_version for now

### DIFF
--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -93,6 +93,7 @@ class DSLConfig(BaseModel):
     registry_version: str = Field(
         default=REGISTRY_VERSION,
         description="The registry version to use for the workflow.",
+        exclude=True,  # Prevent users from configuring this
     )
 
 


### PR DESCRIPTION
We need a better way to manage registry versions.