### PR TITLE
feat: Add error path + join strategy

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -45,6 +45,14 @@ export const $ActionControlFlow = {
             title: 'Start Delay',
             description: 'Delay before starting the action in seconds.',
             default: 0
+        },
+        join_strategy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/JoinStrategy'
+                }
+            ],
+            default: 'all'
         }
     },
     type: 'object',
@@ -232,6 +240,15 @@ export const $ActionStatement_Input = {
             title: 'Start Delay',
             description: 'Delay before starting the action in seconds.',
             default: 0
+        },
+        join_strategy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/JoinStrategy'
+                }
+            ],
+            description: 'The strategy to use when joining on this task. By default, all branches must complete successfully before the join task can complete.',
+            default: 'all'
         }
     },
     type: 'object',
@@ -314,6 +331,15 @@ export const $ActionStatement_Output = {
             title: 'Start Delay',
             description: 'Delay before starting the action in seconds.',
             default: 0
+        },
+        join_strategy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/JoinStrategy'
+                }
+            ],
+            description: 'The strategy to use when joining on this task. By default, all branches must complete successfully before the join task can complete.',
+            default: 'all'
         }
     },
     type: 'object',
@@ -395,6 +421,15 @@ export const $ActionStatement_Any_ = {
             title: 'Start Delay',
             description: 'Delay before starting the action in seconds.',
             default: 0
+        },
+        join_strategy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/JoinStrategy'
+                }
+            ],
+            description: 'The strategy to use when joining on this task. By default, all branches must complete successfully before the join task can complete.',
+            default: 'all'
         }
     },
     type: 'object',
@@ -1084,11 +1119,20 @@ export const $EventGroup = {
         },
         start_delay: {
             type: 'number',
-            title: 'Start Delay'
+            title: 'Start Delay',
+            default: 0
+        },
+        join_strategy: {
+            allOf: [
+                {
+                    '$ref': '#/components/schemas/JoinStrategy'
+                }
+            ],
+            default: 'all'
         }
     },
     type: 'object',
-    required: ['event_id', 'udf_namespace', 'udf_name', 'udf_key', 'action_id', 'action_ref', 'action_title', 'action_description', 'action_input', 'retry_policy', 'start_delay'],
+    required: ['event_id', 'udf_namespace', 'udf_name', 'udf_key', 'action_id', 'action_ref', 'action_title', 'action_description', 'action_input'],
     title: 'EventGroup'
 } as const;
 
@@ -1244,6 +1288,12 @@ export const $HTTPValidationError = {
     },
     type: 'object',
     title: 'HTTPValidationError'
