### PR TITLE
feat+fix: Optional secrets

### DIFF
--- a/docker-compose.prod.override.yml
+++ b/docker-compose.prod.override.yml
@@ -1,0 +1,22 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      TRACECAT__APP_ENV: production
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      TRACECAT__APP_ENV: production
+
+  ui:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    environment:
+      NODE_ENV: "production"
+      NEXT_PUBLIC_APP_ENV: "production"

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1846,6 +1846,11 @@ export const $RegistrySecret = {
                 }
             ],
             title: 'Optional Keys'
+        },
+        optional: {
+            type: 'boolean',
+            title: 'Optional',
+            default: false
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -653,6 +653,7 @@ export type RegistrySecret = {
     name: string;
     keys?: Array<(string)> | null;
     optional_keys?: Array<(string)> | null;
+    optional?: boolean;
 };
 
 /**

--- a/registry/tracecat_registry/_internal/models.py
+++ b/registry/tracecat_registry/_internal/models.py
@@ -11,8 +11,16 @@ SecretKey = Annotated[str, StringConstraints(pattern=r"[a-zA-Z0-9_]+")]
 
 class RegistrySecret(BaseModel):
     name: SecretName
+    """The name of the secret."""
+
     keys: list[SecretKey] | None = None
+    """Keys that are required to be set in the environment."""
+
     optional_keys: list[SecretKey] | None = None
+    """Keys that are optional to be set in the environment."""
+
+    optional: bool = False
+    """Indicates if the secret is optional."""
 
     @model_validator(mode="after")
     def validate_keys(cls, v):

--- a/registry/tracecat_registry/base/core/http.py
+++ b/registry/tracecat_registry/base/core/http.py
@@ -16,6 +16,7 @@ JSONObjectOrArray = dict[str, Any] | list[Any]
 ssl_secret = RegistrySecret(
     name="ssl",
     optional_keys=["SSL_CLIENT_CERT", "SSL_CLIENT_KEY", "SSL_CLIENT_PASSWORD"],
+    optional=True,
 )
 """HTTP SSL certificate secrets.
 

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -143,8 +143,9 @@ class AuthSandbox:
 
         if len(unique_secret_names) != len(secrets):
             missing_secrets = unique_secret_names - {secret.name for secret in secrets}
+            logger.error("Missing secrets", missing_secrets=missing_secrets)
             raise TracecatCredentialsError(
-                "Failed to retrieve secrets. Please contact support for help.",
+                f"Missing secrets: {', '.join(missing_secrets)}",
                 detail=[
                     {"secret_name": name, "environment": self._environment}
                     for name in missing_secrets

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -136,9 +136,7 @@ class AuthSandbox:
             logger.info("Retrieving secrets", secret_names=unique_secret_names)
 
             secrets = await service.search_secrets(
-                SecretSearch(
-                    names=list(unique_secret_names), environment=self._environment
-                )
+                SecretSearch(names=unique_secret_names, environment=self._environment)
             )
 
         if len(unique_secret_names) != len(secrets):

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -35,7 +35,7 @@ class AuthSandbox:
         | None = None,  # This can be either 'my_secret.KEY' or 'my_secret'
         target: Literal["env", "context"] = "context",
         environment: str = DEFAULT_SECRETS_ENVIRONMENT,
-        optional_secrets: list[str] | None = None,
+        optional_secrets: list[str] | None = None,  # Base secret names only
     ):
         self._role = role or ctx_role.get()
         self._secret_paths: list[str] = secrets or []
@@ -144,9 +144,9 @@ class AuthSandbox:
 
         # Filter out optional secrets
         unique_req_secret_names = {
-            secret.name
-            for secret in secrets
-            if secret.name not in self._optional_secrets
+            secret_name
+            for secret_name in unique_secret_names
+            if secret_name not in self._optional_secrets
         }
         defined_req_secret_names = {
             secret.name

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -159,6 +159,7 @@ class AuthSandbox:
             optional_secrets=self._optional_secrets,
         )
 
+        # This check only validates required/optional secrets and doesn't validate secret keys
         if len(unique_req_secret_names) != len(defined_req_secret_names):
             missing_secrets = unique_req_secret_names - defined_req_secret_names
             logger.error("Missing secrets", missing_secrets=missing_secrets)

--- a/tracecat/registry/executor.py
+++ b/tracecat/registry/executor.py
@@ -80,11 +80,17 @@ async def run_single_action(
 
     logger.info("Running regular UDF async", action=action_name)
     secret_names = [secret.name for secret in action.secrets or []]
+    optional_secrets = [
+        secret.name for secret in action.secrets or [] if secret.optional
+    ]
     run_context = ctx_run.get()
     environment = getattr(run_context, "environment", DEFAULT_SECRETS_ENVIRONMENT)
     async with (
         AuthSandbox(
-            secrets=secret_names, target="context", environment=environment
+            secrets=secret_names,
+            target="context",
+            environment=environment,
+            optional_secrets=optional_secrets,
         ) as sandbox,
     ):
         # Flatten the secrets to a dict[str, str]

--- a/tracecat/secrets/secrets_manager.py
+++ b/tracecat/secrets/secrets_manager.py
@@ -5,7 +5,6 @@ from collections.abc import Iterator
 from typing import overload
 
 from tracecat.contexts import ctx_env
-from tracecat.logger import logger
 
 
 @overload
@@ -19,7 +18,6 @@ def get(name: str, default: str, /) -> str: ...
 def get(name: str, default: str | None = None, /) -> str | None:
     """Get a secret that was set in the current context."""
     _env = ctx_env.get()
-    logger.info(f"Getting secret {name=}", env=_env)
     try:
         return _env[name]
     except KeyError:


### PR DESCRIPTION
# Changes
- Fix issue with http request node requiring that `ssl` secret must be defined, when it should be optional
- To address this, implement optional secrets that skip assertion for optional `RegistrySecret`s, if not defined in the SM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced support for optional secrets in the `AuthSandbox` class, allowing for more flexible secret management.
	- Added a new `optional` property to the `$RegistrySecret` schema, enhancing the flexibility of secret definitions.
	- Implemented a new Docker Compose configuration for production deployment, facilitating the setup of multiple services.

- **Bug Fixes**
	- Improved error handling for missing secrets, providing clearer feedback on which secrets are not found.

- **Tests**
	- Enhanced testing coverage for the `AuthSandbox` class with new tests for handling required and optional secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->