### PR TITLE
feat(app): Preparations to remove search attributes

### DIFF
--- a/tests/unit/test_base62.py
+++ b/tests/unit/test_base62.py
@@ -1,0 +1,82 @@
+"""Unit tests for base62 encoding/decoding functionality."""
+
+import pytest
+
+from tracecat.base62 import b62decode, b62encode
+
+
+def test_b62encode_zero() -> None:
+    """Test encoding zero returns '0'."""
+    assert b62encode(0) == "0"
+
+
+def test_b62encode_single_digit() -> None:
+    """Test encoding single-digit numbers."""
+    assert b62encode(5) == "5"
+    assert b62encode(9) == "9"
+
+
+def test_b62encode_double_digit() -> None:
+    """Test encoding double-digit numbers."""
+    assert b62encode(10) == "a"
+    assert b62encode(35) == "z"
+    assert b62encode(36) == "A"
+    assert b62encode(61) == "Z"
+
+
+def test_b62encode_large_numbers() -> None:
+    """Test encoding larger numbers."""
+    assert b62encode(100) == "1C"
+    assert b62encode(1000) == "g8"
+    assert b62encode(999999) == "4c91"
+
+
+def test_b62encode_negative() -> None:
+    """Test encoding negative numbers raises ValueError."""
+    with pytest.raises(ValueError, match="Number must be non-negative"):
+        b62encode(-1)
+
+
+def test_b62decode_zero() -> None:
+    """Test decoding '0' returns 0."""
+    assert b62decode("0") == 0
+
+
+def test_b62decode_single_char() -> None:
+    """Test decoding single characters."""
+    assert b62decode("5") == 5
+    assert b62decode("a") == 10
+    assert b62decode("z") == 35
+    assert b62decode("A") == 36
+    assert b62decode("Z") == 61
+
+
+def test_b62decode_multiple_chars() -> None:
+    """Test decoding multiple characters."""
+    assert b62decode("1C") == 100
+    assert b62decode("g8") == 1000
+    assert b62decode("4c91") == 999999
+
+
+def test_b62decode_invalid_chars() -> None:
+    """Test decoding invalid characters raises ValueError."""
+    invalid_inputs = ["!", "@", "#", "$", "hello!"]
+
+    for invalid_input in invalid_inputs:
+        with pytest.raises(ValueError) as e:
+            b62decode(invalid_input)
+            assert f"Invalid base62 character: {invalid_input}" in str(e.value)
+
+
+def test_encode_decode_roundtrip() -> None:
+    """Test encoding followed by decoding returns original number."""
+    test_numbers = [0, 1, 10, 62, 100, 1000, 999999]
+    for num in test_numbers:
+        assert b62decode(b62encode(num)) == num
+
+
+def test_decode_encode_roundtrip() -> None:
+    """Test decoding followed by encoding returns original string."""
+    test_strings = ["0", "9", "a", "Z", "1C", "g8", "4c91"]
+    for string in test_strings:
+        assert b62encode(b62decode(string)) == string

