### PR TITLE
feat(engine): Add optional keys for registry secret

### DIFF
--- a/registry/tracecat_registry/_internal/models.py
+++ b/registry/tracecat_registry/_internal/models.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import BaseModel, StringConstraints
+from pydantic import BaseModel, StringConstraints, model_validator
 
 SecretName = Annotated[str, StringConstraints(pattern=r"[a-z0-9_]+")]
 """Validator for a secret name. e.g. 'aws_access_key_id'"""
@@ -11,4 +11,13 @@ SecretKey = Annotated[str, StringConstraints(pattern=r"[a-zA-Z0-9_]+")]
 
 class RegistrySecret(BaseModel):
     name: SecretName
-    keys: list[SecretKey]
+    keys: list[SecretKey] | None = None
+    optional_keys: list[SecretKey] | None = None
+
+    @model_validator(mode="after")
+    def validate_keys(cls, v):
+        if v.keys is None and v.optional_keys is None:
+            raise ValueError(
+                "At least one of 'keys' or 'optional_keys' must be specified"
+            )
+        return v


### PR DESCRIPTION
# Features
- `RegistrySecret.keys` remains as required keys
- Use `RegistrySecret.optional_keys` to define optional keys