### PR TITLE
fix(integration): Incorrect template action format

### DIFF
--- a/registry/tracecat_registry/templates/crowdsec/search_ip_address.yml
+++ b/registry/tracecat_registry/templates/crowdsec/search_ip_address.yml
@@ -1,24 +1,26 @@
-name: search_ip_address
-namespace: integrations.crowdsec
-title: Search for an IP address using the CTI CrowdSec API.
-description: Get threat intel report for an IP address from CrowdSec.
-display_group: CrowdSec
-secrets:
-  - name: crowdsec
-    keys:
-      - CROWDSEC_API_KEY
-    optional_keys: null
-expects:
-  ip_address:
-    type: str
-    description: The IP address to search
-    default: null
-steps:
-  - ref: search_ip_address
-    action: core.http_request
-    args:
-      url: https://cti.api.crowdsec.net/v2/smoke/${{ inputs.ip_address }}
-      method: GET
-      headers:
-        x-api-key: ${{ SECRETS.crowdsec.CROWDSEC_API_KEY }}
-returns: ${{ steps.search_ip_address.result }}
+type: action
+definition:
+  name: search_ip_address
+  namespace: integrations.crowdsec
+  title: Search for an IP address using the CTI CrowdSec API.
+  description: Get threat intel report for an IP address from CrowdSec.
+  display_group: CrowdSec
+  secrets:
+    - name: crowdsec
+      keys:
+        - CROWDSEC_API_KEY
+      optional_keys: null
+  expects:
+    ip_address:
+      type: str
+      description: The IP address to search
+      default: null
+  steps:
+    - ref: search_ip_address
+      action: core.http_request
+      args:
+        url: https://cti.api.crowdsec.net/v2/smoke/${{ inputs.ip_address }}
+        method: GET
+        headers:
+          x-api-key: ${{ SECRETS.crowdsec.CROWDSEC_API_KEY }}
+  returns: ${{ steps.search_ip_address.result }}


### PR DESCRIPTION
Closes #461 
Missing `definition` key

# TODO
- Add test that checks that all actions can be imported safely @topher-lo 