### PR TITLE
fix(integrations): Add missing display groups

### DIFF
--- a/registry/tracecat_registry/integrations/checkpoint.py
+++ b/registry/tracecat_registry/integrations/checkpoint.py
@@ -27,6 +27,7 @@ checkpoint_secret = RegistrySecret(
 @registry.register(
     default_title="Get Checkpoint auth token",
     description="Get an auth token for Checkpoint API calls.",
+    display_group="Checkpoint",
     namespace="integrations.checkpoint",
     secrets=[checkpoint_secret],
 )

--- a/registry/tracecat_registry/integrations/limacharlie.py
+++ b/registry/tracecat_registry/integrations/limacharlie.py
@@ -26,6 +26,7 @@ limacharlie_secret = RegistrySecret(
 @registry.register(
     default_title="Get Limacharlie auth token",
     description="Get an auth token for Limacharlie API calls.",
+    display_group="Limacharlie",
     namespace="integrations.limacharlie",
     secrets=[limacharlie_secret],
 )

--- a/registry/tracecat_registry/integrations/microsoft_graph.py
+++ b/registry/tracecat_registry/integrations/microsoft_graph.py
@@ -33,6 +33,7 @@ microsoft_graph_secret = RegistrySecret(
 @registry.register(
     default_title="Get Microsoft Graph auth token",
     description="Get an auth token for Microsoft Graph API calls.",
+    display_group="Microsoft Graph",
     namespace="integrations.microsoft_graph",
     secrets=[microsoft_graph_secret],
 )

--- a/registry/tracecat_registry/integrations/wiz.py
+++ b/registry/tracecat_registry/integrations/wiz.py
@@ -32,6 +32,7 @@ wiz_secret = RegistrySecret(
 @registry.register(
     default_title="Get Wiz auth token",
     description="Get an auth token for Wiz API calls.",
+    display_group="Wiz",
     namespace="integrations.wiz",
     secrets=[wiz_secret],
 )


### PR DESCRIPTION
Users will have to re-sync their `tracecat_registry` (maybe also restart their instances) to get the right grouping