### PR TITLE
fix(engine): Fix and simplify dsl type hints

### DIFF
--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -35,10 +35,7 @@ from tracecat.expressions.eval import (
 )
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
-from tracecat.registry.actions.models import (
-    ArgsClsT,
-    BoundRegistryAction,
-)
+from tracecat.registry.actions.models import BoundRegistryAction
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets.common import apply_masks_object
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
@@ -52,7 +49,7 @@ from tracecat.types.exceptions import TracecatException
 type ArgsT = Mapping[str, Any]
 
 
-def sync_executor_entrypoint(input: RunActionInput[ArgsT], role: Role) -> Any:
+def sync_executor_entrypoint(input: RunActionInput, role: Role) -> Any:
     """We run this on the ray cluster."""
 
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -78,9 +75,7 @@ def sync_executor_entrypoint(input: RunActionInput[ArgsT], role: Role) -> Any:
         loop.close()  # We always close the loop
 
 
-async def _run_action_direct(
-    *, action: BoundRegistryAction[ArgsClsT], args: ArgsT
-) -> Any:
+async def _run_action_direct(*, action: BoundRegistryAction, args: ArgsT) -> Any:
     """Execute the UDF directly.
 
     At this point, the UDF cannot be a template.
@@ -105,7 +100,7 @@ async def _run_action_direct(
 
 async def run_single_action(
     *,
-    action: BoundRegistryAction[ArgsClsT],
+    action: BoundRegistryAction,
     args: ArgsT,
     context: ExecutionContext,
 ) -> Any:
@@ -150,7 +145,7 @@ async def run_single_action(
 
 async def run_template_action(
     *,
-    action: BoundRegistryAction[ArgsClsT],
+    action: BoundRegistryAction,
     args: ArgsT,
     context: ExecutionContext | None = None,
 ) -> Any:

--- a/tracecat/registry/loaders.py
+++ b/tracecat/registry/loaders.py
@@ -44,7 +44,7 @@ def get_bound_action_impl(
         args_docs = get_signature_docs(fn)
         # Generate the model from the function signature
         args_cls, rtype, rtype_adapter = generate_model_from_function(
-            func=fn, namespace=validated_kwargs.namespace
+            func=fn, udf_kwargs=validated_kwargs
         )
         return BoundRegistryAction(
             fn=fn,

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -1,8 +1,8 @@
 from collections.abc import Mapping, Sequence
 from itertools import chain
-from typing import Any, cast
+from typing import Any
 
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlmodel.ext.asyncio.session import AsyncSession
 from tracecat_registry import RegistrySecret
@@ -169,8 +169,8 @@ async def validate_registry_action_args(
             # Note that we're allowing type coercion for the input arguments
             # Use cases would be transforming a UTC string to a datetime object
             # We return the validated input arguments as a dictionary
-            validated: BaseModel = model.model_validate(args)
-            validated_args = cast(Mapping[str, Any], validated.model_dump())
+            validated = model.model_validate(args)
+            validated_args = validated.model_dump()
         except ValidationError as e:
             logger.warning(f"Validation error for UDF {action_name!r}. {e.errors()!r}")
             raise RegistryValidationError(


### PR DESCRIPTION
# Changes
- Remove generic from `BoundRegistryAction` and use `type[BaseModel]`
- Pass `udf_kwargs` around instead of its fields

