### PR TITLE
fix(app): Attempt to fix RegisterKwargs validation error

### DIFF
--- a/registry/tracecat_registry/_internal/registry.py
+++ b/registry/tracecat_registry/_internal/registry.py
@@ -98,7 +98,7 @@ def register(
                 "include_in_schema": include_in_schema,
                 "namespace": namespace,
                 "description": description,
-                "secrets": secrets,
+                "secrets": [s.model_dump() for s in secrets] if secrets else None,
             },
         )
         return fn

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -321,7 +321,7 @@ class Repository:
                 )
 
             # Load the repository module
-            logger.warning("Loading local repository", repo_path=repo_path.as_posix())
+            logger.debug("Loading local repository", repo_path=repo_path.as_posix())
             module = await self._load_repository(repo_path.as_posix(), package_name)
             logger.info(
                 "Imported and reloaded local repository",


### PR DESCRIPTION
# Description
We recently started to observe the following error:

<img width="893" alt="image" src="https://github.com/user-attachments/assets/46ef52c1-728d-45c4-9d76-03f1663a74b9" />

This error appears to be flaky and inconsistent -- particularly because the input data seems correct. We suspect that it has to do with different versions of `RegistrySecret` being used from different Tracecat repos. The current workaround is to delete the repo, add it again and re-sync. We will be adding a button that performs the workaround as a `reset` button if this ever shows up again (TODO), as a single DB transaction as workflows lookup this table.

# Fix
Attempt to fix by serializing secrets in the `register` decorator to avoid any ambiguity in `RegisterSecret` types.