### PR TITLE
feat: Enable multiple workflow entrypoints

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -755,7 +755,14 @@ export const $DSLContext = {
 export const $DSLEntrypoint = {
     properties: {
         ref: {
-            type: 'string',
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Ref',
             description: 'The entrypoint action ref'
         },
@@ -776,7 +783,6 @@ export const $DSLEntrypoint = {
         }
     },
     type: 'object',
-    required: ['ref'],
     title: 'DSLEntrypoint'
 } as const;
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -275,7 +275,7 @@ export type DSLEntrypoint = {
     /**
      * The entrypoint action ref
      */
-    ref: string;
+    ref?: string | null;
     /**
      * Expected trigger input schema. Use this to specify the expected shape of the trigger input.
      */

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -133,7 +133,7 @@ export function ActionPanel({
 }) {
   const { workspaceId } = useWorkspace()
   const { validationErrors } = useWorkflow()
-  const { action, actionIsLoading, updateAction, isSaving } = useAction(
+  const { action, actionIsLoading, updateAction } = useAction(
     node.id,
     workspaceId,
     workflowId

--- a/frontend/src/components/workbench/panel/trigger-panel.tsx
+++ b/frontend/src/components/workbench/panel/trigger-panel.tsx
@@ -135,23 +135,6 @@ export function TriggerPanel({
           "trigger-schedules",
         ]}
       >
-        {/* General */}
-        <AccordionItem value="trigger-settings">
-          <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-            <div className="flex items-center">
-              <SettingsIcon className="mr-3 size-4" />
-              <span>General</span>
-            </div>
-          </AccordionTrigger>
-          <AccordionContent>
-            <div className="my-4 space-y-2 px-4">
-              <GeneralControls
-                entrypointRef={workflow.entrypoint ?? undefined}
-              />
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-
         {/* Webhooks */}
         <AccordionItem value="trigger-webhooks">
           <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
@@ -185,35 +168,6 @@ export function TriggerPanel({
           </AccordionContent>
         </AccordionItem>
       </Accordion>
-    </div>
-  )
-}
-
-export function GeneralControls({ entrypointRef }: { entrypointRef?: string }) {
-  return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <Label className="flex items-center gap-2 text-xs text-muted-foreground">
-          <span>Entrypoint</span>
-          {entrypointRef ? (
-            <CopyButton
-              value={entrypointRef}
-              toastMessage="Copied entrypoint ID to clipboard"
-            />
-          ) : (
-            <BanIcon className="size-3 text-muted-foreground" />
-          )}
-        </Label>
-        <div className="rounded-md border shadow-sm">
-          <Input
-            name="entrypointId"
-            className="rounded-md border-none text-xs shadow-none"
-            value={entrypointRef || "No entrypoint"}
-            readOnly
-            disabled
-          />
-        </div>
-      </div>
     </div>
   )
 }

--- a/frontend/src/components/workbench/panel/trigger-panel.tsx
+++ b/frontend/src/components/workbench/panel/trigger-panel.tsx
@@ -8,10 +8,8 @@ import { useWorkspace } from "@/providers/workspace"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import {
-  BanIcon,
   CalendarClockIcon,
   PlusCircleIcon,
-  SettingsIcon,
   WebhookIcon,
 } from "lucide-react"
 import { useForm } from "react-hook-form"

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,0 +1,58 @@
+import pytest
+
+from tracecat.dsl.common import DSLInput
+from tracecat.types.auth import Role
+from tracecat.workflow.management.management import WorkflowsManagementService
+from tracecat.workflow.management.models import ExternalWorkflowDefinition
+
+
+@pytest.mark.asyncio
+async def test_workflow_can_import(test_role: Role):
+    dsl = ExternalWorkflowDefinition(
+        definition=DSLInput(
+            **{
+                "title": "multiple_entrypoints",
+                "description": "Test that workflow can have multiple entrypoints",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "entrypoint_1",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_1"},
+                    },
+                    {
+                        "ref": "entrypoint_2",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_2"},
+                    },
+                    {
+                        "ref": "entrypoint_3",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_3"},
+                    },
+                    {
+                        "ref": "join",
+                        "action": "core.transform.reshape",
+                        "args": {
+                            "value": {
+                                "first": "${{ ACTIONS.entrypoint_1.result }}",
+                                "second": "${{ ACTIONS.entrypoint_2.result }}",
+                                "third": "${{ ACTIONS.entrypoint_3.result }}",
+                            }
+                        },
+                        "depends_on": ["entrypoint_1", "entrypoint_2", "entrypoint_3"],
+                        "join_strategy": "all",
+                    },
+                ],
+                "returns": "${{ ACTIONS.join.result }}",
+            }
+        )
+    )
+
+    # Import it into the database
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        import_data = dsl.model_dump(mode="json")
+
+        workflow = await service.create_workflow_from_external_definition(import_data)
+
+        assert workflow.actions and len(workflow.actions) == 4

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -36,7 +36,7 @@ from tracecat.workflow.actions.models import ActionControlFlow
 
 
 class DSLEntrypoint(BaseModel):
-    ref: str = Field(..., description="The entrypoint action ref")
+    ref: str | None = Field(default=None, description="The entrypoint action ref")
     expects: dict[str, ExpectedField] | None = Field(
         None,
         description=(

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -180,15 +180,16 @@ class DSLInput(BaseModel):
                 )
                 nodes.append(node)
 
-                for src_ref in action.depends_on:
-                    src_id = ref2id[src_ref]
-                    edges.append(RFEdge(source=src_id, target=dst_id))
+                if not action.depends_on:
+                    # If there are no dependencies, this is an entrypoint
+                    entrypoint_id = ref2id[action.ref]
+                    edges.append(RFEdge(source=trigger_node.id, target=entrypoint_id))
+                else:
+                    # Otherwise, add edges for all dependencies
+                    for src_ref in action.depends_on:
+                        src_id = ref2id[src_ref]
+                        edges.append(RFEdge(source=src_id, target=dst_id))
 
-            entrypoint_id = ref2id[self.entrypoint.ref]
-            # Add trigger edge
-            edges.append(
-                RFEdge(source=trigger_node.id, target=entrypoint_id, label="⚡ Trigger")
-            )
             return RFGraph(nodes=nodes, edges=edges)
         except Exception as e:
             logger.opt(exception=e).error("Error creating graph")

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -69,7 +69,9 @@ class DSLInput(BaseModel):
     inputs: dict[str, Any] = Field(
         default_factory=dict, description="Static input parameters"
     )
-    returns: Any | None = Field(None, description="The action ref or value to return.")
+    returns: Any | None = Field(
+        default=None, description="The action ref or value to return."
+    )
 
     @model_validator(mode="after")
     def validate_structure(self) -> Self:

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -84,14 +84,9 @@ class DSLInput(BaseModel):
                 "All action references (the action title in snake case) must be unique."
                 f" Duplicate refs: {duplicates}"
             )
-        valid_actions = tuple(action.ref for action in self.actions)
-        if self.entrypoint.ref not in valid_actions:
-            raise TracecatDSLError(
-                f"Entrypoint reference must be one of the actions {valid_actions!r}"
-            )
         n_entrypoints = sum(1 for action in self.actions if not action.depends_on)
-        if n_entrypoints != 1:
-            raise TracecatDSLError(f"Expected 1 entrypoint, got {n_entrypoints}")
+        if n_entrypoints == 0:
+            raise TracecatDSLError("No entrypoints found")
 
         # Validate that all the refs in depends_on are valid actions
         valid_actions = {a.ref for a in self.actions}

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -201,7 +201,11 @@ class DSLScheduler:
 
     async def start(self) -> None:
         """Run the scheduler in dynamic mode."""
-        self.queue.put_nowait(self.dsl.entrypoint.ref)
+        # Instead of explicitly setting the entrypoint, we set all zero-indegree
+        # tasks to the queue.
+        for task_ref, indegree in self.indegrees.items():
+            if indegree == 0:
+                self.queue.put_nowait(task_ref)
         while not self.task_exceptions and (
             not self.queue.empty() or len(self.completed_tasks) < len(self.tasks)
         ):

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -15,7 +15,6 @@ from pydantic.alias_generators import to_camel
 
 from tracecat.dsl.enums import EdgeType
 from tracecat.identifiers import action
-from tracecat.logger import logger
 from tracecat.types.exceptions import TracecatValidationError
 
 if TYPE_CHECKING:
@@ -161,23 +160,6 @@ class RFGraph(TSObject):
                 "Trigger node should not have edges in the main graph"
             )
 
-        # Can't have one of the entrypoints as None
-        if (self.logical_entrypoint is None) ^ (self.entrypoint is None):
-            raise TracecatValidationError(
-                "One of the logical and physical entrypoints are None:"
-                f"({self.logical_entrypoint=}) != ({self.entrypoint=})",
-            )
-
-        # Check if the logical entrypoint matches the physical entrypoint
-        if (
-            self.logical_entrypoint
-            and self.entrypoint
-            and self.logical_entrypoint.ref != self.entrypoint.ref
-        ):
-            logger.error(
-                f"Entrypoint doesn't match: {self.logical_entrypoint.ref!r} != {self.entrypoint.ref!r}"
-            )
-            raise TracecatValidationError("Entrypoint doesn't match")
         return self
 
     @property
@@ -217,32 +199,10 @@ class RFGraph(TSObject):
         return indegree
 
     @property
-    def entrypoint(self) -> RFNode[UDFNodeData] | None:
-        """The physical entrypoint of the graph. It is the node with the trigger as the source."""
-        if len(self.action_nodes()) == 0:
-            return None
-        entrypoints = {
-            edge.target for edge in self.edges if edge.source == self.trigger.id
-        }
-        if (n := len(entrypoints)) != 1:
-            raise TracecatValidationError(
-                f"Expected 1 physical entrypoint, got {n}: {entrypoints!r}"
-            )
-        return self.node_map[entrypoints.pop()]
-
-    @property
-    def logical_entrypoint(self) -> UDFNode | None:
-        """The logical entrypoint of the graph. It is the node with no incoming edges when the
-        graph is considered only with `udf` nodes."""
+    def entrypoints(self) -> list[UDFNode]:
+        """Return all entrypoints of the graph."""
         act_nodes = self.action_nodes()
-        if len(act_nodes) == 0:
-            return None
-        entrypoints = [node for node in act_nodes if self.indegree[node.id] == 0]
-        if (n := len(entrypoints)) != 1:
-            raise TracecatValidationError(
-                f"Expected 1 logical entrypoint, got {n}: {entrypoints!r}"
-            )
-        return entrypoints[0]
+        return [node for node in act_nodes if self.indegree[node.id] == 0]
 
     def action_edges(self) -> list[RFEdge]:
         """Return all edges that are not connected to the trigger node."""


### PR DESCRIPTION
# Changes
- Enables multiple entrypoints, without the need for a no-op reshape node. Note that having multiple entrypoints causes the workflow to execute them concurrently.
<img width="1551" alt="image" src="https://github.com/user-attachments/assets/f5822826-707b-4b19-9e8f-c5ee2754a6aa">
(concurrent execution)
<img width="742" alt="image" src="https://github.com/user-attachments/assets/17c5878e-968c-4a2b-b8b9-fd8e6e10ded5">

- Consolidate entrypoint logic in models
- Entrypoint in `DSLInput` still kept for backward compatiblity
- Remove entrypoint details in ui
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/7def21fb-413b-4f6f-8bd2-2d78895eb2f2">

