### PR TITLE
refactor(engine): Cleanup identifiers and patterns

### DIFF
--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -1,23 +1,20 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
-from typing import TYPE_CHECKING
 
 import loguru
 from pydantic import BaseModel
 
-from tracecat import identifiers
-
-if TYPE_CHECKING:
-    from tracecat.types.auth import Role
+from tracecat.identifiers import WorkflowExecutionID, WorkflowID, WorkflowRunID
+from tracecat.types.auth import Role
 
 
 class RunContext(BaseModel):
     """This is the runtime context model for a workflow run. Passed into activities."""
 
-    wf_id: identifiers.WorkflowID
-    wf_exec_id: identifiers.WorkflowExecutionID | identifiers.WorkflowScheduleID
-    wf_run_id: identifiers.WorkflowRunID
+    wf_id: WorkflowID
+    wf_exec_id: WorkflowExecutionID
+    wf_run_id: WorkflowRunID
     environment: str
 
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -657,7 +657,7 @@ class DSLWorkflow:
 
     async def _run_child_workflow(self, run_args: DSLRunArgs) -> Any:
         self.logger.info("Running child workflow", run_args=run_args)
-        wf_exec_id = identifiers.workflow.exec_id(run_args.wf_id)
+        wf_exec_id = identifiers.workflow.generate_exec_id(run_args.wf_id)
         wf_info = workflow.info()
         return await workflow.execute_child_workflow(
             DSLWorkflow.run,

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -49,9 +49,9 @@ from tracecat.identifiers.resource import id_factory
 from tracecat.identifiers.schedules import ScheduleID
 from tracecat.identifiers.workflow import (
     WorkflowExecutionID,
+    WorkflowExecutionSuffixID,
     WorkflowID,
     WorkflowRunID,
-    WorkflowScheduleID,
 )
 
 UserID = UUID4
@@ -80,7 +80,7 @@ __all__ = [
     "ActionRef",
     "WorkflowID",
     "WorkflowExecutionID",
-    "WorkflowScheduleID",
+    "WorkflowExecutionSuffixID",
     "WorkflowRunID",
     "ScheduleID",
     "UserID",

--- a/tracecat/identifiers/schedules.py
+++ b/tracecat/identifiers/schedules.py
@@ -4,7 +4,12 @@ from typing import Annotated
 
 from pydantic import StringConstraints
 
-ScheduleID = Annotated[str, StringConstraints(pattern=r"sch-[0-9a-f]{32}")]
+# Patterns
+SCHEDULE_ID_PATTERN = r"sch-[0-9a-f]{32}"
+SCHEDULE_EXEC_ID_PATTERN = rf"{SCHEDULE_ID_PATTERN}-.*"
+
+# Annotations
+ScheduleID = Annotated[str, StringConstraints(pattern=SCHEDULE_ID_PATTERN)]
 """A unique ID for a schedule.
 
 This is the equivalent of a Schedule ID in Temporal.
@@ -13,3 +18,8 @@ Exapmles
 --------
 - `sch-77932a0b140a4465a1a25a5c95edcfb8`
 """
+
+ScheduleExecutionID = Annotated[
+    str, StringConstraints(pattern=SCHEDULE_EXEC_ID_PATTERN)
+]
+"""The full unique ID for a scheduled workflow execution."""

--- a/tracecat/identifiers/workflow.py
+++ b/tracecat/identifiers/workflow.py
@@ -65,7 +65,7 @@ WorkflowExecutionSuffixID = Annotated[
 """The suffix of a workflow execution ID."""
 
 
-def generate_exec_id(workflow_id: str) -> WorkflowExecutionID:
+def generate_exec_id(workflow_id: WorkflowID) -> WorkflowExecutionID:
     """Inner workflow ID for a run, using the workflow ID and run ID."""
     exec_id = generate_resource_id(ResourcePrefix.WORKFLOW_EXECUTION)
     return f"{workflow_id}:{exec_id}"

--- a/tracecat/workflow/executions/dependencies.py
+++ b/tracecat/workflow/executions/dependencies.py
@@ -3,12 +3,12 @@ from typing import Annotated
 
 from fastapi import Depends
 
-from tracecat.workflow.executions.models import ExecutionOrScheduleID
+from tracecat.workflow.executions.models import WorkflowExecutionID
 
 
-def unquote_dep(execution_id: ExecutionOrScheduleID) -> ExecutionOrScheduleID:
+def unquote_dep(execution_id: WorkflowExecutionID) -> WorkflowExecutionID:
     return urllib.parse.unquote(execution_id)
 
 
-UnquotedExecutionOrScheduleID = Annotated[ExecutionOrScheduleID, Depends(unquote_dep)]
-"""Dependency for an unquoted execution or schedule ID."""
+UnquotedExecutionID = Annotated[WorkflowExecutionID, Depends(unquote_dep)]
+"""Dependency for an unquoted execution ID."""

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -20,7 +20,7 @@ from tracecat.dsl.models import (
     RunActionInput,
     TriggerInputs,
 )
-from tracecat.identifiers import WorkflowExecutionID, WorkflowID, WorkflowScheduleID
+from tracecat.identifiers import WorkflowExecutionID, WorkflowID
 from tracecat.types.auth import Role
 from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
 
@@ -34,8 +34,6 @@ WorkflowExecutionStatusLiteral = Literal[
     "TIMED_OUT",
 ]
 """Mapped literal types for workflow execution statuses."""
-
-ExecutionOrScheduleID = WorkflowExecutionID | WorkflowScheduleID
 
 
 class EventHistoryType(StrEnum):
@@ -137,7 +135,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
     retry_policy: ActionRetryPolicy = Field(default_factory=ActionRetryPolicy)
     start_delay: float = 0.0
     join_strategy: JoinStrategy = JoinStrategy.ALL
-    related_wf_exec_id: ExecutionOrScheduleID | None = None
+    related_wf_exec_id: WorkflowExecutionID | None = None
 
     @staticmethod
     def from_scheduled_activity(
@@ -196,7 +194,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
             raise ValueError("Event is not a child workflow initiated event.")
 
         wf_exec_id = cast(
-            ExecutionOrScheduleID,
+            WorkflowExecutionID,
             event.start_child_workflow_execution_initiated_event_attributes.workflow_id,
         )
         # Load the input data
@@ -270,7 +268,7 @@ class EventHistoryResponse(BaseModel, Generic[EventInput]):
     failure: EventFailure | None = None
     result: Any | None = None
     role: Role | None = None
-    parent_wf_exec_id: ExecutionOrScheduleID | None = None
+    parent_wf_exec_id: WorkflowExecutionID | None = None
     workflow_timeout: float | None = None
 
 

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -17,7 +17,7 @@ from tracecat.dsl.common import DSLInput
 from tracecat.identifiers import WorkflowID
 from tracecat.logger import logger
 from tracecat.types.exceptions import TracecatValidationError
-from tracecat.workflow.executions.dependencies import UnquotedExecutionOrScheduleID
+from tracecat.workflow.executions.dependencies import UnquotedExecutionID
 from tracecat.workflow.executions.models import (
     CreateWorkflowExecutionParams,
     CreateWorkflowExecutionResponse,
@@ -52,7 +52,7 @@ async def list_workflow_executions(
 @router.get("/{execution_id}", tags=["workflow-executions"])
 async def get_workflow_execution(
     role: WorkspaceUserRole,
-    execution_id: UnquotedExecutionOrScheduleID,
+    execution_id: UnquotedExecutionID,
 ) -> WorkflowExecutionResponse:
     """Get a workflow execution."""
     with logger.contextualize(role=role):
@@ -64,7 +64,7 @@ async def get_workflow_execution(
 @router.get("/{execution_id}/history", tags=["workflow-executions"])
 async def list_workflow_execution_event_history(
     role: WorkspaceUserRole,
-    execution_id: UnquotedExecutionOrScheduleID,
+    execution_id: UnquotedExecutionID,
 ) -> list[EventHistoryResponse]:
     """Get a workflow execution."""
     with logger.contextualize(role=role):
@@ -124,7 +124,7 @@ async def create_workflow_execution(
 )
 async def cancel_workflow_execution(
     role: WorkspaceUserRole,
-    execution_id: UnquotedExecutionOrScheduleID,
+    execution_id: UnquotedExecutionID,
 ) -> None:
     """Get a workflow execution."""
     with logger.contextualize(role=role):
@@ -148,7 +148,7 @@ async def cancel_workflow_execution(
 )
 async def terminate_workflow_execution(
     role: WorkspaceUserRole,
-    execution_id: UnquotedExecutionOrScheduleID,
+    execution_id: UnquotedExecutionID,
     params: TerminateWorkflowExecutionParams,
 ) -> None:
     """Get a workflow execution."""

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -31,8 +31,7 @@ from tracecat.dsl.workflow import DSLWorkflow, retry_policies
 from tracecat.identifiers.workflow import (
     WorkflowExecutionID,
     WorkflowID,
-    WorkflowScheduleID,
-    exec_id,
+    generate_exec_id,
 )
 from tracecat.logger import logger
 from tracecat.types.auth import Role
@@ -373,7 +372,7 @@ class WorkflowExecutionsService:
         return CreateWorkflowExecutionResponse(
             message="Workflow execution started",
             wf_id=wf_id,
-            wf_exec_id=exec_id(wf_id),
+            wf_exec_id=generate_exec_id(wf_id),
         )
 
     def create_workflow_execution(
@@ -394,11 +393,10 @@ class WorkflowExecutionsService:
                 validation_result.msg, detail=validation_result.detail
             )
 
-        wf_exec_id = exec_id(wf_id)
         return self._dispatch_workflow(
             dsl=dsl,
             wf_id=wf_id,
-            wf_exec_id=wf_exec_id,
+            wf_exec_id=generate_exec_id(wf_id),
             trigger_inputs=payload,
         )
 
@@ -458,16 +456,13 @@ class WorkflowExecutionsService:
         return DispatchWorkflowResult(wf_id=wf_id, final_context=result)
 
     def cancel_workflow_execution(
-        self,
-        wf_exec_id: WorkflowExecutionID | WorkflowScheduleID,
+        self, wf_exec_id: WorkflowExecutionID
     ) -> Awaitable[None]:
         """Cancel a workflow execution."""
         return self.handle(wf_exec_id).cancel()
 
     def terminate_workflow_execution(
-        self,
-        wf_exec_id: WorkflowExecutionID | WorkflowScheduleID,
-        reason: str | None = None,
+        self, wf_exec_id: WorkflowExecutionID, reason: str | None = None
     ) -> Awaitable[None]:
         """Terminate a workflow execution."""
         return self.handle(wf_exec_id).terminate(reason=reason)


### PR DESCRIPTION
# Changes
- Standardize `WorkflowExecutionID` to be the union of manual and scheduled workflow executions