### PR TITLE
fix(engine): Fix repository not syncing in production docker compose builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,16 @@ RUN chmod +x auto-update.sh && \
 RUN groupadd -g 1001 apiuser && \
     useradd -m -u 1001 -g apiuser apiuser
 
+# Set up directories for uv and pip
+RUN mkdir -p /home/apiuser/.cache/uv /home/apiuser/.local && \
+    chown -R apiuser:apiuser /home/apiuser/.cache /home/apiuser/.local && \
+    chmod -R 755 /home/apiuser/.cache /home/apiuser/.local
+
+ENV PYTHONUSERBASE="/home/apiuser/.local"
+ENV UV_CACHE_DIR="/home/apiuser/.cache/uv"
+ENV PYTHONPATH=/home/apiuser/.local:$PYTHONPATH
+ENV PATH=/home/apiuser/.local/bin:$PATH
+
 # Set the working directory inside the container
 WORKDIR /app
 
@@ -47,6 +57,9 @@ RUN chmod +x /app/entrypoint.sh
 # Install package and registry
 RUN uv pip install .
 RUN uv pip install ./registry
+
+# Ensure apiuser has write permissions to necessary directories
+RUN chown -R apiuser:apiuser /tmp /home/apiuser
 
 # Change to the non-root user
 USER apiuser

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from typing import Literal
 
 from tracecat.auth.constants import AuthType
 
@@ -12,7 +13,9 @@ TRACECAT__SCHEDULE_INTERVAL_SECONDS = os.environ.get(
     "TRACECAT__SCHEDULE_INTERVAL_SECONDS", 60
 )
 TRACECAT__SCHEDULE_MAX_CONNECTIONS = 6
-TRACECAT__APP_ENV = os.environ.get("TRACECAT__APP_ENV", "development")
+TRACECAT__APP_ENV: Literal["development", "staging", "production"] = os.environ.get(
+    "TRACECAT__APP_ENV", "development"
+)
 TRACECAT__API_URL = os.environ.get("TRACECAT__API_URL", "http://localhost:8000")
 TRACECAT__PUBLIC_RUNNER_URL = os.environ.get(
     "TRACECAT__PUBLIC_RUNNER_URL", "http://localhost/api"

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -20,7 +20,7 @@ from tracecat.registry.repositories.models import (
 from tracecat.registry.repositories.service import RegistryReposService
 from tracecat.registry.repository import ensure_base_repository
 from tracecat.types.auth import Role
-from tracecat.types.exceptions import TracecatNotFoundError
+from tracecat.types.exceptions import RegistryError, TracecatNotFoundError
 
 router = APIRouter(prefix="/registry/repos", tags=["registry-repositories"])
 
@@ -66,6 +66,11 @@ async def sync_registry_repositories(
     actions_service = RegistryActionsService(session, role=role)
     try:
         await actions_service.sync_actions(repos)
+    except RegistryError as e:
+        logger.warning("Cannot sync repository", origin=origin, exc=e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
     except TracecatNotFoundError as e:
         logger.error("Error while syncing repository", exc=e)
         raise HTTPException(


### PR DESCRIPTION
# Fixes
- Fix permission error (no 13) when we install the remote github repo through `uv`
- Change ownership of certain directories that `uv` and `python` will use to load and import modules to `apiuser` when `APP_ENV=production`