### PR TITLE
feat(engine): Basic implementation for pull-based executor and remove internal executor endpoints

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -78,8 +78,6 @@ import type {
   RegistryRepositoriesGetRegistryRepositoryResponse,
   RegistryRepositoriesListRegistryRepositoriesResponse,
   RegistryRepositoriesReloadRegistryRepositoriesResponse,
-  RegistryRepositoriesSyncExecutorFromRegistryRepositoryData,
-  RegistryRepositoriesSyncExecutorFromRegistryRepositoryResponse,
   RegistryRepositoriesSyncRegistryRepositoryData,
   RegistryRepositoriesSyncRegistryRepositoryResponse,
   RegistryRepositoriesUpdateRegistryRepositoryData,
@@ -1885,28 +1883,6 @@ export const registryRepositoriesSyncRegistryRepository = (
   return __request(OpenAPI, {
     method: "POST",
     url: "/registry/repos/{repository_id}/sync",
-    path: {
-      repository_id: data.repositoryId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Sync Executor From Registry Repository
- * @param data The data for the request.
- * @param data.repositoryId
- * @returns void Successful Response
- * @throws ApiError
- */
-export const registryRepositoriesSyncExecutorFromRegistryRepository = (
-  data: RegistryRepositoriesSyncExecutorFromRegistryRepositoryData
-): CancelablePromise<RegistryRepositoriesSyncExecutorFromRegistryRepositoryResponse> => {
-  return __request(OpenAPI, {
-    method: "POST",
-    url: "/registry/repos/{repository_id}/sync-executor",
     path: {
       repository_id: data.repositoryId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1884,13 +1884,6 @@ export type RegistryRepositoriesSyncRegistryRepositoryData = {
 
 export type RegistryRepositoriesSyncRegistryRepositoryResponse = void
 
-export type RegistryRepositoriesSyncExecutorFromRegistryRepositoryData = {
-  repositoryId: string
-}
-
-export type RegistryRepositoriesSyncExecutorFromRegistryRepositoryResponse =
-  void
-
 export type RegistryRepositoriesListRegistryRepositoriesResponse =
   Array<RegistryRepositoryReadMinimal>
 
@@ -3003,21 +2996,6 @@ export type $OpenApiTs = {
   "/registry/repos/{repository_id}/sync": {
     post: {
       req: RegistryRepositoriesSyncRegistryRepositoryData
-      res: {
-        /**
-         * Successful Response
-         */
-        204: void
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/registry/repos/{repository_id}/sync-executor": {
-    post: {
-      req: RegistryRepositoriesSyncExecutorFromRegistryRepositoryData
       res: {
         /**
          * Successful Response

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -37,8 +37,6 @@ import {
   RegistryRepositoriesDeleteRegistryRepositoryData,
   registryRepositoriesListRegistryRepositories,
   registryRepositoriesReloadRegistryRepositories,
-  registryRepositoriesSyncExecutorFromRegistryRepository,
-  RegistryRepositoriesSyncExecutorFromRegistryRepositoryData,
   registryRepositoriesSyncRegistryRepository,
   RegistryRepositoriesSyncRegistryRepositoryData,
   RegistryRepositoryReadMinimal,
@@ -1159,40 +1157,6 @@ export function useRegistryRepositories() {
     },
   })
 
-  const {
-    mutateAsync: syncExecutor,
-    isPending: syncExecutorIsPending,
-    error: syncExecutorError,
-  } = useMutation({
-    mutationFn: async (
-      params: RegistryRepositoriesSyncExecutorFromRegistryRepositoryData
-    ) => await registryRepositoriesSyncExecutorFromRegistryRepository(params),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["registry_repositories"] })
-      queryClient.invalidateQueries({ queryKey: ["registry_actions"] })
-      toast({
-        title: "Synced executor",
-        description: "Executor synced successfully.",
-      })
-    },
-    onError: (error: TracecatApiError) => {
-      const apiError = error as TracecatApiError
-      switch (apiError.status) {
-        case 403:
-          toast({
-            title: "You cannot perform this action",
-            description: `${apiError.message}: ${apiError.body.detail}`,
-          })
-          break
-        default:
-          toast({
-            title: "Failed to sync executor",
-            description: `An unexpected error occurred while syncing the executor. ${apiError.message}: ${apiError.body.detail}`,
-          })
-      }
-    },
-  })
-
   return {
     repos,
     reposIsLoading,
@@ -1203,9 +1167,6 @@ export function useRegistryRepositories() {
     deleteRepo,
     deleteRepoIsPending,
     deleteRepoError,
-    syncExecutor,
-    syncExecutorIsPending,
-    syncExecutorError,
   }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "alembic==1.13.2",
     "asyncpg==0.29.0",
     "authlib>=1.3.1,<1.4.0",
+    "async-lru==2.0.4",
     "cloudpickle==3.0.0",
     "colorlog==6.8.2",
     "cryptography==43.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "tenacity==8.3.0",
     "uv==0.4.10",
     "uvicorn==0.29.0",
+    "virtualenv==20.27.0",
 ]
 dynamic = ["version"]
 

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -1,0 +1,145 @@
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tracecat.dsl.models import ActionStatement, RunActionInput, RunContext
+from tracecat.executor.models import DispatchActionContext
+from tracecat.executor.service import _dispatch_action, dispatch_action_on_cluster
+from tracecat.expressions.common import ExprContext
+from tracecat.git import GitUrl
+from tracecat.types.auth import Role
+
+
+@pytest.fixture
+def mock_session():
+    return AsyncMock()
+
+
+@pytest.fixture
+def basic_task_input():
+    """Fixture that provides a basic RunActionInput without looping."""
+    wf_id = "wf-" + uuid.uuid4().hex
+    wf_exec_id = wf_id + ":exec-test"
+    wf_run_id = uuid.uuid4()
+    return RunActionInput(
+        task=ActionStatement(
+            action="test_action",
+            args={"key": "value"},
+            ref="test_ref",
+        ),
+        exec_context={
+            ExprContext.ACTIONS: {
+                "test_action": {
+                    "args": {"key": "value"},
+                    "ref": "test-ref",
+                }
+            }
+        },
+        run_context=RunContext(
+            wf_id=wf_id,
+            wf_exec_id=wf_exec_id,
+            wf_run_id=wf_run_id,
+            environment="test-env",
+        ),
+    )
+
+
+@pytest.fixture
+def basic_looped_task_input():
+    wf_id = "wf-" + uuid.uuid4().hex
+    wf_exec_id = wf_id + ":exec-test"
+    wf_run_id = uuid.uuid4()
+    return RunActionInput(
+        task=ActionStatement(
+            action="test_action",
+            args={"key": "value"},
+            ref="test_ref",
+            for_each="${{ for var.x in [1,2,3] }}",
+        ),
+        exec_context={
+            ExprContext.ACTIONS: {
+                "test_action": {
+                    "args": {"key": "value"},
+                    "ref": "test-ref",
+                }
+            }
+        },
+        run_context=RunContext(
+            wf_id=wf_id,
+            wf_exec_id=wf_exec_id,
+            wf_run_id=wf_run_id,
+            environment="test-env",
+        ),
+    )
+
+
+@pytest.fixture
+def dispatch_context():
+    return DispatchActionContext(
+        role=Role(type="service", service_id="tracecat-executor"),
+        ssh_command="ssh -i /tmp/key",
+        git_url=GitUrl(host="github.com", org="org", repo="repo", ref="abc123"),
+    )
+
+
+@pytest.mark.anyio
+async def test_dispatch_action_basic(mock_session, basic_task_input, dispatch_context):
+    with patch("tracecat.executor.service.run_action_on_ray_cluster") as mock_ray:
+        mock_ray.return_value = {"result": "success"}
+
+        result = await _dispatch_action(input=basic_task_input, ctx=dispatch_context)
+
+        assert result == {"result": "success"}
+        mock_ray.assert_called_once_with(basic_task_input, dispatch_context)
+
+
+@pytest.mark.anyio
+async def test_dispatch_action_with_foreach(
+    mock_session, basic_looped_task_input, dispatch_context
+):
+    with patch("tracecat.executor.service.run_action_on_ray_cluster") as mock_ray:
+        mock_ray.return_value = {"result": "success"}
+
+        result = await _dispatch_action(
+            input=basic_looped_task_input, ctx=dispatch_context
+        )
+
+        assert result == [{"result": "success"}] * 3
+
+        # Assert the number of calls
+        assert mock_ray.call_count == 3
+
+        # Get all calls and their arguments
+        calls = mock_ray.call_args_list
+
+        # Verify each call's arguments
+        for i, call in enumerate(calls, 1):
+            args, kwargs = call
+            input_arg = args[0]
+            # Verify the loop variable 'x' was set to different values (1, 2, 3)
+            assert input_arg.task.args["key"] == "value"
+            assert input_arg.exec_context[ExprContext.LOCAL_VARS] == {"x": i}
+            assert args[1] == dispatch_context
+
+
+@pytest.mark.anyio
+async def test_dispatch_action_with_git_url(mock_session, basic_task_input):
+    with (
+        patch("tracecat.executor.service.prepare_git_url") as mock_git_url,
+        patch("tracecat.executor.service._dispatch_action") as mock_dispatch,
+        patch("tracecat.executor.service.opt_temp_key_file") as mock_key_file,
+    ):
+        mock_git_url.return_value = GitUrl(
+            host="github.com", org="org", repo="repo", ref="abc123"
+        )
+        mock_key_file.return_value.__aenter__.return_value = "ssh -i /tmp/key"
+        mock_dispatch.return_value = {"result": "success"}
+
+        result = await dispatch_action_on_cluster(
+            input=basic_task_input, session=mock_session
+        )
+
+        assert result == {"result": "success"}
+        mock_git_url.assert_called_once()
+        mock_key_file.return_value.__aenter__.assert_called_once()

--- a/tracecat/api/executor.py
+++ b/tracecat/api/executor.py
@@ -6,7 +6,6 @@ from fastapi.responses import ORJSONResponse
 
 from tracecat import config
 from tracecat.api.common import (
-    bootstrap_role,
     custom_generate_unique_id,
     generic_exception_handler,
     setup_oss_models,
@@ -16,9 +15,6 @@ from tracecat.executor.engine import setup_ray
 from tracecat.executor.router import router as executor_router
 from tracecat.logger import logger
 from tracecat.middleware import RequestLoggingMiddleware
-from tracecat.registry.repositories.service import RegistryReposService
-from tracecat.registry.repository import Repository
-from tracecat.settings.service import get_setting
 from tracecat.types.exceptions import TracecatException
 
 
@@ -28,47 +24,8 @@ async def lifespan(app: FastAPI):
         await setup_oss_models()
     except Exception as e:
         logger.error("Failed to preload OSS models", error=e)
-    try:
-        await setup_custom_remote_repository()
-    except Exception as e:
-        logger.error("Error setting up custom remote repository", exc=e)
-
     with setup_ray():
         yield
-
-
-async def setup_custom_remote_repository():
-    """Install the remote repository if it is set.
-
-    Steps
-    -----
-    1. Get the SHA of the remote repository from the DB
-    2. If it doesn't exist, create it
-    3. If it does exist, sync it
-    """
-    role = bootstrap_role()
-    url = await get_setting(
-        "git_repo_url",
-        role=role,
-        # TODO: Deprecate in future version
-        default=config.TRACECAT__REMOTE_REPOSITORY_URL,
-    )
-    if not url:
-        logger.info("Remote repository URL not set, skipping")
-        return
-    logger.info("Remote repository URL found", url=url)
-    async with RegistryReposService.with_session(role) as service:
-        db_repo = await service.get_repository(url)
-        # If it doesn't exist, do nothing
-        if db_repo is None:
-            logger.warning("Remote repository not found in DB, skipping")
-            return
-        # If it does exist, sync it
-        if db_repo.last_synced_at is None:
-            logger.info("Remote repository not synced, skipping")
-            return
-        repo = Repository(db_repo.origin, role=role)
-        await repo.load_from_origin(commit_sha=db_repo.commit_sha)
 
 
 def create_app(**kwargs) -> FastAPI:

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Annotated, Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, Field
 
 from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.expressions.common import ExprContext
-from tracecat.expressions.validation import ExpressionStr, TemplateValidator
+from tracecat.expressions.validation import ExpressionStr
 from tracecat.identifiers import WorkflowExecutionID, WorkflowID, WorkflowRunID
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 
@@ -94,20 +94,13 @@ class ActionStatement(BaseModel):
 
     """Control flow options"""
 
-    run_if: Annotated[
-        str | None,
-        Field(default=None, description="Condition to run the task"),
-        TemplateValidator(),
-    ]
-
-    for_each: Annotated[
-        str | list[str] | None,
-        Field(
-            default=None,
-            description="Iterate over a list of items and run the task for each item.",
-        ),
-        TemplateValidator(),
-    ]
+    run_if: ExpressionStr | None = Field(
+        default=None, description="Condition to run the task"
+    )
+    for_each: ExpressionStr | list[ExpressionStr] | None = Field(
+        default=None,
+        description="Iterate over a list of items and run the task for each item.",
+    )
     retry_policy: ActionRetryPolicy = Field(
         default_factory=ActionRetryPolicy, description="Retry policy for the action."
     )

--- a/tracecat/executor/models.py
+++ b/tracecat/executor/models.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import traceback
+from dataclasses import dataclass
 
 from pydantic import UUID4, BaseModel
 
 from tracecat.config import TRACECAT__APP_ENV
+from tracecat.git import GitUrl
+from tracecat.types.auth import Role
 
 
 class ExecutorSyncInput(BaseModel):
@@ -56,3 +59,10 @@ class ExecutorActionErrorInfo(BaseModel):
             function=tb.name,
             lineno=tb.lineno,
         )
+
+
+@dataclass
+class DispatchActionContext:
+    role: Role
+    ssh_command: str | None = None
+    git_url: GitUrl | None = None

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -331,7 +331,7 @@ async def run_action_on_ray_cluster(
     if ctx.git_url and ctx.git_url.ref:
         url = ctx.git_url.to_url()
         additional_vars["pip"] = [url]
-        logger.info("Adding git URL to runtime env", git_url=ctx.git_url, url=url)
+        logger.trace("Adding git URL to runtime env", git_url=ctx.git_url, url=url)
 
     runtime_env = RuntimeEnv(env_vars=env_vars, **additional_vars)
 
@@ -386,7 +386,7 @@ async def dispatch_action_on_cluster(
     role = ctx_role.get()
 
     async with opt_temp_key_file(git_url=git_url, session=session) as ssh_command:
-        logger.info("SSH command", ssh_command=ssh_command)
+        logger.trace("SSH command", ssh_command=ssh_command)
         ctx = DispatchActionContext(role=role, git_url=git_url, ssh_command=ssh_command)
         result = await _dispatch_action(input=input, ctx=ctx)
     return result

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -1,8 +1,3 @@
-"""Functions for executing actions and templates.
-
-NOTE: This is only used in the API server, not the worker
-"""
-
 from __future__ import annotations
 
 import asyncio
@@ -13,6 +8,8 @@ from typing import Any, cast
 import ray
 import uvloop
 from ray.exceptions import RayTaskError
+from ray.runtime_env import RuntimeEnv
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat import config
 from tracecat.auth.sandbox import AuthSandbox
@@ -27,22 +24,22 @@ from tracecat.dsl.models import (
     RunActionInput,
 )
 from tracecat.executor.engine import EXECUTION_TIMEOUT
-from tracecat.executor.models import ExecutorActionErrorInfo
+from tracecat.executor.models import DispatchActionContext, ExecutorActionErrorInfo
 from tracecat.expressions.common import ExprContext, ExprOperand
 from tracecat.expressions.eval import (
     eval_templated_object,
     extract_templated_secrets,
     get_iterables_from_expression,
 )
+from tracecat.git import GitUrl, prepare_git_url
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
-from tracecat.registry.actions.models import (
-    BoundRegistryAction,
-)
+from tracecat.registry.actions.models import BoundRegistryAction
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets.common import apply_masks_object
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.secrets.secrets_manager import env_sandbox
+from tracecat.ssh import opt_temp_key_file
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatException, WrappedExecutionError
 
@@ -319,15 +316,27 @@ def run_action_task(input: RunActionInput, role: Role) -> ExecutionResult:
 
 
 async def run_action_on_ray_cluster(
-    input: RunActionInput, role: Role
+    input: RunActionInput, ctx: DispatchActionContext
 ) -> ExecutionResult:
     """Run an action on the ray cluster.
 
     If any exceptions are thrown here, they're platform level errors.
     All application/user level errors are caught by the executor and returned as values.
     """
+    # Initialize runtime environment variables
+    env_vars = {"GIT_SSH_COMMAND": ctx.ssh_command} if ctx.ssh_command else {}
+    additional_vars: dict[str, Any] = {}
 
-    obj_ref = run_action_task.remote(input, role)
+    # Add git URL to pip dependencies if SHA is present
+    if ctx.git_url and ctx.git_url.ref:
+        url = ctx.git_url.to_url()
+        additional_vars["pip"] = [url]
+        logger.info("Adding git URL to runtime env", git_url=ctx.git_url, url=url)
+
+    runtime_env = RuntimeEnv(env_vars=env_vars, **additional_vars)
+
+    logger.info("Running action on ray cluster", runtime_env=runtime_env)
+    obj_ref = run_action_task.options(runtime_env=runtime_env).remote(input, ctx.role)
     try:
         coro = asyncio.to_thread(ray.get, obj_ref)
         exec_result = await asyncio.wait_for(coro, timeout=EXECUTION_TIMEOUT)
@@ -349,7 +358,12 @@ async def run_action_on_ray_cluster(
     return exec_result
 
 
-async def dispatch_action_on_cluster(input: RunActionInput, role: Role) -> Any:
+async def dispatch_action_on_cluster(
+    input: RunActionInput,
+    *,
+    session: AsyncSession,
+    git_url: GitUrl | None = None,
+) -> Any:
     """Schedule actions on the ray cluster.
 
     This function handles dispatching actions to be executed on a Ray cluster. It supports
@@ -358,7 +372,7 @@ async def dispatch_action_on_cluster(input: RunActionInput, role: Role) -> Any:
     Args:
         input: The RunActionInput containing the task definition and execution context
         role: The Role used for authorization
-
+        git_url: The Git URL to use for the action
     Returns:
         Any: For single actions, returns the ExecutionResult. For for_each loops, returns
              a list of results from all parallel executions.
@@ -367,12 +381,26 @@ async def dispatch_action_on_cluster(input: RunActionInput, role: Role) -> Any:
         TracecatException: If there are errors evaluating for_each expressions or during execution
         ExecutorErrorWrapper: If there are errors from the executor itself
     """
+    git_url = await prepare_git_url()
 
+    role = ctx_role.get()
+
+    async with opt_temp_key_file(git_url=git_url, session=session) as ssh_command:
+        logger.info("SSH command", ssh_command=ssh_command)
+        ctx = DispatchActionContext(role=role, git_url=git_url, ssh_command=ssh_command)
+        result = await _dispatch_action(input=input, ctx=ctx)
+    return result
+
+
+async def _dispatch_action(
+    input: RunActionInput,
+    ctx: DispatchActionContext,
+) -> Any:
     task = input.task
-
+    logger.info("Preparing runtime environment", ctx=ctx)
     # If there's no for_each, execute normally
     if not task.for_each:
-        return await run_action_on_ray_cluster(input, role)
+        return await run_action_on_ray_cluster(input, ctx)
 
     logger.info("Running for_each on action in parallel", action=task.action)
 
@@ -383,7 +411,7 @@ async def dispatch_action_on_cluster(input: RunActionInput, role: Role) -> Any:
     iterators = get_iterables_from_expression(expr=task.for_each, operand=base_context)
 
     async def coro(patched_input: RunActionInput):
-        return await run_action_on_ray_cluster(patched_input, role)
+        return await run_action_on_ray_cluster(patched_input, ctx)
 
     try:
         async with GatheringTaskGroup() as tg:

--- a/tracecat/git.py
+++ b/tracecat/git.py
@@ -7,7 +7,7 @@ from tracecat import config
 from tracecat.contexts import ctx_role
 from tracecat.logger import logger
 from tracecat.registry.repositories.service import RegistryReposService
-from tracecat.settings.service import get_setting
+from tracecat.settings.service import get_setting_cached
 from tracecat.ssh import SshEnv
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatSettingsError
@@ -111,7 +111,7 @@ async def prepare_git_url(role: Role | None = None) -> GitUrl | None:
     role = role or ctx_role.get()
 
     # Handle the git repo
-    url = await get_setting(
+    url = await get_setting_cached(
         "git_repo_url",
         # TODO: Deprecate in future version
         default=config.TRACECAT__REMOTE_REPOSITORY_URL,
@@ -122,10 +122,11 @@ async def prepare_git_url(role: Role | None = None) -> GitUrl | None:
 
     logger.debug("Runtime environment", url=url)
 
-    allowed_domains_setting = await get_setting(
+    allowed_domains_setting = await get_setting_cached(
         "git_allowed_domains",
         # TODO: Deprecate in future version
-        default=config.TRACECAT__ALLOWED_GIT_DOMAINS,
+        # Must be hashable
+        default=frozenset(config.TRACECAT__ALLOWED_GIT_DOMAINS),
     )
     allowed_domains = cast(set[str], allowed_domains_setting or {"github.com"})
 

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -29,9 +29,10 @@ from typing_extensions import Doc
 
 from tracecat import config
 from tracecat.contexts import ctx_role
+from tracecat.db.engine import get_async_session_context_manager
 from tracecat.expressions.expectations import create_expectation_model
 from tracecat.expressions.validation import TemplateValidator
-from tracecat.git import get_git_repository_sha, parse_git_url
+from tracecat.git import GitUrl, get_git_repository_sha, parse_git_url
 from tracecat.logger import logger
 from tracecat.parse import safe_url
 from tracecat.registry.actions.models import BoundRegistryAction, TemplateAction
@@ -41,14 +42,8 @@ from tracecat.registry.constants import (
 )
 from tracecat.registry.repositories.models import RegistryRepositoryCreate
 from tracecat.registry.repositories.service import RegistryReposService
-from tracecat.secrets.service import SecretsService
 from tracecat.settings.service import get_setting
-from tracecat.ssh import (
-    SshEnv,
-    add_host_to_known_hosts,
-    add_ssh_key_to_agent,
-    temporary_ssh_agent,
-)
+from tracecat.ssh import SshEnv, ssh_context
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import RegistryError
 
@@ -117,10 +112,6 @@ class Repository:
     def get(self, name: str) -> BoundRegistryAction[ArgsClsT]:
         """Retrieve a registered udf."""
         return self._store[name]
-
-    def safe_remote_url(self, remote_registry_url: str) -> str:
-        """Clean a remote registry url."""
-        return safe_url(remote_registry_url)
 
     def init(self, include_base: bool = True, include_templates: bool = True) -> None:
         """Initialize the registry."""
@@ -223,11 +214,6 @@ class Repository:
             origin=origin,
         )
 
-    def _reset(self) -> None:
-        logger.warning("Resetting registry")
-        self._store = {}
-        self._is_initialized = False
-
     def _load_base_udfs(self) -> None:
         """Load all udfs and template actions into the registry."""
         # Load udfs
@@ -262,8 +248,9 @@ class Repository:
             or {"github.com"},
         )
 
+        cleaned_url = safe_url(self._origin)
         try:
-            git_url = parse_git_url(self._origin, allowed_domains=allowed_domains)
+            git_url = parse_git_url(cleaned_url, allowed_domains=allowed_domains)
             host = git_url.host
             org = git_url.org
             repo_name = git_url.repo
@@ -288,35 +275,36 @@ class Repository:
             package_name=package_name,
         )
 
-        cleaned_url = self.safe_remote_url(self._origin)
-        logger.debug("Cleaned URL", url=cleaned_url)
+        logger.debug("Git URL", git_url=git_url)
         commit_sha = await self._install_remote_repository(
-            host=host, repo_url=cleaned_url, commit_sha=commit_sha
+            git_url=git_url, commit_sha=commit_sha
         )
         module = await self._load_remote_repository(cleaned_url, package_name)
         logger.info(
             "Imported and reloaded remote repository",
             module_name=module.__name__,
             package_name=package_name,
+            commit_sha=commit_sha,
         )
         return commit_sha
 
     async def _install_remote_repository(
-        self, host: str, repo_url: str, commit_sha: str | None = None
+        self, git_url: GitUrl, commit_sha: str | None = None
     ) -> str:
         """Install the remote repository into the filesystem and return the commit sha."""
 
-        logger.info("Getting SSH key", role=self.role)
-        async with SecretsService.with_session(role=self.role) as service:
-            secret = await service.get_ssh_key()
+        logger.info("Getting SSH key", role=self.role, git_url=git_url)
 
-        async with temporary_ssh_agent() as env:
-            logger.info("Entered temporary SSH agent context")
-            await add_ssh_key_to_agent(secret.reveal().value, env=env)
-            await add_host_to_known_hosts(host, env=env)
+        url = git_url.to_url()
+        async with (
+            get_async_session_context_manager() as session,
+            ssh_context(role=self.role, git_url=git_url, session=session) as env,
+        ):
+            if env is None:
+                raise RegistryError("No SSH key found")
             if commit_sha is None:
-                commit_sha = await get_git_repository_sha(repo_url, env=env)
-            await install_remote_repository(repo_url, commit_sha=commit_sha, env=env)
+                commit_sha = await get_git_repository_sha(url, env=env)
+            await install_remote_repository(url, commit_sha=commit_sha, env=env)
         return commit_sha
 
     async def _load_remote_repository(

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -293,8 +293,6 @@ class Repository:
     ) -> str:
         """Install the remote repository into the filesystem and return the commit sha."""
 
-        logger.info("Getting SSH key", role=self.role, git_url=git_url)
-
         url = git_url.to_url()
         async with (
             get_async_session_context_manager() as session,

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -279,7 +279,6 @@ class SecretsService(BaseService):
         key_name: str = GIT_SSH_KEY_SECRET_NAME,
         environment: str | None = None,
     ) -> SecretKeyValue:
-        logger.info("Getting SSH key", key_name=key_name, role=self.role)
         try:
             secret = await self.get_org_secret_by_name(key_name, environment)
             key = self.decrypt_keys(secret.encrypted_keys)[0]

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -279,14 +279,14 @@ class SecretsService(BaseService):
         key_name: str = GIT_SSH_KEY_SECRET_NAME,
         environment: str | None = None,
     ) -> SecretKeyValue:
-        # NOTE: Don't set the workspace_id, as we want to search for
-        # organization secrets if it's not set.
         logger.info("Getting SSH key", key_name=key_name, role=self.role)
         try:
             secret = await self.get_org_secret_by_name(key_name, environment)
+            key = self.decrypt_keys(secret.encrypted_keys)[0]
+            logger.debug("SSH key found", key_name=key_name, key_length=len(key.value))
+            return key
         except TracecatNotFoundError as e:
             raise TracecatNotFoundError(
                 f"SSH key {key_name} not found. Please check whether this key exists.\n\n"
                 " If not, please create a key in your organization's credentials page and try again."
             ) from e
-        return self.decrypt_keys(secret.encrypted_keys)[0]

--- a/tracecat/ssh.py
+++ b/tracecat/ssh.py
@@ -239,7 +239,6 @@ async def ssh_context(
     if git_url is None:
         yield None
     else:
-        logger.info("Getting SSH key", role=role, git_url=git_url)
         sec_svc = SecretsService(session, role=role)
         secret = await sec_svc.get_ssh_key()
         async with temporary_ssh_agent() as env:


### PR DESCRIPTION
# Description
- Use Ray's RuntimeEnv to manage custom udf repository, instead of having to push to executor to sync updates.
- Instead, when a user syncs the repo, we still pull the repo and update the action interfaces for the builder and registry, but we don't allow pushing to executor.
- We update the executor so that it checks the db repo for a SHA.
- For stability, we enforce that we pass a SHA with the git url into the ray RuntimeEnv. If no SHA is available, we don't install the remote repo as a dep.
  - Ray caches the dependencies depending on the hash of the RuntimeEnv. If a change is observed, it will automatically `pip install` the updated version. For this reason, we always pass a SHA into the git url.



# Changes
- Remove sync executors and validation from executor 