### PR TITLE
fix(ui): Scrolling making workflow builder minify

### DIFF
--- a/frontend/src/components/workbench/canvas/selector-node.tsx
+++ b/frontend/src/components/workbench/canvas/selector-node.tsx
@@ -114,7 +114,17 @@ export default React.memo(function SelectorNode({
           ref={inputRef}
           className="!py-0 text-xs"
           placeholder="Start typing to search for an action..."
-          onValueChange={(value) => setInputValue(value)}
+          onValueChange={(value) => {
+            // First update the value
+            setInputValue(value)
+            // Then force scroll to top of the list
+            requestAnimationFrame(() => {
+              const commandList = document.querySelector('[cmdk-list]')
+              if (commandList) {
+                commandList.scrollTop = 0
+              }
+            })
+          }}
           autoFocus
         />
         <CommandList className="border-b">
@@ -129,7 +139,7 @@ export default React.memo(function SelectorNode({
       <Handle
         type="target"
         position={targetPosition ?? Position.Top}
-        isConnectable={false} // Prevent initiating a connection from the selector node
+        isConnectable={false}
         className={cn(
           "left-1/2 !size-8 !-translate-x-1/2 !border-none !bg-transparent"
         )}

--- a/frontend/src/components/workbench/canvas/selector-node.tsx
+++ b/frontend/src/components/workbench/canvas/selector-node.tsx
@@ -147,21 +147,12 @@ function ActionCommandSelector({
 }) {
   const { registryActions, registryActionsIsLoading, registryActionsError } =
     useWorkbenchRegistryActions()
-  const scrollAreaRef = useRef<HTMLDivElement>(null)
-
-  // Add effect to reset scroll position when search results change
-  useEffect(() => {
-    if (scrollAreaRef.current) {
-      scrollAreaRef.current.scrollTop = 0
-    }
-  }, [inputValue])
 
   if (!registryActions || registryActionsIsLoading) {
     return (
-      <ScrollArea className="h-full" ref={scrollAreaRef}>
-        <CommandGroup heading="Loading Actions..." className="text-xs">
-          {/* Render 5 skeleton items */}
-          {Array.from({ length: 5 }).map((_, index) => (
+      <ScrollArea className="h-full">
+        <CommandGroup heading="Loading actions..." className="text-xs">
+          {Array.from({ length: 3 }).map((_, index) => (
             <CommandItem key={index} className="text-xs">
               <div className="w-full flex-col">
                 <div className="flex items-center justify-start">
@@ -186,13 +177,15 @@ function ActionCommandSelector({
   }
 
   return (
-    <ScrollArea className="h-full" ref={scrollAreaRef}>
-      <ActionCommandGroup
-        group="Suggestions"
-        nodeId={nodeId}
-        registryActions={registryActions}
-        inputValue={inputValue}
-      />
+    <ScrollArea className="h-full overflow-y-auto">
+      {filterActions(registryActions, inputValue).length > 0 && (
+        <ActionCommandGroup
+          group="Suggestions"
+          nodeId={nodeId}
+          registryActions={registryActions}
+          inputValue={inputValue}
+        />
+      )}
     </ScrollArea>
   )
 }
@@ -282,18 +275,8 @@ function ActionCommandGroup({
     [getNode, nodeId, workflowId, workspaceId, setNodes, setEdges]
   )
 
-  // Add ref for the command group
-  const commandGroupRef = useRef<HTMLDivElement>(null)
-
-  // Reset scroll position when filter results change
-  useEffect(() => {
-    if (commandGroupRef.current) {
-      commandGroupRef.current.scrollIntoView({ block: "start" })
-    }
-  }, [filterResults])
-
   return (
-    <CommandGroup heading={group} className="text-xs" ref={commandGroupRef}>
+    <CommandGroup heading={group} className="text-xs">
       {filterResults.map((result) => {
         const action = result.obj
 


### PR DESCRIPTION
## Fix Command Menu Scroll Position During Search

This PR fixes an issue where the command menu's scroll position would jump unexpectedly when deleting characters in the search input. The scroll position should remain at the top regardless of whether the user is typing new characters or deleting them.

### Problem
When deleting characters in the search input, more items become visible in the filtered list. The browser tries to maintain the relative scroll position of currently visible elements, causing an undesirable jumping effect.

### Solution
We now force the scroll position to stay at the top after any input value changes by:
1. Updating the input value
2. Using `requestAnimationFrame` to wait for DOM updates
3. Explicitly setting the scroll position to 0 on the command list element

### Technical Details
- Using `requestAnimationFrame` ensures our scroll reset happens after React's re-render but before the next paint
- We target the `[cmdk-list]` element directly as it's the actual scrollable container
- The timing of the scroll reset prevents any visible jumping

### Testing
- [x] Typing characters keeps scroll at top
- [x] Deleting characters keeps scroll at top
- [x] No visible jumping when filtering results
- [x] Smooth user experience during search