### PR TITLE
docs(integrations): Clearer descriptions for `payload` and `form_data`

### DIFF
--- a/registry/tracecat_registry/base/core/http.py
+++ b/registry/tracecat_registry/base/core/http.py
@@ -61,17 +61,19 @@ async def http_request(
         dict[str, str],
         Field(description="HTTP request headers"),
     ] = None,
-    payload: Annotated[
-        JSONObjectOrArray,
-        Field(description="HTTP request payload"),
-    ] = None,
     params: Annotated[
         dict[str, Any],
         Field(description="URL query parameters"),
     ] = None,
+    payload: Annotated[
+        JSONObjectOrArray,
+        Field(
+            description="JSON serializable data in request body (POST, PUT, and PATCH)"
+        ),
+    ] = None,
     form_data: Annotated[
         dict[str, Any],
-        Field(description="HTTP form encoded data"),
+        Field(description="Form encoded data in request body (POST, PUT, and PATCH)"),
     ] = None,
     auth: Annotated[
         dict[str, str],


### PR DESCRIPTION
I also get confused sometimes between `params`, `payload`, and `form_data` and their associated methods. I don't think changing `payload` to `body` is a good idea, since technically `form_data` is also inside the request body. Anyway i think these descriptions clarify things. Does for me.

Prior art: I looked at curl / httpx's official descriptions of `data` / `json` arguments.