### PR TITLE
feat(ui): Replace 'Sync all repositories' with 'Refresh repositories'

### DIFF
--- a/frontend/src/app/registry/repositories/page.tsx
+++ b/frontend/src/app/registry/repositories/page.tsx
@@ -1,54 +1,23 @@
 "use client"
 
-import { useState } from "react"
 import { RefreshCcw } from "lucide-react"
 
-import { useRegistryRepositories } from "@/lib/hooks"
+import { useRegistryRepositoriesReload } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
 import { toast } from "@/components/ui/use-toast"
-import { ConfirmationDialog } from "@/components/confirmation-dialog"
 import { RegistryRepositoriesTable } from "@/components/registry/registry-repos-table"
 
 export default function RegistryRepositoriesPage() {
-  const { repos, syncRepo } = useRegistryRepositories()
-  const [syncing, setSyncing] = useState(false)
-  const handleSyncRepositories = async () => {
-    if (!repos) return
+  const { reloadRegistryRepositories, reloadRegistryRepositoriesIsPending } =
+    useRegistryRepositoriesReload()
+  const refreshRepositories = async () => {
     try {
-      // Sync all repositories and get their results
-      setSyncing(true)
-      const results = await Promise.allSettled(
-        repos.map((repo) => syncRepo({ repositoryId: repo.id }))
-      )
-
-      // Filter out the failed promises
-      const failures = results.filter(
-        (result): result is PromiseRejectedResult =>
-          result.status === "rejected"
-      )
-
-      if (failures.length > 0) {
-        // Some repositories failed to sync
-        toast({
-          title: "Partial sync failure",
-          description: `Couldn't sync ${failures.map((f) => f.reason.body?.detail || f.reason.message).join(", ")}`,
-        })
-      } else {
-        // All repositories synced successfully
-        toast({
-          title: "Repositories synced",
-          description: `Successfully synced ${results.length} repositories`,
-        })
-      }
+      await reloadRegistryRepositories()
     } catch (error) {
-      // This catch block will only trigger for errors in the Promise.allSettled handling itself
       toast({
-        title: "Failed to sync repositories",
-        description: "An unexpected error occurred while syncing repositories",
-        variant: "destructive",
+        title: "Error",
+        description: "Failed to reload repositories",
       })
-    } finally {
-      setSyncing(false)
     }
   }
   return (
@@ -64,21 +33,16 @@ export default function RegistryRepositoriesPage() {
             </p>
           </div>
           <div className="ml-auto flex items-center space-x-2">
-            <ConfirmationDialog
-              title="Sync All Repositories"
-              description="Are you sure you want to sync all repositories? This will replace all existing actions with the latest from the repositories."
-              onConfirm={handleSyncRepositories}
+            <Button
+              role="combobox"
+              variant="outline"
+              className="items-center space-x-2"
+              disabled={reloadRegistryRepositoriesIsPending}
+              onClick={refreshRepositories}
             >
-              <Button
-                role="combobox"
-                variant="outline"
-                className="items-center space-x-2"
-                disabled={syncing}
-              >
-                <RefreshCcw className="size-4 text-muted-foreground/80" />
-                <span>Sync All Repositories</span>
-              </Button>
-            </ConfirmationDialog>
+              <RefreshCcw className="size-4 text-muted-foreground/80" />
+              <span>Refresh Repositories</span>
+            </Button>
           </div>
         </div>
         <RegistryRepositoriesTable />


### PR DESCRIPTION
Due to the org settings changes in (#716, #718, ...), git settings are now configurable from the UI. This means if a git repo url changes, we need a way to refresh the list of repos. This lets you do that.

Also, we recommend syncing repos individually.