### PR TITLE
feat(engine): Add `wait_until` and `retry_until`

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -43,6 +43,14 @@ export const $ActionControlFlow = {
       ],
       title: "For Each",
     },
+    join_strategy: {
+      allOf: [
+        {
+          $ref: "#/components/schemas/JoinStrategy",
+        },
+      ],
+      default: "all",
+    },
     retry_policy: {
       $ref: "#/components/schemas/ActionRetryPolicy",
     },
@@ -52,13 +60,17 @@ export const $ActionControlFlow = {
       description: "Delay before starting the action in seconds.",
       default: 0,
     },
-    join_strategy: {
-      allOf: [
+    wait_until: {
+      anyOf: [
         {
-          $ref: "#/components/schemas/JoinStrategy",
+          type: "string",
+        },
+        {
+          type: "null",
         },
       ],
-      default: "all",
+      title: "Wait Until",
+      description: "Delay until a specific date and time.",
     },
   },
   type: "object",
@@ -181,6 +193,18 @@ export const $ActionRetryPolicy = {
       description: "Timeout for the action in seconds.",
       default: 300,
     },
+    retry_until: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Retry Until",
+      description: "Retry until a specific condition is met.",
+    },
   },
   type: "object",
   title: "ActionRetryPolicy",
@@ -260,8 +284,22 @@ export const $ActionStatement = {
     start_delay: {
       type: "number",
       title: "Start Delay",
-      description: "Delay before starting the action in seconds.",
+      description:
+        "Delay before starting the action in seconds. If `wait_until` is also provided, the wait_until timer will take precedence.",
       default: 0,
+    },
+    wait_until: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Wait Until",
+      description:
+        "Delay until a specific date and time. Overrides `start_delay` if both are provided.",
     },
     join_strategy: {
       allOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8,12 +8,16 @@ export type AccessLevel = 0 | 999
 export type ActionControlFlow = {
   run_if?: string | null
   for_each?: string | Array<string> | null
+  join_strategy?: JoinStrategy
   retry_policy?: ActionRetryPolicy
   /**
    * Delay before starting the action in seconds.
    */
   start_delay?: number
-  join_strategy?: JoinStrategy
+  /**
+   * Delay until a specific date and time.
+   */
+  wait_until?: string | null
 }
 
 export type ActionCreate = {
@@ -50,6 +54,10 @@ export type ActionRetryPolicy = {
    * Timeout for the action in seconds.
    */
   timeout?: number
+  /**
+   * Retry until a specific condition is met.
+   */
+  retry_until?: string | null
 }
 
 export type ActionStatement = {
@@ -85,9 +93,13 @@ export type ActionStatement = {
    */
   retry_policy?: ActionRetryPolicy
   /**
-   * Delay before starting the action in seconds.
+   * Delay before starting the action in seconds. If `wait_until` is also provided, the wait_until timer will take precedence.
    */
   start_delay?: number
+  /**
+   * Delay until a specific date and time. Overrides `start_delay` if both are provided.
+   */
+  wait_until?: string | null
   /**
    * The strategy to use when joining on this task. By default, all branches must complete successfully before the join task can complete.
    */

--- a/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
+++ b/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
@@ -220,10 +220,10 @@ export function ControlFlowOptionsTooltip() {
         <div>Supports various formats including:</div>
         <ul className="list-disc pl-4 text-xs">
           <li>
-            Natural language: &quot;tomorrow at 3pm&quot;, &quot;in 2
-            hours&quot;
+            Natural language: &quot;tomorrow at 3pm&quot;, &quot;yesterday
+            5pm&quot;
           </li>
-          <li>Relative: &quot;3 days&quot;, &quot;2 weeks from now&quot;</li>
+          <li>Relative: &quot;3 days ago&quot;, &quot;in 2 weeks&quot;</li>
           <li>
             Absolute: &quot;2024-03-21 15:30:00&quot;, &quot;March 21st
             3:30pm&quot;
@@ -246,25 +246,18 @@ export function ControlFlowOptionsTooltip() {
       <div className="flex w-full flex-col space-y-2 text-muted-foreground">
         <div className="rounded-md border bg-muted-foreground/10 p-2">
           <pre className="whitespace-pre-wrap break-words text-xs text-foreground/70">
-            <p>
-              wait_until: tomorrow at 3pm{" "}
-              <span className="text-xs text-muted-foreground">
-                # wait until 3pm the next day from the time the action is
-                scheduled
-              </span>
-            </p>
-            <p>
-              wait_until: in 2 hours{" "}
-              <span className="text-xs text-muted-foreground">
-                # wait until 2 hours from the time the action is scheduled
-              </span>
-            </p>
-            <p>
-              wait_until: &quot;2026-03-21 15:30:00&quot;{" "}
-              <span className="text-xs text-muted-foreground">
-                # wait until 3:30pm on March 21st, 2026
-              </span>
-            </p>
+            <span className="text-xs text-muted-foreground">
+              # Run at 3pm the next day
+            </span>
+            <p>wait_until: tomorrow at 3pm </p>
+            <span className="text-xs text-muted-foreground">
+              # Run 2 hours after the action is scheduled
+            </span>
+            <p>wait_until: in 2 hours </p>
+            <span className="text-xs text-muted-foreground">
+              # Run at 3:30pm on March 21st, 2026
+            </span>
+            <p>wait_until: &quot;2026-03-21 15:30:00&quot; </p>
           </pre>
         </div>
         <div className="rounded-md border bg-muted-foreground/10 p-2">

--- a/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
+++ b/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
@@ -1,3 +1,5 @@
+import { ExternalLinkIcon } from "lucide-react"
+
 export function RunIfTooltip() {
   return (
     <div className="w-full space-y-4">
@@ -174,15 +176,65 @@ export function ControlFlowOptionsTooltip() {
         </div>
         <div>Defaults to `all`.</div>
       </div>
+      <div className="flex w-full items-center justify-between text-muted-foreground ">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm font-semibold">wait_until</span>
+          <span className="text-xs font-normal text-muted-foreground/80">
+            string
+          </span>
+        </div>
+        <span className="text-xs text-muted-foreground/80">(optional)</span>
+      </div>
+      <div className="w-full items-center space-y-2 text-start text-muted-foreground">
+        <div>
+          Specifies when to start the action using natural language or datetime
+          strings. We use the Python `dateparser` library to parse these
+          strings.
+        </div>
+        <div>Supports various formats including:</div>
+        <ul className="list-disc pl-4 text-xs">
+          <li>Natural language: "tomorrow at 3pm", "in 2 hours"</li>
+          <li>Relative: "3 days", "2 weeks from now"</li>
+          <li>Absolute: "2024-03-21 15:30:00", "March 21st 3:30pm"</li>
+        </ul>
+        {/* docs link */}
+        <a
+          href="https://dateparser.readthedocs.io/en/latest/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-blue-500 hover:text-blue-600 hover:underline"
+        >
+          <span>View dateparser documentation</span>
+          <ExternalLinkIcon className="size-3" />
+        </a>
+      </div>
       <div className="w-full items-center text-start">
         <span>Example inputs: </span>
       </div>
-      <div className="flex w-full flex-col text-muted-foreground">
+      <div className="flex w-full flex-col space-y-2 text-muted-foreground">
         <div className="rounded-md border bg-muted-foreground/10 p-2">
           <pre className="text-xs text-foreground/70">
-            {
-              "start_delay: 1.5  # 1.5 seconds\njoin_strategy: any  # continue on any branch completion"
-            }
+            <p>
+              <strong>wait_until: tomorrow at 3pm</strong>
+            </p>
+          </pre>
+        </div>
+        <div className="rounded-md border bg-muted-foreground/10 p-2">
+          <pre className="text-xs text-foreground/70">
+            <p>
+              <strong>wait_until: in 2 hours</strong>
+            </p>
+          </pre>
+        </div>
+        <div className="rounded-md border bg-muted-foreground/10 p-2">
+          <pre className="text-xs text-foreground/70">
+            <p>
+              <strong>start_delay: 1.5</strong> # 1.5 seconds
+            </p>
+            <p>
+              <strong>wait_until: 2024-03-21 15:30:00</strong> # specific
+              datetime
+            </p>
           </pre>
         </div>
       </div>

--- a/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
+++ b/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
@@ -193,9 +193,15 @@ export function ControlFlowOptionsTooltip() {
         </div>
         <div>Supports various formats including:</div>
         <ul className="list-disc pl-4 text-xs">
-          <li>Natural language: "tomorrow at 3pm", "in 2 hours"</li>
-          <li>Relative: "3 days", "2 weeks from now"</li>
-          <li>Absolute: "2024-03-21 15:30:00", "March 21st 3:30pm"</li>
+          <li>
+            Natural language: &quot;tomorrow at 3pm&quot;, &quot;in 2
+            hours&quot;
+          </li>
+          <li>Relative: &quot;3 days&quot;, &quot;2 weeks from now&quot;</li>
+          <li>
+            Absolute: &quot;2024-03-21 15:30:00&quot;, &quot;March 21st
+            3:30pm&quot;
+          </li>
         </ul>
         {/* docs link */}
         <a

--- a/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
+++ b/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
@@ -127,13 +127,39 @@ export function RetryPolicyTooltip() {
         </div>
         <div>Defaults to 300s (5 minutes).</div>
       </div>
+      <div className="flex w-full items-center justify-between text-muted-foreground ">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm font-semibold">retry_until</span>
+          <span className="text-xs font-normal text-muted-foreground/80">
+            expression string
+          </span>
+        </div>
+        <span className="text-xs text-muted-foreground/80">(optional)</span>
+      </div>
+      <div className="w-full items-center space-y-2 text-start text-muted-foreground">
+        <div>
+          An expression that retries the action until it evalutes to `true`.
+          This only applies to successful action runs. If an error is raised,
+          the regular retry policy will apply.
+        </div>
+      </div>
       <div className="w-full items-center text-start">
         <span>Example inputs: </span>
       </div>
-      <div className="flex w-full flex-col text-muted-foreground">
+      <div className="flex w-full flex-col space-y-2 text-muted-foreground">
         <div className="rounded-md border bg-muted-foreground/10 p-2">
-          <pre className="text-xs text-foreground/70">
-            {"max_attempts: 5\ntimeout: 300  # 5 minutes"}
+          <pre className="whitespace-pre-wrap break-words text-xs text-foreground/70">
+            <p>max_attempts: 5</p>
+            <p>
+              timeout: 300{" "}
+              <span className="text-xs text-muted-foreground"># 5 minutes</span>
+            </p>
+            <p>
+              retry_until: ${`{{ ACTIONS.this_action.result == "success" }}`}{" "}
+              <span className="text-xs text-muted-foreground">
+                # wait until the result is `success`
+              </span>
+            </p>
           </pre>
         </div>
       </div>
@@ -220,26 +246,27 @@ export function ControlFlowOptionsTooltip() {
       <div className="flex w-full flex-col space-y-2 text-muted-foreground">
         <div className="rounded-md border bg-muted-foreground/10 p-2">
           <pre className="text-xs text-foreground/70">
-            <p>
-              <strong>wait_until: tomorrow at 3pm</strong>
-            </p>
+            <p>wait_until: tomorrow at 3pm</p>
+          </pre>
+        </div>
+        <div className="rounded-md border bg-muted-foreground/10 p-2">
+          <pre className="text-xs text-foreground/70">
+            <p>wait_until: in 2 hours</p>
           </pre>
         </div>
         <div className="rounded-md border bg-muted-foreground/10 p-2">
           <pre className="text-xs text-foreground/70">
             <p>
-              <strong>wait_until: in 2 hours</strong>
-            </p>
-          </pre>
-        </div>
-        <div className="rounded-md border bg-muted-foreground/10 p-2">
-          <pre className="text-xs text-foreground/70">
-            <p>
-              <strong>start_delay: 1.5</strong> # 1.5 seconds
+              start_delay: 1.5{" "}
+              <span className="text-xs text-muted-foreground">
+                # 1.5 seconds
+              </span>
             </p>
             <p>
-              <strong>wait_until: 2024-03-21 15:30:00</strong> # specific
-              datetime
+              wait_until: 2024-03-21 15:30:00{" "}
+              <span className="text-xs text-muted-foreground">
+                # specific datetime
+              </span>
             </p>
           </pre>
         </div>

--- a/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
+++ b/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
@@ -245,13 +245,26 @@ export function ControlFlowOptionsTooltip() {
       </div>
       <div className="flex w-full flex-col space-y-2 text-muted-foreground">
         <div className="rounded-md border bg-muted-foreground/10 p-2">
-          <pre className="text-xs text-foreground/70">
-            <p>wait_until: tomorrow at 3pm</p>
-          </pre>
-        </div>
-        <div className="rounded-md border bg-muted-foreground/10 p-2">
-          <pre className="text-xs text-foreground/70">
-            <p>wait_until: in 2 hours</p>
+          <pre className="whitespace-pre-wrap break-words text-xs text-foreground/70">
+            <p>
+              wait_until: tomorrow at 3pm{" "}
+              <span className="text-xs text-muted-foreground">
+                # wait until 3pm the next day from the time the action is
+                scheduled
+              </span>
+            </p>
+            <p>
+              wait_until: in 2 hours{" "}
+              <span className="text-xs text-muted-foreground">
+                # wait until 2 hours from the time the action is scheduled
+              </span>
+            </p>
+            <p>
+              wait_until: &quot;2026-03-21 15:30:00&quot;{" "}
+              <span className="text-xs text-muted-foreground">
+                # wait until 3:30pm on March 21st, 2026
+              </span>
+            </p>
           </pre>
         </div>
         <div className="rounded-md border bg-muted-foreground/10 p-2">
@@ -260,12 +273,6 @@ export function ControlFlowOptionsTooltip() {
               start_delay: 1.5{" "}
               <span className="text-xs text-muted-foreground">
                 # 1.5 seconds
-              </span>
-            </p>
-            <p>
-              wait_until: 2024-03-21 15:30:00{" "}
-              <span className="text-xs text-muted-foreground">
-                # specific datetime
               </span>
             </p>
           </pre>

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -123,6 +123,13 @@ const actionFormSchema = z.object({
 })
 type ActionFormSchema = z.infer<typeof actionFormSchema>
 
+const isControlFlowOption = (key: string) => {
+  return [
+    "control_flow.wait_until",
+    "control_flow.join_strategy",
+    "control_flow.start_delay",
+  ].includes(key)
+}
 const typeToLabel: Record<
   RegistryActionRead["type"],
   { label: string; icon: LucideIcon }
@@ -214,7 +221,7 @@ export function ActionPanel({
           description: values.description,
           inputs: values.inputs,
           control_flow: {
-            ...parseYaml(values.control_flow.options),
+            ...parseYaml(values.control_flow.options), // Miscellaneous options
             for_each: parseYaml(values.control_flow.for_each),
             run_if: parseYaml(values.control_flow.run_if),
             retry_policy: parseYaml(values.control_flow.retry_policy),
@@ -229,12 +236,29 @@ export function ActionPanel({
           console.error("Application failed to validate action", apiError.body)
 
           // Set form errors from API validation errors
+
+          const errors: Record<string, { message: string }> = {}
           const details = apiError.body.detail as RequestValidationError[]
-          details.forEach((detail) => {
-            methods.setError(detail.loc[1] as keyof ActionFormSchema, {
-              message: detail.msg,
+          console.error("Validation errors", details)
+          details.forEach(({ loc, msg }) => {
+            let key: string = loc.slice(1).join(".")
+            if (isControlFlowOption(key)) {
+              key = "control_flow.options"
+            }
+            // Combine errors if they have the same key
+            if (errors[key]) {
+              errors[key].message += `\n${msg}`
+            } else {
+              errors[key] = { message: msg }
+            }
+          })
+          Object.entries(errors).forEach(([key, { message }]) => {
+            console.log("Setting error", key, message)
+            methods.setError(key as keyof ActionFormSchema, {
+              message,
             })
           })
+          console.log("Errors", errors)
         } else {
           console.error("Validation failed, unknown error", error)
         }
@@ -477,7 +501,7 @@ export function ActionPanel({
                                     {...field}
                                   />
                                 </FormControl>
-                                <FormMessage />
+                                <FormMessage className="whitespace-pre-line" />
                               </FormItem>
                             )}
                           />
@@ -496,7 +520,7 @@ export function ActionPanel({
                                     {...field}
                                   />
                                 </FormControl>
-                                <FormMessage />
+                                <FormMessage className="whitespace-pre-line" />
                               </FormItem>
                             )}
                           />
@@ -625,7 +649,7 @@ export function ActionPanel({
                             render={({ field }) => (
                               <FormItem>
                                 {/* Place form message above because it's not visible otherwise */}
-                                <FormMessage />
+                                <FormMessage className="whitespace-pre-line" />
                                 <FormControl>
                                   <DynamicCustomEditor
                                     className="min-h-[40rem] w-full"
@@ -713,7 +737,7 @@ export function ActionPanel({
                                     workspaceId={workspaceId}
                                   />
                                 </FormControl>
-                                <FormMessage />
+                                <FormMessage className="whitespace-pre-line" />
                               </FormItem>
                             )}
                           />
@@ -760,7 +784,7 @@ export function ActionPanel({
                                     workflowId={workflowId}
                                   />
                                 </FormControl>
-                                <FormMessage />
+                                <FormMessage className="whitespace-pre-line" />
                               </FormItem>
                             )}
                           />
@@ -807,7 +831,7 @@ export function ActionPanel({
                                     workflowId={workflowId}
                                   />
                                 </FormControl>
-                                <FormMessage />
+                                <FormMessage className="whitespace-pre-line" />
                               </FormItem>
                             )}
                           />
@@ -871,7 +895,7 @@ export function ActionPanel({
                                     workflowId={workflowId}
                                   />
                                 </FormControl>
-                                <FormMessage />
+                                <FormMessage className="whitespace-pre-line" />
                               </FormItem>
                             )}
                           />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "cloudpickle==3.0.0",
     "colorlog==6.8.2",
     "cryptography==43.0.1",
+    "dateparser>=1.2.0",
     "email-validator>=2.0.0",
     "fastapi-users[sqlalchemy,oauth]==13.0.0",
     "fastapi==0.111.0",

--- a/tests/unit/test_workflow_timers.py
+++ b/tests/unit/test_workflow_timers.py
@@ -1,0 +1,756 @@
+"""Tests for workflow timer and retry functionality.
+
+Tests both timer control flow (wait_until, start_delay) and retry_until behavior.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from typing import NoReturn
+
+import dateparser
+import pytest
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from tests.shared import TEST_WF_ID, generate_test_exec_id
+from tracecat.dsl._converter import pydantic_data_converter
+from tracecat.dsl.action import DSLActivities
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.models import ActionRetryPolicy, ActionStatement, RunActionInput
+from tracecat.dsl.worker import get_activities, new_sandbox_runner
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.types.auth import Role
+
+
+@pytest.fixture
+async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter
+    ) as env:
+        yield env
+
+
+@pytest.mark.parametrize(
+    "future_time",
+    [
+        (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+        "in 1 hour",
+        "in 1h",
+    ],
+)
+@pytest.mark.anyio
+async def test_workflow_wait_until_future(
+    test_role: Role, env: WorkflowEnvironment, future_time: str
+):
+    """Test that wait_until with future date causes time skip."""
+
+    dsl = DSLInput(
+        title="wait_until_future",
+        description="Test wait_until with future date",
+        entrypoint=DSLEntrypoint(ref="delayed_action"),
+        actions=[
+            ActionStatement(
+                ref="delayed_action",
+                action="core.transform.reshape",
+                args={"value": "test"},
+                wait_until=future_time,
+            )
+        ],
+    )
+
+    num_activity_executions = 0
+
+    # Mock out the activity to count executions
+    @activity.defn(name="run_action_activity")
+    async def run_action_activity_mock(input: RunActionInput, role: Role) -> str:
+        nonlocal num_activity_executions
+        num_activity_executions += 1
+        return input.task.args["value"]
+
+    # Mock out the activity to count executions
+    activities = get_activities()
+    activities.remove(DSLActivities.run_action_activity)
+    activities.append(run_action_activity_mock)
+
+    async with Worker(
+        env.client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=activities,
+        workflow_runner=new_sandbox_runner(),
+    ):
+        start_time = await env.get_current_time()
+        handle = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_wait_until_future"),
+            task_queue="test-queue",
+        )
+        # Time skip 2 minutes
+        await env.sleep(timedelta(hours=2))
+        # Check that the activity has been called, we're now waiting for the sleep to finish.
+        assert num_activity_executions == 1
+
+        # Expect more than 2 hours to have passed
+        assert (await env.get_current_time() - start_time) > timedelta(hours=2)
+
+        # Verify result
+        result = await handle.result()
+        assert result["ACTIONS"]["delayed_action"]["result"] == "test"
+
+
+@pytest.mark.anyio
+async def test_workflow_retry_until_condition(
+    env: WorkflowEnvironment, test_role: Role
+):
+    """Test retry_until with a condition based on action result. No timers involved."""
+
+    dsl = DSLInput(
+        title="retry_until_condition",
+        description="Test retry_until with condition",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                # NOTE: This is mocked out in the test
+                args={"value": "<MOCKED_OUT>"},
+                retry_policy=ActionRetryPolicy(
+                    # Retry until the action returns a 'success' status value
+                    retry_until="${{ ACTIONS.retry_action.result.status == 'success' }}",
+                ),
+            )
+        ],
+    )
+
+    num_activity_executions = 0
+
+    # Mock out the activity to count executions
+    @activity.defn(name="run_action_activity")
+    async def run_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> dict[str, str]:
+        nonlocal num_activity_executions
+        num_activity_executions += 1
+        if num_activity_executions < 3:
+            return {"status": "loading"}
+        return {"status": "success"}
+
+    # Mock out the activity to count executions
+    activities = get_activities()
+    activities.remove(DSLActivities.run_action_activity)
+    activities.append(run_action_activity_mock)
+
+    async with Worker(
+        env.client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=activities,
+        workflow_runner=new_sandbox_runner(),
+    ):
+        result = await env.client.execute_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_retry_until_condition"),
+            task_queue="test-queue",
+        )
+
+        # Expect 3 activity executions
+        assert num_activity_executions == 3
+
+        # Verify action was retried until condition met
+        assert result["ACTIONS"]["retry_action"]["result"]["status"] == "success"
+
+
+@pytest.mark.anyio
+async def test_workflow_waits_until_tomorrow_9am(
+    env: WorkflowEnvironment,
+    test_role: Role,
+):
+    """Test retry_until with a condition based on action result. With wait_until involved.
+
+    The action should wait for the specified time before it runs, then retry 3 times until it succeeds.
+    On each retry, it should wait the same amount of time before retrying.
+    """
+
+    dsl = DSLInput(
+        title="retry_until_condition",
+        description="Test retry_until with condition",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                args={"value": "<MOCKED_OUT>"},
+                wait_until="9am tomorrow",
+            )
+        ],
+    )
+
+    num_activity_executions = 0
+
+    # Mock out the activity to count executions
+    @activity.defn(name="run_action_activity")
+    async def run_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> dict[str, str]:
+        nonlocal num_activity_executions
+        num_activity_executions += 1
+        return {"status": "success"}
+
+    # Mock out the activity to count executions
+    activities = get_activities()
+    activities.remove(DSLActivities.run_action_activity)
+    activities.append(run_action_activity_mock)
+
+    async with Worker(
+        env.client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=activities,
+        workflow_runner=new_sandbox_runner(),
+    ):
+        start_time = await env.get_current_time()
+        _ = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_retry_until_condition"),
+            task_queue="test-queue",
+        )
+        # Duration until 9am tomorrow
+        t = dateparser.parse(
+            "9am tomorrow",
+            settings={"TIMEZONE": "UTC", "RETURN_AS_TIMEZONE_AWARE": True},
+        )
+        assert t is not None
+        expected_delay = t - start_time
+
+        # Time skip expected delay plus 1 min buffer
+        await env.sleep(expected_delay + timedelta(minutes=1))
+        # Expect 1 activity execution
+        assert num_activity_executions == 1
+
+        # Check that is it indeed 9am tomorrow
+        assert (await env.get_current_time()) >= t
+
+
+@pytest.mark.parametrize(
+    "wait_time,expected_delay",
+    [
+        ("in 5 minutes", timedelta(minutes=5)),
+        ("in 1 hour", timedelta(hours=1)),
+    ],
+)
+@pytest.mark.anyio
+async def test_workflow_retry_until_condition_with_wait_until(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    wait_time: str,
+    expected_delay: timedelta,
+):
+    """Test retry_until with a condition based on action result. With wait_until involved.
+
+    The action should wait for the specified time before it runs, then retry 3 times until it succeeds.
+    On each retry, it should wait the same amount of time before retrying.
+    """
+
+    dsl = DSLInput(
+        title="retry_until_condition",
+        description="Test retry_until with condition",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                args={"value": "<MOCKED_OUT>"},
+                retry_policy=ActionRetryPolicy(
+                    retry_until="${{ ACTIONS.retry_action.result.status == 'success' }}",
+                ),
+                wait_until=wait_time,
+            )
+        ],
+    )
+
+    num_activity_executions = 0
+
+    # Mock out the activity to count executions
+    @activity.defn(name="run_action_activity")
+    async def run_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> dict[str, str]:
+        nonlocal num_activity_executions
+        num_activity_executions += 1
+        if num_activity_executions < 3:
+            return {"status": "loading"}
+        return {"status": "success"}
+
+    # Mock out the activity to count executions
+    activities = get_activities()
+    activities.remove(DSLActivities.run_action_activity)
+    activities.append(run_action_activity_mock)
+
+    async with Worker(
+        env.client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=activities,
+        workflow_runner=new_sandbox_runner(),
+    ):
+        start_time = await env.get_current_time()
+        handle = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_retry_until_condition"),
+            task_queue="test-queue",
+        )
+        # Time skip expected delay plus 1 min buffer
+        await env.sleep(expected_delay + timedelta(minutes=1))
+        # Expect 1 activity execution
+        assert num_activity_executions == 1
+
+        # Skip expected delay again
+        await env.sleep(expected_delay + timedelta(minutes=1))
+        # Expect 2 activity executions
+        assert num_activity_executions == 2
+
+        # Skip longer time to ensure final execution
+        await env.sleep(expected_delay * 2)
+
+        # Expect 3 activity executions
+        assert num_activity_executions == 3
+
+        # Expect more than 2x the expected delay has passed
+        assert (await env.get_current_time() - start_time) > (expected_delay * 2)
+
+        # Verify action was retried until condition met
+        result = await handle.result()
+        assert result["ACTIONS"]["retry_action"]["result"]["status"] == "success"
+
+
+@pytest.mark.parametrize(
+    "past_time",
+    [
+        (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+        "1 hour ago",
+        "1h",
+    ],
+)
+@pytest.mark.anyio
+async def test_workflow_wait_until_past(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+    past_time: str,
+):
+    """Test that wait_until with past date skips timer."""
+
+    # Monkeypatch out  asyncio.sleep with a counter
+    num_sleeps = 0
+
+    async def sleep_mock(seconds: float) -> NoReturn:
+        nonlocal num_sleeps
+        num_sleeps += 1
+
+    monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+    dsl = DSLInput(
+        title="wait_until_past",
+        description="Test wait_until with past date",
+        entrypoint=DSLEntrypoint(ref="delayed_action"),
+        actions=[
+            ActionStatement(
+                ref="delayed_action",
+                action="core.transform.reshape",
+                args={"value": "test"},
+                wait_until=past_time,
+            )
+        ],
+    )
+
+    async with Worker(
+        env.client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=get_activities(),
+        workflow_runner=new_sandbox_runner(),
+    ):
+        await env.client.execute_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_wait_until_past"),
+            task_queue="test-queue",
+        )
+        # Assert that no sleeps occurred
+        assert num_sleeps == 0
+
+
+@pytest.mark.anyio
+async def test_workflow_start_delay(env: WorkflowEnvironment, test_role: Role):
+    """Test that start_delay creates appropriate timer."""
+    delay_seconds = 3600  # 1 hour
+
+    dsl = DSLInput(
+        title="start_delay",
+        description="Test start_delay timer",
+        entrypoint=DSLEntrypoint(ref="delayed_action"),
+        actions=[
+            ActionStatement(
+                ref="delayed_action",
+                action="core.transform.reshape",
+                args={"value": "<MOCKED_OUT>"},
+                start_delay=delay_seconds,
+            )
+        ],
+    )
+
+    num_activity_executions = 0
+
+    # Mock out the activity to count executions
+    @activity.defn(name="run_action_activity")
+    async def run_action_activity_mock(input: RunActionInput, role: Role) -> str:
+        nonlocal num_activity_executions
+        num_activity_executions += 1
+        return "test"
+
+    # Mock out the activity to count executions
+    activities = get_activities()
+    activities.remove(DSLActivities.run_action_activity)
+    activities.append(run_action_activity_mock)
+
+    async with Worker(
+        env.client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=activities,
+        workflow_runner=new_sandbox_runner(),
+    ):
+        start_time = await env.get_current_time()
+        handle = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_start_delay"),
+            task_queue="test-queue",
+        )
+        # Time skip 1 hour
+        await env.sleep(timedelta(hours=2))
+        # Assert that the activity has been called
+        assert num_activity_executions == 1
+
+        await handle.result()
+
+        # Verify time was skipped by over the delay amount
+        assert (await env.get_current_time() - start_time) >= timedelta(
+            seconds=delay_seconds
+        )
+
+
+### TODO: Finish the tests below later
+
+
+@pytest.mark.skip
+@pytest.mark.anyio
+async def test_workflow_wait_until_precedence(
+    env: WorkflowEnvironment, test_role: Role
+):
+    """Test that wait_until takes precedence over start_delay."""
+    future_time = datetime.now(UTC) + timedelta(hours=1)
+
+    dsl = DSLInput(
+        title="wait_until_precedence",
+        description="Test wait_until precedence over start_delay",
+        entrypoint=DSLEntrypoint(ref="delayed_action"),
+        actions=[
+            ActionStatement(
+                ref="delayed_action",
+                action="core.transform.reshape",
+                args={"value": "test"},
+                wait_until=future_time.isoformat(),
+                start_delay=30,  # Should be ignored in favor of wait_until
+            )
+        ],
+    )
+
+    client = env.client
+    async with Worker(
+        client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=[DSLActivities.parse_wait_until_activity],
+    ):
+        start_time = datetime.now(UTC)
+        result = await client.execute_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_wait_until_precedence"),
+            task_queue="test-queue",
+        )
+        end_time = datetime.now(UTC)
+
+        # Verify wait_until time was used instead of start_delay
+        assert end_time - start_time >= timedelta(hours=1)
+        assert result["ACTIONS"]["delayed_action"]["result"] == "test"
+
+
+@pytest.mark.skip
+@pytest.mark.anyio
+async def test_workflow_invalid_wait_until(env: WorkflowEnvironment, test_role: Role):
+    """Test that invalid wait_until date format raises error."""
+    dsl = DSLInput(
+        title="invalid_wait_until",
+        description="Test invalid wait_until format",
+        entrypoint=DSLEntrypoint(ref="delayed_action"),
+        actions=[
+            ActionStatement(
+                ref="delayed_action",
+                action="core.transform.reshape",
+                args={"value": "test"},
+                wait_until="invalid-date-format",
+            )
+        ],
+    )
+
+    client = env.client
+    async with Worker(
+        client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=[DSLActivities.parse_wait_until_activity],
+    ):
+        with pytest.raises(ApplicationError, match="Invalid wait until date"):
+            await client.execute_workflow(
+                DSLWorkflow.run,
+                DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+                id=generate_test_exec_id("test_workflow_invalid_wait_until"),
+                task_queue="test-queue",
+            )
+
+
+@pytest.mark.skip
+@pytest.mark.anyio
+async def test_workflow_retry_until_max_attempts(
+    env: WorkflowEnvironment, test_role: Role
+):
+    """Test retry_until with max attempts exceeded."""
+    dsl = DSLInput(
+        title="retry_until_max_attempts",
+        description="Test retry_until with max attempts",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                args={"value": "${{ ACTIONS.retry_action.attempt or 1 }}"},
+                retry_policy=ActionRetryPolicy(
+                    retry_until="${{ ACTIONS.retry_action.result >= 10 }}",  # Impossible condition
+                    max_attempts=3,
+                    timeout=10,
+                ),
+            )
+        ],
+    )
+
+    client = env.client
+    async with Worker(
+        client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=[DSLActivities.parse_wait_until_activity],
+    ):
+        with pytest.raises(ApplicationError, match="Maximum attempts exceeded"):
+            await client.execute_workflow(
+                DSLWorkflow.run,
+                DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+                id=generate_test_exec_id("test_workflow_retry_until_max_attempts"),
+                task_queue="test-queue",
+            )
+
+
+@pytest.mark.skip
+@pytest.mark.anyio
+async def test_workflow_retry_until_timeout(env: WorkflowEnvironment, test_role: Role):
+    """Test retry_until with timeout exceeded."""
+    dsl = DSLInput(
+        title="retry_until_timeout",
+        description="Test retry_until with timeout",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                args={"value": "${{ ACTIONS.retry_action.attempt or 1 }}"},
+                retry_policy=ActionRetryPolicy(
+                    retry_until="${{ ACTIONS.retry_action.result >= 10 }}",
+                    max_attempts=10,
+                    timeout=1,  # Short timeout to trigger error
+                ),
+            )
+        ],
+    )
+
+    client = env.client
+    async with Worker(
+        client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=[DSLActivities.parse_wait_until_activity],
+    ):
+        with pytest.raises(ApplicationError, match="Activity timeout"):
+            await client.execute_workflow(
+                DSLWorkflow.run,
+                DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+                id=generate_test_exec_id("test_workflow_retry_until_timeout"),
+                task_queue="test-queue",
+            )
+
+
+@pytest.mark.skip
+@pytest.mark.anyio
+async def test_workflow_multiple_timed_actions(
+    env: WorkflowEnvironment, test_role: Role
+):
+    """Test multiple actions with different timing behaviors."""
+    future_time = datetime.now(UTC) + timedelta(minutes=30)
+
+    dsl = DSLInput(
+        title="multiple_timed_actions",
+        description="Test multiple timed actions",
+        entrypoint=DSLEntrypoint(ref="action1"),
+        actions=[
+            ActionStatement(
+                ref="action1",
+                action="core.transform.reshape",
+                args={"value": "first"},
+                start_delay=60,
+            ),
+            ActionStatement(
+                ref="action2",
+                action="core.transform.reshape",
+                args={"value": "second"},
+                wait_until=future_time.isoformat(),
+                depends_on=["action1"],
+            ),
+            ActionStatement(
+                ref="action3",
+                action="core.transform.reshape",
+                args={"value": "${{ ACTIONS.action3.attempt or 1 }}"},
+                retry_policy=ActionRetryPolicy(
+                    retry_until="${{ ACTIONS.action3.result >= 3 }}",
+                    max_attempts=5,
+                    timeout=10,
+                ),
+                depends_on=["action2"],
+            ),
+        ],
+    )
+
+    client = env.client
+    async with Worker(
+        client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=[DSLActivities.parse_wait_until_activity],
+    ):
+        start_time = datetime.now(UTC)
+        result = await client.execute_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_multiple_timed_actions"),
+            task_queue="test-queue",
+        )
+        end_time = datetime.now(UTC)
+
+        # Verify timing and results
+        assert end_time - start_time >= timedelta(minutes=30)
+        assert result["ACTIONS"]["action1"]["result"] == "first"
+        assert result["ACTIONS"]["action2"]["result"] == "second"
+        assert result["ACTIONS"]["action3"]["result"] == 3
+
+
+@pytest.mark.skip
+@pytest.mark.anyio
+async def test_workflow_retry_until_time_condition(
+    env: WorkflowEnvironment, test_role: Role
+):
+    """Test retry_until with time-based condition."""
+    target_time = datetime.now(UTC) + timedelta(minutes=5)
+
+    dsl = DSLInput(
+        title="retry_until_time",
+        description="Test retry_until with time condition",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                args={"value": datetime.now(UTC).isoformat()},
+                retry_policy=ActionRetryPolicy(
+                    retry_until=f"${{ datetime.fromisoformat(ACTIONS.retry_action.result) >= datetime.fromisoformat('{target_time.isoformat()}') }}",
+                    max_attempts=10,
+                    timeout=300,
+                ),
+            )
+        ],
+    )
+
+    client = env.client
+    async with Worker(
+        client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=[DSLActivities.parse_wait_until_activity],
+    ):
+        result = await client.execute_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id("test_workflow_retry_until_time_condition"),
+            task_queue="test-queue",
+        )
+
+        # Verify the final result time is after target time
+        final_time = datetime.fromisoformat(result["ACTIONS"]["retry_action"]["result"])
+        assert final_time >= target_time
+
+
+@pytest.mark.skip
+@pytest.mark.anyio
+async def test_workflow_invalid_retry_until_expression(
+    env: WorkflowEnvironment, test_role: Role
+):
+    """Test that invalid retry_until expression raises error."""
+    dsl = DSLInput(
+        title="invalid_retry_until",
+        description="Test invalid retry_until expression",
+        entrypoint=DSLEntrypoint(ref="retry_action"),
+        actions=[
+            ActionStatement(
+                ref="retry_action",
+                action="core.transform.reshape",
+                args={"value": "test"},
+                retry_policy=ActionRetryPolicy(
+                    retry_until="invalid {{ expression",
+                    max_attempts=3,
+                    timeout=10,
+                ),
+            )
+        ],
+    )
+
+    client = env.client
+    async with Worker(
+        client,
+        task_queue="test-queue",
+        workflows=[DSLWorkflow],
+        activities=[DSLActivities.parse_wait_until_activity],
+    ):
+        with pytest.raises(ApplicationError, match="Invalid retry_until expression"):
+            await client.execute_workflow(
+                DSLWorkflow.run,
+                DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+                id=generate_test_exec_id(
+                    "test_workflow_invalid_retry_until_expression"
+                ),
+                task_queue="test-queue",
+            )

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
 from httpx_oauth.clients.google import GoogleOAuth2
 from pydantic import BaseModel
+from pydantic_core import to_jsonable_python
 from sqlalchemy.exc import IntegrityError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -89,13 +90,15 @@ async def setup_workspace_defaults(session: AsyncSession, admin_role: Role):
 def validation_exception_handler(request: Request, exc: RequestValidationError):
     """Improves visiblity of 422 errors."""
     errors = exc.errors()
+    ser_errors = to_jsonable_python(errors, fallback=str)
     logger.error(
         "API Model Validation error",
         request=request,
-        errors=errors,
+        errors=ser_errors,
     )
     return ORJSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"detail": errors}
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content={"detail": ser_errors},
     )
 
 

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -43,6 +43,7 @@ def tracecat_exception_handler(request: Request, exc: TracecatException):
         role=ctx_role.get(),
         params=request.query_params,
         path=request.url.path,
+        detail=exc.detail,
     )
     return ORJSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -357,6 +357,7 @@ def build_action_statements(
             for_each=control_flow.for_each,
             retry_policy=control_flow.retry_policy,
             start_delay=control_flow.start_delay,
+            wait_until=control_flow.wait_until,
             join_strategy=control_flow.join_strategy,
         )
         statements.append(action_stmt)

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -106,7 +106,17 @@ class ActionStatement(BaseModel):
         default_factory=ActionRetryPolicy, description="Retry policy for the action."
     )
     start_delay: float = Field(
-        default=0.0, description="Delay before starting the action in seconds."
+        default=0.0,
+        description=(
+            "Delay before starting the action in seconds. "
+            "If `wait_until` is also provided, the `wait_until` timer will take precedence."
+        ),
+    )
+    wait_until: str | None = Field(
+        default=None,
+        description=(
+            "Wait until a specific date and time before starting. Overrides `start_delay` if both are provided."
+        ),
     )
     join_strategy: JoinStrategy = Field(
         default=JoinStrategy.ALL,

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, field_validator
 from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.expressions.common import ExprContext
-from tracecat.expressions.validation import ExpressionStr
+from tracecat.expressions.validation import ExpressionStr, RequiredExpressionStr
 from tracecat.identifiers import WorkflowExecutionID, WorkflowRunID
 from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
@@ -64,6 +64,9 @@ class ActionRetryPolicy(BaseModel):
     )
     timeout: int = Field(
         default=DEFAULT_ACTION_TIMEOUT, description="Timeout for the action in seconds."
+    )
+    retry_until: RequiredExpressionStr | None = Field(
+        default=None, description="Retry until a specific condition is met."
     )
 
 

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import uuid
 from collections.abc import Generator, Iterable
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from temporalio import workflow
@@ -18,6 +18,7 @@ from temporalio.exceptions import (
 )
 
 with workflow.unsafe.imports_passed_through():
+    import dateparser  # noqa: F401
     import jsonpath_ng.ext.parser  # noqa: F401
     import jsonpath_ng.lexer  # noqa
     import jsonpath_ng.parser  # noqa
@@ -374,20 +375,112 @@ class DSLWorkflow:
                 type=e.__class__.__name__,
             ) from e
 
+    async def _handle_timers(self, task: ActionStatement) -> None:
+        """Perform any timing control flow logic (start_delay, wait_until).
+
+        Note
+        -----
+        - asyncio.sleep() produces a Temporal durable timer when called within a workflow.
+        """
+        ### Timing control flow logic
+        # If we have a retry_until, we need to run wait_until inside.
+        # If we have a wait_until, we need to create a durable timer
+        if task.wait_until:
+            self.logger.info("Creating wait until timer", wait_until=task.wait_until)
+
+            # Parse the delay until date
+            wait_until = await workflow.execute_activity(
+                DSLActivities.parse_wait_until_activity,
+                task.wait_until,
+                start_to_close_timeout=timedelta(seconds=10),
+            )
+            self.logger.info("Parsed wait until date", wait_until=wait_until)
+            if wait_until is None:
+                # Unreachable as this should have been validated at the API level
+                raise ApplicationError(
+                    "Invalid wait until date",
+                    non_retryable=True,
+                )
+            # We no
+
+            current_time = datetime.now(UTC)
+            logger.info("Current time", current_time=current_time)
+            wait_until_dt = datetime.fromisoformat(wait_until)
+            if wait_until_dt > current_time:
+                duration = wait_until_dt - current_time
+                self.logger.info(
+                    "Waiting until", wait_until=wait_until, duration=duration
+                )
+                await asyncio.sleep(duration.total_seconds())
+            else:
+                self.logger.warning(
+                    "Wait until is in the past, skipping timer",
+                    wait_until=wait_until,
+                    current_time=current_time,
+                )
+        # Create a durable timer if we have a start_delay
+        elif task.start_delay > 0:
+            logger.info("Starting action with delay", delay=task.start_delay)
+            # In Temporal 1.9.0+, we can use workflow.sleep() as well
+            await asyncio.sleep(task.start_delay)
+
     async def execute_task(self, task: ActionStatement) -> Any:
+        """Execute a task and manage the results."""
+        if task.retry_policy.retry_until:
+            return await self._execute_task_until_condition(task)
+        return await self._execute_task(task)
+
+    async def _execute_task_until_condition(
+        self, task: ActionStatement
+    ) -> DSLNodeResult:
+        """Execute a task until a condition is met."""
+        retry_until = task.retry_policy.retry_until
+        if retry_until is None:
+            raise ValueError("Retry until is not set")
+        ctx = self.context.copy()
+        result = None
+        while True:
+            # NOTE: This only works with successful results
+            result = await self._execute_task(task)
+            ctx[ExprContext.ACTIONS][task.ref] = result
+            retry_until_result = eval_templated_object(retry_until.strip(), operand=ctx)
+            if not isinstance(retry_until_result, bool):
+                try:
+                    retry_until_result = bool(retry_until_result)
+                except Exception:
+                    raise ApplicationError(
+                        "Retry until result is not a boolean", non_retryable=True
+                    ) from None
+            if retry_until_result:
+                break
+        return result
+
+    async def _execute_task(self, task: ActionStatement) -> DSLNodeResult:
         """Purely execute a task and manage the results.
+
+
+        Prelude
+        ------
+        - Before this point, we've already evaluated conditional branching logic (run_if) and decided
+            that this node must be executed.
+        - We should now perform any timing control flow logic (start_delay, wait_until).
+        - Note that we're not inside an activity here, so any timers created are DURABLE TEMPORAL TIMERS
 
         Preflight checks
         ---------------
-        1. Evaluate `run_if` condition
-        2. Resolve all templated arguments
-        3. If there's an ActionTest, skip execution and return the patched result.
-            - Note that we still schedule the task for execution, but we don't actually run it.
+        1. Perform any timing control flow logic
+            - Create a durable timer if we have a start_delay
+            - Create a durable timer if we have a wait_until
+            - If we have both, the wait_until timer will take precedence
+        2. Decide whether we're running a child workflow or not
         """
 
         logger.info("Begin task execution", task_ref=task.ref)
         task_result = DSLNodeResult(result=None, result_typename=type(None).__name__)
+
         try:
+            await self._handle_timers(task)
+            # Do action stuff
             if self._should_execute_child_workflow(task):
                 # NOTE: We don't support (nor recommend, unless a use case is justified) passing SECRETS to child workflows
                 # 1. Prepare the child workflow
@@ -457,6 +550,7 @@ class DSLWorkflow:
         finally:
             logger.debug("Setting action result", task_result=task_result)
             self.context[ExprContext.ACTIONS][task.ref] = task_result  # type: ignore
+        return task_result
 
     ERROR_TYPE_TO_MESSAGE = {
         ActivityError.__name__: "Activity execution failed",

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -401,7 +401,6 @@ class DSLWorkflow:
                     "Invalid wait until date",
                     non_retryable=True,
                 )
-            # We no
 
             current_time = datetime.now(UTC)
             logger.info("Current time", current_time=current_time)

--- a/tracecat/expressions/validation.py
+++ b/tracecat/expressions/validation.py
@@ -47,4 +47,16 @@ class TemplateValidator:
         return handler(v, info)
 
 
+class RequiredTemplateValidator:
+    def __new__(cls):
+        return WrapValidator(cls.must_expression)
+
+    @classmethod
+    def must_expression(cls, v: T, handler: ValidatorFunctionWrapHandler, info) -> T:
+        if isinstance(v, str) and not is_full_template(v):
+            raise ValueError(f"'{v}' is not a valid expression")
+        return handler(v, info)
+
+
 ExpressionStr = Annotated[str, TemplateValidator()]
+RequiredExpressionStr = Annotated[str, RequiredTemplateValidator()]

--- a/tracecat/workflow/actions/models.py
+++ b/tracecat/workflow/actions/models.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel, Field
+import dateparser
+from pydantic import BaseModel, Field, field_validator
 
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy
@@ -9,11 +10,35 @@ from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowIDShort
 class ActionControlFlow(BaseModel):
     run_if: str | None = Field(default=None, max_length=1000)
     for_each: str | list[str] | None = Field(default=None, max_length=1000)
-    retry_policy: ActionRetryPolicy = Field(default_factory=ActionRetryPolicy)
-    start_delay: float = Field(
-        default=0.0, description="Delay before starting the action in seconds."
-    )
     join_strategy: JoinStrategy = Field(default=JoinStrategy.ALL)
+    # Retries
+    retry_policy: ActionRetryPolicy = Field(default_factory=ActionRetryPolicy)
+    # Timers
+    start_delay: float = Field(
+        default=0.0,
+        description=(
+            "Delay before starting the action in seconds. "
+            "If `wait_until` is also provided, the `wait_until` timer will take precedence."
+        ),
+    )
+    wait_until: str | None = Field(
+        default=None,
+        description=(
+            "Wait until a specific date and time before starting. Overrides `start_delay` if both are provided."
+        ),
+    )
+
+    @field_validator("wait_until", mode="before")
+    def validate_wait_until(cls, v: str | None) -> str | None:
+        if v is not None:
+            if (
+                dateparser.parse(
+                    v, settings={"TIMEZONE": "UTC", "RETURN_AS_TIMEZONE_AWARE": True}
+                )
+                is None
+            ):
+                raise ValueError(f"'{v}' is not a valid `wait_until` value")
+        return v
 
 
 class ActionRead(BaseModel):

--- a/tracecat/workflow/executions/common.py
+++ b/tracecat/workflow/executions/common.py
@@ -65,6 +65,7 @@ UTILITY_ACTIONS = {
     "get_schedule_activity",
     "validate_trigger_inputs_activity",
     "validate_action_activity",
+    "parse_wait_until_activity",
     WorkflowsManagementService.resolve_workflow_alias_activity.__name__,
     WorkflowsManagementService.get_error_handler_workflow_id.__name__,
 }

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -314,7 +314,7 @@ class WorkflowExecutionEventCompact(BaseModel):
 
         act_type = attrs.activity_type.name
         if act_type in (UTILITY_ACTIONS | {"get_workflow_definition_activity"}):
-            logger.debug("Utility action is not supported.", act_type=act_type)
+            logger.trace("Utility action is not supported.", act_type=act_type)
             return None
         action_input = RunActionInput(**activity_input_data)
         task = action_input.task

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -208,7 +208,7 @@ class WorkflowExecutionsService:
                 # Create a new source event
                 source = WorkflowExecutionEventCompact.from_source_event(event)
                 if source is None:
-                    logger.debug(
+                    logger.trace(
                         "Skipping scheduled event as there is no source",
                         event_id=event.event_id,
                     )

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -324,6 +324,7 @@ class WorkflowsManagementService(BaseService):
                 for_each=act_stmt.for_each,
                 retry_policy=act_stmt.retry_policy,
                 start_delay=act_stmt.start_delay,
+                wait_until=act_stmt.wait_until,
                 join_strategy=act_stmt.join_strategy,
             )
             new_action = Action(


### PR DESCRIPTION
# Description
- Add `wait_until` - a `dateparser` compatible string that describes a datetime/relative timedelta for the action to wait before it executes
- Add `retry_until` - an optional expression field that returns a conditional, which will continue to rerun this action until this condition is met