### PR TITLE
fix(infra): Align network configuration for api and ollama in docker-compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -173,6 +173,8 @@ services:
     container_name: ollama
     tty: true
     restart: unless-stopped
+    networks:
+      - core
     image: ollama/ollama:${OLLAMA__VERSION}
     ports:
       - 11434:11434

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,8 @@ services:
     container_name: ollama
     tty: true
     restart: unless-stopped
+    networks:
+      - core
     image: ollama/ollama:${OLLAMA__VERSION}
     ports:
       - 11434:11434


### PR DESCRIPTION
- Updated ollama service to use the same network as api service.

## Description
This PR fixes a bug where the api service could not connect to the ollama service, causing workflows using the ai_action step with the llama3.2:1b model to fail. The issue was due to the ollama service not being part of the same network as the api service. By aligning the network configuration in the docker-compose file, requests from the api service to the ollama service will now succeed.

## Screenshots/Recordings

Sample workflow
![image](https://github.com/user-attachments/assets/6e5815d3-4ff5-4c12-8335-3273e48a9975)

Error logs
![image](https://github.com/user-attachments/assets/76a6896a-7dbc-4284-bb14-a5aa7206b3b5)


## Steps to QA

1. Follow the deploy tutorial, using the latest docker-compose.yaml file
2. Run a workflow with an ai_action step using the llama3.2:1b model. You can recreate the workflow shown in the above image.
3. Confirm that the workflow completes successfully and the ai_action step does not fail.

