### PR TITLE
feat(engine): Use uv in ray runtime env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,16 @@ RUN chmod +x auto-update.sh && \
 RUN groupadd -g 1001 apiuser && \
     useradd -m -u 1001 -g apiuser apiuser
 
-# Set up directories for uv and pip
-RUN mkdir -p /home/apiuser/.cache/uv /home/apiuser/.local && \
+# Set up directories for uv and pip with proper permissions
+RUN mkdir -p /home/apiuser/.cache/uv /home/apiuser/.local/bin /home/apiuser/.local/lib/python3.12/site-packages && \
     chown -R apiuser:apiuser /home/apiuser/.cache /home/apiuser/.local && \
     chmod -R 755 /home/apiuser/.cache /home/apiuser/.local
 
+# Ensure PYTHONUSERBASE and UV paths are set
 ENV PYTHONUSERBASE="/home/apiuser/.local"
 ENV UV_CACHE_DIR="/home/apiuser/.cache/uv"
-ENV PYTHONPATH=/home/apiuser/.local:$PYTHONPATH
-ENV PATH=/home/apiuser/.local/bin:$PATH
+ENV PATH="/home/apiuser/.local/bin:$PATH"
+ENV PYTHONPATH="/home/apiuser/.local/lib/python3.12/site-packages:$PYTHONPATH"
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -57,6 +58,9 @@ RUN chmod +x /app/entrypoint.sh
 # Install package and registry
 RUN uv pip install .
 RUN uv pip install ./registry
+
+# Create symlink for uv binary to point to /home/apiuser/.local/bin/uv
+RUN ln -s $(command -v uv) /home/apiuser/.local/bin/uv
 
 # Ensure apiuser has write permissions to necessary directories
 RUN chown -R apiuser:apiuser /tmp /home/apiuser

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,6 +30,9 @@ RUN chmod +x /app/entrypoint.sh
 RUN uv pip install -e .
 RUN uv pip install -e ./registry
 
+# Create symlink for uv binary to point to /root/.local/bin/uv
+RUN mkdir -p ~/.local/bin && ln -s $(command -v uv) ~/.local/bin/uv
+
 # Install git
 RUN apt-get update && apt-get install -y git
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
 
   api:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.27.0}
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: api
     restart: unless-stopped
     networks:
@@ -66,7 +68,10 @@ services:
       - executor
 
   worker:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.27.0}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: worker
     restart: unless-stopped
     networks:
       - core
@@ -96,13 +101,16 @@ services:
     command: ["python", "tracecat/dsl/worker.py"]
 
   executor:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.27.0}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: executor
     restart: unless-stopped
     networks:
       - core-db
       - temporal
-    # ports:
-    #   - 8265:8265
+    ports:
+      - 8265:8265
     environment:
       # Common
       LOG_LEVEL: ${LOG_LEVEL}


### PR DESCRIPTION
UV cache is out in ray 2.41.0.
Our dockerfile uses `/home/apiuser/.local/bin`
But the below error indicates its looking in `/root/.local/bin`:

```
worker-1              | Traceback (most recent call last):
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/agent/runtime_env_agent.py", line 387, in _create_runtime_env_with_retry
worker-1              |     runtime_env_context = await asyncio.wait_for(
worker-1              |                           ^^^^^^^^^^^^^^^^^^^^^^^
worker-1              |   File "/usr/local/lib/python3.12/asyncio/tasks.py", line 520, in wait_for
worker-1              |     return await fut
worker-1              |            ^^^^^^^^^
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/agent/runtime_env_agent.py", line 351, in _setup_runtime_env
worker-1              |     await create_for_plugin_if_needed(
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/plugin.py", line 254, in create_for_plugin_if_needed
worker-1              |     size_bytes = await plugin.create(uri, runtime_env, context, logger=logger)
worker-1              |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/uv.py", line 312, in create
worker-1              |     uv_dir_bytes = await task
worker-1              |                    ^^^^^^^^^^
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/uv.py", line 292, in _create_for_hash
worker-1              |     await UvProcessor(
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/uv.py", line 202, in _run
worker-1              |     await self._install_uv_packages(
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/uv.py", line 181, in _install_uv_packages
worker-1              |     await check_output_cmd(pip_install_cmd, logger=logger, cwd=cwd, env=pip_env)
worker-1              |   File "/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/utils.py", line 105, in check_output_cmd
worker-1              |     raise SubprocessCalledProcessError(
worker-1              | ray._private.runtime_env.utils.SubprocessCalledProcessError: Run cmd[15] failed with the following details.
worker-1              | Command '['/tmp/ray/session_2025-01-23_18-48-52_275580_7/runtime_resources/uv/060bd28d0aa7053cb41735921f7965cf50b2d538/virtualenv/bin/python', '-m', 'uv', 'pip', 'install', '--no-cache', '-r', '/tmp/ray/session_2025-01-23_18-48-52_275580_7/runtime_resources/uv/060bd28d0aa7053cb41735921f7965cf50b2d538/ray_runtime_env_internal_pip_requirements.txt']' returned non-zero exit status 1.
worker-1              | Last 50 lines of stdout:
worker-1              |     Traceback (most recent call last):
worker-1              |       File "<frozen runpy>", line 198, in _run_module_as_main
worker-1              |       File "<frozen runpy>", line 88, in _run_code
worker-1              |       File "/usr/local/lib/python3.12/site-packages/uv/__main__.py", line 47, in <module>
worker-1              |         _run()
worker-1              |       File "/usr/local/lib/python3.12/site-packages/uv/__main__.py", line 27, in _run
worker-1              |         uv = os.fsdecode(find_uv_bin())
worker-1              |                          ^^^^^^^^^^^^^
worker-1              |       File "/usr/local/lib/python3.12/site-packages/uv/__init__.py", line 36, in find_uv_bin
worker-1              |         raise FileNotFoundError(path)
worker-1              |     FileNotFoundError: /root/.local/bin/uv
worker-1              |
worker-1              |
worker-1              | ------------------------------
worker-1              | File: /usr/local/lib/python3.12/site-packages/ray/_private/worker.py
worker-1              | Function: get_objects
worker-1              | Line: 908
```


We need a way to tell ray and uv where the uv binary is