### PR TITLE
feat(engine): Use WorkflowUUID as canonical ID

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
@@ -14,6 +14,7 @@ import "react18-json-view/src/style.css"
 import { useParams } from "next/navigation"
 import { History } from "lucide-react"
 
+import { formatExecutionId } from "@/lib/event-history"
 import { WorkflowExecutionEventDetailView } from "@/components/executions/event-details"
 import { WorkflowExecutionEventHistory } from "@/components/executions/event-history"
 import { SectionHead } from "@/components/executions/section"
@@ -30,7 +31,7 @@ export default function ExecutionPage() {
     WorkflowExecutionEvent | undefined
   >()
 
-  const fullExecutionId = `${workflowId}:${executionId}`
+  const fullExecutionId = formatExecutionId(workflowId, executionId)
   return (
     <ResizablePanelGroup
       direction="horizontal"

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -68,8 +68,16 @@ export const $ActionControlFlow = {
 export const $ActionCreate = {
   properties: {
     workflow_id: {
-      type: "string",
-      pattern: "wf-[0-9a-f]{32}",
+      anyOf: [
+        {
+          type: "string",
+          pattern: "wf_[0-9a-zA-Z]+",
+        },
+        {
+          type: "string",
+          pattern: "wf-[0-9a-f]{32}",
+        },
+      ],
       title: "Workflow Id",
     },
     type: {
@@ -133,7 +141,7 @@ export const $ActionReadMinimal = {
     },
     workflow_id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}",
+      pattern: "wf_[0-9a-zA-Z]+",
       title: "Workflow Id",
     },
     type: {
@@ -768,7 +776,6 @@ export const $DSLRunArgs = {
     },
     wf_id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}",
       title: "Wf Id",
     },
     trigger_inputs: {
@@ -1052,7 +1059,8 @@ export const $EventGroup = {
       anyOf: [
         {
           type: "string",
-          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+          pattern:
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
         },
         {
           type: "null",
@@ -1128,7 +1136,6 @@ export const $GetWorkflowDefinitionActivityInputs = {
     },
     workflow_id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}",
       title: "Workflow Id",
     },
     version: {
@@ -2297,12 +2304,12 @@ export const $RunContext = {
   properties: {
     wf_id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}",
       title: "Wf Id",
     },
     wf_exec_id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+      pattern:
+        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
       title: "Wf Exec Id",
     },
     wf_run_id: {
@@ -2515,8 +2522,16 @@ export const $Schedule = {
 export const $ScheduleCreate = {
   properties: {
     workflow_id: {
-      type: "string",
-      pattern: "wf-[0-9a-f]{32}",
+      anyOf: [
+        {
+          type: "string",
+          pattern: "wf_[0-9a-zA-Z]+",
+        },
+        {
+          type: "string",
+          pattern: "wf-[0-9a-f]{32}",
+        },
+      ],
       title: "Workflow Id",
     },
     inputs: {
@@ -3825,6 +3840,7 @@ export const $WorkflowCommitResponse = {
   properties: {
     workflow_id: {
       type: "string",
+      pattern: "wf_[0-9a-zA-Z]+",
       title: "Workflow Id",
     },
     status: {
@@ -3956,8 +3972,16 @@ export const $WorkflowEventType = {
 export const $WorkflowExecutionCreate = {
   properties: {
     workflow_id: {
-      type: "string",
-      pattern: "wf-[0-9a-f]{32}",
+      anyOf: [
+        {
+          type: "string",
+          pattern: "wf_[0-9a-zA-Z]+",
+        },
+        {
+          type: "string",
+          pattern: "wf-[0-9a-f]{32}",
+        },
+      ],
       title: "Workflow Id",
     },
     inputs: {
@@ -3983,12 +4007,12 @@ export const $WorkflowExecutionCreateResponse = {
     },
     wf_id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}",
       title: "Wf Id",
     },
     wf_exec_id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+      pattern:
+        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
       title: "Wf Exec Id",
     },
   },
@@ -4060,7 +4084,8 @@ export const $WorkflowExecutionEvent = {
       anyOf: [
         {
           type: "string",
-          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+          pattern:
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
         },
         {
           type: "null",
@@ -4156,7 +4181,8 @@ export const $WorkflowExecutionEventCompact = {
       anyOf: [
         {
           type: "string",
-          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+          pattern:
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
         },
         {
           type: "null",
@@ -4266,7 +4292,8 @@ export const $WorkflowExecutionRead = {
       anyOf: [
         {
           type: "string",
-          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+          pattern:
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
         },
         {
           type: "null",
@@ -4370,7 +4397,8 @@ export const $WorkflowExecutionReadCompact = {
       anyOf: [
         {
           type: "string",
-          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+          pattern:
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
         },
         {
           type: "null",
@@ -4474,7 +4502,8 @@ export const $WorkflowExecutionReadMinimal = {
       anyOf: [
         {
           type: "string",
-          pattern: "wf-[0-9a-f]{32}:(exec-[\\w-]+|sch-[0-9a-f]{32}-.*)",
+          pattern:
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
         },
         {
           type: "null",
@@ -4518,7 +4547,7 @@ export const $WorkflowRead = {
   properties: {
     id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}",
+      pattern: "wf_[0-9a-zA-Z]+",
       title: "Id",
     },
     title: {
@@ -4665,7 +4694,7 @@ export const $WorkflowReadMinimal = {
   properties: {
     id: {
       type: "string",
-      pattern: "wf-[0-9a-f]{32}",
+      pattern: "wf_[0-9a-zA-Z]+",
       title: "Id",
     },
     title: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -209,8 +209,8 @@ import type {
  * This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
  * The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
  * @param data The data for the request.
- * @param data.path
  * @param data.secret
+ * @param data.workflowId
  * @param data.contentType
  * @returns WorkflowExecutionCreateResponse Successful Response
  * @throws ApiError
@@ -220,10 +220,10 @@ export const publicIncomingWebhook = (
 ): CancelablePromise<PublicIncomingWebhookResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/webhooks/{path}/{secret}",
+    url: "/webhooks/{workflow_id}/{secret}",
     path: {
-      path: data.path,
       secret: data.secret,
+      workflow_id: data.workflowId,
     },
     headers: {
       "content-type": data.contentType,
@@ -241,8 +241,8 @@ export const publicIncomingWebhook = (
  * This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
  * The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
  * @param data The data for the request.
- * @param data.path
  * @param data.secret
+ * @param data.workflowId
  * @param data.contentType
  * @returns unknown Successful Response
  * @throws ApiError
@@ -252,10 +252,10 @@ export const publicIncomingWebhookWait = (
 ): CancelablePromise<PublicIncomingWebhookWaitResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/webhooks/{path}/{secret}/wait",
+    url: "/webhooks/{workflow_id}/{secret}/wait",
     path: {
-      path: data.path,
       secret: data.secret,
+      workflow_id: data.workflowId,
     },
     headers: {
       "content-type": data.contentType,
@@ -853,10 +853,10 @@ export const triggersUpdateWebhook = (
  * List all workflow executions.
  * @param data The data for the request.
  * @param data.workspaceId
- * @param data.workflowId
  * @param data.trigger
  * @param data.userId
  * @param data.limit
+ * @param data.workflowId
  * @returns WorkflowExecutionReadMinimal Successful Response
  * @throws ApiError
  */
@@ -867,11 +867,11 @@ export const workflowExecutionsListWorkflowExecutions = (
     method: "GET",
     url: "/workflow-executions",
     query: {
-      workflow_id: data.workflowId,
       trigger: data.trigger,
       user_id: data.userId,
       limit: data.limit,
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1020,8 +1020,8 @@ export const workflowExecutionsTerminateWorkflowExecution = (
  * List Actions
  * List all actions for a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns ActionReadMinimal Successful Response
  * @throws ApiError
  */
@@ -1032,8 +1032,8 @@ export const actionsListActions = (
     method: "GET",
     url: "/actions",
     query: {
-      workflow_id: data.workflowId,
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1072,8 +1072,8 @@ export const actionsCreateAction = (
  * Get an action.
  * @param data The data for the request.
  * @param data.actionId
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns ActionRead Successful Response
  * @throws ApiError
  */
@@ -1087,8 +1087,8 @@ export const actionsGetAction = (
       action_id: data.actionId,
     },
     query: {
-      workflow_id: data.workflowId,
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1213,8 +1213,8 @@ export const workflowsAddTag = (
 /**
  * Remove Tag
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.tagId
+ * @param data.workflowId
  * @param data.workspaceId
  * @returns void Successful Response
  * @throws ApiError
@@ -1226,8 +1226,8 @@ export const workflowsRemoveTag = (
     method: "DELETE",
     url: "/workflows/{workflow_id}/tags/{tag_id}",
     path: {
-      workflow_id: data.workflowId,
       tag_id: data.tagId,
+      workflow_id: data.workflowId,
     },
     query: {
       workspace_id: data.workspaceId,
@@ -1419,8 +1419,8 @@ export const schedulesListSchedules = (
     method: "GET",
     url: "/schedules",
     query: {
-      workflow_id: data.workflowId,
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1840,8 +1840,8 @@ export const editorListFunctions = (
 /**
  * List Actions
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns EditorActionRead Successful Response
  * @throws ApiError
  */
@@ -1852,8 +1852,8 @@ export const editorListActions = (
     method: "GET",
     url: "/editor/actions",
     query: {
-      workflow_id: data.workflowId,
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1557,16 +1557,16 @@ export type login = {
 
 export type PublicIncomingWebhookData = {
   contentType?: string | null
-  path: string
   secret: string
+  workflowId: string
 }
 
 export type PublicIncomingWebhookResponse = WorkflowExecutionCreateResponse
 
 export type PublicIncomingWebhookWaitData = {
   contentType?: string | null
-  path: string
   secret: string
+  workflowId: string
 }
 
 export type PublicIncomingWebhookWaitResponse = unknown
@@ -2248,7 +2248,7 @@ export type PublicCheckHealthResponse = {
 }
 
 export type $OpenApiTs = {
-  "/webhooks/{path}/{secret}": {
+  "/webhooks/{workflow_id}/{secret}": {
     post: {
       req: PublicIncomingWebhookData
       res: {
@@ -2263,7 +2263,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/webhooks/{path}/{secret}/wait": {
+  "/webhooks/{workflow_id}/{secret}/wait": {
     post: {
       req: PublicIncomingWebhookWaitData
       res: {

--- a/frontend/src/lib/event-history.ts
+++ b/frontend/src/lib/event-history.ts
@@ -65,13 +65,37 @@ export function getRelativeTime(date: Date) {
  * - "wf-123:1234567890" -> ["wf-123", "1234567890"]
  * - "wf-123:1234567890:1" -> ["wf-123", "1234567890:1"]
  */
+/**
+ * Parses a full execution ID into workflow ID and execution ID components
+ * @param fullExecutionId - Full execution ID string in format "workflowId:executionId" or "workflowId/executionId"
+ * @returns Tuple of [workflowId, executionId]
+ * @throws Error if execution ID format is invalid
+ */
 export function parseExecutionId(fullExecutionId: string): [string, string] {
-  // Split at most once from the left, keeping any remaining colons in the second part
-  const splitIndex = fullExecutionId.indexOf(":")
-  if (splitIndex === -1) {
-    throw new Error("Invalid execution ID format - missing colon separator")
+  const separators = ["/", ":"]
+  for (const separator of separators) {
+    const splitIndex = fullExecutionId.indexOf(separator)
+    if (splitIndex !== -1) {
+      return [
+        fullExecutionId.slice(0, splitIndex),
+        fullExecutionId.slice(splitIndex + 1),
+      ]
+    }
   }
-  const workflowId = fullExecutionId.slice(0, splitIndex)
-  const executionId = fullExecutionId.slice(splitIndex + 1)
-  return [workflowId, executionId]
+  throw new Error("Invalid execution ID format - missing separator (: or /)")
+}
+
+/**
+ * Formats and URL encodes a workflow execution ID
+ * @param workflowId - ID of the workflow
+ * @param executionId - ID of the execution
+ * @returns URL encoded execution ID in format "workflowId/executionId"
+ */
+export function formatExecutionId(
+  workflowId: string,
+  executionId: string,
+  separator: string = "/"
+): string {
+  const encodedSeparator = encodeURIComponent(separator)
+  return `${workflowId}${encodedSeparator}${executionId}`
 }

--- a/registry/tracecat_registry/base/core/workflow.py
+++ b/registry/tracecat_registry/base/core/workflow.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Any, Literal
 
 from pydantic import Field
-from tracecat.identifiers import WorkflowID
+from tracecat.identifiers.workflow import AnyWorkflowID
 
 from tracecat_registry import RegistryActionError, registry
 
@@ -15,7 +15,7 @@ from tracecat_registry import RegistryActionError, registry
 async def execute(
     *,
     workflow_id: Annotated[
-        WorkflowID | None,
+        AnyWorkflowID | None,
         Field(
             default=None,
             description=(

--- a/tests/playbooks/test_playbooks.py
+++ b/tests/playbooks/test_playbooks.py
@@ -16,6 +16,7 @@ from tracecat.dsl.common import DSLRunArgs
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow, retry_policies
 from tracecat.expressions.common import ExprType
+from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.registry.repository import Repository
 from tracecat.types.auth import Role
@@ -131,7 +132,8 @@ async def test_playbook_live_run(
     defn_service = WorkflowDefinitionsService(session, role=test_role)
 
     logger.info("Creating workflow definition")
-    await defn_service.create_workflow_definition(workflow_id=workflow.id, dsl=dsl)
+    wf_id = WorkflowUUID.new(workflow.id)
+    await defn_service.create_workflow_definition(workflow_id=wf_id, dsl=dsl)
 
     wf_exec_id = generate_test_exec_id(f"{path.stem}-{workflow.title}")
     run_args = DSLRunArgs(

--- a/tests/playbooks/test_playbooks.py
+++ b/tests/playbooks/test_playbooks.py
@@ -9,11 +9,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from temporalio.client import Client
 from temporalio.worker import Worker
 
-from tests.shared import DSL_UTILITIES, TEST_WF_ID, generate_test_exec_id
+from tests.shared import TEST_WF_ID, generate_test_exec_id
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.dsl.action import DSLActivities
 from tracecat.dsl.common import DSLRunArgs
-from tracecat.dsl.worker import new_sandbox_runner
+from tracecat.dsl.worker import get_activities, new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow, retry_policies
 from tracecat.expressions.common import ExprType
 from tracecat.identifiers.workflow import WorkflowUUID
@@ -148,7 +147,7 @@ async def test_playbook_live_run(
     async with Worker(
         temporal_client,
         task_queue=queue,
-        activities=DSLActivities.load() + DSL_UTILITIES,
+        activities=get_activities(),
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
     ):

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -7,9 +7,7 @@ import os
 import httpx
 from slugify import slugify
 
-from tracecat.dsl.validation import validate_trigger_inputs_activity
 from tracecat.identifiers.workflow import EXEC_ID_PREFIX, WorkflowUUID
-from tracecat.workflow.management.definitions import get_workflow_definition_activity
 
 
 def user_client() -> httpx.AsyncClient:
@@ -25,6 +23,3 @@ TEST_WF_ID = WorkflowUUID(int=0)
 
 def generate_test_exec_id(name: str) -> str:
     return TEST_WF_ID.short() + f"/{EXEC_ID_PREFIX}" + slugify(name, separator="_")
-
-
-DSL_UTILITIES = [get_workflow_definition_activity, validate_trigger_inputs_activity]

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -2,41 +2,14 @@
 
 from __future__ import annotations
 
-import json
 import os
-from pathlib import Path
 
 import httpx
 from slugify import slugify
 
-from tracecat.db.schemas import BaseSecret
 from tracecat.dsl.validation import validate_trigger_inputs_activity
-from tracecat.identifiers.resource import ResourcePrefix
+from tracecat.identifiers.workflow import EXEC_ID_PREFIX, WorkflowUUID
 from tracecat.workflow.management.definitions import get_workflow_definition_activity
-
-
-def write_cookies(cookies: httpx.Cookies, cookies_path: Path) -> None:
-    """Write cookies to file."""
-    cookies_dict = dict(cookies)
-
-    # Overwrite the cookies file
-    with cookies_path.open(mode="w") as f:
-        json.dump(cookies_dict, f)
-
-
-def read_cookies(cookies_path: Path) -> httpx.Cookies:
-    """Read cookies from file."""
-    try:
-        with cookies_path.open() as f:
-            cookies_dict = json.load(f)
-        return httpx.Cookies(cookies_dict)
-    except (FileNotFoundError, json.JSONDecodeError):
-        return httpx.Cookies()
-
-
-def delete_cookies(cookies_path: Path) -> None:
-    """Delete cookies file."""
-    cookies_path.unlink(missing_ok=True)
 
 
 def user_client() -> httpx.AsyncClient:
@@ -47,90 +20,11 @@ def user_client() -> httpx.AsyncClient:
     )
 
 
-async def create_workflow(
-    title: str | None = None, description: str | None = None, file: Path | None = None
-):
-    # Passing a file supercedes creating a blank workflow with title and description
-    if file:
-        with file.open() as f:
-            yaml_content = f.read()
-        async with user_client() as client:
-            res = await client.post(
-                "/workflows",
-                files={"file": (file.name, yaml_content, "application/yaml")},
-            )
-    else:
-        params = {}
-        if title:
-            params["title"] = title
-        if description:
-            params["description"] = description
-        async with user_client() as client:
-            # Get the webhook url
-            res = await client.post("/workflows", data=params)
-
-    return handle_response(res)
-
-
-async def activate_workflow(workflow_id: str, with_webhook: bool = False):
-    async with user_client() as client:
-        res = await client.patch(f"/workflows/{workflow_id}", json={"status": "online"})
-        res.raise_for_status()
-        if with_webhook:
-            res = await client.patch(
-                f"/workflows/{workflow_id}/webhook", json={"status": "online"}
-            )
-            res.raise_for_status()
-
-
-def format_secrets_as_json(secrets: list[BaseSecret]) -> dict[str, str]:
-    """Format secrets as a dict."""
-    secret_dict = {}
-    for secret in secrets:
-        secret_dict[secret.name] = {
-            kv.key: kv.value.get_secret_value() for kv in secret.encrypted_keys
-        }
-    return secret_dict
-
-
-async def commit_workflow(workflow_id: str):
-    """Create a workflow definition from a workflow."""
-    async with user_client() as client:
-        res = await client.post(f"/workflows/{workflow_id}/commit")
-        res.raise_for_status()
-        return res.json()
-
-
-def handle_response(res: httpx.Response):
-    """Handle API responses.
-
-    1. Checks for specific status codes and raises exceptions.
-    2. Raise for status
-    3. Try to decode JSON response
-    4. If 3 fails, return the response text.
-    """
-    if res.status_code == 422:
-        # Unprocessable entity
-        raise ValueError(res.json())
-    if res.status_code == 204:
-        # No content
-        return None
-    res.raise_for_status()
-    try:
-        return res.json()
-    except json.JSONDecodeError:
-        return res.text
-
-
-TEST_WF_ID = "wf-00000000000000000000000000000000"
+TEST_WF_ID = WorkflowUUID(int=0)
 
 
 def generate_test_exec_id(name: str) -> str:
-    return (
-        TEST_WF_ID
-        + f":{ResourcePrefix.WORKFLOW_EXECUTION}-"
-        + slugify(name, separator="_")
-    )
+    return TEST_WF_ID.short() + f"/{EXEC_ID_PREFIX}" + slugify(name, separator="_")
 
 
 DSL_UTILITIES = [get_workflow_definition_activity, validate_trigger_inputs_activity]

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -8,7 +8,8 @@ from tests import shared
 from tracecat.contexts import ctx_role
 from tracecat.dsl.action import DSLActivities
 from tracecat.dsl.client import get_temporal_client
-from tracecat.dsl.common import DSLInput, DSLRunArgs
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.models import ActionStatement
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow, retry_policies
 from tracecat.logger import logger
@@ -84,23 +85,22 @@ async def test_execution_fails_invalid_expressions(
     dsl = DSLInput(
         title="Testing invalid expressions: " + expected_error,
         description="Testing different invalid expression scenarios",
-        entrypoint={
-            "ref": "failing_action",
-        },
+        entrypoint=DSLEntrypoint(
+            ref="failing_action",
+        ),
         actions=[
-            {
-                "ref": "failing_action",
-                "action": "core.transform.reshape",
-                "args": {
+            ActionStatement(
+                ref="failing_action",
+                action="core.transform.reshape",
+                args={
                     "value": {"data": expression},
                 },
-                "depends_on": [],
-                "description": "",
-            },
+                depends_on=[],
+                description="",
+            ),
         ],
         inputs={},
         returns=None,
-        tests=[],
         triggers=[],
     )
     test_name = f"test_execution_fails_invalid_expressions-{dsl.title}"

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -11,6 +11,7 @@ from tracecat.dsl.models import ActionStatement, RunActionInput, RunContext
 from tracecat.executor.models import ExecutorActionErrorInfo
 from tracecat.executor.service import run_action_from_input, sync_executor_entrypoint
 from tracecat.expressions.expectations import ExpectedField
+from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.registry.actions.models import (
     ActionStep,
@@ -32,7 +33,7 @@ def mock_run_context():
     wf_exec_id = f"{wf_id}:{exec_id}"
     run_id = uuid.uuid4()
     return RunContext(
-        wf_id=wf_id,
+        wf_id=WorkflowUUID.from_legacy(wf_id),
         wf_exec_id=wf_exec_id,
         wf_run_id=run_id,
         environment="default",

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -8,6 +8,7 @@ from tracecat.executor.models import DispatchActionContext
 from tracecat.executor.service import _dispatch_action, dispatch_action_on_cluster
 from tracecat.expressions.common import ExprContext
 from tracecat.git import GitUrl
+from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.types.auth import Role
 
 
@@ -19,8 +20,8 @@ def mock_session():
 @pytest.fixture
 def basic_task_input():
     """Fixture that provides a basic RunActionInput without looping."""
-    wf_id = "wf-" + uuid.uuid4().hex
-    wf_exec_id = wf_id + ":exec-test"
+    wf_id = WorkflowUUID.new_uuid4()
+    wf_exec_id = wf_id.short() + "/exec_test"
     wf_run_id = uuid.uuid4()
     return RunActionInput(
         task=ActionStatement(
@@ -47,8 +48,8 @@ def basic_task_input():
 
 @pytest.fixture
 def basic_looped_task_input():
-    wf_id = "wf-" + uuid.uuid4().hex
-    wf_exec_id = wf_id + ":exec-test"
+    wf_id = WorkflowUUID.new_uuid4()
+    wf_exec_id = wf_id.short() + "/exec_test"
     wf_run_id = uuid.uuid4()
     return RunActionInput(
         task=ActionStatement(

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -42,7 +42,7 @@ from tracecat.dsl.models import (
 from tracecat.dsl.worker import get_activities, new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow, retry_policies
 from tracecat.expressions.common import ExprContext
-from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowID
+from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowID, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.secrets.models import SecretCreate, SecretKeyValue
 from tracecat.secrets.service import SecretsService
@@ -568,14 +568,15 @@ async def _create_and_commit_workflow(
         workflow = res.workflow
         if not workflow:
             return pytest.fail("Workflow wasn't created")
+        workflow_id = WorkflowUUID.new(workflow.id)
         if alias:
-            await mgmt_service.update_workflow(workflow.id, WorkflowUpdate(alias=alias))
+            await mgmt_service.update_workflow(workflow_id, WorkflowUpdate(alias=alias))
         constructed_dsl = await mgmt_service.build_dsl_from_workflow(workflow)
 
         # Commit the child workflow
         defn_service = WorkflowDefinitionsService(session, role=role)
         await defn_service.create_workflow_definition(
-            workflow_id=workflow.id, dsl=constructed_dsl
+            workflow_id=workflow_id, dsl=constructed_dsl
         )
         return workflow
 
@@ -715,7 +716,7 @@ async def test_child_workflow_context_passing(test_role, temporal_client):
     child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
 
     # Parent
-    parent_workflow_id = "wf-00000000000000000000000000000002"
+    parent_workflow_id = WorkflowUUID.new("wf-00000000000000000000000000000002")
     parent_dsl = DSLInput(
         **{
             "title": "Parent",
@@ -881,7 +882,7 @@ async def test_child_workflow_loop(
     run_args = DSLRunArgs(
         dsl=parent_dsl,
         role=test_role,
-        wf_id="wf-00000000000000000000000000000002",
+        wf_id=WorkflowUUID.new("wf-00000000000000000000000000000002"),
         trigger_inputs={
             "data": "__EXPECTED_DATA__",
         },
@@ -964,7 +965,7 @@ async def test_single_child_workflow_alias(
     run_args = DSLRunArgs(
         dsl=parent_dsl,
         role=test_role,
-        wf_id="wf-00000000000000000000000000000002",
+        wf_id=WorkflowUUID.new("wf-00000000000000000000000000000002"),
     )
     result = await _run_workflow(temporal_client, wf_exec_id, run_args)
     # Parent expected
@@ -1042,7 +1043,7 @@ async def test_child_workflow_alias_with_loop(
     run_args = DSLRunArgs(
         dsl=parent_dsl,
         role=test_role,
-        wf_id="wf-00000000000000000000000000000002",
+        wf_id=WorkflowUUID.new("wf-00000000000000000000000000000002"),
         trigger_inputs="__EXPECTED_DATA__",
     )
     result = await _run_workflow(temporal_client, wf_exec_id, run_args)
@@ -1546,16 +1547,17 @@ async def test_pull_based_workflow_fetches_latest_version(temporal_client, test_
         if not workflow:
             return pytest.fail("Workflow wasn't created")
         constructed_dsl = await mgmt_service.build_dsl_from_workflow(workflow)
+        workflow_id = WorkflowUUID.new(workflow.id)
 
         # 2) Create first workflow definition
         defn_service = WorkflowDefinitionsService(session, role=test_role)
         await defn_service.create_workflow_definition(
-            workflow_id=workflow.id, dsl=constructed_dsl
+            workflow_id=workflow_id, dsl=constructed_dsl
         )
 
     run_args = DSLRunArgs(
         role=test_role,
-        wf_id=workflow.id,
+        wf_id=workflow_id,
         # NOTE: Not setting dsl here to make it pull based
         # Not setting schedule_id here to make it use the passed in trigger inputs
     )
@@ -1589,7 +1591,7 @@ async def test_pull_based_workflow_fetches_latest_version(temporal_client, test_
         # 4) Create second workflow definition
         defn_service = WorkflowDefinitionsService(session, role=test_role)
         await defn_service.create_workflow_definition(
-            workflow_id=workflow.id, dsl=second_dsl
+            workflow_id=workflow_id, dsl=second_dsl
         )
 
     result = await _run_workflow(temporal_client, f"{wf_exec_id}:second", run_args)
@@ -2396,19 +2398,20 @@ async def error_handler_wf_and_dsl(
         workflow = res.workflow
         if not workflow:
             raise ValueError("Workflow wasn't created")
+        workflow_id = WorkflowUUID.new(workflow.id)
         if alias:
-            await mgmt_service.update_workflow(workflow.id, WorkflowUpdate(alias=alias))
+            await mgmt_service.update_workflow(workflow_id, WorkflowUpdate(alias=alias))
         constructed_dsl = await mgmt_service.build_dsl_from_workflow(workflow)
 
         # Commit the child workflow
         defn_service = WorkflowDefinitionsService(session, role=test_role)
         await defn_service.create_workflow_definition(
-            workflow_id=workflow.id, dsl=constructed_dsl
+            workflow_id=workflow_id, dsl=constructed_dsl
         )
         try:
             yield ErrorHandlerWfAndDslT(dsl, workflow)
         finally:
-            await mgmt_service.delete_workflow(workflow.id)
+            await mgmt_service.delete_workflow(workflow_id)
 
 
 @pytest.fixture
@@ -2528,10 +2531,10 @@ def assert_error_handler_initiated_correctly(
                 "type": "ExecutorClientError",
             }
         },
-        "handler_wf_id": handler_wf.id,
+        "handler_wf_id": str(WorkflowUUID.new(handler_wf.id)),
         "message": "Workflow failed with 1 task exception(s)\n\n==================== (1/1) ACTIONS.failing_action ====================\n\nExecutorClientError: [ACTIONS.failing_action -> run_action] (Attempt 1)\n\nThere was an error in the executor when calling action 'core.transform.reshape' (500).\n\nTracecatExpressionError: Error evaluating expression `1/0`\n\n[evaluator] Evaluation failed at node:\n```\nbinary_op\n  literal\t1\n  /\n  literal\t0\n\n```\nReason: Error trying to process rule \"binary_op\":\n\nCannot divide by zero\n\n------------------------------\nFile: /app/tracecat/expressions/core.py\nFunction: result\nLine: 74",
         "orig_wf_exec_id": failing_wf_exec_id,
-        "orig_wf_id": failing_wf_id,
+        "orig_wf_id": str(failing_wf_id),
     }
     return evt
 
@@ -2607,7 +2610,7 @@ async def test_workflow_error_handler_success(
 
     match mode:
         case "id":
-            error_handler = handler_wf.id
+            error_handler = WorkflowUUID.new(handler_wf.id).short()
         case "alias":
             error_handler = handler_wf.alias
         case _:
@@ -2665,7 +2668,7 @@ async def test_workflow_error_handler_success(
     [
         pytest.param(
             "wf-00000000000000000000000000000000",
-            "TracecatException: Workflow definition not found for 'wf-00000000000000000000000000000000', version=None",
+            "TracecatException: Workflow definition not found for WorkflowUUID('00000000-0000-0000-0000-000000000000'), version=None",
             id="id-no-match",
         ),
         pytest.param(

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -36,7 +36,8 @@ from tracecat.dsl.view import RFEdge, RFGraph, RFNode, TriggerNode, UDFNode, UDF
 from tracecat.expressions import patterns
 from tracecat.expressions.common import ExprContext
 from tracecat.expressions.expectations import ExpectedField
-from tracecat.identifiers import ScheduleID, WorkflowID
+from tracecat.identifiers import ScheduleID
+from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowID, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
 from tracecat.types.auth import Role
@@ -235,6 +236,12 @@ class DSLRunArgs(BaseModel):
         description="The schedule ID that triggered this workflow, if any.",
     )
 
+    @field_validator("wf_id", mode="before")
+    @classmethod
+    def validate_workflow_id(cls, v: AnyWorkflowID) -> WorkflowUUID:
+        """Convert any valid workflow ID format to WorkflowUUID."""
+        return WorkflowUUID.new(v)
+
 
 class ExecuteChildWorkflowArgs(BaseModel):
     workflow_id: WorkflowID | None = None
@@ -261,6 +268,12 @@ class ExecuteChildWorkflowArgs(BaseModel):
                 },
             )
         return self
+
+    @field_validator("workflow_id", mode="before")
+    @classmethod
+    def validate_workflow_id(cls, v: AnyWorkflowID) -> WorkflowUUID:
+        """Convert any valid workflow ID format to WorkflowUUID."""
+        return WorkflowUUID.new(v)
 
 
 class ChildWorkflowMemo(BaseModel):

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -4,13 +4,14 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, TypedDict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.expressions.common import ExprContext
 from tracecat.expressions.validation import ExpressionStr
-from tracecat.identifiers import WorkflowExecutionID, WorkflowID, WorkflowRunID
+from tracecat.identifiers import WorkflowExecutionID, WorkflowRunID
+from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 
 SLUG_PATTERN = r"^[a-z0-9_]+$"
@@ -170,10 +171,16 @@ class DSLEnvironment(TypedDict, total=False):
 class RunContext(BaseModel):
     """This is the runtime context model for a workflow run. Passed into activities."""
 
-    wf_id: WorkflowID
+    wf_id: WorkflowUUID
     wf_exec_id: WorkflowExecutionID
     wf_run_id: WorkflowRunID
     environment: str
+
+    @field_validator("wf_id", mode="before")
+    @classmethod
+    def validate_workflow_id(cls, v: AnyWorkflowID) -> WorkflowUUID:
+        """Convert any valid workflow ID format to WorkflowUUID."""
+        return WorkflowUUID.new(v)
 
 
 class RunActionInput(BaseModel):

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -190,7 +190,7 @@ class DSLWorkflow:
             )
             # 1. Get the error handler workflow ID
             handler_wf_id = await self._get_error_handler_workflow_id(args)
-            if not handler_wf_id:
+            if handler_wf_id is None:
                 self.logger.warning("No error handler workflow ID found, raising error")
                 raise e
 

--- a/tracecat/editor/router.py
+++ b/tracecat/editor/router.py
@@ -1,13 +1,13 @@
 import inspect
 from typing import Union, get_type_hints
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, status
 
 from tracecat.auth.credentials import RoleACL
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.editor.models import EditorActionRead, EditorFunctionRead, EditorParamRead
 from tracecat.expressions.functions import FUNCTION_MAPPING
-from tracecat.identifiers import WorkflowID
+from tracecat.identifiers.workflow import AnyWorkflowIDQuery
 from tracecat.types.auth import Role
 from tracecat.workflow.management.management import WorkflowsManagementService
 
@@ -82,7 +82,7 @@ async def list_actions(
         require_workspace="yes",
     ),
     session: AsyncDBSession,
-    workflow_id: WorkflowID = Query(...),
+    workflow_id: AnyWorkflowIDQuery,
 ):
     # find actions that are in the workflow
     service = WorkflowsManagementService(session, role=role)

--- a/tracecat/identifiers/common.py
+++ b/tracecat/identifiers/common.py
@@ -140,6 +140,7 @@ class TracecatUUID[ShortID: str](UUID):
 
     @classmethod
     def new(cls, id: Any) -> Self:
+        """Coerce an ID into an instance of TracecatUUID. Handles legacy ids."""
         if isinstance(id, cls):
             return id
         match id:

--- a/tracecat/webhooks/models.py
+++ b/tracecat/webhooks/models.py
@@ -3,6 +3,7 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 from tracecat.db.schemas import Resource
+from tracecat.identifiers.workflow import WorkflowID
 
 
 class WebhookResponse(Resource):
@@ -12,7 +13,7 @@ class WebhookResponse(Resource):
     entrypoint_ref: str | None = None
     filters: dict[str, Any]
     method: Literal["GET", "POST"]
-    workflow_id: str
+    workflow_id: WorkflowID
     url: str
 
 

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from tracecat.contexts import ctx_role
 from tracecat.dsl.common import DSLInput
+from tracecat.identifiers.workflow import AnyWorkflowIDPath
 from tracecat.logger import logger
 from tracecat.webhooks.dependencies import PayloadDep, WorkflowDefinitionFromWebhook
 from tracecat.workflow.executions.enums import TriggerType
@@ -13,9 +14,11 @@ from tracecat.workflow.executions.service import WorkflowExecutionsService
 router = APIRouter(prefix="/webhooks")
 
 
-@router.post("/{path}/{secret}", tags=["public"])
+@router.post("/{workflow_id}/{secret}", tags=["public"])
 async def incoming_webhook(
-    defn: WorkflowDefinitionFromWebhook, path: str, payload: PayloadDep
+    defn: WorkflowDefinitionFromWebhook,
+    workflow_id: AnyWorkflowIDPath,
+    payload: PayloadDep,
 ) -> WorkflowExecutionCreateResponse:
     """
     Webhook endpoint to trigger a workflow.
@@ -23,23 +26,25 @@ async def incoming_webhook(
     This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
     The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
     """
-    logger.info("Webhook hit", path=path, payload=payload, role=ctx_role.get())
+    logger.info("Webhook hit", path=workflow_id, payload=payload, role=ctx_role.get())
 
     dsl_input = DSLInput(**defn.content)
 
     service = await WorkflowExecutionsService.connect()
     response = service.create_workflow_execution_nowait(
         dsl=dsl_input,
-        wf_id=path,
+        wf_id=workflow_id,
         payload=payload,
         trigger_type=TriggerType.WEBHOOK,
     )
     return response
 
 
-@router.post("/{path}/{secret}/wait", tags=["public"])
+@router.post("/{workflow_id}/{secret}/wait", tags=["public"])
 async def incoming_webhook_wait(
-    defn: WorkflowDefinitionFromWebhook, path: str, payload: PayloadDep
+    defn: WorkflowDefinitionFromWebhook,
+    workflow_id: AnyWorkflowIDPath,
+    payload: PayloadDep,
 ) -> Any:
     """
     Webhook endpoint to trigger a workflow.
@@ -47,14 +52,14 @@ async def incoming_webhook_wait(
     This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
     The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
     """
-    logger.info("Webhook hit", path=path, payload=payload, role=ctx_role.get())
+    logger.info("Webhook hit", path=workflow_id, payload=payload, role=ctx_role.get())
 
     dsl_input = DSLInput(**defn.content)
 
     service = await WorkflowExecutionsService.connect()
     response = await service.create_workflow_execution(
         dsl=dsl_input,
-        wf_id=path,
+        wf_id=workflow_id,
         payload=payload,
         trigger_type=TriggerType.WEBHOOK,
     )

--- a/tracecat/workflow/actions/models.py
+++ b/tracecat/workflow/actions/models.py
@@ -7,7 +7,7 @@ from pydantic_core import PydanticCustomError
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy
 from tracecat.identifiers.action import ActionID
-from tracecat.identifiers.workflow import WorkflowID
+from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowIDShort
 
 
 class ActionControlFlow(BaseModel):
@@ -32,7 +32,7 @@ class ActionRead(BaseModel):
 
 class ActionReadMinimal(BaseModel):
     id: ActionID
-    workflow_id: WorkflowID
+    workflow_id: WorkflowIDShort
     type: str
     title: str
     description: str
@@ -40,7 +40,7 @@ class ActionReadMinimal(BaseModel):
 
 
 class ActionCreate(BaseModel):
-    workflow_id: WorkflowID
+    workflow_id: AnyWorkflowID
     type: str
     title: str = Field(..., min_length=1, max_length=100)
 

--- a/tracecat/workflow/executions/common.py
+++ b/tracecat/workflow/executions/common.py
@@ -143,10 +143,17 @@ def build_query(
     workflow_id: WorkflowID | None = None,
     trigger_types: set[TriggerType] | None = None,
     triggered_by_user_id: UserID | None = None,
+    _include_legacy: bool = True,
 ) -> str:
     query = []
     if workflow_id:
-        query.append(f"WorkflowId STARTS_WITH '{workflow_id}'")
+        short_id = workflow_id.short()
+        wf_id_query = f"WorkflowId STARTS_WITH '{short_id}'"
+        if _include_legacy:
+            # NOTE(COMPAT): Include legacy workflow ID for backwards compatibility
+            legacy_wf_id = workflow_id.to_legacy()
+            wf_id_query += f" OR WorkflowId STARTS_WITH '{legacy_wf_id}'"
+        query.append(wf_id_query)
     if trigger_types:
         if len(trigger_types) == 1:
             query.append(f"TracecatTriggerType = '{trigger_types.pop().value}'")

--- a/tracecat/workflow/executions/dependencies.py
+++ b/tracecat/workflow/executions/dependencies.py
@@ -3,10 +3,10 @@ from typing import Annotated
 
 from fastapi import Depends
 
-from tracecat.workflow.executions.models import WorkflowExecutionID
+from tracecat.identifiers.workflow import WorkflowExecutionID
 
 
-def unquote_dep(execution_id: WorkflowExecutionID) -> WorkflowExecutionID:
+def unquote_dep(execution_id: str) -> WorkflowExecutionID:
     return urllib.parse.unquote(execution_id)
 
 

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -22,6 +22,7 @@ from tracecat.dsl.models import (
     TriggerInputs,
 )
 from tracecat.identifiers import WorkflowExecutionID, WorkflowID
+from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.types.auth import Role
 from tracecat.workflow.executions.common import (
@@ -203,12 +204,13 @@ class EventGroup(BaseModel, Generic[EventInput]):
             action_title = None
             action_description = None
 
+        wf_id = WorkflowUUID.new(dsl_run_args.wf_id)
         return EventGroup(
             event_id=event.event_id,
             udf_namespace="core.workflow",
             udf_name="execute",
             udf_key="core.workflow.execute",
-            action_id=dsl_run_args.wf_id,
+            action_id=wf_id.short(),
             action_ref=None,
             action_title=action_title,
             action_description=action_description,
@@ -366,7 +368,7 @@ class WorkflowExecutionEventCompact(BaseModel):
 
 
 class WorkflowExecutionCreate(BaseModel):
-    workflow_id: WorkflowID
+    workflow_id: AnyWorkflowID
     inputs: TriggerInputs | None = None
 
 

--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -43,7 +43,7 @@ async def create_schedule(
     if task_timeout := config.TEMPORAL__TASK_TIMEOUT:
         schedule_kwargs["task_timeout"] = timedelta(seconds=float(task_timeout))
 
-    workflow_schedule_id = f"{workflow_id}:{schedule_id}"
+    workflow_schedule_id = f"{workflow_id.short()}/{schedule_id}"
 
     if config.TEMPORAL__API_KEY__ARN or config.TEMPORAL__API_KEY:
         logger.warning(

--- a/tracecat/workflow/schedules/models.py
+++ b/tracecat/workflow/schedules/models.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from tracecat.identifiers import OwnerID, ScheduleID, WorkflowID
+from tracecat.identifiers.workflow import AnyWorkflowID
 from tracecat.types.auth import Role
 
 
@@ -24,7 +25,7 @@ class ScheduleRead(BaseModel):
 
 
 class ScheduleCreate(BaseModel):
-    workflow_id: WorkflowID
+    workflow_id: AnyWorkflowID
     inputs: dict[str, Any] | None = None
     cron: str | None = None
     every: timedelta = Field(..., description="ISO 8601 duration string")

--- a/tracecat/workflow/schedules/router.py
+++ b/tracecat/workflow/schedules/router.py
@@ -4,7 +4,8 @@ from sqlmodel import select
 from tracecat.auth.dependencies import WorkspaceUserRole
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.schemas import Schedule
-from tracecat.identifiers import ScheduleID, WorkflowID
+from tracecat.identifiers import ScheduleID
+from tracecat.identifiers.workflow import OptionalAnyWorkflowIDQuery
 from tracecat.logger import logger
 from tracecat.types.exceptions import TracecatNotFoundError, TracecatServiceError
 from tracecat.workflow.schedules.models import (
@@ -21,7 +22,7 @@ router = APIRouter(prefix="/schedules")
 async def list_schedules(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
-    workflow_id: WorkflowID | None = None,
+    workflow_id: OptionalAnyWorkflowIDQuery,
 ) -> list[Schedule]:
     service = WorkflowSchedulesService(session, role=role)
     return await service.list_schedules(workflow_id=workflow_id)

--- a/tracecat/workflow/tags/router.py
+++ b/tracecat/workflow/tags/router.py
@@ -4,7 +4,7 @@ from sqlalchemy.exc import NoResultFound
 
 from tracecat.auth.dependencies import WorkspaceUserRole
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.identifiers.workflow import WorkflowID
+from tracecat.identifiers.workflow import AnyWorkflowIDPath
 from tracecat.tags.models import TagRead
 from tracecat.workflow.tags.models import WorkflowTagCreate
 from tracecat.workflow.tags.service import WorkflowTagsService
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/workflows", tags=["workflows"])
 async def list_tags(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
-    workflow_id: WorkflowID,
+    workflow_id: AnyWorkflowIDPath,
 ) -> list[TagRead]:
     """List all tags for a workflow."""
     service = WorkflowTagsService(session, role=role)
@@ -29,7 +29,7 @@ async def list_tags(
 async def add_tag(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
-    workflow_id: WorkflowID,
+    workflow_id: AnyWorkflowIDPath,
     params: WorkflowTagCreate,
 ) -> None:
     """Add a tag to a workflow."""
@@ -41,7 +41,7 @@ async def add_tag(
 async def remove_tag(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
-    workflow_id: WorkflowID,
+    workflow_id: AnyWorkflowIDPath,
     tag_id: UUID4,
 ) -> None:
     service = WorkflowTagsService(session, role=role)


### PR DESCRIPTION
# What
Replace legacy ID (`r"wf-[0-9a-z]{32}"`) with WorkflowUUID as the canonical ID in the app. 

We accept both the new and legacy ID types at the following data exchange boundaries:
- FastAPI routers
- Temporal client workflow executions subsystem
- Database


This means we pass around WorkflowUUID internally, then when needed convert to a different representation (like short ID, or legacy format). Currently, for API responses we return short IDs (base62 `r"<prefix>_[0-9a-zA-Z]{22}"`), and when interfacing with the DB/Temporal wf runs we convert to the legacy format as part of the larger transition of moving off the legacy ID format.

We also introduce short IDs for workflows and workflow executions.

# Why
These changes allow both legacy and new IDs to coexist together. We will only migrate the db schema after this PR, so that if we ever downgrade the DB post workflow ID schema change and workflow runs have been created with both old and new IDs, we fallback to a state of the app with this change and can support both IDs.