### PR TITLE
feat(ui): Fuzzy selector node search

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^0.2.1",
     "date-fns": "^2.30.0",
+    "fuzzysort": "^3.1.0",
     "install": "^0.13.0",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.359.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
+      fuzzysort:
+        specifier: ^3.1.0
+        version: 3.1.0
       install:
         specifier: ^0.13.0
         version: 0.13.0
@@ -2914,6 +2917,9 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuzzysort@3.1.0:
+    resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -7994,6 +8000,8 @@ snapshots:
       functions-have-names: 1.2.3
 
   functions-have-names@1.2.3: {}
+
+  fuzzysort@3.1.0: {}
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
Closes #429 .

# Changes 
- Override the default shadcn `Command` search and use `fuzzysort`
- Includes realtime highlighting of fuzzy-match components
- Allow scrolling over selector node area

# Screens

https://github.com/user-attachments/assets/0e20025c-2524-4b95-9424-c3bb6f185ede


