### PR TITLE
fix(engine): Improve action loop error display

### DIFF
--- a/tests/data/test_actions/test_executor_functions.py
+++ b/tests/data/test_actions/test_executor_functions.py
@@ -9,6 +9,14 @@ def add_100(num: int) -> int:
     return num + 100
 
 
+@registry.register(
+    description="This is a test function that adds a list of numbers",
+    namespace="testing",
+)
+def add_nums(nums: list[int]) -> int:
+    return sum(nums)
+
+
 test_secret = RegistrySecret(name="test", keys=["KEY"])
 
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,4 +1,5 @@
 import asyncio
+import traceback
 import uuid
 from pathlib import Path
 from typing import Any
@@ -9,7 +10,13 @@ from pydantic import SecretStr
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.dsl.models import ActionStatement, RunActionInput, RunContext
 from tracecat.executor.models import ExecutorActionErrorInfo
-from tracecat.executor.service import run_action_from_input, sync_executor_entrypoint
+from tracecat.executor.service import (
+    _dispatch_action,
+    flatten_wrapped_exc_error_group,
+    run_action_from_input,
+    sync_executor_entrypoint,
+)
+from tracecat.expressions.common import ExprContext
 from tracecat.expressions.expectations import ExpectedField
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
@@ -24,6 +31,7 @@ from tracecat.registry.repository import Repository
 from tracecat.secrets.models import SecretCreate, SecretKeyValue
 from tracecat.secrets.service import SecretsService
 from tracecat.types.auth import Role
+from tracecat.types.exceptions import ExecutionError, LoopExecutionError
 
 
 @pytest.fixture
