### PR TITLE
fix(engine): Better HTTP error propagation

### DIFF
--- a/frontend/src/components/workbench/panel/udf-panel.tsx
+++ b/frontend/src/components/workbench/panel/udf-panel.tsx
@@ -237,7 +237,7 @@ export function UDFActionPanel({
                       <p className="mt-2 text-xs text-muted-foreground">
                         Type: {registryAction.type === "udf" && "UDF"}
                         {registryAction.type === "template" &&
-                          "Tempalte Action"}
+                          "Template Action"}
                       </p>
                       <p className="mt-2 text-xs text-muted-foreground">
                         Origin: {registryAction.origin}

--- a/tracecat/registry/actions/router.py
+++ b/tracecat/registry/actions/router.py
@@ -123,8 +123,11 @@ async def run_registry_action(
     try:
         return await executor.run_action_from_input(input=action_input)
     except Exception as e:
-        act_logger.error(f"Error running action {action_name} in executor: {e}")
-        raise
+        act_logger.error("Error running action", action_name=action_name, error=e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        ) from e
 
 
 @router.post("/{action_name}/validate")

--- a/tracecat/registry/executor.py
+++ b/tracecat/registry/executor.py
@@ -58,8 +58,10 @@ async def _run_action_direct(
         logger.info("Running UDF sync")
         return await asyncio.to_thread(action.fn, **args)
     except Exception as e:
-        logger.error(f"Error running UDF {action.action!r}: {e}")
-        raise
+        logger.error(
+            f"Error running UDF {action.action!r}", error=e, type=type(e).__name__
+        )
+        raise e
 
 
 async def run_single_action(


### PR DESCRIPTION
# Fixes
- We weren't propagating errors properly across the HTTP boundary. 
- Fix spelling of 'Template Action'

![image](https://github.com/user-attachments/assets/83ffbd38-66ce-4c9a-97e8-ec4fe5d0b163)
