### PR TITLE
feat(integration)!: Normalize Okta templates  

### DIFF
--- a/registry/tracecat_registry/templates/okta/expire_sessions.yml
+++ b/registry/tracecat_registry/templates/okta/expire_sessions.yml
@@ -3,12 +3,16 @@ definition:
   title: Expire Okta Sessions
   description: Expire all sessions for an Okta user by user ID
   display_group: Okta
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserSessions/#tag/UserSessions/operation/revokeUserSessions
   namespace: integrations.okta
   name: expire_sessions
   secrets:
     - name: okta
-      keys: ["OKTA_API_TOKEN", "OKTA_BASE_URL"]
+      keys: ["OKTA_API_TOKEN"]
   expects:
+    base_url:
+      type: str
+      description: The base URL of the Okta org
     user_id:
       type: str
       description: ID of the user whose sessions to expire
@@ -17,7 +21,7 @@ definition:
       action: core.http_request
       args:
         method: DELETE
-        url: https://${{ SECRETS.okta.OKTA_BASE_URL }}/api/v1/users/${{ inputs.user_id }}/sessions
+        url: ${{ inputs.base_url }}/api/v1/users/${{ inputs.user_id }}/sessions
         headers:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.expire_sessions.result }}

--- a/registry/tracecat_registry/templates/okta/get_user.yml
+++ b/registry/tracecat_registry/templates/okta/get_user.yml
@@ -3,12 +3,16 @@ definition:
   title: Get Okta User
   description: Retrieve an Okta user by ID or Login
   display_group: Okta
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/getUser
   namespace: integrations.okta
   name: get_user
   secrets:
     - name: okta
-      keys: ["OKTA_API_TOKEN", "OKTA_BASE_URL"]
+      keys: ["OKTA_API_TOKEN"]
   expects:
+    base_url:
+      type: str
+      description: The base URL of the Okta org
     user_id:
       type: str
       description: User ID, login (e.g. `jdoe@example.com`), or login shortname (e.g. `jdoe`) of the user to retrieve.
@@ -17,7 +21,9 @@ definition:
       action: core.http_request
       args:
         method: GET
-        url: https://${{ SECRETS.okta.OKTA_BASE_URL }}/api/v1/users/${{ inputs.user_id }}
+        url: ${{ inputs.base_url }}/api/v1/users
+        params:
+          id: ${{ inputs.user_id }}
         headers:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.get_user.result }}

--- a/registry/tracecat_registry/templates/okta/get_user_by_email.yml
+++ b/registry/tracecat_registry/templates/okta/get_user_by_email.yml
@@ -3,23 +3,31 @@ definition:
   title: Get Okta User by Email
   description: Get an Okta user by email address
   display_group: Okta
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers
   namespace: integrations.okta
   name: get_user_by_email
   secrets:
     - name: okta
-      keys: ["OKTA_API_TOKEN", "OKTA_BASE_URL"]
+      keys: ["OKTA_API_TOKEN"]
   expects:
+    base_url:
+      type: str
+      description: The base URL of the Okta org
     email:
       type: str
       description: Email address of the user to find
   steps:
+    - ref: create_query
+      action: core.reshape
+      args:
+        query: profile.email eq ${{ inputs.email }}
     - ref: get_user_by_email
       action: core.http_request
       args:
         method: GET
-        url: https://${{ SECRETS.okta.OKTA_BASE_URL }}/api/v1/users
+        url: ${{ inputs.base_url }}/api/v1/users
         headers:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
         params:
-          search: profile.email eq "${{ inputs.email }}"
+          search: ${{ FN.url_encode(steps.create_query.result) }}
   returns: ${{ steps.get_user_by_email.result }}

--- a/registry/tracecat_registry/templates/okta/list_user_events.yml
+++ b/registry/tracecat_registry/templates/okta/list_user_events.yml
@@ -3,12 +3,16 @@ definition:
   title: List Okta User Events
   description: List events for an Okta user by user ID for a specified time range.
   display_group: Okta
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/#tag/SystemLog/operation/listLogEvents
   namespace: integrations.okta
   name: list_user_events
   secrets:
     - name: okta
-      keys: ["OKTA_API_TOKEN", "OKTA_BASE_URL"]
+      keys: ["OKTA_API_TOKEN"]
   expects:
+    base_url:
+      type: str
+      description: The base URL of the Okta org
     user_id:
       type: str
       description: ID of the user whose events to list
@@ -22,15 +26,19 @@ definition:
       type: int
       description: Maximum number of events to return
   steps:
+    - ref: create_query
+      action: core.reshape
+      args:
+        query: actor.id eq ${{ inputs.user_id }}
     - ref: list_user_events
       action: core.http_request
       args:
         method: GET
-        url: https://${{ SECRETS.okta.OKTA_BASE_URL }}/api/v1/logs
+        url: ${{ inputs.base_url }}/api/v1/logs
         headers:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
         params:
-          filter: actor.id eq "${{ inputs.user_id }}"
+          filter: ${{ FN.url_encode(steps.create_query.result) }}
           since: ${{ FN.to_datestring(inputs.start_time, "%Y-%m-%dT%H:%M:%S") }}
           until: ${{ FN.to_datestring(inputs.end_time, "%Y-%m-%dT%H:%M:%S") }}
           limit: ${{ inputs.limit }}

--- a/registry/tracecat_registry/templates/okta/reset_password.yml
+++ b/registry/tracecat_registry/templates/okta/reset_password.yml
@@ -6,10 +6,14 @@ definition:
   title: Reset Password
   description: Reset the password of an Okta user
   display_group: Okta
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserCred/#tag/UserCred/operation/resetPassword
   secrets:
     - name: okta
-      keys: ["OKTA_API_TOKEN", "OKTA_BASE_URL"]
+      keys: ["OKTA_API_TOKEN"]
   expects:
+    base_url:
+      type: str
+      description: The base URL of the Okta org
     user_id:
       type: str
       description: The ID of the user to reset the password for
@@ -26,7 +30,7 @@ definition:
       action: core.http_request
       args:
         method: POST
-        url: ${{ SECRETS.okta.OKTA_BASE_URL }}/api/v1/users/{{ inputs.user_id }}/lifecycle/reset_password
+        url: ${{ inputs.base_url }}/api/v1/users/{{ inputs.user_id }}/lifecycle/reset_password
         headers:
           Authorization: "SSWS {{ SECRETS.okta.OKTA_API_TOKEN }}"
         payload:

--- a/registry/tracecat_registry/templates/okta/suspend_user.yml
+++ b/registry/tracecat_registry/templates/okta/suspend_user.yml
@@ -3,12 +3,16 @@ definition:
   title: Suspend Okta User
   description: Suspend an Okta user by user ID
   display_group: Okta
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserLifecycle/#tag/UserLifecycle/operation/suspendUser
   namespace: integrations.okta
   name: suspend_user
   secrets:
     - name: okta
-      keys: ["OKTA_API_TOKEN", "OKTA_BASE_URL"]
+      keys: ["OKTA_API_TOKEN"]
   expects:
+    base_url:
+      type: str
+      description: The base URL of the Okta org
     user_id:
       type: str
       description: ID of the user to suspend
@@ -17,7 +21,7 @@ definition:
       action: core.http_request
       args:
         method: POST
-        url: https://${{ SECRETS.okta.OKTA_BASE_URL }}/api/v1/users/${{ inputs.user_id }}/lifecycle/suspend
+        url: ${{ inputs.base_url }}/api/v1/users/${{ inputs.user_id }}/lifecycle/suspend
         headers:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.suspend_user.result }}

--- a/registry/tracecat_registry/templates/okta/unsuspend_user.yml
+++ b/registry/tracecat_registry/templates/okta/unsuspend_user.yml
@@ -3,12 +3,16 @@ definition:
   title: Unsuspend Okta User
   description: Unsuspend an Okta user by user ID
   display_group: Okta
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserLifecycle/#tag/UserLifecycle/operation/unsuspendUser
   namespace: integrations.okta
   name: unsuspend_user
   secrets:
     - name: okta
-      keys: ["OKTA_API_TOKEN", "OKTA_BASE_URL"]
+      keys: ["OKTA_API_TOKEN"]
   expects:
+    base_url:
+      type: str
+      description: The base URL of the Okta org
     user_id:
       type: str
       description: ID of the user to unsuspend
@@ -17,7 +21,7 @@ definition:
       action: core.http_request
       args:
         method: POST
-        url: https://${{ SECRETS.okta.OKTA_BASE_URL }}/api/v1/users/${{ inputs.user_id }}/lifecycle/unsuspend
+        url: ${{ inputs.base_url }}/api/v1/users/${{ inputs.user_id }}/lifecycle/unsuspend
         headers:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.unsuspend_user.result }}


### PR DESCRIPTION
## What changed
- Replaced BASE_DOMAIN secret with BASE_URL arg
- Added doc_url to templates
- urlencoded email fields in path params

## Breaking changes
- Must provide url (with https://) vs domain
- URL is provided via inputs not secrets