### PR TITLE
feat(integrations): Support datetime or string in datetime functions

### DIFF
--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -942,10 +942,26 @@ def test_difference(a: Sequence[Any], b: Sequence[Any], expected: list[Any]) -> 
 @pytest.mark.parametrize(
     "input_val,unit,expected",
     [
-        (1609459200, "s", datetime(2021, 1, 1, 0, 0)),  # 2021-01-01 00:00:00
-        (1609459200000, "ms", datetime(2021, 1, 1, 0, 0)),  # Same time in milliseconds
-        (1672531200, "s", datetime(2023, 1, 1, 0, 0)),  # 2023-01-01 00:00:00
-        (1672531200000, "ms", datetime(2023, 1, 1, 0, 0)),  # Same time in milliseconds
+        (
+            1609459200,
+            "s",
+            datetime(2021, 1, 1, 0, 0, tzinfo=UTC),
+        ),  # 2021-01-01 00:00:00
+        (
+            1609459200000,
+            "ms",
+            datetime(2021, 1, 1, 0, 0, tzinfo=UTC),
+        ),  # Same time in milliseconds
+        (
+            1672531200,
+            "s",
+            datetime(2023, 1, 1, 0, 0, tzinfo=UTC),
+        ),  # 2023-01-01 00:00:00
+        (
+            1672531200000,
+            "ms",
+            datetime(2023, 1, 1, 0, 0, tzinfo=UTC),
+        ),  # Same time in milliseconds
     ],
 )
 def test_from_timestamp(input_val: int, unit: str, expected: datetime) -> None:
@@ -955,10 +971,26 @@ def test_from_timestamp(input_val: int, unit: str, expected: datetime) -> None:
 @pytest.mark.parametrize(
     "input_val,unit,expected",
     [
-        (datetime(2021, 1, 1, 0, 0), "s", 1609459200),  # 2021-01-01 00:00:00
-        (datetime(2021, 1, 1, 0, 0), "ms", 1609459200000),  # Same time in milliseconds
-        (datetime(2023, 1, 1, 0, 0), "s", 1672531200),  # 2023-01-01 00:00:00
-        (datetime(2023, 1, 1, 0, 0), "ms", 1672531200000),  # Same time in milliseconds
+        (
+            datetime(2021, 1, 1, 0, 0, tzinfo=UTC),
+            "s",
+            1609459200,
+        ),  # 2021-01-01 00:00:00
+        (
+            datetime(2021, 1, 1, 0, 0, tzinfo=UTC),
+            "ms",
+            1609459200000,
+        ),  # Same time in milliseconds
+        (
+            datetime(2023, 1, 1, 0, 0, tzinfo=UTC),
+            "s",
+            1672531200,
+        ),  # 2023-01-01 00:00:00
+        (
+            datetime(2023, 1, 1, 0, 0, tzinfo=UTC),
+            "ms",
+            1672531200000,
+        ),  # Same time in milliseconds
         ("2021-01-01T00:00:00", "s", 1609459200),  # String input
         ("2023-01-01T00:00:00", "ms", 1672531200000),  # String input with ms
     ],
@@ -1013,13 +1045,21 @@ def test_parse_datetime(input_str: str, format_str: str, expected: datetime) -> 
             "%Y-%m-%d",
             "2021-01-01",
         ),
+        # With timezone
+        (
+            datetime(2021, 1, 1, 0, 0, tzinfo=UTC),
+            "%Y-%m-%d %H:%M:%S",
+            "2021-01-01 00:00:00",
+        ),
+        # With timezone in ISO 8601 datetime string
+        (
+            "2021-01-01T00:00:00+00:00",
+            "%Y-%m-%d %H:%M:%S",
+            "2021-01-01 00:00:00",
+        ),
     ],
 )
 def test_format_datetime(
     input_val: datetime | str, format_str: str, expected: str
 ) -> None:
     assert format_datetime(input_val, format_str) == expected
