### PR TITLE
feat: Add configurable action retries

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -122,10 +122,10 @@ export const $ActionResponse = {
 
 export const $ActionRetryPolicy = {
     properties: {
-        maximum_attempts: {
+        max_attempts: {
             type: 'integer',
-            title: 'Maximum Attempts',
-            description: 'Number of attempts if the action fails.',
+            title: 'Max Attempts',
+            description: 'Total number of execution attempts. 0 means unlimited, 1 means no retries.',
             default: 1
         },
         timeout: {
@@ -3486,30 +3486,6 @@ export const $WorkflowExecutionResponse = {
             type: 'integer',
             title: 'History Length',
             description: 'Number of events in the history'
-        },
-        parent_id: {
-            anyOf: [
-                {
-                    type: 'string'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Parent Id',
-            description: 'The ID of the parent workflow if this was started as a child.'
-        },
-        parent_run_id: {
-            anyOf: [
-                {
-                    type: 'string'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Parent Run Id',
-            description: 'The run ID of the parent workflow if this was started as a child.'
         }
     },
     type: 'object',

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -36,6 +36,9 @@ export const $ActionControlFlow = {
                 }
             ],
             title: 'For Each'
+        },
+        retry_policy: {
+            '$ref': '#/components/schemas/ActionRetryPolicy'
         }
     },
     type: 'object',
@@ -117,6 +120,25 @@ export const $ActionResponse = {
     title: 'ActionResponse'
 } as const;
 
+export const $ActionRetryPolicy = {
+    properties: {
+        maximum_attempts: {
+            type: 'integer',
+            title: 'Maximum Attempts',
+            description: 'Number of attempts if the action fails.',
+            default: 1
+        },
+        timeout: {
+            type: 'integer',
+            title: 'Timeout',
+            description: 'Timeout for the action in seconds.',
+            default: 300
+        }
+    },
+    type: 'object',
+    title: 'ActionRetryPolicy'
+} as const;
+
 export const $ActionStatement_Input = {
     properties: {
         id: {
@@ -190,6 +212,14 @@ export const $ActionStatement_Input = {
             ],
             title: 'For Each',
             description: 'Iterate over a list of items and run the task for each item.'
+        },
+        retry_policy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/ActionRetryPolicy'
+                }
+            ],
+            description: 'Retry policy for the action.'
         }
     },
     type: 'object',
@@ -258,6 +288,14 @@ export const $ActionStatement_Output = {
             ],
             title: 'For Each',
             description: 'Iterate over a list of items and run the task for each item.'
+        },
+        retry_policy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/ActionRetryPolicy'
+                }
+            ],
+            description: 'Retry policy for the action.'
         }
     },
     type: 'object',
@@ -325,6 +363,14 @@ export const $ActionStatement_Any_ = {
             ],
             title: 'For Each',
             description: 'Iterate over a list of items and run the task for each item.'
+        },
+        retry_policy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/ActionRetryPolicy'
+                }
+            ],
+            description: 'Retry policy for the action.'
         }
     },
     type: 'object',
@@ -985,10 +1031,24 @@ export const $EventGroup = {
                 }
             ],
             title: 'Action Result'
+        },
+        current_attempt: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Current Attempt'
+        },
+        retry_policy: {
+            '$ref': '#/components/schemas/ActionRetryPolicy'
         }
     },
     type: 'object',
-    required: ['event_id', 'udf_namespace', 'udf_name', 'udf_key', 'action_id', 'action_ref', 'action_title', 'action_description', 'action_input'],
+    required: ['event_id', 'udf_namespace', 'udf_name', 'udf_key', 'action_id', 'action_ref', 'action_title', 'action_description', 'action_input', 'retry_policy'],
     title: 'EventGroup'
 } as const;
 
