### PR TITLE
refactor(app): Separate org secrets

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -963,10 +963,6 @@ export const $EventFailure = {
       type: "string",
       title: "Message",
     },
-    stack_trace: {
-      type: "string",
-      title: "Stack Trace",
-    },
     cause: {
       anyOf: [
         {
@@ -978,13 +974,9 @@ export const $EventFailure = {
       ],
       title: "Cause",
     },
-    application_failure_info: {
-      type: "object",
-      title: "Application Failure Info",
-    },
   },
   type: "object",
-  required: ["message", "stack_trace"],
+  required: ["message"],
   title: "EventFailure",
 } as const
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3171,22 +3171,6 @@ export const $SecretUpdate = {
       ],
       title: "Environment",
     },
-    level: {
-      anyOf: [
-        {
-          allOf: [
-            {
-              $ref: "#/components/schemas/tracecat__secrets__enums__SecretLevel__1",
-            },
-          ],
-          maxLength: 100,
-          minLength: 1,
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
   },
   type: "object",
   title: "SecretUpdate",
@@ -4729,16 +4713,4 @@ export const $login = {
   type: "object",
   required: ["username", "password"],
   title: "Body_auth-auth:database.login",
-} as const
-
-export const $tracecat__secrets__enums__SecretLevel__1 = {
-  type: "string",
-  enum: ["workspace", "organization"],
-  title: "SecretLevel",
-  description: "The level of a secret.",
-} as const
-
-export const $tracecat__secrets__enums__SecretLevel__2 = {
-  $ref: "#/components/schemas/tracecat__secrets__enums__SecretLevel__1",
-  minLength: 1,
 } as const

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -44,6 +44,16 @@ import type {
   OrganizationDeleteSessionResponse,
   OrganizationListOrgMembersResponse,
   OrganizationListSessionsResponse,
+  OrganizationSecretsCreateOrgSecretData,
+  OrganizationSecretsCreateOrgSecretResponse,
+  OrganizationSecretsDeleteOrgSecretByIdData,
+  OrganizationSecretsDeleteOrgSecretByIdResponse,
+  OrganizationSecretsGetOrgSecretByNameData,
+  OrganizationSecretsGetOrgSecretByNameResponse,
+  OrganizationSecretsListOrgSecretsData,
+  OrganizationSecretsListOrgSecretsResponse,
+  OrganizationSecretsUpdateOrgSecretByIdData,
+  OrganizationSecretsUpdateOrgSecretByIdResponse,
   OrganizationUpdateOrgMemberData,
   OrganizationUpdateOrgMemberResponse,
   PublicCheckHealthResponse,
@@ -1229,11 +1239,10 @@ export const workflowsRemoveTag = (
  * Search secrets.
  * @param data The data for the request.
  * @param data.environment
+ * @param data.workspaceId
  * @param data.name Filter by secret name
  * @param data.id Filter by secret ID
  * @param data.type Filter by secret type
- * @param data.level Filter by secret level
- * @param data.workspaceId
  * @returns SecretRead Successful Response
  * @throws ApiError
  */
@@ -1248,7 +1257,6 @@ export const secretsSearchSecrets = (
       name: data.name,
       id: data.id,
       type: data.type,
-      level: data.level,
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -1261,21 +1269,19 @@ export const secretsSearchSecrets = (
  * List Secrets
  * List user secrets.
  * @param data The data for the request.
- * @param data.type Filter by secret type
- * @param data.level Filter by secret level
  * @param data.workspaceId
+ * @param data.type Filter by secret type
  * @returns SecretReadMinimal Successful Response
  * @throws ApiError
  */
 export const secretsListSecrets = (
-  data: SecretsListSecretsData = {}
+  data: SecretsListSecretsData
 ): CancelablePromise<SecretsListSecretsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
     url: "/secrets",
     query: {
       type: data.type,
-      level: data.level,
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -1288,8 +1294,8 @@ export const secretsListSecrets = (
  * Create Secret
  * Create a secret.
  * @param data The data for the request.
- * @param data.requestBody
  * @param data.workspaceId
+ * @param data.requestBody
  * @returns unknown Successful Response
  * @throws ApiError
  */
@@ -1342,8 +1348,8 @@ export const secretsGetSecretByName = (
  * Update a secret by ID.
  * @param data The data for the request.
  * @param data.secretId
- * @param data.requestBody
  * @param data.workspaceId
+ * @param data.requestBody
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -2256,6 +2262,127 @@ export const settingsUpdateOauthSettings = (
     url: "/settings/oauth",
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Org Secrets
+ * List organization secrets.
+ * @param data The data for the request.
+ * @param data.type Filter by secret type
+ * @returns SecretReadMinimal Successful Response
+ * @throws ApiError
+ */
+export const organizationSecretsListOrgSecrets = (
+  data: OrganizationSecretsListOrgSecretsData = {}
+): CancelablePromise<OrganizationSecretsListOrgSecretsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/organization/secrets",
+    query: {
+      type: data.type,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Org Secret
+ * Create an organization secret.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const organizationSecretsCreateOrgSecret = (
+  data: OrganizationSecretsCreateOrgSecretData
+): CancelablePromise<OrganizationSecretsCreateOrgSecretResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/organization/secrets",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Org Secret By Name
+ * Get an organization secret by name.
+ * @param data The data for the request.
+ * @param data.secretName
+ * @param data.environment
+ * @returns SecretRead Successful Response
+ * @throws ApiError
+ */
+export const organizationSecretsGetOrgSecretByName = (
+  data: OrganizationSecretsGetOrgSecretByNameData
+): CancelablePromise<OrganizationSecretsGetOrgSecretByNameResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/organization/secrets/{secret_name}",
+    path: {
+      secret_name: data.secretName,
+    },
+    query: {
+      environment: data.environment,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Org Secret By Id
+ * Update an organization secret by ID.
+ * @param data The data for the request.
+ * @param data.secretId
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const organizationSecretsUpdateOrgSecretById = (
+  data: OrganizationSecretsUpdateOrgSecretByIdData
+): CancelablePromise<OrganizationSecretsUpdateOrgSecretByIdResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/organization/secrets/{secret_id}",
+    path: {
+      secret_id: data.secretId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Org Secret By Id
+ * Delete an organization secret by ID.
+ * @param data The data for the request.
+ * @param data.secretId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const organizationSecretsDeleteOrgSecretById = (
+  data: OrganizationSecretsDeleteOrgSecretByIdData
+): CancelablePromise<OrganizationSecretsDeleteOrgSecretByIdResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/organization/secrets/{secret_id}",
+    path: {
+      secret_id: data.secretId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1006,7 +1006,6 @@ export type SecretUpdate = {
     [key: string]: string
   } | null
   environment?: string | null
-  level?: tracecat__secrets__enums__SecretLevel__1 | null
 }
 
 export type SessionRead = {
@@ -1411,16 +1410,6 @@ export type login = {
   client_id?: string | null
   client_secret?: string | null
 }
-
-/**
- * The level of a secret.
- */
-export type tracecat__secrets__enums__SecretLevel__1 =
-  | "workspace"
-  | "organization"
-
-export type tracecat__secrets__enums__SecretLevel__2 =
-  tracecat__secrets__enums__SecretLevel__1
 
 export type PublicIncomingWebhookData = {
   contentType?: string | null

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1714,10 +1714,6 @@ export type SecretsSearchSecretsData = {
    */
   id?: Array<string> | null
   /**
-   * Filter by secret level
-   */
-  level?: Array<tracecat__secrets__enums__SecretLevel__1> | null
-  /**
    * Filter by secret name
    */
   name?: Array<string> | null
@@ -1725,35 +1721,31 @@ export type SecretsSearchSecretsData = {
    * Filter by secret type
    */
   type?: Array<SecretType> | null
-  workspaceId?: string | null
+  workspaceId: string
 }
 
 export type SecretsSearchSecretsResponse = Array<SecretRead>
 
 export type SecretsListSecretsData = {
   /**
-   * Filter by secret level
-   */
-  level?: tracecat__secrets__enums__SecretLevel__1
-  /**
    * Filter by secret type
    */
   type?: Array<SecretType> | null
-  workspaceId?: string | null
+  workspaceId: string
 }
 
 export type SecretsListSecretsResponse = Array<SecretReadMinimal>
 
 export type SecretsCreateSecretData = {
   requestBody: SecretCreate
-  workspaceId?: string | null
+  workspaceId: string
 }
 
 export type SecretsCreateSecretResponse = unknown
 
 export type SecretsGetSecretByNameData = {
   secretName: string
-  workspaceId?: string | null
+  workspaceId: string
 }
 
 export type SecretsGetSecretByNameResponse = SecretRead
@@ -1761,14 +1753,14 @@ export type SecretsGetSecretByNameResponse = SecretRead
 export type SecretsUpdateSecretByIdData = {
   requestBody: SecretUpdate
   secretId: string
-  workspaceId?: string | null
+  workspaceId: string
 }
 
 export type SecretsUpdateSecretByIdResponse = void
 
 export type SecretsDeleteSecretByIdData = {
   secretId: string
-  workspaceId?: string | null
+  workspaceId: string
 }
 
 export type SecretsDeleteSecretByIdResponse = void
@@ -1998,6 +1990,41 @@ export type SettingsUpdateOauthSettingsData = {
 }
 
 export type SettingsUpdateOauthSettingsResponse = void
+
+export type OrganizationSecretsListOrgSecretsData = {
+  /**
+   * Filter by secret type
+   */
+  type?: Array<SecretType> | null
+}
+
+export type OrganizationSecretsListOrgSecretsResponse = Array<SecretReadMinimal>
+
+export type OrganizationSecretsCreateOrgSecretData = {
+  requestBody: SecretCreate
+}
+
+export type OrganizationSecretsCreateOrgSecretResponse = unknown
+
+export type OrganizationSecretsGetOrgSecretByNameData = {
+  environment?: string | null
+  secretName: string
+}
+
+export type OrganizationSecretsGetOrgSecretByNameResponse = SecretRead
+
+export type OrganizationSecretsUpdateOrgSecretByIdData = {
+  requestBody: SecretUpdate
+  secretId: string
+}
+
+export type OrganizationSecretsUpdateOrgSecretByIdResponse = void
+
+export type OrganizationSecretsDeleteOrgSecretByIdData = {
+  secretId: string
+}
+
+export type OrganizationSecretsDeleteOrgSecretByIdResponse = void
 
 export type UsersUsersCurrentUserResponse = UserRead
 
@@ -3220,6 +3247,77 @@ export type $OpenApiTs = {
     }
     patch: {
       req: SettingsUpdateOauthSettingsData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/secrets": {
+    get: {
+      req: OrganizationSecretsListOrgSecretsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<SecretReadMinimal>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: OrganizationSecretsCreateOrgSecretData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: unknown
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/secrets/{secret_name}": {
+    get: {
+      req: OrganizationSecretsGetOrgSecretByNameData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: SecretRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/secrets/{secret_id}": {
+    post: {
+      req: OrganizationSecretsUpdateOrgSecretByIdData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: OrganizationSecretsDeleteOrgSecretByIdData
       res: {
         /**
          * Successful Response

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -334,13 +334,9 @@ export type ErrorModel = {
 
 export type EventFailure = {
   message: string
-  stack_trace: string
   cause?: {
     [key: string]: unknown
   } | null
-  application_failure_info?: {
-    [key: string]: unknown
-  }
 }
 
 export type EventGroup = {
@@ -1738,7 +1734,7 @@ export type SecretsListSecretsData = {
   /**
    * Filter by secret level
    */
-  level?: tracecat__secrets__enums__SecretLevel__1 | null
+  level?: tracecat__secrets__enums__SecretLevel__1
   /**
    * Filter by secret type
    */

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -17,6 +17,10 @@ import {
   OrganizationDeleteSessionData,
   organizationListOrgMembers,
   organizationListSessions,
+  organizationSecretsCreateOrgSecret,
+  organizationSecretsDeleteOrgSecretById,
+  organizationSecretsListOrgSecrets,
+  organizationSecretsUpdateOrgSecretById,
   organizationUpdateOrgMember,
   OrganizationUpdateOrgMemberData,
   OrgMemberRead,
@@ -606,7 +610,6 @@ export function useWorkspaceSecrets() {
     queryFn: async () =>
       await secretsListSecrets({
         workspaceId,
-        level: "workspace",
         type: ["custom"],
       }),
   })
@@ -715,8 +718,7 @@ export function useOrgSecrets() {
   } = useQuery<SecretReadMinimal[]>({
     queryKey: ["org-custom-secrets"],
     queryFn: async () =>
-      await secretsListSecrets({
-        level: "organization",
+      await organizationSecretsListOrgSecrets({
         type: ["custom"],
       }),
   })
@@ -729,8 +731,7 @@ export function useOrgSecrets() {
   } = useQuery<SecretReadMinimal[]>({
     queryKey: ["org-ssh-keys"],
     queryFn: async () =>
-      await secretsListSecrets({
-        level: "organization",
+      await organizationSecretsListOrgSecrets({
         type: ["ssh-key"],
       }),
   })
@@ -738,7 +739,7 @@ export function useOrgSecrets() {
   // create
   const { mutateAsync: createSecret } = useMutation({
     mutationFn: async (params: SecretCreate) =>
-      await secretsCreateSecret({ requestBody: params }),
+      await organizationSecretsCreateOrgSecret({ requestBody: params }),
     onSuccess: (_, variables) => {
       switch (variables.type) {
         case "ssh-key":
@@ -766,7 +767,11 @@ export function useOrgSecrets() {
     }: {
       secretId: string
       params: SecretUpdate
-    }) => await secretsUpdateSecretById({ secretId, requestBody: params }),
+    }) =>
+      await organizationSecretsUpdateOrgSecretById({
+        secretId,
+        requestBody: params,
+      }),
     onSuccess: (_, variables) => {
       switch (variables.params.type) {
         case "ssh-key":
@@ -789,7 +794,7 @@ export function useOrgSecrets() {
   // delete
   const { mutateAsync: deleteSecretById } = useMutation({
     mutationFn: async (secret: SecretReadMinimal) =>
-      await secretsDeleteSecretById({ secretId: secret.id }),
+      await organizationSecretsDeleteOrgSecretById({ secretId: secret.id }),
     onSuccess: (_, variables) => {
       switch (variables.type) {
         case "ssh-key":

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -130,8 +130,8 @@ async def test_executor_can_run_udf_with_secrets(
         # Assert
         assert result == "__SECRET_VALUE_UDF__"
     finally:
-        secret = await sec_service.get_secret_by_name("test", raise_on_error=True)
-        await sec_service.delete_secret_by_id(secret.id)
+        secret = await sec_service.get_secret_by_name("test")
+        await sec_service.delete_secret(secret)
 
 
 @pytest.mark.integration
@@ -233,8 +233,8 @@ async def test_executor_can_run_template_action_with_secret(
         # Assert
         assert result == "__SECRET_VALUE__"
     finally:
-        secret = await sec_service.get_secret_by_name("test", raise_on_error=True)
-        await sec_service.delete_secret_by_id(secret.id)
+        secret = await sec_service.get_secret_by_name("test")
+        await sec_service.delete_secret(secret)
 
 
 async def mock_action(input: Any, **kwargs):

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -38,6 +38,7 @@ from tracecat.organization.router import router as org_router
 from tracecat.registry.actions.router import router as registry_actions_router
 from tracecat.registry.common import reload_registry
 from tracecat.registry.repositories.router import router as registry_repos_router
+from tracecat.secrets.router import org_router as org_secrets_router
 from tracecat.secrets.router import router as secrets_router
 from tracecat.settings.router import router as org_settings_router
 from tracecat.settings.service import SettingsService
@@ -165,6 +166,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(registry_repos_router)
     app.include_router(registry_actions_router)
     app.include_router(org_settings_router)
+    app.include_router(org_secrets_router)
     app.include_router(
         fastapi_users.get_users_router(UserRead, UserUpdate),
         prefix="/users",

--- a/tracecat/secrets/enums.py
+++ b/tracecat/secrets/enums.py
@@ -1,13 +1,6 @@
 from enum import StrEnum
 
 
-class SecretLevel(StrEnum):
-    """The level of a secret."""
-
-    WORKSPACE = "workspace"
-    ORGANIZATION = "organization"
-
-
 class SecretType(StrEnum):
     """The type of a secret."""
 

--- a/tracecat/secrets/models.py
+++ b/tracecat/secrets/models.py
@@ -16,7 +16,7 @@ from pydantic import (
 from tracecat.db.schemas import BaseSecret
 from tracecat.identifiers import OwnerID, SecretID
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
-from tracecat.secrets.enums import SecretLevel, SecretType
+from tracecat.secrets.enums import SecretType
 
 SecretName = Annotated[str, StringConstraints(pattern=r"[a-z0-9_]+")]
 """Validator for a secret name. e.g. 'aws_access_key_id'"""
@@ -126,7 +126,6 @@ class SecretUpdate(BaseModel):
     )
     tags: dict[str, str] | None = Field(default=None, min_length=0, max_length=1000)
     environment: str | None = Field(default=None, min_length=1, max_length=100)
-    level: SecretLevel | None = Field(default=None, min_length=1, max_length=100)
 
 
 class SecretSearch(BaseModel):
@@ -135,7 +134,6 @@ class SecretSearch(BaseModel):
     environment: str
     owner_ids: set[UUID] | None = None
     types: set[SecretType] | None = None
-    levels: set[SecretLevel] | None = None
 
 
 class SecretReadMinimal(BaseModel):

--- a/tracecat/secrets/router.py
+++ b/tracecat/secrets/router.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
@@ -7,7 +7,7 @@ from tracecat.auth.credentials import RoleACL
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers import SecretID
 from tracecat.logger import logger
-from tracecat.secrets.enums import SecretLevel, SecretType
+from tracecat.secrets.enums import SecretType
 from tracecat.secrets.models import (
     SecretCreate,
     SecretRead,
@@ -19,21 +19,34 @@ from tracecat.secrets.service import SecretsService
 from tracecat.types.auth import AccessLevel, Role
 from tracecat.types.exceptions import TracecatNotFoundError
 
-router = APIRouter(prefix="/secrets")
+router = APIRouter(prefix="/secrets", tags=["secrets"])
+org_router = APIRouter(prefix="/organization/secrets", tags=["organization-secrets"])
 
-
-@router.get("/search", tags=["secrets"], response_model=list[SecretRead])
-async def search_secrets(
-    *,
-    # If workspace_id is passed here, it signals that the user wishes to search inside a workspace
-    # If this dependency passes, the user is authorized to access the workspace secrets
-    # The role returned indicates the scope of resources that the user can access
-    role: Role = RoleACL(
+WorkspaceAdminUser = Annotated[
+    Role,
+    RoleACL(
         allow_user=True,
         allow_service=False,
-        require_workspace="optional",
+        require_workspace="yes",
         min_access_level=AccessLevel.ADMIN,
     ),
+]
+
+OrgAdminUser = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="no",
+        min_access_level=AccessLevel.ADMIN,
+    ),
+]
+
+
+@router.get("/search", response_model=list[SecretRead])
+async def search_secrets(
+    *,
+    role: WorkspaceAdminUser,
     session: AsyncDBSession,
     environment: str = Query(...),
     names: set[str] | None = Query(
@@ -45,18 +58,8 @@ async def search_secrets(
     types: set[SecretType] | None = Query(
         None, alias="type", description="Filter by secret type"
     ),
-    levels: set[SecretLevel] | None = Query(
-        None, alias="level", description="Filter by secret level"
-    ),
 ) -> list[SecretRead]:
     """Search secrets."""
-    if not role.workspace_id and (
-        levels and any(lv == SecretLevel.WORKSPACE for lv in levels)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="This role is cannot access workspace secrets",
-        )
     service = SecretsService(session, role=role)
     params: dict[str, Any] = {"environment": environment}
     if names:
@@ -65,8 +68,6 @@ async def search_secrets(
         params["ids"] = ids
     if types:
         params["types"] = types
-    if levels:
-        params["levels"] = levels
     secrets = await service.search_secrets(SecretSearch(**params))
     decrypted = []
     for secret in secrets:
@@ -74,37 +75,18 @@ async def search_secrets(
     return [SecretRead.from_database(secret) for secret in secrets]
 
 
-@router.get("", tags=["secrets"])
+@router.get("")
 async def list_secrets(
     *,
-    role: Role = RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="optional",
-        min_access_level=AccessLevel.ADMIN,
-    ),
+    role: WorkspaceAdminUser,
     session: AsyncDBSession,
-    # Visibility is determined by the role ACL.
-    # Filters on returned secrets. This is separate from the visibility
     types: set[SecretType] | None = Query(
         None, alias="type", description="Filter by secret type"
-    ),
-    level: SecretLevel = Query(
-        SecretLevel.WORKSPACE, description="Filter by secret level"
     ),
 ) -> list[SecretReadMinimal]:
     """List user secrets."""
     service = SecretsService(session, role=role)
-
-    match level:
-        case SecretLevel.WORKSPACE:
-            secrets = await service.list_secrets(types=types)
-        case SecretLevel.ORGANIZATION:
-            secrets = await service.list_org_secrets(types=types)
-        case _:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid level"
-            )
+    secrets = await service.list_secrets(types=types)
     return [
         SecretReadMinimal(
             id=secret.id,
@@ -118,15 +100,10 @@ async def list_secrets(
     ]
 
 
-@router.get("/{secret_name}", tags=["secrets"])
+@router.get("/{secret_name}")
 async def get_secret_by_name(
     *,
-    role: Role = RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="optional",
-        min_access_level=AccessLevel.ADMIN,
-    ),
+    role: WorkspaceAdminUser,
     session: AsyncDBSession,
     secret_name: str,
 ) -> SecretRead:
@@ -139,20 +116,13 @@ async def get_secret_by_name(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Secret not found"
         ) from e
-    # NOTE: IMPLICIT TYPE COERCION
-    # Encrypted keys as bytes gets cast a string as to be JSON serializable
     return SecretRead.from_database(secret)
 
 
-@router.post("", status_code=status.HTTP_201_CREATED, tags=["secrets"])
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def create_secret(
     *,
-    role: Role = RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="optional",
-        min_access_level=AccessLevel.ADMIN,
-    ),
+    role: WorkspaceAdminUser,
     session: AsyncDBSession,
     params: SecretCreate,
 ) -> None:
@@ -168,15 +138,10 @@ async def create_secret(
         ) from e
 
 
-@router.post("/{secret_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["secrets"])
+@router.post("/{secret_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def update_secret_by_id(
     *,
-    role: Role = RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="optional",
-        min_access_level=AccessLevel.ADMIN,
-    ),
+    role: WorkspaceAdminUser,
     session: AsyncDBSession,
     secret_id: SecretID,
     params: SecretUpdate,
@@ -198,15 +163,10 @@ async def update_secret_by_id(
         ) from e
 
 
-@router.delete("/{secret_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["secrets"])
+@router.delete("/{secret_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_secret_by_id(
     *,
-    role: Role = RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="optional",
-        min_access_level=AccessLevel.ADMIN,
-    ),
+    role: WorkspaceAdminUser,
     session: AsyncDBSession,
     secret_id: SecretID,
 ) -> None:
@@ -219,4 +179,121 @@ async def delete_secret_by_id(
         logger.info(f"Secret {secret_id=} not found")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Secret does not exist"
+        ) from e
+
+
+@org_router.get("")
+async def list_org_secrets(
+    *,
+    role: OrgAdminUser,
+    session: AsyncDBSession,
+    types: set[SecretType] | None = Query(
+        None, alias="type", description="Filter by secret type"
+    ),
+) -> list[SecretReadMinimal]:
+    """List organization secrets."""
+    service = SecretsService(session, role=role)
+    secrets = await service.list_org_secrets(types=types)
+    return [
+        SecretReadMinimal(
+            id=secret.id,
+            type=SecretType(secret.type),
+            name=secret.name,
+            description=secret.description,
+            keys=[kv.key for kv in service.decrypt_keys(secret.encrypted_keys)],
+            environment=secret.environment,
+        )
+        for secret in secrets
+    ]
+
+
+@org_router.get("/{secret_name}")
+async def get_org_secret_by_name(
+    *,
+    role: OrgAdminUser,
+    session: AsyncDBSession,
+    secret_name: str,
+    environment: str | None = Query(None),
+) -> SecretRead:
+    """Get an organization secret by name."""
+    service = SecretsService(session, role=role)
+    try:
+        secret = await service.get_org_secret_by_name(secret_name, environment)
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization secret not found",
+        ) from e
+    return SecretRead.from_database(secret)
+
+
+@org_router.post("", status_code=status.HTTP_201_CREATED)
+async def create_org_secret(
+    *,
+    role: OrgAdminUser,
+    session: AsyncDBSession,
+    params: SecretCreate,
+) -> None:
+    """Create an organization secret."""
+    service = SecretsService(session, role=role)
+    try:
+        await service.create_org_secret(params)
+    except IntegrityError as e:
+        logger.error("Organization secret integrity error", e=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Organization secret creation integrity error: {e!r}",
+        ) from e
+
+
+@org_router.post(
+    "/{secret_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def update_org_secret_by_id(
+    *,
+    role: OrgAdminUser,
+    session: AsyncDBSession,
+    secret_id: SecretID,
+    params: SecretUpdate,
+) -> None:
+    """Update an organization secret by ID."""
+    service = SecretsService(session, role)
+    try:
+        secret = await service.get_org_secret(secret_id)
+        await service.update_org_secret(secret, params)
+    except TracecatNotFoundError as e:
+        logger.error("Organization secret not found", secret_id=secret_id)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization secret does not exist",
+        ) from e
+    except IntegrityError as e:
+        logger.info("Organization secret already exists", secret_id=secret_id)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Organization secret already exists",
+        ) from e
+
+
+@org_router.delete(
+    "/{secret_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_org_secret_by_id(
+    *,
+    role: OrgAdminUser,
+    session: AsyncDBSession,
+    secret_id: SecretID,
+) -> None:
+    """Delete an organization secret by ID."""
+    service = SecretsService(session, role=role)
+    try:
+        secret = await service.get_org_secret(secret_id)
+        await service.delete_org_secret(secret)
+    except TracecatNotFoundError as e:
+        logger.info(f"Organization secret {secret_id=} not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization secret does not exist",
         ) from e

--- a/tracecat/secrets/router.py
+++ b/tracecat/secrets/router.py
@@ -1,5 +1,7 @@
+from typing import Any
+
 from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.exc import IntegrityError
 
 from tracecat.auth.credentials import RoleACL
 from tracecat.db.dependencies import AsyncDBSession
@@ -15,6 +17,7 @@ from tracecat.secrets.models import (
 )
 from tracecat.secrets.service import SecretsService
 from tracecat.types.auth import AccessLevel, Role
+from tracecat.types.exceptions import TracecatNotFoundError
 
 router = APIRouter(prefix="/secrets")
 
@@ -33,16 +36,16 @@ async def search_secrets(
     ),
     session: AsyncDBSession,
     environment: str = Query(...),
-    names: list[str] | None = Query(
+    names: set[str] | None = Query(
         None, alias="name", description="Filter by secret name"
     ),
-    ids: list[SecretID] | None = Query(
+    ids: set[SecretID] | None = Query(
         None, alias="id", description="Filter by secret ID"
     ),
-    types: list[SecretType] | None = Query(
+    types: set[SecretType] | None = Query(
         None, alias="type", description="Filter by secret type"
     ),
-    levels: list[SecretLevel] | None = Query(
+    levels: set[SecretLevel] | None = Query(
         None, alias="level", description="Filter by secret level"
     ),
 ) -> list[SecretRead]:
@@ -55,15 +58,15 @@ async def search_secrets(
             detail="This role is cannot access workspace secrets",
         )
     service = SecretsService(session, role=role)
-    params = {"environment": environment}
+    params: dict[str, Any] = {"environment": environment}
     if names:
-        params["names"] = set(names or ())
+        params["names"] = names
     if ids:
-        params["ids"] = set(ids or ())
+        params["ids"] = ids
     if types:
-        params["types"] = set(types or ())
+        params["types"] = types
     if levels:
-        params["levels"] = set(levels or ())
+        params["levels"] = levels
     secrets = await service.search_secrets(SecretSearch(**params))
     decrypted = []
     for secret in secrets:
@@ -83,22 +86,21 @@ async def list_secrets(
     session: AsyncDBSession,
     # Visibility is determined by the role ACL.
     # Filters on returned secrets. This is separate from the visibility
-    types: list[SecretType] | None = Query(
+    types: set[SecretType] | None = Query(
         None, alias="type", description="Filter by secret type"
     ),
-    level: SecretLevel | None = Query(None, description="Filter by secret level"),
+    level: SecretLevel = Query(
+        SecretLevel.WORKSPACE, description="Filter by secret level"
+    ),
 ) -> list[SecretReadMinimal]:
     """List user secrets."""
     service = SecretsService(session, role=role)
 
-    types = set(types) if types else None
     match level:
         case SecretLevel.WORKSPACE:
-            secrets = await service.list_workspace_secrets(types=types)
-        case SecretLevel.ORGANIZATION:
-            secrets = await service.list_organization_secrets(types=types)
-        case None:
             secrets = await service.list_secrets(types=types)
+        case SecretLevel.ORGANIZATION:
+            secrets = await service.list_org_secrets(types=types)
         case _:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid level"
@@ -106,7 +108,7 @@ async def list_secrets(
     return [
         SecretReadMinimal(
             id=secret.id,
-            type=secret.type,
+            type=SecretType(secret.type),
             name=secret.name,
             description=secret.description,
             keys=[kv.key for kv in service.decrypt_keys(secret.encrypted_keys)],
@@ -131,11 +133,12 @@ async def get_secret_by_name(
     """Get a secret."""
 
     service = SecretsService(session, role=role)
-    secret = await service.get_secret_by_name(secret_name)
-    if secret is None:
+    try:
+        secret = await service.get_secret_by_name(secret_name)
+    except TracecatNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Secret not found"
-        )
+        ) from e
     # NOTE: IMPLICIT TYPE COERCION
     # Encrypted keys as bytes gets cast a string as to be JSON serializable
     return SecretRead.from_database(secret)
@@ -181,8 +184,9 @@ async def update_secret_by_id(
     """Update a secret by ID."""
     service = SecretsService(session, role)
     try:
-        await service.update_secret_by_id(secret_id=secret_id, params=params)
-    except NoResultFound as e:
+        secret = await service.get_secret(secret_id)
+        await service.update_secret(secret, params)
+    except TracecatNotFoundError as e:
         logger.error("Secret not found", secret_id=secret_id)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Secret does not exist"
@@ -209,8 +213,9 @@ async def delete_secret_by_id(
     """Delete a secret by ID."""
     service = SecretsService(session, role=role)
     try:
-        await service.delete_secret_by_id(secret_id)
-    except NoResultFound as e:
+        secret = await service.get_secret(secret_id)
+        await service.delete_secret(secret)
+    except TracecatNotFoundError as e:
         logger.info(f"Secret {secret_id=} not found")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Secret does not exist"

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import os
 from collections.abc import Sequence
-from itertools import chain
-from typing import Literal, overload
 
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlmodel import col, select
@@ -14,6 +12,7 @@ from tracecat.db.schemas import BaseSecret, OrganizationSecret, Secret
 from tracecat.identifiers import SecretID
 from tracecat.logger import logger
 from tracecat.registry.constants import GIT_SSH_KEY_SECRET_NAME
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.secrets.encryption import decrypt_keyvalues, encrypt_keyvalues
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.models import (
@@ -24,7 +23,7 @@ from tracecat.secrets.models import (
 )
 from tracecat.service import BaseService
 from tracecat.types.auth import Role
-from tracecat.types.exceptions import TracecatNotFoundError
+from tracecat.types.exceptions import TracecatAuthorizationError, TracecatNotFoundError
 
 
 class SecretsService(BaseService):
@@ -39,7 +38,18 @@ class SecretsService(BaseService):
         except KeyError as e:
             raise KeyError("TRACECAT__DB_ENCRYPTION_KEY is not set") from e
 
+    def decrypt_keys(self, encrypted_keys: bytes) -> list[SecretKeyValue]:
+        """Decrypt and return the keys for a secret."""
+        return decrypt_keyvalues(encrypted_keys, key=self._encryption_key)
+
+    def encrypt_keys(self, keys: list[SecretKeyValue]) -> bytes:
+        """Encrypt and return the keys for a secret."""
+        return encrypt_keyvalues(keys, key=self._encryption_key)
+
+    # === Base secrets ===
+
     async def _update_secret(self, secret: BaseSecret, params: SecretUpdate) -> None:
+        """Update a base secret."""
         set_fields = params.model_dump(exclude_unset=True)
         # Handle keys separately
         if keys := set_fields.pop("keys", None):
@@ -54,57 +64,29 @@ class SecretsService(BaseService):
         await self.session.commit()
 
     async def _delete_secret(self, secret: BaseSecret) -> None:
-        """Delete a secret by name."""
+        """Delete a base secret."""
         await self.session.delete(secret)
         await self.session.commit()
 
-    async def list_workspace_secrets(
-        self, *, types: set[SecretType] | None = None
-    ) -> Sequence[Secret]:
-        statement = select(Secret).where(Secret.owner_id == self.role.workspace_id)
-        if types:
-            types_set = set(types)
-            statement = statement.where(Secret.type.in_(types_set))  # type: ignore
-        result = await self.session.exec(statement)
-        return result.all()
+    # === Workspace secrets ===
 
     async def list_secrets(
         self, *, types: set[SecretType] | None = None
-    ) -> Sequence[BaseSecret]:
-        """List secrets.
+    ) -> Sequence[Secret]:
+        """List all workspace secrets."""
 
-        Visibility
-        ---------
-        - If no workspace ID is set, list only the organization secrets.
-        """
-        org_secrets = await self.list_organization_secrets(types=types)
+        statement = select(Secret).where(Secret.owner_id == self.role.workspace_id)
+        if types:
+            statement = statement.where(col(Secret.type).in_(types))
+        result = await self.session.exec(statement)
+        return result.all()
 
-        if self.role.workspace_id is not None:
-            workspace_secrets = await self.list_workspace_secrets(types=types)
-        else:
-            workspace_secrets = []
+    async def get_secret(self, secret_id: SecretID) -> Secret:
+        """Get a workspace secret by ID."""
 
-        # Combine and return the results
-        secrets = list(chain(org_secrets, workspace_secrets))
-        self.logger.warning("Listed secrets", secrets=secrets)
-        return secrets
-
-    @overload
-    async def get_secret_by_id(
-        self, secret_id: str, raise_on_error: Literal[True]
-    ) -> BaseSecret: ...
-
-    @overload
-    async def get_secret_by_id(
-        self, secret_id: str, raise_on_error: Literal[False]
-    ) -> BaseSecret | None: ...
-
-    async def get_secret_by_id(
-        self, secret_id: SecretID, raise_on_error: bool = False
-    ) -> BaseSecret | None:
-        owner_id, secret_cls = self._get_secret_owner_and_cls()
-        statement = select(secret_cls).where(
-            secret_cls.owner_id == owner_id, secret_cls.id == secret_id
+        statement = select(Secret).where(
+            Secret.owner_id == self.role.workspace_id,
+            Secret.id == secret_id,
         )
         result = await self.session.exec(statement)
         try:
@@ -113,107 +95,56 @@ class SecretsService(BaseService):
             logger.error(
                 "Multiple secrets found",
                 secret_id=secret_id,
-                owner_id=owner_id,
-                cls=secret_cls,
+                owner_id=self.role.workspace_id,
             )
-            if raise_on_error:
-                raise MultipleResultsFound(
-                    "Multiple secrets found when searching by ID"
-                ) from e
+            raise TracecatNotFoundError(
+                "Multiple secrets found when searching by ID"
+            ) from e
         except NoResultFound as e:
             logger.error(
                 "Secret not found",
                 secret_id=secret_id,
-                owner_id=owner_id,
-                cls=secret_cls,
+                owner_id=self.role.workspace_id,
             )
-            if raise_on_error:
-                raise NoResultFound(
-                    "Secret not found when searching by ID. Please check that the ID was correctly input."
-                ) from e
-        return None
-
-    @overload
-    async def get_secret_by_name(
-        self,
-        secret_name: str,
-        raise_on_error: Literal[True],
-        environment: str | None = None,
-    ) -> BaseSecret: ...
-
-    @overload
-    async def get_secret_by_name(
-        self,
-        secret_name: str,
-        raise_on_error: Literal[False],
-        environment: str | None = None,
-    ) -> BaseSecret | None: ...
+            raise TracecatNotFoundError(
+                "Secret not found when searching by ID. Please check that the ID was correctly input."
+            ) from e
 
     async def get_secret_by_name(
         self,
         secret_name: str,
-        raise_on_error: bool = False,
         environment: str | None = None,
-    ) -> BaseSecret | None:
-        """
-        Retrieve a secret by its name.
+    ) -> Secret:
+        """Get a workspace secret by name."""
 
-        Parameters
-        ----------
-        secret_name : str
-            The name of the secret to retrieve.
-        raise_on_error : bool, optional
-            If True, raise exceptions for multiple results or no results found.
-            Default is False.
-        environment : str | None, optional
-            The environment to filter the secret search. If None, search across
-            all environments. Default is None.
-
-        Returns
-        -------
-        Secret | None
-            The retrieved Secret object if found, None otherwise.
-
-        Raises
-        ------
-        MultipleResultsFound
-            If multiple secrets are found and raise_on_error is True.
-        NoResultFound
-            If no secret is found and raise_on_error is True.
-
-        Notes
-        -----
-        This method queries the database for a secret with the given name
-        and optionally filters by environment. It handles cases where
-        multiple secrets or no secrets are found based on the raise_on_error flag.
-        """
-        owner_id, secret_cls = self._get_secret_owner_and_cls()
-        statement = select(secret_cls).where(
-            secret_cls.owner_id == owner_id,
-            secret_cls.name == secret_name,
+        statement = select(Secret).where(
+            Secret.owner_id == self.role.workspace_id,
+            Secret.name == secret_name,
         )
         if environment:
-            statement = statement.where(secret_cls.environment == environment)
+            statement = statement.where(Secret.environment == environment)
         result = await self.session.exec(statement)
         try:
             return result.one()
         except MultipleResultsFound as e:
-            if raise_on_error:
-                raise MultipleResultsFound(
-                    "Multiple secrets found when searching by name."
-                    f" Expected one secret {secret_name!r} (env: {environment!r}) only."
-                ) from e
+            raise TracecatNotFoundError(
+                "Multiple secrets found when searching by name."
+                f" Expected one secret {secret_name!r} (env: {environment!r}) only."
+            ) from e
         except NoResultFound as e:
-            if raise_on_error:
-                raise NoResultFound(
-                    f"Secret {secret_name!r} (env: {environment!r}) not found when searching by name."
-                    " Please double check that the name was correctly input."
-                ) from e
-        return None
+            raise TracecatNotFoundError(
+                f"Secret {secret_name!r} (env: {environment!r}) not found when searching by name."
+                " Please double check that the name was correctly input."
+            ) from e
 
     async def create_secret(self, params: SecretCreate) -> None:
-        owner_id, secret_cls = self._get_secret_owner_and_cls()
-        secret = secret_cls(
+        """Create a workspace secret."""
+        owner_id = self.role.workspace_id
+        if owner_id is None:
+            raise TracecatAuthorizationError(
+                "Workspace ID is required to create a secret in a workspace"
+            )
+        secret = Secret(
             owner_id=owner_id,
             name=params.name,
             type=params.type,
@@ -225,54 +156,93 @@ class SecretsService(BaseService):
         self.session.add(secret)
         await self.session.commit()
 
-    async def update_secret_by_name(
-        self, secret_name: str, params: SecretUpdate
-    ) -> None:
-        secret = await self.get_secret_by_name(secret_name, raise_on_error=True)
+    async def update_secret(self, secret: Secret, params: SecretUpdate) -> None:
+        """Update a workspace secret."""
+
         await self._update_secret(secret=secret, params=params)
 
-    async def update_secret_by_id(
-        self, secret_id: SecretID, params: SecretUpdate
-    ) -> None:
-        secret = await self.get_secret_by_id(secret_id, raise_on_error=True)
-        await self._update_secret(secret=secret, params=params)
+    async def delete_secret(self, secret: Secret) -> None:
+        """Delete a workspace secret."""
 
-    async def delete_secret_by_id(self, secret_id: SecretID) -> None:
-        secret = await self.get_secret_by_id(secret_id, raise_on_error=True)
         await self._delete_secret(secret)
 
-    def decrypt_keys(self, encrypted_keys: bytes) -> list[SecretKeyValue]:
-        """Decrypt and return the keys for a secret."""
-        return decrypt_keyvalues(encrypted_keys, key=self._encryption_key)
-
-    def encrypt_keys(self, keys: list[SecretKeyValue]) -> bytes:
-        """Encrypt and return the keys for a secret."""
-        return encrypt_keyvalues(keys, key=self._encryption_key)
-
-    async def search_secrets(self, params: SecretSearch) -> Sequence[BaseSecret]:
-        """Search secrets by name."""
+    async def search_secrets(self, params: SecretSearch) -> Sequence[Secret]:
+        """Search workspace secrets."""
         if not any((params.ids, params.names, params.environment)):
             return []
 
-        owner_id, secret_cls = self._get_secret_owner_and_cls()
-        statement = select(secret_cls).where(secret_cls.owner_id == owner_id)
+        owner_id = self.role.workspace_id
+        if owner_id is None:
+            raise TracecatAuthorizationError(
+                "Unauthorized to search secrets for organization secrets"
+            )
+        stmt = select(Secret).where(Secret.owner_id == owner_id)
         fields = params.model_dump(exclude_unset=True)
         self.logger.info("Searching secrets", set_fields=fields)
 
         if ids := fields.get("ids"):
-            statement = statement.where(col(secret_cls.id).in_(ids))
+            stmt = stmt.where(col(Secret.id).in_(ids))
         if names := fields.get("names"):
-            statement = statement.where(col(secret_cls.name).in_(names))
+            stmt = stmt.where(col(Secret.name).in_(names))
         if "environment" in fields:
-            statement = statement.where(secret_cls.environment == fields["environment"])
+            stmt = stmt.where(Secret.environment == fields["environment"])
 
-        result = await self.session.exec(statement)
+        result = await self.session.exec(stmt)
         return result.all()
 
-    """Organization secrets"""
+    # === Organization secrets ===
 
-    async def create_organization_secret(self, params: SecretCreate) -> None:
-        """Create a new organization-wide secret."""
+    async def list_org_secrets(
+        self, *, types: set[SecretType] | None = None
+    ) -> Sequence[OrganizationSecret]:
+        """List all organization secrets."""
+
+        stmt = select(OrganizationSecret).where(
+            OrganizationSecret.owner_id == config.TRACECAT__DEFAULT_ORG_ID
+        )
+        if types:
+            stmt = stmt.where(col(OrganizationSecret.type).in_(types))
+        result = await self.session.exec(stmt)
+        return result.all()
+
+    async def get_org_secret(self, secret_id: SecretID) -> OrganizationSecret:
+        """Get an organization secret by ID."""
+
+        statement = select(OrganizationSecret).where(
+            OrganizationSecret.owner_id == config.TRACECAT__DEFAULT_ORG_ID,
+            OrganizationSecret.id == secret_id,
+        )
+        result = await self.session.exec(statement)
+        return result.one()
+
+    async def get_org_secret_by_name(
+        self,
+        secret_name: str,
+        environment: str | None = None,
+    ) -> OrganizationSecret:
+        """Retrieve an organization-wide secret by its name."""
+        environment = environment or DEFAULT_SECRETS_ENVIRONMENT
+        statement = select(OrganizationSecret).where(
+            OrganizationSecret.owner_id == config.TRACECAT__DEFAULT_ORG_ID,
+            OrganizationSecret.name == secret_name,
+            OrganizationSecret.environment == environment,
+        )
+        result = await self.session.exec(statement)
+        try:
+            return result.one()
+        except MultipleResultsFound as e:
+            raise TracecatNotFoundError(
+                "Multiple organization secrets found when searching by name."
+                f" Expected one secret {secret_name!r} (env: {environment!r}) only."
+            ) from e
+        except NoResultFound as e:
+            raise TracecatNotFoundError(
+                f"Organization secret {secret_name!r} (env: {environment!r}) not found when searching by name."
+                " Please double check that the name was correctly input."
+            ) from e
+
+    async def create_org_secret(self, params: SecretCreate) -> None:
+        """Create a new organization secret."""
         secret = OrganizationSecret(
             owner_id=config.TRACECAT__DEFAULT_ORG_ID,
             name=params.name,
@@ -285,79 +255,25 @@ class SecretsService(BaseService):
         self.session.add(secret)
         await self.session.commit()
 
-    async def get_organization_secret_by_name(
-        self,
-        secret_name: str,
-        raise_on_error: bool = False,
-        environment: str | None = None,
-    ) -> OrganizationSecret | None:
-        """Retrieve an organization-wide secret by its name."""
-        statement = select(OrganizationSecret).where(
-            OrganizationSecret.owner_id == config.TRACECAT__DEFAULT_ORG_ID,
-            OrganizationSecret.name == secret_name,
-        )
-        if environment:
-            statement = statement.where(OrganizationSecret.environment == environment)
-        result = await self.session.exec(statement)
-        try:
-            return result.one()
-        except MultipleResultsFound as e:
-            if raise_on_error:
-                raise MultipleResultsFound(
-                    "Multiple organization secrets found when searching by name."
-                    f" Expected one secret {secret_name!r} (env: {environment!r}) only."
-                ) from e
-        except NoResultFound as e:
-            if raise_on_error:
-                raise NoResultFound(
-                    f"Organization secret {secret_name!r} (env: {environment!r}) not found when searching by name."
-                    " Please double check that the name was correctly input."
-                ) from e
-        return None
-
-    async def update_organization_secret_by_name(
-        self, secret_name: str, params: SecretUpdate
+    async def update_org_secret(
+        self, secret: OrganizationSecret, params: SecretUpdate
     ) -> None:
-        """Update an organization-wide secret by its name."""
-        secret = await self.get_organization_secret_by_name(
-            secret_name, raise_on_error=True
-        )
         await self._update_secret(secret=secret, params=params)
 
-    # Delete
-    async def delete_organization_secret_by_name(self, secret_name: str) -> None:
-        """Delete an organization-wide secret by its name."""
-        secret = await self.get_organization_secret_by_name(
-            secret_name, raise_on_error=True
-        )
-        await self._delete_secret(secret)
-
-    async def list_organization_secrets(
-        self, *, types: set[SecretType] | None = None
-    ) -> Sequence[OrganizationSecret]:
-        """List all organization-wide secrets."""
-        statement = select(OrganizationSecret).where(
-            OrganizationSecret.owner_id == config.TRACECAT__DEFAULT_ORG_ID
-        )
-        if types:
-            statement = statement.where(OrganizationSecret.type.in_(types))
-        result = await self.session.exec(statement)
-        return result.all()
-
-    def _get_secret_owner_and_cls(self) -> tuple[int, type[BaseSecret]]:
-        if self.role.workspace_id is not None:
-            return self.role.workspace_id, Secret
-        return config.TRACECAT__DEFAULT_ORG_ID, OrganizationSecret
+    async def delete_org_secret(self, org_secret: OrganizationSecret) -> None:
+        await self._delete_secret(org_secret)
 
     async def get_ssh_key(
-        self, key_name: str = GIT_SSH_KEY_SECRET_NAME
+        self,
+        key_name: str = GIT_SSH_KEY_SECRET_NAME,
+        environment: str | None = None,
     ) -> SecretKeyValue:
         # NOTE: Don't set the workspace_id, as we want to search for
         # organization secrets if it's not set.
         logger.info("Getting SSH key", key_name=key_name, role=self.role)
         try:
-            secret = await self.get_secret_by_name(key_name, raise_on_error=True)
-        except NoResultFound as e:
+            secret = await self.get_org_secret_by_name(key_name, environment)
+        except TracecatNotFoundError as e:
             raise TracecatNotFoundError(
                 f"SSH key {key_name} not found. Please check whether this key exists.\n\n"
                 " If not, please create a key in your organization's credentials page and try again."

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -46,7 +46,6 @@ async def validate_single_secret(
     try:
         defined_secret = await secrets_service.get_secret_by_name(
             registry_secret.name,
-            raise_on_error=True,
             environment=environment,
         )
     except (NoResultFound, MultipleResultsFound) as e:


### PR DESCRIPTION
# Motivation
Separate out org secrets service methods and routers from workspace secrets. Note that they are currently stored in separate tables.

It's better security wise to keep these separate and prevents careless mistakes.

# Changes
- Remove overloads from secrets service methods
- Remove `SecretLevel`
- Separate org secrets methods in secrets service
- Separate org secrets routers
- Use separate `RoleACL` for ws/org secret routers

# Testing
Regular secrets usage works
Push/pull repos works