--- a/tests/unit/test_identifiers.py
+++ b/tests/unit/test_identifiers.py
@@ -1,0 +1,262 @@
+import uuid
+from typing import Self
+from uuid import UUID
+
+import pytest
+from pydantic import BaseModel
+
+from tracecat.identifiers.common import (
+    TracecatUUID,
+    id_from_short,
+    id_to_short,
+)
+from tracecat.identifiers.workflow import WorkflowUUID
+
+
+def test_id_to_short() -> None:
+    """Test conversion of UUID to shortened string format."""
+    test_uuid = UUID(int=12345)
+    result = id_to_short(test_uuid, prefix="test_")
+
+    # Verify prefix
+    assert result.startswith("test_")
+    # Verify total length (prefix + 22 chars for padded base62)
+    assert len(result) == len("test_") + 22
+    # Verify we can convert it back
+    assert id_from_short(result, "test_") == test_uuid
+
+
+def test_id_from_short_invalid_prefix() -> None:
+    """Test that id_from_short raises ValueError for invalid prefix."""
+    with pytest.raises(ValueError, match="Invalid short ID string"):
+        id_from_short("invalid_12345", prefix="test_")
+
+
+class MockUUID(TracecatUUID[str]):
+    """Test implementation of TracecatUUID."""
+
+    prefix = "test_"
+    legacy_prefix = "test-legacy-"
+
+    @classmethod
+    def from_legacy(cls, id: str) -> Self:
+        assert cls.legacy_prefix is not None
+        assert id.startswith(cls.legacy_prefix)
+        n = len(cls.legacy_prefix)
+        return cls.from_uuid(UUID(id[n:]))
+
+
+@pytest.fixture
+def test_uuid_str() -> str:
+    """Fixture providing a consistent test UUID string."""
+    return "12345678-1234-1234-1234-123456789012"
+
+
+class TestTracecatUUID:
+    """Test suite for TracecatUUID base class."""
+
+    def test_missing_prefix(self) -> None:
+        """Test that TracecatUUID requires a prefix."""
+
+        class InvalidUUID(TracecatUUID):
+            pass
+
+        with pytest.raises(ValueError, match="requires a prefix to be set"):
+            InvalidUUID()
+
+    def test_short_conversion(self) -> None:
+        """Test conversion to and from short format."""
+        test_uuid = UUID(int=12345)
+        uuid_obj = MockUUID(int=test_uuid.int)
+        short_id = uuid_obj.short()
+
+        # Test conversion to short format
+        assert short_id.startswith("test_")
+        assert len(short_id) == len("test_") + 22
+
+        # Test conversion back from short format
+        recovered = MockUUID.from_short(short_id)
+        assert recovered == uuid_obj
+
+    def test_new_uuid4(self) -> None:
+        """Test generation of new UUID4."""
+        uuid1 = MockUUID.new_uuid4()
+        uuid2 = MockUUID.new_uuid4()
+
+        assert isinstance(uuid1, MockUUID)
+        assert uuid1 != uuid2  # Verify uniqueness
+
+    def test_make_short(self) -> None:
+        """Test make_short class method."""
+
+        original_uuid = UUID(int=12345)
+        short_id = MockUUID.make_short(original_uuid)
+
+        assert short_id.startswith("test_")
+        assert len(short_id) == len("test_") + 22
+
+    def test_from_any_invalid(self) -> None:
+        """Test new with invalid input."""
+
+        with pytest.raises(ValueError, match="Invalid MockUUID ID:"):
+            MockUUID.new(123)  # type: ignore
+
+        with pytest.raises(ValueError):
+            MockUUID.new("not-a-uuid")
+
+    def test_equality(self) -> None:
+        """Test that TracecatUUID instances can be compared using ==."""
+
+        # Create two UUIDs with the same value
+        uuid_int = 12345
+        uuid1 = MockUUID(int=uuid_int)
+        uuid2 = MockUUID(int=uuid_int)
+
+        # Create a different UUID for comparison
+        uuid3 = MockUUID(int=67890)
+
+        # Test equality
+        assert uuid1 == uuid2
+        assert uuid1 != uuid3
+
+        # Test equality with regular UUID
+        regular_uuid = UUID(int=uuid_int)
+        assert uuid1 == regular_uuid
+
+        # Test equality with non-UUID type
+        assert uuid1 != "not-a-uuid"
+        assert uuid1 != 12345
+
+    def test_equality_with_normal_uuid(self) -> None:
+        """Test that TracecatUUID instances can be compared with normal UUIDs."""
+
+        test_uuid = MockUUID(int=12345)
+        normal_uuid = UUID(int=12345)
+        assert test_uuid == normal_uuid
+
+
+class TestWorkflowUUID:
+    """Test suite for WorkflowUUID."""
+
+    def test_prefix(self) -> None:
+        """Test WorkflowUUID prefix."""
+        assert WorkflowUUID.prefix == "wf_"
+
+    def test_roundtrip(self) -> None:
+        """Test conversion to and from short format."""
+        original = WorkflowUUID.new_uuid4()
+        short_id = original.short()
+        recovered = WorkflowUUID.from_short(short_id)
+        assert original == recovered
+
+    def test_from_uuid(self) -> None:
+        """Test creation from regular UUID."""
+        regular_uuid = UUID(int=12345)
+        workflow_uuid = WorkflowUUID.from_uuid(regular_uuid)
+        assert workflow_uuid.int == regular_uuid.int
+
+    def test_from_legacy_valid(self) -> None:
+        """Test from_legacy with valid legacy ID."""
+        # Legacy IDs are 'wf' followed by UUID hex without hyphens
+        id = uuid.uuid4()
+        legacy_id = "wf-" + id.hex
+        workflow_uuid = WorkflowUUID.from_legacy(legacy_id)
+        assert isinstance(workflow_uuid, WorkflowUUID)
+        assert workflow_uuid == id
+
+    def test_from_legacy_invalid(self) -> None:
+        """Test from_legacy with invalid legacy ID."""
+        invalid_ids = [
+            "workflow_123",  # Wrong prefix
+            "wf_short",  # Too short
+            "wfGHIJKLMN",  # Invalid hex
+        ]
+
+        for invalid_id in invalid_ids:
+            with pytest.raises(ValueError):
+                WorkflowUUID.from_legacy(invalid_id)
+
+
+def test_tracecat_uuid_serialization(test_uuid_str):
+    """Test that TracecatUUID can be serialized and deserialized correctly."""
+
+    class TestModel(BaseModel):
+        """Test model that uses TestUUID."""
+
+        id: MockUUID
+
+    original_uuid = UUID(test_uuid_str)
+    test_uuid = MockUUID.from_uuid(original_uuid)
+
+    assert MockUUID.new(test_uuid_str) == test_uuid
+    assert MockUUID.new(test_uuid) == test_uuid
+    assert MockUUID.new(test_uuid.short()) == test_uuid
+
+    # Create a model instance
+    model = TestModel(id=test_uuid)
+
+    # Serialize to dict/JSON
+    serialized_json = model.model_dump_json()
+    assert serialized_json == f'{{"id":"{test_uuid}"}}'
+
+    serialized_python = model.model_dump()
+    assert serialized_python == {"id": test_uuid}
+
+    # Try from uuid string
+
+    # Deserialize back
+    deserialized = TestModel.model_validate_json(serialized_json)
+
+    # Verify the UUID matches
+    assert isinstance(deserialized.id, MockUUID)
+    assert deserialized.id == test_uuid
+    assert str(deserialized.id) == str(original_uuid)
+
+    # Test direct string UUID initialization
+    str_model = TestModel(id=str(original_uuid))  # type: ignore
+    assert str_model.id == test_uuid
+
+
+def test_tracecat_uuid_construction(test_uuid_str):
+    """Test that TracecatUUID can be constructed from various inputs."""
+    original_uuid = UUID(test_uuid_str)
+    test_uuid = MockUUID.from_uuid(original_uuid)
+    short_id = test_uuid.short()
+
+    # Test model construction
+    class TestModel(BaseModel):
+        """Test model that uses MockUUID."""
+
+        id: MockUUID
+
+    from_uuid_str = TestModel(id=test_uuid_str)  # type: ignore
+    assert isinstance(from_uuid_str.id, MockUUID)
+    assert from_uuid_str.id == test_uuid
+
+    json_str = f'{{"id":"{test_uuid_str}"}}'
+    from_json_str = TestModel.model_validate_json(json_str)
+    assert isinstance(from_json_str.id, MockUUID)
+    assert from_json_str.id == MockUUID(test_uuid_str)
+
+    json_dict = {"id": test_uuid}
+    from_json_dict = TestModel.model_validate(json_dict)
+    assert isinstance(from_json_dict.id, MockUUID)
+    assert from_json_dict.id == test_uuid
+
+    # short id
+    assert MockUUID.from_short(short_id) == test_uuid
+
+    # We actually get a type error here, but it works anyway
+    from_short_str = TestModel(id=short_id)  # type: ignore
+    assert isinstance(from_short_str.id, MockUUID)
+    assert from_short_str.id == test_uuid
+
+    with pytest.raises(
+        ValueError, match="Invalid prefix 'test_' for MockUUID, expected 'test_'"
+    ):
+        MockUUID.from_short("invalid_12345")
+
+    # Legacy
+
+    assert MockUUID.from_legacy(f"test-legacy-{test_uuid.hex}") == test_uuid
+    assert MockUUID.new(f"test-legacy-{test_uuid.hex}") == test_uuid

