### PR TITLE
security: Drop stack trace from failure message

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -84,10 +84,6 @@ export function WorkflowExecutionEventDetailView({
             <AccordionContent>
               <div className="my-4 flex flex-col space-y-8 px-4">
                 <CodeBlock title="Message">{event.failure.message}</CodeBlock>
-                <CodeBlock title="Stack Trace">
-                  {event.failure.stack_trace}
-                </CodeBlock>
-                <JsonViewWithControls src={event.failure} />
               </div>
             </AccordionContent>
           </AccordionItem>

--- a/tracecat/executor/models.py
+++ b/tracecat/executor/models.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import traceback
-from tracecat.config import TRACECAT__APP_ENV
 
 from pydantic import UUID4, BaseModel
+
+from tracecat.config import TRACECAT__APP_ENV
 
 
 class ExecutorSyncInput(BaseModel):

--- a/tracecat/executor/models.py
+++ b/tracecat/executor/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import traceback
+from tracecat.config import TRACECAT__APP_ENV
 
 from pydantic import UUID4, BaseModel
 
@@ -31,13 +32,16 @@ class ExecutorActionErrorInfo(BaseModel):
     """Line number where the error occurred."""
 
     def __str__(self) -> str:
-        return (
-            f"{self.type}: {self.message}"
-            f"\n\n{'-' * 30}"
-            f"\nFile: {self.filename}"
-            f"\nFunction: {self.function}"
-            f"\nLine: {self.lineno}"
-        )
+        if TRACECAT__APP_ENV == "development":
+            return (
+                f"{self.type}: {self.message}"
+                f"\n\n{'-' * 30}"
+                f"\nFile: {self.filename}"
+                f"\nFunction: {self.function}"
+                f"\nLine: {self.lineno}"
+            )
+        else:
+            return f"{self.type}: {self.message}"
 
     @staticmethod
     def from_exc(e: Exception, action_name: str) -> ExecutorActionErrorInfo:

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -226,9 +226,7 @@ class EventGroup(BaseModel, Generic[EventInput]):
 
 class EventFailure(BaseModel):
     message: str
-    stack_trace: str
     cause: dict[str, Any] | None = None
-    application_failure_info: dict[str, Any] = Field(default_factory=dict)
 
     @staticmethod
     def from_history_event(
@@ -254,9 +252,7 @@ class EventFailure(BaseModel):
 
         return EventFailure(
             message=failure.message,
-            stack_trace=failure.stack_trace,
             cause=MessageToDict(failure.cause) if failure.cause is not None else None,
-            application_failure_info=MessageToDict(failure.application_failure_info),
         )
 
 


### PR DESCRIPTION
## What changed
- Drop stack trace in failure handler
- Only show filename, function, and lineno in ExecutorActionErrorInfo if app env is "development"
- Also I think it's cleaner too from a UX perspective

<img width="1398" alt="Screenshot 2025-01-10 at 12 19 37 PM" src="https://github.com/user-attachments/assets/cbc0b569-de5d-4590-9a9c-a6052e8e74f6" />
