### PR TITLE
fix(engine): Propagate executor error messages safely

### DIFF
--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -33,7 +33,6 @@ from tracecat.dsl.enums import LoopStrategy
 from tracecat.dsl.models import ActionStatement, DSLConfig, ExecutionContext
 from tracecat.dsl.worker import get_activities, new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow, retry_policies
-from tracecat.executor.service import run_action_on_ray_cluster
 from tracecat.expressions.common import ExprContext
 from tracecat.logger import logger
 from tracecat.secrets.models import SecretCreate, SecretKeyValue
@@ -1603,8 +1602,8 @@ PARTIAL_DIVISION_BY_ZERO_ERROR = {
         "Cannot divide by zero\n"
         "\n"
         "------------------------------\n"
-        f"File: /app/{"/".join(run_action_on_ray_cluster.__module__.split('.'))}.py\n"
-        f"Function: {run_action_on_ray_cluster.__name__}\n"
+        # f"File: /app/{"/".join(run_action_on_ray_cluster.__module__.split('.'))}.py\n"
+        # f"Function: {run_action_on_ray_cluster.__name__}\n"
         # f"Line: {run_action_on_ray_cluster.__code__.co_firstlineno}"
     ),
     "type": "ActionExecutionError",

--- a/tracecat/executor/router.py
+++ b/tracecat/executor/router.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
 
 from tracecat.auth.credentials import RoleACL
 from tracecat.contexts import ctx_logger, ctx_role
@@ -16,6 +17,7 @@ from tracecat.registry.actions.models import (
 )
 from tracecat.registry.repository import RegistryReposService, Repository
 from tracecat.types.auth import Role
+from tracecat.types.exceptions import WrappedExecutionError
 from tracecat.validation.service import validate_registry_action_args
 
 router = APIRouter()
@@ -64,12 +66,25 @@ async def run_action(
     act_logger.info("Starting action")
     try:
         return await dispatch_action_on_cluster(input=action_input, role=role)
-    except Exception as e:
-        err_info = RegistryActionErrorInfo.from_exc(e, action_name)
-        act_logger.error("Error running action", **err_info.model_dump())
+    except WrappedExecutionError as e:
+        # This is an error that occurred inside an executing action
+        err = e.error
+        if isinstance(err, BaseModel):
+            err_info_dict = err.model_dump(mode="json")
+        else:
+            err_info_dict = {"message": str(err)}
+        act_logger.error("Error in action", **err_info_dict)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=err_info.model_dump(mode="json"),
+            detail=err_info_dict,
+        ) from e
+    except Exception as e:
+        err_info = RegistryActionErrorInfo.from_exc(e, action_name)
+        err_info_dict = err_info.model_dump(mode="json")
+        act_logger.error("Error running action", **err_info_dict)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=err_info_dict,
         ) from e
 
 

--- a/tracecat/types/exceptions.py
+++ b/tracecat/types/exceptions.py
@@ -84,3 +84,11 @@ class TaskUnreachable(TracecatException):
 
 class ActionExecutionError(TracecatException):
     """Exception raised when an action execution error occurs."""
+
+
+class WrappedExecutionError(TracecatException):
+    """Exception raised when an error occurs during action execution.
+    Use this to wrap errors from the executor so that we should reraise"""
+
+    def __init__(self, error: Any):
+        self.error = error


### PR DESCRIPTION
# Changes
- Structure errors as `RegistryActionErrorInfo` and return them when returning from the ray executor
- Reraise these as `WrappedExecutionError` and handle appropriately at the route level

# Screens
Before
<img width="1546" alt="Screenshot 2024-12-30 at 01 50 50" src="https://github.com/user-attachments/assets/23765529-807b-49a2-b854-9d840abe8d2d" />

After
<img width="1550" alt="Screenshot 2024-12-30 at 01 51 03" src="https://github.com/user-attachments/assets/4e1a2775-5d2f-4e01-8e09-27fe27fd282f" />
