### PR TITLE
feat: Allow deletion of remote repository

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -1205,15 +1205,15 @@ export const registryRepositoriesUpdateRegistryRepository = (data: RegistryRepos
  * Delete Registry Repository
  * Delete a registry repository.
  * @param data The data for the request.
- * @param data.origin
+ * @param data.id
  * @returns void Successful Response
  * @throws ApiError
  */
 export const registryRepositoriesDeleteRegistryRepository = (data: RegistryRepositoriesDeleteRegistryRepositoryData): CancelablePromise<RegistryRepositoriesDeleteRegistryRepositoryResponse> => { return __request(OpenAPI, {
     method: 'DELETE',
-    url: '/registry/repos/{origin}',
+    url: '/registry/repos/{id}',
     path: {
-        origin: data.origin
+        id: data.id
     },
     errors: {
         422: 'Validation Error'

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1602,7 +1602,7 @@ export type RegistryRepositoriesUpdateRegistryRepositoryData = {
 export type RegistryRepositoriesUpdateRegistryRepositoryResponse = RegistryRepositoryRead;
 
 export type RegistryRepositoriesDeleteRegistryRepositoryData = {
-    origin: string;
+    id: string;
 };
 
 export type RegistryRepositoriesDeleteRegistryRepositoryResponse = void;
@@ -2481,6 +2481,8 @@ export type $OpenApiTs = {
                 422: HTTPValidationError;
             };
         };
+    };
+    '/registry/repos/{id}': {
         delete: {
             req: RegistryRepositoriesDeleteRegistryRepositoryData;
             res: {

--- a/frontend/src/components/registry/registry-repos-table.tsx
+++ b/frontend/src/components/registry/registry-repos-table.tsx
@@ -116,9 +116,13 @@ export function RegistryRepositoriesTable() {
               console.error("No repository selected")
               return
             }
-            console.log("Deleting repository", selectedRepo.origin)
+            console.log(
+              "Deleting repository",
+              selectedRepo.origin,
+              selectedRepo.id
+            )
             try {
-              await deleteRepo({ origin: selectedRepo.origin })
+              await deleteRepo({ id: selectedRepo.id })
             } catch (error) {
               console.error("Error deleting repository", error)
             } finally {


### PR DESCRIPTION
Closes #457

# Changes
- Update registry repository delete endpoint to accept ID instead of origin

# Remarks
- Unblocking this so users can clear incorrect/accidental repo origins
- If you accidentally delete your main remote repository, you still have to restart your instance to reload it