### PR TITLE
feat(integration): Crowdstrike incidents + combined Get Detects/Incident templates

### DIFF
--- a/registry/tracecat_registry/templates/crowdstrike/get_detections.yml
+++ b/registry/tracecat_registry/templates/crowdstrike/get_detections.yml
@@ -1,0 +1,44 @@
+type: action
+definition:
+  name: get_cs_detects
+  namespace: integrations.crowdstrike
+  title: Get CrowdStrike Detections
+  description: |
+    Query for CrowdStrike detection IDs, and get all details for these IDs.
+    Uses the following two falcony operations -
+    1. https://falconpy.io/Service-Collections/Detects.html#querydetects
+    2. https://falconpy.io/Service-Collections/Detects.html#getdetectsummaries
+  display_group: CrowdStrike
+  expects:
+    limit:
+      type: int
+      description: Maximum number of alerts to return
+      default: null
+    filter:
+      type: str
+      description: |
+        (Optional) Falcon Query Language (FQL) filter to apply to alerts.
+        If specified, overrides default filter of 'created_timestamp >= now-15m'
+      default: null
+    member_cid:
+      type: str
+      description: CrowdStrike Member CID
+      default: null
+  steps:
+    - ref: query_detects
+      action: integrations.crowdstrike.call_falconpy_command
+      args:
+        operation_id: QueryDetects
+        member_cid: ${{ inputs.member_cid }}
+        params:
+          filter: ${{ inputs.filter || "created_timestamp:>='now-15m'" }}
+          limit: ${{ inputs.limit }}
+    - ref: get_summaries
+      action: integrations.crowdstrike.call_falconpy_command
+      args:
+        params:
+          body:
+            ids: ${{ steps.query_detects.result.body.resources }}
+        member_cid: ${{ inputs.member_cid }}
+        operation_id: GetDetectSummaries
+  returns: ${{ steps.get_summaries.result }}

--- a/registry/tracecat_registry/templates/crowdstrike/get_incident_summaries.yml
+++ b/registry/tracecat_registry/templates/crowdstrike/get_incident_summaries.yml
@@ -1,0 +1,22 @@
+type: action
+definition:
+  name: list_incident_summaries
+  namespace: integrations.crowdstrike
+  title: List CrowdStrike CrowdScore Incident Summaries
+  description: |
+    Query for CrowdStrike CrowdScore Incident summaries using
+    the following falconpy operation: https://falconpy.io/Service-Collections/Incidents.html#getincidents
+  display_group: CrowdStrike
+  expects:
+    incident_ids:
+      type: list[str]
+      description: List of Incident IDs to search for
+  steps:
+    - ref: get_summaries
+      action: integrations.crowdstrike.call_falconpy_command
+      args:
+        operation_id: GetIncidents
+        params:
+          body:
+            ids: ${{ inputs.incident_ids }}
+  returns: ${{ steps.get_summaries.result }}

--- a/registry/tracecat_registry/templates/crowdstrike/get_incidents.yml
+++ b/registry/tracecat_registry/templates/crowdstrike/get_incidents.yml
@@ -1,0 +1,42 @@
+type: action
+definition:
+  name: get_cs_incidents
+  namespace: integrations.crowdstrike
+  title: Get CrowdStrike CrowdScore Incidents
+  description: |
+    Query for CrowdStrike CrowdScore Incident IDs, and get all details for these IDs. 
+    Uses the following two falcony operations -
+    1. https://falconpy.io/Service-Collections/Incidents.html#queryincidents 2. https://falconpy.io/Service-Collections/Incidents.html#getincidents
+  display_group: CrowdStrike
+  expects:
+    limit:
+      type: int
+      description: Maximum number of alerts to return
+      default: null
+    filter:
+      type: str
+      description: |
+        (Optional) Falcon Query Language (FQL) filter to apply to incidents.
+        If specified, overrides default filter of "state:'open'"
+      default: null
+    member_cid:
+      type: str
+      description: CrowdStrike Member CID
+      default: null
+  steps:
+    - ref: query_incidents
+      action: integrations.crowdstrike.call_falconpy_command
+      args:
+        operation_id: QueryIncidents
+        member_cid: ${{ inputs.member_cid }}
+        params:
+          filter: ${{ inputs.filter || "state:'open'" }}
+          limit: ${{ inputs.limit }}
+    - ref: get_summaries
+      action: integrations.crowdstrike.call_falconpy_command
+      args:
+        operation_id: GetIncidents
+        params:
+          body:
+            ids: ${{ steps.query_incidents.result.body.resources }}
+  returns: ${{ steps.get_summaries.result }}

--- a/registry/tracecat_registry/templates/crowdstrike/list_incidents.yml
+++ b/registry/tracecat_registry/templates/crowdstrike/list_incidents.yml
@@ -1,0 +1,34 @@
+type: action
+definition:
+  name: list_incidents
+  namespace: integrations.crowdstrike
+  title: List New CrowdStrike CrowdScore Incidents
+  description: |
+    Query for CrowdStrike CrowdScore Incidents (state:open) using
+    the following falconpy operation: https://falconpy.io/Service-Collections/Incidents.html#queryincidents
+  display_group: CrowdStrike
+  expects:
+    limit:
+      type: int
+      description: Maximum number of incidents to return
+      default: null
+    filter:
+      type: str
+      description: |
+        (Optional) Falcon Query Language (FQL) filter to apply to incidents.
+        If specified, overrides default filter of "state:'open'"
+      default: null
+    member_cid:
+      type: str
+      description: CrowdStrike Member CID
+      default: null
+  steps:
+    - ref: query_incidents
+      action: integrations.crowdstrike.call_falconpy_command
+      args:
+        operation_id: QueryIncidents
+        member_cid: ${{ inputs.member_cid }}
+        params:
+          filter: ${{ inputs.filter || "state:'open'" }}
+          limit: ${{ inputs.limit }}
+  returns: ${{ steps.query_incidents.result }}


### PR DESCRIPTION
## Description

Adds templates for retrieving CrowdStrike CrowdScore Incidents and CrowdStrike CrowdScore Incident summaries. Also adds combined templates for retrieving detection/incident IDs and their summaries, all in one action.

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

1. Validate new action templates are valid

## [optional] What gif best describes this PR?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
