### PR TITLE
fix(engine): Use ALLOW_ALL schedule overlap policy

### DIFF
--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -60,6 +60,10 @@ async def create_schedule(
                 start_at=start_at,
                 end_at=end_at,
             ),
+            policy=temporalio.client.SchedulePolicy(
+                # Allow overlapping workflows to run in parallel
+                overlap=temporalio.client.ScheduleOverlapPolicy.ALLOW_ALL,
+            ),
         ),
     )
 


### PR DESCRIPTION
# Changes
- Fixes issue where workflows that take longer than the scheduled interval aren't ran in parallel, and are cancelled.
- NOTE: Users will have to recreate their schedules for the update to take place

# Testing
Deployed and QAd on local + staging