### PR TITLE
fix(integration): Add sentinel value for LDAP connection attribute

### DIFF
--- a/registry/tracecat_registry/integrations/ldap3.py
+++ b/registry/tracecat_registry/integrations/ldap3.py
@@ -43,6 +43,7 @@ class LdapClient:
             host, port=int(port), use_ssl=use_ssl, get_info=ldap3.ALL
         )
         self._ldap_active_directory = is_active_directory
+        self._connection = None
 
     def __enter__(self, *args, **kwargs):
         self.bind()


### PR DESCRIPTION
## Description

With the refactoring to registry and removal of async, accessing _connection before it's instantiated throws an exception.  This ensures that it exists when the check is performed before binding.

## Related Tickets & Documents

Didn't open an issue, minor fix.

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

Using any of the functions provided by this integration would throw exceptions without this fix.

## [optional] What gif best describes this PR?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
