### PR TITLE
feat(ui): Add workflow alias to workbench navbar

### DIFF
--- a/frontend/src/components/nav/workbench-nav.tsx
+++ b/frontend/src/components/nav/workbench-nav.tsx
@@ -134,7 +134,17 @@ export function WorkbenchNav() {
             <BreadcrumbSeparator className="shrink-0 font-semibold">
               {"/"}
             </BreadcrumbSeparator>
-            <BreadcrumbItem>{workflow.title}</BreadcrumbItem>
+            <BreadcrumbItem>
+              <span>{workflow.title}</span>
+              {workflow.alias && (
+                <Badge
+                  variant="secondary"
+                  className="font-mono text-xs font-normal tracking-tighter text-muted-foreground hover:cursor-default"
+                >
+                  {workflow.alias}
+                </Badge>
+              )}
+            </BreadcrumbItem>
           </BreadcrumbList>
         </Breadcrumb>
       </div>


### PR DESCRIPTION
Show the current workflow alias in the navbar (and nothing if there's none) without having to view the workflow panel.

# Screens
See `workflows.root` in navbar breadcrumbs
<img width="1713" alt="image" src="https://github.com/user-attachments/assets/d5bf11dd-0593-4695-a635-8ccf681d0760" />
