### PR TITLE
refactor(app): Standardize workflow execution service routes

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -182,7 +182,6 @@
                 "api-reference/reference/workflow-executions/list-workflow-executions",
                 "api-reference/reference/workflow-executions/create-workflow-execution",
                 "api-reference/reference/workflow-executions/get-workflow-execution",
-                "api-reference/reference/workflow-executions/list-workflow-execution-event-history",
                 "api-reference/reference/workflow-executions/cancel-workflow-execution",
                 "api-reference/reference/workflow-executions/terminate-workflow-execution"
               ]

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -55,7 +55,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateWorkflowExecutionResponse'
+                $ref: '#/components/schemas/WorkflowExecutionCreateResponse'
         '422':
           description: Validation Error
           content:
@@ -987,7 +987,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WorkflowExecutionResponse'
+                  $ref: '#/components/schemas/WorkflowExecutionReadMinimal'
                 title: Response Workflow-Executions-List Workflow Executions
         '422':
           description: Validation Error
@@ -1017,14 +1017,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateWorkflowExecutionParams'
+              $ref: '#/components/schemas/WorkflowExecutionCreate'
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateWorkflowExecutionResponse'
+                $ref: '#/components/schemas/WorkflowExecutionCreateResponse'
         '422':
           description: Validation Error
           content:
@@ -1062,49 +1062,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowExecutionResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /workflow-executions/{execution_id}/history:
-    get:
-      tags:
-      - workflow-executions
-      summary: List Workflow Execution Event History
-      description: Get a workflow execution.
-      operationId: workflow-executions-list_workflow_execution_event_history
-      security:
-      - APIKeyCookie: []
-      - APIKeyHeader: []
-      parameters:
-      - name: execution_id
-        in: path
-        required: true
-        schema:
-          type: string
-          pattern: wf-[0-9a-f]{32}:(exec-[\w-]+|sch-[0-9a-f]{32}-.*)
-          title: Execution Id
-      - name: workspace_id
-        in: query
-        required: true
-        schema:
-          type: string
-          format: uuid
-          title: Workspace Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EventHistoryResponse'
-                title: Response Workflow-Executions-List Workflow Execution Event
-                  History
+                $ref: '#/components/schemas/WorkflowExecutionRead'
         '422':
           description: Validation Error
           content:
@@ -1175,7 +1133,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TerminateWorkflowExecutionParams'
+              $ref: '#/components/schemas/WorkflowExecutionTerminate'
       responses:
         '204':
           description: Successful Response
@@ -3997,40 +3955,6 @@ components:
           title: File
       type: object
       title: Body_workflows-create_workflow
-    CreateWorkflowExecutionParams:
-      properties:
-        workflow_id:
-          type: string
-          pattern: wf-[0-9a-f]{32}
-          title: Workflow Id
-        inputs:
-          anyOf:
-          - {}
-          - type: 'null'
-          title: Inputs
-      type: object
-      required:
-      - workflow_id
-      title: CreateWorkflowExecutionParams
-    CreateWorkflowExecutionResponse:
-      properties:
-        message:
-          type: string
-          title: Message
-        wf_id:
-          type: string
-          pattern: wf-[0-9a-f]{32}
-          title: Wf Id
-        wf_exec_id:
-          type: string
-          pattern: wf-[0-9a-f]{32}:(exec-[\w-]+|sch-[0-9a-f]{32}-.*)
-          title: Wf Exec Id
-      type: object
-      required:
-      - message
-      - wf_id
-      - wf_exec_id
-      title: CreateWorkflowExecutionResponse
     CreateWorkspaceMembershipParams:
       properties:
         user_id:
@@ -4390,57 +4314,6 @@ components:
       - udf_key
       - action_input
       title: EventGroup
-    EventHistoryResponse:
-      properties:
-        event_id:
-          type: integer
-          title: Event Id
-        event_time:
-          type: string
-          format: date-time
-          title: Event Time
-        event_type:
-          $ref: '#/components/schemas/EventHistoryType'
-        task_id:
-          type: integer
-          title: Task Id
-        event_group:
-          anyOf:
-          - $ref: '#/components/schemas/EventGroup'
-          - type: 'null'
-          description: The action group of the event. We use this to keep track of
-            what events are related to each other.
-        failure:
-          anyOf:
-          - $ref: '#/components/schemas/EventFailure'
-          - type: 'null'
-        result:
-          anyOf:
-          - {}
-          - type: 'null'
-          title: Result
-        role:
-          anyOf:
-          - $ref: '#/components/schemas/Role'
-          - type: 'null'
-        parent_wf_exec_id:
-          anyOf:
-          - type: string
-            pattern: wf-[0-9a-f]{32}:(exec-[\w-]+|sch-[0-9a-f]{32}-.*)
-          - type: 'null'
-          title: Parent Wf Exec Id
-        workflow_timeout:
-          anyOf:
-          - type: number
-          - type: 'null'
-          title: Workflow Timeout
-      type: object
-      required:
-      - event_id
-      - event_time
-      - event_type
-      - task_id
-      title: EventHistoryResponse
     EventHistoryType:
       type: string
       enum:
