### PR TITLE
feat(engine): Implement runtime workflow alias resolution for child workflows

### DIFF
--- a/registry/tracecat_registry/base/core/workflow.py
+++ b/registry/tracecat_registry/base/core/workflow.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Any, Literal
 
 from pydantic import Field
-from tracecat import identifiers
+from tracecat.identifiers import WorkflowID
 
 from tracecat_registry import RegistryActionError, registry
 
@@ -13,13 +13,25 @@ from tracecat_registry import RegistryActionError, registry
     display_group="Workflows",
 )
 async def execute(
+    *,
     workflow_id: Annotated[
-        identifiers.WorkflowID,
+        WorkflowID | None,
         Field(
-            ...,
-            description=("The title of the child workflow. "),
+            default=None,
+            description=(
+                "The ID of the child workflow to execute. Must be provided if workflow_alias is not provided."
+            ),
         ),
-    ],
+    ] = None,
+    workflow_alias: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "The alias of the child workflow to execute. Must be provided if workflow_id is not provided."
+            ),
+        ),
+    ] = None,
     trigger_inputs: Annotated[
         dict[str, Any],
         Field(

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -17,6 +17,7 @@ from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy, RunActionInput, TriggerInputs
 from tracecat.identifiers import WorkflowExecutionID, WorkflowID
 from tracecat.types.auth import Role
+from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
 
 WorkflowExecutionStatusLiteral = Literal[
@@ -112,6 +113,7 @@ IGNORED_UTILITY_ACTIONS = {
     "get_schedule_activity",
     "validate_trigger_inputs_activity",
     "validate_action_activity",
+    WorkflowsManagementService.resolve_workflow_alias_activity.__name__,
 }
 
 


### PR DESCRIPTION
# Changes
- Allow workflows to reference a child workflow by an alias
- Aliases are resolved into their corresponding workflow IDs
- Turn `ExecuteChildWorkflowArgs` into a pydantic `BaseModel`. 
  - Add custom validator that checks that either workflow ID or alias is defined, now that workflow ID is marked optional in the UDF interface.
- Simplify how batch iteration works - consollidate all 3 strategies to use `itertoold.batched()` with different sizes.
- On `core.workflow.execute` udf schema
  - Since this is a special action that doesn't run user logic, but rather platform logic, it's ok to have platform-level validation logic. 
  - We no longer use validation from the `RegistryAction` table to validate this action but use the new pydantic BaseModel directly, since it has the custom validator (and also because pydantic's jsonschema serialization cannot express these particular validation semantics)   

# Screens
Note: This PR doesn't carry the UI configuration to set a workflow alias, but below is an example of the custom valdiation
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/d5e655bb-a952-496c-a450-cfd3a6f1a778" />


# Testing
- Add integration tests for different child workflow loop strategies when calling with workflow ID and workflow alias