### PR TITLE
ci(infra): Add temporal ui variables

### DIFF
--- a/deployments/aws/ecs/ecs-temporal-ui.tf
+++ b/deployments/aws/ecs/ecs-temporal-ui.tf
@@ -1,5 +1,7 @@
 # ECS Task Definition for Temporal UI Service
 resource "aws_ecs_task_definition" "temporal_ui_task_definition" {
+  count = var.disable_temporal_ui ? 0 : 1
+
   family                   = "TemporalUiTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -69,9 +71,10 @@ resource "aws_ecs_task_definition" "temporal_ui_task_definition" {
 }
 
 resource "aws_ecs_service" "temporal_ui_service" {
+  count                = var.disable_temporal_ui ? 0 : 1
   name                 = "temporal-ui"
   cluster              = aws_ecs_cluster.tracecat_cluster.id
-  task_definition      = aws_ecs_task_definition.temporal_ui_task_definition.arn
+  task_definition      = aws_ecs_task_definition.temporal_ui_task_definition[count.index].arn
   launch_type          = "FARGATE"
   desired_count        = 1
   force_new_deployment = var.force_new_deployment

--- a/deployments/aws/ecs/variables.tf
+++ b/deployments/aws/ecs/variables.tf
@@ -105,6 +105,12 @@ variable "tracecat_ui_image" {
   default = "ghcr.io/tracecathq/tracecat-ui"
 }
 
+variable "disable_temporal_ui" {
+  type        = bool
+  description = "Whether to disable the Temporal UI service in the deployment"
+  default     = false
+}
+
 variable "TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA" {
   description = "Terraform Cloud only: the git commit SHA of that triggered the run"
   type        = string

--- a/deployments/aws/main.tf
+++ b/deployments/aws/main.tf
@@ -73,6 +73,12 @@ module "ecs" {
   saml_idp_certificate_arn  = var.saml_idp_certificate_arn
   saml_idp_metadata_url_arn = var.saml_idp_metadata_url_arn
 
+  # Temporal UI
+  temporal_auth_provider_url      = var.temporal_auth_provider_url
+  temporal_auth_client_id_arn     = var.temporal_auth_client_id_arn
+  temporal_auth_client_secret_arn = var.temporal_auth_client_secret_arn
+  disable_temporal_ui             = var.disable_temporal_ui
+
   # Compute / memory
   api_cpu                     = var.api_cpu
   api_memory                  = var.api_memory

--- a/deployments/aws/variables.tf
+++ b/deployments/aws/variables.tf
@@ -56,6 +56,12 @@ variable "force_new_deployment" {
   default     = false
 }
 
+variable "disable_temporal_ui" {
+  type        = bool
+  description = "Whether to disable the Temporal UI service in the deployment"
+  default     = false
+}
+
 ### Secret ARNs
 
 variable "tracecat_db_encryption_key_arn" {
@@ -106,6 +112,24 @@ variable "saml_idp_certificate_arn" {
 variable "saml_idp_metadata_url_arn" {
   type        = string
   description = "The ARN of the secret containing the SAML IDP metadata URL (optional)"
+  default     = null
+}
+
+variable "temporal_auth_provider_url" {
+  type        = string
+  description = "The URL of the Temporal auth provider"
+  default     = null
+}
+
+variable "temporal_auth_client_id_arn" {
+  type        = string
+  description = "The ARN of the secret containing the Temporal auth client ID (optional)"
+  default     = null
+}
+
+variable "temporal_auth_client_secret_arn" {
+  type        = string
+  description = "The ARN of the secret containing the Temporal auth client secret (optional)"
   default     = null
 }
 


### PR DESCRIPTION
## What changed
- Added variable `disable_temporal_ui` to disable / enable temporal UI service (`false` by default)
- Added missing Temporal UI variables in root terraform module