-
-    # Test invalid format
-    with pytest.raises(ValueError):
-        format_datetime(input_val, "invalid_format")

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -200,17 +200,39 @@ def test_base64_invalid_input(invalid_input: str, decode_func) -> None:
 @pytest.mark.parametrize(
     "input_val,timezone,expected",
     [
+        # UTC timestamp for 2021-01-01 00:00:00
         (
             1609459200,
             "UTC",
             datetime(2021, 1, 1, 0, 0, tzinfo=UTC),
-        ),  # UTC timestamp for 2021-01-01 00:00:00
+        ),
         ("2021-01-01T00:00:00", None, datetime(2021, 1, 1, 0, 0)),
+        # ISO string with timezone
+        ("2021-01-01T00:00:00+00:00", None, datetime(2021, 1, 1, 0, 0, tzinfo=UTC)),
+        # ISO string without timezone
+        ("2021-01-01T00:00:00", "UTC", datetime(2021, 1, 1, 0, 0, tzinfo=UTC)),
+        # ISO date only
+        ("2021-01-01", None, datetime(2021, 1, 1, 0, 0)),
+        # Datetime object
         (datetime(2021, 1, 1, 0, 0), None, datetime(2021, 1, 1, 0, 0)),
     ],
 )
 def test_to_datetime(input_val: Any, timezone: str, expected: datetime) -> None:
     assert to_datetime(input_val, timezone) == expected
+
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        # US mm/dd/yyyy format
+        "1/1/2021",
+        # ISO 8601 string with invalid date
+        "2021-02-31T00:00:00",
+    ],
+)
+def test_to_datetime_invalid_date_string(input: str) -> None:
+    with pytest.raises(ValueError):
+        to_datetime(input)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -200,24 +200,17 @@ def test_base64_invalid_input(invalid_input: str, decode_func) -> None:
 @pytest.mark.parametrize(
     "input_val,timezone,expected",
     [
-        # UTC timestamp for 2021-01-01 00:00:00
-        (
-            1609459200,
-            "UTC",
-            datetime(2021, 1, 1, 0, 0, tzinfo=UTC),
-        ),
+        (1609459200, "UTC", datetime(2021, 1, 1, 0, 0, tzinfo=UTC)),
         ("2021-01-01T00:00:00", None, datetime(2021, 1, 1, 0, 0)),
-        # ISO string with timezone
         ("2021-01-01T00:00:00+00:00", None, datetime(2021, 1, 1, 0, 0, tzinfo=UTC)),
-        # ISO string without timezone
         ("2021-01-01T00:00:00", "UTC", datetime(2021, 1, 1, 0, 0, tzinfo=UTC)),
-        # ISO date only
         ("2021-01-01", None, datetime(2021, 1, 1, 0, 0)),
-        # Datetime object
         (datetime(2021, 1, 1, 0, 0), None, datetime(2021, 1, 1, 0, 0)),
+        ("2021-01-01T00:00:00Z", None, datetime(2021, 1, 1, 0, 0, tzinfo=UTC)),
+        ("2021-01-01T00:00:00Z", "UTC", datetime(2021, 1, 1, 0, 0, tzinfo=UTC)),
     ],
 )
-def test_to_datetime(input_val: Any, timezone: str, expected: datetime) -> None:
+def test_to_datetime(input_val: Any, timezone: str | None, expected: datetime) -> None:
     assert to_datetime(input_val, timezone) == expected
 
 

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -414,7 +414,7 @@ def prettify_json_str(x: Any) -> str:
 
 
 def to_datetime(x: Any, timezone: str | None = None) -> datetime:
-    """Convert input to datetime object from timestamp, ISO string or existing datetime.
+    """Convert input to datetime object from timestamp (in seconds), ISO 8601 string or existing datetime.
     Supports timezone-aware datetime objects if IANA timezone is provided.
     """
     tzinfo = None
@@ -428,7 +428,10 @@ def to_datetime(x: Any, timezone: str | None = None) -> datetime:
     elif isinstance(x, str):
         dt = datetime.fromisoformat(x)
     else:
-        raise ValueError(f"Invalid datetime value {x!r}")
+        raise ValueError(
+            "Expected ISO 8601 string or integer timestamp in seconds. Got "
+            f"{type(x)}: {x!r}"
+        )
 
     if tzinfo:
         dt = dt.astimezone(tzinfo)


### PR DESCRIPTION
## Rationale
We JSON serialize all inputs post-Pydantic validation before sending it over to the executor. This means datetimes are passed into each step in an action template as a JSON supported dtype (string, integer, float, object) only. There are no native JSON datetime objects.

## What changed
- All datetime functions e.g. `format_datetime` run `to_datetime` (which converts an ISO 8601 datetime string into a datetime object) if the input is a string.
- Added more tests to check that important datetime functions e.g. `to_datetime` and `format_datetime` correct support both datetime and ISO string with and without timezone data.
- Added `parse_datetime` function, which supports python `strftime` formatting
- Dropped `to_timestamp_str` (the functionality and naming is strange, likely a hallucination, and I don't think anybody is using it)