### PR TITLE
feat(ui): Add refetchInterval of 2s to useWorkflowExecutionEventHistory

### DIFF
--- a/frontend/src/components/executions/event-history.tsx
+++ b/frontend/src/components/executions/event-history.tsx
@@ -32,6 +32,8 @@ import "react18-json-view/src/style.css"
 
 import { ERROR_EVENT_TYPES, parseEventType } from "@/lib/event-history"
 
+const REFETCH_INTERVAL = 2000 // 2 seconds
+
 /**
  * Event history for a specific workflow execution
  * @param param0
@@ -47,7 +49,9 @@ export function WorkflowExecutionEventHistory({
   setSelectedEvent: (event: EventHistoryResponse) => void
 }) {
   const { eventHistory, eventHistoryLoading, eventHistoryError } =
-    useWorkflowExecutionEventHistory(executionId)
+    useWorkflowExecutionEventHistory(executionId, {
+      refetchInterval: REFETCH_INTERVAL,
+    })
 
   if (eventHistoryLoading) {
     return <CenteredSpinner />

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -446,6 +446,9 @@ export function useWorkspaceManager() {
 export function useWorkflowExecutions(
   workflowId: string,
   options?: {
+    /**
+     * Refetch interval in milliseconds
+     */
     refetchInterval?: number
   }
 ) {
@@ -470,7 +473,15 @@ export function useWorkflowExecutions(
   }
 }
 
-export function useWorkflowExecutionEventHistory(workflowExecutionId: string) {
+export function useWorkflowExecutionEventHistory(
+  workflowExecutionId: string,
+  options?: {
+    /**
+     * Refetch interval in milliseconds
+     */
+    refetchInterval?: number
+  }
+) {
   const { workspaceId } = useWorkspace()
   const {
     data: eventHistory,
@@ -483,6 +494,7 @@ export function useWorkflowExecutionEventHistory(workflowExecutionId: string) {
         workspaceId,
         executionId: workflowExecutionId,
       }),
+    ...options,
   })
   return {
     eventHistory,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -338,7 +338,7 @@ class WorkflowExecutionsService:
                         )
                     )
                 case _:
-                    logger.debug("Unhandled event type", event_type=event.event_type)
+                    logger.trace("Unhandled event type", event_type=event.event_type)
                     continue
         return events
 


### PR DESCRIPTION
# Changes
- Add 2s refetch to the events column (this was present in the runs column) so you don't have to spam refresh