### PR TITLE
fix: Separate out source and target handles for different node types

### DIFF
--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -10,7 +10,7 @@ import {
   LayoutListIcon,
   ScanSearchIcon,
 } from "lucide-react"
-import { Node, NodeProps, Position, useEdges } from "reactflow"
+import { Node, NodeProps, useEdges } from "reactflow"
 
 import { useAction } from "@/lib/hooks"
 import { cn, copyToClipboard, slugify } from "@/lib/utils"

--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -32,9 +32,9 @@ import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/components/ui/use-toast"
 import { getIcon } from "@/components/icons"
 import {
-  CustomFloatingHandle,
-  ErrorHandle,
-  SuccessHandle,
+  ActionSoruceSuccessHandle,
+  ActionSourceErrorHandle,
+  ActionTargetHandle,
 } from "@/components/workbench/canvas/custom-handle"
 
 export interface ActionNodeData {
@@ -50,8 +50,6 @@ export type ActionNodeType = Node<ActionNodeData>
 export default React.memo(function ActionNode({
   data: { title, isConfigured, numberOfEvents, type: key },
   selected,
-  sourcePosition,
-  targetPosition,
   id,
 }: NodeProps<ActionNodeData>) {
   const { workflowId, getNode, workspaceId, reactFlow } = useWorkflowBuilder()
@@ -161,14 +159,12 @@ export default React.memo(function ActionNode({
         </div>
       </CardContent>
 
-      <CustomFloatingHandle
-        type="target"
-        position={targetPosition ?? Position.Top}
+      <ActionTargetHandle
         join_strategy={action?.control_flow?.join_strategy}
         indegree={incomingEdges.length}
       />
-      <SuccessHandle type="source" />
-      <ErrorHandle type="source" />
+      <ActionSoruceSuccessHandle type="source" />
+      <ActionSourceErrorHandle type="source" />
     </Card>
   )
 })

--- a/frontend/src/components/workbench/canvas/custom-handle.tsx
+++ b/frontend/src/components/workbench/canvas/custom-handle.tsx
@@ -89,13 +89,7 @@ export function CustomFloatingHandle({
   type,
   position,
   className,
-  join_strategy,
-  indegree,
-}: HandleProps &
-  React.HTMLProps<HTMLDivElement> & {
-    join_strategy?: JoinStrategy
-    indegree?: number
-  }) {
+}: HandleProps & React.HTMLProps<HTMLDivElement>) {
   return (
     <Handle
       type={type}
@@ -106,6 +100,41 @@ export function CustomFloatingHandle({
         position === Position.Bottom && "!-bottom-8",
         position === Position.Left && "!-left-8",
         position === Position.Right && "!-right-8",
+        className
+      )}
+    >
+      <div className="pointer-events-none absolute left-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/50 transition-all group-hover:size-4 group-hover:bg-emerald-400 group-hover:shadow-lg" />
+    </Handle>
+  )
+}
+
+export function TriggerSourceHandle({
+  className,
+}: React.HTMLProps<HTMLDivElement>) {
+  return (
+    <CustomHandle
+      type="source"
+      position={Position.Bottom}
+      isConnectable={1}
+      className={className}
+    />
+  )
+}
+
+export function ActionTargetHandle({
+  className,
+  join_strategy,
+  indegree,
+}: React.HTMLProps<HTMLDivElement> & {
+  join_strategy?: JoinStrategy
+  indegree?: number
+}) {
+  return (
+    <Handle
+      type="target"
+      position={Position.Top}
+      className={cn(
+        "group !-top-8 left-1/2 !size-8 !-translate-x-1/2 !border-none !bg-transparent",
         className
       )}
     >
@@ -139,7 +168,7 @@ export function CustomFloatingHandle({
   )
 }
 
-export function SuccessHandle({
+export function ActionSoruceSuccessHandle({
   type,
   className,
 }: Omit<HandleProps, "position"> & React.HTMLProps<HTMLDivElement>) {
@@ -165,7 +194,7 @@ export function SuccessHandle({
   )
 }
 
-export function ErrorHandle({
+export function ActionSourceErrorHandle({
   type,
   className,
 }: Omit<HandleProps, "position"> & React.HTMLProps<HTMLDivElement>) {

--- a/frontend/src/components/workbench/canvas/trigger-node.tsx
+++ b/frontend/src/components/workbench/canvas/trigger-node.tsx
@@ -13,7 +13,7 @@ import {
   UnplugIcon,
   WebhookIcon,
 } from "lucide-react"
-import { Node, NodeProps, Position } from "reactflow"
+import { Node, NodeProps } from "reactflow"
 
 import { useSchedules } from "@/lib/hooks"
 import { durationToHumanReadable } from "@/lib/time"
@@ -43,7 +43,7 @@ import {
 } from "@/components/ui/table"
 import { getIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
-import { CustomHandle } from "@/components/workbench/canvas/custom-handle"
+import { TriggerSourceHandle } from "@/components/workbench/canvas/custom-handle"
 
 export interface TriggerNodeData {
   type: "trigger"
@@ -60,7 +60,6 @@ export const TriggerTypename = "trigger" as const
 export default React.memo(function TriggerNode({
   data: { title, isConfigured, type },
   selected,
-  sourcePosition,
 }: NodeProps<TriggerNodeData>) {
   const { workflow } = useWorkflow()
 
@@ -151,11 +150,7 @@ export default React.memo(function TriggerNode({
         </div>
       </CardContent>
 
-      <CustomHandle
-        type="source"
-        position={sourcePosition ?? Position.Bottom}
-        isConnectable={1}
-      />
+      <TriggerSourceHandle />
     </Card>
   )
 })


### PR DESCRIPTION
Issue dragging out node because of the new join target node handle. Also made names mode explicit/clearer