### PR TITLE
feat: Tighten input validation

### DIFF
--- a/frontend/src/app/registry/actions/edit/page.tsx
+++ b/frontend/src/app/registry/actions/edit/page.tsx
@@ -112,8 +112,14 @@ function EditTemplateActionView({
 }
 
 const editTemplateActionFormSchema = z.object({
-  origin: z.string(),
-  definition: z.string(),
+  origin: z
+    .string()
+    .min(1, "Origin is required")
+    .max(1000, "Origin cannot exceed 1000 characters"),
+  definition: z
+    .string()
+    .min(1, "Definition is required")
+    .max(50000, "Definition cannot exceed 50,000 characters"),
 })
 
 type EditTemplateActionFormSchema = z.infer<typeof editTemplateActionFormSchema>

--- a/frontend/src/app/registry/actions/new/page.tsx
+++ b/frontend/src/app/registry/actions/new/page.tsx
@@ -120,8 +120,14 @@ function NewTemplateActionView({
 }
 
 const newTemplateActionFormSchema = z.object({
-  origin: z.string(),
-  definition: z.string(),
+  origin: z
+    .string()
+    .min(1, "Origin is required")
+    .max(1000, "Origin cannot exceed 1000 characters"),
+  definition: z
+    .string()
+    .min(1, "Definition is required")
+    .max(50000, "Definition cannot exceed 50,000 characters"),
 })
 
 type NewTemplateActionFormSchema = z.infer<typeof newTemplateActionFormSchema>

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -13,6 +13,7 @@ export const $ActionControlFlow = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
         },
         {
           type: "null",
@@ -23,13 +24,18 @@ export const $ActionControlFlow = {
     for_each: {
       anyOf: [
         {
-          type: "string",
-        },
-        {
-          items: {
-            type: "string",
-          },
-          type: "array",
+          anyOf: [
+            {
+              type: "string",
+            },
+            {
+              items: {
+                type: "string",
+              },
+              type: "array",
+            },
+          ],
+          maxLength: 1000,
         },
         {
           type: "null",
@@ -63,6 +69,7 @@ export const $ActionCreate = {
   properties: {
     workflow_id: {
       type: "string",
+      pattern: "wf-[0-9a-f]{32}",
       title: "Workflow Id",
     },
     type: {
@@ -71,6 +78,8 @@ export const $ActionCreate = {
     },
     title: {
       type: "string",
+      maxLength: 100,
+      minLength: 1,
       title: "Title",
     },
   },
@@ -83,6 +92,7 @@ export const $ActionRead = {
   properties: {
     id: {
       type: "string",
+      pattern: "act-[0-9a-f]{32}",
       title: "Id",
     },
     type: {
@@ -118,10 +128,12 @@ export const $ActionReadMinimal = {
   properties: {
     id: {
       type: "string",
+      pattern: "act-[0-9a-f]{32}",
       title: "Id",
     },
     workflow_id: {
       type: "string",
+      pattern: "wf-[0-9a-f]{32}",
       title: "Workflow Id",
     },
     type: {
@@ -286,6 +298,8 @@ export const $ActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -297,6 +311,7 @@ export const $ActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
         },
         {
           type: "null",
@@ -338,6 +353,7 @@ export const $ActionUpdate = {
     },
   },
   type: "object",
+  required: ["title", "description"],
   title: "ActionUpdate",
 } as const
 
@@ -490,6 +506,8 @@ export const $Body_workflows_create_workflow = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -501,6 +519,7 @@ export const $Body_workflows_create_workflow = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
         },
         {
           type: "null",
@@ -586,6 +605,8 @@ export const $CreateWorkspaceParams = {
   properties: {
     name: {
       type: "string",
+      maxLength: 100,
+      minLength: 1,
       title: "Name",
     },
     settings: {
@@ -1516,11 +1537,14 @@ export const $RegistryActionCreate = {
   properties: {
     name: {
       type: "string",
+      maxLength: 100,
+      minLength: 1,
       title: "Name",
       description: "The name of the action",
     },
     description: {
       type: "string",
+      maxLength: 1000,
       title: "Description",
       description: "The description of the action",
     },
@@ -1537,6 +1561,8 @@ export const $RegistryActionCreate = {
     },
     origin: {
       type: "string",
+      maxLength: 1000,
+      minLength: 1,
       title: "Origin",
       description: "The origin of the action as a url",
     },
@@ -1573,6 +1599,8 @@ export const $RegistryActionCreate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1585,6 +1613,8 @@ export const $RegistryActionCreate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1597,6 +1627,8 @@ export const $RegistryActionCreate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1609,6 +1641,8 @@ export const $RegistryActionCreate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1677,11 +1711,14 @@ export const $RegistryActionRead = {
   properties: {
     name: {
       type: "string",
+      maxLength: 100,
+      minLength: 1,
       title: "Name",
       description: "The name of the action",
     },
     description: {
       type: "string",
+      maxLength: 1000,
       title: "Description",
       description: "The description of the action",
     },
@@ -1698,6 +1735,8 @@ export const $RegistryActionRead = {
     },
     origin: {
       type: "string",
+      maxLength: 1000,
+      minLength: 1,
       title: "Origin",
       description: "The origin of the action as a url",
     },
@@ -1734,6 +1773,8 @@ export const $RegistryActionRead = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1746,6 +1787,8 @@ export const $RegistryActionRead = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1758,6 +1801,8 @@ export const $RegistryActionRead = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1770,6 +1815,8 @@ export const $RegistryActionRead = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1897,6 +1944,8 @@ export const $RegistryActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1909,6 +1958,7 @@ export const $RegistryActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
         },
         {
           type: "null",
@@ -1962,6 +2012,8 @@ export const $RegistryActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1974,6 +2026,8 @@ export const $RegistryActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1986,6 +2040,8 @@ export const $RegistryActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
+          minLength: 1,
         },
         {
           type: "null",
@@ -1998,6 +2054,8 @@ export const $RegistryActionUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -2063,7 +2121,10 @@ export const $RegistryRepositoryCreate = {
   properties: {
     origin: {
       type: "string",
+      maxLength: 255,
+      minLength: 1,
       title: "Origin",
+      description: "The origin of the repository",
     },
   },
   type: "object",
@@ -2176,23 +2237,29 @@ export const $RegistryRepositoryUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 255,
+          minLength: 1,
         },
         {
           type: "null",
         },
       ],
       title: "Commit Sha",
+      description: "The commit SHA of the repository",
     },
     origin: {
       anyOf: [
         {
           type: "string",
+          maxLength: 255,
+          minLength: 1,
         },
         {
           type: "null",
         },
       ],
       title: "Origin",
+      description: "The origin of the repository",
     },
   },
   type: "object",
@@ -2829,12 +2896,16 @@ export const $SecretCreate = {
     },
     name: {
       type: "string",
+      maxLength: 100,
+      minLength: 1,
       title: "Name",
     },
     description: {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
+          minLength: 0,
         },
         {
           type: "null",
@@ -2847,6 +2918,8 @@ export const $SecretCreate = {
         $ref: "#/components/schemas/SecretKeyValue",
       },
       type: "array",
+      maxItems: 100,
+      minItems: 1,
       title: "Keys",
     },
     tags: {
@@ -2897,13 +2970,6 @@ export const $SecretKeyValue = {
   type: "object",
   required: ["key", "value"],
   title: "SecretKeyValue",
-} as const
-
-export const $SecretLevel = {
-  type: "string",
-  enum: ["workspace", "organization"],
-  title: "SecretLevel",
-  description: "The level of a secret.",
 } as const
 
 export const $SecretRead = {
@@ -3047,6 +3113,8 @@ export const $SecretUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -3058,6 +3126,8 @@ export const $SecretUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
+          minLength: 0,
         },
         {
           type: "null",
@@ -3072,6 +3142,8 @@ export const $SecretUpdate = {
             $ref: "#/components/schemas/SecretKeyValue",
           },
           type: "array",
+          maxItems: 100,
+          minItems: 1,
         },
         {
           type: "null",
@@ -3086,6 +3158,8 @@ export const $SecretUpdate = {
             type: "string",
           },
           type: "object",
+          maxProperties: 1000,
+          minProperties: 0,
         },
         {
           type: "null",
@@ -3097,6 +3171,8 @@ export const $SecretUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -3107,7 +3183,13 @@ export const $SecretUpdate = {
     level: {
       anyOf: [
         {
-          $ref: "#/components/schemas/SecretLevel",
+          allOf: [
+            {
+              $ref: "#/components/schemas/tracecat__secrets__enums__SecretLevel__1",
+            },
+          ],
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -3158,6 +3240,8 @@ export const $TagCreate = {
   properties: {
     name: {
       type: "string",
+      maxLength: 50,
+      minLength: 1,
       title: "Name",
     },
     color: {
@@ -3170,11 +3254,13 @@ export const $TagCreate = {
         },
       ],
       title: "Color",
+      description: "Hex color code",
     },
   },
   type: "object",
   required: ["name"],
   title: "TagCreate",
+  description: "Model for creating new tags with validation.",
 } as const
 
 export const $TagRead = {
@@ -3186,6 +3272,8 @@ export const $TagRead = {
     },
     name: {
       type: "string",
+      maxLength: 50,
+      minLength: 1,
       title: "Name",
     },
     color: {
@@ -3198,11 +3286,13 @@ export const $TagRead = {
         },
       ],
       title: "Color",
+      description: "Hex color code",
     },
   },
   type: "object",
   required: ["id", "name"],
   title: "TagRead",
+  description: "Model for reading tag data with validation.",
 } as const
 
 export const $TagUpdate = {
@@ -3211,6 +3301,8 @@ export const $TagUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 50,
+          minLength: 1,
         },
         {
           type: "null",
@@ -3228,10 +3320,12 @@ export const $TagUpdate = {
         },
       ],
       title: "Color",
+      description: "Hex color code",
     },
   },
   type: "object",
   title: "TagUpdate",
+  description: "Model for updating existing tags with validation.",
 } as const
 
 export const $TemplateAction_Input = {
@@ -3427,6 +3521,8 @@ export const $UpdateWorkspaceParams = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 1,
         },
         {
           type: "null",
@@ -4310,23 +4406,28 @@ export const $WorkflowUpdate = {
       anyOf: [
         {
           type: "string",
+          maxLength: 100,
+          minLength: 3,
         },
         {
           type: "null",
         },
       ],
       title: "Title",
+      description: "Workflow title, between 3 and 100 characters",
     },
     description: {
       anyOf: [
         {
           type: "string",
+          maxLength: 1000,
         },
         {
           type: "null",
         },
       ],
       title: "Description",
+      description: "Optional workflow description, up to 1000 characters",
     },
     status: {
       anyOf: [
@@ -4637,4 +4738,16 @@ export const $login = {
   type: "object",
   required: ["username", "password"],
   title: "Body_auth-auth:database.login",
+} as const
+
+export const $tracecat__secrets__enums__SecretLevel__1 = {
+  type: "string",
+  enum: ["workspace", "organization"],
+  title: "SecretLevel",
+  description: "The level of a secret.",
+} as const
+
+export const $tracecat__secrets__enums__SecretLevel__2 = {
+  $ref: "#/components/schemas/tracecat__secrets__enums__SecretLevel__1",
+  minLength: 1,
 } as const

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -353,7 +353,6 @@ export const $ActionUpdate = {
     },
   },
   type: "object",
-  required: ["title", "description"],
   title: "ActionUpdate",
 } as const
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -108,8 +108,8 @@ export type ActionStep = {
 }
 
 export type ActionUpdate = {
-  title: string | null
-  description: string | null
+  title?: string | null
+  description?: string | null
   status?: string | null
   inputs?: {
     [key: string]: unknown

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -108,8 +108,8 @@ export type ActionStep = {
 }
 
 export type ActionUpdate = {
-  title?: string | null
-  description?: string | null
+  title: string | null
+  description: string | null
   status?: string | null
   inputs?: {
     [key: string]: unknown
@@ -707,6 +707,9 @@ export type RegistryActionValidateResponse = {
 }
 
 export type RegistryRepositoryCreate = {
+  /**
+   * The origin of the repository
+   */
   origin: string
 }
 
@@ -727,7 +730,13 @@ export type RegistryRepositoryReadMinimal = {
 
 export type RegistryRepositoryUpdate = {
   last_synced_at?: string | null
+  /**
+   * The commit SHA of the repository
+   */
   commit_sha?: string | null
+  /**
+   * The origin of the repository
+   */
   origin?: string | null
 }
 
@@ -954,11 +963,6 @@ export type SecretKeyValue = {
   value: string
 }
 
-/**
- * The level of a secret.
- */
-export type SecretLevel = "workspace" | "organization"
-
 export type SecretRead = {
   id: string
   type: SecretType
@@ -1006,7 +1010,7 @@ export type SecretUpdate = {
     [key: string]: string
   } | null
   environment?: string | null
-  level?: SecretLevel | null
+  level?: tracecat__secrets__enums__SecretLevel__1 | null
 }
 
 export type SessionRead = {
@@ -1016,19 +1020,37 @@ export type SessionRead = {
   user_email: string
 }
 
+/**
+ * Model for creating new tags with validation.
+ */
 export type TagCreate = {
   name: string
+  /**
+   * Hex color code
+   */
   color?: string | null
 }
 
+/**
+ * Model for reading tag data with validation.
+ */
 export type TagRead = {
   id: string
   name: string
+  /**
+   * Hex color code
+   */
   color?: string | null
 }
 
+/**
+ * Model for updating existing tags with validation.
+ */
 export type TagUpdate = {
   name?: string | null
+  /**
+   * Hex color code
+   */
   color?: string | null
 }
 
@@ -1328,7 +1350,13 @@ export type WorkflowTagCreate = {
 }
 
 export type WorkflowUpdate = {
+  /**
+   * Workflow title, between 3 and 100 characters
+   */
   title?: string | null
+  /**
+   * Optional workflow description, up to 1000 characters
+   */
   description?: string | null
   status?: "online" | "offline" | null
   object?: {
@@ -1387,6 +1415,16 @@ export type login = {
   client_id?: string | null
   client_secret?: string | null
 }
+
+/**
+ * The level of a secret.
+ */
+export type tracecat__secrets__enums__SecretLevel__1 =
+  | "workspace"
+  | "organization"
+
+export type tracecat__secrets__enums__SecretLevel__2 =
+  tracecat__secrets__enums__SecretLevel__1
 
 export type PublicIncomingWebhookData = {
   contentType?: string | null
@@ -1682,7 +1720,7 @@ export type SecretsSearchSecretsData = {
   /**
    * Filter by secret level
    */
-  level?: Array<SecretLevel> | null
+  level?: Array<tracecat__secrets__enums__SecretLevel__1> | null
   /**
    * Filter by secret name
    */
@@ -1700,7 +1738,7 @@ export type SecretsListSecretsData = {
   /**
    * Filter by secret level
    */
-  level?: SecretLevel | null
+  level?: tracecat__secrets__enums__SecretLevel__1 | null
   /**
    * Filter by secret type
    */

--- a/frontend/src/components/dashboard/workflow-tags-sidebar.tsx
+++ b/frontend/src/components/dashboard/workflow-tags-sidebar.tsx
@@ -43,6 +43,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -55,6 +56,7 @@ const createTagSchema = z.object({
   name: z
     .string()
     .min(1, "Tag name cannot be empty")
+    .max(50, "Tag name cannot be longer than 50 characters")
     .trim()
     .refine(
       (name) => name.trim().length > 0,
@@ -92,7 +94,6 @@ export function WorkflowTagsSidebar({ workspaceId }: { workspaceId: string }) {
         return
       }
 
-      console.log("createTag", params)
       await createTag({
         workspaceId: workspaceId,
         requestBody: params,
@@ -169,6 +170,9 @@ export function WorkflowTagsSidebar({ workspaceId }: { workspaceId: string }) {
                         {...methods.register("name")}
                       />
                     </FormControl>
+                    <FormDescription>
+                      Max 50 alphanumeric characters
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -216,6 +220,23 @@ enum TagItemAction {
   Delete = "delete",
 }
 
+const updateTagSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Tag name cannot be empty")
+    .max(50, "Tag name cannot be longer than 50 characters")
+    .trim()
+    .refine(
+      (name) => name.trim().length > 0,
+      "Tag name cannot be only whitespace"
+    )
+    .optional(),
+  color: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/, "Color must be a valid hex color code")
+    .optional(),
+})
+
 function TagItemActionDialogContent({
   action,
   tag,
@@ -227,6 +248,7 @@ function TagItemActionDialogContent({
   const { workspaceId } = useWorkspace()
   const { updateTag, deleteTag } = useTags(workspaceId)
   const methods = useForm<TagUpdate>({
+    resolver: zodResolver(updateTagSchema),
     defaultValues: {
       name: tag.name,
       color: tag.color || "#aabbcc",
@@ -316,6 +338,9 @@ function TagItemActionDialogContent({
                           value={field.value ?? ""}
                         />
                       </FormControl>
+                      <FormDescription>
+                        Max 50 alphanumeric characters
+                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -35,6 +35,7 @@ import {
 import { Controller, FormProvider, useForm } from "react-hook-form"
 import YAML from "yaml"
 
+import { RequestValidationError, TracecatApiError } from "@/lib/errors"
 import { useAction, useWorkbenchRegistryActions } from "@/lib/hooks"
 import { cn, itemOrEmptyString, slugify } from "@/lib/utils"
 import {
@@ -210,7 +211,14 @@ export function ActionPanel({
         setTimeout(() => setSaveState(SaveState.SAVED), 300)
       } catch (error) {
         if (error instanceof ApiError) {
-          console.error("Application failed to validate action", error.body)
+          const apiError = error as TracecatApiError
+          console.error("Application failed to validate action", apiError.body)
+          const details = apiError.body.detail as RequestValidationError[]
+          details.forEach((detail: RequestValidationError) => {
+            methods.setError(detail.loc[1] as keyof ActionFormSchema, {
+              message: detail.msg,
+            })
+          })
         } else {
           console.error("Validation failed, unknown error", error)
         }
@@ -449,7 +457,7 @@ export function ActionPanel({
                                 <FormControl>
                                   <Input
                                     className="text-xs"
-                                    placeholder="Name your workflow..."
+                                    placeholder="Name your action..."
                                     {...field}
                                   />
                                 </FormControl>
@@ -468,7 +476,7 @@ export function ActionPanel({
                                 <FormControl>
                                   <Textarea
                                     className="text-xs"
-                                    placeholder="Describe your workflow..."
+                                    placeholder="Describe your action..."
                                     {...field}
                                   />
                                 </FormControl>
@@ -481,7 +489,7 @@ export function ActionPanel({
                               <span>Action ID</span>
                               <CopyButton
                                 value={action.id}
-                                toastMessage="Copied workflow ID to clipboard"
+                                toastMessage="Copied action ID to clipboard"
                               />
                             </Label>
                             <div className="rounded-md border shadow-sm">

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -32,7 +32,7 @@ import {
   SquareFunctionIcon,
   ToyBrickIcon,
 } from "lucide-react"
-import { Controller, FormProvider, useForm } from "react-hook-form"
+import { FormProvider, useForm } from "react-hook-form"
 import YAML from "yaml"
 
 import { RequestValidationError, TracecatApiError } from "@/lib/errors"
@@ -600,23 +600,29 @@ export function ActionPanel({
                           <span className="text-xs text-muted-foreground">
                             Define action inputs in YAML below.
                           </span>
-                          <Controller
+                          <FormField
                             name="inputs"
                             control={methods.control}
                             render={({ field }) => (
-                              <DynamicCustomEditor
-                                className="min-h-[40rem] w-full resize-y overflow-auto"
-                                value={field.value}
-                                onChange={field.onChange}
-                                defaultLanguage="yaml-extended"
-                                workspaceId={workspaceId}
-                                workflowId={workflowId}
-                                options={{
-                                  scrollbar: {
-                                    handleMouseWheel: false,
-                                  },
-                                }}
-                              />
+                              <FormItem>
+                                {/* Place form message above because it's not visible otherwise */}
+                                <FormMessage />
+                                <FormControl>
+                                  <DynamicCustomEditor
+                                    className="min-h-[40rem] w-full resize-y overflow-auto"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    defaultLanguage="yaml-extended"
+                                    workspaceId={workspaceId}
+                                    workflowId={workflowId}
+                                    options={{
+                                      scrollbar: {
+                                        handleMouseWheel: false,
+                                      },
+                                    }}
+                                  />
+                                </FormControl>
+                              </FormItem>
                             )}
                           />
                           {!!finalValErrors && finalValErrors.length > 0 && (
@@ -679,18 +685,22 @@ export function ActionPanel({
                               the action executes.
                             </span>
                           </div>
-
-                          <Controller
+                          <FormField
                             name="control_flow.run_if"
                             control={methods.control}
                             render={({ field }) => (
-                              <DynamicCustomEditor
-                                className="h-24 w-full"
-                                defaultLanguage="yaml-extended"
-                                value={field.value}
-                                onChange={field.onChange}
-                                workspaceId={workspaceId}
-                              />
+                              <FormItem>
+                                <FormControl>
+                                  <DynamicCustomEditor
+                                    className="h-24 w-full"
+                                    defaultLanguage="yaml-extended"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    workspaceId={workspaceId}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
                             )}
                           />
                         </div>
@@ -721,19 +731,23 @@ export function ActionPanel({
                               to iterate over.
                             </span>
                           </div>
-
-                          <Controller
+                          <FormField
                             name="control_flow.for_each"
                             control={methods.control}
                             render={({ field }) => (
-                              <DynamicCustomEditor
-                                className="h-24 w-full"
-                                defaultLanguage="yaml-extended"
-                                value={field.value}
-                                onChange={field.onChange}
-                                workspaceId={workspaceId}
-                                workflowId={workflowId}
-                              />
+                              <FormItem>
+                                <FormControl>
+                                  <DynamicCustomEditor
+                                    className="h-24 w-full"
+                                    defaultLanguage="yaml-extended"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    workspaceId={workspaceId}
+                                    workflowId={workflowId}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
                             )}
                           />
                         </div>
@@ -764,18 +778,23 @@ export function ActionPanel({
                               action.
                             </span>
                           </div>
-                          <Controller
+                          <FormField
                             name="control_flow.options"
                             control={methods.control}
                             render={({ field }) => (
-                              <DynamicCustomEditor
-                                className="h-24 w-full"
-                                defaultLanguage="yaml-extended"
-                                value={field.value}
-                                onChange={field.onChange}
-                                workspaceId={workspaceId}
-                                workflowId={workflowId}
-                              />
+                              <FormItem>
+                                <FormControl>
+                                  <DynamicCustomEditor
+                                    className="h-24 w-full"
+                                    defaultLanguage="yaml-extended"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    workspaceId={workspaceId}
+                                    workflowId={workflowId}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
                             )}
                           />
                         </div>
@@ -823,18 +842,23 @@ export function ActionPanel({
                               Define the retry policy for the action.
                             </span>
                           </div>
-                          <Controller
+                          <FormField
                             name="control_flow.retry_policy"
                             control={methods.control}
                             render={({ field }) => (
-                              <DynamicCustomEditor
-                                className="h-24 w-full"
-                                defaultLanguage="yaml-extended"
-                                value={field.value}
-                                onChange={field.onChange}
-                                workspaceId={workspaceId}
-                                workflowId={workflowId}
-                              />
+                              <FormItem>
+                                <FormControl>
+                                  <DynamicCustomEditor
+                                    className="h-24 w-full"
+                                    defaultLanguage="yaml-extended"
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                    workspaceId={workspaceId}
+                                    workflowId={workflowId}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
                             )}
                           />
                         </div>

--- a/frontend/src/components/workbench/panel/workflow-panel.tsx
+++ b/frontend/src/components/workbench/panel/workflow-panel.tsx
@@ -51,8 +51,14 @@ import { CopyButton } from "@/components/copy-button"
 import { DynamicCustomEditor } from "@/components/editor/dynamic"
 
 const workflowUpdateFormSchema = z.object({
-  title: z.string(),
-  description: z.string(),
+  title: z
+    .string()
+    .min(1, { message: "Name is required" })
+    .max(100, { message: "Name cannot exceed 100 characters" }),
+  description: z
+    .string()
+    .max(1000, { message: "Description cannot exceed 1000 characters" })
+    .optional(),
   alias: z.string().nullish(),
   config: z.string().transform((val, ctx) => {
     try {
@@ -168,6 +174,15 @@ export function WorkflowPanel({
       const result = await workflowUpdateFormSchema.safeParseAsync(values)
       if (!result.success) {
         console.error("Validation failed:", result.error)
+        // Set form errors with field name and message
+        Object.entries(result.error.formErrors.fieldErrors).forEach(
+          ([fieldName, error]) => {
+            methods.setError(fieldName as keyof WorkflowUpdateForm, {
+              type: "validation",
+              message: error[0] || "Invalid value",
+            })
+          }
+        )
         return
       }
       await onSubmit(result.data)

--- a/frontend/src/components/workbench/panel/workflow-panel.tsx
+++ b/frontend/src/components/workbench/panel/workflow-panel.tsx
@@ -59,56 +59,74 @@ const workflowUpdateFormSchema = z.object({
     .string()
     .max(1000, { message: "Description cannot exceed 1000 characters" })
     .optional(),
-  alias: z.string().nullish(),
-  config: z.string().transform((val, ctx) => {
-    try {
-      return YAML.parse(val) || {}
-    } catch (error) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          "Invalid YAML format. Please check workflow definition for errors.",
-      })
-      return z.NEVER
-    }
-  }),
-  static_inputs: z.string().transform((val, ctx) => {
-    try {
-      return YAML.parse(val) || {}
-    } catch (error) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Invalid YAML format",
-      })
-      return z.NEVER
-    }
-  }),
+  alias: z
+    .string()
+    .max(100, { message: "Alias cannot exceed 100 characters" })
+    .nullish(),
+  config: z
+    .string()
+    .max(10000, { message: "Config cannot exceed 10000 characters" })
+    .transform((val, ctx) => {
+      try {
+        return YAML.parse(val) || {}
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "Invalid YAML format. Please check workflow definition for errors.",
+        })
+        return z.NEVER
+      }
+    }),
+  static_inputs: z
+    .string()
+    .max(10000, { message: "Static inputs cannot exceed 10000 characters" })
+    .transform((val, ctx) => {
+      try {
+        return YAML.parse(val) || {}
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Invalid YAML format",
+        })
+        return z.NEVER
+      }
+    }),
   /* Input Schema */
-  expects: z.string().transform((val, ctx) => {
-    try {
-      return YAML.parse(val) || {}
-    } catch (error) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Invalid YAML format",
-      })
-      return z.NEVER
-    }
-  }),
+  expects: z
+    .string()
+    .max(10000, { message: "Input schema cannot exceed 10000 characters" })
+    .transform((val, ctx) => {
+      try {
+        return YAML.parse(val) || {}
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Invalid YAML format",
+        })
+        return z.NEVER
+      }
+    }),
   /* Output Schema */
-  returns: z.string().transform((val, ctx) => {
-    try {
-      return YAML.parse(val) || null
-    } catch (error) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Invalid YAML format",
-      })
-      return z.NEVER
-    }
-  }),
+  returns: z
+    .string()
+    .max(10000, { message: "Output schema cannot exceed 10000 characters" })
+    .transform((val, ctx) => {
+      try {
+        return YAML.parse(val) || null
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Invalid YAML format",
+        })
+        return z.NEVER
+      }
+    }),
   /* Error Handler */
-  error_handler: z.string().nullish(),
+  error_handler: z
+    .string()
+    .max(100, { message: "Error handler cannot exceed 100 characters" })
+    .nullish(),
 })
 
 type WorkflowUpdateForm = z.infer<typeof workflowUpdateFormSchema>
@@ -148,7 +166,6 @@ export function WorkflowPanel({
       error_handler: workflow.error_handler || "",
     },
   })
-  console.log("workflow alias", workflow.alias)
 
   const onSubmit = async (values: WorkflowUpdateForm) => {
     console.log("Saving changes...", values)

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -15,3 +15,16 @@ export function retryHandler(failureCount: number, error: ApiError) {
   // Retry for all other errors up to 3 times
   return failureCount < 3
 }
+
+/**
+ * Type for request validation errors
+ * Returned with 422 status code
+ */
+export type RequestValidationError = {
+  loc: string[]
+  ctx: {
+    [key: string]: unknown
+  }
+  msg: string
+  type: string
+}

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -87,10 +87,14 @@ async def setup_workspace_defaults(session: AsyncSession, admin_role: Role):
 # Catch-all exception handler to prevent stack traces from leaking
 def validation_exception_handler(request: Request, exc: RequestValidationError):
     """Improves visiblity of 422 errors."""
-    exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
-    logger.error(f"{request}: {exc_str}")
+    errors = exc.errors()
+    logger.error(
+        "API Model Validation error",
+        request=request,
+        errors=errors,
+    )
     return ORJSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content=exc_str
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"detail": errors}
     )
 
 

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -226,24 +226,54 @@ class RegistryActionBase(BaseModel):
     """API read model for a registered action."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    name: str = Field(..., description="The name of the action")
-    description: str = Field(..., description="The description of the action")
+    name: str = Field(
+        ...,
+        description="The name of the action",
+        min_length=1,
+        max_length=100,
+    )
+    description: str = Field(
+        ...,
+        description="The description of the action",
+        max_length=1000,
+    )
     namespace: str = Field(..., description="The namespace of the action")
     type: RegistryActionType = Field(..., description="The type of the action")
-    origin: str = Field(..., description="The origin of the action as a url")
+    origin: str = Field(
+        ...,
+        description="The origin of the action as a url",
+        min_length=1,
+        max_length=1000,
+    )
     secrets: list[RegistrySecret] | None = Field(
         None, description="The secrets required by the action"
     )
     interface: RegistryActionInterface
     implementation: AnnotatedRegistryActionImpl
     default_title: str | None = Field(
-        None, description="The default title of the action"
+        None,
+        description="The default title of the action",
+        min_length=1,
+        max_length=100,
     )
     display_group: str | None = Field(
-        None, description="The presentation group of the action"
+        None,
+        description="The presentation group of the action",
+        min_length=1,
+        max_length=100,
     )
-    doc_url: str | None = Field(None, description="Link to documentation")
-    author: str | None = Field(None, description="Author of the action")
+    doc_url: str | None = Field(
+        None,
+        description="Link to documentation",
+        min_length=1,
+        max_length=1000,
+    )
+    author: str | None = Field(
+        None,
+        description="Author of the action",
+        min_length=1,
+        max_length=100,
+    )
     options: RegistryActionOptions = Field(
         default_factory=lambda: RegistryActionOptions(),
         description="The options for the action",
@@ -320,33 +350,56 @@ class RegistryActionCreate(RegistryActionBase):
 class RegistryActionUpdate(BaseModel):
     """API update model for a registered action."""
 
-    name: str | None = Field(default=None, description="Update the name of the action")
+    name: str | None = Field(
+        default=None,
+        description="Update the name of the action",
+        min_length=1,
+        max_length=100,
+    )
     description: str | None = Field(
-        default=None, description="Update the description of the action"
+        default=None,
+        description="Update the description of the action",
+        max_length=1000,
     )
     secrets: list[RegistrySecret] | None = Field(
-        default=None, description="Update the secrets of the action"
+        default=None,
+        description="Update the secrets of the action",
     )
     interface: RegistryActionInterface | None = Field(
-        default=None, description="Update the interface of the action"
+        default=None,
+        description="Update the interface of the action",
     )
     implementation: AnnotatedRegistryActionImpl | None = Field(
-        default=None, description="Update the implementation of the action"
+        default=None,
+        description="Update the implementation of the action",
     )
     default_title: str | None = Field(
-        default=None, description="Update the default title of the action"
+        default=None,
+        description="Update the default title of the action",
+        min_length=1,
+        max_length=100,
     )
     display_group: str | None = Field(
-        default=None, description="Update the display group of the action"
+        default=None,
+        description="Update the display group of the action",
+        min_length=1,
+        max_length=100,
     )
     doc_url: str | None = Field(
-        default=None, description="Update the doc url of the action"
+        default=None,
+        description="Update the doc url of the action",
+        min_length=1,
+        max_length=1000,
     )
     author: str | None = Field(
-        default=None, description="Update the author of the action"
+        default=None,
+        description="Update the author of the action",
+        min_length=1,
+        max_length=100,
     )
     options: RegistryActionOptions | None = Field(
-        default=None, description="Update the options of the action"
+        default=None,
+        description="Update the options of the action",
     )
 
     @staticmethod

--- a/tracecat/registry/repositories/models.py
+++ b/tracecat/registry/repositories/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import UUID4, BaseModel
+from pydantic import UUID4, BaseModel, Field
 
 from tracecat.registry.actions.models import RegistryActionRead
 
@@ -21,10 +21,25 @@ class RegistryRepositoryReadMinimal(BaseModel):
 
 
 class RegistryRepositoryCreate(BaseModel):
-    origin: str
+    origin: str = Field(
+        ...,
+        description="The origin of the repository",
+        min_length=1,
+        max_length=255,
+    )
 
 
 class RegistryRepositoryUpdate(BaseModel):
     last_synced_at: datetime | None = None
-    commit_sha: str | None = None
-    origin: str | None = None
+    commit_sha: str | None = Field(
+        default=None,
+        description="The commit SHA of the repository",
+        min_length=1,
+        max_length=255,
+    )
+    origin: str | None = Field(
+        default=None,
+        description="The origin of the repository",
+        min_length=1,
+        max_length=255,
+    )

--- a/tracecat/secrets/models.py
+++ b/tracecat/secrets/models.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     SecretStr,
     StringConstraints,
     field_validator,
@@ -87,9 +88,9 @@ class SecretCreate(BaseModel):
     - `oauth2`: OAuth2 Client Credentials (TBC)"""
 
     type: SecretType = SecretType.CUSTOM
-    name: str
-    description: str | None = None
-    keys: list[SecretKeyValue]
+    name: str = Field(..., min_length=1, max_length=100)
+    description: str | None = Field(default=None, min_length=0, max_length=1000)
+    keys: list[SecretKeyValue] = Field(..., min_length=1, max_length=100)
     tags: dict[str, str] | None = None
     environment: str = DEFAULT_SECRETS_ENVIRONMENT
 
@@ -118,12 +119,14 @@ class SecretUpdate(BaseModel):
     - `oauth2`: OAuth2 Client Credentials (TBC)"""
 
     type: SecretType | None = None
-    name: str | None = None
-    description: str | None = None
-    keys: list[SecretKeyValue] | None = None
-    tags: dict[str, str] | None = None
-    environment: str | None = None
-    level: SecretLevel | None = None
+    name: str | None = Field(default=None, min_length=1, max_length=100)
+    description: str | None = Field(default=None, min_length=0, max_length=1000)
+    keys: list[SecretKeyValue] | None = Field(
+        default=None, min_length=1, max_length=100
+    )
+    tags: dict[str, str] | None = Field(default=None, min_length=0, max_length=1000)
+    environment: str | None = Field(default=None, min_length=1, max_length=100)
+    level: SecretLevel | None = Field(default=None, min_length=1, max_length=100)
 
 
 class SecretSearch(BaseModel):

--- a/tracecat/tags/models.py
+++ b/tracecat/tags/models.py
@@ -1,19 +1,25 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from tracecat.identifiers import TagID
 
 
 class TagRead(BaseModel):
+    """Model for reading tag data with validation."""
+
     id: TagID
-    name: str
-    color: str | None = None
+    name: str = Field(min_length=1, max_length=50)
+    color: str | None = Field(default=None, description="Hex color code")
 
 
 class TagCreate(BaseModel):
-    name: str
-    color: str | None = None
+    """Model for creating new tags with validation."""
+
+    name: str = Field(min_length=1, max_length=50)
+    color: str | None = Field(default=None, description="Hex color code")
 
 
 class TagUpdate(BaseModel):
-    name: str | None = None
-    color: str | None = None
+    """Model for updating existing tags with validation."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=50)
+    color: str | None = Field(default=None, description="Hex color code")

--- a/tracecat/workflow/actions/models.py
+++ b/tracecat/workflow/actions/models.py
@@ -42,12 +42,12 @@ class ActionReadMinimal(BaseModel):
 class ActionCreate(BaseModel):
     workflow_id: WorkflowID
     type: str
-    title: str = Field(min_length=1, max_length=100)
+    title: str = Field(..., min_length=1, max_length=100)
 
 
 class ActionUpdate(BaseModel):
-    title: str | None = Field(min_length=1, max_length=100)
-    description: str | None = Field(max_length=1000)
+    title: str | None = Field(default=None, min_length=1, max_length=100)
+    description: str | None = Field(default=None, max_length=1000)
     status: str | None = None
     inputs: dict[str, Any] | None = None
     control_flow: ActionControlFlow | None = None

--- a/tracecat/workflow/actions/models.py
+++ b/tracecat/workflow/actions/models.py
@@ -38,12 +38,12 @@ class ActionReadMinimal(BaseModel):
 class ActionCreate(BaseModel):
     workflow_id: str
     type: str
-    title: str
+    title: str = Field(min_length=1, max_length=100)
 
 
 class ActionUpdate(BaseModel):
-    title: str | None = None
-    description: str | None = None
+    title: str | None = Field(min_length=1, max_length=100)
+    description: str | None = Field(max_length=1000)
     status: str | None = None
     inputs: dict[str, Any] | None = None
     control_flow: ActionControlFlow | None = None

--- a/tracecat/workflow/actions/models.py
+++ b/tracecat/workflow/actions/models.py
@@ -1,14 +1,18 @@
 from typing import Any
 
-from pydantic import BaseModel, Field
+import orjson
+from pydantic import BaseModel, Field, field_validator
+from pydantic_core import PydanticCustomError
 
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy
+from tracecat.identifiers.action import ActionID
+from tracecat.identifiers.workflow import WorkflowID
 
 
 class ActionControlFlow(BaseModel):
-    run_if: str | None = None
-    for_each: str | list[str] | None = None
+    run_if: str | None = Field(default=None, max_length=1000)
+    for_each: str | list[str] | None = Field(default=None, max_length=1000)
     retry_policy: ActionRetryPolicy = Field(default_factory=ActionRetryPolicy)
     start_delay: float = Field(
         default=0.0, description="Delay before starting the action in seconds."
@@ -17,7 +21,7 @@ class ActionControlFlow(BaseModel):
 
 
 class ActionRead(BaseModel):
-    id: str
+    id: ActionID
     type: str
     title: str
     description: str
@@ -27,8 +31,8 @@ class ActionRead(BaseModel):
 
 
 class ActionReadMinimal(BaseModel):
-    id: str
-    workflow_id: str
+    id: ActionID
+    workflow_id: WorkflowID
     type: str
     title: str
     description: str
@@ -36,7 +40,7 @@ class ActionReadMinimal(BaseModel):
 
 
 class ActionCreate(BaseModel):
-    workflow_id: str
+    workflow_id: WorkflowID
     type: str
     title: str = Field(min_length=1, max_length=100)
 
@@ -47,3 +51,13 @@ class ActionUpdate(BaseModel):
     status: str | None = None
     inputs: dict[str, Any] | None = None
     control_flow: ActionControlFlow | None = None
+
+    @field_validator("inputs")
+    def validate_inputs(cls, v: dict[str, Any]) -> dict[str, Any]:
+        if len(orjson.dumps(v)) >= 10000:
+            raise PydanticCustomError(
+                "value_error.inputs_too_long",
+                "Inputs must be less than 10000 characters",
+                {"loc": ["inputs"]},
+            )
+        return v

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -78,7 +78,8 @@ class WorkflowUpdate(BaseModel):
 
 
 class WorkflowCreate(BaseModel):
-    title: str = Field(
+    title: str | None = Field(
+        default=None,
         min_length=3,
         max_length=100,
         description="Workflow title, between 3 and 100 characters",

--- a/tracecat/workflow/management/models.py
+++ b/tracecat/workflow/management/models.py
@@ -53,8 +53,17 @@ class WorkflowReadMinimal(BaseModel):
 
 
 class WorkflowUpdate(BaseModel):
-    title: str | None = None
-    description: str | None = None
+    title: str | None = Field(
+        default=None,
+        min_length=3,
+        max_length=100,
+        description="Workflow title, between 3 and 100 characters",
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=1000,
+        description="Optional workflow description, up to 1000 characters",
+    )
     status: Literal["online", "offline"] | None = None
     object: dict[str, Any] | None = None
     version: int | None = None
@@ -69,8 +78,16 @@ class WorkflowUpdate(BaseModel):
 
 
 class WorkflowCreate(BaseModel):
-    title: str | None = None
-    description: str | None = None
+    title: str = Field(
+        min_length=3,
+        max_length=100,
+        description="Workflow title, between 3 and 100 characters",
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=1000,
+        description="Optional workflow description, up to 1000 characters",
+    )
 
 
 class GetWorkflowDefinitionActivityInputs(BaseModel):

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -84,9 +84,9 @@ async def list_workflows(
 async def create_workflow(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
-    title: str | None = Form(None),
-    description: str | None = Form(None),
-    file: UploadFile | None = File(None),
+    title: str | None = Form(default=None, min_length=1, max_length=100),
+    description: str | None = Form(default=None, max_length=1000),
+    file: UploadFile | None = File(default=None),
 ) -> WorkflowReadMinimal:
     """Create a new Workflow.
 

--- a/tracecat/workspaces/models.py
+++ b/tracecat/workspaces/models.py
@@ -9,13 +9,13 @@ from tracecat.identifiers import OwnerID, UserID, WorkspaceID
 
 # Params
 class CreateWorkspaceParams(BaseModel):
-    name: str
+    name: str = Field(..., min_length=1, max_length=100)
     settings: dict[str, str] | None = None
     owner_id: OwnerID = Field(default=config.TRACECAT__DEFAULT_ORG_ID)
 
 
 class UpdateWorkspaceParams(BaseModel):
-    name: str | None = None
+    name: str | None = Field(default=None, min_length=1, max_length=100)
     settings: dict[str, str] | None = None
 
 


### PR DESCRIPTION
# Changes
- Make 422 unprocessible entity errors return an object with detail field: `{"detail": ...}`
- Tighten up input validation across FE zod schemas and API layer pydantic models
- Replace certain `Controller` fields with shadcn `FormField`

# Screens
![Screenshot 2025-01-11 at 00 05 37](https://github.com/user-attachments/assets/93a39d84-5b5d-4d29-8140-ac89c93c5171)

![Screenshot 2025-01-11 at 00 02 34](https://github.com/user-attachments/assets/b8e8e60b-ece7-4bb3-9e65-be92f0b858e0)

![Screenshot 2025-01-11 at 00 02 09](https://github.com/user-attachments/assets/011460ea-78dd-4a17-83d7-9b1cf4df38c2)
