### PR TITLE
Load monaco editor from npm package not cdn

### DIFF
--- a/frontend/src/components/editor/editor.tsx
+++ b/frontend/src/components/editor/editor.tsx
@@ -3,10 +3,12 @@
 import { useEffect } from "react"
 import { EditorFunctionRead, editorListFunctions } from "@/client"
 import {
-  EditorProps,
+  loader,
   Editor as ReactMonacoEditor,
+  type EditorProps,
   type Monaco,
 } from "@monaco-editor/react"
+import * as monaco from "monaco-editor"
 import { editor, IDisposable, IRange, languages } from "monaco-editor"
 
 import { cn } from "@/lib/utils"
@@ -32,6 +34,8 @@ import {
   language as yamlLanguage,
 } from "@/components/editor/yaml-lang"
 import { CenteredSpinner } from "@/components/loading/spinner"
+
+loader.config({ monaco })
 
 const constructDslLang = (): {
   conf: languages.LanguageConfiguration


### PR DESCRIPTION
# Resources
- https://github.com/suren-atoyan/monaco-react/issues/217
- https://github.com/suren-atoyan/monaco-react/issues/217#issuecomment-1080391893
- https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#loader-config
- https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#use-monaco-editor-as-an-npm-package