### PR TITLE
fix: Allow sourceHandle to be null for trigger

### DIFF
--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -113,7 +113,7 @@ class RFEdge(TSObject):
 
     label: str | None = Field(default=None, description="Edge label")
 
-    source_handle: EdgeType = Field(
+    source_handle: EdgeType | None = Field(
         default=EdgeType.SUCCESS, description="Edge source handle type"
     )
 


### PR DESCRIPTION
# Changes
- Make `RFGraph.source_handle` nullable, such that we avoid when `sourceHandle` is returned as `null` from the FE in the trigger node.
![image](https://github.com/user-attachments/assets/9af60b75-f177-45ac-92fa-30d620fa6ddf)
