### PR TITLE
feat: Organization users management

### DIFF
--- a/frontend/src/app/organization/members/page.tsx
+++ b/frontend/src/app/organization/members/page.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { OrgMembersTable } from "@/components/organization/org-members-table"
+
+export default function MembersPage() {
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
+        <div className="flex w-full">
+          <div className="items-start space-y-3 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">
+              Organization Members
+            </h2>
+            <p className="text-md text-muted-foreground">
+              View all organization members here.
+            </p>
+          </div>
+          <div className="ml-auto flex items-center space-x-2"></div>
+        </div>
+        <div className="space-y-4">
+          <>
+            <h6 className="text-sm font-semibold">Manage Members</h6>
+            <OrgMembersTable />
+          </>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/organization/sidebar-nav.tsx
+++ b/frontend/src/app/organization/sidebar-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { KeyRoundIcon, LucideIcon } from "lucide-react"
+import { KeyRoundIcon, LucideIcon, UsersIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
@@ -13,7 +13,7 @@ type NavItem = {
   href: string
 }
 
-const navItems: NavItem[] = [
+const secretNavItems: NavItem[] = [
   {
     title: "Credentials",
     href: "/organization/credentials",
@@ -21,6 +21,13 @@ const navItems: NavItem[] = [
   {
     title: "SSH Keys",
     href: "/organization/ssh-keys",
+  },
+]
+
+const userNavItems: NavItem[] = [
+  {
+    title: "Members",
+    href: "/organization/members",
   },
 ]
 
@@ -36,7 +43,12 @@ export function OrganizationSidebarNav() {
       <div className="space-y-0.5">
         <h2 className="text-xl font-bold tracking-tight">Organization</h2>
       </div>
-      <SidebarNavBlock title="Secrets" icon={KeyRoundIcon} items={navItems} />
+      <SidebarNavBlock
+        title="Secrets"
+        icon={KeyRoundIcon}
+        items={secretNavItems}
+      />
+      <SidebarNavBlock title="Users" icon={UsersIcon} items={userNavItems} />
     </div>
   )
 }

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1313,6 +1313,61 @@ export const $OAuth2AuthorizeResponse = {
     title: 'OAuth2AuthorizeResponse'
 } as const;
 
+export const $OrgMemberRead = {
+    properties: {
+        user_id: {
+            type: 'string',
+            format: 'uuid4',
+            title: 'User Id'
+        },
+        first_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'First Name'
+        },
+        last_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Name'
+        },
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        },
+        role: {
+            '$ref': '#/components/schemas/UserRole'
+        },
+        is_active: {
+            type: 'boolean',
+            title: 'Is Active'
+        },
+        is_superuser: {
+            type: 'boolean',
+            title: 'Is Superuser'
+        },
+        is_verified: {
+            type: 'boolean',
+            title: 'Is Verified'
+        }
+    },
+    type: 'object',
+    required: ['user_id', 'first_name', 'last_name', 'email', 'role', 'is_active', 'is_superuser', 'is_verified'],
+    title: 'OrgMemberRead'
+} as const;
+
 export const $RegistryActionCreate = {
     properties: {
         name: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { PublicIncomingWebhookData, PublicIncomingWebhookResponse, PublicIncomingWebhookWaitData, PublicIncomingWebhookWaitResponse, WorkspacesListWorkspacesResponse, WorkspacesCreateWorkspaceData, WorkspacesCreateWorkspaceResponse, WorkspacesSearchWorkspacesData, WorkspacesSearchWorkspacesResponse, WorkspacesGetWorkspaceData, WorkspacesGetWorkspaceResponse, WorkspacesUpdateWorkspaceData, WorkspacesUpdateWorkspaceResponse, WorkspacesDeleteWorkspaceData, WorkspacesDeleteWorkspaceResponse, WorkspacesListWorkspaceMembershipsData, WorkspacesListWorkspaceMembershipsResponse, WorkspacesCreateWorkspaceMembershipData, WorkspacesCreateWorkspaceMembershipResponse, WorkspacesGetWorkspaceMembershipData, WorkspacesGetWorkspaceMembershipResponse, WorkspacesDeleteWorkspaceMembershipData, WorkspacesDeleteWorkspaceMembershipResponse, WorkflowsListWorkflowsData, WorkflowsListWorkflowsResponse, WorkflowsCreateWorkflowData, WorkflowsCreateWorkflowResponse, WorkflowsGetWorkflowData, WorkflowsGetWorkflowResponse, WorkflowsUpdateWorkflowData, WorkflowsUpdateWorkflowResponse, WorkflowsDeleteWorkflowData, WorkflowsDeleteWorkflowResponse, WorkflowsCommitWorkflowData, WorkflowsCommitWorkflowResponse, WorkflowsExportWorkflowData, WorkflowsExportWorkflowResponse, WorkflowsGetWorkflowDefinitionData, WorkflowsGetWorkflowDefinitionResponse, WorkflowsCreateWorkflowDefinitionData, WorkflowsCreateWorkflowDefinitionResponse, TriggersCreateWebhookData, TriggersCreateWebhookResponse, TriggersGetWebhookData, TriggersGetWebhookResponse, TriggersUpdateWebhookData, TriggersUpdateWebhookResponse, WorkflowExecutionsListWorkflowExecutionsData, WorkflowExecutionsListWorkflowExecutionsResponse, WorkflowExecutionsCreateWorkflowExecutionData, WorkflowExecutionsCreateWorkflowExecutionResponse, WorkflowExecutionsGetWorkflowExecutionData, WorkflowExecutionsGetWorkflowExecutionResponse, WorkflowExecutionsListWorkflowExecutionEventHistoryData, WorkflowExecutionsListWorkflowExecutionEventHistoryResponse, WorkflowExecutionsCancelWorkflowExecutionData, WorkflowExecutionsCancelWorkflowExecutionResponse, WorkflowExecutionsTerminateWorkflowExecutionData, WorkflowExecutionsTerminateWorkflowExecutionResponse, ActionsListActionsData, ActionsListActionsResponse, ActionsCreateActionData, ActionsCreateActionResponse, ActionsGetActionData, ActionsGetActionResponse, ActionsUpdateActionData, ActionsUpdateActionResponse, ActionsDeleteActionData, ActionsDeleteActionResponse, SecretsSearchSecretsData, SecretsSearchSecretsResponse, SecretsListSecretsData, SecretsListSecretsResponse, SecretsCreateSecretData, SecretsCreateSecretResponse, SecretsGetSecretByNameData, SecretsGetSecretByNameResponse, SecretsUpdateSecretByIdData, SecretsUpdateSecretByIdResponse, SecretsDeleteSecretByIdData, SecretsDeleteSecretByIdResponse, SchedulesListSchedulesData, SchedulesListSchedulesResponse, SchedulesCreateScheduleData, SchedulesCreateScheduleResponse, SchedulesGetScheduleData, SchedulesGetScheduleResponse, SchedulesUpdateScheduleData, SchedulesUpdateScheduleResponse, SchedulesDeleteScheduleData, SchedulesDeleteScheduleResponse, SchedulesSearchSchedulesData, SchedulesSearchSchedulesResponse, UsersSearchUserData, UsersSearchUserResponse, RegistryRepositoriesSyncRegistryRepositoriesData, RegistryRepositoriesSyncRegistryRepositoriesResponse, RegistryRepositoriesListRegistryRepositoriesResponse, RegistryRepositoriesCreateRegistryRepositoryData, RegistryRepositoriesCreateRegistryRepositoryResponse, RegistryRepositoriesGetRegistryRepositoryData, RegistryRepositoriesGetRegistryRepositoryResponse, RegistryRepositoriesUpdateRegistryRepositoryData, RegistryRepositoriesUpdateRegistryRepositoryResponse, RegistryRepositoriesDeleteRegistryRepositoryData, RegistryRepositoriesDeleteRegistryRepositoryResponse, RegistryActionsListRegistryActionsResponse, RegistryActionsCreateRegistryActionData, RegistryActionsCreateRegistryActionResponse, RegistryActionsGetRegistryActionData, RegistryActionsGetRegistryActionResponse, RegistryActionsUpdateRegistryActionData, RegistryActionsUpdateRegistryActionResponse, RegistryActionsDeleteRegistryActionData, RegistryActionsDeleteRegistryActionResponse, RegistryActionsRunRegistryActionData, RegistryActionsRunRegistryActionResponse, RegistryActionsValidateRegistryActionData, RegistryActionsValidateRegistryActionResponse, UsersUsersCurrentUserResponse, UsersUsersPatchCurrentUserData, UsersUsersPatchCurrentUserResponse, UsersUsersUserData, UsersUsersUserResponse, UsersUsersPatchUserData, UsersUsersPatchUserResponse, UsersUsersDeleteUserData, UsersUsersDeleteUserResponse, AuthAuthDatabaseLoginData, AuthAuthDatabaseLoginResponse, AuthAuthDatabaseLogoutResponse, AuthRegisterRegisterData, AuthRegisterRegisterResponse, AuthResetForgotPasswordData, AuthResetForgotPasswordResponse, AuthResetResetPasswordData, AuthResetResetPasswordResponse, AuthVerifyRequestTokenData, AuthVerifyRequestTokenResponse, AuthVerifyVerifyData, AuthVerifyVerifyResponse, AuthOauthGoogleDatabaseAuthorizeData, AuthOauthGoogleDatabaseAuthorizeResponse, AuthOauthGoogleDatabaseCallbackData, AuthOauthGoogleDatabaseCallbackResponse, AuthSamlDatabaseLoginResponse, AuthSsoAcsData, AuthSsoAcsResponse, PublicCheckHealthResponse } from './types.gen';
+import type { PublicIncomingWebhookData, PublicIncomingWebhookResponse, PublicIncomingWebhookWaitData, PublicIncomingWebhookWaitResponse, WorkspacesListWorkspacesResponse, WorkspacesCreateWorkspaceData, WorkspacesCreateWorkspaceResponse, WorkspacesSearchWorkspacesData, WorkspacesSearchWorkspacesResponse, WorkspacesGetWorkspaceData, WorkspacesGetWorkspaceResponse, WorkspacesUpdateWorkspaceData, WorkspacesUpdateWorkspaceResponse, WorkspacesDeleteWorkspaceData, WorkspacesDeleteWorkspaceResponse, WorkspacesListWorkspaceMembershipsData, WorkspacesListWorkspaceMembershipsResponse, WorkspacesCreateWorkspaceMembershipData, WorkspacesCreateWorkspaceMembershipResponse, WorkspacesGetWorkspaceMembershipData, WorkspacesGetWorkspaceMembershipResponse, WorkspacesDeleteWorkspaceMembershipData, WorkspacesDeleteWorkspaceMembershipResponse, WorkflowsListWorkflowsData, WorkflowsListWorkflowsResponse, WorkflowsCreateWorkflowData, WorkflowsCreateWorkflowResponse, WorkflowsGetWorkflowData, WorkflowsGetWorkflowResponse, WorkflowsUpdateWorkflowData, WorkflowsUpdateWorkflowResponse, WorkflowsDeleteWorkflowData, WorkflowsDeleteWorkflowResponse, WorkflowsCommitWorkflowData, WorkflowsCommitWorkflowResponse, WorkflowsExportWorkflowData, WorkflowsExportWorkflowResponse, WorkflowsGetWorkflowDefinitionData, WorkflowsGetWorkflowDefinitionResponse, WorkflowsCreateWorkflowDefinitionData, WorkflowsCreateWorkflowDefinitionResponse, TriggersCreateWebhookData, TriggersCreateWebhookResponse, TriggersGetWebhookData, TriggersGetWebhookResponse, TriggersUpdateWebhookData, TriggersUpdateWebhookResponse, WorkflowExecutionsListWorkflowExecutionsData, WorkflowExecutionsListWorkflowExecutionsResponse, WorkflowExecutionsCreateWorkflowExecutionData, WorkflowExecutionsCreateWorkflowExecutionResponse, WorkflowExecutionsGetWorkflowExecutionData, WorkflowExecutionsGetWorkflowExecutionResponse, WorkflowExecutionsListWorkflowExecutionEventHistoryData, WorkflowExecutionsListWorkflowExecutionEventHistoryResponse, WorkflowExecutionsCancelWorkflowExecutionData, WorkflowExecutionsCancelWorkflowExecutionResponse, WorkflowExecutionsTerminateWorkflowExecutionData, WorkflowExecutionsTerminateWorkflowExecutionResponse, ActionsListActionsData, ActionsListActionsResponse, ActionsCreateActionData, ActionsCreateActionResponse, ActionsGetActionData, ActionsGetActionResponse, ActionsUpdateActionData, ActionsUpdateActionResponse, ActionsDeleteActionData, ActionsDeleteActionResponse, SecretsSearchSecretsData, SecretsSearchSecretsResponse, SecretsListSecretsData, SecretsListSecretsResponse, SecretsCreateSecretData, SecretsCreateSecretResponse, SecretsGetSecretByNameData, SecretsGetSecretByNameResponse, SecretsUpdateSecretByIdData, SecretsUpdateSecretByIdResponse, SecretsDeleteSecretByIdData, SecretsDeleteSecretByIdResponse, SchedulesListSchedulesData, SchedulesListSchedulesResponse, SchedulesCreateScheduleData, SchedulesCreateScheduleResponse, SchedulesGetScheduleData, SchedulesGetScheduleResponse, SchedulesUpdateScheduleData, SchedulesUpdateScheduleResponse, SchedulesDeleteScheduleData, SchedulesDeleteScheduleResponse, SchedulesSearchSchedulesData, SchedulesSearchSchedulesResponse, UsersSearchUserData, UsersSearchUserResponse, RegistryRepositoriesSyncRegistryRepositoriesData, RegistryRepositoriesSyncRegistryRepositoriesResponse, RegistryRepositoriesListRegistryRepositoriesResponse, RegistryRepositoriesCreateRegistryRepositoryData, RegistryRepositoriesCreateRegistryRepositoryResponse, RegistryRepositoriesGetRegistryRepositoryData, RegistryRepositoriesGetRegistryRepositoryResponse, RegistryRepositoriesUpdateRegistryRepositoryData, RegistryRepositoriesUpdateRegistryRepositoryResponse, RegistryRepositoriesDeleteRegistryRepositoryData, RegistryRepositoriesDeleteRegistryRepositoryResponse, RegistryActionsListRegistryActionsResponse, RegistryActionsCreateRegistryActionData, RegistryActionsCreateRegistryActionResponse, RegistryActionsGetRegistryActionData, RegistryActionsGetRegistryActionResponse, RegistryActionsUpdateRegistryActionData, RegistryActionsUpdateRegistryActionResponse, RegistryActionsDeleteRegistryActionData, RegistryActionsDeleteRegistryActionResponse, RegistryActionsRunRegistryActionData, RegistryActionsRunRegistryActionResponse, RegistryActionsValidateRegistryActionData, RegistryActionsValidateRegistryActionResponse, OrganizationListOrgMembersResponse, OrganizationDeleteOrgMemberData, OrganizationDeleteOrgMemberResponse, OrganizationUpdateOrgMemberData, OrganizationUpdateOrgMemberResponse, UsersUsersCurrentUserResponse, UsersUsersPatchCurrentUserData, UsersUsersPatchCurrentUserResponse, UsersUsersUserData, UsersUsersUserResponse, UsersUsersPatchUserData, UsersUsersPatchUserResponse, UsersUsersDeleteUserData, UsersUsersDeleteUserResponse, AuthAuthDatabaseLoginData, AuthAuthDatabaseLoginResponse, AuthAuthDatabaseLogoutResponse, AuthRegisterRegisterData, AuthRegisterRegisterResponse, AuthResetForgotPasswordData, AuthResetForgotPasswordResponse, AuthResetResetPasswordData, AuthResetResetPasswordResponse, AuthVerifyRequestTokenData, AuthVerifyRequestTokenResponse, AuthVerifyVerifyData, AuthVerifyVerifyResponse, AuthOauthGoogleDatabaseAuthorizeData, AuthOauthGoogleDatabaseAuthorizeResponse, AuthOauthGoogleDatabaseCallbackData, AuthOauthGoogleDatabaseCallbackResponse, AuthSamlDatabaseLoginResponse, AuthSsoAcsData, AuthSsoAcsResponse, PublicCheckHealthResponse } from './types.gen';
 
 /**
  * Incoming Webhook
@@ -1343,6 +1343,55 @@ export const registryActionsValidateRegistryAction = (data: RegistryActionsValid
     url: '/registry/actions/{action_name}/validate',
     path: {
         action_name: data.actionName
+    },
+    body: data.requestBody,
+    mediaType: 'application/json',
+    errors: {
+        422: 'Validation Error'
+    }
+}); };
+
+/**
+ * List Org Members
+ * @returns OrgMemberRead Successful Response
+ * @throws ApiError
+ */
+export const organizationListOrgMembers = (): CancelablePromise<OrganizationListOrgMembersResponse> => { return __request(OpenAPI, {
+    method: 'GET',
+    url: '/organization/members'
+}); };
+
+/**
+ * Delete Org Member
+ * @param data The data for the request.
+ * @param data.userId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const organizationDeleteOrgMember = (data: OrganizationDeleteOrgMemberData): CancelablePromise<OrganizationDeleteOrgMemberResponse> => { return __request(OpenAPI, {
+    method: 'DELETE',
+    url: '/organization/members/{user_id}',
+    path: {
+        user_id: data.userId
+    },
+    errors: {
+        422: 'Validation Error'
+    }
+}); };
+
+/**
+ * Update Org Member
+ * @param data The data for the request.
+ * @param data.userId
+ * @param data.requestBody
+ * @returns OrgMemberRead Successful Response
+ * @throws ApiError
+ */
+export const organizationUpdateOrgMember = (data: OrganizationUpdateOrgMemberData): CancelablePromise<OrganizationUpdateOrgMemberResponse> => { return __request(OpenAPI, {
+    method: 'PATCH',
+    url: '/organization/members/{user_id}',
+    path: {
+        user_id: data.userId
     },
     body: data.requestBody,
     mediaType: 'application/json',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -436,6 +436,17 @@ export type OAuth2AuthorizeResponse = {
     authorization_url: string;
 };
 
+export type OrgMemberRead = {
+    user_id: string;
+    first_name: string | null;
+    last_name: string | null;
+    email: string;
+    role: UserRole;
+    is_active: boolean;
+    is_superuser: boolean;
+    is_verified: boolean;
+};
+
 /**
  * API create model for a registered action.
  */
@@ -1665,6 +1676,21 @@ export type RegistryActionsValidateRegistryActionData = {
 
 export type RegistryActionsValidateRegistryActionResponse = RegistryActionValidateResponse;
 
+export type OrganizationListOrgMembersResponse = Array<OrgMemberRead>;
+
+export type OrganizationDeleteOrgMemberData = {
+    userId: string;
+};
+
+export type OrganizationDeleteOrgMemberResponse = void;
+
+export type OrganizationUpdateOrgMemberData = {
+    requestBody: UserUpdate;
+    userId: string;
+};
+
+export type OrganizationUpdateOrgMemberResponse = OrgMemberRead;
+
 export type UsersUsersCurrentUserResponse = UserRead;
 
 export type UsersUsersPatchCurrentUserData = {
@@ -2601,6 +2627,44 @@ export type $OpenApiTs = {
                  * Successful Response
                  */
                 200: RegistryActionValidateResponse;
+                /**
+                 * Validation Error
+                 */
+                422: HTTPValidationError;
+            };
+        };
+    };
+    '/organization/members': {
+        get: {
+            res: {
+                /**
+                 * Successful Response
+                 */
+                200: Array<OrgMemberRead>;
+            };
+        };
+    };
+    '/organization/members/{user_id}': {
+        delete: {
+            req: OrganizationDeleteOrgMemberData;
+            res: {
+                /**
+                 * Successful Response
+                 */
+                204: void;
+                /**
+                 * Validation Error
+                 */
+                422: HTTPValidationError;
+            };
+        };
+        patch: {
+            req: OrganizationUpdateOrgMemberData;
+            res: {
+                /**
+                 * Successful Response
+                 */
+                200: OrgMemberRead;
                 /**
                  * Validation Error
                  */

--- a/frontend/src/components/organization/org-members-table.tsx
+++ b/frontend/src/components/organization/org-members-table.tsx
@@ -1,0 +1,351 @@
+"use client"
+
+import { useState } from "react"
+import { OrgMemberRead, UserRole } from "@/client"
+import { useAuth } from "@/providers/auth"
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+
+import { userIsPrivileged } from "@/lib/auth"
+import { useOrgMembers } from "@/lib/hooks"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+import {
+  DataTable,
+  DataTableColumnHeader,
+  type DataTableToolbarProps,
+} from "@/components/table"
+
+export function OrgMembersTable() {
+  const [selectedMember, setSelectedMember] = useState<OrgMemberRead | null>(
+    null
+  )
+  const [isChangeRoleOpen, setIsChangeRoleOpen] = useState(false)
+  const { user } = useAuth()
+  const { orgMembers, updateOrgMember, deleteOrgMember } = useOrgMembers()
+
+  const handleChangeRole = async (role: UserRole) => {
+    try {
+      if (selectedMember) {
+        if (selectedMember.role === role) {
+          toast({
+            title: "Update skipped",
+            description: `User ${selectedMember.email} is already a ${role} member`,
+          })
+          return
+        }
+        console.log("Changing role", selectedMember, role)
+        await updateOrgMember({
+          userId: selectedMember.user_id,
+          requestBody: { role },
+        })
+      }
+    } catch (error) {
+      console.error("Failed to change role", error)
+    } finally {
+      setIsChangeRoleOpen(false)
+      setSelectedMember(null)
+    }
+  }
+
+  const handleRemoveMember = async () => {
+    if (selectedMember) {
+      console.log("Removing member", selectedMember)
+      try {
+        await deleteOrgMember({
+          userId: selectedMember.user_id,
+        })
+      } catch (error) {
+        console.error("Failed to remove member", error)
+      } finally {
+        setSelectedMember(null)
+      }
+    }
+  }
+  // Since this is the org members table, should only superusers be able to change roles?
+  const privileged = userIsPrivileged(user)
+  return (
+    <Dialog open={isChangeRoleOpen} onOpenChange={setIsChangeRoleOpen}>
+      <AlertDialog
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setSelectedMember(null)
+          }
+        }}
+      >
+        <DataTable
+          data={orgMembers}
+          initialSortingState={[{ id: "email", desc: false }]}
+          columns={[
+            {
+              accessorKey: "email",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Email"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {row.getValue<OrgMemberRead["email"]>("email")}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "first_name",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="First Name"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {row.getValue<OrgMemberRead["first_name"]>("first_name") ||
+                    "-"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "last_name",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Last Name"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {row.getValue<OrgMemberRead["last_name"]>("last_name") || "-"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "role",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Role"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs capitalize">
+                  {row.getValue<OrgMemberRead["role"]>("role")}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "is_active",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Active"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs capitalize">
+                  {row.getValue<OrgMemberRead["is_active"]>("is_active")
+                    ? "Yes"
+                    : "No"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "is_superuser",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Superuser"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs capitalize">
+                  {row.getValue<OrgMemberRead["is_superuser"]>("is_superuser")
+                    ? "Yes"
+                    : "No"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              id: "actions",
+              enableHiding: false,
+              cell: ({ row }) => {
+                return (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" className="size-8 p-0">
+                        <span className="sr-only">Open menu</span>
+                        <DotsHorizontalIcon className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() =>
+                          navigator.clipboard.writeText(row.original.user_id)
+                        }
+                      >
+                        Copy user ID
+                      </DropdownMenuItem>
+
+                      {privileged && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuLabel>Admin</DropdownMenuLabel>
+                          <DialogTrigger asChild>
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setSelectedMember(row.original)
+                                setIsChangeRoleOpen(true)
+                              }}
+                            >
+                              Change role
+                            </DropdownMenuItem>
+                          </DialogTrigger>
+
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              className="text-rose-500 focus:text-rose-600"
+                              onClick={() => {
+                                setSelectedMember(row.original)
+                                console.debug("Selected user", row.original)
+                              }}
+                            >
+                              Remove from workspace
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )
+              },
+            },
+          ]}
+          toolbarProps={defaultToolbarProps}
+        />
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove this user from the organization?
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleRemoveMember}
+            >
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <ChangeUserRoleDialog
+        selectedUser={selectedMember}
+        setOpen={setIsChangeRoleOpen}
+        onConfirm={handleChangeRole}
+      />
+    </Dialog>
+  )
+}
+
+function ChangeUserRoleDialog({
+  selectedUser,
+  setOpen,
+  onConfirm,
+}: {
+  selectedUser: OrgMemberRead | null
+  setOpen: (open: boolean) => void
+  onConfirm: (role: UserRole) => void
+}) {
+  const [newRole, setNewRole] = useState<UserRole>("basic")
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Change User Role</DialogTitle>
+        <DialogDescription>
+          Select a new role for {selectedUser?.email}
+        </DialogDescription>
+      </DialogHeader>
+      <Select
+        value={newRole}
+        onValueChange={(value) => setNewRole(value as UserRole)}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Select a role" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="admin">Admin</SelectItem>
+          <SelectItem value="basic">Basic</SelectItem>
+        </SelectContent>
+      </Select>
+      <DialogFooter>
+        <Button variant="outline" onClick={() => setOpen(false)}>
+          Cancel
+        </Button>
+        <Button onClick={() => onConfirm(newRole)}>Change Role</Button>
+      </DialogFooter>
+    </DialogContent>
+  )
+}
+
+const defaultToolbarProps: DataTableToolbarProps = {
+  filterProps: {
+    placeholder: "Filter users by email...",
+    column: "email",
+  },
+}

--- a/frontend/src/components/table/table.tsx
+++ b/frontend/src/components/table/table.tsx
@@ -50,6 +50,7 @@ interface DataTableProps<TData, TValue> {
   emptyMessage?: string
   errorMessage?: string
   showSelectedRows?: boolean
+  initialSortingState?: SortingState
 }
 
 export function DataTable<TData, TValue>({
@@ -63,6 +64,7 @@ export function DataTable<TData, TValue>({
   emptyMessage,
   errorMessage,
   showSelectedRows = false,
+  initialSortingState: initialSorting = [],
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = React.useState({})
   const [columnVisibility, setColumnVisibility] =
@@ -70,7 +72,7 @@ export function DataTable<TData, TValue>({
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     []
   )
-  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [sorting, setSorting] = React.useState<SortingState>(initialSorting)
 
   const table = useReactTable({
     data: data || [],

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { UserRead, UserRole } from "@/client"
+import { UserRead } from "@/client"
 import { AxiosError } from "axios"
 
 import { client } from "@/lib/api"

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { UserRead } from "@/client"
+import { UserRead, UserRole } from "@/client"
 import { AxiosError } from "axios"
 
 import { client } from "@/lib/api"
@@ -17,4 +17,11 @@ export async function getCurrentUser(): Promise<UserRead | null> {
       throw error
     }
   }
+}
+
+export function userIsPrivileged(user: UserRead | null): boolean {
+  if (!user) {
+    return false
+  }
+  return user.is_superuser || user.role === "admin"
 }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -56,7 +56,6 @@ import {
   WorkflowsCreateWorkflowData,
   workflowsDeleteWorkflow,
   workflowsListWorkflows,
-  WorkspaceMember,
   workspacesCreateWorkspace,
   workspacesDeleteWorkspace,
   workspacesListWorkspaces,

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -8,6 +8,12 @@ import {
   ApiError,
   CreateWorkspaceParams,
   EventHistoryResponse,
+  organizationDeleteOrgMember,
+  OrganizationDeleteOrgMemberData,
+  organizationListOrgMembers,
+  organizationUpdateOrgMember,
+  OrganizationUpdateOrgMemberData,
+  OrgMemberRead,
   RegistryActionCreate,
   RegistryActionRead,
   registryActionsCreateRegistryAction,
@@ -50,6 +56,7 @@ import {
   WorkflowsCreateWorkflowData,
   workflowsDeleteWorkflow,
   workflowsListWorkflows,
+  WorkspaceMember,
   workspacesCreateWorkspace,
   workspacesDeleteWorkspace,
   workspacesListWorkspaces,
@@ -1056,5 +1063,87 @@ export function useRegistryRepositories() {
     deleteRepo,
     deleteRepoIsPending,
     deleteRepoError,
+  }
+}
+
+export function useOrgMembers() {
+  const queryClient = useQueryClient()
+  const { data: orgMembers } = useQuery<OrgMemberRead[]>({
+    queryKey: ["org-members"],
+    queryFn: async () => await organizationListOrgMembers(),
+  })
+
+  const {
+    mutateAsync: updateOrgMember,
+    isPending: updateOrgMemberIsPending,
+    error: updateOrgMemberError,
+  } = useMutation({
+    mutationFn: async (params: OrganizationUpdateOrgMemberData) =>
+      await organizationUpdateOrgMember(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-members"] })
+      toast({
+        title: "Updated organization member",
+        description: "Organization member updated successfully.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      const apiError = error as TracecatApiError
+      switch (apiError.status) {
+        case 403:
+          toast({
+            title: "You cannot perform this action",
+            description: `${apiError.message}: ${apiError.body.detail}`,
+          })
+          break
+        default:
+          toast({
+            title: "Failed to update organization member",
+            description: `An unexpected error occurred while updating the organization member. ${apiError.message}: ${apiError.body.detail}`,
+          })
+      }
+    },
+  })
+
+  const {
+    mutateAsync: deleteOrgMember,
+    isPending: deleteOrgMemberIsPending,
+    error: deleteOrgMemberError,
+  } = useMutation({
+    mutationFn: async (params: OrganizationDeleteOrgMemberData) =>
+      await organizationDeleteOrgMember(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-members"] })
+      toast({
+        title: "Deleted organization member",
+        description: "Organization member deleted successfully.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      const apiError = error as TracecatApiError
+      switch (apiError.status) {
+        case 403:
+          toast({
+            title: "You cannot perform this action",
+            description: `${apiError.message}: ${apiError.body.detail}`,
+          })
+          break
+        default:
+          toast({
+            title: "Failed to delete organization member",
+            description: `An unexpected error occurred while deleting the organization member. ${apiError.message}: ${apiError.body.detail}`,
+          })
+      }
+    },
+  })
+
+  return {
+    orgMembers,
+    updateOrgMember,
+    updateOrgMemberIsPending,
+    updateOrgMemberError,
+    deleteOrgMember,
+    deleteOrgMemberIsPending,
+    deleteOrgMemberError,
   }
 }

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -24,6 +24,7 @@ from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.logger import logger
 from tracecat.middleware import RequestLoggingMiddleware
+from tracecat.organization.router import router as org_router
 from tracecat.registry.actions.router import router as registry_actions_router
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.registry.constants import (
@@ -251,6 +252,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(users_router)
     app.include_router(registry_repos_router)
     app.include_router(registry_actions_router)
+    app.include_router(org_router)
     app.include_router(
         fastapi_users.get_users_router(UserRead, UserUpdate),
         prefix="/users",

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -11,9 +11,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat import config
-from tracecat.api.routers.users import router as users_router
 from tracecat.auth.constants import AuthType
 from tracecat.auth.models import UserCreate, UserRead, UserUpdate
+from tracecat.auth.router import router as users_router
 from tracecat.auth.users import (
     FastAPIUsersException,
     InvalidDomainException,

--- a/tracecat/auth/router.py
+++ b/tracecat/auth/router.py
@@ -1,13 +1,12 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import EmailStr
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.models import UserRead
-from tracecat.db.engine import get_async_session
+from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.schemas import User
-from tracecat.logger import logger
 from tracecat.types.auth import AccessLevel, Role
 
 router = APIRouter(prefix="/users")
@@ -22,11 +21,10 @@ async def search_user(
         require_workspace="no",
         min_access_level=AccessLevel.ADMIN,
     ),
-    email: str | None = Query(None),
-    session: AsyncSession = Depends(get_async_session),
+    email: EmailStr | None = Query(None),
+    session: AsyncDBSession,
 ) -> UserRead:
     """Create new user."""
-    logger.info("HIT SEARCH")
     if not email:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/organization/models.py
+++ b/tracecat/organization/models.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, EmailStr
+
+from tracecat.auth.models import UserRole
+from tracecat.identifiers import UserID
+
+# Members
+
+
+class OrgMemberRead(BaseModel):
+    user_id: UserID
+    first_name: str | None
+    last_name: str | None
+    email: EmailStr
+    role: UserRole
+    is_active: bool
+    is_superuser: bool
+    is_verified: bool
+
+
+# Organization
+
+
+class OrgRead(BaseModel):
+    id: str
+    name: str

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -1,0 +1,110 @@
+from fastapi import APIRouter, HTTPException, status
+from sqlalchemy.exc import NoResultFound
+
+from tracecat.auth.credentials import RoleACL
+from tracecat.auth.models import UserUpdate
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.identifiers import UserID
+from tracecat.organization.models import OrgMemberRead, OrgRead
+from tracecat.organization.service import OrgService
+from tracecat.types.auth import AccessLevel, Role
+from tracecat.types.exceptions import TracecatAuthorizationError
+
+router = APIRouter(prefix="/organization", tags=["organization"])
+
+
+@router.get("", response_model=OrgRead, include_in_schema=False)
+async def get_organization(
+    *,
+    role: Role = RoleACL(allow_user=True, allow_service=False, require_workspace="no"),
+):
+    raise NotImplementedError
+
+
+@router.get("/members", response_model=list[OrgMemberRead])
+async def list_org_members(
+    *,
+    role: Role = RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="no",
+        min_access_level=AccessLevel.ADMIN,
+    ),
+    session: AsyncDBSession,
+):
+    service = OrgService(session, role=role)
+    members = await service.list_members()
+    return [
+        OrgMemberRead(
+            user_id=user.id,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            is_superuser=user.is_superuser,
+            is_verified=user.is_verified,
+        )
+        for user in members
+    ]
+
+
+@router.delete("/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_org_member(
+    *,
+    role: Role = RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="no",
+        min_access_level=AccessLevel.ADMIN,
+    ),
+    session: AsyncDBSession,
+    user_id: UserID,
+):
+    service = OrgService(session, role=role)
+    try:
+        await service.delete_member(user_id)
+    except NoResultFound as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        ) from e
+    except TracecatAuthorizationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+        ) from e
+
+
+@router.patch("/members/{user_id}", response_model=OrgMemberRead)
+async def update_org_member(
+    *,
+    role: Role = RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="no",
+        min_access_level=AccessLevel.ADMIN,
+    ),
+    session: AsyncDBSession,
+    user_id: UserID,
+    params: UserUpdate,
+):
+    service = OrgService(session, role=role)
+    try:
+        user = await service.update_member(user_id, params)
+        return OrgMemberRead(
+            user_id=user.id,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            is_superuser=user.is_superuser,
+            is_verified=user.is_verified,
+        )
+    except NoResultFound as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        ) from e
+    except TracecatAuthorizationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+        ) from e

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Sequence
+from contextlib import asynccontextmanager
+
+from sqlmodel import select
+
+from tracecat.auth.models import UserUpdate
+from tracecat.auth.users import (
+    UserManager,
+    get_user_db_context,
+    get_user_manager_context,
+)
+from tracecat.authz.controls import require_access_level
+from tracecat.db.schemas import User
+from tracecat.identifiers import UserID
+from tracecat.service import Service
+from tracecat.types.auth import AccessLevel
+from tracecat.types.exceptions import TracecatAuthorizationError
+
+
+class OrgService(Service):
+    """Manage the organization."""
+
+    _service_name = "org"
+
+    @asynccontextmanager
+    async def _manager(self) -> AsyncGenerator[UserManager, None]:
+        async with get_user_db_context(self.session) as user_db:
+            async with get_user_manager_context(user_db) as user_manager:
+                yield user_manager
+
+    # === Manage members ===
+
+    @require_access_level(AccessLevel.ADMIN)
+    async def list_members(self) -> Sequence[User]:
+        """
+        Retrieve a list of all members in the organization.
+
+        This method queries the database to obtain all user records
+        associated with the organization. It returns a sequence of
+        User objects representing each member.
+
+        Returns:
+            Sequence[User]: A sequence containing User objects of all
+            members in the organization.
+        """
+        statement = select(User)
+        result = await self.session.exec(statement)
+        return result.all()
+
+    @require_access_level(AccessLevel.ADMIN)
+    async def get_member(self, user_id: UserID) -> User:
+        """Retrieve a member of the organization by their user ID.
+
+        Args:
+            user_id (UserID): The unique identifier of the user.
+
+        Returns:
+            User: The user object representing the member of the organization.
+
+        Raises:
+            NoResultFound: If no user with the given ID exists.
+        """
+        statement = select(User).where(User.id == user_id)
+        result = await self.session.exec(statement)
+        return result.one()
+
+    @require_access_level(AccessLevel.ADMIN)
+    async def delete_member(self, user_id: UserID) -> None:
+        """
+        Remove a member of the organization.
+
+        This method deletes a specified member from the organization.
+        It first checks if the member is a superuser and raises an
+        authorization error if so, as superusers cannot be deleted.
+
+        Args:
+            user_id (UserID): The unique identifier of the user to be removed.
+
+        Raises:
+            TracecatAuthorizationError: If the user is a superuser and cannot be deleted.
+        """
+        user = await self.get_member(user_id)
+        if user.is_superuser:
+            raise TracecatAuthorizationError("Cannot delete superuser")
+        async with self._manager() as user_manager:
+            await user_manager.delete(user)
+
+    @require_access_level(AccessLevel.ADMIN)
+    async def update_member(self, user_id: UserID, params: UserUpdate) -> User:
+        """
+        Update a member of the organization.
+
+        This method updates the details of a specified member within the organization.
+        It checks if the member is a superuser and raises an authorization error if so.
+
+        Args:
+            user_id (UserID): The unique identifier of the user to be updated.
+            params (UserUpdate): The parameters containing the updated user information.
+
+        Returns:
+            User: The updated user object representing the member of the organization.
+
+        Raises:
+            TracecatAuthorizationError: If the user is a superuser and cannot be updated.
+        """
+        user = await self.get_member(user_id)
+        if user.is_superuser:
+            raise TracecatAuthorizationError("Cannot update superuser")
+        async with self._manager() as user_manager:
+            updated_user = await user_manager.update(
+                user_update=params, user=user, safe=True
+            )
+        return updated_user
+
+    # === Manage settings ===
+
+    @require_access_level(AccessLevel.ADMIN)
+    async def get_settings(self) -> dict[str, str]:
+        """Get the organization settings."""
+        raise NotImplementedError

--- a/tracecat/service.py
+++ b/tracecat/service.py
@@ -1,0 +1,30 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Self
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tracecat.contexts import ctx_role
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.logger import logger
+from tracecat.types.auth import Role
+
+
+class Service:
+    """Base class for services."""
+
+    _service_name: str
+
+    def __init__(self, session: AsyncSession, role: Role | None = None):
+        self.session = session
+        self.role = role or ctx_role.get()
+        self.logger = logger.bind(service=self._service_name)
+
+    @classmethod
+    @asynccontextmanager
+    async def with_session(
+        cls,
+        role: Role | None = None,
+    ) -> AsyncGenerator[Self, None]:
+        async with get_async_session_context_manager() as session:
+            yield cls(session, role=role)


### PR DESCRIPTION
# Changes
- Add base service class (eventually have services inherit from this)
- Add org service for members management under `/organization/members`. Will also support managing settings under `/organization/settings` in the future

# PS
Most of the LOC added here are from copying and pasting frontend table code


# Screens
In this clip i show:
- Cannot delete/change role of superuser
- New user logging in and becomes visible in this page. Not yet part of any workspace.
- We log into an admin account and promote this user to an admin.
- On the next signin, that user is now confirmed to be an admin and can see any workspace


https://github.com/user-attachments/assets/c08f492e-bb0f-4cc5-8252-69ff29d2e847

In this second clip I start in member@tracecat.com (1), then log into test@tracecat.com and delete (1). Then i try to log into (1) whose password is password1234, and am no longer able to login.

https://github.com/user-attachments/assets/62e1a190-8c7e-4339-bf95-5f85f3445ce8

# Security
Registering and trying to list org members is blocked by default beacuse of the admin level requirement

<img width="718" alt="image" src="https://github.com/user-attachments/assets/b89979d3-ddc3-46f1-9bad-b9704069c869">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `MembersPage` component for managing organization members.
  - Added `OrgMembersTable` component to display member details with management options.
  - Enhanced sidebar navigation with a new "Users" section for member management.
  - Implemented API endpoints for listing, deleting, and updating organization members.
  
- **Bug Fixes**
  - Improved error handling for member management operations.

- **Documentation**
  - Updated API documentation to reflect new endpoints and functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->