@@ -303,3 +311,163 @@ def test_sync_executor_entrypoint_returns_wrapped_error(
     assert result.action_name == "test.error_action"
     assert result.filename == __file__
     assert result.function == "mock_error"
+
+
+@pytest.mark.skip(reason="Flaky test")
+@pytest.mark.anyio
+async def test_dispatcher(
+    mock_package,
+    test_role,
+    mock_run_context,
+    db_session_with_repo,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Try to replicate `Error in loop`ty error, where usually we fail validation inside the executor loop.
+
+    We will execute everything in the current thread.
+    1. Add mock package with a function that will raise an error
+    """
+
+    # Mock out run_action_on_ray_cluster
+    async def mocked_executor_entrypoint(
+        input: RunActionInput, role: Role, *args, **kwargs
+    ):
+        try:
+            return await run_action_from_input(input=input, role=role)
+        except Exception as e:
+            # Raise the error proxy here
+            logger.error(
+                "Error running action, raising error proxy",
+                error=e,
+                type=type(e).__name__,
+                traceback=traceback.format_exc(),
+            )
+            iteration = kwargs.get("iteration", None)
+            exec_result = ExecutorActionErrorInfo.from_exc(e, input.task.action)
+            if iteration is not None:
+                exec_result.loop_iteration = iteration
+                exec_result.loop_vars = input.exec_context[ExprContext.LOCAL_VARS]
+            raise ExecutionError(info=exec_result) from None
+
+    monkeypatch.setattr(
+        "tracecat.executor.service.run_action_on_ray_cluster",
+        mocked_executor_entrypoint,
+    )
+    session, db_repo_id = db_session_with_repo
+    repo = Repository()
+    repo._register_udfs_from_package(mock_package)
+
+    # Sanity check: We've registered the UDFs correctly
+    assert repo.get("testing.add_100").fn(1) == 101  # type: ignore
+
+    ra_service = RegistryActionsService(session, role=test_role)
+    await ra_service.create_action(
+        RegistryActionCreate.from_bound(repo.get("testing.add_100"), db_repo_id)
+    )
+
+    input = RunActionInput(
+        task=ActionStatement(
+            ref="test",
+            action="testing.add_100",
+            run_if=None,
+            args={"num": "${{ var.x }}"},
+            for_each="${{ for var.x in [1,2,3,4,5] }}",
+        ),
+        exec_context=create_default_execution_context(),
+        run_context=mock_run_context,
+    )
+
+    # Act
+
+    result = await _dispatch_action(input, test_role)
+
+    # This should run correctly
+    assert result == [101, 102, 103, 104, 105]
+
+    # Now, force a validation error
+
+    input = RunActionInput(
+        task=ActionStatement(
+            ref="test",
+            action="testing.add_100",
+            run_if=None,
+            args={"num": "${{ var.x }}"},
+            for_each="${{ for var.x in [1,2,None,4,5] }}",
+        ),
+        exec_context=create_default_execution_context(),
+        run_context=mock_run_context,
+    )
+
+    # Act
+    with pytest.raises(LoopExecutionError):
+        result = await _dispatch_action(input, test_role)
+
+    # Try another dispatch with a different error
+
+    input = RunActionInput(
+        task=ActionStatement(
+            ref="test",
+            action="testing.add_100",
+            run_if=None,
+            args={"num": "${{ FN.flatten(var.x) }}"},
+            for_each="${{ for var.x in [[1], None, [3], [4], [5]] }}",
+        ),
+        exec_context=create_default_execution_context(),
+        run_context=mock_run_context,
+    )
+
+    # Act
+    with pytest.raises(LoopExecutionError):
+        result = await _dispatch_action(input, test_role)
+
+
+@pytest.fixture
+def sample_execution_error() -> ExecutionError:
+    """Create a sample ExecutionError for testing."""
+    return ExecutionError(
+        info=ExecutorActionErrorInfo(
+            action_name="test_action",
+            type="ValueError",
+            message="Test error",
+            filename=__file__,
+            function="sample_execution_error",
+        )
+    )
+
+
+def test_flatten_single_error(sample_execution_error: ExecutionError) -> None:
+    """Test flattening a single ExecutionError."""
+    result = flatten_wrapped_exc_error_group(sample_execution_error)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0] == sample_execution_error
+
+
+def test_flatten_exception_group(sample_execution_error: ExecutionError) -> None:
+    """Test flattening an ExceptionGroup containing ExecutionErrors."""
+    # Create an ExceptionGroup with multiple ExecutionErrors
+    eg = ExceptionGroup(
+        "test_group",
+        [sample_execution_error, sample_execution_error, sample_execution_error],
+    )
+
+    result = flatten_wrapped_exc_error_group(eg)
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(err, ExecutionError) for err in result)
+
+
+def test_flatten_nested_exception_groups(
+    sample_execution_error: ExecutionError,
+) -> None:
+    """Test flattening nested ExceptionGroups containing ExecutionErrors."""
+    # Create nested ExceptionGroups
+    inner_group = ExceptionGroup(
+        "inner_group", [sample_execution_error, sample_execution_error]
+    )
+    outer_group = ExceptionGroup("outer_group", [sample_execution_error, inner_group])
+
+    result = flatten_wrapped_exc_error_group(outer_group)  # type: ignore
+    assert isinstance(result, list)
+    assert len(result) == 3  # 1 from outer + 2 from inner
+    assert all(isinstance(err, ExecutionError) for err in result)

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tracecat.expressions.common import eval_jsonpath
 from tracecat.parse import (
     get_pyproject_toml_required_deps,
+    to_flat_dict,
     traverse_expressions,
     traverse_leaves,
 )
@@ -172,3 +173,27 @@ invalid toml content
     # Test parsing
     deps = get_pyproject_toml_required_deps(pyproject)
     assert deps == []
+
+
+def test_to_flat_dict_basic() -> None:
+    """Test basic dictionary flattening."""
+    result = to_flat_dict({"a": [{"b": 1}, {"b": 2}]})
+    assert result == {"a[0].b": 1, "a[1].b": 2}
+
+
+def test_to_flat_dict_with_dots() -> None:
+    """Test flattening dictionary with dots in keys."""
+    result = to_flat_dict({"a.b": {"c": 1}})
+    assert result == {"'a.b'.c": 1}
+
+
+def test_to_flat_dict_nested() -> None:
+    """Test flattening deeply nested dictionary."""
+    result = to_flat_dict({"a": {"b": {"c": 1, "d": 2}}})
+    assert result == {"a.b.c": 1, "a.b.d": 2}
+
+
+def test_to_flat_dict_with_prefix() -> None:
+    """Test flattening dictionary with prefix."""
+    result = to_flat_dict({"a": {"b": {"c": 1, "d": 2}}, "e": 3}, prefix="var")
+    assert result == {"var.a.b.c": 1, "var.a.b.d": 2, "var.e": 3}

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -2525,13 +2525,52 @@ def assert_error_handler_initiated_correctly(
             "failing_action": {
                 "attempt": 1,
                 "expr_context": "ACTIONS",
-                "message": "There was an error in the executor when calling action 'core.transform.reshape' (500).\n\nTracecatExpressionError: Error evaluating expression `1/0`\n\n[evaluator] Evaluation failed at node:\n```\nbinary_op\n  literal\t1\n  /\n  literal\t0\n\n```\nReason: Error trying to process rule \"binary_op\":\n\nCannot divide by zero\n\n------------------------------\nFile: /app/tracecat/expressions/core.py\nFunction: result\nLine: 74",
+                "message": (
+                    "There was an error in the executor when calling action 'core.transform.reshape' (500).\n\n"
+                    "\n"
+                    "TracecatExpressionError: Error evaluating expression `1/0`\n\n"
+                    "[evaluator] Evaluation failed at node:\n"
+                    "```\n"
+                    "binary_op\n"
+                    "  literal\t1\n"
+                    "  /\n"
+                    "  literal\t0\n\n"
+                    "```\n"
+                    'Reason: Error trying to process rule "binary_op":\n\n'
+                    "Cannot divide by zero\n\n"
+                    "\n"
+                    "------------------------------\n"
+                    "File: /app/tracecat/expressions/core.py\n"
+                    "Function: result\n"
+                    "Line: 74"
+                ),
                 "ref": "failing_action",
                 "type": "ExecutorClientError",
             }
         },
         "handler_wf_id": str(WorkflowUUID.new(handler_wf.id)),
-        "message": "Workflow failed with 1 task exception(s)\n\n==================== (1/1) ACTIONS.failing_action ====================\n\nExecutorClientError: [ACTIONS.failing_action -> run_action] (Attempt 1)\n\nThere was an error in the executor when calling action 'core.transform.reshape' (500).\n\nTracecatExpressionError: Error evaluating expression `1/0`\n\n[evaluator] Evaluation failed at node:\n```\nbinary_op\n  literal\t1\n  /\n  literal\t0\n\n```\nReason: Error trying to process rule \"binary_op\":\n\nCannot divide by zero\n\n------------------------------\nFile: /app/tracecat/expressions/core.py\nFunction: result\nLine: 74",
+        "message": (
+            "Workflow failed with 1 task exception(s)\n\n"
+            "==================== (1/1) ACTIONS.failing_action ====================\n\n"
+            "ExecutorClientError: [ACTIONS.failing_action -> run_action] (Attempt 1)\n\n"
+            "There was an error in the executor when calling action 'core.transform.reshape' (500).\n\n"
+            "\n"
+            "TracecatExpressionError: Error evaluating expression `1/0`\n\n"
+            "[evaluator] Evaluation failed at node:\n"
+            "```\n"
+            "binary_op\n"
+            "  literal\t1\n"
+            "  /\n"
+            "  literal\t0\n\n"
+            "```\n"
+            'Reason: Error trying to process rule "binary_op":\n\n'
+            "Cannot divide by zero\n\n"
+            "\n"
+            "------------------------------\n"
+            "File: /app/tracecat/expressions/core.py\n"
+            "Function: result\n"
+            "Line: 74"
+        ),
         "orig_wf_exec_id": failing_wf_exec_id,
         "orig_wf_id": str(failing_wf_id),
     }

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1603,6 +1603,7 @@ PARTIAL_DIVISION_BY_ZERO_ERROR = {
     "message": (
         "There was an error in the executor when calling action 'core.transform.reshape' (500).\n"
         "\n"
+        "\n"
         "TracecatExpressionError: Error evaluating expression `1/0`\n"
         "\n"
         "[evaluator] Evaluation failed at node:\n"
@@ -1616,6 +1617,7 @@ PARTIAL_DIVISION_BY_ZERO_ERROR = {
         'Reason: Error trying to process rule "binary_op":\n'
         "\n"
         "Cannot divide by zero\n"
+        "\n"
         "\n"
         "------------------------------\n"
         # f"File: /app/{"/".join(run_action_on_ray_cluster.__module__.split('.'))}.py\n"

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -10,7 +10,6 @@ from temporalio.exceptions import ApplicationError
 
 from tracecat.contexts import ctx_logger, ctx_run
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.dsl.common import context_locator
 from tracecat.dsl.models import ActionErrorInfo, ActionStatement, RunActionInput
 from tracecat.executor.client import ExecutorClient
 from tracecat.logger import logger
@@ -18,16 +17,6 @@ from tracecat.registry.actions.models import RegistryActionValidateResponse
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import ExecutorClientError, RegistryError
 from tracecat.validation.service import validate_registry_action_args
-
-
-def contextualize_message(
-    task: ActionStatement,
-    msg: str | BaseException,
-    *,
-    attempt: int,
-    loc: str = "run_action",
-) -> str:
-    return f"[{context_locator(task, loc)}] (Attempt {attempt})\n\n{msg}"
 
 
 class ValidateActionActivityInput(BaseModel):

--- a/tracecat/executor/models.py
+++ b/tracecat/executor/models.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import json
 import traceback
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic import UUID4, BaseModel
 
 from tracecat.config import TRACECAT__APP_ENV
+from tracecat.expressions.common import ExprContext
 from tracecat.git import GitUrl
+from tracecat.parse import to_flat_dict
 from tracecat.types.auth import Role
 
 
@@ -35,17 +39,35 @@ class ExecutorActionErrorInfo(BaseModel):
     lineno: int | None = None
     """Line number where the error occurred."""
 
+    loop_iteration: int | None = None
+    """Iteration number of the loop that caused the error."""
+
+    loop_vars: dict[str, Any] | None = None
+    """Variables of the loop that caused the error."""
+
     def __str__(self) -> str:
+        parts = []
+        msg = f"\n{self.type}: {self.message}"
+        if self.loop_iteration is not None:
+            flattened = to_flat_dict(
+                self.loop_vars or {}, prefix=ExprContext.LOCAL_VARS
+            )
+            parts.append(
+                f"\n[for_each] (Iteration {self.loop_iteration})"
+                f"\n\nLoop variables:\n```\n{json.dumps(flattened, indent=2)}\n```"
+                f"\n\n{msg}"
+                "\n\nPlease ensure that the loop is iterable and that the loop variable has the correct type."
+            )
+        else:
+            parts.append(msg)
         if TRACECAT__APP_ENV == "development":
-            return (
-                f"{self.type}: {self.message}"
+            parts.append(
                 f"\n\n{'-' * 30}"
                 f"\nFile: {self.filename}"
                 f"\nFunction: {self.function}"
                 f"\nLine: {self.lineno}"
             )
-        else:
-            return f"{self.type}: {self.message}"
+        return "\n".join(parts)
 
     @staticmethod
     def from_exc(e: Exception, action_name: str) -> ExecutorActionErrorInfo:

--- a/tracecat/expressions/validation.py
+++ b/tracecat/expressions/validation.py
@@ -44,7 +44,7 @@ class TemplateValidator:
             return v
         # Otherwise, it's an inline template or non-template
         # Call the default handler
-        return handler(v, info)
+        return handler(v)
 
 
 class RequiredTemplateValidator:

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypedDict, TypeVar, cast
@@ -143,14 +144,12 @@ class BoundRegistryAction(BaseModel):
             validated_args = validated.model_dump(mode="json")
             return validated_args
         except ValidationError as e:
-            logger.error(
-                f"Validation error for bound registry action {self.action!r}. {e.errors()!r}"
+            msg = (
+                f"Validation error for bound registry action {self.action!r}."
+                f"\n{json.dumps(e.errors(include_url=False), indent=2)}"
             )
-            raise RegistryValidationError(
-                f"Validation error for bound registry action {self.action!r}. {e.errors()!r}",
-                key=self.action,
-                err=e,
-            ) from e
+            logger.error(msg)
+            raise RegistryValidationError(msg, key=self.action, err=e) from e
         except Exception as e:
             raise RegistryValidationError(
                 f"Unexpected error when validating input arguments for bound registry action {self.action!r}. {e!r}",

--- a/tracecat/types/exceptions.py
+++ b/tracecat/types/exceptions.py
@@ -7,9 +7,14 @@ meant to be displayed to the user in a user-friendly way. We expose these
 through FastAPI exception handlers, which match the exception type.
 """
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from pydantic_core import ValidationError
+
+if TYPE_CHECKING:
+    from tracecat.executor.models import ExecutorActionErrorInfo
 
 
 class TracecatException(Exception):
@@ -86,12 +91,19 @@ class ExecutorClientError(TracecatException):
     """Exception raised when an error occurs in the executor client."""
 
 
-class WrappedExecutionError(TracecatException):
+class ExecutionError(TracecatException):
     """Exception raised when an error occurs during action execution.
     Use this to wrap errors from the executor so that we should reraise"""
 
-    def __init__(self, error: Any):
-        self.error = error
+    def __init__(self, info: ExecutorActionErrorInfo):
+        self.info = info
+
+
+class LoopExecutionError(TracecatException):
+    """Exception raised when an error occurs during loop execution."""
+
+    def __init__(self, loop_errors: list[ExecutionError]):
+        self.loop_errors = loop_errors
 
 
 class TracecatSettingsError(TracecatException):


### PR DESCRIPTION
We weren't handling `WrappedExecutionError` properly in loop iteration, which led to uninformative errors like `Error in loop:` with no information. Now we capture more information and show it nicely.

# Testing
- Added executor tests to reproduce the error, and ensure that we catch the improved exception with better diagnostics

# Screens
Example of a loop iteration passing [1,2, None] into a UDF that expects an integer.

https://github.com/user-attachments/assets/c4c56937-a5cd-403f-9435-a0430f988caa

