### PR TITLE
fix(integrations): Use correct function name for ansible run playbook

### DIFF
--- a/registry/tracecat_registry/templates/ansible/run_playbook_from_s3.yml
+++ b/registry/tracecat_registry/templates/ansible/run_playbook_from_s3.yml
@@ -26,7 +26,7 @@ definition:
         bucket: ${{ steps.parse_uri.result.bucket }}
         key: ${{ steps.parse_uri.result.key }}
     - ref: run_playbook
-      action: integrations.ansible.run_playbook
+      action: integrations.ansible.run_ansible_playbook
       args:
         playbook: ${{ steps.download_playbook.result }}
         extra_vars: ${{ inputs.extra_vars }}


### PR DESCRIPTION
# Changes
- Use `integrations.ansible.run_ansible_playbook` (correct, from UDF) over `integrations.ansible.run_playbook`