### PR TITLE
fix(integration): Incorrect key name in crowdsec and wazuh

### DIFF
--- a/registry/tracecat_registry/templates/crowdsec/search_ip_address.yml
+++ b/registry/tracecat_registry/templates/crowdsec/search_ip_address.yml
@@ -22,5 +22,5 @@ definition:
         url: https://cti.api.crowdsec.net/v2/smoke/${{ inputs.ip_address }}
         method: GET
         headers:
-          x-api-key: ${{ SECRETS.crowdsec.CTI_API_KEY }}
+          x-api-key: ${{ SECRETS.crowdsec_cti.CTI_API_KEY }}
   returns: ${{ steps.search_ip_address.result }}

--- a/registry/tracecat_registry/templates/wazuh/update_agents.yml
+++ b/registry/tracecat_registry/templates/wazuh/update_agents.yml
@@ -42,6 +42,6 @@ definition:
         params:
           agents_list: ${{ FN.join(steps.upgrade_agents.result.data.data.affected_items[*].id, ",") }}
         headers:
-          Authorization: Bearer ${{ SECRETS.wazuh_token.WAZUH_API_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.wazuh.WAZUH_API_TOKEN }}
         verify_ssl: ${{ inputs.verify_ssl  }}
   returns: ${{ steps.upgrade_result.result }}


### PR DESCRIPTION
Incorrect key name in `wazuh/update_agents.yml/upgrade_result`.