### PR TITLE
fix(engine): Use wf execution or schedule id for related wf exec ids

### DIFF
--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -137,7 +137,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
     retry_policy: ActionRetryPolicy = Field(default_factory=ActionRetryPolicy)
     start_delay: float = 0.0
     join_strategy: JoinStrategy = JoinStrategy.ALL
-    related_wf_exec_id: WorkflowExecutionID | None = None
+    related_wf_exec_id: ExecutionOrScheduleID | None = None
 
     @staticmethod
     def from_scheduled_activity(
@@ -196,7 +196,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
             raise ValueError("Event is not a child workflow initiated event.")
 
         wf_exec_id = cast(
-            WorkflowExecutionID,
+            ExecutionOrScheduleID,
             event.start_child_workflow_execution_initiated_event_attributes.workflow_id,
         )
         # Load the input data
@@ -270,7 +270,7 @@ class EventHistoryResponse(BaseModel, Generic[EventInput]):
     failure: EventFailure | None = None
     result: Any | None = None
     role: Role | None = None
-    parent_wf_exec_id: WorkflowExecutionID | None = None
+    parent_wf_exec_id: ExecutionOrScheduleID | None = None
     workflow_timeout: float | None = None
 
 


### PR DESCRIPTION
# Changes
- Fix types in wf runs history