### PR TITLE
feat(integration)!: Rewrite LDAP UDFs into templates

### DIFF
--- a/registry/tracecat_registry/integrations/ldap3.py
+++ b/registry/tracecat_registry/integrations/ldap3.py
@@ -8,17 +8,19 @@ Requires: A secret named `ldap` with the following keys:
 
 """
 
-import json
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import ldap3
+import orjson
+from ldap3.utils.conv import escape_filter_chars
+from ldap3.utils.dn import escape_rdn
 from pydantic import Field
 
 from tracecat_registry import RegistrySecret, registry, secrets
 
 ldap_secret = RegistrySecret(
     name="ldap",
-    keys=["LDAP_HOST", "LDAP_PORT", "LDAP_BIND_DN", "LDAP_BIND_PASS"],
+    keys=["LDAP_HOST", "LDAP_PORT", "LDAP_USER", "LDAP_PASSWORD"],
 )
 """LDAP secret.
 
@@ -26,8 +28,8 @@ ldap_secret = RegistrySecret(
 - keys:
     - `LDAP_HOST`
     - `LDAP_PORT`
-    - `LDAP_BIND_DN`
-    - `LDAP_BIND_PASS`
+    - `LDAP_USER`
+    - `LDAP_PASSWORD`
 """
 
 
@@ -36,162 +38,224 @@ class LdapClient:
         self,
         host: str,
         port: int,
-        use_ssl: bool = False,
-        is_active_directory: bool = False,
+        user: str,
+        password: str,
+        server_kwargs: dict[str, Any] | None = None,
+        connection_kwargs: dict[str, Any] | None = None,
     ):
-        self._server = ldap3.Server(
-            host, port=int(port), use_ssl=use_ssl, get_info=ldap3.ALL
-        )
-        self._ldap_active_directory = is_active_directory
-        self._connection = None
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.server_kwargs = server_kwargs or {}
+        self.connection_kwargs = connection_kwargs or {}
 
-    def __enter__(self, *args, **kwargs):
-        self.bind()
+    def __enter__(self):
+        user = escape_rdn(self.user)  # LDAP injection mitigation
+        server = ldap3.Server(
+            self.host,
+            port=self.port,
+            **self.server_kwargs,
+        )
+        self.connection = ldap3.Connection(
+            server,
+            user=user,
+            password=self.password,
+            auto_bind=True,
+            auto_escape=True,
+            **self.connection_kwargs,
+        )
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self._connection:
-            self._connection.unbind()
+        if self.connection:
+            self.connection.unbind()
 
-    def bind(self) -> bool:
-        if self._connection is not None:
-            return True
+    def add_entry(
+        self,
+        dn: str,
+        object_class: str,
+        attributes: dict[str, Any],
+    ) -> None:
+        escaped_dn = escape_rdn(dn)  # LDAP injection mitigation
+        # Escape attribute values
+        escaped_attributes = {
+            k: escape_filter_chars(v) if isinstance(v, str) else v
+            for k, v in attributes.items()
+        }
 
-        self._connection = ldap3.Connection(
-            self._server,
-            user=secrets.get("LDAP_BIND_DN"),
-            password=secrets.get("LDAP_BIND_PASS"),
-            auto_bind=True,
+        result = self.connection.add(
+            escaped_dn,
+            object_class=object_class,
+            attributes=escaped_attributes,
         )
+        if not result:
+            raise PermissionError(self.connection.result)
 
-    def _search(self, base_dn: str, ldap_query: str):
-        results = self._connection.search(
-            base_dn, ldap_query, ldap3.SUBTREE, attributes=ldap3.ALL_ATTRIBUTES
+    def delete_entry(self, dn: str) -> None:
+        escaped_dn = escape_rdn(dn)  # LDAP injection mitigation
+        result = self.connection.delete(escaped_dn)
+        if not result:
+            raise PermissionError(self.connection.result)
+
+    def modify_entry(self, dn: str, changes: dict[str, Any]) -> None:
+        escaped_dn = escape_rdn(dn)
+        result = self.connection.modify(escaped_dn, changes)
+        if not result:
+            raise PermissionError(self.connection.result)
+
+    def search(
+        self,
+        search_base: str,
+        search_filter: str,
+        search_scope: Literal["BASE", "ONE", "SUBTREE"] = "SUBTREE",
+        attributes: Literal["ALL_ATTRIBUTES", "ALL_OPERATIONAL_ATTRIBUTES"]
+        | list[str] = "ALL_ATTRIBUTES",
+        **kwargs,
+    ) -> list[dict[str, Any]]:
+        escaped_base = escape_rdn(search_base)  # LDAP injection mitigation
+        escaped_filter = escape_filter_chars(search_filter)  # LDAP injection mitigation
+
+        scope = getattr(ldap3, search_scope)
+        if isinstance(attributes, str):
+            attributes = getattr(ldap3, attributes)
+
+        entries = self.connection.search(
+            search_base=escaped_base,
+            search_filter=escaped_filter,
+            search_scope=scope,
+            attributes=attributes,
+            **kwargs,
         )
-        if results:
-            entries = []
-            for entry in self._connection.entries:
-                entries += [
-                    {
-                        "dn": entry.entry_dn,
-                        "attributes": json.loads(entry.entry_to_json())[
-                            "attributes"
-                        ],  # entry is CaseInsensitiveDict containing other types that cannot be serialized
-                    }
-                ]
-            return entries
-        else:
-            return []
-
-    def _search_one(self, base_dn: str):
-        results = self._connection.search(
-            base_dn, "(objectClass=*)", ldap3.BASE, attributes=ldap3.ALL_ATTRIBUTES
-        )
-        if results:
-            for entry in self._connection.entries:
-                return dict(entry.attributes)
-
-    def find_users(self, base_dn: str, search_value: str):
-        filter = ""
-        if self._ldap_active_directory:
-            filter = f"(|(anr={search_value})(mail={search_value})(proxyAddresses=*:{search_value}))"
-        else:
-            filter = f"(anr={search_value})"
-        return self._search(base_dn, filter)
-
-    def get_user(self, user_dn: str) -> dict:
-        return self._searchone(user_dn, "(objectClass=*)")
-
-    def disable_user(self, user_dn: str):
-        return self._connection.modify(user_dn, {"userAccountControl": [(2, [514])]})
-
-    def enable_user(self, user_dn: str):
-        return self._connection.modify(user_dn, {"userAccountControl": [(2, [512])]})
+        if entries:
+            return [orjson.loads(entry.entry_to_json()) for entry in entries]
+        return []
 
 
-def create_ldap_client(
-    use_ssl: bool = True,
-    is_active_directory: bool = False,
-) -> LdapClient:
-    client = LdapClient(
-        host=secrets.get("LDAP_HOST"),
-        port=secrets.get("LDAP_PORT"),
-        use_ssl=use_ssl,
-        is_active_directory=is_active_directory,
-    )
-    return client
+def get_ldap_secrets() -> dict[str, Any]:
+    return {
+        "LDAP_HOST": secrets.get("LDAP_HOST"),
+        "LDAP_PORT": int(secrets.get("LDAP_PORT")),
+        "LDAP_USER": secrets.get("LDAP_USER"),
+        "LDAP_PASSWORD": secrets.get("LDAP_PASSWORD"),
+    }
 
 
 @registry.register(
-    default_title="Find LDAP Users",
-    description="Find LDAP users by login username or email",
+    default_title="Add LDAP entry",
+    description="Add an entry to the LDAP directory.",
     display_group="LDAP",
     namespace="integrations.ldap",
     secrets=[ldap_secret],
 )
-def find_ldap_users(
-    username_or_email: Annotated[
-        str,
-        Field(..., description="Login username or e-mail to find"),
+def add_entry(
+    dn: Annotated[str, Field(..., description="Distinguished name of the entry")],
+    object_class: Annotated[str, Field(..., description="Object class of the entry")],
+    attributes: Annotated[
+        dict[str, Any], Field(..., description="Attributes of the entry")
     ],
-    base_dn: Annotated[
-        str,
-        Field(..., description="Search base DN for querying LDAP"),
-    ],
-    use_ssl: Annotated[
-        bool,
-        Field(..., description="Use SSL for LDAP connection"),
-    ] = True,
-    is_active_directory: Annotated[
-        bool,
-        Field(..., description="Is Active Directory"),
-    ] = False,
-) -> list[dict[str, Any]]:
-    with create_ldap_client(
-        use_ssl=use_ssl, is_active_directory=is_active_directory
+    server_kwargs: Annotated[
+        dict[str, Any] | None, Field(..., description="Additional server parameters")
+    ] = None,
+    connection_kwargs: Annotated[
+        dict[str, Any] | None,
+        Field(..., description="Additional connection parameters"),
+    ] = None,
+) -> None:
+    host = secrets.get("LDAP_HOST")
+    port = int(secrets.get("LDAP_PORT"))
+    user = secrets.get("LDAP_USER")
+    password = secrets.get("LDAP_PASSWORD")
+    with LdapClient(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        server_kwargs=server_kwargs,
+        connection_kwargs=connection_kwargs,
     ) as client:
-        return client.find_users(base_dn, username_or_email)
+        return client.add_entry(dn, object_class, attributes)
 
 
 @registry.register(
-    default_title="Disable AD User",
-    description="Disable AD user by distinguished name",
+    default_title="Delete LDAP entry",
+    description="Delete an entry from the LDAP directory.",
     display_group="LDAP",
     namespace="integrations.ldap",
     secrets=[ldap_secret],
 )
-def disable_active_directory_user(
-    user_dn: Annotated[
-        str,
-        Field(..., description="User distinguished name"),
-    ],
-    use_ssl: Annotated[
-        bool,
-        Field(..., description="Use SSL for LDAP connection"),
-    ] = True,
-) -> dict[str, Any]:
-    with create_ldap_client(use_ssl=use_ssl, is_active_directory=True) as client:
-        result = client.disable_user(user_dn)
-        return result
+def delete_entry(
+    dn: Annotated[str, Field(..., description="Distinguished name of the entry")],
+    server_kwargs: Annotated[
+        dict[str, Any] | None, Field(..., description="Additional server parameters")
+    ] = None,
+    connection_kwargs: Annotated[
+        dict[str, Any] | None,
+        Field(..., description="Additional connection parameters"),
+    ] = None,
+) -> None:
+    with LdapClient(
+        **get_ldap_secrets(),
+        server_kwargs=server_kwargs,
+        connection_kwargs=connection_kwargs,
+    ) as client:
+        return client.delete_entry(dn)
 
 
 @registry.register(
-    default_title="Enable AD User",
-    description="Enable AD user by distinguished name",
+    default_title="Modify LDAP entry",
+    description="Modify an LDAP entry in the directory.",
     display_group="LDAP",
     namespace="integrations.ldap",
     secrets=[ldap_secret],
 )
-def enable_active_directory_user(
-    user_dn: Annotated[
-        str,
-        Field(..., description="User distinguished name"),
-    ],
-    use_ssl: Annotated[
-        bool,
-        Field(..., description="Use SSL for LDAP connection"),
-    ] = True,
-) -> dict[str, Any]:
-    with create_ldap_client(use_ssl=use_ssl, is_active_directory=True) as client:
-        result = client.enable_user(user_dn)
-        return result
+def modify_entry(
+    dn: Annotated[str, Field(..., description="Distinguished name of the entry")],
+    changes: Annotated[dict[str, Any], Field(..., description="Changes to the entry")],
+    server_kwargs: Annotated[
+        dict[str, Any] | None, Field(..., description="Additional server parameters")
+    ] = None,
+    connection_kwargs: Annotated[
+        dict[str, Any] | None,
+        Field(..., description="Additional connection parameters"),
+    ] = None,
+) -> None:
+    with LdapClient(
+        **get_ldap_secrets(),
+        server_kwargs=server_kwargs,
+        connection_kwargs=connection_kwargs,
+    ) as client:
+        return client.modify_entry(dn, changes)
+
+
+@registry.register(
+    default_title="Search LDAP directory",
+    description="Search the LDAP directory for entries matching the query.",
+    display_group="LDAP",
+    namespace="integrations.ldap",
+    secrets=[ldap_secret],
+)
+def search_entries(
+    search_base: Annotated[str, Field(..., description="Search base")],
+    search_filter: Annotated[str, Field(..., description="Search filter")],
+    search_scope: Annotated[
+        Literal["BASE", "ONE", "SUBTREE"], Field(..., description="Search scope")
+    ] = "SUBTREE",
+    attributes: Annotated[
+        Literal["ALL_ATTRIBUTES", "ALL_OPERATIONAL_ATTRIBUTES"] | list[str],
+        Field(..., description="Attributes to return"),
+    ] = "ALL_ATTRIBUTES",
+    server_kwargs: Annotated[
+        dict[str, Any] | None, Field(..., description="Additional server parameters")
+    ] = None,
+    connection_kwargs: Annotated[
+        dict[str, Any] | None,
+        Field(..., description="Additional connection parameters"),
+    ] = None,
+) -> list[dict[str, Any]]:
+    with LdapClient(
+        **get_ldap_secrets(),
+        server_kwargs=server_kwargs,
+        connection_kwargs=connection_kwargs,
+    ) as client:
+        return client.search(search_base, search_filter, search_scope, attributes)

--- a/registry/tracecat_registry/integrations/ldap3.py
+++ b/registry/tracecat_registry/integrations/ldap3.py
@@ -98,8 +98,12 @@ class LdapClient:
         if not result:
             raise PermissionError(self.connection.result)
 
-    def modify_entry(self, dn: str, changes: dict[str, Any]) -> None:
-        escaped_dn = escape_rdn(dn)
+    def modify_entry(
+        self,
+        dn: str,
+        changes: dict[str, list[tuple[str, list[str | int]]]],
+    ) -> None:
+        escaped_dn = escape_rdn(dn)  # LDAP injection mitigation
         result = self.connection.modify(escaped_dn, changes)
         if not result:
             raise PermissionError(self.connection.result)
@@ -211,7 +215,10 @@ def delete_entry(
 )
 def modify_entry(
     dn: Annotated[str, Field(..., description="Distinguished name of the entry")],
-    changes: Annotated[dict[str, Any], Field(..., description="Changes to the entry")],
+    changes: Annotated[
+        dict[str, list[tuple[str, list[str | int]]]],
+        Field(..., description="Changes to the entry"),
+    ],
     server_kwargs: Annotated[
         dict[str, Any] | None, Field(..., description="Additional server parameters")
     ] = None,

--- a/registry/tracecat_registry/templates/ldap/disable_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/disable_active_directory_user.yml
@@ -1,0 +1,22 @@
+type: action
+definition:
+  name: disable_active_directory_user
+  namespace: integrations.ldap
+  title: Disable Active Directory User
+  description: Disable a user in Active Directory using LDAP.
+  display_group: LDAP
+  secrets:
+    - name: ldap
+  expects:
+    dn:
+      type: str
+      description: Distinguished Name of the user to disable
+  steps:
+    - ref: disable_user
+      action: integrations.ldap.modify_entry
+      args:
+        dn: ${{ inputs.dn }}
+        changes:
+          userAccountControl:
+            - ["MODIFY_REPLACE", 514]
+  returns: ${{ steps.disable_user.result }}

--- a/registry/tracecat_registry/templates/ldap/disable_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/disable_active_directory_user.yml
@@ -5,8 +5,6 @@ definition:
   title: Disable Active Directory User
   description: Disable a user in Active Directory using LDAP.
   display_group: LDAP
-  secrets:
-    - name: ldap
   expects:
     dn:
       type: str

--- a/registry/tracecat_registry/templates/ldap/disable_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/disable_active_directory_user.yml
@@ -11,6 +11,12 @@ definition:
     dn:
       type: str
       description: Distinguished Name of the user to disable
+    server_kwargs:
+      type: dict
+      description: Additional server parameters
+    connection_kwargs:
+      type: dict
+      description: Additional connection parameters
   steps:
     - ref: disable_user
       action: integrations.ldap.modify_entry
@@ -19,4 +25,6 @@ definition:
         changes:
           userAccountControl:
             - ["MODIFY_REPLACE", 514]
+        server_kwargs: ${{ inputs.server_kwargs }}
+        connection_kwargs: ${{ inputs.connection_kwargs }}
   returns: ${{ steps.disable_user.result }}

--- a/registry/tracecat_registry/templates/ldap/enable_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/enable_active_directory_user.yml
@@ -11,6 +11,12 @@ definition:
     dn:
       type: str
       description: Distinguished Name of the user to enable
+    server_kwargs:
+      type: dict
+      description: Additional server parameters
+    connection_kwargs:
+      type: dict
+      description: Additional connection parameters
   steps:
     - ref: enable_user
       action: integrations.ldap.modify_entry
@@ -19,4 +25,6 @@ definition:
         changes:
           userAccountControl:
             - ["MODIFY_REPLACE", 512]
+        server_kwargs: ${{ inputs.server_kwargs }}
+        connection_kwargs: ${{ inputs.connection_kwargs }}
   returns: ${{ steps.enable_user.result }}

--- a/registry/tracecat_registry/templates/ldap/enable_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/enable_active_directory_user.yml
@@ -1,0 +1,22 @@
+type: action
+definition:
+  name: enable_active_directory_user
+  namespace: integrations.ldap
+  title: Enable Active Directory User
+  description: Enable a user in Active Directory using LDAP.
+  display_group: LDAP
+  secrets:
+    - name: ldap
+  expects:
+    dn:
+      type: str
+      description: Distinguished Name of the user to enable
+  steps:
+    - ref: enable_user
+      action: integrations.ldap.modify_entry
+      args:
+        dn: ${{ inputs.dn }}
+        changes:
+          userAccountControl:
+            - ["MODIFY_REPLACE", 512]
+  returns: ${{ steps.enable_user.result }}

--- a/registry/tracecat_registry/templates/ldap/enable_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/enable_active_directory_user.yml
@@ -5,8 +5,6 @@ definition:
   title: Enable Active Directory User
   description: Enable a user in Active Directory using LDAP.
   display_group: LDAP
-  secrets:
-    - name: ldap
   expects:
     dn:
       type: str

--- a/registry/tracecat_registry/templates/ldap/expire_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/expire_active_directory_user.yml
@@ -1,0 +1,34 @@
+type: action
+definition:
+  name: expire_active_directory_user
+  namespace: integrations.ldap
+  title: Expire Active Directory User
+  description: Expire a user in Active Directory using LDAP.
+  display_group: LDAP
+  secrets:
+    - name: ldap
+  expects:
+    dn:
+      type: str
+      description: Distinguished Name of the user to expire
+    expiration:
+      type: datetime
+      description: Expiration datetime of the user
+    server_kwargs:
+      type: dict
+      description: Additional server parameters
+    connection_kwargs:
+      type: dict
+      description: Additional connection parameters
+  steps:
+    - ref: expire_user
+      action: integrations.ldap.modify_entry
+      args:
+        dn: ${{ inputs.dn }}
+        changes:
+          accountExpires:
+            # Windows file time (100-nanosecond intervals since 1601-01-01)
+            - ["MODIFY_REPLACE", "${{ FN.windows_filetime(inputs.expiration) }}"]
+        server_kwargs: ${{ inputs.server_kwargs }}
+        connection_kwargs: ${{ inputs.connection_kwargs }}
+  returns: ${{ steps.expire_user.result }}

--- a/registry/tracecat_registry/templates/ldap/expire_active_directory_user.yml
+++ b/registry/tracecat_registry/templates/ldap/expire_active_directory_user.yml
@@ -5,8 +5,6 @@ definition:
   title: Expire Active Directory User
   description: Expire a user in Active Directory using LDAP.
   display_group: LDAP
-  secrets:
-    - name: ldap
   expects:
     dn:
       type: str

--- a/registry/tracecat_registry/templates/ldap/expire_user.yml
+++ b/registry/tracecat_registry/templates/ldap/expire_user.yml
@@ -5,8 +5,6 @@ definition:
   title: Expire LDAP User
   description: Expire a user in LDAP
   display_group: LDAP
-  secrets:
-    - name: ldap
   expects:
     dn:
       type: str

--- a/registry/tracecat_registry/templates/ldap/expire_user.yml
+++ b/registry/tracecat_registry/templates/ldap/expire_user.yml
@@ -1,0 +1,34 @@
+type: action
+definition:
+  name: expire_user
+  namespace: integrations.ldap
+  title: Expire LDAP User
+  description: Expire a user in LDAP
+  display_group: LDAP
+  secrets:
+    - name: ldap
+  expects:
+    dn:
+      type: str
+      description: Distinguished Name of the user to expire
+    expiration:
+      type: datetime
+      description: Expiration datetime of the user
+    server_kwargs:
+      type: dict
+      description: Additional server parameters
+    connection_kwargs:
+      type: dict
+      description: Additional connection parameters
+  steps:
+    - ref: expire_user
+      action: integrations.ldap.modify_entry
+      args:
+        dn: ${{ inputs.dn }}
+        changes:
+          shadowExpire:
+            # UNIX timestamp in days since 1970-01-01
+            - ["MODIFY_REPLACE", "${{ FN.days_between(inputs.expiration, FN.datetime(1970, 1, 1)) }}"]
+        server_kwargs: ${{ inputs.server_kwargs }}
+        connection_kwargs: ${{ inputs.connection_kwargs }}
+  returns: ${{ steps.expire_user.result }}

--- a/registry/tracecat_registry/templates/ldap/find_active_directory_users.yml
+++ b/registry/tracecat_registry/templates/ldap/find_active_directory_users.yml
@@ -1,0 +1,31 @@
+type: action
+definition:
+  name: find_active_directory_users
+  namespace: integrations.ldap
+  title: Find Active Directory Users
+  description: Find Active Directory users using LDAP search.
+  display_group: LDAP
+  secrets:
+    - name: ldap
+  expects:
+    dn:
+      type: str
+      description: Base Distinguished Name to search for users
+    username_or_email:
+      type: str
+      description: Username or email to search for
+    server_kwargs:
+      type: dict
+      description: Additional server parameters
+    connection_kwargs:
+      type: dict
+      description: Additional connection parameters
+  steps:
+    - ref: find_users
+      action: integrations.ldap.search_entries
+      args:
+        search_base: ${{ inputs.dn }}
+        search_filter: ${{ (|(anr={inputs.username_or_email})(mail={inputs.username_or_email})(proxyAddresses=SMTP:{inputs.username_or_email})(userPrincipalName={inputs.username_or_email})(sAMAccountName={inputs.username_or_email})) }}
+        server_kwargs: ${{ inputs.server_kwargs }}
+        connection_kwargs: ${{ inputs.connection_kwargs }}
+  returns: ${{ steps.find_users.result }}

--- a/registry/tracecat_registry/templates/ldap/find_active_directory_users.yml
+++ b/registry/tracecat_registry/templates/ldap/find_active_directory_users.yml
@@ -5,8 +5,6 @@ definition:
   title: Find Active Directory Users
   description: Find Active Directory users using LDAP search.
   display_group: LDAP
-  secrets:
-    - name: ldap
   expects:
     dn:
       type: str

--- a/registry/tracecat_registry/templates/ldap/find_users.yml
+++ b/registry/tracecat_registry/templates/ldap/find_users.yml
@@ -5,8 +5,6 @@ definition:
   title: Find LDAP Users
   description: Find LDAP users using LDAP search.
   display_group: LDAP
-  secrets:
-    - name: ldap
   expects:
     dn:
       type: str

--- a/registry/tracecat_registry/templates/ldap/find_users.yml
+++ b/registry/tracecat_registry/templates/ldap/find_users.yml
@@ -1,0 +1,31 @@
+type: action
+definition:
+  name: find_users
+  namespace: integrations.ldap
+  title: Find LDAP Users
+  description: Find LDAP users using LDAP search.
+  display_group: LDAP
+  secrets:
+    - name: ldap
+  expects:
+    dn:
+      type: str
+      description: Base Distinguished Name to search for users
+    username_or_email:
+      type: str
+      description: Username or email to search for
+    server_kwargs:
+      type: dict
+      description: Additional server parameters
+    connection_kwargs:
+      type: dict
+      description: Additional connection parameters
+  steps:
+    - ref: find_users
+      action: integrations.ldap.search_entries
+      args:
+        search_base: ${{ inputs.dn }}
+        search_filter: ${{ (|(uid={inputs.username_or_email})(mail={inputs.username_or_email})(cn={inputs.username_or_email})(displayName={inputs.username_or_email})(givenName={inputs.username_or_email})) }}
+        server_kwargs: ${{ inputs.server_kwargs }}
+        connection_kwargs: ${{ inputs.connection_kwargs }}
+  returns: ${{ steps.find_users.result }}

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -433,6 +433,18 @@ def to_timestamp_str(x: datetime) -> float:
     return x.timestamp()
 
 
+def create_datetime(
+    year: int,
+    month: int,
+    day: int,
+    hour: int = 0,
+    minute: int = 0,
+    second: int = 0,
+) -> datetime:
+    """Create datetime from year, month, day, hour, minute, and second."""
+    return datetime(year, month, day, hour, minute, second)
+
+
 def get_second(x: datetime) -> int:
     """Get second (0-59) from datetime."""
     return x.second
@@ -612,6 +624,22 @@ def set_timezone(x: datetime, timezone: str) -> datetime:
 def unset_timezone(x: datetime) -> datetime:
     """Remove timezone information from datetime without changing the time."""
     return x.replace(tzinfo=None)
+
+
+def windows_filetime(x: datetime) -> int:
+    """Convert datetime to Windows filetime."""
+    # Define Windows and Unix epochs
+    windows_epoch = datetime(1601, 1, 1, tzinfo=UTC)
+
+    # Ensure input datetime is UTC
+    if x.tzinfo is None:
+        x = x.replace(tzinfo=UTC)
+    elif x.tzinfo != UTC:
+        x = x.astimezone(UTC)
+
+    # Calculate number of 100-nanosecond intervals since Windows epoch
+    delta = x - windows_epoch
+    return int(delta.total_seconds() * 10_000_000)
 
 
 # Comparison functions
@@ -831,6 +859,7 @@ _FUNCTION_MAPPING = {
     "get_day_of_week": get_day_of_week,
     "get_month": get_month,
     "get_year": get_year,
+    "datetime": create_datetime,
     "seconds": create_seconds,
     "minutes": create_minutes,
     "hours": create_hours,
@@ -850,6 +879,7 @@ _FUNCTION_MAPPING = {
     "to_datetime": to_datetime,
     "to_isoformat": to_iso_format,
     "to_timestamp": to_timestamp_str,
+    "windows_filetime": windows_filetime,
     # Base64
     "to_base64": str_to_b64,
     "from_base64": b64_to_str,


### PR DESCRIPTION
## What changed?
- Converted existing LDAP UDFs into reusable templates to improve code maintainability and consistency.
- Added `add` and `delete` operations to LDAP client
- Introduced templates for enabling and disabling Active Directory users.
- Added templates for setting account expiration.
- Incorporated server and connection keyword arguments into LDAP templates for improved flexibility.
- Added function for handling Windows filetime conversions.
- Made the find users filters more precise