### PR TITLE
Attempt to fix issue where first execution doesn't load

### DIFF
--- a/frontend/src/components/workbench/canvas/selector-node.tsx
+++ b/frontend/src/components/workbench/canvas/selector-node.tsx
@@ -119,7 +119,7 @@ export default React.memo(function SelectorNode({
             setInputValue(value)
             // Then force scroll to top of the list
             requestAnimationFrame(() => {
-              const commandList = document.querySelector('[cmdk-list]')
+              const commandList = document.querySelector("[cmdk-list]")
               if (commandList) {
                 commandList.scrollTop = 0
               }


### PR DESCRIPTION
## Description
The first execution doesn't load properly because we are using 2 hooks - (A)`useManualWorkflowExecution` and (B) `useCompactWorkflowExecution`. We are passing the output of A into B. For some reason there is some kind of race condition where the execution ID is observed as undefined, even though we manually triggered the workflow. 

## Solution
We add a small delay and then refetch the query key for "last-manual-execution" twice (seems like a timing issue, which is why this works). It works when you refetch twice but just adding delay as a failsafe