--- a/tracecat/base62.py
+++ b/tracecat/base62.py
@@ -1,0 +1,52 @@
+# Base62 character set: 0-9, a-z, A-Z
+_BASE62_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+# Mapping of base62 characters to their corresponding integer values
+_BASE62_CHAR_TO_INT = {char: i for i, char in enumerate(_BASE62_CHARS)}
+
+
+def b62encode(num: int) -> str:
+    """Convert a non-negative integer to a base62 string.
+
+    Args:
+        num: Non-negative integer to encode
+
+    Returns:
+        Base62 encoded string
+
+    Raises:
+        ValueError: If input is negative
+    """
+    if num < 0:
+        raise ValueError("Number must be non-negative")
+
+    if num == 0:
+        return _BASE62_CHARS[0]
+
+    encoded = []
+    while num:
+        num, remainder = divmod(num, 62)
+        encoded.append(_BASE62_CHARS[remainder])
+
+    return "".join(reversed(encoded))
+
+
+def b62decode(encoded: str) -> int:
+    """Convert a base62 string back to an integer.
+
+    Args:
+        encoded: Base62 encoded string
+
+    Returns:
+        Decoded integer value
+
+    Raises:
+        ValueError: If string contains invalid characters
+    """
+    num = 0
+    for char in encoded:
+        try:
+            num = num * 62 + _BASE62_CHAR_TO_INT[char]
+        except KeyError as e:
+            raise ValueError(f"Invalid base62 character: {char}") from e
+    return num

