### PR TITLE
release: 0.21.8

### DIFF
--- a/deployments/aws/ecs/variables.tf
+++ b/deployments/aws/ecs/variables.tf
@@ -103,7 +103,7 @@ variable "tracecat_ui_image" {
 
 variable "tracecat_image_tag" {
   type    = string
-  default = "0.21.7"
+  default = "0.21.8"
 }
 
 variable "temporal_server_image" {

--- a/deployments/aws/variables.tf
+++ b/deployments/aws/variables.tf
@@ -71,7 +71,7 @@ variable "tracecat_ui_image" {
 
 variable "tracecat_image_tag" {
   type    = string
-  default = "0.21.7"
+  default = "0.21.8"
 }
 
 variable "temporal_server_image" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
 
   api:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.21.7}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.21.8}
     container_name: api
     restart: unless-stopped
     networks:
@@ -60,7 +60,7 @@ services:
       OLLAMA__API_URL: ${OLLAMA__API_URL}
 
   worker:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.21.7}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.21.8}
     restart: unless-stopped
     networks:
       - core
@@ -85,7 +85,7 @@ services:
     command: ["python", "tracecat/dsl/worker.py"]
 
   executor:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.21.7}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.21.8}
     restart: unless-stopped
     networks:
       - core
@@ -120,7 +120,7 @@ services:
       ]
 
   ui:
-    image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-0.21.7}
+    image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-0.21.8}
     container_name: ui
     restart: unless-stopped
     networks:

--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -48,10 +48,10 @@ Use the commands listed below to download the required configuration files
 
 ```bash
 # 1. Download the env.sh installation script
-curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.7/env.sh
+curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.8/env.sh
 
 # 2. Download the .env.example template file (env.sh needs this to generate your .env file)
-curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.7/.env.example
+curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.8/.env.example
 
 # 3. Make the env.sh script executable and run it
 chmod +x env.sh && ./env.sh
@@ -87,13 +87,13 @@ Tracecat uses Caddy as a reverse proxy.
 You'll need to download the following `Caddyfile` to configure this service.
 
 ```bash
-curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.7/Caddyfile
+curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.8/Caddyfile
 ```
 
 ## Download Docker Compose File
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.7/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.8/docker-compose.yml
 ```
 
 ## Start Tracecat

--- a/docs/tutorials/updating.mdx
+++ b/docs/tutorials/updating.mdx
@@ -23,8 +23,8 @@ description: Learn how to safely update versions and run data migrations.
     version.
 
     ```
-    curl -o env-migration.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.7/env-migration.sh
-    curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.7/.env.example
+    curl -o env-migration.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.8/env-migration.sh
+    curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.8/.env.example
     ```
   </Step>
   <Step title="Execute environment variables migration">
@@ -39,7 +39,7 @@ description: Learn how to safely update versions and run data migrations.
     Download the latest Docker Compose file.
 
     ```
-    curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.7/docker-compose.yml
+    curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.21.8/docker-compose.yml
     ```
   </Step>
   <Step title="Restart Tracecat">

--- a/tracecat/__init__.py
+++ b/tracecat/__init__.py
@@ -1,3 +1,3 @@
 """Tracecat is the open source Tines / Splunk SOAR alternative."""
 
-__version__ = "0.21.7"
+__version__ = "0.21.8"


### PR DESCRIPTION
#785 needs to be in a separate PR from the workflow DB migration changes. This is so that if we rollback from 0.21.8+ (which contains ID changes in DB), the app won't just entirely break down. We may not be able to read workflow runs created in 0.21.8+, but at least you'll sitll be able to read existing workflow runs and operate on 0.21.8.