### PR TITLE
feat(engine): Use parsed workflow trigger inputs

### DIFF
--- a/tracecat/dsl/validation.py
+++ b/tracecat/dsl/validation.py
@@ -33,9 +33,9 @@ def validate_trigger_inputs(
     }
     if isinstance(payload, dict):
         # NOTE: We only validate dict payloads for now
-        validator = create_expectation_model(expects_schema, model_name=model_name)
+        model = create_expectation_model(expects_schema, model_name=model_name)
         try:
-            validator(**payload)
+            validated_payload = model(**payload).model_dump(mode="json")
         except ValidationError as e:
             if raise_exceptions:
                 raise
@@ -44,7 +44,12 @@ def validate_trigger_inputs(
                 msg=f"Validation error in trigger inputs ({e.title}). Please refer to the schema for more details.",
                 detail={"errors": e.errors()},
             )
-    return ValidationResult(status="success", msg="Trigger inputs are valid.")
+    result = ValidationResult(
+        status="success",
+        msg="Trigger inputs are valid.",
+        payload=validated_payload,
+    )
+    return result
 
 
 class ValidateTriggerInputsActivityInputs(BaseModel):

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -225,10 +225,11 @@ class DSLWorkflow:
             ) from e
 
         # Prepare user facing context
+        validated_payload = validation_result.payload or {}
         self.context: ExecutionContext = {
             ExprContext.ACTIONS: {},
             ExprContext.INPUTS: self.dsl.inputs,
-            ExprContext.TRIGGER: trigger_inputs,
+            ExprContext.TRIGGER: validated_payload,
             ExprContext.ENV: DSLEnvironment(
                 workflow={
                     "start_time": wf_info.start_time,

--- a/tracecat/validation/models.py
+++ b/tracecat/validation/models.py
@@ -14,6 +14,7 @@ class ValidationResult(BaseModel):
     msg: str = ""
     detail: Any | None = None
     ref: str | None = None
+    payload: dict[str, Any] | None = None
 
     def __hash__(self) -> int:
         detail = json.dumps(self.detail, sort_keys=True)


### PR DESCRIPTION
Requires #644 for enum expectations.

## Why
- Previously the workflow expects Pydantic model was only used for validation not parsing / model coercion (see distinction in pydantic docs: https://docs.pydantic.dev/1.10/usage/models/ and screenshot below)
- This means defaults in expects weren't injected into the trigger inputs for workflow runs
- Related issue for template actions (#644) where pydantic model wasn't used to parse args

## What changed
- Add multiple parameterized unit tests for trigger inputs with expects (with defaults, without defaults, with enums)
- Added `payload` to `ValidationResult`
- Passed validated payload (aka parsed trigger inputs that conforms to expects pydantic model) into execution context.

## References
<img width="809" alt="Screenshot 2024-12-21 at 1 07 15 PM" src="https://github.com/user-attachments/assets/89806f03-ceeb-47bf-a427-aa2d775b8070" />