### PR TITLE
fix(app): Add fallback for org settings

### DIFF
--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -282,13 +282,12 @@ async def test_get_setting_shorthand(
     create_params: SettingCreate,
     svc_admin_role: Role,
 ) -> None:
-    """Test the get_setting shorthand function with and without roles."""
+    """Test the get_setting shorthand function with roles and defaults."""
     token = ctx_role.set(None)  # type: ignore
     assert ctx_role.get() is None, "Role should be cleared"
     try:
         # Create a test setting first
         curr_session = settings_service.session
-
         created_setting = await settings_service.create_org_setting(create_params)
 
         # Test with valid role (should return value)
@@ -303,11 +302,21 @@ async def test_get_setting_shorthand(
         )
         assert no_role_value is None
 
-        # Test retrieving non-existent setting
-        nonexistent_value = await get_setting(
+        # Test retrieving non-existent setting with default
+        default_value = {"default": "value"}
+        nonexistent_with_default = await get_setting(
+            "nonexistent-key",
+            role=svc_admin_role,
+            session=curr_session,
+            default=default_value,
+        )
+        assert nonexistent_with_default == default_value
+
+        # Test retrieving non-existent setting without default
+        nonexistent_no_default = await get_setting(
             "nonexistent-key", role=svc_admin_role, session=curr_session
         )
-        assert nonexistent_value is None
+        assert nonexistent_no_default is None
     finally:
         ctx_role.set(token)  # type: ignore
 

--- a/tracecat/api/executor.py
+++ b/tracecat/api/executor.py
@@ -47,7 +47,12 @@ async def setup_custom_remote_repository():
     3. If it does exist, sync it
     """
     role = bootstrap_role()
-    url = await get_setting("git_repo_url", role=role)
+    url = await get_setting(
+        "git_repo_url",
+        role=role,
+        # TODO: Deprecate in future version
+        default=config.TRACECAT__REMOTE_REPOSITORY_URL,
+    )
     if not url:
         logger.info("Remote repository URL not set, skipping")
         return

--- a/tracecat/auth/dependencies.py
+++ b/tracecat/auth/dependencies.py
@@ -40,6 +40,8 @@ async def verify_auth_type(auth_type: AuthType) -> None:
 
     # 2. Check that the setting is enabled
     key = AUTH_TYPE_TO_SETTING_KEY[auth_type]
+    # NOTE: These settings werek introduced after org settings implemented
+    # so no defaults required
     setting = await get_setting(key=key, role=bootstrap_role())
     if setting is None or not isinstance(setting, bool):
         raise HTTPException(

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -68,7 +68,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def validate_email(self, email: str) -> None:
         allowed_domains = cast(
             list[str] | None,
-            await get_setting("auth_allowed_email_domains", role=self.role),
+            await get_setting(
+                "auth_allowed_email_domains",
+                role=self.role,
+                # TODO: Deprecate in future version
+                default=list(config.TRACECAT__AUTH_ALLOWED_DOMAINS),
+            ),
         )
         validate_email(email=email, allowed_domains=allowed_domains)
 

--- a/tracecat/registry/common.py
+++ b/tracecat/registry/common.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from tracecat import config
 from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.registry.constants import (
@@ -45,7 +46,12 @@ async def reload_registry(session: AsyncSession, role: Role):
         logger.info("Custom repository already exists", origin=custom_origin)
 
     # Setup custom remote repository
-    if maybe_remote_url := await get_setting("git_repo_url", role=role):
+    if maybe_remote_url := await get_setting(
+        "git_repo_url",
+        role=role,
+        # TODO: Deprecate in future version
+        default=config.TRACECAT__REMOTE_REPOSITORY_URL,
+    ):
         remote_url = cast(str, maybe_remote_url)
         parsed_url = urlparse(remote_url)
         logger.info("Setting up remote registry repository", url=parsed_url)

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -248,7 +248,13 @@ class Repository:
 
         allowed_domains = cast(
             set[str],
-            await get_setting("git_allowed_domains", role=self.role) or {"github.com"},
+            await get_setting(
+                "git_allowed_domains",
+                role=self.role,
+                # TODO: Deprecate in future version
+                default=config.TRACECAT__ALLOWED_GIT_DOMAINS,
+            )
+            or {"github.com"},
         )
 
         try:
@@ -269,7 +275,13 @@ class Repository:
             branch=branch,
         )
         package_name = (
-            await get_setting("git_repo_package_name", role=self.role) or repo_name
+            await get_setting(
+                "git_repo_package_name",
+                role=self.role,
+                # TODO: Deprecate in future version
+                default=config.TRACECAT__REMOTE_REPOSITORY_PACKAGE_NAME,
+            )
+            or repo_name
         )
 
         cleaned_url = self.safe_remote_url(self._origin)

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -256,15 +256,23 @@ class SettingsService(BaseService):
 
 
 async def get_setting(
-    key: str, *, role: Role | None = None, session: AsyncSession | None = None
+    key: str,
+    *,
+    role: Role | None = None,
+    session: AsyncSession | None = None,
+    default: Any | None = None,
 ) -> Any | None:
     """Shorthand to get a setting value from the database."""
     if session:
         service = SettingsService(session=session, role=role)
         setting = await service.get_org_setting(key)
-        return service.get_value(setting) if setting else None
+        no_default_val = service.get_value(setting) if setting else None
 
     else:
         async with SettingsService.with_session(role=role) as service:
             setting = await service.get_org_setting(key)
-            return service.get_value(setting) if setting else None
+            no_default_val = service.get_value(setting) if setting else None
+
+    if no_default_val is None and default:
+        return default
+    return no_default_val


### PR DESCRIPTION
# Changes
- Add fallback to org settings `get_setting` as when users first move upgrade, they'll have empty configs in the db. We will fallback to the existing config variables to aid with the migration.