--- a/tracecat/identifiers/common.py
+++ b/tracecat/identifiers/common.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, ClassVar, Self, cast
+from uuid import UUID
+
+from pydantic_core import CoreSchema, core_schema
+
+from tracecat import base62
+from tracecat.logger import logger
+
+
+def id_to_short(id: UUID, prefix: str) -> str:
+    """Convert a workflow ID to a string with consistent length.
+
+    Args:
+        id: UUID to convert
+        prefix: Prefix to add to the encoded string
+
+    Returns:
+        str: Prefixed base62 encoded string, padded to 22 characters
+    """
+    suffix = base62.b62encode(id.int)
+    # Pad to 22 characters which is the maximum length needed for a UUID
+    padded_suffix = suffix.zfill(22)
+    return f"{prefix}{padded_suffix}"
+
+
+def id_from_short(short_id: str, prefix: str) -> UUID:
+    """Convert a workflow ID string to a UUID."""
+    if not short_id.startswith(prefix):
+        raise ValueError("Invalid short ID string")
+    prefix_len = len(prefix)
+    suffix = short_id[prefix_len:]
+    return UUID(int=base62.b62decode(suffix))
+
+
+class TracecatUUID[ShortID: str](UUID):
+    """Base class for prefixed Tracecat UUIDs.
+
+    This class serves as a base for specialized UUIDs that have specific prefixes
+    for different types of resources (workflows, nodes, etc.).
+
+    Generic Args:
+        ShortIDType: Type of the short ID representation, must be str or subclass
+    """
+
+    prefix: ClassVar[str]
+    legacy_prefix: ClassVar[str | None] = None
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize a TracecatUUID.
+
+        Args:
+            *args: Positional arguments passed to UUID constructor
+            **kwargs: Keyword arguments passed to UUID constructor
+
+        Raises:
+            ValueError: If the prefix is not set by the subclass
+        """
+        if not hasattr(self, "prefix"):
+            raise ValueError(f"{self.__class__.__name__} requires a prefix to be set")
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: Any,
+        _handler: Any,
+    ) -> CoreSchema:
+        """Generate Pydantic core schema for validation and serialization."""
+
+        def validate_from_str(value: str) -> Self:
+            logger.info("validate_from_str", value=value)
+            return cls.new(value)
+
+        def serializer(x: Self) -> str:
+            logger.info("serializer", x=x)
+            return str(x)
+
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.union_schema(
+                [
+                    core_schema.no_info_plain_validator_function(validate_from_str),
+                ]
+            ),
+            python_schema=core_schema.union_schema(
+                [
+                    core_schema.is_instance_schema(cls),
+                    core_schema.no_info_plain_validator_function(validate_from_str),
+                ]
+            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                serializer,
+                return_schema=core_schema.str_schema(),
+                when_used="json",
+            ),
+        )
+
+    def short(self) -> ShortID:
+        """Convert the UUID to a shortened, prefixed string representation.
+
+        Returns:
+            ShortIDType: The shortened ID string with prefix
+        """
+        return id_to_short(self, self.prefix)  # type: ignore
+
+    @classmethod
+    def from_short(cls, short_id: ShortID) -> Self:
+        """Create a TracecatUUID instance from a shortened ID string.
+
+        Args:
+            short_id: The shortened ID string with prefix
+
+        Returns:
+            TracecatUUID[ShortIDType]: A new instance created from the short ID
+
+        Raises:
+            ValueError: If the short_id has an invalid prefix
+        """
+        if not short_id.startswith(cls.prefix):
+            raise ValueError(
+                f"Invalid prefix '{cls.prefix}' for {cls.__name__}, expected '{cls.prefix}'"
+            )
+
+        uuid_obj = id_from_short(short_id, prefix=cls.prefix)
+        return cls(int=uuid_obj.int)
+
+    @classmethod
+    def make_short(cls, uuid: UUID) -> ShortID:
+        return cast(ShortID, id_to_short(uuid, cls.prefix))
+
+    @classmethod
+    def from_uuid(cls, uuid: UUID) -> Self:
+        return cls(int=uuid.int)
+
+    @classmethod
+    def new_uuid4(cls) -> Self:
+        return cls.from_uuid(uuid.uuid4())
+
+    @classmethod
+    def new(cls, id: Any) -> Self:
+        match id:
+            case UUID():
+                # This is a full UUID
+                return cls.from_uuid(id)
+            case str() if id.startswith(cls.prefix):
+                # This is a short ID
+                return cls.from_short(cast(ShortID, id))
+            case str() if cls.legacy_prefix and id.startswith(cls.legacy_prefix):
+                return cls.from_legacy(id)
+            case str():
+                # This is a full UUID string
+                return cls.from_uuid(UUID(id))
+            case _:
+                raise ValueError(f"Invalid {cls.__name__} ID: {id}")
+
+    @classmethod
+    def from_legacy(cls, id: str) -> Self:
+        if cls.legacy_prefix is None:
+            raise ValueError(f"Legacy IDs are not supported for {cls.__name__}")
+        prefix_len = len(cls.legacy_prefix)
+        hex_str = id[prefix_len - 1 :]
+        return cls.from_uuid(UUID(hex_str))
+
+    def to_legacy(self) -> str:
+        if self.legacy_prefix is None:
+            raise ValueError(
+                f"Legacy IDs are not supported for {self.__class__.__name__}"
+            )
+        return f"{self.legacy_prefix}{self.hex}"

--- a/tracecat/identifiers/common.py
+++ b/tracecat/identifiers/common.py
@@ -140,6 +140,8 @@ class TracecatUUID[ShortID: str](UUID):
 
     @classmethod
     def new(cls, id: Any) -> Self:
+        if isinstance(id, cls):
+            return id
         match id:
             case UUID():
                 # This is a full UUID

--- a/tracecat/identifiers/workflow.py
+++ b/tracecat/identifiers/workflow.py
@@ -29,11 +29,13 @@ Examples
 - short -> `wf_4itKqkgCZrLhgYiq5L211X`
 """
 