@@ -3426,6 +3486,30 @@ export const $WorkflowExecutionResponse = {
             type: 'integer',
             title: 'History Length',
             description: 'Number of events in the history'
+        },
+        parent_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Parent Id',
+            description: 'The ID of the parent workflow if this was started as a child.'
+        },
+        parent_run_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Parent Run Id',
+            description: 'The run ID of the parent workflow if this was started as a child.'
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -36,9 +36,9 @@ export type ActionResponse = {
 
 export type ActionRetryPolicy = {
     /**
-     * Number of attempts if the action fails.
+     * Total number of execution attempts. 0 means unlimited, 1 means no retries.
      */
-    maximum_attempts?: number;
+    max_attempts?: number;
     /**
      * Timeout for the action in seconds.
      */
@@ -1131,14 +1131,6 @@ export type WorkflowExecutionResponse = {
      * Number of events in the history
      */
     history_length: number;
-    /**
-     * The ID of the parent workflow if this was started as a child.
-     */
-    parent_id?: string | null;
-    /**
-     * The run ID of the parent workflow if this was started as a child.
-     */
-    parent_run_id?: string | null;
 };
 
 export type status3 = 'RUNNING' | 'COMPLETED' | 'FAILED' | 'CANCELED' | 'TERMINATED' | 'CONTINUED_AS_NEW' | 'TIMED_OUT';

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8,6 +8,7 @@ export type AccessLevel = 0 | 999;
 export type ActionControlFlow = {
     run_if?: string | null;
     for_each?: string | Array<(string)> | null;
+    retry_policy?: ActionRetryPolicy;
 };
 
 export type ActionMetadataResponse = {
@@ -31,6 +32,17 @@ export type ActionResponse = {
     };
     key: string;
     control_flow?: ActionControlFlow;
+};
+
+export type ActionRetryPolicy = {
+    /**
+     * Number of attempts if the action fails.
+     */
+    maximum_attempts?: number;
+    /**
+     * Timeout for the action in seconds.
+     */
+    timeout?: number;
 };
 
 export type ActionStatement_Input = {
@@ -65,6 +77,10 @@ export type ActionStatement_Input = {
      * Iterate over a list of items and run the task for each item.
      */
     for_each?: string | Array<(string)> | null;
+    /**
+     * Retry policy for the action.
+     */
+    retry_policy?: ActionRetryPolicy;
 };
 
 export type ActionStatement_Output = {
@@ -95,6 +111,10 @@ export type ActionStatement_Output = {
      * Iterate over a list of items and run the task for each item.
      */
     for_each?: string | Array<(string)> | null;
+    /**
+     * Retry policy for the action.
+     */
+    retry_policy?: ActionRetryPolicy;
 };
 
 export type ActionStatement_Any_ = {
@@ -123,6 +143,10 @@ export type ActionStatement_Any_ = {
      * Iterate over a list of items and run the task for each item.
      */
     for_each?: string | Array<(string)> | null;
+    /**
+     * Retry policy for the action.
+     */
+    retry_policy?: ActionRetryPolicy;
 };
 
 export type ActionStep = {
@@ -359,6 +383,8 @@ export type EventGroup = {
     action_description: string;
     action_input: RunActionInput_Output | DSLRunArgs | GetWorkflowDefinitionActivityInputs;
     action_result?: unknown | null;
+    current_attempt?: number | null;
+    retry_policy: ActionRetryPolicy;
 };
 
 export type EventHistoryResponse = {
@@ -1105,6 +1131,14 @@ export type WorkflowExecutionResponse = {
      * Number of events in the history
      */
     history_length: number;
+    /**
+     * The ID of the parent workflow if this was started as a child.
+     */
+    parent_id?: string | null;
+    /**
+     * The run ID of the parent workflow if this was started as a child.
+     */
+    parent_run_id?: string | null;
 };
 
 export type status3 = 'RUNNING' | 'COMPLETED' | 'FAILED' | 'CANCELED' | 'TERMINATED' | 'CONTINUED_AS_NEW' | 'TIMED_OUT';

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -142,7 +142,7 @@ export function EventGeneralInfo({ event }: { event: EventHistoryResponse }) {
   const { event_group } = event
   const formattedEventType = parseEventType(event.event_type)
   const eventTimeDate = new Date(event.event_time)
-  const { maximum_attempts, timeout } = event_group?.retry_policy || {}
+  const { max_attempts, timeout } = event_group?.retry_policy || {}
   return (
     <div className="my-4 flex flex-col space-y-2 px-4">
       <div className="flex w-full items-center space-x-4">
@@ -250,7 +250,7 @@ export function EventGeneralInfo({ event }: { event: EventHistoryResponse }) {
           </Label>
           <DescriptorBadge
             className="font-mono"
-            text={`${maximum_attempts && maximum_attempts > 0 ? `Max ${maximum_attempts} attempt(s)` : "Unlimited attempts"}${timeout ? `, ${timeout}s timeout` : ""}`}
+            text={`${max_attempts && max_attempts > 0 ? `Max ${max_attempts} attempt(s)` : "Unlimited attempts"}${timeout ? `, ${timeout}s timeout` : ""}`}
           />
         </div>
       )}

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -142,6 +142,7 @@ export function EventGeneralInfo({ event }: { event: EventHistoryResponse }) {
   const { event_group } = event
   const formattedEventType = parseEventType(event.event_type)
   const eventTimeDate = new Date(event.event_time)
+  const { maximum_attempts, timeout } = event_group?.retry_policy || {}
   return (
     <div className="my-4 flex flex-col space-y-2 px-4">
       <div className="flex w-full items-center space-x-4">
@@ -241,6 +242,19 @@ export function EventGeneralInfo({ event }: { event: EventHistoryResponse }) {
         )}
       </div>
 
+      {/* Retry policy */}
+      {event_group?.retry_policy && (
+        <div className="space-x-2">
+          <Label className="w-24 text-xs text-muted-foreground">
+            Retry Policy
+          </Label>
+          <DescriptorBadge
+            className="font-mono"
+            text={`${maximum_attempts && maximum_attempts > 0 ? `Max ${maximum_attempts} attempt(s)` : "Unlimited attempts"}${timeout ? `, ${timeout}s timeout` : ""}`}
+          />
+        </div>
+      )}
+
       {isRunActionInput_Output(event_group?.action_input) && (
         <ActionEventGeneralInfo input={event_group.action_input} />
       )}
@@ -258,7 +272,7 @@ export function DescriptorBadge({
   return (
     <Badge
       variant="secondary"
-      className={cn("bg-indigo-50 text-foreground/60", className)}
+      className={cn("bg-muted-foreground/5 text-foreground/60", className)}
     >
       {text}
     </Badge>
@@ -282,7 +296,7 @@ function ActionEventGeneralInfo({ input }: { input: RunActionInput_Output }) {
   return (
     <div>
       <div className="space-x-2">
-        {input.task.depends_on && (
+        {input.task.depends_on && input.task.depends_on.length > 0 && (
           <>
             <Label className="w-24 text-xs text-muted-foreground">
               Dependencies

--- a/tracecat/dsl/constants.py
+++ b/tracecat/dsl/constants.py
@@ -1,0 +1,1 @@
+DEFAULT_ACTION_TIMEOUT = 300  # Seconds

--- a/tracecat/dsl/graph.py
+++ b/tracecat/dsl/graph.py
@@ -274,6 +274,7 @@ class RFGraph(TSObject):
             control_flow = ActionControlFlow(
                 run_if=action.control_flow.get("run_if"),
                 for_each=action.control_flow.get("for_each"),
+                retry_policy=action.control_flow.get("retry_policy"),
             )
             action_stmt = ActionStatement(
                 id=action.id,
@@ -283,6 +284,7 @@ class RFGraph(TSObject):
                 depends_on=dependencies,
                 run_if=control_flow.run_if,
                 for_each=control_flow.for_each,
+                retry_policy=control_flow.retry_policy,
             )
             statements.append(action_stmt)
         return statements

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Generic, Literal, TypedDict, TypeVar
 from pydantic import BaseModel, Field
 
 from tracecat.contexts import RunContext
+from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
 from tracecat.expressions.validation import ExpressionStr, TemplateValidator
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.types.auth import Role
@@ -20,6 +21,15 @@ class DSLNodeResult(TypedDict):
 
 
 ArgsT = TypeVar("ArgsT", bound=Mapping[str, Any])
+
+
+class ActionRetryPolicy(BaseModel):
+    maximum_attempts: int = Field(
+        default=1, description="Number of attempts if the action fails."
+    )
+    timeout: int = Field(
+        default=DEFAULT_ACTION_TIMEOUT, description="Timeout for the action in seconds."
+    )
 
 
 class ActionStatement(BaseModel, Generic[ArgsT]):
@@ -60,6 +70,9 @@ class ActionStatement(BaseModel, Generic[ArgsT]):
         ),
         TemplateValidator(),
     ]
+    retry_policy: ActionRetryPolicy = Field(
+        default_factory=ActionRetryPolicy, description="Retry policy for the action."
+    )
 
     @property
     def title(self) -> str:

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -24,8 +24,9 @@ ArgsT = TypeVar("ArgsT", bound=Mapping[str, Any])
 
 
 class ActionRetryPolicy(BaseModel):
-    maximum_attempts: int = Field(
-        default=1, description="Number of attempts if the action fails."
+    max_attempts: int = Field(
+        default=1,
+        description="Total number of execution attempts. 0 means unlimited, 1 means no retries.",
     )
     timeout: int = Field(
         default=DEFAULT_ACTION_TIMEOUT, description="Timeout for the action in seconds."

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -804,7 +804,7 @@ class DSLWorkflow:
             arg=arg,
             start_to_close_timeout=timedelta(seconds=task.retry_policy.timeout),
             retry_policy=RetryPolicy(
-                maximum_attempts=task.retry_policy.maximum_attempts,
+                maximum_attempts=task.retry_policy.max_attempts,
             ),
         )
 

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from tracecat.db.schemas import Resource
+from tracecat.dsl.models import ActionRetryPolicy
 
 # TODO: Consistent API design
 # Action and Workflow create / update params
@@ -16,6 +17,7 @@ RunStatus = Literal["pending", "running", "failure", "success", "canceled"]
 class ActionControlFlow(BaseModel):
     run_if: str | None = None
     for_each: str | list[str] | None = None
+    retry_policy: ActionRetryPolicy = Field(default_factory=ActionRetryPolicy)
 
 
 class ActionResponse(BaseModel):

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -165,7 +165,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
             action_description=task.description,
             action_input=action_input,
             retry_policy=ActionRetryPolicy(
-                maximum_attempts=retry_policy.maximum_attempts,
+                max_attempts=retry_policy.maximum_attempts,
                 timeout=timeout.seconds,
             ),
         )

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -9,17 +9,12 @@ import temporalio.api.common.v1
 import temporalio.api.enums.v1
 import temporalio.api.history.v1
 from google.protobuf.json_format import MessageToDict
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    PlainSerializer,
-)
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 
 from tracecat import identifiers
 from tracecat.dsl.common import DSLRunArgs
-from tracecat.dsl.models import DSLContext, RunActionInput
+from tracecat.dsl.models import ActionRetryPolicy, DSLContext, RunActionInput
 from tracecat.types.auth import Role
 from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
 
@@ -125,6 +120,8 @@ class EventGroup(BaseModel, Generic[EventInput]):
     action_description: str
     action_input: EventInput
     action_result: Any | None = None
+    current_attempt: int | None = None
+    retry_policy: ActionRetryPolicy
 
     @staticmethod
     def from_scheduled_activity(
@@ -136,35 +133,42 @@ class EventGroup(BaseModel, Generic[EventInput]):
         ):
             raise ValueError("Event is not an activity task scheduled event.")
         # Load the input data
-        action_stmt_data = orjson.loads(
-            event.activity_task_scheduled_event_attributes.input.payloads[0].data
-        )
+        attrs = event.activity_task_scheduled_event_attributes
+        activity_input_data = orjson.loads(attrs.input.payloads[0].data)
+        # Retry policy
 
-        act_type = event.activity_task_scheduled_event_attributes.activity_type.name
-        if act_type == "get_workflow_definition_activity":
-            action_input = GetWorkflowDefinitionActivityInputs(**action_stmt_data)
-        elif act_type in IGNORED_UTILITY_ACTIONS:
+        act_type = attrs.activity_type.name
+        if act_type in IGNORED_UTILITY_ACTIONS:
             return None
+        if act_type == "get_workflow_definition_activity":
+            action_input = GetWorkflowDefinitionActivityInputs(**activity_input_data)
         else:
-            action_input = RunActionInput(**action_stmt_data)
+            action_input = RunActionInput(**activity_input_data)
+        if action_input.task is None:
+            # It's a utility action.
+            return None
         # Create an event group
-        if action_input.task:
-            namespace, task_name = destructure_slugified_namespace(
-                action_input.task.action, delimiter="."
-            )
-            return EventGroup(
-                event_id=event.event_id,
-                udf_namespace=namespace,
-                udf_name=task_name,
-                udf_key=action_input.task.action,
-                action_id=action_input.task.id,
-                action_ref=action_input.task.ref,
-                action_title=action_input.task.title,
-                action_description=action_input.task.description,
-                action_input=action_input,
-            )
-        # It's a utility action.
-        return None
+        retry_policy = attrs.retry_policy
+        timeout = attrs.start_to_close_timeout
+        task = action_input.task
+        namespace, task_name = destructure_slugified_namespace(
+            task.action, delimiter="."
+        )
+        return EventGroup(
+            event_id=event.event_id,
+            udf_namespace=namespace,
+            udf_name=task_name,
+            udf_key=task.action,
+            action_id=task.id,
+            action_ref=task.ref,
+            action_title=task.title,
+            action_description=task.description,
+            action_input=action_input,
+            retry_policy=ActionRetryPolicy(
+                maximum_attempts=retry_policy.maximum_attempts,
+                timeout=timeout.seconds,
+            ),
+        )
 
     @staticmethod
     def from_initiated_child_workflow(

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -244,12 +244,13 @@ class WorkflowExecutionsService:
                     )
                 case EventType.EVENT_TYPE_ACTIVITY_TASK_STARTED:
                     # The parent event here is always the scheduled event, which has the UDF name
-                    parent_event_id = (
-                        event.activity_task_started_event_attributes.scheduled_event_id
-                    )
+                    attrs = event.activity_task_started_event_attributes
+                    parent_event_id = attrs.scheduled_event_id
                     if not (group := event_group_names.get(parent_event_id)):
                         continue
-                    event_group_names[event.event_id] = group
+                    event_group_names[event.event_id] = group.model_copy(
+                        update={"current_attempt": attrs.attempt}
+                    )
                     events.append(
                         EventHistoryResponse(
                             event_id=event.event_id,

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -293,6 +293,7 @@ class WorkflowsManagementService:
                 control_flow={
                     "run_if": act_stmt.run_if,
                     "for_each": act_stmt.for_each,
+                    "retry_policy": act_stmt.retry_policy.model_dump(),
                 },
             )
             actions.append(new_action)


### PR DESCRIPTION
# Changes
- Add `ActionRetryPolicy` to configure maximum attempts (default: 1) and timeout (default: 300s)
- By default, the action will fail immediately unless max attempts is > 1
- If it's 0, will retry indefinitely (temporal semantics)
- Clean up some error handling logic in the run action activity as we transform the error in the registry client

# Testing
- Manual testing with http action failing to hit endpoint

# Screens


![Screenshot 2024-10-23 at 01 46 28](https://github.com/user-attachments/assets/ac80b78c-bbcf-4d03-8291-cfc6b488b2fd)
![Screenshot 2024-10-23 at 01 46 38](https://github.com/user-attachments/assets/8310f855-f865-4bd1-ad0e-d999132c249c)
