### PR TITLE
refactor(engine): Cleanup and consolidate expressions module

### DIFF
--- a/tests/playbooks/test_playbooks.py
+++ b/tests/playbooks/test_playbooks.py
@@ -15,7 +15,7 @@ from tracecat.dsl.action import DSLActivities
 from tracecat.dsl.common import DSLRunArgs
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow, retry_policies
-from tracecat.expressions.shared import ExprType
+from tracecat.expressions.common import ExprType
 from tracecat.logger import logger
 from tracecat.registry.repository import Repository
 from tracecat.types.auth import Role

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -715,7 +715,7 @@ def test_expression_parser(expr, expected):
     # assert parser.walk_expr(expr, visitor) == expected
     parser = ExprParser()
     parse_tree = parser.parse(expr)
-    ev = ExprEvaluator(context=context)
+    ev = ExprEvaluator(operand=context)
     actual = ev.transform(parse_tree)
     assert actual == expected
 
@@ -766,13 +766,13 @@ def test_parser_error():
     with pytest.raises(TracecatExpressionError):
         parser.parse(expr)
 
-    strict_evaluator = ExprEvaluator(context=context, strict=True)
+    strict_evaluator = ExprEvaluator(operand=context, strict=True)
     with pytest.raises(TracecatExpressionError):
         test = "ACTIONS.action_test.foo"
         parse_tree = parser.parse(test)
         strict_evaluator.evaluate(parse_tree)
 
-    evaluator = ExprEvaluator(context=context, strict=False)
+    evaluator = ExprEvaluator(operand=context, strict=False)
     test = "ACTIONS.action_test.foo.bar.baz"
     parse_tree = parser.parse(test)
     assert evaluator.evaluate(parse_tree) is None
