### PR TITLE
feat(ui): Break long words in schema table

### DIFF
--- a/frontend/src/components/jsonschema-table.tsx
+++ b/frontend/src/components/jsonschema-table.tsx
@@ -57,11 +57,11 @@ export function JSONSchemaTable({ schema }: { schema: JSONSchema7 }) {
                     align="start"
                     sideOffset={20}
                   >
-                    <div className="flex w-full items-center justify-between text-muted-foreground ">
-                      <span className="font-mono text-sm font-semibold">
+                    <div className="flex w-full items-center justify-between text-muted-foreground">
+                      <span className="break-words font-mono text-sm font-semibold">
                         {row.parameter}
                       </span>
-                      <span className="text-xs text-muted-foreground/80">
+                      <span className="whitespace-nowrap text-xs text-muted-foreground/80">
                         &nbsp;{row.required ? "(required)" : "(optional)"}
                       </span>
                     </div>
@@ -69,7 +69,7 @@ export function JSONSchemaTable({ schema }: { schema: JSONSchema7 }) {
                       <span className="text-xs font-semibold text-muted-foreground">
                         Description
                       </span>
-                      <p className="text-xs text-foreground/70">
+                      <p className="break-words text-xs text-foreground/70">
                         {row.description}
                       </p>
                     </div>
@@ -77,7 +77,7 @@ export function JSONSchemaTable({ schema }: { schema: JSONSchema7 }) {
                       <span className="text-xs font-semibold text-muted-foreground">
                         Constraints
                       </span>
-                      <p className="text-xs text-foreground/70">
+                      <p className="break-words text-xs text-foreground/70">
                         {row.constraints || "None"}
                       </p>
                     </div>


### PR DESCRIPTION
# Screens
Before
![image](https://github.com/user-attachments/assets/b89533f8-00a0-43e8-a47a-3124911e53fd)

After
<img width="676" alt="image" src="https://github.com/user-attachments/assets/ec69603e-628a-4e8f-9533-9d1801be6838">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual presentation of the `HoverCardContent` in the JSON Schema Table.
  
- **Bug Fixes**
	- Improved text handling for better word wrapping and readability in the parameter and description displays.
	- Ensured required status text does not wrap to the next line for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->