### PR TITLE
feat(app): Setting env override

### DIFF
--- a/deployments/aws/ecs/locals.tf
+++ b/deployments/aws/ecs/locals.tf
@@ -48,6 +48,7 @@ locals {
       TRACECAT__APP_ENV                        = var.tracecat_app_env
       TRACECAT__AUTH_ALLOWED_DOMAINS           = var.auth_allowed_domains
       TRACECAT__AUTH_TYPES                     = var.auth_types
+      TRACECAT__SETTING_OVERRIDE_SAML_ENABLED  = var.setting_override_saml_enabled
       TRACECAT__DB_ENDPOINT                    = local.core_db_hostname
       TRACECAT__EXECUTOR_URL                   = local.internal_executor_url
       TRACECAT__PUBLIC_API_URL                 = local.public_api_url

--- a/deployments/aws/ecs/variables.tf
+++ b/deployments/aws/ecs/variables.tf
@@ -77,6 +77,11 @@ variable "auth_allowed_domains" {
   description = "Comma separated list of allowed domains for authentication (e.g. `acme.com,acme.ai`)"
   default     = null
 }
+variable "setting_override_saml_enabled" {
+  type        = string
+  description = "Override the SAML setting"
+  default     = null
+}
 
 ### Images and Versions
 

--- a/deployments/aws/main.tf
+++ b/deployments/aws/main.tf
@@ -74,8 +74,9 @@ module "ecs" {
   tracecat_signing_secret_arn    = var.tracecat_signing_secret_arn
 
   # Authentication
-  auth_types           = var.auth_types
-  auth_allowed_domains = var.auth_allowed_domains
+  auth_types                    = var.auth_types
+  auth_allowed_domains          = var.auth_allowed_domains
+  setting_override_saml_enabled = var.setting_override_saml_enabled
 
   # OAuth
   oauth_client_id_arn     = var.oauth_client_id_arn

--- a/deployments/aws/variables.tf
+++ b/deployments/aws/variables.tf
@@ -43,6 +43,14 @@ variable "auth_allowed_domains" {
   default     = null
 }
 
+
+variable "setting_override_saml_enabled" {
+  type        = string
+  description = "Override the SAML setting"
+  default     = null
+}
+
+
 ### Images and Versions
 
 variable "tracecat_image" {

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -41,7 +41,7 @@ from tracecat.registry.repositories.router import router as registry_repos_route
 from tracecat.secrets.router import org_router as org_secrets_router
 from tracecat.secrets.router import router as secrets_router
 from tracecat.settings.router import router as org_settings_router
-from tracecat.settings.service import SettingsService
+from tracecat.settings.service import SettingsService, get_setting_override
 from tracecat.tags.router import router as tags_router
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatException
@@ -283,6 +283,8 @@ async def info(session: AsyncDBSession) -> AppInfo:
     service = SettingsService(session, role=bootstrap_role())
     settings = await service.list_org_settings(keys=keys)
     keyvalues = {s.key: service.get_value(s) for s in settings}
+    for key in keys:
+        keyvalues[key] = get_setting_override(key) or keyvalues[key]
     return AppInfo(
         public_app_url=config.TRACECAT__PUBLIC_APP_URL,
         auth_allowed_types=list(config.TRACECAT__AUTH_TYPES),


### PR DESCRIPTION
There are certain use cases where it's handy to be able to override a setting from the outside. For example, when bootstrapping an instance or getting locked out because none of the auth settings are activated.