@@ -5945,15 +5818,6 @@ components:
       - steps
       - returns
       title: TemplateActionDefinition
-    TerminateWorkflowExecutionParams:
-      properties:
-        reason:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Reason
-      type: object
-      title: TerminateWorkflowExecutionParams
     Trigger:
       properties:
         type:
@@ -6338,7 +6202,158 @@ components:
         -------------
 
         - 1 Workflow to many WorkflowDefinitions'
-    WorkflowExecutionResponse:
+    WorkflowExecutionCreate:
+      properties:
+        workflow_id:
+          type: string
+          pattern: wf-[0-9a-f]{32}
+          title: Workflow Id
+        inputs:
+          anyOf:
+          - {}
+          - type: 'null'
+          title: Inputs
+      type: object
+      required:
+      - workflow_id
+      title: WorkflowExecutionCreate
+    WorkflowExecutionCreateResponse:
+      properties:
+        message:
+          type: string
+          title: Message
+        wf_id:
+          type: string
+          pattern: wf-[0-9a-f]{32}
+          title: Wf Id
+        wf_exec_id:
+          type: string
+          pattern: wf-[0-9a-f]{32}:(exec-[\w-]+|sch-[0-9a-f]{32}-.*)
+          title: Wf Exec Id
+      type: object
+      required:
+      - message
+      - wf_id
+      - wf_exec_id
+      title: WorkflowExecutionCreateResponse
+    WorkflowExecutionEvent:
+      properties:
+        event_id:
+          type: integer
+          title: Event Id
+        event_time:
+          type: string
+          format: date-time
+          title: Event Time
+        event_type:
+          $ref: '#/components/schemas/EventHistoryType'
+        task_id:
+          type: integer
+          title: Task Id
+        event_group:
+          anyOf:
+          - $ref: '#/components/schemas/EventGroup'
+          - type: 'null'
+          description: The action group of the event. We use this to keep track of
+            what events are related to each other.
+        failure:
+          anyOf:
+          - $ref: '#/components/schemas/EventFailure'
+          - type: 'null'
+        result:
+          anyOf:
+          - {}
+          - type: 'null'
+          title: Result
+        role:
+          anyOf:
+          - $ref: '#/components/schemas/Role'
+          - type: 'null'
+        parent_wf_exec_id:
+          anyOf:
+          - type: string
+            pattern: wf-[0-9a-f]{32}:(exec-[\w-]+|sch-[0-9a-f]{32}-.*)
+          - type: 'null'
+          title: Parent Wf Exec Id
+        workflow_timeout:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Workflow Timeout
+      type: object
+      required:
+      - event_id
+      - event_time
+      - event_type
+      - task_id
+      title: WorkflowExecutionEvent
+    WorkflowExecutionRead:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: The ID of the workflow execution
+        run_id:
+          type: string
+          title: Run Id
+          description: The run ID of the workflow execution
+        start_time:
+          type: string
+          format: date-time
+          title: Start Time
+          description: The start time of the workflow execution
+        execution_time:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Execution Time
+          description: When this workflow run started or should start.
+        close_time:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Close Time
+          description: When the workflow was closed if closed.
+        status:
+          type: string
+          enum:
+          - RUNNING
+          - COMPLETED
+          - FAILED
+          - CANCELED
+          - TERMINATED
+          - CONTINUED_AS_NEW
+          - TIMED_OUT
+        workflow_type:
+          type: string
+          title: Workflow Type
+        task_queue:
+          type: string
+          title: Task Queue
+        history_length:
+          type: integer
+          title: History Length
+          description: Number of events in the history
+        events:
+          items:
+            $ref: '#/components/schemas/WorkflowExecutionEvent'
+          type: array
+          title: Events
+          description: The events in the workflow execution
+      type: object
+      required:
+      - id
+      - run_id
+      - start_time
+      - status
+      - workflow_type
+      - task_queue
+      - history_length
+      - events
+      title: WorkflowExecutionRead
+    WorkflowExecutionReadMinimal:
       properties:
         id:
           type: string
