### PR TITLE
feat(ui): Add action panel tabs + cleanup action panel description section

### DIFF
--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -8,6 +8,7 @@ import {
   ActionUpdate,
   ApiError,
   JoinStrategy,
+  RegistryActionRead,
   RegistryActionValidateResponse,
 } from "@/client"
 import { useWorkflow } from "@/providers/workflow"
@@ -15,12 +16,16 @@ import { useWorkspace } from "@/providers/workspace"
 import {
   AlertTriangleIcon,
   CheckCheck,
+  Database,
   Info,
   LayoutListIcon,
   Loader2Icon,
+  LucideIcon,
   RepeatIcon,
   SettingsIcon,
   Shapes,
+  SquareFunctionIcon,
+  ToyBrickIcon,
 } from "lucide-react"
 import { Controller, FormProvider, useForm } from "react-hook-form"
 import { type Node } from "reactflow"
@@ -41,11 +46,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
@@ -57,7 +57,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import { CopyButton } from "@/components/copy-button"
 import { CustomEditor } from "@/components/editor"
@@ -90,6 +96,20 @@ type ControlFlowOptions = {
   join_strategy?: JoinStrategy
 }
 
+const typeToLabel: Record<
+  RegistryActionRead["type"],
+  { label: string; icon: LucideIcon }
+> = {
+  udf: {
+    label: "User Defined Function",
+    icon: SquareFunctionIcon,
+  },
+  template: {
+    label: "Template Action",
+    icon: ToyBrickIcon,
+  },
+}
+
 export function ActionPanel({
   node,
   workflowId,
@@ -98,7 +118,7 @@ export function ActionPanel({
   workflowId: string
 }) {
   const { workspaceId } = useWorkspace()
-  const { validationErrors, setValidationErrors } = useWorkflow()
+  const { validationErrors } = useWorkflow()
   const { action, actionIsLoading, updateAction, isSaving } = useAction(
     node.id,
     workspaceId,
@@ -252,6 +272,7 @@ export function ActionPanel({
   const finalValErrors = validationErrors
     ?.filter((error) => error.action_ref === slugify(action.title))
     .concat(actionValidationErrors || [])
+  const ActionIcon = typeToLabel[registryAction.type].icon
   return (
     <div
       className="size-full overflow-auto"
@@ -260,19 +281,21 @@ export function ActionPanel({
       // Need tabIndex to receive blur events
       tabIndex={-1}
     >
-      <FormProvider {...methods}>
-        <form
-          onSubmit={methods.handleSubmit(onSubmit)}
-          className="flex max-w-full flex-col overflow-auto"
-        >
-          <div className="grid grid-cols-3">
-            <div className="col-span-2 overflow-hidden">
-              <h3 className="p-4">
-                <div className="flex w-full items-center space-x-4">
-                  {getIcon(registryAction.action, {
-                    className: "size-10 p-2",
-                    flairsize: "md",
-                  })}
+      <Tabs defaultValue="inputs">
+        <FormProvider {...methods}>
+          <form
+            onSubmit={methods.handleSubmit(onSubmit)}
+            className="flex max-w-full flex-col overflow-auto"
+          >
+            <div className="relative">
+              <h3 className="p-4 py-6">
+                <div className="flex w-full items-start space-x-4">
+                  <div className="flex-col">
+                    {getIcon(registryAction.action, {
+                      className: "size-10 p-2",
+                      flairsize: "md",
+                    })}
+                  </div>
                   <div className="flex w-full flex-1 justify-between space-x-12">
                     <div className="flex flex-col">
                       <div className="flex w-full items-center justify-between text-xs font-medium leading-none">
@@ -283,376 +306,429 @@ export function ActionPanel({
                           <span className="italic">No description</span>
                         )}
                       </p>
-                      <p className="mt-2 text-xs text-muted-foreground">
-                        Type: {registryAction.type === "udf" && "UDF"}
-                        {registryAction.type === "template" &&
-                          "Template Action"}
-                      </p>
-                      <p className="mt-2 text-xs text-muted-foreground">
-                        Origin: {registryAction.origin}
-                      </p>
+                      <div className="mt-2 hover:cursor-default">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                              <ActionIcon className="mr-1 size-3 stroke-2" />
+                              <span>
+                                {typeToLabel[registryAction.type].label}
+                              </span>
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent side="left" sideOffset={10}>
+                            Action Type
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                              <Database className="mr-1 size-3 stroke-2" />
+                              <span>{registryAction.origin}</span>
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent side="left" sideOffset={10}>
+                            Origin
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
                     </div>
                   </div>
                 </div>
               </h3>
+              <SaveStateIcon saveState={saveState} />
             </div>
-            <div
-              className={cn(
-                "animate-fade-out flex justify-end space-x-2 p-4 transition-opacity duration-200",
-                saveState === "idle" && "opacity-0"
-              )}
-            >
-              {saveState === "saving" && (
-                <Loader2Icon className="size-4 animate-spin text-muted-foreground/70" />
-              )}
-              {saveState === "success" && (
-                <CheckCheck className="size-4 text-green-500" />
-              )}
-            </div>
-          </div>
-          <Separator />
-          {/* Metadata */}
-          <Accordion
-            type="multiple"
-            defaultValue={["action-schema", "action-inputs"]}
-            className="pb-10"
-          >
-            <AccordionItem value="action-settings">
-              <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                <div className="flex items-center">
-                  <SettingsIcon className="mr-3 size-4" />
-                  <span>General</span>
-                </div>
-              </AccordionTrigger>
-              {/* General settings for the action */}
-              <AccordionContent>
-                <div className="my-4 space-y-2 px-4">
-                  <FormField
-                    control={methods.control}
-                    name="title"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel className="text-xs">Name</FormLabel>
-                        <FormControl>
-                          <Input
-                            className="text-xs"
-                            placeholder="Name your workflow..."
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={methods.control}
-                    name="description"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel className="text-xs">Description</FormLabel>
-                        <FormControl>
-                          <Textarea
-                            className="text-xs"
-                            placeholder="Describe your workflow..."
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <div className="space-y-2">
-                    <Label className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <span>Action ID</span>
-                      <CopyButton
-                        value={action.id}
-                        toastMessage="Copied workflow ID to clipboard"
-                      />
-                    </Label>
-                    <div className="rounded-md border shadow-sm">
-                      <Input
-                        value={action.id}
-                        className="rounded-md border-none text-xs shadow-none"
-                        readOnly
-                        disabled
-                      />
-                    </div>
-                  </div>
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-
-            {/* Schema */}
-            <AccordionItem value="action-schema">
-              <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                <div className="flex items-center">
-                  <Shapes className="mr-3 size-4" />
-                  <span>Input Schema</span>
-                </div>
-              </AccordionTrigger>
-              <AccordionContent className="space-y-4">
-                {/* Action secrets */}
-                <div className="space-y-4 px-4">
-                  {registryAction.secrets ? (
-                    <div className="text-xs text-muted-foreground">
-                      <span>This action requires the following secrets:</span>
-                      <Table>
-                        <TableHeader>
-                          <TableRow className="h-6  text-xs capitalize">
-                            <TableHead className="font-bold" colSpan={1}>
-                              Secret Name
-                            </TableHead>
-                            <TableHead className="font-bold" colSpan={1}>
-                              Required Keys
-                            </TableHead>
-                            <TableHead className="font-bold" colSpan={1}>
-                              Optional Keys
-                            </TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {registryAction.secrets.map((secret, idx) => (
-                            <TableRow
-                              key={idx}
-                              className="font-mono text-xs tracking-tight text-muted-foreground"
-                            >
-                              <TableCell>{secret.name}</TableCell>
-                              <TableCell>
-                                {secret.keys?.join(", ") || "-"}
-                              </TableCell>
-                              <TableCell>
-                                {secret.optional_keys?.join(", ") || "-"}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  ) : (
-                    <span className="text-xs text-muted-foreground">
-                      No secrets required.
-                    </span>
-                  )}
-                </div>
-                {/* Action inputs */}
-                <div className="space-y-4 px-4">
-                  <span className="text-xs text-muted-foreground">
-                    Hover over each row for details.
-                  </span>
-                  <JSONSchemaTable schema={registryAction.interface.expects} />
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-
-            {/* Inputs */}
-            <AccordionItem value="action-inputs">
-              <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                <div className="flex items-center">
-                  <LayoutListIcon className="mr-3 size-4" />
+            <div className="flex items-center justify-start">
+              <TabsList className="grid h-8 grid-cols-2 rounded-none bg-transparent p-0">
+                <TabsTrigger
+                  className="size-full w-full rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  value="inputs"
+                >
+                  <LayoutListIcon className="mr-2 size-4" />
                   <span>Inputs</span>
-                </div>
-              </AccordionTrigger>
-              <AccordionContent>
-                <div className="flex flex-col space-y-4 px-4">
-                  {!!finalValErrors && finalValErrors.length > 0 && (
-                    <div className="flex items-center space-x-2">
-                      <AlertTriangleIcon className="size-4 fill-rose-500 stroke-white" />
-                      <span className="text-xs text-rose-500">
-                        Validation errors occurred, please see below.
-                      </span>
-                    </div>
-                  )}
-                  <span className="text-xs text-muted-foreground">
-                    Define action inputs in YAML below.
-                  </span>
-                  <Controller
-                    name="inputs"
-                    control={methods.control}
-                    render={({ field }) => (
-                      <CustomEditor
-                        className="h-72 w-full"
-                        defaultLanguage="yaml"
-                        value={field.value}
-                        onChange={field.onChange}
-                      />
-                    )}
-                  />
-                  {!!finalValErrors && finalValErrors.length > 0 && (
-                    <div className="rounded-md border border-rose-400 bg-rose-100 p-4 font-mono text-xs text-rose-500">
-                      <span className="font-bold">Validation Errors</span>
-                      <Separator className="my-2 bg-rose-400" />
-                      {finalValErrors.map((error, index) => (
-                        <div key={index} className="mb-4">
-                          <span>{error.message}</span>
-                          <pre>{YAML.stringify(error.detail)}</pre>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="action-control-flow">
-              <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                <div className="flex items-center">
-                  <RepeatIcon className="mr-3 size-4" />
+                </TabsTrigger>
+                <TabsTrigger
+                  className="size-full w-full rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  value="control-flow"
+                >
+                  <RepeatIcon className="mr-2 size-4" />
                   <span>Control Flow</span>
-                </div>
-              </AccordionTrigger>
-              <AccordionContent className="space-y-4">
-                {/* Run if */}
-                <div className="flex flex-col space-y-4 px-4">
-                  <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                    <span>Run If</span>
-                  </FormLabel>
-                  <div className="flex items-center">
-                    <HoverCard openDelay={100} closeDelay={100}>
-                      <HoverCardTrigger asChild className="hover:border-none">
-                        <Info className="mr-1 size-3 stroke-muted-foreground" />
-                      </HoverCardTrigger>
-                      <HoverCardContent
-                        className="w-[500px] p-3 font-mono text-xs tracking-tight"
-                        side="left"
-                        sideOffset={20}
-                      >
-                        <RunIfTooltip />
-                      </HoverCardContent>
-                    </HoverCard>
-
-                    <span className="text-xs text-muted-foreground">
-                      Define a conditional expression that determines if the
-                      action executes.
-                    </span>
-                  </div>
-
-                  <Controller
-                    name="control_flow.run_if"
-                    control={methods.control}
-                    render={({ field }) => (
-                      <CustomEditor
-                        className="h-24 w-full"
-                        defaultLanguage="yaml"
-                        value={field.value}
-                        onChange={field.onChange}
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            <Separator />
+            <TabsContent value="inputs">
+              {/* Metadata */}
+              <Accordion
+                type="multiple"
+                defaultValue={["action-schema", "action-inputs"]}
+                className="pb-10"
+              >
+                <AccordionItem value="action-settings">
+                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                    <div className="flex items-center">
+                      <SettingsIcon className="mr-3 size-4" />
+                      <span>General</span>
+                    </div>
+                  </AccordionTrigger>
+                  {/* General settings for the action */}
+                  <AccordionContent>
+                    <div className="my-4 space-y-2 px-4">
+                      <FormField
+                        control={methods.control}
+                        name="title"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel className="text-xs">Name</FormLabel>
+                            <FormControl>
+                              <Input
+                                className="text-xs"
+                                placeholder="Name your workflow..."
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
                       />
-                    )}
-                  />
-                </div>
-                {/* Loop */}
-                <div className="flex flex-col space-y-4 px-4">
-                  <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                    <span>Loop Iteration</span>
-                  </FormLabel>
-                  <div className="flex items-center">
-                    <HoverCard openDelay={100} closeDelay={100}>
-                      <HoverCardTrigger asChild className="hover:border-none">
-                        <Info className="mr-1 size-3 stroke-muted-foreground" />
-                      </HoverCardTrigger>
-                      <HoverCardContent
-                        className="w-[500px] p-3 font-mono text-xs tracking-tight"
-                        side="left"
-                        sideOffset={20}
-                      >
-                        <ForEachTooltip />
-                      </HoverCardContent>
-                    </HoverCard>
-
-                    <span className="text-xs text-muted-foreground">
-                      Define one or more loop expressions for the action to
-                      iterate over.
-                    </span>
-                  </div>
-
-                  <Controller
-                    name="control_flow.for_each"
-                    control={methods.control}
-                    render={({ field }) => (
-                      <CustomEditor
-                        className="h-24 w-full"
-                        defaultLanguage="yaml"
-                        value={field.value}
-                        onChange={field.onChange}
+                      <FormField
+                        control={methods.control}
+                        name="description"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel className="text-xs">
+                              Description
+                            </FormLabel>
+                            <FormControl>
+                              <Textarea
+                                className="text-xs"
+                                placeholder="Describe your workflow..."
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
                       />
-                    )}
-                  />
-                </div>
-                {/* Retry Policy */}
-                <div className="flex flex-col space-y-4 px-4">
-                  <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                    <span>Retry Policy</span>
-                  </FormLabel>
-                  <div className="flex items-center">
-                    <HoverCard openDelay={100} closeDelay={100}>
-                      <HoverCardTrigger asChild className="hover:border-none">
-                        <Info className="mr-1 size-3 stroke-muted-foreground" />
-                      </HoverCardTrigger>
-                      <HoverCardContent
-                        className="w-[500px] p-3 font-mono text-xs tracking-tight"
-                        side="left"
-                        sideOffset={20}
-                      >
-                        <RetryPolicyTooltip />
-                      </HoverCardContent>
-                    </HoverCard>
+                      <div className="space-y-2">
+                        <Label className="flex items-center gap-2 text-xs text-muted-foreground">
+                          <span>Action ID</span>
+                          <CopyButton
+                            value={action.id}
+                            toastMessage="Copied workflow ID to clipboard"
+                          />
+                        </Label>
+                        <div className="rounded-md border shadow-sm">
+                          <Input
+                            value={action.id}
+                            className="rounded-md border-none text-xs shadow-none"
+                            readOnly
+                            disabled
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
 
-                    <span className="text-xs text-muted-foreground">
-                      Define the retry policy for the action.
-                    </span>
-                  </div>
-                  <Controller
-                    name="control_flow.retry_policy"
-                    control={methods.control}
-                    render={({ field }) => (
-                      <CustomEditor
-                        className="h-24 w-full"
-                        defaultLanguage="yaml"
-                        value={field.value}
-                        onChange={field.onChange}
+                {/* Schema */}
+                <AccordionItem value="action-schema">
+                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                    <div className="flex items-center">
+                      <Shapes className="mr-3 size-4" />
+                      <span>Input Schema</span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4">
+                    {/* Action secrets */}
+                    <div className="space-y-4 px-4">
+                      {registryAction.secrets ? (
+                        <div className="text-xs text-muted-foreground">
+                          <span>
+                            This action requires the following secrets:
+                          </span>
+                          <Table>
+                            <TableHeader>
+                              <TableRow className="h-6  text-xs capitalize">
+                                <TableHead className="font-bold" colSpan={1}>
+                                  Secret Name
+                                </TableHead>
+                                <TableHead className="font-bold" colSpan={1}>
+                                  Required Keys
+                                </TableHead>
+                                <TableHead className="font-bold" colSpan={1}>
+                                  Optional Keys
+                                </TableHead>
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {registryAction.secrets.map((secret, idx) => (
+                                <TableRow
+                                  key={idx}
+                                  className="font-mono text-xs tracking-tight text-muted-foreground"
+                                >
+                                  <TableCell>{secret.name}</TableCell>
+                                  <TableCell>
+                                    {secret.keys?.join(", ") || "-"}
+                                  </TableCell>
+                                  <TableCell>
+                                    {secret.optional_keys?.join(", ") || "-"}
+                                  </TableCell>
+                                </TableRow>
+                              ))}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          No secrets required.
+                        </span>
+                      )}
+                    </div>
+                    {/* Action inputs */}
+                    <div className="space-y-4 px-4">
+                      <span className="text-xs text-muted-foreground">
+                        Hover over each row for details.
+                      </span>
+                      <JSONSchemaTable
+                        schema={registryAction.interface.expects}
                       />
-                    )}
-                  />
-                </div>
-                {/* Other options */}
-                <div className="flex flex-col space-y-4 px-4">
-                  <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                    <span>Options</span>
-                  </FormLabel>
-                  <div className="flex items-center">
-                    <HoverCard openDelay={100} closeDelay={100}>
-                      <HoverCardTrigger asChild className="hover:border-none">
-                        <Info className="mr-1 size-3 stroke-muted-foreground" />
-                      </HoverCardTrigger>
-                      <HoverCardContent
-                        className="w-[500px] p-3 font-mono text-xs tracking-tight"
-                        side="left"
-                        sideOffset={20}
-                      >
-                        <ControlFlowConfigTooltip />
-                      </HoverCardContent>
-                    </HoverCard>
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
 
-                    <span className="text-xs text-muted-foreground">
-                      Define additional control flow options for the action.
-                    </span>
-                  </div>
-                  <Controller
-                    name="control_flow.options"
-                    control={methods.control}
-                    render={({ field }) => (
-                      <CustomEditor
-                        className="h-24 w-full"
-                        defaultLanguage="yaml"
-                        value={field.value}
-                        onChange={field.onChange}
+                {/* Inputs */}
+                <AccordionItem value="action-inputs">
+                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                    <div className="flex items-center">
+                      <LayoutListIcon className="mr-3 size-4" />
+                      <span>Inputs</span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="flex flex-col space-y-4 px-4">
+                      {!!finalValErrors && finalValErrors.length > 0 && (
+                        <div className="flex items-center space-x-2">
+                          <AlertTriangleIcon className="size-4 fill-rose-500 stroke-white" />
+                          <span className="text-xs text-rose-500">
+                            Validation errors occurred, please see below.
+                          </span>
+                        </div>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        Define action inputs in YAML below.
+                      </span>
+                      <Controller
+                        name="inputs"
+                        control={methods.control}
+                        render={({ field }) => (
+                          <CustomEditor
+                            className="h-72 w-full"
+                            defaultLanguage="yaml"
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
+                        )}
                       />
-                    )}
-                  />
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </form>
-      </FormProvider>
+                      {!!finalValErrors && finalValErrors.length > 0 && (
+                        <div className="rounded-md border border-rose-400 bg-rose-100 p-4 font-mono text-xs text-rose-500">
+                          <span className="font-bold">Validation Errors</span>
+                          <Separator className="my-2 bg-rose-400" />
+                          {finalValErrors.map((error, index) => (
+                            <div key={index} className="mb-4">
+                              <span>{error.message}</span>
+                              <pre>{YAML.stringify(error.detail)}</pre>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            </TabsContent>
+            <TabsContent value="control-flow">
+              <Accordion
+                type="multiple"
+                defaultValue={["action-control-flow"]}
+                className="pb-10"
+              >
+                <AccordionItem value="action-control-flow">
+                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                    <div className="flex items-center">
+                      <RepeatIcon className="mr-3 size-4" />
+                      <span>Control Flow</span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4">
+                    {/* Run if */}
+                    <div className="flex flex-col space-y-4 px-4">
+                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                        <span>Run If</span>
+                      </FormLabel>
+                      <div className="flex items-center">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                              <Info className="mr-1 size-3 stroke-muted-foreground" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <RunIfTooltip />
+                          </TooltipContent>
+                        </Tooltip>
+
+                        <span className="text-xs text-muted-foreground">
+                          Define a conditional expression that determines if the
+                          action executes.
+                        </span>
+                      </div>
+
+                      <Controller
+                        name="control_flow.run_if"
+                        control={methods.control}
+                        render={({ field }) => (
+                          <CustomEditor
+                            className="h-24 w-full"
+                            defaultLanguage="yaml"
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
+                        )}
+                      />
+                    </div>
+                    {/* Loop */}
+                    <div className="flex flex-col space-y-4 px-4">
+                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                        <span>Loop Iteration</span>
+                      </FormLabel>
+                      <div className="flex items-center">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                              <Info className="mr-1 size-3 stroke-muted-foreground" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <ForEachTooltip />
+                          </TooltipContent>
+                        </Tooltip>
+
+                        <span className="text-xs text-muted-foreground">
+                          Define one or more loop expressions for the action to
+                          iterate over.
+                        </span>
+                      </div>
+
+                      <Controller
+                        name="control_flow.for_each"
+                        control={methods.control}
+                        render={({ field }) => (
+                          <CustomEditor
+                            className="h-24 w-full"
+                            defaultLanguage="yaml"
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
+                        )}
+                      />
+                    </div>
+                    {/* Retry Policy */}
+                    <div className="flex flex-col space-y-4 px-4">
+                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                        <span>Retry Policy</span>
+                      </FormLabel>
+                      <div className="flex items-center">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                              <Info className="mr-1 size-3 stroke-muted-foreground" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <RetryPolicyTooltip />
+                          </TooltipContent>
+                        </Tooltip>
+
+                        <span className="text-xs text-muted-foreground">
+                          Define the retry policy for the action.
+                        </span>
+                      </div>
+                      <Controller
+                        name="control_flow.retry_policy"
+                        control={methods.control}
+                        render={({ field }) => (
+                          <CustomEditor
+                            className="h-24 w-full"
+                            defaultLanguage="yaml"
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
+                        )}
+                      />
+                    </div>
+                    {/* Other options */}
+                    <div className="flex flex-col space-y-4 px-4">
+                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                        <span>Options</span>
+                      </FormLabel>
+                      <div className="flex items-center">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                              <Info className="mr-1 size-3 stroke-muted-foreground" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <ControlFlowConfigTooltip />
+                          </TooltipContent>
+                        </Tooltip>
+
+                        <span className="text-xs text-muted-foreground">
+                          Define additional control flow options for the action.
+                        </span>
+                      </div>
+                      <Controller
+                        name="control_flow.options"
+                        control={methods.control}
+                        render={({ field }) => (
+                          <CustomEditor
+                            className="h-24 w-full"
+                            defaultLanguage="yaml"
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
+                        )}
+                      />
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            </TabsContent>
+          </form>
+        </FormProvider>
+      </Tabs>
+    </div>
+  )
+}
+function SaveStateIcon({
+  saveState,
+}: {
+  saveState: "idle" | "saving" | "success"
+}) {
+  return (
+    <div
+      className={cn(
+        "animate-fade-out absolute right-4 top-4 flex justify-end space-x-2 transition-opacity duration-200",
+        saveState === "idle" && "opacity-0"
+      )}
+    >
+      {saveState === "saving" && (
+        <Loader2Icon className="size-4 animate-spin text-muted-foreground/70" />
+      )}
+      {saveState === "success" && (
+        <CheckCheck className="size-4 text-green-500" />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
# Features
- Add action panel tabs to split accordion into smaller chunks
- Add icons and tooltips to `type` and `origin` in the action description
- Align action icon to top left


# Screens

https://github.com/user-attachments/assets/00e4d249-824e-465b-9b21-11888a8f7a70


