### PR TITLE
feat(engine): Implement error handler workflow functionality in DSLWorkflow

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -912,15 +912,36 @@ export const $EventGroup = {
             title: 'Action Id'
         },
         action_ref: {
-            type: 'string',
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Action Ref'
         },
         action_title: {
-            type: 'string',
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Action Title'
         },
         action_description: {
-            type: 'string',
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Action Description'
         },
         action_input: {
@@ -987,7 +1008,7 @@ export const $EventGroup = {
         }
     },
     type: 'object',
-    required: ['event_id', 'udf_namespace', 'udf_name', 'udf_key', 'action_id', 'action_ref', 'action_title', 'action_description', 'action_input'],
+    required: ['event_id', 'udf_namespace', 'udf_name', 'udf_key', 'action_input'],
     title: 'EventGroup'
 } as const;
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -315,10 +315,10 @@ export type EventGroup = {
     udf_namespace: string;
     udf_name: string;
     udf_key: string;
-    action_id: string | null;
-    action_ref: string;
-    action_title: string;
-    action_description: string;
+    action_id?: string | null;
+    action_ref?: string | null;
+    action_title?: string | null;
+    action_description?: string | null;
     action_input: RunActionInput | DSLRunArgs | GetWorkflowDefinitionActivityInputs;
     action_result?: unknown | null;
     current_attempt?: number | null;

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -2666,7 +2666,7 @@ async def test_workflow_error_handler_success(
     [
         pytest.param(
             "id",
-            "wf-" + "0" * 32,
+            "wf-00000000000000000000000000000000",
             "TracecatException: Workflow definition not found for 'wf-00000000000000000000000000000000', version=None",
             id="id-no-match",
         ),

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -2662,16 +2662,14 @@ async def test_workflow_error_handler_success(
 
 
 @pytest.mark.parametrize(
-    "mode,id_or_alias,expected_err_msg",
+    "id_or_alias,expected_err_msg",
     [
         pytest.param(
-            "id",
             "wf-00000000000000000000000000000000",
             "TracecatException: Workflow definition not found for 'wf-00000000000000000000000000000000', version=None",
             id="id-no-match",
         ),
         pytest.param(
-            "alias",
             "invalid_error_handler",
             "RuntimeError: Couldn't find matching workflow for alias 'invalid_error_handler'",
             id="alias-no-match",
@@ -2684,7 +2682,6 @@ async def test_workflow_error_handler_invalid_handler_fail_no_match(
     test_role: Role,
     temporal_client: Client,
     failing_dsl: DSLInput,
-    mode: Literal["id", "alias"],
     id_or_alias: str,
     expected_err_msg: str,
 ):

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -9,7 +9,6 @@ Objectives
 """
 
 import asyncio
-import json
 import os
 from datetime import timedelta
 from pathlib import Path
@@ -18,7 +17,6 @@ from typing import Any
 import pytest
 import yaml
 from pydantic import SecretStr
-from pydantic_core import to_jsonable_python
 from temporalio.client import Client, WorkflowFailureError
 from temporalio.common import RetryPolicy
 from temporalio.worker import Worker
@@ -2428,7 +2426,6 @@ async def test_workflow_error_handler(test_role: Role, temporal_client: Client):
     exec_svc = await WorkflowExecutionsService.connect(role=test_role)
     events = await exec_svc.list_workflow_execution_event_history(wf_exec_id)
     assert len(events) > 0
-    logger.info(f"{json.dumps(to_jsonable_python(events), indent=2)}")
 
     # 4. Verify the failing task is in the event history
     fail_evt = assert_erroneous_task_failed_correctly(events)

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -45,7 +45,7 @@ from tracecat.workflow.actions.models import ActionControlFlow
 class DSLEntrypoint(BaseModel):
     ref: str | None = Field(default=None, description="The entrypoint action ref")
     expects: dict[str, ExpectedField] | None = Field(
-        None,
+        default=None,
         description=(
             "Expected trigger input schema. "
             "Use this to specify the expected shape of the trigger input."

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -196,3 +196,9 @@ class DSLExecutionError(TypedDict, total=False):
 
     message: str
     """The message of the exception."""
+
+
+@dataclass(frozen=True)
+class TaskExceptionInfo:
+    exception: Exception
+    details: ActionErrorInfo | None = None

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -22,7 +22,7 @@ with workflow.unsafe.imports_passed_through():
     import jsonpath_ng.lexer  # noqa
     import jsonpath_ng.parser  # noqa
     import tracecat_registry  # noqa
-    from pydantic import ValidationError
+    from pydantic import TypeAdapter, ValidationError
 
     from tracecat import identifiers
     from tracecat.concurrency import GatheringTaskGroup
@@ -40,6 +40,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.constants import CHILD_WORKFLOW_EXECUTE_ACTION
     from tracecat.dsl.enums import FailStrategy, LoopStrategy
     from tracecat.dsl.models import (
+        ActionErrorInfo,
         ActionStatement,
         DSLConfig,
         DSLEnvironment,
@@ -57,6 +58,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.executor.service import evaluate_templated_args, iter_for_each
     from tracecat.expressions.common import ExprContext
     from tracecat.expressions.eval import eval_templated_object
+    from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowID
     from tracecat.logger import logger
     from tracecat.types.exceptions import (
         TracecatCredentialsError,
@@ -67,11 +69,13 @@ with workflow.unsafe.imports_passed_through():
         TracecatValidationError,
     )
     from tracecat.validation.models import ValidationResult
+    from tracecat.workflow.executions.models import ErrorHandlerWorkflowInput
     from tracecat.workflow.management.definitions import (
         get_workflow_definition_activity,
     )
     from tracecat.workflow.management.management import WorkflowsManagementService
     from tracecat.workflow.management.models import (
+        GetErrorHandlerWorkflowIDActivityInputs,
         GetWorkflowDefinitionActivityInputs,
         ResolveWorkflowAliasActivityInputs,
     )
@@ -120,20 +124,22 @@ class DSLWorkflow:
 
     @workflow.run
     async def run(self, args: DSLRunArgs) -> Any:
-        # Set runtime args
         self.role = args.role
         self.start_to_close_timeout = args.timeout
-        ctx_role.set(self.role)
         wf_info = workflow.info()
-
+        wf_exec_id = wf_info.workflow_id
+        wf_run_id = wf_info.run_id
         self.logger = logger.bind(
             wf_id=args.wf_id,
-            wf_exec_id=wf_info.workflow_id,
-            wf_run_id=wf_info.run_id,
+            wf_exec_id=wf_exec_id,
+            wf_run_id=wf_run_id,
             role=self.role,
-            unit="dsl-workflow-runner",
+            service="dsl-workflow-runner",
         )
+        # Set runtime args
+        ctx_role.set(self.role)
         ctx_logger.set(self.logger)
+
         self.logger.debug("DSL workflow started", args=args)
         try:
             self.logger.info(
@@ -148,8 +154,8 @@ class DSLWorkflow:
         except Exception as e:
             self.logger.error("Failed to show workflow info", error=e)
 
-        # Figure out what this worker will be running
-        # Setup workflow definition
+        # Set DSL
+
         if args.dsl:
             # Use the provided DSL
             self.logger.debug("Using provided workflow definition")
@@ -168,6 +174,64 @@ class DSLWorkflow:
                     type=e.__class__.__name__,
                 ) from e
             self.dispatch_type = "pull"
+
+        # Note that we can't run the error handler above this
+        # Run the workflow with error handling
+        try:
+            return await self._run_workflow(args)
+        except ApplicationError as e:
+            # Application error
+            self.logger.warning(
+                "Error running workflow, running error handler",
+                type=e.__class__.__name__,
+            )
+            # 1. Get the error handler workflow ID
+            handler_wf_id = await self._get_error_handler_workflow_id(args)
+            if not handler_wf_id:
+                self.logger.warning("No error handler workflow ID found, raising error")
+                raise e
+
+            if e.details:
+                err_info_map = e.details[0]
+                self.logger.info("Raising error info", err_info_data=err_info_map)
+                ta = TypeAdapter(ActionErrorInfo)
+                errors = {
+                    ref: ta.validate_python(data) for ref, data in err_info_map.items()
+                }
+            else:
+                errors = None
+
+            try:
+                err_run_args = await self._prepare_error_handler_workflow(
+                    handler_wf_id,
+                    message=e.message,
+                    handler_wf_id=handler_wf_id,
+                    orig_wf_id=args.wf_id,
+                    orig_wf_exec_id=wf_exec_id,
+                    errors=errors,
+                )
+                await self._run_error_handler_workflow(err_run_args)
+            except Exception as err_handler_exc:
+                self.logger.error(
+                    "Failed to run error handler workflow",
+                    error=err_handler_exc,
+                )
+                raise err_handler_exc from e
+
+            # Finally, raise the original error
+            raise e
+        except Exception as e:
+            # Platform error
+            self.logger.error(
+                "Unexpected error running workflow",
+                type=e.__class__.__name__,
+                error=e,
+            )
+            raise e
+
+    async def _run_workflow(self, args: DSLRunArgs) -> Any:
+        """Actual workflow execution logic."""
+        wf_info = workflow.info()
 
         # Consolidate runtime config
         if "runtime_config" in args.model_fields_set:
@@ -267,17 +331,28 @@ class DSLWorkflow:
             context=self.context,
         )
         try:
-            exceptions = await self.scheduler.start()
+            task_exceptions = await self.scheduler.start()
         except Exception as e:
             msg = f"DSL scheduler failed with unexpected error: {e}"
             raise ApplicationError(
                 msg, non_retryable=True, type=e.__class__.__name__
             ) from e
 
-        if exceptions:
-            msg = f"Workflow failed with task exceptions:\n\n{'\n'.join(str(e) for e in exceptions)}"
+        if task_exceptions:
+            n_exc = len(task_exceptions)
+            formatted_exc = "\n".join(
+                f"{'='*20} ({i+1}/{n_exc}) {details.expr_context}.{ref} {'='*20}\n\n{info.exception!s}"
+                for i, (ref, info) in enumerate(task_exceptions.items())
+                if (details := info.details)
+            )
+            # NOTE: This error is shown in the final activity in the workflow history
             raise ApplicationError(
-                msg, non_retryable=True, type=ApplicationError.__name__
+                f"Workflow failed with {n_exc} task exception(s)\n\n{formatted_exc}",
+                # We should add the details of the exceptions to the error message because this will get captured
+                # in the error handler workflow
+                {ref: info.details for ref, info in task_exceptions.items()},
+                non_retryable=True,
+                type=ApplicationError.__name__,
             )
 
         try:
@@ -335,19 +410,25 @@ class DSLWorkflow:
                 result=action_result, result_typename=type(action_result).__name__
             )
         # NOTE: By the time we receive an exception, we've exhausted all retry attempts
+        # Note that execute_task is called by the scheduler, so we don't have to return ApplicationError
         except (ActivityError, ChildWorkflowError, FailureError) as e:
             # These are deterministic and expected errors that
             err_type = e.__class__.__name__
             msg = self.ERROR_TYPE_TO_MESSAGE[err_type]
-            logger.error(msg, error=e.message)
+            self.logger.error(msg, role=self.role, e=e, cause=e.cause, type=err_type)
             match cause := e.cause:
-                case ApplicationError(details=[err_info, *_]):
-                    task_result.update(
-                        error=err_info, error_typename=cause.type or err_type
-                    )
+                case ApplicationError(details=details) if details:
+                    err_info = details[0]
+                    err_type = cause.type or err_type
+                    task_result.update(error=err_info, error_typename=err_type)
+                    # Reraise the cause, as it's wrapped by the ApplicationError
+                    raise cause from e
                 case _:
+                    self.logger.warning("Unexpected error cause", cause=cause)
                     task_result.update(error=e.message, error_typename=err_type)
-            raise ApplicationError(e.message, non_retryable=True, type=err_type) from e
+                    raise ApplicationError(
+                        e.message, non_retryable=True, type=err_type
+                    ) from cause
 
         except TracecatExpressionError as e:
             err_type = e.__class__.__name__
@@ -694,3 +775,79 @@ class DSLWorkflow:
 
     def _should_execute_child_workflow(self, task: ActionStatement) -> bool:
         return task.action == CHILD_WORKFLOW_EXECUTE_ACTION
+
+    async def _get_error_handler_workflow_id(
+        self, args: DSLRunArgs
+    ) -> WorkflowID | None:
+        """Get the error handler workflow ID.
+
+        This is done by checking if the error is a TracecatValidationError or
+        TracecatExpressionError.
+        """
+        return await workflow.execute_activity(
+            WorkflowsManagementService.get_error_handler_workflow_id,
+            arg=GetErrorHandlerWorkflowIDActivityInputs(args=args, role=self.role),
+            start_to_close_timeout=args.timeout,
+            retry_policy=retry_policies["activity:fail_fast"],
+        )
+
+    async def _prepare_error_handler_workflow(
+        self,
+        wf_id: WorkflowID,
+        *,
+        message: str,
+        handler_wf_id: WorkflowID,
+        orig_wf_id: WorkflowID,
+        orig_wf_exec_id: WorkflowExecutionID,
+        errors: dict[str, ActionErrorInfo] | None = None,
+    ) -> DSLRunArgs:
+        """Grab a workflow definition and create error handler workflow run args"""
+
+        dsl = await self._get_workflow_definition(handler_wf_id)
+
+        self.logger.debug(
+            "Got workflow definition for error handler",
+            dsl=dsl,
+            dsl_config=dsl.config,
+            self_config=self.runtime_config,
+        )
+        runtime_config = DSLConfig(
+            # Override the environment in the runtime config,
+            # otherwise use the default provided in the workflow definition
+            environment=self.runtime_config.environment,
+            timeout=self.runtime_config.timeout,
+        )
+        self.logger.debug("Runtime config", runtime_config=runtime_config)
+
+        return DSLRunArgs(
+            role=self.role,
+            dsl=dsl,
+            wf_id=wf_id,
+            parent_run_context=ctx_run.get(),
+            trigger_inputs=ErrorHandlerWorkflowInput(
+                message=message,
+                handler_wf_id=wf_id,
+                orig_wf_id=orig_wf_id,
+                orig_wf_exec_id=orig_wf_exec_id,
+                errors=errors,
+            ),
+            runtime_config=runtime_config,
+        )
+
+    async def _run_error_handler_workflow(
+        self,
+        args: DSLRunArgs,
+    ) -> None:
+        self.logger.info("Running error handler workflow", args=args)
+        wf_exec_id = identifiers.workflow.generate_exec_id(args.wf_id)
+        wf_info = workflow.info()
+        await workflow.execute_child_workflow(
+            DSLWorkflow.run,
+            args,
+            id=wf_exec_id,
+            retry_policy=retry_policies["workflow:fail_fast"],
+            # Propagate the parent workflow attributes to the child workflow
+            task_queue=wf_info.task_queue,
+            execution_timeout=wf_info.execution_timeout,
+            task_timeout=wf_info.task_timeout,
+        )

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Any, Generic, Literal, TypedDict, TypeVar, cast
@@ -14,8 +15,14 @@ from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 
 from tracecat.dsl.common import DSLRunArgs
 from tracecat.dsl.enums import JoinStrategy
-from tracecat.dsl.models import ActionRetryPolicy, RunActionInput, TriggerInputs
+from tracecat.dsl.models import (
+    ActionErrorInfo,
+    ActionRetryPolicy,
+    RunActionInput,
+    TriggerInputs,
+)
 from tracecat.identifiers import WorkflowExecutionID, WorkflowID
+from tracecat.logger import logger
 from tracecat.types.auth import Role
 from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.models import GetWorkflowDefinitionActivityInputs
@@ -114,6 +121,7 @@ IGNORED_UTILITY_ACTIONS = {
     "validate_trigger_inputs_activity",
     "validate_action_activity",
     WorkflowsManagementService.resolve_workflow_alias_activity.__name__,
+    WorkflowsManagementService.get_error_handler_workflow_id.__name__,
 }
 
 
@@ -122,10 +130,10 @@ class EventGroup(BaseModel, Generic[EventInput]):
     udf_namespace: str
     udf_name: str
     udf_key: str
-    action_id: str | None
-    action_ref: str
-    action_title: str
-    action_description: str
+    action_id: str | None = None
+    action_ref: str | None = None
+    action_title: str | None = None
+    action_description: str | None = None
     action_input: EventInput
     action_result: Any | None = None
     current_attempt: int | None = None
@@ -190,27 +198,30 @@ class EventGroup(BaseModel, Generic[EventInput]):
         ):
             raise ValueError("Event is not a child workflow initiated event.")
 
-        wf_exec_id = cast(
-            WorkflowExecutionID,
-            event.start_child_workflow_execution_initiated_event_attributes.workflow_id,
-        )
+        attrs = event.start_child_workflow_execution_initiated_event_attributes
+        wf_exec_id = cast(WorkflowExecutionID, attrs.workflow_id)
         # Load the input data
-        input = orjson.loads(
-            event.start_child_workflow_execution_initiated_event_attributes.input.payloads[
-                0
-            ].data
-        )
+        logger.info("Child workflow initiated event attributes:", attrs=attrs)
+        input = orjson.loads(attrs.input.payloads[0].data)
         dsl_run_args = DSLRunArgs(**input)
         # Create an event group
+
+        if dsl := dsl_run_args.dsl:
+            action_title = dsl.title
+            action_description = dsl.description
+        else:
+            action_title = None
+            action_description = None
+
         return EventGroup(
             event_id=event.event_id,
             udf_namespace="core.workflow",
             udf_name="execute",
             udf_key="core.workflow.execute",
             action_id=dsl_run_args.wf_id,
-            action_ref=dsl_run_args.dsl.title,
-            action_title=dsl_run_args.dsl.title,
-            action_description=dsl_run_args.dsl.description,
+            action_ref=None,
+            action_title=action_title,
+            action_description=action_description,
             action_input=dsl_run_args,
             related_wf_exec_id=wf_exec_id,
         )
@@ -287,3 +298,12 @@ class DispatchWorkflowResult(TypedDict):
 
 class TerminateWorkflowExecutionParams(BaseModel):
     reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ErrorHandlerWorkflowInput:
+    message: str
+    handler_wf_id: WorkflowID
+    orig_wf_id: WorkflowID
+    orig_wf_exec_id: WorkflowExecutionID
+    errors: dict[str, ActionErrorInfo] | None

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -436,7 +436,9 @@ class WorkflowExecutionsService:
                 **kwargs,
             )
         except WorkflowFailureError as e:
-            self.logger.error(str(e), role=self.role, wf_exec_id=wf_exec_id, e=e)
+            self.logger.error(
+                str(e), role=self.role, wf_exec_id=wf_exec_id, cause=e.cause
+            )
             raise e
         except RPCError as e:
             self.logger.error(

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
@@ -13,6 +14,7 @@ from tracecat.dsl.common import DSLEntrypoint, DSLInput, build_action_statements
 from tracecat.dsl.models import DSLConfig
 from tracecat.dsl.view import RFGraph
 from tracecat.identifiers import WorkflowID
+from tracecat.identifiers.workflow import WF_ID_PATTERN
 from tracecat.registry.actions.models import RegistryActionValidateResponse
 from tracecat.service import BaseService
 from tracecat.types.exceptions import TracecatValidationError
@@ -20,6 +22,7 @@ from tracecat.validation.service import validate_dsl
 from tracecat.workflow.actions.models import ActionControlFlow
 from tracecat.workflow.management.models import (
     ExternalWorkflowDefinition,
+    GetErrorHandlerWorkflowIDActivityInputs,
     ResolveWorkflowAliasActivityInputs,
     WorkflowCreate,
     WorkflowDSLCreateResponse,
@@ -360,3 +363,36 @@ class WorkflowsManagementService(BaseService):
     ) -> WorkflowID | None:
         async with WorkflowsManagementService.with_session(input.role) as service:
             return await service.resolve_workflow_alias(input.workflow_alias)
+
+    @staticmethod
+    @activity.defn
+    async def get_error_handler_workflow_id(
+        input: GetErrorHandlerWorkflowIDActivityInputs,
+    ) -> WorkflowID | None:
+        args = input.args
+        id_or_alias = None
+        async with WorkflowsManagementService.with_session(role=args.role) as service:
+            if args.dsl:
+                # 1. If a DSL was provided, we must use its error handler
+                if not args.dsl.error_handler:
+                    activity.logger.info("DSL has no error handler")
+                    return None
+                id_or_alias = args.dsl.error_handler
+            else:
+                # 2. Otherwise, use the error handler defined in the workflow
+                workflow = await service.get_workflow(args.wf_id)
+                if not workflow or not workflow.error_handler:
+                    activity.logger.info("No workflow or error handler found")
+                    return None
+                id_or_alias = workflow.error_handler
+
+            # 3. Convert the error handler to an ID
+            if re.match(WF_ID_PATTERN, id_or_alias):
+                handler_wf_id = id_or_alias
+            else:
+                handler_wf_id = await service.resolve_workflow_alias(id_or_alias)
+                if not handler_wf_id:
+                    raise RuntimeError(
+                        f"Couldn't find matching workflow for alias {id_or_alias!r}"
+                    )
+            return handler_wf_id

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -7,7 +7,7 @@ from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel, Field
 
 from tracecat.db.schemas import Schedule, Workflow, WorkflowDefinition
-from tracecat.dsl.common import DSLInput
+from tracecat.dsl.common import DSLInput, DSLRunArgs
 from tracecat.dsl.models import ActionStatement, DSLConfig
 from tracecat.expressions.expectations import ExpectedField
 from tracecat.identifiers import OwnerID, WorkflowID, WorkspaceID
@@ -83,6 +83,11 @@ class GetWorkflowDefinitionActivityInputs(BaseModel):
 class ResolveWorkflowAliasActivityInputs(BaseModel):
     workflow_alias: str
     role: Role
+
+
+class GetErrorHandlerWorkflowIDActivityInputs(BaseModel):
+    role: Role
+    args: DSLRunArgs
 
 
 WorkflowExportFormat = Literal["json", "yaml"]


### PR DESCRIPTION
Progresses #505

# Changes
- Make workflows return some _sensible error info_. Current impl is a dict of action ref to `ActionErrorInfo`. This improves the final workflow execution event, and the error info shown to callers of child workflows.
- Add error handling functionality to `DSLWorkflow`. 
  - A `Workflow` object may specify a workflow ID or alias as an error handler
  - This must be a workflow that exists
  - This workflow gets run if an error occurs in the primary workflow, and receives error info

## Implementation details
  - We wrap the existing workflow run logic with exception handling that triggers a child workflow that is the error handler.
  - This needs to be embedded inside `DSLWorkflow` because of scheduled and pull-based workflows, where the DSL is not known until it's pulled from the DB after the workflow starts.
  - The error handler child wf receives the _sensible error info_ as trigger input, alongside some additional metadata from the failing workflow

  
  
# Screens
Improved workflow error info
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/f0feb6c8-e2b3-4a94-8d90-52f58953a64c" />


Improved child workflow error info
<img width="830" alt="image" src="https://github.com/user-attachments/assets/296c6474-36e9-4b2f-8c37-cb3e347e2db6" />

Error handler workflow trigger inputs
<img width="1341" alt="image" src="https://github.com/user-attachments/assets/21ab69a1-d21b-4eab-939e-b25b38b99833" />

  
  
  
# Testing
- Add integration test that creates error handler and wf failing wf
 - It then runs the failing wf and uses the `WorkflowExecutionsService` to verify that
   - The failing wf ran
   - The error handler was initialized with correct data
   - The error handler started and completed
- Tset for invalid handler that has no match
   