### PR TITLE
fix(engine): Add retries to recreate DB engine if test conn raises an exception

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,38 +1,40 @@
-import json
-import logging
+import asyncio
 import os
 from logging.config import fileConfig
 
 import alembic_postgresql_enum  # noqa: F401
-import boto3
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.exc import OperationalError
 from sqlmodel import SQLModel
 
 from alembic import context
 from tracecat.db import schemas  # noqa: F401
+from tracecat.db.engine import fetch_db_password, get_connection_string
+from tracecat.logger import logger
 
-TRACECAT__DB_URI = os.getenv("TRACECAT__DB_URI")
-if not TRACECAT__DB_URI:
+
+def _get_db_pass() -> str:
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(fetch_db_password())
+
+
+def _get_db_uri() -> str:
     username = os.getenv("TRACECAT__DB_USER", "postgres")
     host = os.getenv("TRACECAT__DB_ENDPOINT")
     port = os.getenv("TRACECAT__DB_PORT", 5432)
     database = os.getenv("TRACECAT__DB_NAME", "postgres")
+    password = _get_db_pass()
 
-    # Check if in AWS environment
-    if os.getenv("TRACECAT__DB_PASS__ARN"):
-        logging.info("Fetching database password from AWS Secrets Manager")
-        session = boto3.Session()
-        client = session.client("secretsmanager")
-        response = client.get_secret_value(SecretId=os.getenv("TRACECAT__DB_PASS__ARN"))
-        password = json.loads(response["SecretString"])["password"]
-    else:
-        logging.info("Fetching database password from environment variable")
-        password = os.getenv("TRACECAT__DB_PASS")
-
-    TRACECAT__DB_URI = (
-        f"postgresql+psycopg://{username}:{password}@{host}:{port!s}/{database}"
+    return get_connection_string(
+        username=username,
+        password=password,
+        host=host,
+        port=port,
+        database=database,
     )
 
+
+TRACECAT__DB_URI = os.getenv("TRACECAT__DB_URI") or _get_db_uri()
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -70,6 +72,8 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
+    global TRACECAT__DB_URI
+
     connectable = engine_from_config(
         configuration=config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -77,14 +81,32 @@ def run_migrations_online() -> None:
         url=TRACECAT__DB_URI,
     )
 
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+    try:
+        with connectable.connect() as connection:
+            context.configure(connection=connection, target_metadata=target_metadata)
 
-        with context.begin_transaction():
-            context.run_migrations()
+            with context.begin_transaction():
+                context.run_migrations()
+    except OperationalError as e:
+        logger.error("Error connecting to database, password may have rotated", error=e)
+        # Perhaps the database key has rotated. Try to get the password again.
+        password = _get_db_pass()
+        # If password hasn't changed, raise
+        if password in TRACECAT__DB_URI:
+            msg = "Database password has rotated, but new password not found in DB URI"
+            logger.error(msg)
+            raise ValueError(msg) from e
+        # Try to run migrations again with new password
+        TRACECAT__DB_URI = _get_db_uri()
+        return run_migrations_online()
+    except Exception as e:
+        logger.error("Unexpected error connecting to database", error=e)
+        raise
 
 
 if context.is_offline_mode():
+    logger.info("Running migrations offline")
     run_migrations_offline()
 else:
+    logger.info("Running migrations online")
     run_migrations_online()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
+    "aioboto3==13.0.1",
     "alembic_utils==0.8.4",
     "alembic-postgresql-enum==1.3.0",
     "alembic==1.13.2",

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -203,24 +203,10 @@ async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
 
 
 def get_session_context_manager() -> contextlib.AbstractContextManager[Session]:
-    try:
-        return contextlib.contextmanager(get_session)()
-    except SQLAlchemyError:
-        logger.warning(
-            "Database error occurred. Attempting to recreate engine with potentially updated configuration."
-        )
-        get_engine(force_recreate=True)
-        raise
+    return contextlib.contextmanager(get_session)()
 
 
-async def get_async_session_context_manager() -> (
+def get_async_session_context_manager() -> (
     contextlib.AbstractAsyncContextManager[AsyncSession]
 ):
-    try:
-        return contextlib.asynccontextmanager(get_async_session)()
-    except SQLAlchemyError:
-        logger.warning(
-            "Database error occurred. Attempting to recreate async engine with potentially updated configuration."
-        )
-        await get_async_engine(force_recreate=True)
-        raise
+    return contextlib.asynccontextmanager(get_async_session)()

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -202,12 +202,6 @@ async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
             raise
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(1) + wait_random(0, 1),
-    retry=retry_if_exception_type(SQLAlchemyError),
-    reraise=True,
-)
 def get_session_context_manager() -> contextlib.AbstractContextManager[Session]:
     try:
         return contextlib.contextmanager(get_session)()
@@ -219,12 +213,6 @@ def get_session_context_manager() -> contextlib.AbstractContextManager[Session]:
         raise
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(1) + wait_random(0, 1),
-    retry=retry_if_exception_type(SQLAlchemyError),
-    reraise=True,
-)
 async def get_async_session_context_manager() -> (
     contextlib.AbstractAsyncContextManager[AsyncSession]
 ):


### PR DESCRIPTION
## Rationale

Our current database connection handling doesn't adequately address potential connection failures, especially after the initial engine creation. This can lead to unexpected errors and poor user experience when database connections become stale or are interrupted. Additionally, we were using a deprecated method for executing queries with SQLModel.

Moreover, if the database password changes, we also cannot recover from a connection failure.

## What changed

1. Updated both `get_session` and `get_async_session` functions to test the connection immediately after creation.
2. Implemented logic to recreate the engine if a connection test fails.
3. Replaced the deprecated `session.execute()` method with `session.exec()` for SQLModel compatibility.
4. Added retry decorators to `get_session_context_manager` and `get_async_session_context_manager` for additional resilience.
5. Ensured consistent error handling and retry logic between synchronous and asynchronous database operations.

Key code changes:
- Added connection testing in `get_session` and `get_async_session`
- Updated query execution to use `session.exec(select(1))` instead of `session.execute("SELECT 1")`
- Implemented engine recreation on connection failure
- Added retry decorators to context manager functions

## How to QA

Go into Fargate. Force DB key rotation. Check if workflows still run without restarting the API container.