### PR TITLE
fix: Add missing TemplateValidator to dynamic expectation models

### DIFF
--- a/playbooks/tutorials/limacharlie/run_investigation.yml
+++ b/playbooks/tutorials/limacharlie/run_investigation.yml
@@ -26,9 +26,9 @@ definition:
       ref: list_sensors_by_tags
       args:
         url: "{{ INPUTS.api_url }}/tags/{{ SECRETS.limacharlie.LIMACHARLIE_OID }}/{ TRIGGER.tags }"
+        method: GET
         token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "{{ INPUTS.jwt_url }}?oid={{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret={{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
-        method: GET
 
     - action: core.transform.reshape
       ref: extract_sensor_ids
@@ -45,10 +45,12 @@ definition:
       for_each: ${{ for var.sensor_id in ACTIONS.extract_sensor_ids.result.sensor_ids }}
       args:
         url: "${{ INPUTS.api_url }}/${{ var.sensor_id }}/"
+        method: GET
         token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         payload:
-          tasks: ["run --shell-command 'del ${{ INPUTS.payload_dir_path }}\\*.exe'"]
+          tasks:
+            - "run --shell-command 'del ${{ INPUTS.payload_dir_path }}\\*.exe'"
         headers:
           Content-Type: application/x-www-form-urlencoded
 

--- a/playbooks/tutorials/limacharlie/run_tests.yml
+++ b/playbooks/tutorials/limacharlie/run_tests.yml
@@ -31,10 +31,12 @@ definition:
       for_each: ${{ for var.test_id in TRIGGER.test_ids }}
       args:
         url: "${{ INPUTS.api_url }}/${{ TRIGGER.sensor_id }}/"
+        method: GET
         token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         payload:
-          tasks: ["put --payload-name ${{ var.test_id }} --payload-path ${{ TRIGGER.payload_dir_path }}\\${{ var.test_id }}.exe"]
+          tasks:
+            - "put --payload-name ${{ var.test_id }} --payload-path ${{ TRIGGER.payload_dir_path }}\\${{ var.test_id }}.exe"
           investigation_id: ${{ TRIGGER.investigation_id }}
         headers:
           Content-Type: application/x-www-form-urlencoded
@@ -46,10 +48,12 @@ definition:
       for_each: ${{ for var.test_id in TRIGGER.test_ids }}
       args:
         url: "${{ INPUTS.api_url }}/${{ TRIGGER.sensor_id }}/"
+        method: GET
         token_response_key: ${{ INPUTS.token_response_key }}
         jwt_url: "${{ INPUTS.jwt_url }}?oid=${{ SECRETS.limacharlie.LIMACHARLIE_OID }}&secret=${{ SECRETS.limacharlie.LIMACHARLIE_API_SECRET }}"
         payload:
-          tasks: ["run --shell-command '${{ TRIGGER.payload_dir_path }}\\${{ var.test_id }}.exe'"]
+          tasks:
+            - "run --shell-command '${{ TRIGGER.payload_dir_path }}\\${{ var.test_id }}.exe'"
           investigation_id: ${{ TRIGGER.investigation_id }}
         headers:
           Content-Type: application/x-www-form-urlencoded
@@ -75,5 +79,6 @@ definition:
           start=${{ ACTIONS.emulation_times.result.start }}&
           end=${{ ACTIONS.emulation_times.result.end }}&
           event_type=${{ INPUTS.event_type }}
+        method: GET
 
     # TODO: Upload results to records

--- a/tracecat/validation/common.py
+++ b/tracecat/validation/common.py
@@ -1,8 +1,9 @@
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 from pydantic import BaseModel, Field, create_model
 
 from tracecat.expressions.shared import ExprType
+from tracecat.expressions.validation import TemplateValidator
 from tracecat.logger import logger
 from tracecat.secrets.models import SecretSearch
 from tracecat.secrets.service import SecretsService
@@ -52,7 +53,7 @@ def json_schema_to_pydantic(
 
     fields = {}
     for prop_name, prop_schema in properties.items():
-        field_type = create_field(prop_schema)
+        field_type = Annotated[create_field(prop_schema), TemplateValidator()]
         field_params = {}
 
         if "description" in prop_schema:


### PR DESCRIPTION
# Changes
- Fix issue where validating an expression string in a non-string type field would cause an unexpected validation error.
- Update broken playbooks tests for `core.http_request` default `method` field