@@ -962,6 +962,6 @@ async def test_extract_expressions_errors(expr, expected, test_role, env_sandbox
 def test_parse_trigger_json(context, expr, expected):
     parser = ExprParser()
     parse_tree = parser.parse(expr)
-    ev = ExprEvaluator(context=context)
+    ev = ExprEvaluator(operand=context)
     actual = ev.transform(parse_tree)
     assert actual == expected

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -11,6 +11,7 @@ from httpx import Response
 from tracecat import config
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.db.schemas import BaseSecret
+from tracecat.expressions.common import ExprContext, ExprType, IterableExpr
 from tracecat.expressions.core import TemplateExpression
 from tracecat.expressions.eval import (
     eval_templated_object,
@@ -22,7 +23,6 @@ from tracecat.expressions.parser.core import ExprParser
 from tracecat.expressions.parser.evaluator import ExprEvaluator
 from tracecat.expressions.parser.validator import ExprValidationContext, ExprValidator
 from tracecat.expressions.patterns import FULL_TEMPLATE
-from tracecat.expressions.shared import ExprContext, ExprType, IterableExpr
 from tracecat.logger import logger
 from tracecat.secrets.encryption import decrypt_keyvalues, encrypt_keyvalues
 from tracecat.secrets.models import SecretKeyValue

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -34,7 +34,7 @@ from tracecat.dsl.models import DSLConfig, DSLContext
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow, retry_policies
 from tracecat.executor.service import run_action_on_ray_cluster
-from tracecat.expressions.shared import ExprContext
+from tracecat.expressions.common import ExprContext
 from tracecat.logger import logger
 from tracecat.registry.client import RegistryClient
 from tracecat.secrets.models import SecretCreate, SecretKeyValue

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -25,8 +25,8 @@ from tracecat.dsl.models import (
 )
 from tracecat.dsl.view import RFEdge, RFGraph, RFNode, TriggerNode, UDFNode, UDFNodeData
 from tracecat.expressions import patterns
+from tracecat.expressions.common import ExprContext
 from tracecat.expressions.expectations import ExpectedField
-from tracecat.expressions.shared import ExprContext
 from tracecat.identifiers import ScheduleID, WorkflowID
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, JsonValue
 from tracecat.contexts import RunContext
 from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
 from tracecat.dsl.enums import JoinStrategy
-from tracecat.expressions.shared import ExprContext
+from tracecat.expressions.common import ExprContext
 from tracecat.expressions.validation import ExpressionStr, TemplateValidator
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -55,7 +55,7 @@ with workflow.unsafe.imports_passed_through():
         validate_trigger_inputs_activity,
     )
     from tracecat.expressions.eval import eval_templated_object
-    from tracecat.expressions.shared import ExprContext
+    from tracecat.expressions.common import ExprContext
     from tracecat.logger import logger
     from tracecat.executor.service import evaluate_templated_args, iter_for_each
     from tracecat.types.exceptions import (

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -27,9 +27,8 @@ from tracecat.dsl.models import (
     RunActionInput,
 )
 from tracecat.executor.engine import EXECUTION_TIMEOUT
-from tracecat.expressions.common import ExprContext
+from tracecat.expressions.common import ExprContext, ExprOperand
 from tracecat.expressions.eval import (
-    OperandType,
     eval_templated_object,
     extract_templated_secrets,
     get_iterables_from_expression,
@@ -188,7 +187,7 @@ async def run_template_action(
         evaled_args = cast(
             ArgsT,
             eval_templated_object(
-                step.args, operand=cast(OperandType, template_context)
+                step.args, operand=cast(ExprOperand, template_context)
             ),
         )
         async with RegistryActionsService.with_session() as service:
@@ -208,7 +207,7 @@ async def run_template_action(
 
     # Handle returns
     return eval_templated_object(
-        defn.returns, operand=cast(OperandType, template_context)
+        defn.returns, operand=cast(ExprOperand, template_context)
     )
 
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -27,13 +27,13 @@ from tracecat.dsl.models import (
     RunActionInput,
 )
 from tracecat.executor.engine import EXECUTION_TIMEOUT
+from tracecat.expressions.common import ExprContext
 from tracecat.expressions.eval import (
     OperandType,
     eval_templated_object,
     extract_templated_secrets,
     get_iterables_from_expression,
 )
-from tracecat.expressions.shared import ExprContext
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
 from tracecat.registry.actions.models import (

--- a/tracecat/expressions/common.py
+++ b/tracecat/expressions/common.py
@@ -1,7 +1,7 @@
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from enum import StrEnum, auto
-from typing import Any
+from typing import Any, TypeVar
 
 
 class TracecatEnum(StrEnum):
@@ -10,19 +10,35 @@ class TracecatEnum(StrEnum):
 
 
 class ExprContext(TracecatEnum):
-    """Global contexts"""
+    """Expression contexts."""
 
+    # Global contexts
     ACTIONS = "ACTIONS"
-    SECRETS = "SECRETS"
-    FN = "FN"
-    INPUTS = "INPUTS"
-    ENV = "ENV"
-    TRIGGER = "TRIGGER"
+    """Actions context"""
 
-    """Action-local variables"""
+    SECRETS = "SECRETS"
+    """Secrets context"""
+
+    FN = "FN"
+    """Function context"""
+
+    INPUTS = "INPUTS"
+    """Inputs context"""
+
+    ENV = "ENV"
+    """Environment context"""
+
+    TRIGGER = "TRIGGER"
+    """Trigger context"""
+    # Action-local variables
     LOCAL_VARS = "var"
+    """Action-local variables context"""
+
     TEMPLATE_ACTION_INPUTS = "inputs"
+    """Template action inputs context"""
+
     TEMPLATE_ACTION_STEPS = "steps"
+    """Template action steps context"""
 
 
 class ExprType(TracecatEnum):
@@ -56,9 +72,6 @@ VISITOR_NODE_TO_EXPR_TYPE = {
 }
 
 
-ExprContextType = dict[ExprContext, Any]
-
-
 @dataclass
 class IterableExpr[T]:
     """An expression that represents an iterable collection."""
@@ -69,3 +82,7 @@ class IterableExpr[T]:
     def __iter__(self) -> Iterator[tuple[str, T]]:
         for item in self.collection:
             yield self.iterator, item
+
+
+K = TypeVar("K", str, StrEnum)
+ExprOperand = Mapping[K, Any]

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -10,6 +10,7 @@ import re
 import zoneinfo
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import UTC, date, datetime, timedelta
+from enum import StrEnum
 from functools import wraps
 from html.parser import HTMLParser
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
@@ -21,7 +22,7 @@ import jsonpath_ng.ext
 import orjson
 from jsonpath_ng.exceptions import JsonPathParserError
 
-from tracecat.expressions.shared import ExprContext
+from tracecat.expressions.common import ExprContext
 from tracecat.expressions.validation import is_iterable
 from tracecat.logger import logger
 from tracecat.types.exceptions import TracecatExpressionError
@@ -742,7 +743,7 @@ def filter_[T: Any](items: Sequence[T], python_lambda: str) -> list[T]:
 
 def eval_jsonpath(
     expr: str,
-    operand: Mapping[str, Any],
+    operand: Mapping[str | StrEnum, Any],
     *,
     context_type: ExprContext | None = None,
     strict: bool = False,
@@ -939,7 +940,7 @@ def mappable(func: F) -> F:
         zipped_args = zip(*iterables, strict=False)
         return [func(*zipped) for zipped in zipped_args]
 
-    wrapper.map = broadcast_map
+    wrapper.map = broadcast_map  # type: ignore
     wrapper.__doc__ = func.__doc__
     return wrapper
 

--- a/tracecat/expressions/parser/core.py
+++ b/tracecat/expressions/parser/core.py
@@ -1,4 +1,4 @@
-from lark import Lark, Tree
+from lark import Lark, Token, Tree
 from lark.exceptions import UnexpectedCharacters, UnexpectedEOF, UnexpectedInput
 
 from tracecat.expressions.parser.grammar import grammar
@@ -10,7 +10,7 @@ class ExprParser:
     def __init__(self, start_rule: str = "root") -> None:
         self.parser = Lark(grammar, start=start_rule)
 
-    def parse(self, expression: str) -> Tree | None:
+    def parse(self, expression: str) -> Tree[Token] | None:
         try:
             return self.parser.parse(expression)
         except (UnexpectedCharacters, UnexpectedEOF, UnexpectedInput) as e:

--- a/tracecat/expressions/parser/validator.py
+++ b/tracecat/expressions/parser/validator.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.dsl.models import DSLNodeResult
 from tracecat.expressions import functions
-from tracecat.expressions.shared import VISITOR_NODE_TO_EXPR_TYPE, ExprContext, ExprType
+from tracecat.expressions.common import VISITOR_NODE_TO_EXPR_TYPE, ExprContext, ExprType
 from tracecat.logger import logger
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.types.exceptions import TracecatExpressionError

--- a/tracecat/validation/common.py
+++ b/tracecat/validation/common.py
@@ -2,7 +2,7 @@ from typing import Annotated, Any, Optional
 
 from pydantic import BaseModel, Field, create_model
 
-from tracecat.expressions.shared import ExprType
+from tracecat.expressions.common import ExprType
 from tracecat.expressions.validation import TemplateValidator
 from tracecat.logger import logger
 from tracecat.secrets.models import SecretSearch

--- a/tracecat/validation/models.py
+++ b/tracecat/validation/models.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
-from tracecat.expressions.shared import ExprType
+from tracecat.expressions.common import ExprType
 
 
 class ValidationResult(BaseModel):

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -11,9 +11,9 @@ from tracecat.concurrency import GatheringTaskGroup
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import RegistryAction
 from tracecat.dsl.common import DSLInput, context_locator
+from tracecat.expressions.common import ExprType
 from tracecat.expressions.eval import extract_expressions, is_template_only
 from tracecat.expressions.parser.validator import ExprValidationContext, ExprValidator
-from tracecat.expressions.shared import ExprType
 from tracecat.logger import logger
 from tracecat.registry.actions.models import RegistryActionInterface
 from tracecat.registry.actions.service import RegistryActionsService


### PR DESCRIPTION
# Changes
- Rename `tracecat.expressions.shared` -> `tracecat.expressions.common`