@@ -6396,7 +6411,16 @@ components:
       - workflow_type
       - task_queue
       - history_length
-      title: WorkflowExecutionResponse
+      title: WorkflowExecutionReadMinimal
+    WorkflowExecutionTerminate:
+      properties:
+        reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Reason
+      type: object
+      title: WorkflowExecutionTerminate
     WorkflowRead:
       properties:
         id:

--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React from "react"
-import { EventHistoryRead } from "@/client"
+import { WorkflowExecutionEvent } from "@/client"
 
 import {
   ResizableHandle,
@@ -27,7 +27,7 @@ export default function ExecutionPage() {
   }>()
 
   const [selectedEvent, setSelectedEvent] = React.useState<
-    EventHistoryRead | undefined
+    WorkflowExecutionEvent | undefined
   >()
 
   const fullExecutionId = `${workflowId}:${executionId}`

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1072,94 +1072,6 @@ export const $EventGroup = {
   title: "EventGroup",
 } as const
 
-export const $EventHistoryRead = {
-  properties: {
-    event_id: {
-      type: "integer",
-      title: "Event Id",
-    },
-    event_time: {
-      type: "string",
-      format: "date-time",
-      title: "Event Time",
-    },
-    event_type: {
-      $ref: "#/components/schemas/EventHistoryType",
-    },
-    task_id: {
-      type: "integer",
-      title: "Task Id",
-    },
-    event_group: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/EventGroup",
-        },
-        {
-          type: "null",
-        },
-      ],
-      description:
-        "The action group of the event. We use this to keep track of what events are related to each other.",
-    },
-    failure: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/EventFailure",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    result: {
-      anyOf: [
-        {},
-        {
-          type: "null",
-        },
-      ],
-      title: "Result",
-    },
-    role: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/Role",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    parent_wf_exec_id: {
-      anyOf: [
-        {
-          type: "string",
-          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Parent Wf Exec Id",
-    },
-    workflow_timeout: {
-      anyOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Workflow Timeout",
-    },
-  },
-  type: "object",
-  required: ["event_id", "event_time", "event_type", "task_id"],
-  title: "EventHistoryRead",
-} as const
-
 export const $EventHistoryType = {
   type: "string",
   enum: [
@@ -4067,7 +3979,187 @@ export const $WorkflowExecutionCreateResponse = {
   title: "WorkflowExecutionCreateResponse",
 } as const
 
+export const $WorkflowExecutionEvent = {
+  properties: {
+    event_id: {
+      type: "integer",
+      title: "Event Id",
+    },
+    event_time: {
+      type: "string",
+      format: "date-time",
+      title: "Event Time",
+    },
+    event_type: {
+      $ref: "#/components/schemas/EventHistoryType",
+    },
+    task_id: {
+      type: "integer",
+      title: "Task Id",
+    },
+    event_group: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/EventGroup",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description:
+        "The action group of the event. We use this to keep track of what events are related to each other.",
+    },
+    failure: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/EventFailure",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    result: {
+      anyOf: [
+        {},
+        {
+          type: "null",
+        },
+      ],
+      title: "Result",
+    },
+    role: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/Role",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    parent_wf_exec_id: {
+      anyOf: [
+        {
+          type: "string",
+          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Parent Wf Exec Id",
+    },
+    workflow_timeout: {
+      anyOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Workflow Timeout",
+    },
+  },
+  type: "object",
+  required: ["event_id", "event_time", "event_type", "task_id"],
+  title: "WorkflowExecutionEvent",
+} as const
+
 export const $WorkflowExecutionRead = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+      description: "The ID of the workflow execution",
+    },
+    run_id: {
+      type: "string",
+      title: "Run Id",
+      description: "The run ID of the workflow execution",
+    },
+    start_time: {
+      type: "string",
+      format: "date-time",
+      title: "Start Time",
+      description: "The start time of the workflow execution",
+    },
+    execution_time: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Execution Time",
+      description: "When this workflow run started or should start.",
+    },
+    close_time: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Close Time",
+      description: "When the workflow was closed if closed.",
+    },
+    status: {
+      type: "string",
+      enum: [
+        "RUNNING",
+        "COMPLETED",
+        "FAILED",
+        "CANCELED",
+        "TERMINATED",
+        "CONTINUED_AS_NEW",
+        "TIMED_OUT",
+      ],
+    },
+    workflow_type: {
+      type: "string",
+      title: "Workflow Type",
+    },
+    task_queue: {
+      type: "string",
+      title: "Task Queue",
+    },
+    history_length: {
+      type: "integer",
+      title: "History Length",
+      description: "Number of events in the history",
+    },
+    events: {
+      items: {
+        $ref: "#/components/schemas/WorkflowExecutionEvent",
+      },
+      type: "array",
+      title: "Events",
+      description: "The events in the workflow execution",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "run_id",
+    "start_time",
+    "status",
+    "workflow_type",
+    "task_queue",
+    "history_length",
+    "events",
+  ],
+  title: "WorkflowExecutionRead",
+} as const
+
+export const $WorkflowExecutionReadMinimal = {
   properties: {
     id: {
       type: "string",
@@ -4147,7 +4239,7 @@ export const $WorkflowExecutionRead = {
     "task_queue",
     "history_length",
   ],
-  title: "WorkflowExecutionRead",
+  title: "WorkflowExecutionReadMinimal",
 } as const
 
 export const $WorkflowExecutionTerminate = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -151,8 +151,6 @@ import type {
   WorkflowExecutionsCreateWorkflowExecutionResponse,
   WorkflowExecutionsGetWorkflowExecutionData,
   WorkflowExecutionsGetWorkflowExecutionResponse,
-  WorkflowExecutionsListWorkflowExecutionEventHistoryData,
-  WorkflowExecutionsListWorkflowExecutionEventHistoryResponse,
   WorkflowExecutionsListWorkflowExecutionsData,
   WorkflowExecutionsListWorkflowExecutionsResponse,
   WorkflowExecutionsTerminateWorkflowExecutionData,
@@ -854,7 +852,7 @@ export const triggersUpdateWebhook = (
  * @param data The data for the request.
  * @param data.workspaceId
  * @param data.workflowId
- * @returns WorkflowExecutionRead Successful Response
+ * @returns WorkflowExecutionReadMinimal Successful Response
  * @throws ApiError
  */
 export const workflowExecutionsListWorkflowExecutions = (
@@ -914,33 +912,6 @@ export const workflowExecutionsGetWorkflowExecution = (
   return __request(OpenAPI, {
     method: "GET",
     url: "/workflow-executions/{execution_id}",
-    path: {
-      execution_id: data.executionId,
-    },
-    query: {
-      workspace_id: data.workspaceId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * List Workflow Execution Event History
- * Get a workflow execution.
- * @param data The data for the request.
- * @param data.executionId
- * @param data.workspaceId
- * @returns EventHistoryRead Successful Response
- * @throws ApiError
- */
-export const workflowExecutionsListWorkflowExecutionEventHistory = (
-  data: WorkflowExecutionsListWorkflowExecutionEventHistoryData
-): CancelablePromise<WorkflowExecutionsListWorkflowExecutionEventHistoryResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/workflow-executions/{execution_id}/history",
     path: {
       execution_id: data.executionId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -349,22 +349,6 @@ export type EventGroup = {
   related_wf_exec_id?: string | null
 }
 
-export type EventHistoryRead = {
-  event_id: number
-  event_time: string
-  event_type: EventHistoryType
-  task_id: number
-  /**
-   * The action group of the event. We use this to keep track of what events are related to each other.
-   */
-  event_group?: EventGroup | null
-  failure?: EventFailure | null
-  result?: unknown | null
-  role?: Role | null
-  parent_wf_exec_id?: string | null
-  workflow_timeout?: number | null
-}
-
 /**
  * The event types we care about.
  */
@@ -1266,6 +1250,22 @@ export type WorkflowExecutionCreateResponse = {
   wf_exec_id: string
 }
 
+export type WorkflowExecutionEvent = {
+  event_id: number
+  event_time: string
+  event_type: EventHistoryType
+  task_id: number
+  /**
+   * The action group of the event. We use this to keep track of what events are related to each other.
+   */
+  event_group?: EventGroup | null
+  failure?: EventFailure | null
+  result?: unknown | null
+  role?: Role | null
+  parent_wf_exec_id?: string | null
+  workflow_timeout?: number | null
+}
+
 export type WorkflowExecutionRead = {
   /**
    * The ID of the workflow execution
@@ -1301,6 +1301,10 @@ export type WorkflowExecutionRead = {
    * Number of events in the history
    */
   history_length: number
+  /**
+   * The events in the workflow execution
+   */
+  events: Array<WorkflowExecutionEvent>
 }
 
 export type status3 =
@@ -1311,6 +1315,43 @@ export type status3 =
   | "TERMINATED"
   | "CONTINUED_AS_NEW"
   | "TIMED_OUT"
+
+export type WorkflowExecutionReadMinimal = {
+  /**
+   * The ID of the workflow execution
+   */
+  id: string
+  /**
+   * The run ID of the workflow execution
+   */
+  run_id: string
+  /**
+   * The start time of the workflow execution
+   */
+  start_time: string
+  /**
+   * When this workflow run started or should start.
+   */
+  execution_time?: string | null
+  /**
+   * When the workflow was closed if closed.
+   */
+  close_time?: string | null
+  status:
+    | "RUNNING"
+    | "COMPLETED"
+    | "FAILED"
+    | "CANCELED"
+    | "TERMINATED"
+    | "CONTINUED_AS_NEW"
+    | "TIMED_OUT"
+  workflow_type: string
+  task_queue: string
+  /**
+   * Number of events in the history
+   */
+  history_length: number
+}
 
 export type WorkflowExecutionTerminate = {
   reason?: string | null
@@ -1613,7 +1654,7 @@ export type WorkflowExecutionsListWorkflowExecutionsData = {
 }
 
 export type WorkflowExecutionsListWorkflowExecutionsResponse =
-  Array<WorkflowExecutionRead>
+  Array<WorkflowExecutionReadMinimal>
 
 export type WorkflowExecutionsCreateWorkflowExecutionData = {
   requestBody: WorkflowExecutionCreate
@@ -1630,14 +1671,6 @@ export type WorkflowExecutionsGetWorkflowExecutionData = {
 
 export type WorkflowExecutionsGetWorkflowExecutionResponse =
   WorkflowExecutionRead
-
-export type WorkflowExecutionsListWorkflowExecutionEventHistoryData = {
-  executionId: string
-  workspaceId: string
-}
-
-export type WorkflowExecutionsListWorkflowExecutionEventHistoryResponse =
-  Array<EventHistoryRead>
 
 export type WorkflowExecutionsCancelWorkflowExecutionData = {
   executionId: string
@@ -2459,7 +2492,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<WorkflowExecutionRead>
+        200: Array<WorkflowExecutionReadMinimal>
         /**
          * Validation Error
          */
@@ -2488,21 +2521,6 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: WorkflowExecutionRead
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/workflow-executions/{execution_id}/history": {
-    get: {
-      req: WorkflowExecutionsListWorkflowExecutionEventHistoryData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: Array<EventHistoryRead>
         /**
          * Validation Error
          */

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { DSLRunArgs, EventHistoryRead, RunActionInput } from "@/client"
+import { DSLRunArgs, RunActionInput, WorkflowExecutionEvent } from "@/client"
 import JsonView from "react18-json-view"
 
 import {
@@ -44,7 +44,7 @@ import { GenericWorkflowIcon, getIcon } from "@/components/icons"
 export function WorkflowExecutionEventDetailView({
   event,
 }: {
-  event: EventHistoryRead
+  event: WorkflowExecutionEvent
 }) {
   return (
     <div className="size-full overflow-auto">
@@ -142,7 +142,7 @@ export function WorkflowExecutionEventDetailView({
   )
 }
 
-export function EventGeneralInfo({ event }: { event: EventHistoryRead }) {
+export function EventGeneralInfo({ event }: { event: WorkflowExecutionEvent }) {
   const {
     event_group,
     role,

--- a/frontend/src/components/executions/event-history.tsx
+++ b/frontend/src/components/executions/event-history.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React from "react"
-import { EventHistoryRead } from "@/client"
+import { WorkflowExecutionEvent } from "@/client"
 import {
   AlarmClockOffIcon,
   CalendarCheck,
@@ -15,7 +15,7 @@ import {
   WorkflowIcon,
 } from "lucide-react"
 
-import { useWorkflowExecutionEventHistory } from "@/lib/hooks"
+import { useWorkflowExecution } from "@/lib/hooks"
 import { cn, undoSlugify } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -45,27 +45,30 @@ export function WorkflowExecutionEventHistory({
   setSelectedEvent,
 }: {
   executionId: string
-  selectedEvent?: EventHistoryRead
-  setSelectedEvent: (event: EventHistoryRead) => void
+  selectedEvent?: WorkflowExecutionEvent
+  setSelectedEvent: (event: WorkflowExecutionEvent) => void
 }) {
-  const { eventHistory, eventHistoryLoading, eventHistoryError } =
-    useWorkflowExecutionEventHistory(executionId, {
-      refetchInterval: REFETCH_INTERVAL,
-    })
+  const {
+    workflowExecution,
+    workflowExecutionLoading,
+    workflowExecutionError,
+  } = useWorkflowExecution(executionId, {
+    refetchInterval: REFETCH_INTERVAL,
+  })
 
-  if (eventHistoryLoading) {
+  if (workflowExecutionLoading) {
     return <CenteredSpinner />
   }
-  if (eventHistoryError) {
-    return <AlertNotification message={eventHistoryError.message} />
+  if (workflowExecutionError) {
+    return <AlertNotification message={workflowExecutionError.message} />
   }
-  if (!eventHistory) {
+  if (!workflowExecution) {
     return <NoContent message="No event history found." />
   }
   return (
     <div className="group flex flex-col gap-4 py-2">
       <nav className="grid gap-1 px-2">
-        {eventHistory.map((event, index) => (
+        {workflowExecution.events.map((event, index) => (
           <Button
             key={index}
             className={cn(
@@ -107,7 +110,7 @@ export function WorkflowExecutionEventHistory({
 export function EventDescriptor({
   event,
 }: {
-  event: EventHistoryRead
+  event: WorkflowExecutionEvent
 }): React.ReactNode {
   if (event.event_type.startsWith("ACTIVITY_TASK")) {
     return (
@@ -129,7 +132,7 @@ export function EventHistoryItemIcon({
   eventType,
   className,
 }: {
-  eventType: EventHistoryRead["event_type"]
+  eventType: WorkflowExecutionEvent["event_type"]
 } & React.HTMLAttributes<HTMLDivElement>) {
   return (
     <Tooltip>
@@ -144,7 +147,7 @@ export function EventHistoryItemIcon({
 }
 
 function getEventHistoryIcon(
-  eventType: EventHistoryRead["event_type"],
+  eventType: WorkflowExecutionEvent["event_type"],
   className?: string
 ) {
   switch (eventType) {

--- a/frontend/src/components/executions/nav.tsx
+++ b/frontend/src/components/executions/nav.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import {
-  WorkflowExecutionRead,
+  WorkflowExecutionReadMinimal,
   workflowExecutionsTerminateWorkflowExecution,
 } from "@/client"
 import {
@@ -49,7 +49,7 @@ import { toast } from "@/components/ui/use-toast"
 export function WorkflowExecutionNav({
   executions: workflowExecutions,
 }: {
-  executions?: WorkflowExecutionRead[]
+  executions?: WorkflowExecutionReadMinimal[]
 }) {
   const { executionId: currExecutionId } = useParams<{ executionId: string }>()
   const currExecutionIdDecoded = decodeURIComponent(currExecutionId)
@@ -198,7 +198,7 @@ export function WorkflowExecutionStatusIcon({
   status,
   className,
 }: {
-  status: WorkflowExecutionRead["status"]
+  status: WorkflowExecutionReadMinimal["status"]
 } & React.HTMLAttributes<HTMLDivElement>) {
   return (
     <Tooltip>
@@ -212,7 +212,7 @@ export function WorkflowExecutionStatusIcon({
   )
 }
 export function getExecutionStatusIcon(
-  status: WorkflowExecutionRead["status"],
+  status: WorkflowExecutionReadMinimal["status"],
   className?: string
 ) {
   switch (status) {

--- a/frontend/src/lib/event-history.ts
+++ b/frontend/src/lib/event-history.ts
@@ -1,12 +1,12 @@
 import { Buffer } from "buffer"
-import { EventHistoryRead } from "@/client"
+import { WorkflowExecutionEvent } from "@/client"
 
 export const decode = (str: string): string =>
   Buffer.from(str, "base64").toString("binary")
 export const encode = (str: string): string =>
   Buffer.from(str, "binary").toString("base64")
 
-export const ERROR_EVENT_TYPES: EventHistoryRead["event_type"][] = [
+export const ERROR_EVENT_TYPES: WorkflowExecutionEvent["event_type"][] = [
   "WORKFLOW_EXECUTION_FAILED",
   "WORKFLOW_EXECUTION_TERMINATED",
   "WORKFLOW_EXECUTION_TIMED_OUT",
@@ -14,12 +14,12 @@ export const ERROR_EVENT_TYPES: EventHistoryRead["event_type"][] = [
   "ACTIVITY_TASK_TIMED_OUT",
   "CHILD_WORKFLOW_EXECUTION_FAILED",
 ] as const
-export const SUCCESS_EVENT_TYPES: EventHistoryRead["event_type"][] = [
+export const SUCCESS_EVENT_TYPES: WorkflowExecutionEvent["event_type"][] = [
   "ACTIVITY_TASK_COMPLETED",
   "WORKFLOW_EXECUTION_COMPLETED",
   "CHILD_WORKFLOW_EXECUTION_COMPLETED",
 ] as const
-export const STARTED_EVENT_TYPES: EventHistoryRead["event_type"][] = [
+export const STARTED_EVENT_TYPES: WorkflowExecutionEvent["event_type"][] = [
   "ACTIVITY_TASK_STARTED",
   "WORKFLOW_EXECUTION_STARTED",
   "CHILD_WORKFLOW_EXECUTION_STARTED",
@@ -37,7 +37,7 @@ export type WorkflowExecutionStartedDetails = {
   input: Input
 }
 export type WorkflowExecutionStartedEvent = Omit<
-  EventHistoryRead,
+  WorkflowExecutionEvent,
   "details"
 > & {
   details: WorkflowExecutionStartedDetails
@@ -49,11 +49,16 @@ export type ActivityTaskScheduledEventDetails = {
   workflowTaskCompletedEventId: string
 }
 
-export type ActivityTaskStartedEvent = Omit<EventHistoryRead, "details"> & {
+export type ActivityTaskStartedEvent = Omit<
+  WorkflowExecutionEvent,
+  "details"
+> & {
   details: ActivityTaskScheduledEventDetails
 }
 
-export function parseEventType(eventType: EventHistoryRead["event_type"]) {
+export function parseEventType(
+  eventType: WorkflowExecutionEvent["event_type"]
+) {
   return eventType
     .toString()
     .split("_")

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -8,7 +8,6 @@ import {
   ApiError,
   AuthSettingsRead,
   CreateWorkspaceParams,
-  EventHistoryRead,
   GitSettingsRead,
   OAuthSettingsRead,
   organizationDeleteOrgMember,
@@ -82,7 +81,8 @@ import {
   usersUsersPatchCurrentUser,
   UserUpdate,
   WorkflowExecutionRead,
-  workflowExecutionsListWorkflowExecutionEventHistory,
+  WorkflowExecutionReadMinimal,
+  workflowExecutionsGetWorkflowExecution,
   workflowExecutionsListWorkflowExecutions,
   WorkflowReadMinimal,
   workflowsAddTag,
@@ -459,7 +459,7 @@ export function useWorkflowExecutions(
     data: workflowExecutions,
     isLoading: workflowExecutionsIsLoading,
     error: workflowExecutionsError,
-  } = useQuery<WorkflowExecutionRead[], Error>({
+  } = useQuery<WorkflowExecutionReadMinimal[], Error>({
     queryKey: ["workflow-executions", workflowId],
     queryFn: async () =>
       await workflowExecutionsListWorkflowExecutions({
@@ -475,7 +475,7 @@ export function useWorkflowExecutions(
   }
 }
 
-export function useWorkflowExecutionEventHistory(
+export function useWorkflowExecution(
   workflowExecutionId: string,
   options?: {
     /**
@@ -486,22 +486,22 @@ export function useWorkflowExecutionEventHistory(
 ) {
   const { workspaceId } = useWorkspace()
   const {
-    data: eventHistory,
-    isLoading: eventHistoryLoading,
-    error: eventHistoryError,
-  } = useQuery<EventHistoryRead[], Error>({
-    queryKey: ["workflow-executions", workflowExecutionId, "event-history"],
+    data: workflowExecution,
+    isLoading: workflowExecutionLoading,
+    error: workflowExecutionError,
+  } = useQuery<WorkflowExecutionRead, Error>({
+    queryKey: ["workflow-executions", workflowExecutionId],
     queryFn: async () =>
-      await workflowExecutionsListWorkflowExecutionEventHistory({
+      await workflowExecutionsGetWorkflowExecution({
         workspaceId,
         executionId: workflowExecutionId,
       }),
     ...options,
   })
   return {
-    eventHistory,
-    eventHistoryLoading,
-    eventHistoryError,
+    workflowExecution,
+    workflowExecutionLoading,
+    workflowExecutionError,
   }
 }
 

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -49,8 +49,8 @@ from tracecat.secrets.service import SecretsService
 from tracecat.types.auth import Role
 from tracecat.workflow.executions.models import (
     EventGroup,
-    EventHistoryRead,
     EventHistoryType,
+    WorkflowExecutionEvent,
 )
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
@@ -2430,8 +2430,8 @@ def failing_dsl():
 
 
 def assert_erroneous_task_failed_correctly(
-    events: list[EventHistoryRead],
-) -> EventHistoryRead[RunActionInput]:
+    events: list[WorkflowExecutionEvent],
+) -> WorkflowExecutionEvent[RunActionInput]:
     # 4.1 Match the failing task:
     #  - event_type == "ACTIVITY_TASK_FAILED"
     # - Matching action ref
@@ -2477,13 +2477,13 @@ def assert_erroneous_task_failed_correctly(
 
 
 def assert_error_handler_initiated_correctly(
-    events: list[EventHistoryRead],
+    events: list[WorkflowExecutionEvent],
     *,
     handler_dsl: DSLInput,
     handler_wf: Workflow,
     failing_wf_id: WorkflowID,
     failing_wf_exec_id: WorkflowExecutionID,
-) -> EventHistoryRead[RunActionInput]:
+) -> WorkflowExecutionEvent[RunActionInput]:
     # # 5.1 Find the event where the error handler was called
     evt = next(
         (
@@ -2537,8 +2537,8 @@ def assert_error_handler_initiated_correctly(
 
 
 def assert_error_handler_started(
-    events: list[EventHistoryRead],
-) -> EventHistoryRead:
+    events: list[WorkflowExecutionEvent],
+) -> WorkflowExecutionEvent:
     evt = next(
         (
             event
@@ -2557,8 +2557,8 @@ def assert_error_handler_started(
 
 
 def assert_error_handler_completed(
-    events: list[EventHistoryRead],
-) -> EventHistoryRead:
+    events: list[WorkflowExecutionEvent],
+) -> WorkflowExecutionEvent:
     evt = next(
         (
             event

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -2626,7 +2626,7 @@ async def test_workflow_error_handler_success(
 
     # Check temporal event history
     exec_svc = await WorkflowExecutionsService.connect(role=test_role)
-    events = await exec_svc.list_workflow_execution_event_history(wf_exec_id)
+    events = await exec_svc.list_workflow_execution_events(wf_exec_id)
     assert len(events) > 0
 
     # 4. Verify the failing task is in the event history

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -63,7 +63,7 @@ class EventHistoryType(StrEnum):
     )
 
 
-class WorkflowExecutionRead(BaseModel):
+class WorkflowExecutionBase(BaseModel):
     id: str = Field(..., description="The ID of the workflow execution")
     run_id: str = Field(..., description="The run ID of the workflow execution")
     start_time: datetime = Field(
@@ -88,9 +88,11 @@ class WorkflowExecutionRead(BaseModel):
     task_queue: str
     history_length: int = Field(..., description="Number of events in the history")
 
+
+class WorkflowExecutionReadMinimal(WorkflowExecutionBase):
     @staticmethod
-    def from_dataclass(execution: WorkflowExecution) -> WorkflowExecutionRead:
-        return WorkflowExecutionRead(
+    def from_dataclass(execution: WorkflowExecution) -> WorkflowExecutionReadMinimal:
+        return WorkflowExecutionReadMinimal(
             id=execution.id,
             run_id=execution.run_id,
             start_time=execution.start_time,
@@ -101,6 +103,12 @@ class WorkflowExecutionRead(BaseModel):
             task_queue=execution.task_queue,
             history_length=execution.history_length,
         )
+
+
+class WorkflowExecutionRead(WorkflowExecutionBase):
+    events: list[WorkflowExecutionEvent] = Field(
+        ..., description="The events in the workflow execution"
+    )
 
 
 def destructure_slugified_namespace(s: str, delimiter: str = "__") -> tuple[str, str]:
@@ -256,7 +264,7 @@ class EventFailure(BaseModel):
         )
 
 
-class EventHistoryRead(BaseModel, Generic[EventInput]):
+class WorkflowExecutionEvent(BaseModel, Generic[EventInput]):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     event_id: int
     event_time: datetime

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -55,7 +55,7 @@ async def get_workflow_execution(
 ) -> WorkflowExecutionRead:
     """Get a workflow execution."""
     service = await WorkflowExecutionsService.connect(role=role)
-    execution = await service.get_last_execution(execution_id)
+    execution = await service.get_execution(execution_id)
     if not execution:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
- Standardize more models and routes
- Update api docs
- `EventHistoryRead` -> `WorkflowExecutionEvent`
- `GET /workflow-executions` returns `list[WorkflowExecutionReadMinimal]`
- `GET /workflow-executions/{execution_id} `returns `WorkflowExecutionRead`
- Remove `/workflow-executions/{execution_id}/history`