### PR TITLE
fix(engine): Revert Ray SSH agent changes and fix SSH key formatting

### DIFF
--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -123,7 +123,6 @@ async def test_dispatch_action_with_foreach(
             assert args[1] == dispatch_context
 
 
-@pytest.mark.skip(reason="This test is flaky and fails intermittently")
 @pytest.mark.anyio
 async def test_dispatch_action_with_git_url(mock_session, basic_task_input):
     with (

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -29,6 +29,7 @@ from typing_extensions import Doc
 
 from tracecat import config
 from tracecat.contexts import ctx_role
+from tracecat.db.engine import get_async_session_context_manager
 from tracecat.expressions.expectations import create_expectation_model
 from tracecat.expressions.validation import TemplateValidator
 from tracecat.git import GitUrl, get_git_repository_sha, parse_git_url
@@ -293,7 +294,10 @@ class Repository:
         """Install the remote repository into the filesystem and return the commit sha."""
 
         url = git_url.to_url()
-        async with ssh_context(role=self.role, git_url=git_url) as env:
+        async with (
+            get_async_session_context_manager() as session,
+            ssh_context(role=self.role, git_url=git_url, session=session) as env,
+        ):
             if env is None:
                 raise RegistryError("No SSH key found")
             if commit_sha is None:

--- a/tracecat/secrets/models.py
+++ b/tracecat/secrets/models.py
@@ -25,14 +25,6 @@ SecretKey = Annotated[str, StringConstraints(pattern=r"[a-zA-Z0-9_]+")]
 """Validator for a secret key. e.g. 'access_key_id'"""
 
 
-class RevealedSecretKeyValue(BaseModel):
-    key: str
-    value: str
-
-    def conceal(self) -> SecretKeyValue:
-        return SecretKeyValue(key=self.key, value=SecretStr(self.value))
-
-
 class SecretKeyValue(BaseModel):
     key: str
     value: SecretStr
@@ -41,9 +33,6 @@ class SecretKeyValue(BaseModel):
     def from_str(kv: str) -> SecretKeyValue:
         key, value = kv.split("=", 1)
         return SecretKeyValue(key=key, value=SecretStr(value))
-
-    def reveal(self) -> RevealedSecretKeyValue:
-        return RevealedSecretKeyValue(key=self.key, value=self.value.get_secret_value())
 
 
 class SecretBase(BaseModel):

--- a/tracecat/ssh.py
+++ b/tracecat/ssh.py
@@ -224,7 +224,7 @@ async def opt_temp_key_file(
         role = role or ctx_role.get()
         service = SecretsService(session=session, role=role)
         ssh_key = await service.get_ssh_key()
-        async with temp_key_file(key_content=ssh_key.reveal().value) as ssh_cmd:
+        async with temp_key_file(key_content=ssh_key.get_secret_value()) as ssh_cmd:
             yield ssh_cmd
 
 
@@ -242,6 +242,6 @@ async def ssh_context(
         sec_svc = SecretsService(session, role=role)
         secret = await sec_svc.get_ssh_key()
         async with temporary_ssh_agent() as env:
-            await add_ssh_key_to_agent(secret.reveal().value, env=env)
+            await add_ssh_key_to_agent(secret.get_secret_value(), env=env)
             await add_host_to_known_hosts(git_url.host, env=env)
             yield env

--- a/tracecat/ssh.py
+++ b/tracecat/ssh.py
@@ -230,14 +230,17 @@ async def opt_temp_key_file(
 
 @asynccontextmanager
 async def ssh_context(
-    *, git_url: GitUrl | None = None, role: Role | None = None
+    *,
+    git_url: GitUrl | None = None,
+    session: AsyncSession,
+    role: Role | None = None,
 ) -> AsyncIterator[SshEnv | None]:
     """Context manager for SSH environment variables."""
     if git_url is None:
         yield None
     else:
-        async with SecretsService.with_session(role) as sec_svc:
-            secret = await sec_svc.get_ssh_key()
+        sec_svc = SecretsService(session, role=role)
+        secret = await sec_svc.get_ssh_key()
         async with temporary_ssh_agent() as env:
             await add_ssh_key_to_agent(secret.reveal().value, env=env)
             await add_host_to_known_hosts(git_url.host, env=env)


### PR DESCRIPTION
Resolves the error below.
# Changes
- Manual SSH agent management introduced much overhead, so we reverted that change
- Add zod validation in FE for ssh key
- When we pull the ssh key, add trailing newline character if its missing

# Root cause
- We learned that the Permissions Error in libcrypto is caused by a missing trailing newline in the SSH key. 
- The reason why only action execution was failing and not repo sync was because when we sync repos we are using manual ssh agent management. This involved creating SSH key tempfiles, which formats the ssh key properly. 
- With Ray's RuntimeEnv, this formatting does not seem to occur. 
- This error would only occur when the Ray head node detects a change in the dependency and decides it needs to pull deps. This meant that if no new commits were made to the remote repo (i.e. the SHA never changed), then ray would continue to use the cached version and this bug would be avoided.


# Error Example 
```
[ACTIONS.power_of_2 -> run_action] (Attempt 1)

There was an error in the executor when calling action 'tracecat.math.power_of_two' (500).

RuntimeEnvSetupError: Failed to set up runtime environment.
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/agent/runtime_env_agent.py", line 387, in _create_runtime_env_with_retry
    runtime_env_context = await asyncio.wait_for(
                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/tasks.py", line 520, in wait_for
    return await fut
           ^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/agent/runtime_env_agent.py", line 351, in _setup_runtime_env
    await create_for_plugin_if_needed(
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/plugin.py", line 254, in create_for_plugin_if_needed
    size_bytes = await plugin.create(uri, runtime_env, context, logger=logger)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/pip.py", line 309, in create
    pip_dir_bytes = await task
                    ^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/pip.py", line 289, in _create_for_hash
    await PipProcessor(
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/pip.py", line 191, in _run
    await self._install_pip_packages(
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/pip.py", line 167, in _install_pip_packages
    await check_output_cmd(pip_install_cmd, logger=logger, cwd=cwd, env=pip_env)
  File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/utils.py", line 105, in check_output_cmd
    raise SubprocessCalledProcessError(
ray._private.runtime_env.utils.SubprocessCalledProcessError: Run cmd[35] failed with the following details.
Command '['/tmp/ray/session_2025-01-21_15-36-50_649293_1/runtime_resources/pip/4779d795183f5e31e8a33e7b4a0968077dda75ef/virtualenv/bin/python', '-m', 'pip', 'install', '--disable-pip-version-check', '--no-cache-dir', '-r', '/tmp/ray/session_2025-01-21_15-36-50_649293_1/runtime_resources/pip/4779d795183f5e31e8a33e7b4a0968077dda75ef/ray_runtime_env_internal_pip_requirements.txt']' returned non-zero exit status 1.
Last 50 lines of stdout:
    Collecting git+ssh://****@github.com/TracecatHQ/internal-registry.git@6d45e6b748a18494d988bc38100ad9534912c80e (from -r /tmp/ray/session_2025-01-21_15-36-50_649293_1/runtime_resources/pip/4779d795183f5e31e8a33e7b4a0968077dda75ef/ray_runtime_env_internal_pip_requirements.txt (line 1))
      Cloning ssh://****@github.com/TracecatHQ/internal-registry.git (to revision 6d45e6b748a18494d988bc38100ad9534912c80e) to /tmp/pip-req-build-11s5ojoz
      Running command git clone --filter=blob:none --quiet 'ssh://****@github.com/TracecatHQ/internal-registry.git' /tmp/pip-req-build-11s5ojoz
      Load key "/tmp/tmpthkwufw8": error in libcrypto
      git@github.com: Permission denied (publickey).
      fatal: Could not read from remote repository.

      Please make sure you have the correct access rights
      and the repository exists.
      error: subprocess-exited-with-error
  
      × git clone --filter=blob:none --quiet 'ssh://****@github.com/TracecatHQ/internal-registry.git' /tmp/pip-req-build-11s5ojoz did not run successfully.
      │ exit code: 128
      ╰─> See above for output.
  
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: subprocess-exited-with-error

    × git clone --filter=blob:none --quiet 'ssh://****@github.com/TracecatHQ/internal-registry.git' /tmp/pip-req-build-11s5ojoz did not run successfully.
    │ exit code: 128
    ╰─> See above for output.

    note: This error originates from a subprocess, and is likely not a problem with pip.
    ```