+
 class WorkflowUUID(TracecatUUID[WorkflowIDShort]):
     """UUID for workflow resources."""
 
     prefix = WF_ID_PREFIX
     legacy_prefix = "wf-"
+
 
 # Annotations
 WorkflowID = Annotated[str, StringConstraints(pattern=WF_ID_PATTERN)]

--- a/tracecat/identifiers/workflow.py
+++ b/tracecat/identifiers/workflow.py
@@ -9,6 +9,7 @@ from pydantic import (
     StringConstraints,
 )
 
+from tracecat.identifiers.common import TracecatUUID
 from tracecat.identifiers.resource import ResourcePrefix, generate_resource_id
 from tracecat.identifiers.schedules import SCHEDULE_EXEC_ID_PATTERN
 
@@ -17,7 +18,22 @@ WF_ID_PATTERN = r"wf-[0-9a-f]{32}"
 EXEC_ID_PATTERN = r"exec-[\w-]+"
 WF_EXEC_SUFFIX_PATTERN = rf"({EXEC_ID_PATTERN}|{SCHEDULE_EXEC_ID_PATTERN})"
 WF_EXEC_ID_PATTERN = rf"{WF_ID_PATTERN}:{WF_EXEC_SUFFIX_PATTERN}"
+WF_ID_PREFIX = "wf_"
+WF_ID_SHORT_PATTERN = rf"{WF_ID_PREFIX}[0-9a-zA-Z]+"
+WorkflowIDShort = Annotated[str, StringConstraints(pattern=WF_ID_SHORT_PATTERN)]
+"""A short base62 encoded string representation of a workflow UUID.
 
+Examples
+--------
+- long ->  `8d3885a9-6470-4ee0-9d4d-d507cc97393d`
+- short -> `wf_4itKqkgCZrLhgYiq5L211X`
+"""
+
+class WorkflowUUID(TracecatUUID[WorkflowIDShort]):
+    """UUID for workflow resources."""
+
+    prefix = WF_ID_PREFIX
+    legacy_prefix = "wf-"
 
 # Annotations
 WorkflowID = Annotated[str, StringConstraints(pattern=WF_ID_PATTERN)]


