### PR TITLE
feat(ui): Update target handle to show join strategy

### DIFF
--- a/frontend/src/components/workbench/canvas/custom-handle.tsx
+++ b/frontend/src/components/workbench/canvas/custom-handle.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react"
+import { JoinStrategy } from "@/client"
 import {
   Edge,
   getConnectedEdges,
@@ -12,6 +13,7 @@ import {
 } from "reactflow"
 
 import { cn } from "@/lib/utils"
+import { Badge } from "@/components/ui/badge"
 import {
   Tooltip,
   TooltipContent,
@@ -87,7 +89,13 @@ export function CustomFloatingHandle({
   type,
   position,
   className,
-}: HandleProps & React.HTMLProps<HTMLDivElement>) {
+  join_strategy,
+  indegree,
+}: HandleProps &
+  React.HTMLProps<HTMLDivElement> & {
+    join_strategy?: JoinStrategy
+    indegree?: number
+  }) {
   return (
     <Handle
       type={type}
@@ -101,7 +109,32 @@ export function CustomFloatingHandle({
         className
       )}
     >
-      <div className="pointer-events-none absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/50 transition-all group-hover:size-4 group-hover:bg-emerald-400 group-hover:shadow-lg" />
+      <div className="relative size-full">
+        {/* Base dot that fades out */}
+        <div
+          className={cn(
+            "pointer-events-none absolute left-1/2 top-1/2 rounded-full transition-all duration-200",
+            "size-2 -translate-x-1/2 -translate-y-1/2 bg-muted-foreground/50",
+            "group-hover:size-4 group-hover:bg-emerald-400 group-hover:shadow-lg",
+            indegree && indegree > 1 && "opacity-0"
+          )}
+        />
+
+        {/* Badge that fades in */}
+        <Badge
+          className={cn(
+            "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg px-2 text-xs",
+            "transition-all duration-200",
+            !indegree || indegree <= 1
+              ? "scale-75 opacity-0"
+              : "scale-100 opacity-100",
+            join_strategy === "all" && "bg-blue-500/80 hover:bg-blue-600/80",
+            join_strategy === "any" && "bg-amber-500/80 hover:bg-amber-600/80"
+          )}
+        >
+          {join_strategy?.toLocaleUpperCase() || "ALL"}
+        </Badge>
+      </div>
     </Handle>
   )
 }


### PR DESCRIPTION
# Screens

https://github.com/user-attachments/assets/4768015d-3872-4e7c-80a1-36adb2ade0fd


Color scheme suggested by Claude:

```
In this code, the color choices appear to follow common UI/UX patterns for logical operations:

1. **Blue (bg-blue-500/80) for "ALL"**:
   - Blue is often used to represent "AND" operations in logic gates and flow diagrams
   - The color blue typically conveys reliability and completeness
   - In this context, "ALL" means all inputs must be satisfied (logical AND)

2. **Amber/Orange (bg-amber-500/80) for "ANY"**:
   - Amber/Orange is often used to represent "OR" operations
   - It's a warmer color that suggests flexibility or alternative options
   - In this context, "ANY" means any input can satisfy the condition (logical OR)

The `/80` suffix indicates 80% opacity, which gives a slightly translucent effect, making the UI feel lighter and more modern. The `hover` states (`bg-blue-600/80` and `bg-amber-600/80`) use slightly darker shades to provide visual feedback on interaction.

This color coding helps users quickly understand the join strategy at a glance without having to read the text, following established visual patterns from logic and flow diagrams.

Yes, these color conventions for logical operations are fairly common in various tools and diagrams, though there isn't a strict universal standard. Here are some examples:

1. **Logic Gate Diagrams & Circuit Design**
- Logisim (circuit simulator) uses blue for AND gates
- Many digital logic textbooks and educational materials use warm colors (red/orange) for OR gates

2. **Modern Development Tools**
- Azure Logic Apps uses:
  - Blue for "AND" conditions
  - Orange for "OR" conditions
- Apache Airflow:
  - Uses blue for "all_success" trigger rules
  - Uses orange/amber for "one_success" trigger rules

3. **Business Process Management (BPM) Tools**
- Camunda uses:
  - Blue for parallel gateways (ALL)
  - Orange for inclusive gateways (ANY)
- BPMN (Business Process Model and Notation) standard diagrams often follow similar conventions

4. **Other Notable Examples**
- GitHub Actions uses:
  - Blue for required checks
  - Yellow/Amber for optional conditions
- Jenkins Pipeline visualization:
  - Blue for stages requiring all conditions
  - Orange/Amber for parallel or any-condition stages

While not universal, these color choices align with common industry practices where:
- Blue → Strict/All/AND conditions
- Amber/Orange → Flexible/Any/OR conditions

This makes your UI intuitively understandable to users familiar with other development tools.
```

