### PR TITLE
fix(integration): Add missing ApiKey to Authorization header

### DIFF
--- a/registry/tracecat_registry/templates/sentinel_one/get_agents_by_hostname.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/get_agents_by_hostname.yml
@@ -19,7 +19,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/agents
         method: GET
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
         params:
           computerName__contains: ${{ inputs.hostname }}
   returns: ${{ steps.get_agents_by_hostname.result }}

--- a/registry/tracecat_registry/templates/sentinel_one/get_agents_by_hostname_exact.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/get_agents_by_hostname_exact.yml
@@ -19,7 +19,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/agents
         method: GET
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
         params:
           computerName: ${{ inputs.hostname }}
   returns: ${{ steps.get_agents_by_hostname_exact.result }}

--- a/registry/tracecat_registry/templates/sentinel_one/get_agents_by_username.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/get_agents_by_username.yml
@@ -19,7 +19,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/agents
         method: GET
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
         params:
           lastLoggedInUserName__contains: ${{ inputs.username }}
   returns: ${{ steps.get_agents_by_username.result }}

--- a/registry/tracecat_registry/templates/sentinel_one/get_agents_by_username_exact.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/get_agents_by_username_exact.yml
@@ -19,7 +19,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/agents
         method: GET
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
         params:
           lastLoggedInUserName: ${{ inputs.username }}
   returns: ${{ steps.get_agents_by_username.result }}

--- a/registry/tracecat_registry/templates/sentinel_one/get_firewall_rule.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/get_firewall_rule.yml
@@ -25,5 +25,5 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/firewall-control?ids=${{ inputs.rule_ids }}&${{ inputs.scope_type }}=${{ inputs.scope_id }}
         method: GET
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
   returns: ${{ steps.get_firewall_rules.result }}

--- a/registry/tracecat_registry/templates/sentinel_one/isolate_agent.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/isolate_agent.yml
@@ -19,7 +19,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/agents/actions/disconnect
         method: POST
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
           Content-Type: application/json
         payload:
           filter:

--- a/registry/tracecat_registry/templates/sentinel_one/list_alerts.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/list_alerts.yml
@@ -25,7 +25,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/cloud-detection/alerts
         method: GET
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
         params:
           query:
             created_at__gte: ${{ FN.to_datestring(inputs.start_time, "%Y-%m-%dT%H:%M:%S.%fZ") }}

--- a/registry/tracecat_registry/templates/sentinel_one/unisolate_agent.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/unisolate_agent.yml
@@ -19,7 +19,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/agents/actions/connect
         method: POST
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
           Content-Type: application/json
         payload:
           filter:

--- a/registry/tracecat_registry/templates/sentinel_one/update_alert_status.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/update_alert_status.yml
@@ -23,7 +23,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/cloud-detection/alerts/${{ inputs.alert_id }}/status
         method: POST
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
         payload:
           data:
             analystVerdict: ${{ inputs.status }}

--- a/registry/tracecat_registry/templates/sentinel_one/update_firewall_rule.yml
+++ b/registry/tracecat_registry/templates/sentinel_one/update_firewall_rule.yml
@@ -22,7 +22,7 @@ definition:
         url: ${{ SECRETS.sentinel_one.SENTINEL_ONE_BASE_URL }}/web/api/v2.1/firewall-control/${{ inputs.rule_id }}
         method: PUT
         headers:
-          Authorization: ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}
+          Authorization: "ApiToken ${{ SECRETS.sentinel_one.SENTINEL_ONE_API_TOKEN }}"
           Content-Type: application/json
         payload:
           data: ${{ inputs.data }}


### PR DESCRIPTION
The HTTP header for S1 integrations is `Authorization: ApiToken API_TOKEN_VALUE`. The current templates are missing the "ApiToken" prefix.

This PR add the ApiToken prefix.