### PR TITLE
feat(engine): Make executor client timeout configurable with 120s def…

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -24,7 +24,13 @@ TRACECAT__DB_URI = os.environ.get(
 TRACECAT__EXECUTOR_URL = os.environ.get(
     "TRACECAT__EXECUTOR_URL", "http://executor:8000"
 )
+TRACECAT__EXECUTOR_CLIENT_TIMEOUT = float(
+    os.environ.get("TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 120.0)
+)
+"""Timeout for the executor client in seconds (default 120s).
 
+The `httpx.Client` default is 5s, which doesn't work for long-running actions.
+"""
 TRACECAT__DB_NAME = os.environ.get("TRACECAT__DB_NAME")
 TRACECAT__DB_USER = os.environ.get("TRACECAT__DB_USER")
 TRACECAT__DB_PASS = os.environ.get("TRACECAT__DB_PASS")

--- a/tracecat/registry/client.py
+++ b/tracecat/registry/client.py
@@ -45,7 +45,7 @@ class RegistryClient:
 
     _repos_endpoint = REGISTRY_REPOS_PATH
     _actions_endpoint = REGISTRY_ACTIONS_PATH
-    _timeout: float = 60.0
+    _timeout: float = config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
 
     def __init__(self, role: Role | None = None):
         self.role = role or ctx_role.get()


### PR DESCRIPTION
# Changes
- Introduce `TRACECAT__EXECUTOR_CLIENT_TIMEOUT` with 120s default
  - If we don't set a default, it uses the `httpx.Client` default of 5s, which isn't appropriate for long running actions.