### PR TITLE
feat(engine): Improve process pool event loop management

### DIFF
--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -224,42 +224,6 @@ async def test_executor_concurrent_execution():
     assert results == [0.2, 0.3, 0.1]
 
 
-def _worker_task_loop_conflicts():
-    """Task that creates and uses an async operation in the worker"""
-    _init_worker_process()
-
-    async def async_operation():
-        await asyncio.sleep(0.1)
-        return asyncio.get_running_loop()
-
-    # Get the loop from the worker process
-    loop = asyncio.get_event_loop()
-    # Run the async operation
-    worker_result = loop.run_until_complete(async_operation())
-    return id(worker_result)  # Return loop ID for comparison
-
-
-@pytest.mark.anyio
-async def test_executor_prevents_loop_conflicts():
-    """Test that the executor prevents 'Task attached to different loop' errors."""
-
-    # Run multiple worker tasks
-    executor = get_executor()
-    futures = [executor.submit(_worker_task_loop_conflicts) for _ in range(5)]
-
-    # Get the loop IDs from different workers
-    worker_loop_ids = [future.result() for future in futures]
-
-    # Get the main process loop ID
-    main_loop_id = id(asyncio.get_running_loop())
-
-    # Verify that:
-    # 1. Each worker has a different loop from the main process
-    assert all(loop_id != main_loop_id for loop_id in worker_loop_ids)
-    # 2. Each worker has its own unique loop
-    assert len(set(worker_loop_ids)) == len(worker_loop_ids)
-
-
 def _worker_task_loop_matching():
     """Task that creates and uses an async operation in the worker"""
     _init_worker_process()


### PR DESCRIPTION
# Changes
- Attempts to fix `RuntimeError: Task attached to different loop` error in `executor` service
- Use an initializer to create the `uvloop` event loop in each process pool worker instead of using `uvloop.run()` in the entrypoint function

# Tests
- ~Added tests to verify that tasks are waited on the correct loop~
- The above tests were flaky, so rewrote most of them (or removed loop ID uniqueness checks)