### PR TITLE
feat(ui): Rename commit to save

### DIFF
--- a/frontend/src/components/nav/workbench-nav.tsx
+++ b/frontend/src/components/nav/workbench-nav.tsx
@@ -101,7 +101,7 @@ export function WorkbenchNav() {
   const { workspaceId, workspace, workspaceLoading } = useWorkspace()
 
   const handleCommit = async () => {
-    console.log("Committing changes...")
+    console.log("Publishing changes...")
     try {
       const response = await commitWorkflow()
       const { status, errors } = response
@@ -111,7 +111,7 @@ export function WorkbenchNav() {
         setValidationErrors(null)
       }
     } catch (error) {
-      console.error("Failed to commit workflow:", error)
+      console.error("Failed to publish workflow:", error)
     }
   }
 
@@ -158,7 +158,7 @@ export function WorkbenchNav() {
           disabled={manualTriggerDisabled}
           workflowId={workflow.id}
         />
-        {/* Commit button */}
+        {/* Publish button */}
         <div className="flex items-center space-x-2">
           <Tooltip>
             <TooltipTrigger asChild>
@@ -176,7 +176,7 @@ export function WorkbenchNav() {
                 ) : (
                   <GitPullRequestCreateArrowIcon className="mr-2 size-4" />
                 )}
-                Commit
+                Publish
               </Button>
             </TooltipTrigger>
 
@@ -217,7 +217,7 @@ export function WorkbenchNav() {
             variant="secondary"
             className="h-7 text-xs font-normal text-muted-foreground hover:cursor-default"
           >
-            {workflow.version ? `v${workflow.version}` : "Not Committed"}
+            {workflow.version ? `v${workflow.version}` : "Draft"}
           </Badge>
         </div>
 
@@ -246,8 +246,8 @@ export function WorkbenchNav() {
                 </AlertDialogTitle>
                 <AlertDialogDescription>
                   {isOnline
-                    ? "Are you sure you want to disable the workflow? This will stop new executions and event processing."
-                    : "Are you sure you want to enable the workflow? This will start new executions and event processing."}
+                    ? "Are you sure you want to disable the workflow? This will pause all schedules and block webhook events."
+                    : "Are you sure you want to enable the workflow? This will resume all schedules and allow webhook events."}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -262,8 +262,9 @@ export function WorkbenchNav() {
             side="bottom"
             className="max-w-48 border bg-background text-xs text-muted-foreground shadow-lg"
           >
-            {isOnline ? "Disable" : "Enable"} the workflow to{" "}
-            {isOnline ? "stop" : "start"} new executions and receive events.
+            {isOnline
+              ? "Disable the workflow to pause all schedules and block webhook events."
+              : "Enable the workflow to resume all schedules and allow webhook events."}
           </TooltipContent>
         </Tooltip>
 
@@ -526,7 +527,7 @@ function WorkflowManualTrigger({
               </div>
             </div>
           ) : disabled ? (
-            "Please commit changes to enable manual trigger."
+            "Please publish changes to enable manual trigger."
           ) : (
             "Run the workflow manually without a webhook. Click to configure inputs."
           )}

--- a/frontend/src/components/nav/workbench-nav.tsx
+++ b/frontend/src/components/nav/workbench-nav.tsx
@@ -182,7 +182,7 @@ export function WorkbenchNav() {
 
             <TooltipContent
               side="bottom"
-              className="w-auto min-w-72 max-w-lg space-y-2 border bg-background p-0 text-xs text-muted-foreground shadow-lg"
+              className="w-fit p-0 border bg-background text-xs text-muted-foreground shadow-lg"
             >
               {validationErrors ? (
                 <div className="space-y-2 rounded-md border border-rose-400 bg-rose-100 p-2 font-mono tracking-tighter">
@@ -259,7 +259,7 @@ export function WorkbenchNav() {
           </AlertDialog>
           <TooltipContent
             side="bottom"
-            className="max-w-48 border bg-background text-xs text-muted-foreground shadow-lg"
+            className="w-72 border bg-background text-xs text-muted-foreground shadow-lg"
           >
             {isOnline
               ? "Disable the workflow to pause all schedules and block webhook events."

--- a/frontend/src/components/nav/workbench-nav.tsx
+++ b/frontend/src/components/nav/workbench-nav.tsx
@@ -14,7 +14,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   AlertTriangleIcon,
   DownloadIcon,
-  GitPullRequestCreateArrowIcon,
+  SaveIcon,
   MoreHorizontal,
   PlayIcon,
   SquarePlay,
@@ -101,7 +101,7 @@ export function WorkbenchNav() {
   const { workspaceId, workspace, workspaceLoading } = useWorkspace()
 
   const handleCommit = async () => {
-    console.log("Publishing changes...")
+    console.log("Saving changes...")
     try {
       const response = await commitWorkflow()
       const { status, errors } = response
@@ -111,7 +111,7 @@ export function WorkbenchNav() {
         setValidationErrors(null)
       }
     } catch (error) {
-      console.error("Failed to publish workflow:", error)
+      console.error("Failed to save workflow:", error)
     }
   }
 
@@ -158,7 +158,7 @@ export function WorkbenchNav() {
           disabled={manualTriggerDisabled}
           workflowId={workflow.id}
         />
-        {/* Publish button */}
+        {/* Save button */}
         <div className="flex items-center space-x-2">
           <Tooltip>
             <TooltipTrigger asChild>
@@ -174,9 +174,9 @@ export function WorkbenchNav() {
                 {validationErrors ? (
                   <AlertTriangleIcon className="mr-2 size-4 fill-red-500 stroke-white" />
                 ) : (
-                  <GitPullRequestCreateArrowIcon className="mr-2 size-4" />
+                  <SaveIcon className="mr-2 size-4" />
                 )}
-                Publish
+                Save
               </Button>
             </TooltipTrigger>
 
@@ -205,8 +205,7 @@ export function WorkbenchNav() {
               ) : (
                 <div className="p-2">
                   <span>
-                    Create workflow definition v{(workflow.version || 0) + 1}{" "}
-                    with your changes.
+                    Save workflow v{(workflow.version || 0) + 1}{" "} with your changes.
                   </span>
                 </div>
               )}
@@ -527,7 +526,7 @@ function WorkflowManualTrigger({
               </div>
             </div>
           ) : disabled ? (
-            "Please publish changes to enable manual trigger."
+            "Please save changes to enable manual trigger."
           ) : (
             "Run the workflow manually without a webhook. Click to configure inputs."
           )}

--- a/frontend/src/providers/workflow.tsx
+++ b/frontend/src/providers/workflow.tsx
@@ -102,8 +102,8 @@ export function WorkflowProvider({
       if (response.status === "success") {
         queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
         toast({
-          title: "Published changes to workflow",
-          description: "New workflow version published successfully.",
+          title: "Saved changes to workflow",
+          description: "New workflow version saved successfully.",
         })
       } else {
         toast({
@@ -112,9 +112,9 @@ export function WorkflowProvider({
             <div className="flex flex-col space-y-2">
               <p>
                 {response.message ||
-                  "Could not publish workflow due to validation errors."}
+                  "Could not save workflow due to validation errors."}
               </p>
-              <p>Please hover over the publish button to view errors.</p>
+              <p>Please hover over the save button to view errors.</p>
             </div>
           ),
           variant: "destructive",
@@ -122,12 +122,12 @@ export function WorkflowProvider({
       }
     },
     onError: (error: ApiError) => {
-      console.warn("Failed to publish workflow:", error)
+      console.warn("Failed to save workflow:", error)
       toast({
-        title: "Error publishing workflow",
+        title: "Error saving workflow",
         description:
           (error.body as TracecatErrorMessage).message ||
-          "Could not publish workflow. Please try again.",
+          "Could not save workflow. Please try again.",
         variant: "destructive",
       })
     },

--- a/frontend/src/providers/workflow.tsx
+++ b/frontend/src/providers/workflow.tsx
@@ -102,8 +102,8 @@ export function WorkflowProvider({
       if (response.status === "success") {
         queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
         toast({
-          title: "Commited changes to workflow",
-          description: "New workflow deployment created successfully.",
+          title: "Published changes to workflow",
+          description: "New workflow version published successfully.",
         })
       } else {
         toast({
@@ -112,9 +112,9 @@ export function WorkflowProvider({
             <div className="flex flex-col space-y-2">
               <p>
                 {response.message ||
-                  "Could not commit workflow due to valiation errors"}
+                  "Could not publish workflow due to validation errors."}
               </p>
-              <p>Please hover over the commit button to view errors.</p>
+              <p>Please hover over the publish button to view errors.</p>
             </div>
           ),
           variant: "destructive",
@@ -122,12 +122,12 @@ export function WorkflowProvider({
       }
     },
     onError: (error: ApiError) => {
-      console.warn("Failed to commit workflow:", error)
+      console.warn("Failed to publish workflow:", error)
       toast({
-        title: "Error commiting workflow",
+        title: "Error publishing workflow",
         description:
           (error.body as TracecatErrorMessage).message ||
-          "Could not commit workflow. Please try again.",
+          "Could not publish workflow. Please try again.",
         variant: "destructive",
       })
     },

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -143,7 +143,7 @@ class WorkflowsManagementService(BaseService):
             # Convert the workflow into a WorkflowDefinition
             # XXX: When we commit from the workflow, we have action IDs
             dsl = DSLInput.model_validate(dsl_data)
-            self.logger.info("Publishing workflow from database")
+            self.logger.info("Creating workflow from database")
         except* TracecatValidationError as eg:
             self.logger.error(eg.message, error=eg.exceptions)
             construction_errors.extend(
@@ -191,12 +191,12 @@ class WorkflowsManagementService(BaseService):
         # If it still falsy, raise a user facing error
         if not actions:
             raise TracecatValidationError(
-                "Workflow has no actions. Please add an action to the workflow before publishing."
+                "Workflow has no actions. Please add an action to the workflow before saving."
             )
         graph = RFGraph.from_workflow(workflow)
         if not graph.entrypoints:
             raise TracecatValidationError(
-                "Workflow has no entrypoints. Please add an action to the workflow before publishing."
+                "Workflow has no entrypoints. Please add an action to the workflow before saving."
             )
         graph_actions = graph.action_nodes()
         if len(graph_actions) != len(actions):
@@ -214,7 +214,7 @@ class WorkflowsManagementService(BaseService):
             actions = workflow.actions
             if not actions:
                 raise TracecatValidationError(
-                    "Workflow has no actions. Please add an action to the workflow before publishing."
+                    "Workflow has no actions. Please add an action to the workflow before saving."
                 )
             if len(graph_actions) != len(actions):
                 raise TracecatValidationError(

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -143,7 +143,7 @@ class WorkflowsManagementService(BaseService):
             # Convert the workflow into a WorkflowDefinition
             # XXX: When we commit from the workflow, we have action IDs
             dsl = DSLInput.model_validate(dsl_data)
-            self.logger.info("Commiting workflow from database")
+            self.logger.info("Publishing workflow from database")
         except* TracecatValidationError as eg:
             self.logger.error(eg.message, error=eg.exceptions)
             construction_errors.extend(
@@ -191,12 +191,12 @@ class WorkflowsManagementService(BaseService):
         # If it still falsy, raise a user facing error
         if not actions:
             raise TracecatValidationError(
-                "Workflow has no actions. Please add an action to the workflow before committing."
+                "Workflow has no actions. Please add an action to the workflow before publishing."
             )
         graph = RFGraph.from_workflow(workflow)
         if not graph.entrypoints:
             raise TracecatValidationError(
-                "Workflow has no entrypoints. Please add an action to the workflow before committing."
+                "Workflow has no entrypoints. Please add an action to the workflow before publishing."
             )
         graph_actions = graph.action_nodes()
         if len(graph_actions) != len(actions):
@@ -214,7 +214,7 @@ class WorkflowsManagementService(BaseService):
             actions = workflow.actions
             if not actions:
                 raise TracecatValidationError(
-                    "Workflow has no actions. Please add an action to the workflow before committing."
+                    "Workflow has no actions. Please add an action to the workflow before publishing."
                 )
             if len(graph_actions) != len(actions):
                 raise TracecatValidationError(


### PR DESCRIPTION
## What changed
- Cosmetic changes
- Renamed "commit" to "save" in the UI and error messages (components, endpoints, and variables are unchanged)
- Renamed tooltip for "Enable workflow" to be less technical