### PR TITLE
refactor(app): Change builder action inputs to use string

### DIFF
--- a/alembic/versions/4e07917dc4e8_keep_action_inputs_as_yaml_string.py
+++ b/alembic/versions/4e07917dc4e8_keep_action_inputs_as_yaml_string.py
@@ -1,0 +1,99 @@
+"""Keep Action inputs as yaml string
+
+Revision ID: 4e07917dc4e8
+Revises: f92c80ef8c9d
+Create Date: 2025-01-28 16:02:49.388047
+
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+import yaml
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+from tracecat.logger import logger
+
+# revision identifiers, used by Alembic.
+revision: str = "4e07917dc4e8"
+down_revision: str | None = "f92c80ef8c9d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # First alter the column type to text
+    op.alter_column(
+        "action",
+        "inputs",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        type_=sqlmodel.sql.sqltypes.AutoString(),
+        nullable=False,
+    )
+
+    # Then get all existing action inputs
+    connection = op.get_bind()
+    actions = connection.execute(text("SELECT id, inputs FROM action")).fetchall()
+
+    # Convert JSONB to YAML strings
+    for action_id, inputs in actions:
+        # JSONB data is a string. Load it as a dict.
+        # If its an empty dict, coerce it to None (empty string in yaml)
+        data = json.loads(inputs) or None
+        # Convert the dict to a YAML string.
+        yaml_str = yaml.dump(data) if data is not None else ""
+        logger.info(
+            "Updating action with inputs:",
+            inputs=inputs,
+            type=type(inputs).__name__,
+            data=data,
+            data_type=type(data).__name__,
+            yaml_str=yaml_str,
+        )
+
+        if inputs is not None:
+            # If the input is already a string, use it directly
+
+            connection.execute(
+                text("UPDATE action SET inputs = :yaml WHERE id = :id"),
+                {"yaml": yaml_str, "id": action_id},
+            )
+
+
+def downgrade() -> None:
+    # First get all existing action inputs
+    connection = op.get_bind()
+    actions = connection.execute(text("SELECT id, inputs FROM action")).fetchall()
+
+    # Convert strings back to JSON
+    for action_id, inputs in actions:
+        if inputs is not None:
+            # Nonetypes are stored as empty strings
+            try:
+                data = yaml.safe_load(inputs)
+            except yaml.YAMLError:
+                data = inputs
+            data = data or {}
+            json_data = json.dumps(data)
+
+            logger.info(
+                "Downgrading action with inputs:",
+                inputs=inputs,
+                type=type(inputs).__name__,
+                data=data,
+                data_type=type(data).__name__,
+                json_data=json_data,
+                json_data_type=type(json_data),
+            )
+
+            connection.execute(
+                text("UPDATE action SET inputs = :json WHERE id = :id"),
+                {"json": json_data, "id": action_id},
+            )
+
+    # Then alter the column type back to JSONB with explicit USING clause
+    op.execute("ALTER TABLE action ALTER COLUMN inputs TYPE JSONB USING inputs::jsonb")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -120,7 +120,7 @@ export const $ActionRead = {
       title: "Status",
     },
     inputs: {
-      type: "object",
+      type: "string",
       title: "Inputs",
     },
     control_flow: {
@@ -339,15 +339,10 @@ export const $ActionUpdate = {
       title: "Status",
     },
     inputs: {
-      anyOf: [
-        {
-          type: "object",
-        },
-        {
-          type: "null",
-        },
-      ],
+      type: "string",
+      maxLength: 10000,
       title: "Inputs",
+      default: "",
     },
     control_flow: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -28,9 +28,7 @@ export type ActionRead = {
   title: string
   description: string
   status: string
-  inputs: {
-    [key: string]: unknown
-  }
+  inputs: string
   control_flow?: ActionControlFlow
 }
 
@@ -111,9 +109,7 @@ export type ActionUpdate = {
   title?: string | null
   description?: string | null
   status?: string | null
-  inputs?: {
-    [key: string]: unknown
-  } | null
+  inputs?: string
   control_flow?: ActionControlFlow | null
 }
 

--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -10,6 +10,7 @@ import {
   Trash2Icon,
 } from "lucide-react"
 import { Node, NodeProps, useEdges } from "reactflow"
+import YAML from "yaml"
 
 import { useAction, useWorkflowManager } from "@/lib/hooks"
 import { cn, isEmptyObjectOrNullish, slugify } from "@/lib/utils"
@@ -91,11 +92,12 @@ export default React.memo(function ActionNode({
   const edges = useEdges()
   const incomingEdges = edges.filter((edge) => edge.target === id)
   const isChildWorkflow = action?.type === CHILD_WORKFLOW_ACTION_TYPE
-  const childWorkflowId = action?.inputs?.workflow_id
-    ? String(action?.inputs?.workflow_id)
+  const actionInputsObj = action?.inputs ? YAML.parse(action?.inputs) : {}
+  const childWorkflowId = actionInputsObj?.workflow_id
+    ? String(actionInputsObj?.workflow_id)
     : undefined
-  const childWorkflowAlias = action?.inputs?.workflow_alias
-    ? String(action?.inputs?.workflow_alias)
+  const childWorkflowAlias = actionInputsObj?.workflow_alias
+    ? String(actionInputsObj?.workflow_alias)
     : undefined
 
   // Create a skeleton loading state within the card frame

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -37,7 +37,7 @@ import { z } from "zod"
 
 import { RequestValidationError, TracecatApiError } from "@/lib/errors"
 import { useAction, useWorkbenchRegistryActions } from "@/lib/hooks"
-import { cn, itemOrEmptyString, slugify } from "@/lib/utils"
+import { cn, slugify } from "@/lib/utils"
 import {
   Accordion,
   AccordionContent,
@@ -101,7 +101,7 @@ const actionFormSchema = z.object({
   inputs: z
     .string()
     .max(10000, "Inputs must be less than 10000 characters")
-    .optional(),
+    .default(""),
   control_flow: z.object({
     for_each: z
       .string()
@@ -176,7 +176,7 @@ export function ActionPanel({
     values: {
       title: action?.title,
       description: action?.description,
-      inputs: itemOrEmptyString(action?.inputs),
+      inputs: action?.inputs ?? "",
       control_flow: {
         for_each: stringifyYaml(for_each),
         run_if: stringifyYaml(run_if),
@@ -212,7 +212,7 @@ export function ActionPanel({
         const params: ActionUpdate = {
           title: values.title,
           description: values.description,
-          inputs: parseYaml(values.inputs) ?? {},
+          inputs: values.inputs,
           control_flow: {
             ...parseYaml(values.control_flow.options),
             for_each: parseYaml(values.control_flow.for_each),

--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -427,7 +427,13 @@ class Action(Resource, table=True):
     title: str
     description: str
     status: str = "offline"  # "online" or "offline"
-    inputs: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSONB))
+    inputs: str = Field(
+        default="",
+        description=(
+            "YAML string containing input configuration. The default value is an empty "
+            "string, which is `null` in YAML flow style."
+        ),
+    )
     control_flow: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSONB))
 
     workflow_id: uuid.UUID = Field(

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -346,11 +346,12 @@ def build_action_statements(
 
         action = id2action[node.id]
         control_flow = ActionControlFlow.model_validate(action.control_flow)
+        args = yaml.safe_load(action.inputs) or {}
         action_stmt = ActionStatement(
             id=action.id,
             ref=action.ref,
             action=action.type,
-            args=action.inputs,
+            args=args,
             depends_on=dependencies,
             run_if=control_flow.run_if,
             for_each=control_flow.for_each,

--- a/tracecat/workflow/actions/models.py
+++ b/tracecat/workflow/actions/models.py
@@ -1,8 +1,4 @@
-from typing import Any
-
-import orjson
-from pydantic import BaseModel, Field, field_validator
-from pydantic_core import PydanticCustomError
+from pydantic import BaseModel, Field
 
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy
@@ -26,7 +22,7 @@ class ActionRead(BaseModel):
     title: str
     description: str
     status: str
-    inputs: dict[str, Any]
+    inputs: str
     control_flow: ActionControlFlow = Field(default_factory=ActionControlFlow)
 
 
@@ -49,15 +45,5 @@ class ActionUpdate(BaseModel):
     title: str | None = Field(default=None, min_length=1, max_length=100)
     description: str | None = Field(default=None, max_length=1000)
     status: str | None = None
-    inputs: dict[str, Any] | None = None
+    inputs: str = Field(default="", max_length=10000)
     control_flow: ActionControlFlow | None = None
-
-    @field_validator("inputs")
-    def validate_inputs(cls, v: dict[str, Any]) -> dict[str, Any]:
-        if len(orjson.dumps(v)) >= 10000:
-            raise PydanticCustomError(
-                "value_error.inputs_too_long",
-                "Inputs must be less than 10000 characters",
-                {"loc": ["inputs"]},
-            )
-        return v

--- a/tracecat/workflow/actions/router.py
+++ b/tracecat/workflow/actions/router.py
@@ -1,3 +1,4 @@
+import yaml
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import select
@@ -152,6 +153,14 @@ async def update_action(
         action.status = params.status
     if params.inputs is not None:
         action.inputs = params.inputs
+        # Validate that it's a valid YAML string
+        try:
+            yaml.safe_load(action.inputs)
+        except yaml.YAMLError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Action input contains invalid YAML",
+            ) from e
     if params.control_flow is not None:
         action.control_flow = params.control_flow.model_dump(mode="json")
 

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
+import yaml
 from pydantic import ValidationError
 from sqlmodel import and_, col, select
 from temporalio import activity
@@ -329,7 +330,7 @@ class WorkflowsManagementService(BaseService):
                 owner_id=self.role.workspace_id,
                 workflow_id=workflow.id,
                 type=act_stmt.action,
-                inputs=dict(act_stmt.args),
+                inputs=yaml.dump(act_stmt.args),
                 title=act_stmt.title,
                 description=act_stmt.description,
                 control_flow=control_flow.model_dump(),


### PR DESCRIPTION
# Changes
- Save as string instead of json in `Action`
- During commit, we coerce everything to dict and proceed as normal

# Impact
- Prevents auto-sorting fields and preserves original yaml layout
- Prevents removing YAML special syntax like `>`, `>-`
- Prevents issues with the cursor snapping to the bottom during save