### PR TITLE
feat(ui): Add template tab and fix state actions on node click

### DIFF
--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -297,7 +297,7 @@ export function ActionPanel({
   const ActionIcon = typeToLabel[registryAction.type].icon
   return (
     <div onBlur={onPanelBlur}>
-      <Tabs defaultValue="inputs" value={activeTab} onValueChange={setActiveTab}>
+      <Tabs defaultValue="inputs" value={activeTab} onValueChange={setActiveTab} className="w-full">
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
             <h3 className="p-4 py-6">
@@ -373,484 +373,488 @@ export function ActionPanel({
             </h3>
 
             <SaveStateIcon saveState={saveState} />
-            <div className="flex items-center justify-start">
-              <TabsList className="h-8 rounded-none bg-transparent p-0">
-                <TabsTrigger
-                  className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                  value="inputs"
-                >
-                  <LayoutListIcon className="mr-2 size-4" />
-                  <span>Inputs</span>
-                </TabsTrigger>
-                <TabsTrigger
-                  className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                  value="control-flow"
-                >
-                  <SplitIcon className="mr-2 size-4" />
-                  <span>If-condition / Loops</span>
-                </TabsTrigger>
-                <TabsTrigger
-                  className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                  value="retry-policy"
-                >
-                  <RotateCcwIcon className="mr-2 size-4" />
-                  <span>Retries</span>
-                </TabsTrigger>
-                {registryAction.is_template && (
+            <div className="w-[800px] min-w-full">
+              <div className="flex items-center justify-start">
+                <TabsList className="h-8 w-full justify-start rounded-none bg-transparent p-0">
                   <TabsTrigger
-                    className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                    value="template-inputs"
+                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="inputs"
                   >
-                    <FileTextIcon className="mr-2 size-4" />
-                    <span>View template</span>
+                    <LayoutListIcon className="mr-2 size-4" />
+                    <span>Inputs</span>
                   </TabsTrigger>
-                )}
-              </TabsList>
-            </div>
-            <Separator />
-            <TabsContent value="inputs">
-              {/* Metadata */}
-              <Accordion
-                type="multiple"
-                defaultValue={["action-inputs"]}
-                className="pb-10"
-              >
-                <AccordionItem value="action-settings">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <SettingsIcon className="mr-3 size-4" />
-                      <span>General</span>
-                    </div>
-                  </AccordionTrigger>
-                  {/* General settings for the action */}
-                  <AccordionContent>
-                    <div className="my-4 space-y-2 px-4">
-                      <FormField
-                        control={methods.control}
-                        name="title"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs">Name</FormLabel>
-                            <FormControl>
+                  <TabsTrigger
+                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="control-flow"
+                  >
+                    <SplitIcon className="mr-2 size-4" />
+                    <span>If-condition / Loops</span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="retry-policy"
+                  >
+                    <RotateCcwIcon className="mr-2 size-4" />
+                    <span>Retries</span>
+                  </TabsTrigger>
+                  {registryAction.is_template && (
+                    <TabsTrigger
+                      className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                      value="template-inputs"
+                    >
+                      <FileTextIcon className="mr-2 size-4" />
+                      <span>View template</span>
+                    </TabsTrigger>
+                  )}
+                </TabsList>
+              </div>
+              <Separator />
+              <div className="w-full overflow-x-auto">
+                <TabsContent value="inputs">
+                  {/* Metadata */}
+                  <Accordion
+                    type="multiple"
+                    defaultValue={["action-inputs"]}
+                    className="pb-10"
+                  >
+                    <AccordionItem value="action-settings">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <SettingsIcon className="mr-3 size-4" />
+                          <span>General</span>
+                        </div>
+                      </AccordionTrigger>
+                      {/* General settings for the action */}
+                      <AccordionContent>
+                        <div className="my-4 space-y-2 px-4">
+                          <FormField
+                            control={methods.control}
+                            name="title"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel className="text-xs">Name</FormLabel>
+                                <FormControl>
+                                  <Input
+                                    className="text-xs"
+                                    placeholder="Name your workflow..."
+                                    {...field}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                          <FormField
+                            control={methods.control}
+                            name="description"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel className="text-xs">
+                                  Description
+                                </FormLabel>
+                                <FormControl>
+                                  <Textarea
+                                    className="text-xs"
+                                    placeholder="Describe your workflow..."
+                                    {...field}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                          <div className="space-y-2">
+                            <Label className="flex items-center gap-2 text-xs text-muted-foreground">
+                              <span>Action ID</span>
+                              <CopyButton
+                                value={action.id}
+                                toastMessage="Copied workflow ID to clipboard"
+                              />
+                            </Label>
+                            <div className="rounded-md border shadow-sm">
                               <Input
-                                className="text-xs"
-                                placeholder="Name your workflow..."
-                                {...field}
+                                value={action.id}
+                                className="rounded-md border-none text-xs shadow-none"
+                                readOnly
+                                disabled
                               />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={methods.control}
-                        name="description"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs">
-                              Description
-                            </FormLabel>
-                            <FormControl>
-                              <Textarea
-                                className="text-xs"
-                                placeholder="Describe your workflow..."
-                                {...field}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <div className="space-y-2">
-                        <Label className="flex items-center gap-2 text-xs text-muted-foreground">
-                          <span>Action ID</span>
-                          <CopyButton
-                            value={action.id}
-                            toastMessage="Copied workflow ID to clipboard"
-                          />
-                        </Label>
-                        <div className="rounded-md border shadow-sm">
-                          <Input
-                            value={action.id}
-                            className="rounded-md border-none text-xs shadow-none"
-                            readOnly
-                            disabled
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-
-                {/* Schema */}
-                <AccordionItem value="action-schema">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <ShapesIcon className="mr-3 size-4" />
-                      <span>Input Schema</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent className="space-y-4">
-                    {/* Action secrets */}
-                    <div className="space-y-4 px-4">
-                      {registryAction.secrets &&
-                      registryAction.secrets.length > 0 ? (
-                        <div className="text-xs text-muted-foreground">
-                          <span>
-                            This action requires the following secrets:
-                          </span>
-                          <Table>
-                            <TableHeader>
-                              <TableRow className="h-6  text-xs capitalize">
-                                <TableHead className="font-bold" colSpan={1}>
-                                  Secret Name
-                                </TableHead>
-                                <TableHead className="font-bold" colSpan={1}>
-                                  Required Keys
-                                </TableHead>
-                                <TableHead className="font-bold" colSpan={1}>
-                                  Optional Keys
-                                </TableHead>
-                              </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                              {registryAction.secrets.map((secret, idx) => (
-                                <TableRow
-                                  key={idx}
-                                  className="font-mono text-xs tracking-tight text-muted-foreground"
-                                >
-                                  <TableCell>{secret.name}</TableCell>
-                                  <TableCell>
-                                    {secret.keys?.join(", ") || "-"}
-                                  </TableCell>
-                                  <TableCell>
-                                    {secret.optional_keys?.join(", ") || "-"}
-                                  </TableCell>
-                                </TableRow>
-                              ))}
-                            </TableBody>
-                          </Table>
-                        </div>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">
-                          No secrets required.
-                        </span>
-                      )}
-                    </div>
-                    {/* Action inputs */}
-                    <div className="space-y-4 px-4">
-                      <span className="text-xs text-muted-foreground">
-                        Hover over each row for details.
-                      </span>
-                      <JSONSchemaTable
-                        schema={registryAction.interface.expects}
-                      />
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-
-                {/* Inputs */}
-                <AccordionItem value="action-inputs">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <LayoutListIcon className="mr-3 size-4" />
-                      <span>Inputs</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <div className="flex flex-col space-y-4 px-4">
-                      {!!finalValErrors && finalValErrors.length > 0 && (
-                        <div className="flex items-center space-x-2">
-                          <AlertTriangleIcon className="size-4 fill-rose-500 stroke-white" />
-                          <span className="text-xs text-rose-500">
-                            Validation errors occurred, please see below.
-                          </span>
-                        </div>
-                      )}
-                      <span className="text-xs text-muted-foreground">
-                        Define action inputs in YAML below.
-                      </span>
-                      <Controller
-                        name="inputs"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="min-h-[40rem] w-full resize-y overflow-auto"
-                            value={field.value}
-                            onChange={field.onChange}
-                            defaultLanguage="yaml-extended"
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
-                            options={{
-                              scrollbar: {
-                                handleMouseWheel: false,
-                              },
-                            }}
-                          />
-                        )}
-                      />
-                      {!!finalValErrors && finalValErrors.length > 0 && (
-                        <div className="rounded-md border border-rose-400 bg-rose-100 p-4 font-mono text-xs text-rose-500">
-                          <span className="font-bold">Validation Errors</span>
-                          <Separator className="my-2 bg-rose-400" />
-                          {finalValErrors.map((error, index) => (
-                            <div key={index} className="mb-4">
-                              <span>{error.message}</span>
-                              <pre>{YAML.stringify(error.detail)}</pre>
                             </div>
-                          ))}
+                          </div>
                         </div>
-                      )}
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </TabsContent>
-            <TabsContent value="control-flow">
-              <Accordion
-                type="multiple"
-                defaultValue={["action-control-flow"]}
-                className="pb-10"
-              >
-                <AccordionItem value="action-control-flow">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <SplitIcon className="mr-3 size-4" />
-                      <span>Control Flow</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent className="space-y-4">
-                    {/* Run if */}
-                    <div className="flex flex-col space-y-4 px-4">
-                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                        <span>Run If</span>
-                      </FormLabel>
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          <HoverCardContent
-                            className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <RunIfTooltip />
-                          </HoverCardContent>
-                        </HoverCard>
+                      </AccordionContent>
+                    </AccordionItem>
 
-                        <span className="text-xs text-muted-foreground">
-                          Define a conditional expression that determines if the action executes.
-                        </span>
-                      </div>
-
-                      <Controller
-                        name="control_flow.run_if"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-24 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                          />
-                        )}
-                      />
-                    </div>
-                    {/* Loop */}
-                    <div className="flex flex-col space-y-4 px-4">
-                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                        <span>Loop Iteration</span>
-                      </FormLabel>
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          <HoverCardContent
-                            className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <ForEachTooltip />
-                          </HoverCardContent>
-                        </HoverCard>
-
-                        <span className="text-xs text-muted-foreground">
-                          Define one or more loop expressions for the action to iterate over.
-                        </span>
-                      </div>
-
-                      <Controller
-                        name="control_flow.for_each"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-24 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
-                          />
-                        )}
-                      />
-                    </div>
-                    {/* Other options */}
-                    <div className="flex flex-col space-y-4 px-4">
-                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                        <span>Options</span>
-                      </FormLabel>
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          <HoverCardContent
-                            className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <ControlFlowOptionsTooltip />
-                          </HoverCardContent>
-                        </HoverCard>
-
-                        <span className="text-xs text-muted-foreground">
-                          Define additional control flow options for the action.
-                        </span>
-                      </div>
-                      <Controller
-                        name="control_flow.options"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-24 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
-                          />
-                        )}
-                      />
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </TabsContent>
-            <TabsContent value="retry-policy">
-              <Accordion
-                type="multiple"
-                defaultValue={["action-retry-policy"]}
-                className="pb-10"
-              >
-                <AccordionItem value="action-retry-policy">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <RotateCcwIcon className="mr-3 size-4" />
-                      <span>Retry Policy</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent className="space-y-4">
-                    {/* Retry Policy */}
-                    <div className="flex flex-col space-y-4 px-4">
-                      <FormLabel className="flex items-center gap-2 text-xs font-medium">
-                        <span>Retry Policy</span>
-                      </FormLabel>
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          <HoverCardContent
-                            className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <RetryPolicyTooltip />
-                          </HoverCardContent>
-                        </HoverCard>
-
-                        <span className="text-xs text-muted-foreground">
-                          Define the retry policy for the action.
-                        </span>
-                      </div>
-                      <Controller
-                        name="control_flow.retry_policy"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-24 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
-                          />
-                        )}
-                      />
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </TabsContent>
-            {/* Template */}
-            {registryAction?.implementation && (
-              <TabsContent value="template-inputs">
-                <Accordion
-                  type="multiple"
-                  defaultValue={["action-template"]}
-                  className="pb-10"
-                >
-                  <AccordionItem value="action-template">
-                    <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                      <div className="flex items-center">
-                        <FileTextIcon className="mr-3 size-4" />
-                        <span>Template Definition</span>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="space-y-4">
-                      <div className="flex flex-col space-y-4 px-4">
-                        <span className="text-xs text-muted-foreground">
-                          Template action definition in YAML format.
-                        </span>
-                        <DynamicCustomEditor
-                          className="min-h-[30rem] w-full resize-y overflow-auto"
-                          value={YAML.stringify(
-                            'type' in registryAction.implementation &&
-                            registryAction.implementation.type === 'template' ?
-                            registryAction.implementation.template_action : {},
-                            null,
-                            2
+                    {/* Schema */}
+                    <AccordionItem value="action-schema">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <ShapesIcon className="mr-3 size-4" />
+                          <span>Input Schema</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent className="space-y-4">
+                        {/* Action secrets */}
+                        <div className="space-y-4 px-4">
+                          {registryAction.secrets &&
+                          registryAction.secrets.length > 0 ? (
+                            <div className="text-xs text-muted-foreground">
+                              <span>
+                                This action requires the following secrets:
+                              </span>
+                              <Table>
+                                <TableHeader>
+                                  <TableRow className="h-6  text-xs capitalize">
+                                    <TableHead className="font-bold" colSpan={1}>
+                                      Secret Name
+                                    </TableHead>
+                                    <TableHead className="font-bold" colSpan={1}>
+                                      Required Keys
+                                    </TableHead>
+                                    <TableHead className="font-bold" colSpan={1}>
+                                      Optional Keys
+                                    </TableHead>
+                                  </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                  {registryAction.secrets.map((secret, idx) => (
+                                    <TableRow
+                                      key={idx}
+                                      className="font-mono text-xs tracking-tight text-muted-foreground"
+                                    >
+                                      <TableCell>{secret.name}</TableCell>
+                                      <TableCell>
+                                        {secret.keys?.join(", ") || "-"}
+                                      </TableCell>
+                                      <TableCell>
+                                        {secret.optional_keys?.join(", ") || "-"}
+                                      </TableCell>
+                                    </TableRow>
+                                  ))}
+                                </TableBody>
+                              </Table>
+                            </div>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">
+                              No secrets required.
+                            </span>
                           )}
-                          defaultLanguage="yaml"
-                          options={{
-                            readOnly: true,
-                            minimap: {
-                              enabled: false,
-                            },
-                            fontSize: 11
-                          }}
-                        />
-                      </div>
-                    </AccordionContent>
-                  </AccordionItem>
-                </Accordion>
-              </TabsContent>
-            )}
+                        </div>
+                        {/* Action inputs */}
+                        <div className="space-y-4 px-4">
+                          <span className="text-xs text-muted-foreground">
+                            Hover over each row for details.
+                          </span>
+                          <JSONSchemaTable
+                            schema={registryAction.interface.expects}
+                          />
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+
+                    {/* Inputs */}
+                    <AccordionItem value="action-inputs">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <LayoutListIcon className="mr-3 size-4" />
+                          <span>Inputs</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        <div className="flex flex-col space-y-4 px-4">
+                          {!!finalValErrors && finalValErrors.length > 0 && (
+                            <div className="flex items-center space-x-2">
+                              <AlertTriangleIcon className="size-4 fill-rose-500 stroke-white" />
+                              <span className="text-xs text-rose-500">
+                                Validation errors occurred, please see below.
+                              </span>
+                            </div>
+                          )}
+                          <span className="text-xs text-muted-foreground">
+                            Define action inputs in YAML below.
+                          </span>
+                          <Controller
+                            name="inputs"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="min-h-[40rem] w-full resize-y overflow-auto"
+                                value={field.value}
+                                onChange={field.onChange}
+                                defaultLanguage="yaml-extended"
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                                options={{
+                                  scrollbar: {
+                                    handleMouseWheel: false,
+                                  },
+                                }}
+                              />
+                            )}
+                          />
+                          {!!finalValErrors && finalValErrors.length > 0 && (
+                            <div className="rounded-md border border-rose-400 bg-rose-100 p-4 font-mono text-xs text-rose-500">
+                              <span className="font-bold">Validation Errors</span>
+                              <Separator className="my-2 bg-rose-400" />
+                              {finalValErrors.map((error, index) => (
+                                <div key={index} className="mb-4">
+                                  <span>{error.message}</span>
+                                  <pre>{YAML.stringify(error.detail)}</pre>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </TabsContent>
+                <TabsContent value="control-flow">
+                  <Accordion
+                    type="multiple"
+                    defaultValue={["action-control-flow"]}
+                    className="pb-10"
+                  >
+                    <AccordionItem value="action-control-flow">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <SplitIcon className="mr-3 size-4" />
+                          <span>Control Flow</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent className="space-y-4">
+                        {/* Run if */}
+                        <div className="flex flex-col space-y-4 px-4">
+                          <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                            <span>Run If</span>
+                          </FormLabel>
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              <HoverCardContent
+                                className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <RunIfTooltip />
+                              </HoverCardContent>
+                            </HoverCard>
+
+                            <span className="text-xs text-muted-foreground">
+                              Define a conditional expression that determines if the action executes.
+                            </span>
+                          </div>
+
+                          <Controller
+                            name="control_flow.run_if"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-24 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                              />
+                            )}
+                          />
+                        </div>
+                        {/* Loop */}
+                        <div className="flex flex-col space-y-4 px-4">
+                          <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                            <span>Loop Iteration</span>
+                          </FormLabel>
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              <HoverCardContent
+                                className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <ForEachTooltip />
+                              </HoverCardContent>
+                            </HoverCard>
+
+                            <span className="text-xs text-muted-foreground">
+                              Define one or more loop expressions for the action to iterate over.
+                            </span>
+                          </div>
+
+                          <Controller
+                            name="control_flow.for_each"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-24 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                              />
+                            )}
+                          />
+                        </div>
+                        {/* Other options */}
+                        <div className="flex flex-col space-y-4 px-4">
+                          <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                            <span>Options</span>
+                          </FormLabel>
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              <HoverCardContent
+                                className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <ControlFlowOptionsTooltip />
+                              </HoverCardContent>
+                            </HoverCard>
+
+                            <span className="text-xs text-muted-foreground">
+                              Define additional control flow options for the action.
+                            </span>
+                          </div>
+                          <Controller
+                            name="control_flow.options"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-24 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                              />
+                            )}
+                          />
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </TabsContent>
+                <TabsContent value="retry-policy">
+                  <Accordion
+                    type="multiple"
+                    defaultValue={["action-retry-policy"]}
+                    className="pb-10"
+                  >
+                    <AccordionItem value="action-retry-policy">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <RotateCcwIcon className="mr-3 size-4" />
+                          <span>Retry Policy</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent className="space-y-4">
+                        {/* Retry Policy */}
+                        <div className="flex flex-col space-y-4 px-4">
+                          <FormLabel className="flex items-center gap-2 text-xs font-medium">
+                            <span>Retry Policy</span>
+                          </FormLabel>
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <InfoIcon className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              <HoverCardContent
+                                className="w-auto max-w-[500px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <RetryPolicyTooltip />
+                              </HoverCardContent>
+                            </HoverCard>
+
+                            <span className="text-xs text-muted-foreground">
+                              Define the retry policy for the action.
+                            </span>
+                          </div>
+                          <Controller
+                            name="control_flow.retry_policy"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-24 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                              />
+                            )}
+                          />
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </TabsContent>
+                {/* Template */}
+                {registryAction?.implementation && (
+                  <TabsContent value="template-inputs">
+                    <Accordion
+                      type="multiple"
+                      defaultValue={["action-template"]}
+                      className="pb-10"
+                    >
+                      <AccordionItem value="action-template">
+                        <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                          <div className="flex items-center">
+                            <FileTextIcon className="mr-3 size-4" />
+                            <span>Template Definition</span>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent className="space-y-4">
+                          <div className="flex flex-col space-y-4 px-4">
+                            <span className="text-xs text-muted-foreground">
+                              Template action definition in YAML format.
+                            </span>
+                            <DynamicCustomEditor
+                              className="min-h-[30rem] w-full resize-y overflow-auto"
+                              value={YAML.stringify(
+                                'type' in registryAction.implementation &&
+                                registryAction.implementation.type === 'template' ?
+                                registryAction.implementation.template_action : {},
+                                null,
+                                2
+                              )}
+                              defaultLanguage="yaml"
+                              options={{
+                                readOnly: true,
+                                minimap: {
+                                  enabled: false,
+                                },
+                                fontSize: 11
+                              }}
+                            />
+                          </div>
+                        </AccordionContent>
+                      </AccordionItem>
+                    </Accordion>
+                  </TabsContent>
+                )}
+              </div>
+            </div>
           </form>
         </FormProvider>
       </Tabs>

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -354,7 +354,9 @@ export function ActionPanel({
                                 className="h-auto p-0 text-xs text-muted-foreground"
                               >
                                 <Link href={registryAction.doc_url} target="_blank">
-                                  {registryAction.doc_url}
+                                  {registryAction.doc_url.length > 32
+                                    ? registryAction.doc_url.substring(0, 32) + "..."
+                                    : registryAction.doc_url}
                                 </Link>
                               </Button>
                             </div>
@@ -374,21 +376,21 @@ export function ActionPanel({
             <div className="flex items-center justify-start">
               <TabsList className="h-8 rounded-none bg-transparent p-0">
                 <TabsTrigger
-                  className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                   value="inputs"
                 >
                   <LayoutListIcon className="mr-2 size-4" />
                   <span>Inputs</span>
                 </TabsTrigger>
                 <TabsTrigger
-                  className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                   value="control-flow"
                 >
                   <SplitIcon className="mr-2 size-4" />
-                  <span>If-condition and loops</span>
+                  <span>If-condition / Loops</span>
                 </TabsTrigger>
                 <TabsTrigger
-                  className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                   value="retry-policy"
                 >
                   <RotateCcwIcon className="mr-2 size-4" />
@@ -396,7 +398,7 @@ export function ActionPanel({
                 </TabsTrigger>
                 {registryAction.is_template && (
                   <TabsTrigger
-                    className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    className="h-full min-w-24 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="template-inputs"
                   >
                     <FileTextIcon className="mr-2 size-4" />

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -808,13 +808,47 @@ export function ActionPanel({
               </Accordion>
             </TabsContent>
             {/* Template */}
-            {registryAction.is_template && (
-              <TabsContent value="action-template">
-                <div className="flex flex-col space-y-4 px-4">
-                  <span className="text-xs text-muted-foreground">
-                    Template inputs
-                  </span>
-                </div>
+            {registryAction?.implementation && (
+              <TabsContent value="template-inputs">
+                <Accordion
+                  type="multiple"
+                  defaultValue={["action-template"]}
+                  className="pb-10"
+                >
+                  <AccordionItem value="action-template">
+                    <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                      <div className="flex items-center">
+                        <FileTextIcon className="mr-3 size-4" />
+                        <span>Template Definition</span>
+                      </div>
+                    </AccordionTrigger>
+                    <AccordionContent className="space-y-4">
+                      <div className="flex flex-col space-y-4 px-4">
+                        <span className="text-xs text-muted-foreground">
+                          Template action definition in YAML format.
+                        </span>
+                        <DynamicCustomEditor
+                          className="min-h-[30rem] w-full resize-y overflow-auto"
+                          value={YAML.stringify(
+                            'type' in registryAction.implementation &&
+                            registryAction.implementation.type === 'template' ?
+                            registryAction.implementation.template_action : {},
+                            null,
+                            2
+                          )}
+                          defaultLanguage="yaml"
+                          options={{
+                            readOnly: true,
+                            minimap: {
+                              enabled: false,
+                            },
+                            fontSize: 11
+                          }}
+                        />
+                      </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
               </TabsContent>
             )}
           </form>

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -17,15 +17,16 @@ import {
   AlertTriangleIcon,
   CircleCheckIcon,
   Database,
+  FileTextIcon,
   InfoIcon,
   LayoutListIcon,
   LinkIcon,
   Loader2Icon,
   LucideIcon,
-  RepeatIcon,
   RotateCcwIcon,
   SaveIcon,
   SettingsIcon,
+  SplitIcon,
   ShapesIcon,
   SquareFunctionIcon,
   ToyBrickIcon,
@@ -164,6 +165,13 @@ export function ActionPanel({
     RegistryActionValidateResponse[]
   >([])
   const [saveState, setSaveState] = useState<SaveState>(SaveState.IDLE)
+  const [activeTab, setActiveTab] = useState("inputs")
+
+  useEffect(() => {
+    setActiveTab("inputs")
+    setSaveState(SaveState.IDLE)
+    setActionValidationErrors([])
+  }, [actionId])
 
   const handleSave = useCallback(
     async (values: ActionFormSchema) => {
@@ -289,7 +297,7 @@ export function ActionPanel({
   const ActionIcon = typeToLabel[registryAction.type].icon
   return (
     <div className="size-full overflow-auto" onBlur={onPanelBlur} tabIndex={0}>
-      <Tabs defaultValue="inputs">
+      <Tabs defaultValue="inputs" value={activeTab} onValueChange={setActiveTab}>
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
             <div className="relative">
@@ -366,28 +374,37 @@ export function ActionPanel({
               <SaveStateIcon saveState={saveState} />
             </div>
             <div className="flex items-center justify-start">
-              <TabsList className="grid h-8 grid-cols-3 rounded-none bg-transparent p-0">
+              <TabsList className="h-8 rounded-none bg-transparent p-0">
                 <TabsTrigger
-                  className="size-full w-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                   value="inputs"
                 >
                   <LayoutListIcon className="mr-2 size-4" />
                   <span>Inputs</span>
                 </TabsTrigger>
                 <TabsTrigger
-                  className="size-full w-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                   value="control-flow"
                 >
-                  <RepeatIcon className="mr-2 size-4" />
-                  <span>Control Flow</span>
+                  <SplitIcon className="mr-2 size-4" />
+                  <span>If-condition and loops</span>
                 </TabsTrigger>
                 <TabsTrigger
-                  className="size-full w-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                   value="retry-policy"
                 >
                   <RotateCcwIcon className="mr-2 size-4" />
-                  <span>Retry Policy</span>
+                  <span>Retries</span>
                 </TabsTrigger>
+                {registryAction.is_template && (
+                  <TabsTrigger
+                    className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="template-inputs"
+                  >
+                    <FileTextIcon className="mr-2 size-4" />
+                    <span>View template</span>
+                  </TabsTrigger>
+                )}
               </TabsList>
             </div>
             <Separator />
@@ -598,7 +615,7 @@ export function ActionPanel({
                 <AccordionItem value="action-control-flow">
                   <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
                     <div className="flex items-center">
-                      <RepeatIcon className="mr-3 size-4" />
+                      <SplitIcon className="mr-3 size-4" />
                       <span>Control Flow</span>
                     </div>
                   </AccordionTrigger>
@@ -667,8 +684,7 @@ export function ActionPanel({
                         </HoverCard>
 
                         <span className="text-xs text-muted-foreground">
-                          Define one or more loop expressions for the action to
-                          iterate over.
+                          Define one or more loop expressions for the action to iterate over.
                         </span>
                       </div>
 
@@ -791,6 +807,16 @@ export function ActionPanel({
                 </AccordionItem>
               </Accordion>
             </TabsContent>
+            {/* Template */}
+            {registryAction.is_template && (
+              <TabsContent value="action-template">
+                <div className="flex flex-col space-y-4 px-4">
+                  <span className="text-xs text-muted-foreground">
+                    Template inputs
+                  </span>
+                </div>
+              </TabsContent>
+            )}
           </form>
         </FormProvider>
       </Tabs>

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -373,25 +373,25 @@ export function ActionPanel({
             </h3>
 
             <SaveStateIcon saveState={saveState} />
-            <div className="w-[800px] min-w-full">
+            <div className="min-w-[30rem] w-full">
               <div className="flex items-center justify-start">
-                <TabsList className="h-8 w-full justify-start rounded-none bg-transparent p-0">
+                <TabsList className="h-8 justify-start rounded-none bg-transparent p-0">
                   <TabsTrigger
-                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    className="h-full min-w-24 flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="inputs"
                   >
                     <LayoutListIcon className="mr-2 size-4" />
                     <span>Inputs</span>
                   </TabsTrigger>
                   <TabsTrigger
-                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    className="h-full min-w-24 flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="control-flow"
                   >
                     <SplitIcon className="mr-2 size-4" />
                     <span>If-condition / Loops</span>
                   </TabsTrigger>
                   <TabsTrigger
-                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    className="h-full min-w-24 flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="retry-policy"
                   >
                     <RotateCcwIcon className="mr-2 size-4" />
@@ -399,7 +399,7 @@ export function ActionPanel({
                   </TabsTrigger>
                   {registryAction.is_template && (
                     <TabsTrigger
-                      className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                      className="h-full min-w-24 flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                       value="template-inputs"
                     >
                       <FileTextIcon className="mr-2 size-4" />

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -300,9 +300,10 @@ export function ActionPanel({
       <Tabs defaultValue="inputs" value={activeTab} onValueChange={setActiveTab} className="w-full">
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
-            <h3 className="p-4 py-6">
-              <div className="flex w-full items-start space-x-4">
-                <div className="flex-col">
+            <div className="relative">
+              <h3 className="p-4 py-6">
+                <div className="flex w-full items-start space-x-4">
+                  <div className="flex-col">
                   {getIcon(registryAction.action, {
                     className: "size-10 p-2",
                     flairsize: "md",
@@ -370,9 +371,10 @@ export function ActionPanel({
                   </div>
                 </div>
               </div>
-            </h3>
+              <SaveStateIcon saveState={saveState} />
+              </h3>
+            </div>
 
-            <SaveStateIcon saveState={saveState} />
             <div className="min-w-[30rem] w-full">
               <div className="flex items-center justify-start">
                 <TabsList className="h-8 justify-start rounded-none bg-transparent p-0">

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -296,83 +296,81 @@ export function ActionPanel({
   ].filter((error) => error.action_ref === slugify(action.title))
   const ActionIcon = typeToLabel[registryAction.type].icon
   return (
-    <div className="size-full overflow-auto" onBlur={onPanelBlur} tabIndex={0}>
+    <div onBlur={onPanelBlur}>
       <Tabs defaultValue="inputs" value={activeTab} onValueChange={setActiveTab}>
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
-            <div className="relative">
-              <h3 className="p-4 py-6">
-                <div className="flex w-full items-start space-x-4">
-                  <div className="flex-col">
-                    {getIcon(registryAction.action, {
-                      className: "size-10 p-2",
-                      flairsize: "md",
-                    })}
-                  </div>
-                  <div className="flex w-full flex-1 justify-between space-x-12">
-                    <div className="flex flex-col">
-                      <div className="flex w-full items-center justify-between text-xs font-medium leading-none">
-                        <div className="flex w-full">{action.title}</div>
-                      </div>
-                      <p className="mt-2 text-xs text-muted-foreground">
-                        {action.description || (
-                          <span className="italic">No description</span>
-                        )}
-                      </p>
-                      <div className="mt-2 hover:cursor-default">
+            <h3 className="p-4 py-6">
+              <div className="flex w-full items-start space-x-4">
+                <div className="flex-col">
+                  {getIcon(registryAction.action, {
+                    className: "size-10 p-2",
+                    flairsize: "md",
+                  })}
+                </div>
+                <div className="flex w-full flex-1 justify-between space-x-12">
+                  <div className="flex flex-col">
+                    <div className="flex w-full items-center justify-between text-xs font-medium leading-none">
+                      <div className="flex w-full">{action.title}</div>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {action.description || (
+                        <span className="italic">No description</span>
+                      )}
+                    </p>
+                    <div className="mt-2 hover:cursor-default">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                            <ActionIcon className="mr-1 size-3 stroke-2" />
+                            <span>
+                              {typeToLabel[registryAction.type].label}
+                            </span>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent side="left" sideOffset={10}>
+                          Action type
+                        </TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="mt-2 flex items-center text-xs text-muted-foreground">
+                            <Database className="mr-1 size-3 stroke-2" />
+                            <span>{registryAction.origin}</span>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent side="left" sideOffset={10}>
+                          Origin
+                        </TooltipContent>
+                      </Tooltip>
+                      {registryAction.doc_url && (
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <div className="mt-2 flex items-center text-xs text-muted-foreground">
-                              <ActionIcon className="mr-1 size-3 stroke-2" />
-                              <span>
-                                {typeToLabel[registryAction.type].label}
-                              </span>
+                              <LinkIcon className="mr-1 size-3 stroke-2" />
+                              <Button
+                                variant="link"
+                                asChild
+                                className="h-auto p-0 text-xs text-muted-foreground"
+                              >
+                                <Link href={registryAction.doc_url} target="_blank">
+                                  {registryAction.doc_url}
+                                </Link>
+                              </Button>
                             </div>
                           </TooltipTrigger>
                           <TooltipContent side="left" sideOffset={10}>
-                            Action type
+                            Link to docs
                           </TooltipContent>
                         </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
-                              <Database className="mr-1 size-3 stroke-2" />
-                              <span>{registryAction.origin}</span>
-                            </div>
-                          </TooltipTrigger>
-                          <TooltipContent side="left" sideOffset={10}>
-                            Origin
-                          </TooltipContent>
-                        </Tooltip>
-                        {registryAction.doc_url && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="mt-2 flex items-center text-xs text-muted-foreground">
-                                <LinkIcon className="mr-1 size-3 stroke-2" />
-                                <Button
-                                  variant="link"
-                                  asChild
-                                  className="h-auto p-0 text-xs text-muted-foreground"
-                                >
-                                  <Link href={registryAction.doc_url} target="_blank">
-                                    {registryAction.doc_url}
-                                  </Link>
-                                </Button>
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent side="left" sideOffset={10}>
-                              Link to docs
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                      </div>
+                      )}
                     </div>
                   </div>
                 </div>
-              </h3>
+              </div>
+            </h3>
 
-              <SaveStateIcon saveState={saveState} />
-            </div>
+            <SaveStateIcon saveState={saveState} />
             <div className="flex items-center justify-start">
               <TabsList className="h-8 rounded-none bg-transparent p-0">
                 <TabsTrigger

--- a/frontend/src/components/workbench/panel/workflow-panel.tsx
+++ b/frontend/src/components/workbench/panel/workflow-panel.tsx
@@ -177,458 +177,461 @@ export function WorkflowPanel({
 
   return (
     <div onBlur={onPanelBlur}>
-      <Tabs defaultValue="workflow-settings">
+      <Tabs defaultValue="workflow-settings" className="w-full">
         <Form {...methods}>
           <form
             onSubmit={methods.handleSubmit(onSubmit)}
             className="flex max-w-full flex-col overflow-auto"
           >
-            <div className="mt-2 flex items-center justify-start">
-              <TabsList className="grid h-8 grid-cols-3 rounded-none bg-transparent p-0">
-                <TabsTrigger
-                  className="size-full w-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                  value="workflow-settings"
-                >
-                  <LayoutListIcon className="mr-2 size-4" />
-                  <span>General</span>
-                </TabsTrigger>
-                <TabsTrigger
-                  className="size-full w-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                  value="workflow-schema"
-                >
-                  <ShapesIcon className="mr-2 size-4" />
-                  <span>Schema</span>
-                </TabsTrigger>
-                <TabsTrigger
-                  className="size-full w-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                  value="workflow-static-inputs"
-                >
-                  <FileInputIcon className="mr-2 size-4" />
-                  <span>Static Inputs</span>
-                </TabsTrigger>
-              </TabsList>
-            </div>
-            <Separator />
-            {/* Workflow Settings */}
-            <TabsContent value="workflow-settings">
-              <Accordion
-                type="multiple"
-                defaultValue={["workflow-settings", "workflow-config"]}
-              >
-                <AccordionItem value="workflow-settings">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <Settings2Icon className="mr-3 size-4" />
-                      <span>Workflow</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <div className="my-4 space-y-2 px-4">
-                      <FormField
-                        control={methods.control}
-                        name="title"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs">Name</FormLabel>
+            <div className="w-[800px] min-w-full">
+              <div className="mt-2 flex items-center justify-start">
+                <TabsList className="h-8 w-full justify-start rounded-none bg-transparent p-0">
+                  <TabsTrigger
+                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="workflow-settings"
+                  >
+                    <LayoutListIcon className="mr-2 size-4" />
+                    <span>General</span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    className="h-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="workflow-schema"
+                  >
+                    <ShapesIcon className="mr-2 size-4" />
+                    <span>Schema</span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    className="h-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="workflow-static-inputs"
+                  >
+                    <FileInputIcon className="mr-2 size-4" />
+                    <span>Static Inputs</span>
+                  </TabsTrigger>
+                </TabsList>
+              </div>
+              <Separator />
+              <div className="w-full overflow-x-auto">
+                <TabsContent value="workflow-settings">
+                  <Accordion
+                    type="multiple"
+                    defaultValue={["workflow-settings", "workflow-config"]}
+                  >
+                    <AccordionItem value="workflow-settings">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <Settings2Icon className="mr-3 size-4" />
+                          <span>Workflow</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        <div className="my-4 space-y-2 px-4">
+                          <FormField
+                            control={methods.control}
+                            name="title"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel className="text-xs">Name</FormLabel>
 
-                            <FormControl>
-                              <Input
-                                className="text-xs"
-                                placeholder="Name your workflow..."
-                                {...field}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={methods.control}
-                        name="description"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs">
-                              Description
-                            </FormLabel>
-                            <FormControl>
-                              <Textarea
-                                className="text-xs"
-                                placeholder="Describe your workflow..."
-                                {...field}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={methods.control}
-                        name="error_handler"
-                        render={({ field }) => (
-                          <FormItem>
-                            <div className="flex items-center gap-2">
-                              <FormLabel className="flex items-center text-xs">
-                                <HoverCard openDelay={100} closeDelay={100}>
-                                  <HoverCardTrigger asChild className="hover:border-none">
-                                    <Info className="mr-1 size-3 stroke-muted-foreground" />
-                                  </HoverCardTrigger>
-                                  <HoverCardContent
-                                    className="w-[300px] p-3 font-mono text-xs tracking-tight"
-                                    side="right"
-                                    sideOffset={20}
-                                  >
-                                    <div className="w-full space-y-4">
-                                      <div className="flex w-full items-center justify-between text-muted-foreground">
-                                        <span className="font-mono text-sm font-semibold">Error handler workflow</span>
-                                        <span className="text-xs text-muted-foreground/80">(optional)</span>
-                                      </div>
-                                      <span className="text-muted-foreground">
-                                        The ID or alias of another workflow to run when this workflow encounters an error.
-                                      </span>
-                                    </div>
-                                  </HoverCardContent>
-                                </HoverCard>
-                                <span>Error workflow</span>
-                              </FormLabel>
-                              {field.value && (
-                                <CopyButton
-                                  value={field.value}
-                                  toastMessage="Copied error workflow to clipboard"
-                                />
-                              )}
-                            </div>
-                            <FormControl>
-                              <Input
-                                className="text-xs"
-                                placeholder="Workflow to run when an error occurs."
-                                {...field}
-                                value={field.value || ""}
-                                onChange={field.onChange}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={methods.control}
-                        name="alias"
-                        render={({ field }) => (
-                          <FormItem>
-                            <div className="flex items-center gap-2">
-                              <FormLabel className="flex items-center text-xs">
-                                <HoverCard openDelay={100} closeDelay={100}>
-                                  <HoverCardTrigger asChild className="hover:border-none">
-                                    <Info className="mr-1 size-3 stroke-muted-foreground" />
-                                  </HoverCardTrigger>
-                                  <HoverCardContent
-                                    className="w-[300px] p-3 font-mono text-xs tracking-tight"
-                                    side="right"
-                                    sideOffset={20}
-                                  >
-                                    <div className="w-full space-y-4">
-                                      <div className="flex w-full items-center justify-between text-muted-foreground">
-                                        <span className="font-mono text-sm font-semibold">Workflow alias</span>
-                                        <span className="text-xs text-muted-foreground/80">(optional)</span>
-                                      </div>
-                                      <span className="text-muted-foreground">
-                                        A unique identifier for the workflow that can be used instead of the workflow ID.
-                                        Must be unique within your workspace.
-                                      </span>
-                                    </div>
-                                  </HoverCardContent>
-                                </HoverCard>
-                                <span>Alias</span>
-                              </FormLabel>
-                              {field.value && (
-                                <CopyButton
-                                  value={field.value}
-                                  toastMessage="Copied workflow alias to clipboard"
-                                />
-                              )}
-                            </div>
-                            <FormControl>
-                              <Input
-                                className="text-xs"
-                                placeholder="Unique identifier for this workflow."
-                                {...field}
-                                value={field.value || ""}
-                                onChange={field.onChange}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <div className="space-y-2">
-                        <FormLabel className="flex items-center gap-2 text-xs">
-                          <span>Workflow ID</span>
-                          <CopyButton
-                            value={workflow.id}
-                            toastMessage="Copied workflow ID to clipboard"
+                                <FormControl>
+                                  <Input
+                                    className="text-xs"
+                                    placeholder="Name your workflow..."
+                                    {...field}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
                           />
-                        </FormLabel>
-                        <div className="rounded-md border shadow-sm">
-                          <Input
-                            defaultValue={workflow.id}
-                            className="rounded-md border-none text-xs shadow-none"
-                            readOnly
-                            disabled
+                          <FormField
+                            control={methods.control}
+                            name="description"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel className="text-xs">
+                                  Description
+                                </FormLabel>
+                                <FormControl>
+                                  <Textarea
+                                    className="text-xs"
+                                    placeholder="Describe your workflow..."
+                                    {...field}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                          <FormField
+                            control={methods.control}
+                            name="error_handler"
+                            render={({ field }) => (
+                              <FormItem>
+                                <div className="flex items-center gap-2">
+                                  <FormLabel className="flex items-center text-xs">
+                                    <HoverCard openDelay={100} closeDelay={100}>
+                                      <HoverCardTrigger asChild className="hover:border-none">
+                                        <Info className="mr-1 size-3 stroke-muted-foreground" />
+                                      </HoverCardTrigger>
+                                      <HoverCardContent
+                                        className="w-[300px] p-3 font-mono text-xs tracking-tight"
+                                        side="right"
+                                        sideOffset={20}
+                                      >
+                                        <div className="w-full space-y-4">
+                                          <div className="flex w-full items-center justify-between text-muted-foreground">
+                                            <span className="font-mono text-sm font-semibold">Error handler workflow</span>
+                                            <span className="text-xs text-muted-foreground/80">(optional)</span>
+                                          </div>
+                                          <span className="text-muted-foreground">
+                                            The ID or alias of another workflow to run when this workflow encounters an error.
+                                          </span>
+                                        </div>
+                                      </HoverCardContent>
+                                    </HoverCard>
+                                    <span>Error workflow</span>
+                                  </FormLabel>
+                                  {field.value && (
+                                    <CopyButton
+                                      value={field.value}
+                                      toastMessage="Copied error workflow to clipboard"
+                                    />
+                                  )}
+                                </div>
+                                <FormControl>
+                                  <Input
+                                    className="text-xs"
+                                    placeholder="Workflow to run when an error occurs."
+                                    {...field}
+                                    value={field.value || ""}
+                                    onChange={field.onChange}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                          <FormField
+                            control={methods.control}
+                            name="alias"
+                            render={({ field }) => (
+                              <FormItem>
+                                <div className="flex items-center gap-2">
+                                  <FormLabel className="flex items-center text-xs">
+                                    <HoverCard openDelay={100} closeDelay={100}>
+                                      <HoverCardTrigger asChild className="hover:border-none">
+                                        <Info className="mr-1 size-3 stroke-muted-foreground" />
+                                      </HoverCardTrigger>
+                                      <HoverCardContent
+                                        className="w-[300px] p-3 font-mono text-xs tracking-tight"
+                                        side="right"
+                                        sideOffset={20}
+                                      >
+                                        <div className="w-full space-y-4">
+                                          <div className="flex w-full items-center justify-between text-muted-foreground">
+                                            <span className="font-mono text-sm font-semibold">Workflow alias</span>
+                                            <span className="text-xs text-muted-foreground/80">(optional)</span>
+                                          </div>
+                                          <span className="text-muted-foreground">
+                                            A unique identifier for the workflow that can be used instead of the workflow ID.
+                                            Must be unique within your workspace.
+                                          </span>
+                                        </div>
+                                      </HoverCardContent>
+                                    </HoverCard>
+                                    <span>Alias</span>
+                                  </FormLabel>
+                                  {field.value && (
+                                    <CopyButton
+                                      value={field.value}
+                                      toastMessage="Copied workflow alias to clipboard"
+                                    />
+                                  )}
+                                </div>
+                                <FormControl>
+                                  <Input
+                                    className="text-xs"
+                                    placeholder="Unique identifier for this workflow."
+                                    {...field}
+                                    value={field.value || ""}
+                                    onChange={field.onChange}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                          <div className="space-y-2">
+                            <FormLabel className="flex items-center gap-2 text-xs">
+                              <span>Workflow ID</span>
+                              <CopyButton
+                                value={workflow.id}
+                                toastMessage="Copied workflow ID to clipboard"
+                              />
+                            </FormLabel>
+                            <div className="rounded-md border shadow-sm">
+                              <Input
+                                defaultValue={workflow.id}
+                                className="rounded-md border-none text-xs shadow-none"
+                                readOnly
+                                disabled
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                    <AccordionItem value="workflow-config">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <FileSliders className="mr-3 size-4" />
+                          <span>Configuration</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        <div className="flex flex-col space-y-4 px-4">
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <Info className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              {/* Config tooltip */}
+                              <HoverCardContent
+                                className="w-[300px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <div className="w-full space-y-4">
+                                  <div className="flex w-full items-center justify-between text-muted-foreground ">
+                                    <span className="font-mono text-sm font-semibold">
+                                      Runtime configuration
+                                    </span>
+                                    <span className="text-xs text-muted-foreground/80">
+                                      (optional)
+                                    </span>
+                                  </div>
+                                  <div className="flex w-full flex-col items-center justify-between space-y-4 text-muted-foreground">
+                                    <span>
+                                      Configuration that modifies the runtime
+                                      behavior of services.
+                                    </span>
+                                  </div>
+                                  {/* Schema is hardcoded here for now */}
+                                  <div className="space-y-2">
+                                    <span className="w-full font-semibold text-muted-foreground">
+                                      Fields
+                                    </span>
+                                    <pre className="space-y-2 text-wrap rounded-md border bg-muted-foreground/10 p-2 text-xs text-foreground/70">
+                                      <div>
+                                        <b>environment</b>
+                                        {": string | null"}
+                                        <p className="text-muted-foreground">
+                                          # The workflow&apos;s target execution
+                                          environment. Defaults to null.
+                                        </p>
+                                      </div>
+                                      <div>
+                                        <b>timeout</b>
+                                        {": float"}
+                                        <p className="text-muted-foreground">
+                                          # The maximum number of seconds to wait
+                                          for the workflow to complete. Defaults to
+                                          300 seconds (5 minutes).
+                                        </p>
+                                      </div>
+                                    </pre>
+                                  </div>
+                                </div>
+                              </HoverCardContent>
+                            </HoverCard>
+                            <span className="text-xs text-muted-foreground">
+                              Define the runtime configuration for the workflow.
+                            </span>
+                          </div>
+                          <Controller
+                            name="config"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-48 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                              />
+                            )}
                           />
                         </div>
-                      </div>
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-                <AccordionItem value="workflow-config">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <FileSliders className="mr-3 size-4" />
-                      <span>Configuration</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <div className="flex flex-col space-y-4 px-4">
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <Info className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          {/* Config tooltip */}
-                          <HoverCardContent
-                            className="w-[300px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <div className="w-full space-y-4">
-                              <div className="flex w-full items-center justify-between text-muted-foreground ">
-                                <span className="font-mono text-sm font-semibold">
-                                  Runtime configuration
-                                </span>
-                                <span className="text-xs text-muted-foreground/80">
-                                  (optional)
-                                </span>
-                              </div>
-                              <div className="flex w-full flex-col items-center justify-between space-y-4 text-muted-foreground">
-                                <span>
-                                  Configuration that modifies the runtime
-                                  behavior of services.
-                                </span>
-                              </div>
-                              {/* Schema is hardcoded here for now */}
-                              <div className="space-y-2">
-                                <span className="w-full font-semibold text-muted-foreground">
-                                  Fields
-                                </span>
-                                <pre className="space-y-2 text-wrap rounded-md border bg-muted-foreground/10 p-2 text-xs text-foreground/70">
-                                  <div>
-                                    <b>environment</b>
-                                    {": string | null"}
-                                    <p className="text-muted-foreground">
-                                      # The workflow&apos;s target execution
-                                      environment. Defaults to null.
-                                    </p>
-                                  </div>
-                                  <div>
-                                    <b>timeout</b>
-                                    {": float"}
-                                    <p className="text-muted-foreground">
-                                      # The maximum number of seconds to wait
-                                      for the workflow to complete. Defaults to
-                                      300 seconds (5 minutes).
-                                    </p>
-                                  </div>
-                                </pre>
-                              </div>
-                            </div>
-                          </HoverCardContent>
-                        </HoverCard>
-                        <span className="text-xs text-muted-foreground">
-                          Define the runtime configuration for the workflow.
-                        </span>
-                      </div>
-                      <Controller
-                        name="config"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-48 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </TabsContent>
+                <TabsContent value="workflow-schema">
+                  <Accordion
+                    type="multiple"
+                    defaultValue={["workflow-expects", "workflow-returns"]}
+                  >
+                    <AccordionItem value="workflow-expects">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <Redo2Icon className="mr-3 size-4" />
+                          <span className="capitalize">Input Schema</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        <div className="flex flex-col space-y-4 px-4">
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <Info className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              <HoverCardContent
+                                className="w-[300px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <WorkflowInputSchemaTooltip />
+                              </HoverCardContent>
+                            </HoverCard>
+                            <span className="text-xs text-muted-foreground">
+                              Define the schema for the workflow trigger inputs.
+                            </span>
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            If undefined, the workflow will not validate the trigger
+                            inputs.
+                          </span>
+                          <Controller
+                            name="expects"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-48 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                              />
+                            )}
                           />
-                        )}
-                      />
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </TabsContent>
-            <TabsContent value="workflow-schema">
-              <Accordion
-                type="multiple"
-                defaultValue={["workflow-expects", "workflow-returns"]}
-              >
-                <AccordionItem value="workflow-expects">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <Redo2Icon className="mr-3 size-4" />
-                      <span className="capitalize">Input Schema</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <div className="flex flex-col space-y-4 px-4">
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <Info className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          <HoverCardContent
-                            className="w-[300px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <WorkflowInputSchemaTooltip />
-                          </HoverCardContent>
-                        </HoverCard>
-                        <span className="text-xs text-muted-foreground">
-                          Define the schema for the workflow trigger inputs.
-                        </span>
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        If undefined, the workflow will not validate the trigger
-                        inputs.
-                      </span>
-                      <Controller
-                        name="expects"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-48 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                    <AccordionItem value="workflow-returns">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <Undo2Icon className="mr-3 size-4" />
+                          <span className="capitalize">Output Schema</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        <div className="flex flex-col space-y-4 px-4">
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <Info className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              <HoverCardContent
+                                className="w-[300px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <WorkflowReturnValueTooltip />
+                              </HoverCardContent>
+                            </HoverCard>
+                            <span className="text-xs text-muted-foreground">
+                              Define the data returned by the workflow.
+                            </span>
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            If undefined, the entire workflow run context is
+                            returned.
+                          </span>
+                          <Controller
+                            name="returns"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-48 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                              />
+                            )}
                           />
-                        )}
-                      />
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-                <AccordionItem value="workflow-returns">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <Undo2Icon className="mr-3 size-4" />
-                      <span className="capitalize">Output Schema</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <div className="flex flex-col space-y-4 px-4">
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <Info className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          <HoverCardContent
-                            className="w-[300px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <WorkflowReturnValueTooltip />
-                          </HoverCardContent>
-                        </HoverCard>
-                        <span className="text-xs text-muted-foreground">
-                          Define the data returned by the workflow.
-                        </span>
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        If undefined, the entire workflow run context is
-                        returned.
-                      </span>
-                      <Controller
-                        name="returns"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-48 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </TabsContent>
+                <TabsContent value="workflow-static-inputs">
+                  <Accordion
+                    type="multiple"
+                    defaultValue={["workflow-static-inputs"]}
+                  >
+                    <AccordionItem value="workflow-static-inputs">
+                      <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
+                        <div className="flex items-center">
+                          <FileInputIcon className="mr-3 size-4" />
+                          <span>Static Inputs</span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        <div className="flex flex-col space-y-4 px-4">
+                          <div className="flex items-center">
+                            <HoverCard openDelay={100} closeDelay={100}>
+                              <HoverCardTrigger
+                                asChild
+                                className="hover:border-none"
+                              >
+                                <Info className="mr-1 size-3 stroke-muted-foreground" />
+                              </HoverCardTrigger>
+                              <HoverCardContent
+                                className="w-[300px] p-3 font-mono text-xs tracking-tight"
+                                side="left"
+                                sideOffset={20}
+                              >
+                                <StaticInputTooltip />
+                              </HoverCardContent>
+                            </HoverCard>
+                            <span className="text-xs text-muted-foreground">
+                              Define optional static inputs for the workflow.
+                            </span>
+                          </div>
+                          <Controller
+                            name="static_inputs"
+                            control={methods.control}
+                            render={({ field }) => (
+                              <DynamicCustomEditor
+                                className="h-48 w-full"
+                                defaultLanguage="yaml-extended"
+                                value={field.value}
+                                onChange={field.onChange}
+                                workspaceId={workspaceId}
+                                workflowId={workflowId}
+                              />
+                            )}
                           />
-                        )}
-                      />
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </TabsContent>
-            <TabsContent value="workflow-static-inputs">
-              <Accordion
-                type="multiple"
-                defaultValue={["workflow-static-inputs"]}
-              >
-                <AccordionItem value="workflow-static-inputs">
-                  <AccordionTrigger className="px-4 text-xs font-bold tracking-wide">
-                    <div className="flex items-center">
-                      <FileInputIcon className="mr-3 size-4" />
-                      <span>Static Inputs</span>
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <div className="flex flex-col space-y-4 px-4">
-                      <div className="flex items-center">
-                        <HoverCard openDelay={100} closeDelay={100}>
-                          <HoverCardTrigger
-                            asChild
-                            className="hover:border-none"
-                          >
-                            <Info className="mr-1 size-3 stroke-muted-foreground" />
-                          </HoverCardTrigger>
-                          <HoverCardContent
-                            className="w-[300px] p-3 font-mono text-xs tracking-tight"
-                            side="left"
-                            sideOffset={20}
-                          >
-                            <StaticInputTooltip />
-                          </HoverCardContent>
-                        </HoverCard>
-                        <span className="text-xs text-muted-foreground">
-                          Define optional static inputs for the workflow.
-                        </span>
-                      </div>
-                      <Controller
-                        name="static_inputs"
-                        control={methods.control}
-                        render={({ field }) => (
-                          <DynamicCustomEditor
-                            className="h-48 w-full"
-                            defaultLanguage="yaml-extended"
-                            value={field.value}
-                            onChange={field.onChange}
-                            workspaceId={workspaceId}
-                            workflowId={workflowId}
-                          />
-                        )}
-                      />
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </TabsContent>
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </TabsContent>
+              </div>
+            </div>
           </form>
         </Form>
       </Tabs>

--- a/frontend/src/components/workbench/panel/workflow-panel.tsx
+++ b/frontend/src/components/workbench/panel/workflow-panel.tsx
@@ -181,27 +181,27 @@ export function WorkflowPanel({
         <Form {...methods}>
           <form
             onSubmit={methods.handleSubmit(onSubmit)}
-            className="flex max-w-full flex-col overflow-auto"
+            className="flex flex-col overflow-auto"
           >
-            <div className="w-[800px] min-w-full">
+            <div className="min-w-[30rem] w-full">
               <div className="mt-2 flex items-center justify-start">
-                <TabsList className="h-8 w-full justify-start rounded-none bg-transparent p-0">
+                <TabsList className="h-8 justify-start rounded-none bg-transparent p-0">
                   <TabsTrigger
-                    className="h-full min-w-[120px] flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    className="h-full min-w-28 flex items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="workflow-settings"
                   >
                     <LayoutListIcon className="mr-2 size-4" />
                     <span>General</span>
                   </TabsTrigger>
                   <TabsTrigger
-                    className="h-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="workflow-schema"
                   >
                     <ShapesIcon className="mr-2 size-4" />
                     <span>Schema</span>
                   </TabsTrigger>
                   <TabsTrigger
-                    className="h-full min-w-[120px] rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    className="h-full min-w-28 rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="workflow-static-inputs"
                   >
                     <FileInputIcon className="mr-2 size-4" />

--- a/frontend/src/components/workbench/workbench.tsx
+++ b/frontend/src/components/workbench/workbench.tsx
@@ -18,7 +18,7 @@ interface WorkbenchProps {
   defaultCollapsed?: boolean
 }
 
-export function Workbench({ defaultLayout = [60, 30] }: WorkbenchProps) {
+export function Workbench({ defaultLayout = [68, 32] }: WorkbenchProps) {
   return (
     <ReactFlowProvider>
       <WorkflowBuilderProvider>
@@ -36,7 +36,7 @@ export function Workbench({ defaultLayout = [60, 30] }: WorkbenchProps) {
               <WorkflowCanvas />
             </ResizablePanel>
             <ResizableHandle withHandle />
-            <ResizablePanel defaultSize={defaultLayout[1]} minSize={30}>
+            <ResizablePanel defaultSize={defaultLayout[1]} minSize={32}>
               <WorkbenchPanel />
             </ResizablePanel>
           </ResizablePanelGroup>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -144,10 +144,6 @@ export function useAction(
     },
     onError: (error) => {
       console.error("Failed to update action:", error)
-      toast({
-        title: "Failed to save action",
-        description: "Could not update your action. Please try again.",
-      })
       setIsSaving(false)
     },
   })


### PR DESCRIPTION
## Before
- Fixed state issues with error saving state and tabs selected persisting between nodes
- Fixed tab switcher content overflowing and the content (e.g. editor) remains the same size
<img width="392" alt="Screenshot 2025-01-08 at 12 17 54 PM" src="https://github.com/user-attachments/assets/d1809900-3de1-4344-b0e0-c43896b183ff" />

## After
<img width="470" alt="Screenshot 2025-01-08 at 1 11 05 PM" src="https://github.com/user-attachments/assets/19eee5c3-0253-4f96-a5a5-c03b1456db54" />

## Others
- I deleted the toast when an action has malformed YAML. The state is really janky and removes immersion i.e. too aggressive (gives me unnecessary cortisol).
- ^I think this is feature of the past when we didn't have the really nice SaveStateIcon