+} as const;
+
+export const $JoinStrategy = {
+    type: 'string',
+    enum: ['any', 'all'],
+    title: 'JoinStrategy'
 } as const;
 
 export const $OAuth2AuthorizeResponse = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -13,6 +13,7 @@ export type ActionControlFlow = {
      * Delay before starting the action in seconds.
      */
     start_delay?: number;
+    join_strategy?: JoinStrategy;
 };
 
 export type ActionMetadataResponse = {
@@ -89,6 +90,10 @@ export type ActionStatement_Input = {
      * Delay before starting the action in seconds.
      */
     start_delay?: number;
+    /**
+     * The strategy to use when joining on this task. By default, all branches must complete successfully before the join task can complete.
+     */
+    join_strategy?: JoinStrategy;
 };
 
 export type ActionStatement_Output = {
@@ -127,6 +132,10 @@ export type ActionStatement_Output = {
      * Delay before starting the action in seconds.
      */
     start_delay?: number;
+    /**
+     * The strategy to use when joining on this task. By default, all branches must complete successfully before the join task can complete.
+     */
+    join_strategy?: JoinStrategy;
 };
 
 export type ActionStatement_Any_ = {
@@ -163,6 +172,10 @@ export type ActionStatement_Any_ = {
      * Delay before starting the action in seconds.
      */
     start_delay?: number;
+    /**
+     * The strategy to use when joining on this task. By default, all branches must complete successfully before the join task can complete.
+     */
+    join_strategy?: JoinStrategy;
 };
 
 export type ActionStep = {
@@ -404,8 +417,9 @@ export type EventGroup = {
     action_input: RunActionInput_Output | DSLRunArgs | GetWorkflowDefinitionActivityInputs;
     action_result?: unknown | null;
     current_attempt?: number | null;
-    retry_policy: ActionRetryPolicy;
-    start_delay: number;
+    retry_policy?: ActionRetryPolicy;
+    start_delay?: number;
+    join_strategy?: JoinStrategy;
 };
 
 export type EventHistoryResponse = {
@@ -443,6 +457,8 @@ export type GetWorkflowDefinitionActivityInputs = {
 export type HTTPValidationError = {
     detail?: Array<ValidationError>;
 };
+
+export type JoinStrategy = 'any' | 'all';
 
 export type OAuth2AuthorizeResponse = {
     authorization_url: string;

--- a/frontend/src/components/editor.tsx
+++ b/frontend/src/components/editor.tsx
@@ -3,15 +3,19 @@ import {
   Editor as ReactMonacoEditor,
   type Monaco,
 } from "@monaco-editor/react"
-import { editor } from "monaco-editor"
+import { editor, KeyCode, KeyMod } from "monaco-editor"
 
 import { cn } from "@/lib/utils"
 import { CenteredSpinner } from "@/components/loading/spinner"
 
 export function CustomEditor({
   className,
+  onKeyDown,
   ...props
-}: EditorProps & { className?: string }) {
+}: EditorProps & {
+  className?: string
+  onKeyDown?: () => void
+}) {
   const handleEditorDidMount = (
     editor: editor.IStandaloneCodeEditor,
     monaco: Monaco
@@ -42,6 +46,20 @@ export function CustomEditor({
       },
     })
     monaco.editor.setTheme("myCustomTheme")
+    editor.addAction({
+      id: "cmdEnterAction",
+      label: "Save Editor",
+      keybindings: [KeyMod.CtrlCmd | KeyCode.Enter],
+      contextMenuGroupId: "2_execution",
+      precondition:
+        "editorTextFocus && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode " +
+        "&& !quickFixWidgetVisible",
+      run: () => {
+        if (onKeyDown) {
+          onKeyDown()
+        }
+      },
+    })
   }
   return (
     <div className={cn("h-36", className)}>

--- a/frontend/src/components/editor.tsx
+++ b/frontend/src/components/editor.tsx
@@ -3,7 +3,7 @@ import {
   Editor as ReactMonacoEditor,
   type Monaco,
 } from "@monaco-editor/react"
-import { editor, KeyCode, KeyMod } from "monaco-editor"
+import { editor } from "monaco-editor"
 
 import { cn } from "@/lib/utils"
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -46,20 +46,6 @@ export function CustomEditor({
       },
     })
     monaco.editor.setTheme("myCustomTheme")
-    editor.addAction({
-      id: "cmdEnterAction",
-      label: "Save Editor",
-      keybindings: [KeyMod.CtrlCmd | KeyCode.Enter],
-      contextMenuGroupId: "2_execution",
-      precondition:
-        "editorTextFocus && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode " +
-        "&& !quickFixWidgetVisible",
-      run: () => {
-        if (onKeyDown) {
-          onKeyDown()
-        }
-      },
-    })
   }
   return (
     <div className={cn("h-36", className)}>

--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -10,6 +10,7 @@ import ReactFlow, {
   addEdge,
   Background,
   Connection,
+  ConnectionLineType,
   Controls,
   Edge,
   FitViewOptions,
@@ -136,9 +137,8 @@ const defaultEdgeOptions = {
     type: MarkerType.ArrowClosed,
   },
   style: { strokeWidth: 2 },
-  // Increase the radius of the smoothstep curve
   pathOptions: {
-    borderRadius: 100, // Adjust this value to increase or decrease the curve radius
+    borderRadius: 20,
   },
 }
 
@@ -186,6 +186,7 @@ export async function createNewNode(
 export function WorkflowCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
   const connectingNodeId = useRef<string | null>(null)
+  const connectingHandleId = useRef<string | null>(null)
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
   const [reactFlowInstance, setReactFlowInstance] =
@@ -264,6 +265,7 @@ export function WorkflowCanvas() {
       params: OnConnectStartParams
     ) => {
       connectingNodeId.current = params.nodeId
+      connectingHandleId.current = params.handleId
       setIsConnecting(true)
     },
     []
@@ -281,8 +283,6 @@ export function WorkflowCanvas() {
         )
 
         if (targetIsPane) {
-          // we need to remove the wrapper bounds, in order to get the correct position
-          // const bounds = containerRef.current!.getBoundingClientRect()
           const x = (event as MouseEvent).clientX - defaultNodeWidth / 2
           const y = (event as MouseEvent).clientY - defaultNodeHeight / 2
           const id = getId()
@@ -295,15 +295,20 @@ export function WorkflowCanvas() {
           } as Node
 
           setNodes((nds) => nds.concat(newNode))
+
           const edge = {
             id,
             source: connectingNodeId.current,
             target: id,
+            ...(connectingHandleId.current && {
+              sourceHandle: connectingHandleId.current,
+            }),
           } as Edge
           setEdges((eds) => eds.concat(edge))
         }
       } finally {
         console.log("Cleaning up connect end")
+        connectingHandleId.current = null
         setSilhouettePosition(null)
         setIsConnecting(false)
       }
@@ -532,6 +537,7 @@ export function WorkflowCanvas() {
         maxZoom={1}
         minZoom={0.25}
         panOnScroll
+        connectionLineType={ConnectionLineType.SmoothStep}
       >
         <Background />
         <Controls className="rounded-sm" fitViewOptions={fitViewOptions} />

--- a/frontend/src/components/workbench/canvas/custom-handle.tsx
+++ b/frontend/src/components/workbench/canvas/custom-handle.tsx
@@ -12,6 +12,12 @@ import {
 } from "reactflow"
 
 import { cn } from "@/lib/utils"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 interface CustomHandleProps
   extends Omit<HandleProps, "isConnectable">,
@@ -97,5 +103,57 @@ export function CustomFloatingHandle({
     >
       <div className="pointer-events-none absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/50 transition-all group-hover:size-4 group-hover:bg-emerald-400 group-hover:shadow-lg" />
     </Handle>
+  )
+}
+
+export function SuccessHandle({
+  type,
+  className,
+}: Omit<HandleProps, "position"> & React.HTMLProps<HTMLDivElement>) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Handle
+            id="success"
+            type={type}
+            position={Position.Bottom}
+            className={cn(
+              "group !-bottom-8 !left-[45%] !size-8 !-translate-x-1/2 !border-none !bg-transparent",
+              className
+            )}
+          >
+            <div className="pointer-events-none absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-emerald-400 shadow-sm transition-all duration-150 group-hover:size-4 group-hover:bg-emerald-400 group-hover:shadow-lg" />
+          </Handle>
+        </TooltipTrigger>
+        <TooltipContent>Success</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export function ErrorHandle({
+  type,
+  className,
+}: Omit<HandleProps, "position"> & React.HTMLProps<HTMLDivElement>) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Handle
+            id="error"
+            type={type}
+            position={Position.Bottom}
+            className={cn(
+              "group !-bottom-8 !left-[55%] !size-8 !-translate-x-1/2 !border-none !bg-transparent",
+              className
+            )}
+          >
+            <div className="pointer-events-none absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-rose-400 shadow-sm transition-all duration-150 group-hover:size-4 group-hover:bg-rose-400 group-hover:shadow-lg" />
+          </Handle>
+        </TooltipTrigger>
+        <TooltipContent>Error</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }

--- a/frontend/src/components/workbench/canvas/selector-node.tsx
+++ b/frontend/src/components/workbench/canvas/selector-node.tsx
@@ -41,7 +41,6 @@ const groupByDisplayGroup = (
   const groups = {} as Record<string, RegistryActionRead[]>
   actions.forEach((action) => {
     const displayGroup = (action.display_group || TOP_LEVEL_GROUP).toString()
-    console.log("groupByDisplayGroup", displayGroup, action)
     if (!groups[displayGroup]) {
       groups[displayGroup] = []
     }
@@ -64,6 +63,15 @@ export default React.memo(function SelectorNode({
   const { workflowId, reactFlow } = useWorkflowBuilder()
   const { setNodes, setEdges } = reactFlow
   const escapePressed = useKeyPress("Escape")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    // Focus the input after a short delay to allow the command list to open
+    const timer = setTimeout(() => {
+      inputRef.current?.focus()
+    }, 50)
+    return () => clearTimeout(timer)
+  }, [])
 
   const removeSelectorNode = () => {
     setNodes((nodes) => nodes.filter((node) => !isEphemeral(node)))
@@ -101,8 +109,10 @@ export default React.memo(function SelectorNode({
         </div>
         <Separator />
         <CommandInput
+          ref={inputRef}
           className="!py-0 text-xs"
           placeholder="Start typing to search for an action..."
+          autoFocus
         />
         <CommandList className="border-b">
           <CommandEmpty>

--- a/frontend/src/components/workbench/canvas/udf-node.tsx
+++ b/frontend/src/components/workbench/canvas/udf-node.tsx
@@ -30,7 +30,11 @@ import {
 import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/components/ui/use-toast"
 import { getIcon } from "@/components/icons"
-import { CustomFloatingHandle } from "@/components/workbench/canvas/custom-handle"
+import {
+  CustomFloatingHandle,
+  ErrorHandle,
+  SuccessHandle,
+} from "@/components/workbench/canvas/custom-handle"
 
 export interface UDFNodeData {
   type: string // alias for key
@@ -155,10 +159,8 @@ export default React.memo(function UDFNode({
         type="target"
         position={targetPosition ?? Position.Top}
       />
-      <CustomFloatingHandle
-        type="source"
-        position={sourcePosition ?? Position.Bottom}
-      />
+      <SuccessHandle type="source" />
+      <ErrorHandle type="source" />
     </Card>
   )
 })

--- a/frontend/src/components/workbench/panel/udf-panel-tooltips.tsx
+++ b/frontend/src/components/workbench/panel/udf-panel-tooltips.tsx
@@ -155,13 +155,34 @@ export function ControlFlowConfigTooltip() {
         <div>Specifies the delay (in seconds) before starting the action.</div>
         <div>Defaults to 0.0 seconds.</div>
       </div>
+      <div className="flex w-full items-center justify-between text-muted-foreground ">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm font-semibold">join_strategy</span>
+          <span className="text-xs font-normal text-muted-foreground/80">
+            string
+          </span>
+        </div>
+        <span className="text-xs text-muted-foreground/80">(optional)</span>
+      </div>
+      <div className="w-full items-center space-y-2 text-start text-muted-foreground">
+        <div>
+          Strategy to use when joining multiple branches into this action.
+        </div>
+        <div>
+          Can be either `all` (wait for all branches) or `any` (wait for any
+          branch).
+        </div>
+        <div>Defaults to `all`.</div>
+      </div>
       <div className="w-full items-center text-start">
         <span>Example inputs: </span>
       </div>
       <div className="flex w-full flex-col text-muted-foreground">
         <div className="rounded-md border bg-muted-foreground/10 p-2">
           <pre className="text-xs text-foreground/70">
-            {"start_delay: 1.5  # 1.5 seconds"}
+            {
+              "start_delay: 1.5  # 1.5 seconds\njoin_strategy: any  # continue on any branch completion"
+            }
           </pre>
         </div>
       </div>

--- a/frontend/src/components/workbench/panel/udf-panel.tsx
+++ b/frontend/src/components/workbench/panel/udf-panel.tsx
@@ -485,7 +485,6 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
-                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -542,7 +541,6 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
-                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -581,7 +579,6 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
-                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -618,7 +615,6 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
-                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -655,7 +651,6 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
-                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />

--- a/frontend/src/components/workbench/panel/udf-panel.tsx
+++ b/frontend/src/components/workbench/panel/udf-panel.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useState } from "react"
 import {
   ActionControlFlow,
   ApiError,
+  JoinStrategy,
   registryActionsValidateRegistryAction,
   RegistryActionValidateResponse,
   UpdateActionParams,
@@ -89,6 +90,10 @@ type ActionFormSchema = {
     options?: string
   }
 }
+type ControlFlowOptions = {
+  start_delay?: number
+  join_strategy?: JoinStrategy
+}
 
 export function UDFActionPanel({
   node,
@@ -149,7 +154,7 @@ export function UDFActionPanel({
           description: "Please see the error window for more details",
         })
       }
-      const options: { start_delay?: number } | undefined = control_flow.options
+      const options: ControlFlowOptions | undefined = control_flow.options
         ? YAML.parse(control_flow.options)
         : undefined
       const actionControlFlow = {
@@ -162,7 +167,7 @@ export function UDFActionPanel({
         retry_policy: control_flow?.retry_policy
           ? YAML.parse(control_flow.retry_policy)
           : undefined,
-        start_delay: options?.start_delay,
+        ...options,
       } as ActionControlFlow
       try {
         const validateResponse = await registryActionsValidateRegistryAction({

--- a/frontend/src/components/workbench/panel/udf-panel.tsx
+++ b/frontend/src/components/workbench/panel/udf-panel.tsx
@@ -130,10 +130,8 @@ export function UDFActionPanel({
   const [validationErrors, setValidationErrors] =
     useState<RegistryActionValidateResponse | null>(null)
 
-  const onSubmit = useCallback(
+  const handleSave = useCallback(
     async (values: ActionFormSchema) => {
-      console.log("registry action", registryAction)
-      console.log("action", action)
       if (!registryAction || !action) {
         console.error("UDF or action not found")
         return
@@ -206,6 +204,43 @@ export function UDFActionPanel({
     [workspaceId, registryAction, action]
   )
 
+  const onSubmit = useCallback(
+    async (values: ActionFormSchema) => {
+      await handleSave(values)
+    },
+    [handleSave]
+  )
+
+  const onPanelBlur = useCallback(
+    async (event: React.FocusEvent) => {
+      // Only save if we're actually leaving the panel
+      // (not just clicking between elements within it)
+      const panelElement = event.currentTarget
+      // Cast to HTMLElement since event.relatedTarget could be any EventTarget
+      const relatedTarget = event.relatedTarget as HTMLElement | null
+
+      if (!panelElement.contains(relatedTarget)) {
+        const values = methods.getValues()
+        await handleSave(values)
+      }
+    },
+    [methods, handleSave]
+  )
+
+  const handleKeyDownEditor = useCallback(async () => {
+    await handleSave(methods.getValues())
+  }, [methods, handleSave])
+
+  const handleKeyDownPanel = useCallback(
+    async (event: React.KeyboardEvent) => {
+      // Check for Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
+      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        await handleSave(methods.getValues())
+      }
+    },
+    [methods, handleSave]
+  )
+
   if (actionIsLoading) {
     return <CenteredSpinner />
   }
@@ -232,7 +267,13 @@ export function UDFActionPanel({
   console.log("registryAction", registryAction)
 
   return (
-    <div className="size-full overflow-auto">
+    <div
+      className="size-full overflow-auto"
+      onBlur={onPanelBlur}
+      onKeyDown={handleKeyDownPanel}
+      // Need tabIndex to receive blur events
+      tabIndex={-1}
+    >
       <FormProvider {...methods}>
         <form
           onSubmit={methods.handleSubmit(onSubmit)}
@@ -444,6 +485,7 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
+                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -500,6 +542,7 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
+                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -538,6 +581,7 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
+                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -574,6 +618,7 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
+                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />
@@ -610,6 +655,7 @@ export function UDFActionPanel({
                         defaultLanguage="yaml"
                         value={field.value}
                         onChange={field.onChange}
+                        onKeyDown={handleKeyDownEditor}
                       />
                     )}
                   />

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,7 +232,7 @@ def authed_client_controls(test_config_path: Path):
             return {}
 
     def get_client():
-        url = os.getenv("TRACECAT__PUBLIC_API_URL")
+        url = os.environ["TRACECAT__PUBLIC_API_URL"]
         if cookies_data := _read_config().get("cookies"):
             return httpx.Client(base_url=url, cookies=httpx.Cookies(cookies_data))
         raise ValueError("No cookies found in config")
@@ -256,7 +256,7 @@ def authed_client_controls(test_config_path: Path):
 def test_admin_user(env_sandbox, authed_client_controls):
     # Login
 
-    url = os.getenv("TRACECAT__PUBLIC_API_URL")
+    url = os.environ["TRACECAT__PUBLIC_API_URL"]
     get_client, cfg_write, cfg_read = authed_client_controls
 
     # Login

--- a/tests/data/workflows/unit_conditional_adder_diamond_skip_with_join_weak_dep.yml
+++ b/tests/data/workflows/unit_conditional_adder_diamond_skip_with_join_weak_dep.yml
@@ -63,3 +63,4 @@ actions:
     depends_on:
       - b
       - c
+    join_strategy: any

--- a/tests/unit/test_view.py
+++ b/tests/unit/test_view.py
@@ -2,8 +2,8 @@ import pytest
 from pydantic import BaseModel
 
 from tracecat.dsl.common import DSLEntrypoint, DSLInput
-from tracecat.dsl.graph import RFGraph, TriggerNode
 from tracecat.dsl.models import ActionStatement
+from tracecat.dsl.view import RFGraph, TriggerNode
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -99,7 +99,7 @@ def runtime_config() -> DSLConfig:
     "dsl",
     ["shared_adder_tree", "shared_kite", "shared_tree"],
     indirect=True,
-    ids=lambda x: x.title,
+    ids=lambda x: x,
 )
 @pytest.mark.asyncio
 async def test_workflow_can_run_from_yaml(dsl, temporal_cluster, test_role):
@@ -140,7 +140,7 @@ def assert_respectful_exec_order(dsl: DSLInput, final_context: DSLContext):
     "dsl",
     ["unit_ordering_kite", "unit_ordering_kite2"],
     indirect=True,
-    ids=lambda x: x.title,
+    ids=lambda x: x,
 )
 @pytest.mark.asyncio
 async def test_workflow_ordering_is_correct(
@@ -231,9 +231,7 @@ async def test_workflow_completes_and_correct(
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    "dsl", ["stress_adder_tree"], indirect=True, ids=lambda x: x.title
-)
+@pytest.mark.parametrize("dsl", ["stress_adder_tree"], indirect=True, ids=lambda x: x)
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_stress_workflow(dsl, temporal_cluster, test_role):

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -42,6 +42,15 @@ from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.management import WorkflowsManagementService
 
 
+@pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS") is not None,
+    reason="Skip if running in GitHub Actions",
+)
+@pytest.fixture(autouse=True, scope="module")
+def additional_env_vars(monkeysession: pytest.MonkeyPatch):
+    monkeysession.setattr(config, "TRACECAT__API_URL", "http://localhost/api")
+
+
 @pytest.fixture
 def dsl(request: pytest.FixtureRequest) -> DSLInput:
     test_name = request.param

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -22,6 +22,7 @@ from temporalio.common import RetryPolicy
 from temporalio.worker import Worker
 
 from tests.shared import DSL_UTILITIES, TEST_WF_ID, generate_test_exec_id
+from tracecat import config
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1887,6 +1887,7 @@ def _get_test_id(test_case):
                         "action": "core.transform.reshape",
                         "args": {"value": "JOIN"},
                         "depends_on": ["start", "start.error"],
+                        "join_strategy": "any",
                     },
                 ],
                 "inputs": {},
@@ -1934,6 +1935,7 @@ def _get_test_id(test_case):
                             "right",  # RUNS
                             "right.error",  # SKIPS
                         ],
+                        "join_strategy": "any",
                     },
                 ],
                 "inputs": {},
@@ -1985,6 +1987,7 @@ def _get_test_id(test_case):
                             "right",  # RUNS
                             "right.error",  # SKIPS: Absorbs the error path
                         ],
+                        "join_strategy": "any",
                     },
                 ],
                 "inputs": {},

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -9,8 +9,8 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from tracecat.contexts import ctx_logger, ctx_role, ctx_run
-from tracecat.dsl.models import ActionStatement, ArgsT, RunActionInput
-from tracecat.expressions.shared import context_locator
+from tracecat.dsl.common import context_locator
+from tracecat.dsl.models import ActionStatement, ArgsT, DSLTaskErrorInfo, RunActionInput
 from tracecat.logger import logger
 from tracecat.registry.actions.models import RegistryActionValidateResponse
 from tracecat.registry.client import RegistryClient
@@ -110,11 +110,17 @@ class DSLActivities:
         except RegistryActionError as e:
             # We only expect RegistryActionError to be raised from the registry client
             kind = e.__class__.__name__
-            msg = _contextualize_message(task, e, attempt=attempt)
+            msg = str(e)
             act_logger.error(
                 "Application exception occurred", error=msg, detail=e.detail
             )
-            raise ApplicationError(msg, e.detail, type=kind) from e
+            err_info = DSLTaskErrorInfo(
+                ref=task.ref,
+                message=msg,
+                type=kind,
+                attempt=attempt,
+            )
+            raise ApplicationError(msg, err_info, type=kind) from e
         except ApplicationError as e:
             # Unexpected application error - depends
             act_logger.error("ApplicationError occurred", error=e)

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -271,18 +271,16 @@ def build_action_statements(
     statements = []
     for node in graph.action_nodes():
         dependencies: list[str] = []
-        # We are constructing the dependency list from the edge list
         for dep_node_id in graph.dep_list[node.id]:
-            try:
-                edge = next(edge for edge in graph.edges if edge.target == node.id)
-            except StopIteration:
-                raise ValueError(f"No edge found for target {node.id}") from None
             base_ref = graph.node_map[dep_node_id].ref
-            if edge.source_handle == EdgeType.ERROR:
-                ref = dep_from_edge_components(base_ref, edge.source_handle)
-            else:
-                ref = base_ref
-            dependencies.append(ref)
+            for edge in graph.edges:
+                if edge.source != dep_node_id or edge.target != node.id:
+                    continue
+                if edge.source_handle == EdgeType.ERROR:
+                    ref = dep_from_edge_components(base_ref, edge.source_handle)
+                else:
+                    ref = base_ref
+                dependencies.append(ref)
         dependencies = sorted(dependencies)
 
         action = ref2action[node.ref]

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -24,6 +24,7 @@ from tracecat.dsl.graph import (
 from tracecat.dsl.models import ActionStatement, DSLConfig, Trigger
 from tracecat.expressions import patterns
 from tracecat.expressions.expectations import ExpectedField
+from tracecat.expressions.shared import ExprContext
 from tracecat.identifiers import ScheduleID, WorkflowID
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
@@ -247,3 +248,9 @@ class DSLEdge:
 
     def __repr__(self) -> str:
         return f"{self.src}-[{self.type.value}]->{self.dst}"
+
+
+def context_locator(
+    stmt: ActionStatement, loc: str, *, ctx: ExprContext = ExprContext.ACTIONS
+) -> str:
+    return f"{ctx}.{stmt.ref} -> {loc}"

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -12,8 +12,10 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from tracecat.contexts import RunContext
+from tracecat.db.schemas import Action
 from tracecat.dsl.enums import EdgeType, FailStrategy, LoopStrategy
-from tracecat.dsl.graph import (
+from tracecat.dsl.models import ActionStatement, DSLConfig, Trigger
+from tracecat.dsl.view import (
     RFEdge,
     RFGraph,
     RFNode,
@@ -21,13 +23,13 @@ from tracecat.dsl.graph import (
     UDFNode,
     UDFNodeData,
 )
-from tracecat.dsl.models import ActionStatement, DSLConfig, Trigger
 from tracecat.expressions import patterns
 from tracecat.expressions.expectations import ExpectedField
 from tracecat.expressions.shared import ExprContext
 from tracecat.identifiers import ScheduleID, WorkflowID
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
+from tracecat.types.api import ActionControlFlow
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatDSLError
 
@@ -97,7 +99,7 @@ class DSLInput(BaseModel):
         for a in self.actions:
             for dep in a.depends_on:
                 try:
-                    src, _ = get_edge_components(dep)
+                    src, _ = edge_components_from_dep(dep)
                 except ValueError:
                     raise TracecatDSLError(
                         f"Invalid depends_on ref: {dep!r} in action {a.ref!r}"
@@ -231,13 +233,17 @@ class ExecuteChildWorkflowArgs(TypedDict):
 AdjDst = tuple[str, EdgeType]
 
 
-def get_edge_components(dep_ref: str) -> AdjDst:
+def edge_components_from_dep(dep_ref: str) -> AdjDst:
     src_ref, *path = dep_ref.split(".", 1)
     if not path or path[0] == EdgeType.SUCCESS:
         return src_ref, EdgeType.SUCCESS
     elif path[0] == EdgeType.ERROR:
         return src_ref, EdgeType.ERROR
     raise ValueError(f"Invalid edge type: {path[0]} in {dep_ref!r}")
+
+
+def dep_from_edge_components(src_ref: str, edge_type: EdgeType) -> str:
+    return f"{src_ref}.{edge_type.value}"
 
 
 @dataclass(frozen=True)
@@ -254,3 +260,43 @@ def context_locator(
     stmt: ActionStatement, loc: str, *, ctx: ExprContext = ExprContext.ACTIONS
 ) -> str:
     return f"{ctx}.{stmt.ref} -> {loc}"
+
+
+def build_action_statements(
+    graph: RFGraph, actions: list[Action]
+) -> list[ActionStatement]:
+    """Convert DB Actions into ActionStatements using the graph."""
+    ref2action = {action.ref: action for action in actions}
+
+    statements = []
+    for node in graph.action_nodes():
+        dependencies: list[str] = []
+        # We are constructing the dependency list from the edge list
+        for dep_node_id in graph.dep_list[node.id]:
+            try:
+                edge = next(edge for edge in graph.edges if edge.target == node.id)
+            except StopIteration:
+                raise ValueError(f"No edge found for target {node.id}") from None
+            base_ref = graph.node_map[dep_node_id].ref
+            if edge.source_handle == EdgeType.ERROR:
+                ref = dep_from_edge_components(base_ref, edge.source_handle)
+            else:
+                ref = base_ref
+            dependencies.append(ref)
+        dependencies = sorted(dependencies)
+
+        action = ref2action[node.ref]
+        control_flow = ActionControlFlow.model_validate(action.control_flow)
+        action_stmt = ActionStatement(
+            id=action.id,
+            ref=node.ref,
+            action=node.data.type,
+            args=action.inputs,
+            depends_on=dependencies,
+            run_if=control_flow.run_if,
+            for_each=control_flow.for_each,
+            retry_policy=control_flow.retry_policy,
+            start_delay=control_flow.start_delay,
+        )
+        statements.append(action_stmt)
+    return statements

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -295,6 +295,7 @@ def build_action_statements(
             for_each=control_flow.for_each,
             retry_policy=control_flow.retry_policy,
             start_delay=control_flow.start_delay,
+            join_strategy=control_flow.join_strategy,
         )
         statements.append(action_stmt)
     return statements

--- a/tracecat/dsl/constants.py
+++ b/tracecat/dsl/constants.py
@@ -1,1 +1,2 @@
 DEFAULT_ACTION_TIMEOUT = 300  # Seconds
+CHILD_WORKFLOW_EXECUTE_ACTION = "core.workflow.execute"

--- a/tracecat/dsl/enums.py
+++ b/tracecat/dsl/enums.py
@@ -17,6 +17,17 @@ class SkipStrategy(StrEnum):
     PROPAGATE = auto()
 
 
-class TaskMarker(StrEnum):
-    SKIP = auto()
-    TERMINATED = auto()
+class JoinStrategy(StrEnum):
+    ANY = "any"
+    ALL = "all"
+
+
+class EdgeMarker(StrEnum):
+    PENDING = "pending"
+    VISITED = "visited"
+    SKIPPED = "skipped"
+
+
+class EdgeType(StrEnum):
+    SUCCESS = "success"
+    ERROR = "error"

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -15,9 +15,13 @@ SLUG_PATTERN = r"^[a-z0-9_]+$"
 ACTION_TYPE_PATTERN = r"^[a-z0-9_.]+$"
 
 
-class DSLNodeResult(TypedDict):
+class DSLNodeResult(TypedDict, total=False):
+    """Result of executing a DSL node."""
+
     result: Any
     result_typename: str
+    error: Any
+    error_typename: str
 
 
 ArgsT = TypeVar("ArgsT", bound=Mapping[str, Any])
@@ -163,3 +167,27 @@ class RunActionInput(BaseModel, Generic[ArgsT]):
     role: Role
     exec_context: DSLContext
     run_context: RunContext
+
+
+class DSLExecutionError(TypedDict, total=False):
+    """A proxy for an exception.
+
+    This is the object that gets returned in place of an exception returned when
+    using `asyncio.gather(..., return_exceptions=True)`, as Exception types aren't serializable."""
+
+    is_error: bool
+    """A flag to indicate that this object is an error."""
+
+    type: str
+    """The type of the exception. e.g. `ValueError`"""
+
+    message: str
+    """The message of the exception."""
+
+    @staticmethod
+    def from_exception(e: BaseException) -> DSLExecutionError:
+        return DSLExecutionError(
+            is_error=True,
+            type=e.__class__.__name__,
+            message=str(e),
+        )

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Annotated, Any, Generic, Literal, TypedDict, TypeVar
 
 from pydantic import BaseModel, Field
 
 from tracecat.contexts import RunContext
 from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
+from tracecat.expressions.shared import ExprContext
 from tracecat.expressions.validation import ExpressionStr, TemplateValidator
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.types.auth import Role
@@ -20,8 +22,26 @@ class DSLNodeResult(TypedDict, total=False):
 
     result: Any
     result_typename: str
-    error: Any
-    error_typename: str
+    error: Any | None
+    error_typename: str | None
+
+
+@dataclass(frozen=True)
+class DSLTaskErrorInfo:
+    ref: str
+    """The task reference."""
+
+    message: str
+    """The error message."""
+
+    type: str
+    """The error type."""
+
+    expr_context: ExprContext = ExprContext.ACTIONS
+    """The expression context where the error occurred."""
+
+    attempt: int = 1
+    """The attempt number."""
 
 
 ArgsT = TypeVar("ArgsT", bound=Mapping[str, Any])

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from tracecat.contexts import RunContext
 from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
+from tracecat.dsl.enums import JoinStrategy
 from tracecat.expressions.shared import ExprContext
 from tracecat.expressions.validation import ExpressionStr, TemplateValidator
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
@@ -102,6 +103,13 @@ class ActionStatement(BaseModel, Generic[ArgsT]):
     )
     start_delay: float = Field(
         default=0.0, description="Delay before starting the action in seconds."
+    )
+    join_strategy: JoinStrategy = Field(
+        default=JoinStrategy.ALL,
+        description=(
+            "The strategy to use when joining on this task. "
+            "By default, all branches must complete successfully before the join task can complete."
+        ),
     )
 
     @property

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -1,0 +1,278 @@
+import asyncio
+from collections import defaultdict
+from collections.abc import Coroutine
+from typing import Any
+
+from temporalio.exceptions import ApplicationError
+
+from tracecat.contexts import ctx_logger
+from tracecat.dsl.common import AdjDst, DSLEdge, DSLInput, get_edge_components
+from tracecat.dsl.enums import EdgeMarker, EdgeType, JoinStrategy, SkipStrategy
+from tracecat.dsl.models import ActionStatement, ArgsT, DSLContext
+from tracecat.expressions.core import TemplateExpression
+from tracecat.logger import logger
+
+
+class DSLScheduler:
+    """Manage only scheduling of tasks in a topological-like order."""
+
+    _queue_wait_timeout = 1
+    skip_strategy: SkipStrategy
+    """Decide how to handle tasks that are marked for skipping."""
+
+    def __init__(
+        self,
+        *,
+        executor: Coroutine[Any, Any, Any],
+        dsl: DSLInput,
+        skip_strategy: SkipStrategy = SkipStrategy.PROPAGATE,
+        context: DSLContext,
+    ):
+        self.dsl = dsl
+        self.context = context
+        self.tasks: dict[str, ActionStatement] = {}
+        self.queue: asyncio.Queue[str] = asyncio.Queue()
+        self.indegrees: dict[str, int] = {}
+        self.adj: dict[str, set[AdjDst]] = defaultdict(set)
+        """Graph connectivity information."""
+        self.completed_tasks: set[str] = set()
+        self.edges: dict[DSLEdge, EdgeMarker] = {}
+        """Marked edges are used to track the state of edges in the graph.
+
+        When a task succeeds/fails, we need to update all its outgoing edges.
+        This is because we are eliminating node executions from the graph
+        - if task `a` succeeds
+            - edges `a.error -> b` should be marked as skipped
+            - all child edges `a -> <child>` should be marked as completed (taken?)
+        - if task `a` fails
+            - edges `a.success -> b` should be marked as skipped
+            - edges `a.error -> b` should be marked as completed
+
+        """
+        self.skip_strategy = skip_strategy
+        self.task_exceptions: dict[str, BaseException] = {}
+
+        self.executor = executor
+        self.logger = ctx_logger.get(logger).bind(unit="dsl-scheduler")
+        self.logger.warning("Context obj", id_=id(self.context))
+
+        for task in dsl.actions:
+            self.tasks[task.ref] = task
+            # This remains the same regardless of error paths, as each error path counts as an indegree
+            self.indegrees[task.ref] = len(task.depends_on)
+            for dep_ref in task.depends_on:
+                src_ref, edge_type = self._get_edge_components(dep_ref)
+                self.adj[src_ref].add((task.ref, edge_type))
+
+        self.logger.debug(
+            "Scheduler config",
+            adj=self.adj,
+            indegrees=self.indegrees,
+            tasks=self.tasks,
+            edges=self.edges,
+        )
+
+    async def _handle_error_path(self, ref: str, exc: BaseException) -> None:
+        self.logger.debug("Handling error path", ref=ref)
+        # Prune any non-error paths and queue the rest
+        non_err_edges: set[DSLEdge] = {
+            DSLEdge(src=ref, dst=dst, type=edge_type)
+            for dst, edge_type in self.adj[ref]
+            if edge_type != EdgeType.ERROR
+        }
+        if len(non_err_edges) < len(self.adj[ref]):
+            await self._queue_tasks(ref, unreachable=non_err_edges)
+        else:
+            self.logger.error("Task failed with no error paths", ref=ref)
+            self.task_exceptions[ref] = exc
+
+    async def _handle_success_path(self, ref: str) -> None:
+        self.logger.debug("Handling success path", ref=ref)
+        # Prune any non-success paths and queue the rest
+        non_ok_edges: set[DSLEdge] = {
+            DSLEdge(src=ref, dst=dst, type=edge_type)
+            for dst, edge_type in self.adj[ref]
+            if edge_type != EdgeType.SUCCESS
+        }
+        await self._queue_tasks(ref, unreachable=non_ok_edges)
+
+    async def _handle_skip_path(self, task_ref: str) -> None:
+        self.logger.debug("Handling skip path")
+        # If we skip a task, we need to mark all its outgoing edges as skipped
+        all_edges: set[DSLEdge] = {
+            DSLEdge(src=task_ref, dst=dst, type=edge_type)
+            for dst, edge_type in self.adj[task_ref]
+        }
+        await self._queue_tasks(task_ref, unreachable=all_edges)
+
+    async def _queue_tasks(
+        self, ref: str, unreachable: set[DSLEdge] | None = None
+    ) -> None:
+        """Queue the next tasks that are ready to run."""
+        # Update child indegrees
+        # ----------------------
+        # Treat a skipped task as completed, update as usual.
+        # Any child task whose indegree reaches 0 must check if all its parent
+        # dependencies we skipped. if ALL parents were skipped, then the child
+        # task is also marked for skipping. If ANY parent was not skipped, then
+        # the child task is added to the queue.
+
+        # The intuition here is that if you have a task that becomes unreachable,
+        # then some of its children will also become unreachable. A node becomes unreachable
+        # if there is not one successful path that leads to it.
+
+        # This allows us to have diamond-shaped graphs where some branches can be skipped
+        # but at the join point, if any parent was not skipped, then the child can still be executed.
+        next_tasks = self.adj[ref]
+        self.logger.debug(
+            "Queueing tasks",
+            ref=ref,
+            marked_edges=self.edges,
+            visited_tasks=self.completed_tasks,
+            next_tasks=next_tasks,
+            unreachable=unreachable,
+        )
+        async with asyncio.TaskGroup() as tg:
+            for next_ref, edge_type in next_tasks:
+                self.logger.warning("Processing next task", ref=ref, next_ref=next_ref)
+                edge = DSLEdge(src=ref, dst=next_ref, type=edge_type)
+                if unreachable and edge in unreachable:
+                    self._mark_edge(edge, EdgeMarker.SKIPPED)
+                else:
+                    self._mark_edge(edge, EdgeMarker.VISITED)
+                # Mark the edge as processed
+                self.indegrees[next_ref] -= 1
+                self.logger.debug(
+                    "Indegree", next_ref=next_ref, indegree=self.indegrees[next_ref]
+                )
+                if self.indegrees[next_ref] == 0:
+                    # Schedule the next task
+                    self.logger.debug(
+                        "Adding task to queue; mark visited", next_ref=next_ref
+                    )
+                    tg.create_task(self.queue.put(next_ref))
+        self.logger.warning(
+            "Queued tasks",
+            visited_tasks=list(self.completed_tasks),
+            tasks=list(self.tasks.keys()),
+            queue_size=self.queue.qsize(),
+        )
+
+    async def _schedule_task(self, ref: str) -> None:
+        """Schedule a task for execution."""
+        task = self.tasks[ref]
+        try:
+            if self._should_skip_task(task):
+                return await self._handle_skip_path(ref)
+            # NOTE: If an exception is thrown from this coroutine, it signals that
+            # the task failed after all attempts. Adding the exception to the task
+            # exceptions set will cause the workflow to fail.
+            await self.executor(task)  # type: ignore
+        except Exception as e:
+            kind = e.__class__.__name__
+            non_retryable = getattr(e, "non_retryable", True)
+            self.logger.error(
+                f"{kind} in DSLScheduler", ref=ref, error=e, non_retryable=non_retryable
+            )
+            await self._handle_error_path(ref, e)
+        else:
+            await self._handle_success_path(ref)
+        finally:
+            self.logger.info("Task completed", ref=ref)
+            self.completed_tasks.add(ref)
+
+    async def start(self) -> None:
+        """Run the scheduler in dynamic mode."""
+        self.queue.put_nowait(self.dsl.entrypoint.ref)
+        while not self.task_exceptions and (
+            not self.queue.empty() or len(self.completed_tasks) < len(self.tasks)
+        ):
+            self.logger.debug(
+                "Waiting for tasks.",
+                qsize=self.queue.qsize(),
+                n_visited=len(self.completed_tasks),
+                n_tasks=len(self.tasks),
+            )
+            try:
+                task_ref = await asyncio.wait_for(
+                    self.queue.get(), timeout=self._queue_wait_timeout
+                )
+            except TimeoutError:
+                continue
+
+            asyncio.create_task(self._schedule_task(task_ref))
+        if self.task_exceptions:
+            self.logger.error(
+                "DSLScheduler got task exceptions, stopping...",
+                n_exceptions=len(self.task_exceptions),
+                exceptions=self.task_exceptions,
+                n_visited=len(self.completed_tasks),
+                n_tasks=len(self.tasks),
+            )
+            raise ApplicationError(
+                "Task exceptions occurred", *self.task_exceptions.values()
+            )
+        self.logger.info(
+            "All tasks completed",
+            visited_tasks=self.completed_tasks,
+            tasks=self.tasks,
+        )
+
+    def _task_reachable(self, task_ref: str) -> bool:
+        """Check whether a task is reachable based on its dependencies' states.
+
+        Under JoinStrategy.ANY, a task is considered reachable if:
+        - Any of its dependencies completed successfully
+
+        Under JoinStrategy.ALL, a task is considered reachable if:
+        - All of its dependencies completed successfully
+
+        Args:
+            task_ref (str): The reference of the task to check
+
+        Returns:
+            bool: True if the task is reachable, False otherwise
+        """
+
+        task = self.tasks[task_ref]
+        logger.debug("Check task reachability", task=task, marked_edges=self.edges)
+        if not task.depends_on:
+            # Covers any root nodes
+            return True
+        join_strategy = JoinStrategy.ANY
+
+        # Logically, this function should check that there was at least
+        # one successful path (edge) taken to the task.
+        def edge_visited(dep_ref: str) -> bool:
+            # dep_ref might have a path, so we need to check for that
+            src_ref, edge_type = self._get_edge_components(dep_ref)
+            edge = DSLEdge(src=src_ref, dst=task_ref, type=edge_type)
+            return self.edges[edge] == EdgeMarker.VISITED
+
+        outcomes = {parent: edge_visited(parent) for parent in task.depends_on}
+        logger.debug("Check outcomes", outcomes=outcomes, edges=self.edges)
+        if join_strategy == JoinStrategy.ANY:
+            return any(outcomes.values())
+        elif join_strategy == JoinStrategy.ALL:
+            return all(outcomes.values())
+        raise ValueError(f"Unknown join strategy: {join_strategy}")
+
+    def _get_edge_components(self, dep_ref: str) -> AdjDst:
+        return get_edge_components(dep_ref)
+
+    def _mark_edge(self, edge: DSLEdge, marker: EdgeMarker) -> None:
+        logger.debug("Marking edge", edge=edge, marker=marker)
+        self.edges[edge] = marker
+
+    def _should_skip_task(self, task: ActionStatement[ArgsT]) -> bool:
+        if not self._task_reachable(task.ref):
+            self.logger.info("Task is unreachable, skipped")
+            return True
+        # Evaluate the `run_if` condition
+        if task.run_if is not None:
+            expr = TemplateExpression(task.run_if, operand=self.context)
+            self.logger.debug("`run_if` condition", task_run_if=task.run_if)
+            if not bool(expr.result()):
+                self.logger.info("Task `run_if` condition was not met, skipped")
+                return True
+        return False

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -6,7 +6,7 @@ from typing import Any
 from temporalio.exceptions import ApplicationError
 
 from tracecat.contexts import ctx_logger
-from tracecat.dsl.common import AdjDst, DSLEdge, DSLInput, get_edge_components
+from tracecat.dsl.common import AdjDst, DSLEdge, DSLInput, edge_components_from_dep
 from tracecat.dsl.enums import EdgeMarker, EdgeType, JoinStrategy, SkipStrategy
 from tracecat.dsl.models import ActionStatement, ArgsT, DSLContext
 from tracecat.expressions.core import TemplateExpression
@@ -36,7 +36,7 @@ class DSLScheduler:
         self.adj: dict[str, set[AdjDst]] = defaultdict(set)
         """Graph connectivity information."""
         self.completed_tasks: set[str] = set()
-        self.edges: dict[DSLEdge, EdgeMarker] = {}
+        self.edges: dict[DSLEdge, EdgeMarker] = defaultdict(lambda: EdgeMarker.PENDING)
         """Marked edges are used to track the state of edges in the graph.
 
         When a task succeeds/fails, we need to update all its outgoing edges.
@@ -258,7 +258,7 @@ class DSLScheduler:
         raise ValueError(f"Unknown join strategy: {join_strategy}")
 
     def _get_edge_components(self, dep_ref: str) -> AdjDst:
-        return get_edge_components(dep_ref)
+        return edge_components_from_dep(dep_ref)
 
     def _mark_edge(self, edge: DSLEdge, marker: EdgeMarker) -> None:
         logger.debug("Marking edge", edge=edge, marker=marker)

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -120,13 +120,6 @@ class RFEdge(TSObject):
         default=EdgeType.SUCCESS, description="Edge source handle type"
     )
 
-    @model_validator(mode="before")
-    def generate_id(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Generate the ID as a concatenation of source and target with a prefix."""
-        if (source := values.get("source")) and (target := values.get("target")):
-            values["id"] = "-".join(("reactflow__edge", source, target))
-        return values
-
 
 class RFGraph(TSObject):
     """React Flow Graph Object.

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -120,6 +120,13 @@ class RFEdge(TSObject):
         default=EdgeType.SUCCESS, description="Edge source handle type"
     )
 
+    @model_validator(mode="before")
+    def generate_id(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Generate the ID as a concatenation of source and target with a prefix."""
+        if (source := values.get("source")) and (target := values.get("target")):
+            values["id"] = "-".join(("reactflow__edge", source, target))
+        return values
+
 
 class RFGraph(TSObject):
     """React Flow Graph Object.

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -839,4 +839,4 @@ class DSLWorkflow:
         self.scheduler.mark_task(task_ref, marker)
 
     def _should_execute_child_workflow(self, task: ActionStatement[ArgsT]) -> bool:
-        return task.action == "core.workflow.execute"
+        return task.action == CHILD_WORKFLOW_EXECUTE_ACTION

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -3,16 +3,9 @@ from __future__ import annotations
 import asyncio
 import itertools
 import json
-from collections import defaultdict
-from collections.abc import (
-    Awaitable,
-    Callable,
-    Coroutine,
-    Generator,
-    Iterable,
-)
+from collections.abc import Awaitable, Generator, Iterable
 from datetime import timedelta
-from typing import Any, TypedDict
+from typing import Any
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
@@ -37,21 +30,23 @@ with workflow.unsafe.imports_passed_through():
         ValidateActionActivityInput,
     )
     from tracecat.dsl.common import DSLInput, DSLRunArgs, ExecuteChildWorkflowArgs
-    from tracecat.dsl.enums import FailStrategy, LoopStrategy, SkipStrategy, TaskMarker
+    from tracecat.dsl.constants import CHILD_WORKFLOW_EXECUTE_ACTION
+    from tracecat.dsl.enums import FailStrategy, LoopStrategy
     from tracecat.dsl.models import (
         ActionStatement,
         ArgsT,
         DSLConfig,
         DSLContext,
         DSLEnvironment,
+        DSLExecutionError,
         DSLNodeResult,
         RunActionInput,
     )
+    from tracecat.dsl.scheduler import DSLScheduler
     from tracecat.dsl.validation import (
         ValidateTriggerInputsActivityInputs,
         validate_trigger_inputs_activity,
     )
-    from tracecat.expressions.core import TemplateExpression
     from tracecat.expressions.eval import eval_templated_object
     from tracecat.expressions.shared import ExprContext
     from tracecat.logger import logger
@@ -71,30 +66,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
     from tracecat.workflow.schedules.models import GetScheduleActivityInputs
     from tracecat.workflow.schedules.service import WorkflowSchedulesService
-
-
-class DSLExecutionError(TypedDict, total=False):
-    """A proxy for an exception.
-
-    This is the object that gets returned in place of an exception returned when
-    using `asyncio.gather(..., return_exceptions=True)`, as Exception types aren't serializable."""
-
-    is_error: bool
-    """A flag to indicate that this object is an error."""
-
-    type: str
-    """The type of the exception. e.g. `ValueError`"""
-
-    message: str
-    """The message of the exception."""
-
-    @staticmethod
-    def from_exception(e: BaseException) -> DSLExecutionError:
-        return DSLExecutionError(
-            is_error=True,
-            type=e.__class__.__name__,
-            message=str(e),
-        )
 
 
 non_retryable_error_types = [
@@ -130,160 +101,6 @@ retry_policies = {
         non_retryable_error_types=non_retryable_error_types,
     ),
 }
-
-
-class DSLScheduler:
-    """Manage only scheduling of tasks in a topological-like order."""
-
-    _queue_wait_timeout = 1
-    skip_strategy: SkipStrategy
-    """Decide how to handle tasks that are marked for skipping."""
-
-    def __init__(
-        self,
-        *,
-        activity_coro: Callable[[ActionStatement[ArgsT]], Coroutine[Any, Any, None]],
-        dsl: DSLInput,
-        skip_strategy: SkipStrategy = SkipStrategy.PROPAGATE,
-    ):
-        self.dsl = dsl
-        self.tasks: dict[str, ActionStatement[ArgsT]] = {}
-        self.adj: dict[str, set[str]] = defaultdict(set)
-        self.indegrees: dict[str, int] = {}
-        self.queue: asyncio.Queue[str] = asyncio.Queue()
-        # self.running_tasks: dict[str, asyncio.Task[None]] = {}
-        self.completed_tasks: set[str] = set()
-        # Tasks can be marked for termination.
-        # This is useful for tasks that are
-        self.marked_tasks: dict[str, TaskMarker] = {}
-        self.skip_strategy = skip_strategy
-        self.task_exceptions: dict[str, BaseException] = {}
-
-        self.executor = activity_coro
-        self.logger = ctx_logger.get(logger).bind(unit="dsl-scheduler")
-
-        for task in dsl.actions:
-            self.tasks[task.ref] = task
-            self.indegrees[task.ref] = len(task.depends_on)
-            for dep in task.depends_on:
-                self.adj[dep].add(task.ref)
-
-    async def _dynamic_task(self, task_ref: str) -> None:
-        """Dynamic task execution.
-
-        Tasks
-        -----
-        1. Run the task
-        2. Manage the indegrees of the tasks
-        """
-        task = self.tasks[task_ref]
-        try:
-            await self.executor(task)
-
-            # For now, tasks that were marked to skip also join this set
-            self.completed_tasks.add(task_ref)
-            self.logger.info("Task completed", task_ref=task_ref)
-
-            # Update child indegrees
-            # ----------------------
-            # Treat a skipped task as completed, update as usual.
-            # Any child task whose indegree reaches 0 must check if all its parent
-            # dependencies we skipped. if ALL parents were skipped, then the child
-            # task is also marked for skipping. If ANY parent was not skipped, then
-            # the child task is added to the queue.
-
-            # The intuition here is that if you have a task that becomes unreachable,
-            # then some of its children will also become unreachable. A node becomes unreachable
-            # if there is no one successful oath that leads to it.
-
-            # This allows us to have diamond-shaped graphs where some branches can be skipped
-            # but at the join point, if any parent was not skipped, then the child can still be executed.
-            async with asyncio.TaskGroup() as tg:
-                for next_task_ref in self.adj[task_ref]:
-                    self.indegrees[next_task_ref] -= 1
-                    if self.indegrees[next_task_ref] == 0:
-                        if (
-                            self.skip_strategy == SkipStrategy.PROPAGATE
-                            and self.task_is_reachable(next_task_ref)
-                        ):
-                            self.mark_task(next_task_ref, TaskMarker.SKIP)
-                        tg.create_task(self.queue.put(next_task_ref))
-        except ActivityError as e:
-            self.logger.error(
-                "Activity error in DSLScheduler",
-                task_ref=task_ref,
-                msg=e.message,
-                retry_state=e.retry_state,
-            )
-            self.task_exceptions[task_ref] = e
-        except ApplicationError as e:
-            self.logger.error(
-                "Application error in DSLScheduler",
-                task_ref=task_ref,
-                msg=e.message,
-                non_retryable=e.non_retryable,
-            )
-            self.task_exceptions[task_ref] = e
-        except Exception as e:
-            self.logger.error(
-                "Unexpected error in DSLScheduler", task_ref=task_ref, error=e
-            )
-            self.task_exceptions[task_ref] = e
-
-    async def dynamic_start(self) -> None:
-        """Run the scheduler in dynamic mode."""
-        self.queue.put_nowait(self.dsl.entrypoint.ref)
-        while not self.task_exceptions and (
-            not self.queue.empty() or len(self.completed_tasks) < len(self.tasks)
-        ):
-            self.logger.trace(
-                "Waiting for tasks.",
-                qsize=self.queue.qsize(),
-                n_completed=len(self.completed_tasks),
-                n_tasks=len(self.tasks),
-            )
-            try:
-                task_ref = await asyncio.wait_for(
-                    self.queue.get(), timeout=self._queue_wait_timeout
-                )
-            except TimeoutError:
-                continue
-
-            asyncio.create_task(self._dynamic_task(task_ref))
-        if self.task_exceptions:
-            self.logger.error(
-                "DSLScheduler got task exceptions, stopping...",
-                n_exceptions=len(self.task_exceptions),
-                exceptions=self.task_exceptions,
-                n_completed=len(self.completed_tasks),
-                n_tasks=len(self.tasks),
-            )
-            raise ApplicationError(
-                "Task exceptions occurred", *self.task_exceptions.values()
-            )
-        self.logger.info("All tasks completed")
-
-    def mark_task(self, task_ref: str, marker: TaskMarker) -> None:
-        self.marked_tasks[task_ref] = marker
-
-    def task_is_reachable(self, task_ref: str) -> bool:
-        """Check whether a task is reachable by checking if all its dependencies were skipped."""
-        return all(
-            self.marked_tasks.get(parent) == TaskMarker.SKIP
-            for parent in self.tasks[task_ref].depends_on
-        )
-
-    async def _static_task(self, task_ref: str) -> None:
-        raise NotImplementedError
-
-    async def static_start(self) -> None:
-        raise NotImplementedError
-
-    def start(self) -> Awaitable[None]:
-        if self.dsl.config.scheduler == "dynamic":
-            return self.dynamic_start()
-        else:
-            return self.static_start()
 
 
 @workflow.defn
@@ -421,7 +238,9 @@ class DSLWorkflow:
             timeout=self.start_to_close_timeout,
         )
 
-        self.scheduler = DSLScheduler(activity_coro=self.execute_task, dsl=self.dsl)
+        self.scheduler = DSLScheduler(
+            executor=self.execute_task, dsl=self.dsl, context=self.context
+        )
         try:
             await self.scheduler.start()
         except ApplicationError as e:
@@ -452,7 +271,7 @@ class DSLWorkflow:
                 type=e.__class__.__name__,
             ) from e
 
-    async def execute_task(self, task: ActionStatement[ArgsT]) -> None:
+    async def execute_task(self, task: ActionStatement[ArgsT]) -> Any:
         """Purely execute a task and manage the results.
 
         Preflight checks
@@ -462,67 +281,64 @@ class DSLWorkflow:
         3. If there's an ActionTest, skip execution and return the patched result.
             - Note that we still schedule the task for execution, but we don't actually run it.
         """
-        with self.logger.contextualize(task_ref=task.ref):
-            if self._should_skip_execution(task):
-                self._mark_task(task.ref, TaskMarker.SKIP)
-                return
 
-            try:
-                logger.info("Begin task execution", task_ref=task.ref)
-                # Check for a child workflow
-                if self._should_execute_child_workflow(task):
-                    # NOTE: We don't support (nor recommend, unless a use case is justified) passing SECRETS to child workflows
-                    # 1. Prepare the child workflow
-                    logger.trace("Preparing child workflow")
-                    child_run_args = await self._prepare_child_workflow(task)
-                    logger.trace(
-                        "Child workflow prepared", child_run_args=child_run_args
-                    )
-                    # This is the original child runtime args, preset by the DSL
-                    # In contrast, task.args are the runtime args that the parent workflow provided
-                    action_result = await self._execute_child_workflow(
-                        task=task, child_run_args=child_run_args
-                    )
-
-                else:
-                    # Below this point, we're executing the task
-                    logger.trace(
-                        "Running action",
-                        task_ref=task.ref,
-                        runtime_config=self.runtime_config,
-                    )
-                    action_result = await self._run_action(task)
-
-                self.context[ExprContext.ACTIONS][task.ref] = DSLNodeResult(
-                    result=action_result,
-                    result_typename=type(action_result).__name__,
+        logger.info("Begin task execution", task_ref=task.ref)
+        try:
+            if self._should_execute_child_workflow(task):
+                # NOTE: We don't support (nor recommend, unless a use case is justified) passing SECRETS to child workflows
+                # 1. Prepare the child workflow
+                logger.trace("Preparing child workflow")
+                child_run_args = await self._prepare_child_workflow(task)
+                logger.trace("Child workflow prepared", child_run_args=child_run_args)
+                # This is the original child runtime args, preset by the DSL
+                # In contrast, task.args are the runtime args that the parent workflow provided
+                action_result = await self._execute_child_workflow(
+                    task=task, child_run_args=child_run_args
                 )
-            except ActivityError as e:
-                logger.error("Activity execution failed", error=e.message)
-                raise ApplicationError(
-                    e.message, non_retryable=True, type=e.__class__.__name__
-                ) from e
-            except ChildWorkflowError as e:
-                logger.error("Child workflow execution failed", error=e.message)
-                raise ApplicationError(
-                    e.message, non_retryable=True, type=e.__class__.__name__
-                ) from e
-            except FailureError as e:
-                logger.error("Workflow execution failed", error=e.message)
-                raise ApplicationError(
-                    e.message, non_retryable=True, type=e.__class__.__name__
-                ) from e
-            except ValidationError as e:
-                logger.error("Runtime validation error", error=e.errors())
-                raise e
-            except Exception as e:
-                msg = f"Task execution failed with unexpected error: {e}"
-                logger.error(
-                    "Activity execution failed with unexpected error", error=msg
+
+            else:
+                # Below this point, we're executing the task
+                logger.trace(
+                    "Running action",
+                    task_ref=task.ref,
+                    runtime_config=self.runtime_config,
                 )
-                raise ApplicationError(
-                    msg, non_retryable=True, type=e.__class__.__name__
-                ) from e
+                action_result = await self._run_action(task)
+            logger.trace("Action completed successfully", action_result=action_result)
+            self.context[ExprContext.ACTIONS][task.ref] = DSLNodeResult(
+                result=action_result,
+                result_typename=type(action_result).__name__,
+            )
+        # NOTE: By the time we receive an exception, we've exhausted all retry attempts
+        except (ActivityError, ChildWorkflowError, FailureError) as e:
+            # These are deterministic and expected errors that
+            err_type = e.__class__.__name__
+            msg = self.ERROR_TYPE_TO_MESSAGE[err_type]
+            logger.error(msg, error=e.message)
+            # task_result = DSLNodeResult(error=e.message, error_typename=err_type)
+            raise ApplicationError(e.message, non_retryable=True, type=err_type) from e
+        except ValidationError as e:
+            logger.error("Runtime validation error", error=e.errors())
+            # task_result = DSLNodeResult(
+            #     error=e.errors(), error_typename=ValidationError.__name__
+            # )
+            raise e
+        except Exception as e:
+            err_type = e.__class__.__name__
+            msg = f"Task execution failed with unexpected error: {e}"
+            logger.error("Activity execution failed with unexpected error", error=msg)
+            # task_result = DSLNodeResult(error=msg, error_typename=err_type)
+            raise ApplicationError(msg, non_retryable=True, type=err_type) from e
+        # finally:
+        #     logger.warning("Setting action result", task_result=task_result)
+        #     self.context[ExprContext.ACTIONS][task.ref] = task_result
+
+    ERROR_TYPE_TO_MESSAGE = {
+        ActivityError.__name__: "Activity execution failed",
+        ChildWorkflowError.__name__: "Child workflow execution failed",
+        FailureError.__name__: "Workflow execution failed",
+        ValidationError.__name__: "Runtime validation error",
+    }
 
     async def _execute_child_workflow(
         self,
@@ -660,6 +476,7 @@ class DSLWorkflow:
             return result
 
     def _handle_return(self) -> Any:
+        self.logger.debug("Handling return", context=self.context)
         if self.dsl.returns is None:
             # Return the context
             # XXX: Don't return ENV context for now
@@ -797,7 +614,7 @@ class DSLWorkflow:
             run_context=self.run_context,
             exec_context=self.context,
         )
-        self.logger.debug("RUN UDF ACTIVITY", arg=arg, task=task)
+        self.logger.debug("RUN UDF ACTIVITY", arg=arg)
 
         return workflow.execute_activity(
             DSLActivities.run_action_activity,
@@ -821,22 +638,6 @@ class DSLWorkflow:
             retry_policy=retry_policies["workflow:fail_fast"],
             execution_timeout=self.start_to_close_timeout,
         )
-
-    def _should_skip_execution(self, task: ActionStatement[ArgsT]) -> bool:
-        if self.scheduler.marked_tasks.get(task.ref) == TaskMarker.SKIP:
-            self.logger.info("Task marked for skipping, skipped")
-            return True
-        # Evaluate the `run_if` condition
-        if task.run_if is not None:
-            expr = TemplateExpression(task.run_if, operand=self.context)
-            self.logger.debug("`run_if` condition", task_run_if=task.run_if)
-            if not bool(expr.result()):
-                self.logger.info("Task `run_if` condition was not met, skipped")
-                return True
-        return False
-
-    def _mark_task(self, task_ref: str, marker: TaskMarker) -> None:
-        self.scheduler.mark_task(task_ref, marker)
 
     def _should_execute_child_workflow(self, task: ActionStatement[ArgsT]) -> bool:
         return task.action == CHILD_WORKFLOW_EXECUTE_ACTION

--- a/tracecat/expressions/shared.py
+++ b/tracecat/expressions/shared.py
@@ -3,8 +3,6 @@ from dataclasses import dataclass
 from enum import StrEnum, auto
 from typing import Any
 
-from tracecat.dsl.models import ActionStatement
-
 
 class TracecatEnum(StrEnum):
     def __repr__(self) -> str:
@@ -71,9 +69,3 @@ class IterableExpr[T]:
     def __iter__(self) -> Iterator[tuple[str, T]]:
         for item in self.collection:
             yield self.iterator, item
-
-
-def context_locator(
-    stmt: ActionStatement, loc: str, *, ctx: ExprContext = ExprContext.ACTIONS
-) -> str:
-    return f"{ctx}.{stmt.ref} -> {loc}"

--- a/tracecat/registry/actions/service.py
+++ b/tracecat/registry/actions/service.py
@@ -53,7 +53,7 @@ class RegistryActionsService:
         if not include_marked:
             statement = statement.where(
                 cast(RegistryAction.options["include_in_schema"].astext, Boolean)  # noqa: E712
-                == True
+                == True  # noqa: E712
             )
 
         if namespace:

--- a/tracecat/registry/client.py
+++ b/tracecat/registry/client.py
@@ -1,6 +1,6 @@
 """Use this in worker to execute actions."""
 
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import orjson
@@ -22,10 +22,10 @@ from tracecat.types.exceptions import RegistryActionError, RegistryError
 class _RegistryHTTPClient(AuthenticatedServiceClient):
     """Async httpx client for the registry service."""
 
-    def __init__(self, role: Role | None = None, *args, **kwargs):
+    def __init__(self, role: Role | None = None, *args: Any, **kwargs: Any) -> None:
         self._registry_base_url = config.TRACECAT__API_URL
-        super().__init__(*args, role=role, base_url=self._registry_base_url, **kwargs)
-        self.params = self.params.add("workspace_id", str(role.workspace_id))
+        super().__init__(role, *args, base_url=self._registry_base_url, **kwargs)
+        self.params = self.params.add("workspace_id", str(self.role.workspace_id))
 
 
 class RegistryClient:
@@ -41,7 +41,7 @@ class RegistryClient:
 
     """Execution"""
 
-    async def call_action(self, input: RunActionInput[ArgsT]) -> httpx.Response:
+    async def call_action(self, input: RunActionInput[ArgsT]) -> Any:
         """
         Call an action in the registry asynchronously.
 
@@ -153,7 +153,7 @@ class RegistryClient:
             async with _RegistryHTTPClient(self.role) as client:
                 response = await client.get(self._repos_endpoint)
             response.raise_for_status()
-            return response.json()
+            return cast(list[str], response.json())
         except httpx.HTTPStatusError as e:
             raise RegistryError(
                 f"Failed to list registries: HTTP {e.response.status_code}"
@@ -198,7 +198,7 @@ class RegistryClient:
             code: str,
             module_name: str,
             validate_keys: list[str] | None = None,
-        ):
+        ) -> dict[str, Any]:
             """Use this only for testing purposes."""
             if config.TRACECAT__APP_ENV != "development":
                 # Unreachable
@@ -207,7 +207,7 @@ class RegistryClient:
                 async with _RegistryHTTPClient(role=self.role) as client:
                     response = await client.post(
                         "/test-registry",
-                        params={"workspace_id": self.role.workspace_id},
+                        params={"workspace_id": str(self.role.workspace_id)},
                         json={
                             "version": version,
                             "code": code,
@@ -216,7 +216,7 @@ class RegistryClient:
                         },
                     )
                 response.raise_for_status()
-                return response.json()
+                return cast(dict[str, Any], response.json())
             except httpx.HTTPStatusError as e:
                 raise RegistryError(
                     f"Failed to register test module: HTTP {e.response.status_code}"

--- a/tracecat/registry/executor.py
+++ b/tracecat/registry/executor.py
@@ -286,6 +286,8 @@ def iter_for_each(
 ) -> Iterator[ArgsT]:
     """Yield patched contexts for each loop iteration."""
     # Evaluate the loop expression
+    if not task.for_each:
+        raise ValueError("No loop expression found")
     iterators = get_iterables_from_expression(expr=task.for_each, operand=context)
 
     # Assert that all length of the iterables are the same

--- a/tracecat/registry/executor.py
+++ b/tracecat/registry/executor.py
@@ -13,6 +13,7 @@ from tracecat import config
 from tracecat.auth.sandbox import AuthSandbox
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.contexts import ctx_logger, ctx_role, ctx_run
+from tracecat.dsl.common import context_locator
 from tracecat.dsl.models import (
     ActionStatement,
     DSLContext,
@@ -24,7 +25,7 @@ from tracecat.expressions.eval import (
     extract_templated_secrets,
     get_iterables_from_expression,
 )
-from tracecat.expressions.shared import ExprContext, ExprContextType, context_locator
+from tracecat.expressions.shared import ExprContext, ExprContextType
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
 from tracecat.registry.actions.models import ArgsClsT, ArgsT, BoundRegistryAction

--- a/tracecat/types/api.py
+++ b/tracecat/types/api.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from tracecat.db.schemas import Resource
+from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy
 
 # TODO: Consistent API design
@@ -21,6 +22,7 @@ class ActionControlFlow(BaseModel):
     start_delay: float = Field(
         default=0.0, description="Delay before starting the action in seconds."
     )
+    join_strategy: JoinStrategy = Field(default=JoinStrategy.ALL)
 
 
 class ActionResponse(BaseModel):

--- a/tracecat/types/exceptions.py
+++ b/tracecat/types/exceptions.py
@@ -71,3 +71,7 @@ class RegistryValidationError(RegistryError):
 
 class RegistryNotFound(RegistryError):
     """Exception raised when a registry is not found."""
+
+
+class TaskUnreachable(TracecatException):
+    """Raised when a task is unreachable."""

--- a/tracecat/validation.py
+++ b/tracecat/validation.py
@@ -50,10 +50,10 @@ from tracecat_registry import RegistrySecret
 
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.db.schemas import RegistryAction
-from tracecat.dsl.common import DSLInput
+from tracecat.dsl.common import DSLInput, context_locator
 from tracecat.expressions.eval import extract_expressions, is_template_only
 from tracecat.expressions.parser.validator import ExprValidationContext, ExprValidator
-from tracecat.expressions.shared import ExprType, context_locator
+from tracecat.expressions.shared import ExprType
 from tracecat.logger import logger
 from tracecat.registry.actions.models import ArgsT, RegistryActionInterface
 from tracecat.registry.actions.service import RegistryActionsService

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -14,6 +14,7 @@ from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 
 from tracecat import identifiers
 from tracecat.dsl.common import DSLRunArgs
+from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy, DSLContext, RunActionInput
 from tracecat.types.auth import Role
 from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
@@ -123,6 +124,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
     current_attempt: int | None = None
     retry_policy: ActionRetryPolicy = Field(default_factory=ActionRetryPolicy)
     start_delay: float = 0.0
+    join_strategy: JoinStrategy = JoinStrategy.ALL
 
     @staticmethod
     def from_scheduled_activity(
@@ -167,6 +169,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
             action_input=action_input,
             retry_policy=action_retry_policy,
             start_delay=task.start_delay,
+            join_strategy=task.join_strategy,
         )
 
     @staticmethod

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -19,6 +19,7 @@ from tracecat.dsl.view import RFGraph
 from tracecat.identifiers import WorkflowID
 from tracecat.logger import logger
 from tracecat.registry.actions.models import RegistryActionValidateResponse
+from tracecat.types.api import ActionControlFlow
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatValidationError
 from tracecat.workflow.management.models import (
@@ -291,6 +292,13 @@ class WorkflowsManagementService:
         # Create and associate Actions with the Workflow
         actions: list[Action] = []
         for act_stmt in dsl.actions:
+            control_flow = ActionControlFlow(
+                run_if=act_stmt.run_if,
+                for_each=act_stmt.for_each,
+                retry_policy=act_stmt.retry_policy,
+                start_delay=act_stmt.start_delay,
+                join_strategy=act_stmt.join_strategy,
+            )
             new_action = Action(
                 owner_id=self.role.workspace_id,
                 workflow_id=workflow.id,
@@ -298,12 +306,7 @@ class WorkflowsManagementService:
                 inputs=act_stmt.args,
                 title=act_stmt.title,
                 description=act_stmt.description,
-                control_flow={
-                    "run_if": act_stmt.run_if,
-                    "for_each": act_stmt.for_each,
-                    "retry_policy": act_stmt.retry_policy.model_dump(),
-                    "start_delay": act_stmt.start_delay,
-                },
+                control_flow=control_flow.model_dump(),
             )
             actions.append(new_action)
             self.session.add(new_action)

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -13,8 +13,9 @@ from tracecat import validation
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import Action, Webhook, Workflow
-from tracecat.dsl.common import DSLInput
-from tracecat.dsl.graph import RFGraph
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, build_action_statements
+from tracecat.dsl.models import DSLConfig
+from tracecat.dsl.view import RFGraph
 from tracecat.identifiers import WorkflowID
 from tracecat.logger import logger
 from tracecat.registry.actions.models import RegistryActionValidateResponse
@@ -180,7 +181,12 @@ class WorkflowsManagementService:
             raise TracecatValidationError(
                 "Workflow has no actions. Please add an action to the workflow before committing."
             )
+        logger.warning("Building graph from workflow", workflow=workflow)
         graph = RFGraph.from_workflow(workflow)
+        if not graph.logical_entrypoint:
+            raise TracecatValidationError(
+                "Workflow has no starting action. Please add an action to the workflow before committing."
+            )
         graph_actions = graph.action_nodes()
         if len(graph_actions) != len(actions):
             logger.warning(
@@ -195,22 +201,24 @@ class WorkflowsManagementService:
             await self.session.refresh(workflow)
             # Check again
             actions = workflow.actions
+            if not actions:
+                raise TracecatValidationError(
+                    "Workflow has no actions. Please add an action to the workflow before committing."
+                )
             if len(graph_actions) != len(actions):
                 raise TracecatValidationError(
                     "Couldn't synchronize actions between graph and database."
                 )
-        action_statements = graph.build_action_statements(actions)
+        action_statements = build_action_statements(graph, actions)
         return DSLInput(
             title=workflow.title,
             description=workflow.description,
-            entrypoint={
-                # XXX: Sus
-                "ref": graph.logical_entrypoint.ref,
-                "expects": workflow.expects,
-            },
+            entrypoint=DSLEntrypoint(
+                ref=graph.logical_entrypoint.ref, expects=workflow.expects
+            ),
             actions=action_statements,
             inputs=workflow.static_inputs,
-            config=workflow.config,
+            config=DSLConfig(**workflow.config),
             returns=workflow.returns,
             # triggers=workflow.triggers,
         )


### PR DESCRIPTION
# Features
- Allow errors to be caught and propagated to the action's error path (Progresses #265)
  - given `ACTIONS.my_action`, you can now retrieve error info at `ACTIONS.my_action.error`
- Implement `JoinStrategy` (Progresses #336)
  - `JoinStrategy.ALL`: Action proceeds if all dependencies successfully ran 
  - `JoinStrategy.ANY`: Action proceeds if at least 1 dependency successfully ran
- ~Press `cmd+enter` to save action~ (removed because this was causing nextjs build issues when adding keybinds to the monaco editor)
- Action saves on clicking out of the side panel
- Selector node automatically focuses the text box on mount

# Changes
- Change scheduling algorithm to consider edges instead of nodes, because each node can now have `success` and `error` paths
