### PR TITLE
fix(engine): Load udf secrets in env correctly

### DIFF
--- a/tracecat/registry/executor.py
+++ b/tracecat/registry/executor.py
@@ -260,11 +260,11 @@ async def run_single_action(
 
     action_secret_names = set()
     optional_secrets = set()
-    secrets_context = context.get("SECRETS", {})
+    secrets = context.get("SECRETS", {})
 
     for secret in action.secrets or []:
         # Only add if not already pulled
-        if secret.name not in secrets_context:
+        if secret.name not in secrets:
             if secret.optional:
                 optional_secrets.add(secret.name)
             action_secret_names.add(secret.name)
@@ -276,7 +276,7 @@ async def run_single_action(
         environment=get_runtime_env(),
         optional_secrets=list(optional_secrets),
     ) as sandbox:
-        secrets = sandbox.secrets.copy()
+        secrets |= sandbox.secrets.copy()
 
     context["SECRETS"] = context.get("SECRETS", {}) | secrets
     if action.is_template:


### PR DESCRIPTION
# Changes
- Wasn't merging the secrets context correctly

# Testing
- Tested this with a unit test locally, works. Having issues with pytest fixtures here so just adding the patch first

The test i used:
```python
@pytest.mark.anyio
async def test_executor_can_run_udf_with_secrets(
    mock_package, test_role, db_session_with_repo, mock_run_context
):
    """Test that the executor can run a UDF with secrets.

    A UDF should be able to pull secrets directly from the secrets store.
    """

    session, db_repo_id = db_session_with_repo
    # Arrange
    # 1. Register test udfs
    repo = Repository()
    repo._register_udfs_from_package(mock_package)

    # Sanity check: Returns None because we haven't set secrets
    assert repo.get("testing.fetch_secret").fn("KEY") is None  # type: ignore

    # 2. Add secrets
    sec_service = SecretsService(session, role=test_role)
    await sec_service.create_secret(
        SecretCreate(
            name="test",
            environment="default",
            keys=[SecretKeyValue(key="KEY", value=SecretStr("__SECRET_VALUE_UDF__"))],
        )
    )

    ra_service = RegistryActionsService(session, role=test_role)
    await ra_service.create_action(
        RegistryActionCreate.from_bound(repo.get("testing.fetch_secret"), db_repo_id)
    )

    input = RunActionInput(
        task=ActionStatement(
            ref="test",
            action="testing.fetch_secret",
            run_if=None,
            for_each=None,
            args={"secret_key_name": "KEY"},
        ),
        exec_context=create_default_dsl_context(),
        run_context=mock_run_context,
    )

    # Act
    result = await executor.run_action_from_input(input)

    # Assert
    assert result == "__SECRET_VALUE_UDF__"

```