### PR TITLE
feat+fix: Remove reliance on graph object data + improve node loading states

### DIFF
--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      className={cn("animate-pulse rounded-md bg-primary/5", className)}
       {...props}
     />
   )

--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -25,10 +25,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useToast } from "@/components/ui/use-toast"
 import { CopyButton } from "@/components/copy-button"
 import { getIcon } from "@/components/icons"
-import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import {
   ActionSoruceSuccessHandle,
@@ -38,11 +38,7 @@ import {
 
 export interface ActionNodeData {
   type: string // alias for key
-  title: string
-  namespace: string
-  status: "online" | "offline"
   isConfigured: boolean
-  numberOfEvents: number
 }
 export type ActionNodeType = Node<ActionNodeData>
 
@@ -82,72 +78,106 @@ export default React.memo(function ActionNode({
   const edges = useEdges()
   const incomingEdges = edges.filter((edge) => edge.target === id)
 
-  if (actionIsLoading) {
-    return <CenteredSpinner />
-  }
+  // Create a skeleton loading state within the card frame
+  const renderContent = () => {
+    if (actionIsLoading) {
+      return (
+        <>
+          <CardHeader className="p-4">
+            <div className="flex w-full items-center space-x-4">
+              <Skeleton className="size-10 rounded-full" />
+              <div className="flex w-full flex-1 justify-between space-x-12">
+                <div className="flex flex-col space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                <Skeleton className="size-6" />
+              </div>
+            </div>
+          </CardHeader>
+          <Separator />
+          <CardContent className="p-4 py-2">
+            <div className="grid grid-cols-2 space-x-4 text-xs text-muted-foreground">
+              <div className="flex items-center space-x-2">
+                <Skeleton className="size-4" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+          </CardContent>
+        </>
+      )
+    }
 
-  if (!action) {
+    if (!action) {
+      return (
+        <div className="p-4">
+          <AlertNotification
+            variant="warning"
+            title="Could not load action"
+            message="Please try again."
+          />
+        </div>
+      )
+    }
+
     return (
-      <AlertNotification
-        variant="warning"
-        title="Could not load action"
-        message="Please try again."
-      />
+      <>
+        <CardHeader className="p-4">
+          <div className="flex w-full items-center space-x-4">
+            {getIcon(action.type, {
+              className: "size-10 p-2",
+            })}
+
+            <div className="flex w-full flex-1 justify-between space-x-12">
+              <div className="flex flex-col">
+                <CardTitle className="flex w-full items-center space-x-2 text-xs font-medium leading-none">
+                  <span>{action.title}</span>
+                  <CopyButton
+                    value={`\$\{\{ ACTIONS.${slugify(action.title)}.result \}\}`}
+                    toastMessage="Copied action reference to clipboard"
+                    tooltipMessage="Copy action reference"
+                  />
+                </CardTitle>
+                <CardDescription className="mt-2 text-xs text-muted-foreground">
+                  {action.type}
+                </CardDescription>
+              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" className="m-0 size-6 p-0">
+                    <ChevronDownIcon className="m-1 size-4 text-muted-foreground" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={handleDeleteNode}>
+                    <Trash2Icon className="mr-2 size-4 text-red-600" />
+                    <span className="text-xs text-red-600">Delete</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+        </CardHeader>
+        <Separator />
+        <CardContent className="p-4 py-2">
+          <div className="grid grid-cols-2 space-x-4 text-xs text-muted-foreground">
+            <div className="flex items-center space-x-2">
+              {isConfigured ? (
+                <CircleCheckBigIcon className="size-4 text-emerald-500" />
+              ) : (
+                <LayoutListIcon className="size-4 text-gray-400" />
+              )}
+              <span className="text-xs capitalize">{isConfiguredMessage}</span>
+            </div>
+          </div>
+        </CardContent>
+      </>
     )
   }
 
   return (
     <Card className={cn("min-w-72", selected && "shadow-xl drop-shadow-xl")}>
-      <CardHeader className="p-4">
-        <div className="flex w-full items-center space-x-4">
-          {getIcon(action.type, {
-            className: "size-10 p-2",
-          })}
-
-          <div className="flex w-full flex-1 justify-between space-x-12">
-            <div className="flex flex-col">
-              <CardTitle className="flex w-full items-center space-x-2 text-xs font-medium leading-none">
-                <span>{action.title}</span>
-                <CopyButton
-                  value={`\$\{\{ ACTIONS.${slugify(action.title)}.result \}\}`}
-                  toastMessage="Copied action reference to clipboard"
-                  tooltipMessage="Copy action reference"
-                />
-              </CardTitle>
-              <CardDescription className="mt-2 text-xs text-muted-foreground">
-                {action.type}
-              </CardDescription>
-            </div>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="m-0 size-6 p-0">
-                  <ChevronDownIcon className="m-1 size-4 text-muted-foreground" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={handleDeleteNode}>
-                  <Trash2Icon className="mr-2 size-4 text-red-600" />
-                  <span className="text-xs text-red-600">Delete</span>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-      </CardHeader>
-      <Separator />
-      <CardContent className="p-4 py-2">
-        <div className="grid grid-cols-2 space-x-4 text-xs text-muted-foreground">
-          <div className="flex items-center space-x-2">
-            {isConfigured ? (
-              <CircleCheckBigIcon className="size-4 text-emerald-500" />
-            ) : (
-              <LayoutListIcon className="size-4 text-gray-400" />
-            )}
-            <span className="text-xs capitalize">{isConfiguredMessage}</span>
-          </div>
-        </div>
-      </CardContent>
-
+      {renderContent()}
       <ActionTargetHandle
         join_strategy={action?.control_flow?.join_strategy}
         indegree={incomingEdges.length}

--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -36,10 +36,19 @@ import {
   ActionTargetHandle,
 } from "@/components/workbench/canvas/custom-handle"
 
+/**
+ * Represents the data structure for an Action Node
+ * @deprecated Previous version contained additional fields that are no longer used.
+ * Extra fields in existing data structures will be ignored.
+ */
 export interface ActionNodeData {
   type: string // alias for key
   isConfigured: boolean
+
+  // Allow any additional properties from legacy data
+  [key: string]: unknown
 }
+
 export type ActionNodeType = Node<ActionNodeData>
 
 export default React.memo(function ActionNode({

--- a/frontend/src/components/workbench/canvas/selector-node.tsx
+++ b/frontend/src/components/workbench/canvas/selector-node.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react"
-import { RegistryActionRead } from "@/client"
+import { actionsCreateAction, RegistryActionRead } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
 import fuzzysort from "fuzzysort"
 import { CloudOffIcon, XIcon } from "lucide-react"
@@ -21,11 +21,8 @@ import { Separator } from "@/components/ui/separator"
 import { toast } from "@/components/ui/use-toast"
 import { getIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
-import { ActionNodeData } from "@/components/workbench/canvas/action-node"
-import {
-  createNewNode,
-  isEphemeral,
-} from "@/components/workbench/canvas/canvas"
+import { ActionNodeType } from "@/components/workbench/canvas/action-node"
+import { isEphemeral } from "@/components/workbench/canvas/canvas"
 
 export const SelectorTypename = "selector" as const
 
@@ -207,30 +204,33 @@ function ActionCommandGroup({
   }, [sortedActions, inputValue])
 
   const handleSelect = useCallback(
-    async (action: RegistryActionRead) => {
+    async (registryAction: RegistryActionRead) => {
       if (!workflowId) {
         return
       }
-      console.log("Selected action:", action)
-      const { position: currPosition } = getNode(
-        nodeId
-      ) as Node<SelectorNodeData>
-      const nodeData = {
-        type: action.action,
-        title: action.default_title || action.action,
-        namespace: action.namespace,
-        status: "offline",
-        isConfigured: false,
-        numberOfEvents: 0,
-      } as ActionNodeData
+      console.log("Selected action:", registryAction)
+      const { position } = getNode(nodeId) as Node<SelectorNodeData>
+
       try {
-        const newNode = await createNewNode(
-          "udf",
-          workflowId,
+        const type = registryAction.action
+        const title = registryAction.default_title || registryAction.action
+        const { id } = await actionsCreateAction({
           workspaceId,
-          nodeData,
-          currPosition
-        )
+          requestBody: {
+            workflow_id: workflowId,
+            type,
+            title,
+          },
+        })
+        const newNode = {
+          id,
+          type: "udf",
+          position,
+          data: {
+            type,
+            isConfigured: false,
+          },
+        } as ActionNodeType
         // Given successful creation, we can now remove the selector node
         // Find the current "selector" node and replace it with the new node
         // XXX: Actually just filter all ephemeral nodes

--- a/frontend/src/components/workbench/canvas/trigger-node.tsx
+++ b/frontend/src/components/workbench/canvas/trigger-node.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
   TableBody,
@@ -41,7 +42,6 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { getIcon } from "@/components/icons"
-import { CenteredSpinner } from "@/components/loading/spinner"
 import { TriggerSourceHandle } from "@/components/workbench/canvas/custom-handle"
 
 export interface TriggerNodeData {
@@ -156,7 +156,31 @@ function TriggerNodeSchedulesTable({ workflowId }: { workflowId: string }) {
     useSchedules(workflowId)
 
   if (schedulesIsLoading) {
-    return <CenteredSpinner />
+    return (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="h-8 text-center text-xs" colSpan={2}>
+              <div className="flex items-center justify-center gap-1">
+                <Skeleton className="size-3" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          <TableRow className="items-center text-center text-xs">
+            <TableCell>
+              <div className="flex w-full items-center justify-center gap-2">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="size-2 rounded-full" />
+              </div>
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    )
   }
   if (schedulesError || !schedules) {
     return <UnplugIcon className="size-4 text-muted-foreground" />

--- a/frontend/src/components/workbench/panel/trigger-panel.tsx
+++ b/frontend/src/components/workbench/panel/trigger-panel.tsx
@@ -7,11 +7,7 @@ import { ApiError, WebhookResponse, WorkflowResponse } from "@/client"
 import { useWorkspace } from "@/providers/workspace"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
-import {
-  CalendarClockIcon,
-  PlusCircleIcon,
-  WebhookIcon,
-} from "lucide-react"
+import { CalendarClockIcon, PlusCircleIcon, WebhookIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
@@ -88,17 +84,9 @@ import { CopyButton } from "@/components/copy-button"
 import { getIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
-import {
-  TriggerNodeData,
-  TriggerTypename,
-} from "@/components/workbench/canvas/trigger-node"
+import { TriggerTypename } from "@/components/workbench/canvas/trigger-node"
 
-export function TriggerPanel({
-  workflow,
-}: {
-  nodeData: TriggerNodeData
-  workflow: WorkflowResponse
-}) {
+export function TriggerPanel({ workflow }: { workflow: WorkflowResponse }) {
   return (
     <div className="size-full overflow-auto">
       <div className="grid grid-cols-3">

--- a/frontend/src/components/workbench/panel/workbench-panel.tsx
+++ b/frontend/src/components/workbench/panel/workbench-panel.tsx
@@ -2,13 +2,10 @@ import React from "react"
 import { WorkflowResponse } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
-import { Node } from "reactflow"
 
 import { FormLoading } from "@/components/loading/form"
 import { AlertNotification } from "@/components/notifications"
-import { ActionNodeData } from "@/components/workbench/canvas/action-node"
 import { NodeType } from "@/components/workbench/canvas/canvas"
-import { TriggerNodeData } from "@/components/workbench/canvas/trigger-node"
 import { ActionPanel } from "@/components/workbench/panel/action-panel"
 import { TriggerPanel } from "@/components/workbench/panel/trigger-panel"
 import { WorkflowPanel } from "@/components/workbench/panel/workflow-panel"
@@ -58,19 +55,9 @@ function NodePanel({
 }) {
   switch (node.type) {
     case "udf":
-      return (
-        <ActionPanel
-          node={node as Node<ActionNodeData>}
-          workflowId={workflow.id}
-        />
-      )
+      return <ActionPanel actionId={node.id} workflowId={workflow.id} />
     case "trigger":
-      return (
-        <TriggerPanel
-          nodeData={node.data as TriggerNodeData}
-          workflow={workflow}
-        />
-      )
+      return <TriggerPanel workflow={workflow} />
     case "selector":
       // XXX: Unreachable, as we never select the selector node
       return <></>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -54,7 +54,6 @@ import {
   workspacesDeleteWorkspace,
   workspacesListWorkspaces,
 } from "@/client"
-import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkspace } from "@/providers/workspace"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import Cookies from "js-cookie"

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -60,9 +60,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import Cookies from "js-cookie"
 
 import { retryHandler, TracecatApiError } from "@/lib/errors"
-import { isEmptyObject } from "@/lib/utils"
 import { toast } from "@/components/ui/use-toast"
-import { ActionNodeType } from "@/components/workbench/canvas/action-node"
 
 export function useLocalStorage<T>(
   key: string,
@@ -88,7 +86,6 @@ export function useAction(
 ) {
   const [isSaving, setIsSaving] = useState(false)
   const queryClient = useQueryClient()
-  const { setNodes } = useWorkflowBuilder()
   const {
     data: action,
     isLoading: actionIsLoading,
@@ -109,22 +106,7 @@ export function useAction(
         requestBody: values,
       })
     },
-    onSuccess: (updatedAction: ActionRead) => {
-      setNodes((nds: ActionNodeType[]) =>
-        nds.map((node: ActionNodeType) => {
-          if (node.id === actionId) {
-            const { title } = updatedAction
-            node.data = {
-              ...node.data,
-              title,
-              isConfigured:
-                updatedAction.inputs !== null ||
-                isEmptyObject(updatedAction.inputs),
-            }
-          }
-          return node
-        })
-      )
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["action"],
       })

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -1,63 +1,30 @@
-import { actionsCreateAction, workflowsUpdateWorkflow } from "@/client"
 import { ReactFlowInstance } from "reactflow"
 
 import { isEphemeral } from "@/components/workbench/canvas/canvas"
 
-export async function updateWorkflowGraphObject(
-  workspaceId: string,
-  workflowId: string,
-  reactFlowInstance: ReactFlowInstance
-) {
-  try {
-    const object = reactFlowInstance.toObject()
+/**
+ * Prune the graph object to remove ephemeral nodes and edges.
+ * @param reactFlowInstance - The React Flow instance.
+ * @returns The pruned graph object.
+ */
+export function pruneGraphObject(reactFlowInstance: ReactFlowInstance) {
+  const object = reactFlowInstance.toObject()
 
-    // Filter out non-ephemeral nodes and their associated edges
-    const ephemeralNodeIds = new Set(
-      object.nodes.filter(isEphemeral).map((node) => node.id)
-    )
+  // Filter out non-ephemeral nodes and their associated edges
+  const ephemeralNodeIds = new Set(
+    object.nodes.filter(isEphemeral).map((node) => node.id)
+  )
 
-    // Keep nodes that are NOT ephemeral
-    object.nodes = object.nodes.filter((node) => !ephemeralNodeIds.has(node.id))
-    // Keep edges that are NOT connected to ephemeral nodes
-    object.edges = object.edges.filter(
-      (edge) => !ephemeralNodeIds.has(edge.target)
-    )
+  // Keep nodes that are NOT ephemeral
+  object.nodes = object.nodes.filter((node) => !ephemeralNodeIds.has(node.id))
+  // Keep edges that are NOT connected to ephemeral nodes
+  object.edges = object.edges.filter(
+    (edge) => !ephemeralNodeIds.has(edge.target)
+  )
 
-    // Check that the object at least contains the trigger node
-    if (!object.nodes.some((node) => node.type === "trigger")) {
-      throw new Error("Workflow cannot be saved without a trigger node")
-    }
-
-    await workflowsUpdateWorkflow({
-      workspaceId,
-      workflowId,
-      requestBody: {
-        object,
-      },
-    })
-  } catch (error) {
-    console.error("Error updating DnD flow object:", error)
+  // Check that the object at least contains the trigger node
+  if (!object.nodes.some((node) => node.type === "trigger")) {
+    throw new Error("Workflow cannot be saved without a trigger node")
   }
-}
-
-export async function createAction(
-  type: string,
-  title: string,
-  workflowId: string,
-  workspaceId: string
-): Promise<string> {
-  try {
-    const actionMetadata = await actionsCreateAction({
-      workspaceId,
-      requestBody: {
-        workflow_id: workflowId,
-        type: type,
-        title: title,
-      },
-    })
-    return actionMetadata.id
-  } catch (error) {
-    console.error("Error creating action:", error)
-    throw error
-  }
+  return object
 }

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -17,8 +17,7 @@ import {
   useReactFlow,
 } from "reactflow"
 
-import { slugify } from "@/lib/utils"
-import { updateWorkflowGraphObject } from "@/lib/workflow"
+import { pruneGraphObject } from "@/lib/workflow"
 import { NodeType } from "@/components/workbench/canvas/canvas"
 
 interface ReactFlowContextType {
@@ -27,7 +26,6 @@ interface ReactFlowContextType {
   workspaceId: string
   selectedNodeId: string | null
   getNode: (id: string) => NodeType | undefined
-  getNodeRef: (id?: string) => string | undefined
   setNodes: React.Dispatch<SetStateAction<Node[]>>
   setEdges: React.Dispatch<SetStateAction<Edge[]>>
 }
@@ -44,7 +42,7 @@ export const WorkflowBuilderProvider: React.FC<
   ReactFlowInteractionsProviderProps
 > = ({ children }) => {
   const reactFlowInstance = useReactFlow()
-  const { workspaceId, workflowId, error } = useWorkflow()
+  const { workspaceId, workflowId, error, updateWorkflow } = useWorkflow()
 
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   if (!workflowId) {
@@ -54,14 +52,14 @@ export const WorkflowBuilderProvider: React.FC<
   const setReactFlowNodes = useCallback(
     (nodes: NodeType[] | ((nodes: NodeType[]) => NodeType[])) => {
       reactFlowInstance.setNodes(nodes)
-      updateWorkflowGraphObject(workspaceId, workflowId, reactFlowInstance)
+      updateWorkflow({ object: pruneGraphObject(reactFlowInstance) })
     },
     [workflowId, reactFlowInstance]
   )
   const setReactFlowEdges = useCallback(
     (edges: Edge[] | ((edges: Edge[]) => Edge[])) => {
       reactFlowInstance.setEdges(edges)
-      updateWorkflowGraphObject(workspaceId, workflowId, reactFlowInstance)
+      updateWorkflow({ object: pruneGraphObject(reactFlowInstance) })
     },
     [workflowId, reactFlowInstance]
   )
@@ -89,11 +87,6 @@ export const WorkflowBuilderProvider: React.FC<
         setNodes: setReactFlowNodes,
         setEdges: setReactFlowEdges,
         reactFlow: reactFlowInstance,
-        getNodeRef: (id?: string) => {
-          if (!id) return undefined
-          const node = reactFlowInstance.getNode(id)
-          return node ? slugify(node.data.title) : undefined
-        },
       }}
     >
       {children}

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -265,15 +265,15 @@ def build_action_statements(
     graph: RFGraph, actions: list[Action]
 ) -> list[ActionStatement]:
     """Convert DB Actions into ActionStatements using the graph."""
-    ref2action = {action.ref: action for action in actions}
+    id2action = {action.id: action for action in actions}
 
     statements = []
     for node in graph.action_nodes():
         dependencies: list[str] = []
-        for dep_node_id in graph.dep_list[node.id]:
-            base_ref = graph.node_map[dep_node_id].ref
+        for dep_act_id in graph.dep_list[node.id]:
+            base_ref = id2action[dep_act_id].ref
             for edge in graph.edges:
-                if edge.source != dep_node_id or edge.target != node.id:
+                if edge.source != dep_act_id or edge.target != node.id:
                     continue
                 if edge.source_handle == EdgeType.ERROR:
                     ref = dep_from_edge_components(base_ref, edge.source_handle)
@@ -282,12 +282,12 @@ def build_action_statements(
                 dependencies.append(ref)
         dependencies = sorted(dependencies)
 
-        action = ref2action[node.ref]
+        action = id2action[node.id]
         control_flow = ActionControlFlow.model_validate(action.control_flow)
         action_stmt = ActionStatement(
             id=action.id,
-            ref=node.ref,
-            action=node.data.type,
+            ref=action.ref,
+            action=action.type,
             args=action.inputs,
             depends_on=dependencies,
             run_if=control_flow.run_if,

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -186,7 +186,7 @@ class RFGraph(TSObject):
     @cached_property
     def dep_list(self) -> dict[str, set[str]]:
         """Return a dependency list (node IDs) of the graph."""
-        dep_list = defaultdict(set)
+        dep_list: dict[str, set[str]] = defaultdict(set)
         for edge in self.action_edges():
             dep_list[edge.target].add(edge.source)
         return dep_list


### PR DESCRIPTION
Fixes follow on issue to #515, where UI state now appeared correct and backend state becomes out of sync.
Solution was to only reference `action` table as source of truth and remove reliance on `Workflow.object`

# Changes
- Reduce use of `RFGraph` values. Only use action ids to reference actions
- Remove use of `ActionNodeData` values. Only use `useAction` hooks to reference action data
- Cleanup unused/old code
- Improve node loading states