### PR DESCRIPTION
# Motivation
Search attributes are too tightly coupled to Temporal-- meaning we don't have as much control over it as we wish. Even worse in Temporal cloud. Want a simple way to identify workflow runs by their trigger type (scheduled, webhook, manual). 

We eventually want to move into the world of searching executions by prefix. This lays the groundwork for resource prefixes for workflow executions. 

Resource prefixes would be a hierarchical path of short b62 encoded IDs. (inspired by Stripe IDs)
```
# Before
wf-7b8ea32815e544b6af9a38f79fa03622:exec-7b8ea32815e544b6af9a38f79fa03622
# After
wf_7oco8mLhPuLvymQKve50zP/exec_7oco8mLhPuLvymQKve50zP
```

We aim to be able to reference past workflow results through such notation:

`wf_XXXXXXXXXXXXX/exec_XXXXXXXXXXXXX/<action_ref>`

With this, we also want to distinguish between trigger types:
```
# manual
wf_XXXXXXXXXXXXX/exec_XXXXXXXXXXXXX
# manual (alternative)
wf_XXXXXXXXXXXXX/exm_XXXXXXXXXXXXX
# scheduled - note this format is generated by Temporal
wf_XXXXXXXXXXXXX/sch_XXXXXXXXXXXXX-YYYY-MM-DDTHH:MM:SSZ
# webhook
wf_XXXXXXXXXXXXX/wh_exec_XXXXXXXXXXXXX
# webhook (alternative)
wf_XXXXXXXXXXXXX/exw_XXXXXXXXXXXXX
```

Then using Temporal list filters we can simply do:
`WorkflowId STARTS_WITH 'wf_XXXXXXXXXXXXX/exec'` to pull all manual executions
# Changes
- Add TracecatUUID
- Add WorkflowUUID
