### PR TITLE
fix(integrations): Ensure GOOGLE_API_CREDENTIALS is a mapping object

### DIFF
--- a/registry/tracecat_registry/integrations/google_api.py
+++ b/registry/tracecat_registry/integrations/google_api.py
@@ -3,8 +3,10 @@
 Docs: https://googleapis.dev/python/google-auth/latest/reference/google.oauth2.service_account.html
 """
 
+from collections.abc import Mapping
 from typing import Annotated
 
+import orjson
 from google.oauth2 import service_account
 from pydantic import Field
 
@@ -36,7 +38,12 @@ def get_auth_token(
     subject: Annotated[str, Field(..., description="Google API subject.")] = None,
 ) -> str:
     """Retrieve an auth token for Google API calls for a service account."""
-    creds = secrets.get("GOOGLE_API_CREDENTIALS")
+    creds_json_str = secrets.get("GOOGLE_API_CREDENTIALS")
+    creds = orjson.loads(creds_json_str)
+    if not isinstance(creds, Mapping):
+        raise ValueError(
+            "SECRETS.google_api.GOOGLE_API_CREDENTIALS is not a valid JSON string."
+        )
     credentials = service_account.Credentials.from_service_account_info(
         creds,
         scopes=scopes,


### PR DESCRIPTION
Resolve the following error due to passing json string directly into the call, when it expects a `Mapping` 
```
There was an error in the executor when calling action 'integrations.google_api.get_auth_token' (500).

AttributeError: 'str' object has no attribute 'keys'

------------------------------
File: /usr/local/lib/python3.12/site-packages/google/auth/_service_account_info.py
Function: from_dict
```

