### PR TITLE
fix(ci): Pin working corepack version 

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -37,6 +37,9 @@ ENV NEXT_SERVER_API_URL=$NEXT_SERVER_API_URL
 # Copy node_modules from the deps stage
 COPY --from=deps /app/node_modules ./node_modules
 
+# Install working version of corepack
+RUN npm install -g corepack@0.31.0 && corepack --version
+
 # Copy all source files and build the application
 COPY . .
 RUN corepack enable pnpm && pnpm build

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -10,6 +10,9 @@ RUN apk add --no-cache libc6-compat
 # Copy only the necessary files to install dependencies
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 
+# Install working version of corepack
+RUN npm install -g corepack@0.31.0 && corepack --version
+
 # Install dependencies with pnpm
 RUN corepack enable pnpm && pnpm i --frozen-lockfile
 


### PR DESCRIPTION
## Description
https://github.com/stackblitz-labs/bolt.diy/issues/1250
https://github.com/worldcoin/developer-portal/pull/1165
https://github.com/nodejs/corepack/pull/614

CI breaking due to corepack signature verification error. Pin corepack to a working version