### PR TITLE
feat(app): Add structural and args validation for action templates

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2036,6 +2036,50 @@ export const $RegistryActionValidateResponse = {
   title: "RegistryActionValidateResponse",
 } as const
 
+export const $RegistryActionValidationErrorInfo = {
+  properties: {
+    type: {
+      $ref: "#/components/schemas/TemplateActionValidationErrorType",
+    },
+    details: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Details",
+    },
+    is_template: {
+      type: "boolean",
+      title: "Is Template",
+    },
+    step_ref: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Step Ref",
+    },
+    step_action: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Step Action",
+    },
+  },
+  type: "object",
+  required: ["type", "details", "is_template"],
+  title: "RegistryActionValidationErrorInfo",
+} as const
+
 export const $RegistryRepositoryCreate = {
   properties: {
     origin: {
@@ -2049,6 +2093,37 @@ export const $RegistryRepositoryCreate = {
   type: "object",
   required: ["origin"],
   title: "RegistryRepositoryCreate",
+} as const
+
+export const $RegistryRepositoryErrorDetail = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
+    origin: {
+      type: "string",
+      title: "Origin",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+    errors: {
+      additionalProperties: {
+        items: {
+          $ref: "#/components/schemas/RegistryActionValidationErrorInfo",
+        },
+        type: "array",
+      },
+      type: "object",
+      title: "Errors",
+    },
+  },
+  type: "object",
+  required: ["id", "origin", "message", "errors"],
+  title: "RegistryRepositoryErrorDetail",
+  description: "Error response model for registry sync failures.",
 } as const
 
 export const $RegistryRepositoryRead = {
@@ -3398,6 +3473,12 @@ export const $TemplateActionDefinition = {
     "returns",
   ],
   title: "TemplateActionDefinition",
+} as const
+
+export const $TemplateActionValidationErrorType = {
+  type: "string",
+  enum: ["ACTION_NOT_FOUND", "ACTION_NAME_CONFLICT", "STEP_VALIDATION_ERROR"],
+  title: "TemplateActionValidationErrorType",
 } as const
 
 export const $Trigger = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -1878,6 +1878,10 @@ export const registryRepositoriesReloadRegistryRepositories =
 /**
  * Sync Registry Repository
  * Load actions from a specific registry repository.
+ *
+ * Raises:
+ * 422: If there is an error syncing the repository (validation error)
+ * 404: If the repository is not found
  * @param data The data for the request.
  * @param data.repositoryId
  * @returns void Successful Response
@@ -1893,7 +1897,8 @@ export const registryRepositoriesSyncRegistryRepository = (
       repository_id: data.repositoryId,
     },
     errors: {
-      422: "Validation Error",
+      404: "Registry repository not found",
+      422: "Registry sync validation error",
     },
   })
 }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -674,11 +674,31 @@ export type RegistryActionValidateResponse = {
   action_ref?: string | null
 }
 
+export type RegistryActionValidationErrorInfo = {
+  type: TemplateActionValidationErrorType
+  details: Array<string>
+  is_template: boolean
+  step_ref?: string | null
+  step_action?: string | null
+}
+
 export type RegistryRepositoryCreate = {
   /**
    * The origin of the repository
    */
   origin: string
+}
+
+/**
+ * Error response model for registry sync failures.
+ */
+export type RegistryRepositoryErrorDetail = {
+  id: string
+  origin: string
+  message: string
+  errors: {
+    [key: string]: Array<RegistryActionValidationErrorInfo>
+  }
 }
 
 export type RegistryRepositoryRead = {
@@ -1095,6 +1115,11 @@ export type TemplateActionDefinition = {
         [key: string]: unknown
       }
 }
+
+export type TemplateActionValidationErrorType =
+  | "ACTION_NOT_FOUND"
+  | "ACTION_NAME_CONFLICT"
+  | "STEP_VALIDATION_ERROR"
 
 export type Trigger = {
   type: "schedule" | "webhook"
@@ -3156,9 +3181,13 @@ export type $OpenApiTs = {
          */
         204: void
         /**
-         * Validation Error
+         * Registry repository not found
          */
-        422: HTTPValidationError
+        404: unknown
+        /**
+         * Registry sync validation error
+         */
+        422: RegistryRepositoryErrorDetail
       }
     }
   }

--- a/frontend/src/components/registry/registry-action-validation-error.tsx
+++ b/frontend/src/components/registry/registry-action-validation-error.tsx
@@ -1,0 +1,56 @@
+import { AlertCircle, XCircle } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+interface ErrorDisplayProps {
+  title?: string
+  error: Error | string | Record<string, string[]> | null
+  variant?: "default" | "destructive"
+  className?: string
+}
+
+export function ErrorDisplay({
+  title = "Error",
+  error,
+  variant = "destructive",
+  className,
+}: ErrorDisplayProps) {
+  if (!error) return null
+
+  const getErrorMessage = () => {
+    if (error instanceof Error) {
+      return error.message
+    }
+    if (typeof error === "string") {
+      return error
+    }
+    if (typeof error === "object") {
+      return (
+        <ScrollArea className="h-full max-h-[120px]">
+          {Object.entries(error).map(([field, messages]) => (
+            <div key={field} className="mb-2">
+              <span className="font-medium">{field}:</span>
+              <ul className="list-disc pl-4">
+                {messages.map((message, index) => (
+                  <li key={index}>{message}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </ScrollArea>
+      )
+    }
+    return "An unknown error occurred"
+  }
+
+  const Icon = variant === "destructive" ? XCircle : AlertCircle
+
+  return (
+    <Alert variant={variant} className={className}>
+      <Icon className="size-4" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{getErrorMessage()}</AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/src/components/registry/registry-repos-table.tsx
+++ b/frontend/src/components/registry/registry-repos-table.tsx
@@ -1,11 +1,14 @@
 "use client"
 
 import React, { useCallback, useState } from "react"
-import { RegistryRepositoryReadMinimal } from "@/client"
+import { RegistryErrorResponse, RegistryRepositoryReadMinimal } from "@/client"
 import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import {
+  AlertTriangleIcon,
+  ChevronDownIcon,
   CopyIcon,
+  CornerDownRightIcon,
   LoaderCircleIcon,
   RefreshCcw,
   Trash2Icon,
@@ -27,11 +30,17 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import {
   DataTable,
@@ -53,6 +62,7 @@ export function RegistryRepositoriesTable() {
     syncRepo,
     syncRepoIsPending,
     deleteRepo,
+    syncRepoError,
   } = useRegistryRepositories()
   const [selectedRepo, setSelectedRepo] =
     useState<RegistryRepositoryReadMinimal | null>(null)
@@ -184,156 +194,203 @@ export function RegistryRepositoriesTable() {
 
   const alertContent = getAlertContent()
 
+  const errorDetail = syncRepoError?.body.detail as RegistryErrorResponse | null
   return (
-    <AlertDialog open={alertOpen}>
-      <DataTable
-        isLoading={registryReposIsLoading}
-        error={registryReposError ?? undefined}
-        data={registryRepos}
-        emptyMessage="No actions found."
-        errorMessage="Error loading workflows."
-        columns={[
-          {
-            accessorKey: "origin",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Origin"
-              />
-            ),
-            cell: ({ row }) => {
-              return (
-                <div className="text-xs text-foreground/80">
-                  {row.getValue<RegistryRepositoryReadMinimal["origin"]>(
-                    "origin"
-                  ) || "-"}
+    <TooltipProvider>
+      {errorDetail && (
+        <div className="space-y-2 rounded-md border border-rose-400 bg-rose-100 p-2 font-mono tracking-tighter">
+          <Collapsible>
+            <CollapsibleTrigger asChild className="group">
+              <div className="flex cursor-pointer items-center justify-between text-sm font-bold text-rose-500">
+                <div className="flex items-center">
+                  <AlertTriangleIcon className="mr-2 size-4 fill-red-500 stroke-white" />
+                  <span>{errorDetail.message}</span>
                 </div>
-              )
-            },
-            enableSorting: true,
-            enableHiding: false,
-          },
-          {
-            accessorKey: "commit_sha",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Commit SHA"
-              />
-            ),
-            cell: ({ row }) => {
-              const sha =
-                row.getValue<RegistryRepositoryReadMinimal["commit_sha"]>(
-                  "commit_sha"
-                )
-              if (!sha)
-                return <div className="text-xs text-foreground/80">-</div>
-              return (
-                <Badge
-                  className="font-mono text-xs font-normal"
-                  variant="secondary"
-                >
-                  {sha.substring(0, 7)}
-                </Badge>
-              )
-            },
-            enableHiding: false,
-          },
-          {
-            accessorKey: "last_synced_at",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Last synced"
-              />
-            ),
-            cell: ({ row }) => {
-              const lastSyncedAt =
-                row.getValue<RegistryRepositoryReadMinimal["last_synced_at"]>(
-                  "last_synced_at"
-                )
-              if (!lastSyncedAt) {
-                return <div className="text-xs text-foreground/80">-</div>
-              }
-              const date = new Date(lastSyncedAt)
-              const ago = getRelativeTime(date)
-              return (
-                <div className="space-x-2 text-xs">
-                  <span>{date.toLocaleString()}</span>
-                  <span className="text-muted-foreground">({ago})</span>
-                </div>
-              )
-            },
-            enableSorting: true,
-            enableHiding: false,
-          },
-          {
-            id: "actions",
-            enableHiding: false,
-            cell: ({ row }) => {
-              const commitSha = row.original.commit_sha
-              return (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      className="size-8 p-0"
-                      onClick={(e) => e.stopPropagation()} // Prevent row click
-                    >
-                      <span className="sr-only">Open menu</span>
-                      {row.original.id === selectedRepo?.id &&
-                      syncRepoIsPending ? (
-                        <div className="flex items-center space-x-2">
-                          <LoaderCircleIcon className="size-4 animate-spin" />
-                          <span className="text-xs text-muted-foreground">
-                            Pulling...
-                          </span>
-                        </div>
-                      ) : (
-                        <DotsHorizontalIcon className="size-4" />
-                      )}
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuLabel className="p-2 text-xs font-semibold text-muted-foreground">
-                      Actions
-                    </DropdownMenuLabel>
-
-                    <DropdownMenuItem
-                      className="flex items-center text-xs"
-                      onClick={(e) => {
-                        e.stopPropagation() // Prevent row click
-                        navigator.clipboard.writeText(row.original.origin)
-                        toast({
-                          title: "Repository origin copied",
-                          description: (
-                            <div className="flex flex-col space-y-2">
-                              <span className="inline-block">
-                                {row.original.origin}
-                              </span>
+                <ChevronDownIcon className="size-4 group-data-[state=closed]:rotate-0 group-data-[state=open]:rotate-180" />
+              </div>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="border-rose-400 text-sm">
+              <div className="mt-1 max-h-[50vh] space-y-1 overflow-y-auto">
+                <div className="flex flex-col space-y-4 text-foreground/60">
+                  {Object.entries(errorDetail.errors).map(([key, errors]) => (
+                    <div key={key} className="flex flex-col space-y-1">
+                      <span className="font-mono font-semibold tracking-tighter text-foreground/60">
+                        {key}
+                      </span>
+                      <div className="flex flex-col">
+                        {errors.map((error, errorIndex) => {
+                          return (
+                            <div key={errorIndex}>
+                              <div className="flex items-center">
+                                <span className="mx-2 inline-block size-1 rounded-full bg-current" />
+                                <span className="font-mono tracking-tighter">
+                                  {error.is_template ? (
+                                    <span>
+                                      <span className="font-semibold text-foreground/50">
+                                        steps.{error.step_ref}{" "}
+                                      </span>
+                                      <span className="text-muted-foreground">
+                                        ({error.step_action})
+                                      </span>
+                                    </span>
+                                  ) : (
+                                    <span>steps.${error.step_ref}</span>
+                                  )}
+                                </span>
+                              </div>
+                              {error.details.map((detail, detailIndex) => (
+                                <p
+                                  key={`${detail}-${errorIndex}-${detailIndex}`}
+                                  className="ml-4 flex items-center text-foreground/60"
+                                >
+                                  <CornerDownRightIcon className="mr-2 size-3" />
+                                  <span>{detail}</span>
+                                </p>
+                              ))}
                             </div>
-                          ),
-                        })
-                      }}
-                    >
-                      <CopyIcon className="mr-2 size-4" />
-                      <span>Copy repository origin</span>
-                    </DropdownMenuItem>
-                    {commitSha !== null && (
+                          )
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      )}
+      <AlertDialog open={alertOpen}>
+        <DataTable
+          isLoading={registryReposIsLoading}
+          error={registryReposError ?? undefined}
+          data={registryRepos}
+          emptyMessage="No actions found."
+          errorMessage="Error loading workflows."
+          columns={[
+            {
+              accessorKey: "origin",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Origin"
+                />
+              ),
+              cell: ({ row }) => {
+                return (
+                  <div className="text-xs text-foreground/80">
+                    {row.getValue<RegistryRepositoryReadMinimal["origin"]>(
+                      "origin"
+                    ) || "-"}
+                  </div>
+                )
+              },
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "commit_sha",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Commit SHA"
+                />
+              ),
+              cell: ({ row }) => {
+                const sha =
+                  row.getValue<RegistryRepositoryReadMinimal["commit_sha"]>(
+                    "commit_sha"
+                  )
+                if (!sha)
+                  return <div className="text-xs text-foreground/80">-</div>
+                return (
+                  <Badge
+                    className="font-mono text-xs font-normal"
+                    variant="secondary"
+                  >
+                    {sha.substring(0, 7)}
+                  </Badge>
+                )
+              },
+              enableHiding: false,
+            },
+            {
+              accessorKey: "last_synced_at",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Last synced"
+                />
+              ),
+              cell: ({ row }) => {
+                const lastSyncedAt =
+                  row.getValue<RegistryRepositoryReadMinimal["last_synced_at"]>(
+                    "last_synced_at"
+                  )
+                if (!lastSyncedAt) {
+                  return <div className="text-xs text-foreground/80">-</div>
+                }
+                const date = new Date(lastSyncedAt)
+                const ago = getRelativeTime(date)
+                return (
+                  <div className="space-x-2 text-xs">
+                    <span>{date.toLocaleString()}</span>
+                    <span className="text-muted-foreground">({ago})</span>
+                  </div>
+                )
+              },
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              id: "actions",
+              enableHiding: false,
+              cell: ({ row }) => {
+                const commitSha = row.original.commit_sha
+                const isSelected = row.original.id === selectedRepo?.id
+                const Icon = () => {
+                  if (isSelected && syncRepoIsPending) {
+                    return <LoaderCircleIcon className="size-4 animate-spin" />
+                  }
+                  const errorDetail = syncRepoError?.body
+                    .detail as RegistryErrorResponse
+                  if (errorDetail?.id === row.original.id) {
+                    return (
+                      <AlertTriangleIcon className="size-4 fill-rose-600 text-white" />
+                    )
+                  }
+                  return <DotsHorizontalIcon className="size-4" />
+                }
+                return (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        className="size-8 p-0"
+                        onClick={(e) => e.stopPropagation()} // Prevent row click
+                      >
+                        <span className="sr-only">Open menu</span>
+                        <Icon />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuLabel className="p-2 text-xs font-semibold text-muted-foreground">
+                        Actions
+                      </DropdownMenuLabel>
+
                       <DropdownMenuItem
                         className="flex items-center text-xs"
                         onClick={(e) => {
                           e.stopPropagation() // Prevent row click
-                          navigator.clipboard.writeText(commitSha)
+                          navigator.clipboard.writeText(row.original.origin)
                           toast({
-                            title: "Commit SHA copied",
+                            title: "Repository origin copied",
                             description: (
                               <div className="flex flex-col space-y-2">
                                 <span className="inline-block">
-                                  {commitSha}
+                                  {row.original.origin}
                                 </span>
                               </div>
                             ),
@@ -341,68 +398,90 @@ export function RegistryRepositoriesTable() {
                         }}
                       >
                         <CopyIcon className="mr-2 size-4" />
-                        <span>Copy commit SHA</span>
+                        <span>Copy repository origin</span>
                       </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem
-                      className="flex items-center text-xs"
-                      onClick={(e) => {
-                        e.stopPropagation() // Prevent row click
-                        setSelectedRepo(row.original)
-                        setAlertAction(AlertAction.SYNC)
-                        setAlertOpen(true)
-                      }}
-                    >
-                      <RefreshCcw className="mr-2 size-4" />
-                      <span>Sync from remote</span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="flex items-center text-xs text-rose-600"
-                      onClick={(e) => {
-                        e.stopPropagation() // Prevent row click
-                        setSelectedRepo(row.original)
-                        setAlertAction(AlertAction.DELETE)
-                        setAlertOpen(true)
-                      }}
-                    >
-                      <TrashIcon className="mr-2 size-4" />
-                      <span>Delete repository</span>
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )
+                      {commitSha !== null && (
+                        <DropdownMenuItem
+                          className="flex items-center text-xs"
+                          onClick={(e) => {
+                            e.stopPropagation() // Prevent row click
+                            navigator.clipboard.writeText(commitSha)
+                            toast({
+                              title: "Commit SHA copied",
+                              description: (
+                                <div className="flex flex-col space-y-2">
+                                  <span className="inline-block">
+                                    {commitSha}
+                                  </span>
+                                </div>
+                              ),
+                            })
+                          }}
+                        >
+                          <CopyIcon className="mr-2 size-4" />
+                          <span>Copy commit SHA</span>
+                        </DropdownMenuItem>
+                      )}
+                      <DropdownMenuItem
+                        className="flex items-center text-xs"
+                        onClick={(e) => {
+                          e.stopPropagation() // Prevent row click
+                          setSelectedRepo(row.original)
+                          setAlertAction(AlertAction.SYNC)
+                          setAlertOpen(true)
+                        }}
+                      >
+                        <RefreshCcw className="mr-2 size-4" />
+                        <span>Sync from remote</span>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="flex items-center text-xs text-rose-600"
+                        onClick={(e) => {
+                          e.stopPropagation() // Prevent row click
+                          setSelectedRepo(row.original)
+                          setAlertAction(AlertAction.DELETE)
+                          setAlertOpen(true)
+                        }}
+                      >
+                        <TrashIcon className="mr-2 size-4" />
+                        <span>Delete repository</span>
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )
+              },
             },
-          },
-        ]}
-        toolbarProps={defaultToolbarProps}
-      />
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{alertContent?.title}</AlertDialogTitle>
-          <AlertDialogDescription>
-            {alertContent?.description}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel onClick={() => setAlertOpen(false)}>
-            Cancel
-          </AlertDialogCancel>
+          ]}
+          toolbarProps={defaultToolbarProps}
+        />
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{alertContent?.title}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {alertContent?.description}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setAlertOpen(false)}>
+              Cancel
+            </AlertDialogCancel>
 
-          {alertContent?.actions.map((action, index) => (
-            <AlertDialogAction
-              key={index}
-              onClick={async () => {
-                setAlertOpen(false)
-                await action.action()
-              }}
-              disabled={syncRepoIsPending}
-            >
-              {action.label}
-            </AlertDialogAction>
-          ))}
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+            {alertContent?.actions.map((action, index) => (
+              <AlertDialogAction
+                key={index}
+                onClick={async () => {
+                  setAlertOpen(false)
+                  await action.action()
+                }}
+                disabled={syncRepoIsPending}
+              >
+                {action.label}
+              </AlertDialogAction>
+            ))}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </TooltipProvider>
   )
 }
 const defaultToolbarProps: DataTableToolbarProps = {

--- a/frontend/src/components/registry/registry-repos-table.tsx
+++ b/frontend/src/components/registry/registry-repos-table.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import React, { useCallback, useState } from "react"
-import { RegistryErrorResponse, RegistryRepositoryReadMinimal } from "@/client"
+import {
+  RegistryRepositoryErrorDetail,
+  RegistryRepositoryReadMinimal,
+} from "@/client"
 import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import {
@@ -194,7 +197,8 @@ export function RegistryRepositoriesTable() {
 
   const alertContent = getAlertContent()
 
-  const errorDetail = syncRepoError?.body.detail as RegistryErrorResponse | null
+  const errorDetail = syncRepoError?.body
+    .detail as RegistryRepositoryErrorDetail | null
   return (
     <TooltipProvider>
       {errorDetail && (
@@ -355,7 +359,7 @@ export function RegistryRepositoriesTable() {
                     return <LoaderCircleIcon className="size-4 animate-spin" />
                   }
                   const errorDetail = syncRepoError?.body
-                    .detail as RegistryErrorResponse
+                    .detail as RegistryRepositoryErrorDetail
                   if (errorDetail?.id === row.original.id) {
                     return (
                       <AlertTriangleIcon className="size-4 fill-rose-600 text-white" />

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,8 +1,8 @@
 import { ApiError } from "@/client"
 
-export interface TracecatApiError extends ApiError {
+export interface TracecatApiError<T = unknown> extends ApiError {
   readonly body: {
-    detail: unknown
+    detail: T
   }
 }
 

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -32,13 +32,13 @@ import {
   registryActionsListRegistryActions,
   registryActionsUpdateRegistryAction,
   RegistryActionsUpdateRegistryActionData,
-  RegistryErrorResponse,
   registryRepositoriesDeleteRegistryRepository,
   RegistryRepositoriesDeleteRegistryRepositoryData,
   registryRepositoriesListRegistryRepositories,
   registryRepositoriesReloadRegistryRepositories,
   registryRepositoriesSyncRegistryRepository,
   RegistryRepositoriesSyncRegistryRepositoryData,
+  RegistryRepositoryErrorDetail,
   RegistryRepositoryReadMinimal,
   SAMLSettingsRead,
   Schedule,
@@ -1206,7 +1206,8 @@ export function useRegistryRepositories() {
           })
           break
         case 422:
-          const { message, errors } = error.body.detail as RegistryErrorResponse
+          const { message, errors } = error.body
+            .detail as RegistryRepositoryErrorDetail
           toast({
             title: "Got validation errors",
             description: (

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from tracecat.expressions.validation import is_iterable
+from tracecat.common import is_iterable
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,0 +1,83 @@
+"""Tests for validation functions in the expressions module."""
+
+from collections import OrderedDict, defaultdict, deque
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from tracecat.expressions.validation import is_iterable
+
+
+@pytest.mark.parametrize(
+    "value, container_only, expected",
+    [
+        # Test basic types with container_only=True
+        ([], True, True),  # List
+        ((), True, True),  # Tuple
+        (set(), True, True),  # Set
+        ({1, 2, 3}, True, True),  # Non-empty set
+        ([1, 2, 3], True, True),  # Non-empty list
+        # Test string-like types with container_only=True
+        ("hello", True, False),  # String
+        (b"hello", True, False),  # Bytes
+        # Test string-like types with container_only=False
+        ("hello", False, True),  # String
+        (b"hello", False, True),  # Bytes
+        # Test mapping types (should always be False)
+        ({}, True, False),  # Dict
+        ({"a": 1}, True, False),  # Non-empty dict
+        ({}, False, False),  # Dict with container_only=False
+        # Test non-iterable types
+        (42, True, False),  # Integer
+        (3.14, True, False),  # Float
+        (True, True, False),  # Boolean
+        (None, True, False),  # None
+        # Test alternative container types
+        (deque([1, 2, 3]), True, True),  # deque
+        (deque(), True, True),  # Empty deque
+        # Test alternative mapping types (should always be False)
+        (defaultdict(list), True, False),  # defaultdict
+        (defaultdict(list, {"a": [1, 2]}), True, False),  # Non-empty defaultdict
+        (OrderedDict(), True, False),  # OrderedDict
+        (OrderedDict([("a", 1), ("b", 2)]), True, False),  # Non-empty OrderedDict
+    ],
+)
+def test_is_iterable(value: Any, container_only: bool, expected: bool) -> None:
+    """Test the is_iterable function with various input types and container_only settings.
+
+    Args:
+        value: The value to test for iterability
+        container_only: Whether to exclude string-like types from being considered iterable
+        expected: The expected result of the is_iterable function
+    """
+    assert is_iterable(value, container_only=container_only) == expected
+
+
+def test_is_iterable_custom_iterable() -> None:
+    """Test is_iterable with a custom class implementing __iter__."""
+
+    class CustomIterable:
+        def __iter__(self):
+            return iter([1, 2, 3])
+
+    assert is_iterable(CustomIterable(), container_only=True)
+
+
+def test_is_iterable_custom_mapping() -> None:
+    """Test is_iterable with a custom mapping class."""
+
+    class CustomMapping(Mapping):
+        def __init__(self) -> None:
+            self._data: dict[str, int] = {"a": 1}
+
+        def __getitem__(self, key: str) -> int:
+            return self._data[key]
+
+        def __iter__(self):
+            return iter(self._data)
+
+        def __len__(self) -> int:
+            return len(self._data)
+
+    assert not is_iterable(CustomMapping(), container_only=True)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -5,14 +5,14 @@ from pydantic import BaseModel
 from tracecat_registry import registry
 from typing_extensions import Doc
 
-from tracecat.expressions.validation import CoreSchemaTemplateValidator
+from tracecat.expressions.validation import TemplateValidator
 from tracecat.registry.repository import Repository
 from tracecat.types.exceptions import RegistryValidationError
 
 
 def test_template_validator():
     class MyModel(BaseModel):
-        my_action: Annotated[list[str], CoreSchemaTemplateValidator()]
+        my_action: Annotated[list[str], TemplateValidator()]
 
     # Sanity check
     model = MyModel(my_action=["hello", "world"])

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,0 +1,186 @@
+from typing import Annotated, Any
+
+import pytest
+from pydantic import BaseModel
+from tracecat_registry import registry
+from typing_extensions import Doc
+
+from tracecat.expressions.validation import CoreSchemaTemplateValidator
+from tracecat.registry.repository import Repository
+from tracecat.types.exceptions import RegistryValidationError
+
+
+def test_template_validator():
+    class MyModel(BaseModel):
+        my_action: Annotated[list[str], CoreSchemaTemplateValidator()]
+
+    # Sanity check
+    model = MyModel(my_action=["hello", "world"])
+    assert model.my_action == ["hello", "world"]
+
+    model = MyModel(my_action="${{ my_list }}")  # type: ignore
+    assert model.my_action == "${{ my_list }}"
+
+
+def test_validator_function_wrap_handler():
+    """This tests the UDF.validate_args method, which shouldn't raise any exceptions
+    when given a templated expression.
+    """
+    # Register UDFs from the mock package
+    repo = Repository()
+
+    @registry.register(
+        description="This is a test function",
+        namespace="test",
+        doc_url="https://example.com/docs",
+        author="Tracecat",
+    )
+    def f1(
+        num: Annotated[
+            int,
+            Doc("This is a test number"),
+        ],
+    ) -> int:
+        return num
+
+    # Attaches TemplateValidator to the UDF
+    repo._register_udf_from_function(f1, name="f1")
+
+    # Test the registered UDF
+    udf = repo.get("test.f1")
+    udf.validate_args(num="${{ path.to.number }}")
+    udf.validate_args(num=1)
+
+    @registry.register(
+        description="This is a test function",
+        namespace="test",
+        doc_url="https://example.com/docs",
+        author="Tracecat",
+    )
+    def f2(
+        obj: Annotated[
+            dict[str, list[str]],
+            Doc("This is a test dict of list of strings"),
+        ],
+    ) -> Any:
+        return obj["a"]
+
+    repo._register_udf_from_function(f2, name="f2")
+    udf2 = repo.get("test.f2")
+
+    # Test the UDF with an invalid object
+    with pytest.raises(RegistryValidationError):
+        udf2.validate_args(obj={"a": "not a list"})
+
+    # Should not raise
+    udf2.validate_args(obj={"a": "${{ not a list }}"})
+
+    @registry.register(
+        description="This is a test function",
+        namespace="test",
+        doc_url="https://example.com/docs",
+        author="Tracecat",
+    )
+    def f3(
+        obj: Annotated[
+            list[dict[str, int]],
+            Doc("This is a test list of dicts"),
+        ],
+    ) -> Any:
+        return obj[0]
+
+    repo._register_udf_from_function(f3, name="f3")
+    udf3 = repo.get("test.f3")
+
+    # Should not raise
+    udf3.validate_args(obj=[{"a": 1}])
+    x = udf3.args_cls.model_validate({"obj": [{"a": 1}]})
+    assert x.model_dump(warnings=True) == {"obj": [{"a": 1}]}
+    udf3.validate_args(obj=[{"a": "${{ a number }}"}])
+    x = udf3.args_cls.model_validate({"obj": [{"a": "${{ a number }}"}]})
+    assert x.model_dump(warnings=True) == {"obj": [{"a": "${{ a number }}"}]}
+    udf3.validate_args(obj=["${{ a number }}", {"a": "${{ a number }}"}])
+    x = udf3.args_cls.model_validate(
+        {"obj": ["${{ a number }}", {"a": "${{ a number }}"}]}
+    )
+    assert x.model_dump(warnings=True) == {
+        "obj": ["${{ a number }}", {"a": "${{ a number }}"}]
+    }
+
+    # Should raise
+    with pytest.raises(RegistryValidationError):
+        udf3.validate_args(obj=["string"])
+
+    with pytest.raises(RegistryValidationError):
+        udf3.validate_args(obj=[{"a": "string"}])
+
+    # Test deeply nested types
+    @registry.register(
+        description="Test function with deeply nested types",
+        namespace="test",
+        doc_url="https://example.com/docs",
+        author="Tracecat",
+    )
+    def f4(
+        complex_obj: Annotated[
+            dict[str, list[dict[str, list[dict[str, int]]]]],
+            Doc("A deeply nested structure"),
+        ],
+    ) -> Any:
+        return complex_obj
+
+    repo._register_udf_from_function(f4, name="f4")
+    udf4 = repo.get("test.f4")
+
+    # Valid nested structure
+    valid_obj = {"level1": [{"level2": [{"level3": 1}, {"level3": 2}]}]}
+    udf4.validate_args(complex_obj=valid_obj)
+
+    # Valid with template expressions
+    template_obj = {"level1": [{"level2": "${{ template.level2 }}"}]}
+    udf4.validate_args(complex_obj=template_obj)
+
+    template_obj = {"level1": [{"level2": [{"level3": "${{ template.level3 }}"}]}]}
+    udf4.validate_args(complex_obj=template_obj)
+
+    # Invalid nested structure
+    with pytest.raises(RegistryValidationError):
+        invalid_obj = {"level1": [{"level2": [{"level3": "not an int"}]}]}
+        udf4.validate_args(complex_obj=invalid_obj)
+
+    @registry.register(
+        description="Test function with tuple and set types",
+        namespace="test",
+        doc_url="https://example.com/docs",
+        author="Tracecat",
+    )
+    def f5(
+        nested_collections: Annotated[
+            dict[str, tuple[set[int], list[dict[str, set[str]]]]],
+            Doc("Complex nested collections"),
+        ],
+    ) -> Any:
+        return nested_collections
+
+    repo._register_udf_from_function(f5, name="f5")
+    udf5 = repo.get("test.f5")
+
+    # Valid nested collections
+    valid_collections = {"data": ({1, 2, 3}, [{"strings": {"a", "b", "c"}}])}
+    udf5.validate_args(nested_collections=valid_collections)
+
+    # Valid with templates
+    template_collections = {
+        "data": ("${{ template.numbers }}", [{"strings": "${{ template.strings }}"}])
+    }
+    udf5.validate_args(nested_collections=template_collections)
+
+    # Invalid collections
+    with pytest.raises(RegistryValidationError):
+        invalid_collections = {
+            "data": (
+                {"not", "integers"},  # Should be set of ints
+                [{"strings": {1, 2, 3}}],  # Should be set of strings
+            )
+        }
+        udf5.validate_args(nested_collections=invalid_collections)

--- a/tracecat/common.py
+++ b/tracecat/common.py
@@ -1,0 +1,18 @@
+from collections.abc import Mapping
+
+
+def is_iterable(value: object, *, container_only: bool = True) -> bool:
+    """Check if a value is iterable, optionally excluding string-like and mapping types.
+
+    Args:
+        value: The value to check for iterability
+        container_only: If True, excludes strings and bytes objects from being considered iterable
+
+    Returns:
+        bool: True if the value is iterable (according to the specified rules), False otherwise
+    """
+    if isinstance(value, str | bytes):
+        return not container_only
+    if isinstance(value, Mapping):
+        return False
+    return hasattr(value, "__iter__")

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -170,7 +170,9 @@ async def run_template_action(
             ),
         )
         async with RegistryActionsService.with_session() as service:
-            step_action = await service.load_action_impl(action_name=step.action)
+            step_action = await service.load_action_impl(
+                action_name=step.action, mode="execution"
+            )
         logger.trace("Running action step", step_action=step_action.action)
         result = await run_single_action(
             action=step_action,
@@ -202,7 +204,7 @@ async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
     async with RegistryActionsService.with_session() as service:
         reg_action = await service.get_action(action_name)
         action_secrets = await service.fetch_all_action_secrets(reg_action)
-        action = service.get_bound(reg_action)
+        action = service.get_bound(reg_action, mode="execution")
 
     args_secrets = set(extract_templated_secrets(task.args))
     optional_secrets = {s.name for s in action_secrets if s.optional}

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import orjson
 from slugify import slugify
 
-from tracecat.expressions.validation import is_iterable
+from tracecat.common import is_iterable
 
 
 def _bool(x: Any) -> bool:

--- a/tracecat/expressions/patterns.py
+++ b/tracecat/expressions/patterns.py
@@ -7,4 +7,5 @@ TEMPLATE_STRING = re.compile(r"(?P<template>\${{\s*(?P<expr>.+?)\s*}})")  # Lazy
 SECRET_SCAN_TEMPLATE = re.compile(r"\${{\s*SECRETS\.(?P<secret>.+?)\s*}}")
 """Specialized pattern to scan for secrets."""
 
-FULL_TEMPLATE = re.compile(r"^\${{\s*[^{}]*\s*}}$")
+STANDALONE_TEMPLATE = re.compile(r"^\${{\s*(?:(?!\${{).)*?\s*}}$")
+"""Pattern that matches a standalone template expression."""

--- a/tracecat/expressions/validation.py
+++ b/tracecat/expressions/validation.py
@@ -5,12 +5,12 @@ from pydantic import ValidationInfo, ValidatorFunctionWrapHandler
 from pydantic.functional_validators import WrapValidator
 
 from tracecat.common import is_iterable
-from tracecat.expressions.patterns import FULL_TEMPLATE
+from tracecat.expressions.patterns import STANDALONE_TEMPLATE
 
 
-def is_full_template(template: str) -> bool:
+def is_standalone_template(template: str) -> bool:
     """Check if a string is a complete template expression (${{...}})"""
-    return FULL_TEMPLATE.match(template) is not None
+    return STANDALONE_TEMPLATE.match(template) is not None
 
 
 T = TypeVar("T")
@@ -50,7 +50,7 @@ def recursive_validator(v: Any, handler: ValidatorFunctionWrapHandler) -> Any:
     """
     # If the input value is a string and a full template,
     # accept it regardless of the expected type
-    if isinstance(v, str) and is_full_template(v):
+    if isinstance(v, str) and is_standalone_template(v):
         # skip validation for template expressions
         return v
 
@@ -73,7 +73,7 @@ class RequiredTemplateValidator:
 
     @classmethod
     def must_expression(cls, v: T, handler: ValidatorFunctionWrapHandler, info) -> T:
-        if isinstance(v, str) and not is_full_template(v):
+        if isinstance(v, str) and not is_standalone_template(v):
             raise ValueError(f"'{v}' is not a valid expression")
         return handler(v, info)
 

--- a/tracecat/expressions/validation.py
+++ b/tracecat/expressions/validation.py
@@ -1,10 +1,9 @@
-from collections.abc import Mapping
 from typing import Annotated, Any, TypeVar
 
-from pydantic import ValidationInfo, ValidatorFunctionWrapHandler
+from pydantic import GetCoreSchemaHandler, ValidationInfo, ValidatorFunctionWrapHandler
 from pydantic.functional_validators import WrapValidator
+from pydantic_core import core_schema
 
-from tracecat.common import is_iterable
 from tracecat.expressions.patterns import STANDALONE_TEMPLATE
 
 
@@ -30,10 +29,12 @@ class TemplateValidator:
             return handler(v)
         except Exception:
             # Fallback to recursive validation for template expressions
-            return recursive_validator(v, handler)
+            return template_or_original_validator(v, handler)
 
 
-def recursive_validator(v: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+def template_or_original_validator(
+    v: Any, handler: ValidatorFunctionWrapHandler
+) -> Any:
     """Allows for templated expressions in the input data.
 
     This validator is used to validate the input data for templated expressions.
@@ -48,23 +49,49 @@ def recursive_validator(v: Any, handler: ValidatorFunctionWrapHandler) -> Any:
     print(Test(a={"b": "${{ my_list }}"}).model_dump())
     ```
     """
-    # If the input value is a string and a full template,
-    # accept it regardless of the expected type
+    # First check if it's a template string
     if isinstance(v, str) and is_standalone_template(v):
-        # skip validation for template expressions
         return v
-
-    # Handle nested mappings by recursively validating values
-    if isinstance(v, Mapping):
-        return type(v)(
-            **{key: recursive_validator(value, handler) for key, value in v.items()}
-        )
-
-    # Handle nested iterables (lists, tuples, etc.)
-    if is_iterable(v, container_only=True):
-        return type(v)(recursive_validator(item, handler) for item in v)
-
+    # If not a template, validate against the original schema
     return handler(v)
+
+
+class CoreSchemaTemplateValidator:
+    def __get_pydantic_core_schema__(
+        self, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
+        return self._process_nested_schema(schema)
+
+    def _process_nested_schema(
+        self, schema: core_schema.CoreSchema
+    ) -> core_schema.CoreSchema:
+        """Process nested schema types recursively.
+
+        Args:
+            schema: The schema to process
+
+        Returns:
+            Processed schema with template validation added to nested types
+        """
+        match schema:
+            case {"type": "dict", "values_schema": values_schema}:
+                schema["values_schema"] = self._process_nested_schema(values_schema)
+            case {"type": "tuple", "items_schema": items_schema}:
+                schema["items_schema"] = [
+                    self._process_nested_schema(s) for s in items_schema
+                ]
+            case {
+                "type": "list" | "set" | "frozenset" | "generator",
+                "items_schema": items_schema,
+            }:
+                schema["items_schema"] = self._process_nested_schema(items_schema)
+            case _:
+                pass
+        return core_schema.no_info_wrap_validator_function(
+            function=template_or_original_validator,
+            schema=schema,
+        )
 
 
 class RequiredTemplateValidator:
@@ -72,10 +99,12 @@ class RequiredTemplateValidator:
         return WrapValidator(cls.must_expression)
 
     @classmethod
-    def must_expression(cls, v: T, handler: ValidatorFunctionWrapHandler, info) -> T:
+    def must_expression(
+        cls, v: T, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
+    ) -> T:
         if isinstance(v, str) and not is_standalone_template(v):
             raise ValueError(f"'{v}' is not a valid expression")
-        return handler(v, info)
+        return handler(v)
 
 
 ExpressionStr = Annotated[str, TemplateValidator()]

--- a/tracecat/expressions/validation.py
+++ b/tracecat/expressions/validation.py
@@ -15,23 +15,6 @@ def is_standalone_template(template: str) -> bool:
 T = TypeVar("T")
 
 
-# We can bundle validators and unpack them in a single expression
-class TemplateValidator:
-    def __new__(cls):
-        return WrapValidator(cls.maybe_templated_expression)
-
-    @classmethod
-    def maybe_templated_expression(
-        cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
-    ) -> Any:
-        try:
-            # Quick win for simple expressions
-            return handler(v)
-        except Exception:
-            # Fallback to recursive validation for template expressions
-            return template_or_original_validator(v, handler)
-
-
 def template_or_original_validator(
     v: Any, handler: ValidatorFunctionWrapHandler
 ) -> Any:
@@ -56,7 +39,7 @@ def template_or_original_validator(
     return handler(v)
 
 
-class CoreSchemaTemplateValidator:
+class TemplateValidator:
     def __get_pydantic_core_schema__(
         self, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:

--- a/tracecat/expressions/validation.py
+++ b/tracecat/expressions/validation.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, TypeVar
+from collections.abc import Mapping
 
 from pydantic import ValidationInfo, ValidatorFunctionWrapHandler
 from pydantic.functional_validators import WrapValidator
@@ -11,17 +11,21 @@ def is_full_template(template: str) -> bool:
     return FULL_TEMPLATE.match(template) is not None
 
 
-def is_iterable(value: Any, *, container_only: bool = True) -> bool:
-    try:
-        iter(value)
-        if isinstance(value, dict):
-            # We don't consider dictionaries as iterables
-            return False
-        if container_only:
-            return not isinstance(value, str | bytes)
-        return True
-    except TypeError:
+def is_iterable(value: object, *, container_only: bool = True) -> bool:
+    """Check if a value is iterable, optionally excluding string-like and mapping types.
+
+    Args:
+        value: The value to check for iterability
+        container_only: If True, excludes strings and bytes objects from being considered iterable
+
+    Returns:
+        bool: True if the value is iterable (according to the specified rules), False otherwise
+    """
+    if isinstance(value, str | bytes):
+        return not container_only
+    if isinstance(value, Mapping):
         return False
+    return hasattr(value, "__iter__")
 
 
 T = TypeVar("T")

--- a/tracecat/registry/actions/enums.py
+++ b/tracecat/registry/actions/enums.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class TemplateActionValidationErrorType(StrEnum):
+    ACTION_NOT_FOUND = "ACTION_NOT_FOUND"
+    ACTION_NAME_CONFLICT = "ACTION_NAME_CONFLICT"
+    STEP_VALIDATION_ERROR = "STEP_VALIDATION_ERROR"

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -194,6 +194,10 @@ class TemplateActionDefinition(BaseModel):
     # Validate steps
     @model_validator(mode="after")
     def validate_steps(self):
+        # Check for at least 1 step
+        if not self.steps:
+            raise TracecatValidationError("Template action must have at least 1 step")
+
         step_refs = [step.ref for step in self.steps]
         unique_step_refs = set(step_refs)
 

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -22,6 +22,7 @@ from tracecat_registry import RegistrySecret
 from tracecat.db.schemas import RegistryAction
 from tracecat.expressions.expectations import ExpectedField, create_expectation_model
 from tracecat.logger import logger
+from tracecat.registry.actions.enums import TemplateActionValidationErrorType
 from tracecat.types.exceptions import (
     RegistryActionError,
     RegistryValidationError,
@@ -568,3 +569,11 @@ class model_converters:
                     f"Unknown implementation type: {action.implementation}"
                 )
         return intf
+
+
+class RegistryActionValidationErrorInfo(BaseModel):
+    type: TemplateActionValidationErrorType
+    details: list[str]
+    is_template: bool
+    step_ref: str | None = None
+    step_action: str | None = None

--- a/tracecat/registry/actions/service.py
+++ b/tracecat/registry/actions/service.py
@@ -200,6 +200,7 @@ class RegistryActionsService(BaseService):
             )
 
         # NOTE: We should start a transaction here and commit it after the sync is complete
+        await self.upsert_actions_from_repo(repo, db_repo)
 
         return commit_sha
 

--- a/tracecat/registry/actions/service.py
+++ b/tracecat/registry/actions/service.py
@@ -1,27 +1,32 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Sequence
 
-from pydantic import UUID4
-from pydantic_core import to_jsonable_python
+from pydantic import UUID4, ValidationError
+from pydantic_core import ErrorDetails, to_jsonable_python
 from sqlalchemy import Boolean
 from sqlmodel import cast, func, or_, select
 from tracecat_registry import RegistrySecret
 
 from tracecat import config
 from tracecat.db.schemas import RegistryAction, RegistryRepository
+from tracecat.registry.actions.enums import (
+    TemplateActionValidationErrorType,
+)
 from tracecat.registry.actions.models import (
     BoundRegistryAction,
     RegistryActionCreate,
     RegistryActionImplValidator,
     RegistryActionRead,
     RegistryActionUpdate,
+    RegistryActionValidationErrorInfo,
     model_converters,
 )
-from tracecat.registry.loaders import get_bound_action_impl
+from tracecat.registry.loaders import LoaderMode, get_bound_action_impl
 from tracecat.registry.repository import Repository
 from tracecat.service import BaseService
-from tracecat.types.exceptions import RegistryError
+from tracecat.types.exceptions import RegistryError, RegistryValidationError
 
 
 class RegistryActionsService(BaseService):
@@ -172,6 +177,99 @@ class RegistryActionsService(BaseService):
         sha = None if pull_remote else db_repo.commit_sha
         commit_sha = await repo.load_from_origin(commit_sha=sha)
 
+        # TODO: Move this into it's own function and service it from the registry repository router
+        # (1.5) Validate all actions
+        # (A) Validate that all actions and steps are valid
+        # (B) Validate that each step is correctly formatted
+        # - This means taking the step action and looking up the interface
+        # - Then we validate the args against the interface
+        # (C) Validate that template aciton name doesn't conflict with another action? Doesn't seem like we need this
+        # (D) Validate expressions in the args
+        self.logger.info("Validating actions", all_actions=repo.store.keys())
+        val_errs: dict[str, list[RegistryActionValidationErrorInfo]] = defaultdict(list)
+        for action in repo.store.values():
+            if not action.is_template:
+                continue
+            if errs := await self.validate_action_template(action, repo):
+                val_errs[action.action].extend(errs)
+        if val_errs:
+            detail = {k: [e.model_dump() for e in v] for k, v in val_errs.items()}
+            raise RegistryError(
+                f"Got {sum(len(v) for v in val_errs.values())} validation errors",
+                detail=detail,
+            )
+
+        # NOTE: We should start a transaction here and commit it after the sync is complete
+
+        return commit_sha
+
+    async def get_action_or_none(self, action_name: str) -> RegistryAction | None:
+        """Get an action by name, returning None if it doesn't exist."""
+        try:
+            return await self.get_action(action_name)
+        except RegistryError:
+            return None
+
+    async def validate_action_template(
+        self, action: BoundRegistryAction, repo: Repository
+    ) -> list[RegistryActionValidationErrorInfo]:
+        """Validate that a template action is correctly formatted."""
+        if not (action.is_template and action.template_action):
+            return []
+        val_errs: list[RegistryActionValidationErrorInfo] = []
+        for step in action.template_action.definition.steps:
+            # (A) Ensure that the step action type exists
+            if step.action in repo.store:
+                # If this action is already in the repo, we can just use it
+                # We will overwrite the action in the DB anyways
+                bound_action = repo.store[step.action]
+            elif (reg_action := await self.get_action_or_none(step.action)) is not None:
+                bound_action = get_bound_action_impl(reg_action, mode="validation")
+            else:
+                # Action not found in the repo or DB
+                val_errs.append(
+                    RegistryActionValidationErrorInfo(
+                        step_ref=step.ref,
+                        step_action=step.action,
+                        type=TemplateActionValidationErrorType.ACTION_NOT_FOUND,
+                        details=[f"Action `{step.action}` not found in repository."],
+                        is_template=action.is_template,
+                    )
+                )
+                self.logger.warning(
+                    "Step action not found, skipping",
+                    step_ref=step.ref,
+                    step_action=step.action,
+                )
+                continue
+
+            # (B) Validate that the step is correctly formatted
+            try:
+                bound_action.validate_args(**step.args)
+            except RegistryValidationError as e:
+                if isinstance(e.err, ValidationError):
+                    details = []
+                    for err in e.err.errors():
+                        msg = error_details_to_message(err)
+                        details.append(msg)
+                else:
+                    details = [str(e.err)] if e.err else []
+                val_errs.append(
+                    RegistryActionValidationErrorInfo(
+                        step_ref=step.ref,
+                        step_action=step.action,
+                        type=TemplateActionValidationErrorType.STEP_VALIDATION_ERROR,
+                        details=details,
+                        is_template=action.is_template,
+                    )
+                )
+        return val_errs
+
+    # We need to call this first for UDFs
+    async def upsert_actions_from_repo(
+        self, repo: Repository, db_repo: RegistryRepository
+    ) -> None:
+        """Upsert a list of actions."""
         # (2) Handle DB bookkeeping for the API's view of the repository
         # Perform diffing here. The expectation for this endpoint is to sync Tracecat's view of
         # the repository with the remote repository -- meaning any creation/updates/deletions to
@@ -179,14 +277,12 @@ class RegistryActionsService(BaseService):
         # Safety: We're in a db session so we can call this
         db_actions = db_repo.actions
         db_actions_map = {db_action.action: db_action for db_action in db_actions}
-
         self.logger.info(
             "Syncing actions from repository",
             repository=db_repo.origin,
             incoming_actions=len(repo.store.keys()),
             existing_actions=len(db_actions_map.keys()),
         )
-
         n_created = 0
         n_updated = 0
         n_deleted = 0
@@ -237,14 +333,14 @@ class RegistryActionsService(BaseService):
             deleted=n_deleted,
         )
 
-        return commit_sha
-
-    async def load_action_impl(self, action_name: str) -> BoundRegistryAction:
+    async def load_action_impl(
+        self, action_name: str, mode: LoaderMode = "validation"
+    ) -> BoundRegistryAction:
         """
         Load the implementation for a registry action.
         """
         action = await self.get_action(action_name=action_name)
-        bound_action = get_bound_action_impl(action)
+        bound_action = get_bound_action_impl(action, mode=mode)
         return bound_action
 
     async def read_action_with_implicit_secrets(
@@ -284,6 +380,24 @@ class RegistryActionsService(BaseService):
                 secrets.update(step_secrets)
         return secrets
 
-    def get_bound(self, action: RegistryAction) -> BoundRegistryAction:
+    def get_bound(
+        self,
+        action: RegistryAction,
+        mode: LoaderMode = "execution",
+    ) -> BoundRegistryAction:
         """Get the bound action for a registry action."""
-        return get_bound_action_impl(action)
+        return get_bound_action_impl(action, mode=mode)
+
+
+def error_details_to_message(err: ErrorDetails) -> str:
+    loc = err["loc"]
+    if isinstance(loc, tuple):
+        loc = ", ".join(f"'{i}'" for i in loc)
+    match err.get("type"):
+        case "missing":
+            msg = f"Missing required field(s): {loc}"
+        case "extra_forbidden":
+            msg = f"Got unexpected field(s): {loc}"
+        case _:
+            msg = f"{err['msg']}: {loc}"
+    return msg

--- a/tracecat/registry/loaders.py
+++ b/tracecat/registry/loaders.py
@@ -10,7 +10,7 @@ from tracecat_registry import RegistrySecret
 from tracecat import config
 from tracecat.db.schemas import RegistryAction
 from tracecat.expressions.expectations import create_expectation_model
-from tracecat.expressions.validation import CoreSchemaTemplateValidator
+from tracecat.expressions.validation import TemplateValidator
 from tracecat.logger import logger
 from tracecat.registry.actions.models import (
     BoundRegistryAction,
@@ -43,7 +43,7 @@ def get_bound_action_impl(
         # Add validators to the function
         validated_kwargs = RegisterKwargs.model_validate(kwargs)
         if mode == "validation":
-            attach_validators(fn, CoreSchemaTemplateValidator())
+            attach_validators(fn, TemplateValidator())
         args_docs = get_signature_docs(fn)
         # Generate the model from the function signature
         args_cls, rtype, rtype_adapter = generate_model_from_function(

--- a/tracecat/registry/loaders.py
+++ b/tracecat/registry/loaders.py
@@ -10,7 +10,7 @@ from tracecat_registry import RegistrySecret
 from tracecat import config
 from tracecat.db.schemas import RegistryAction
 from tracecat.expressions.expectations import create_expectation_model
-from tracecat.expressions.validation import TemplateValidator
+from tracecat.expressions.validation import CoreSchemaTemplateValidator
 from tracecat.logger import logger
 from tracecat.registry.actions.models import (
     BoundRegistryAction,
@@ -43,7 +43,7 @@ def get_bound_action_impl(
         # Add validators to the function
         validated_kwargs = RegisterKwargs.model_validate(kwargs)
         if mode == "validation":
-            attach_validators(fn, TemplateValidator())
+            attach_validators(fn, CoreSchemaTemplateValidator())
         args_docs = get_signature_docs(fn)
         # Generate the model from the function signature
         args_cls, rtype, rtype_adapter = generate_model_from_function(

--- a/tracecat/registry/repositories/models.py
+++ b/tracecat/registry/repositories/models.py
@@ -3,7 +3,10 @@ from datetime import datetime
 
 from pydantic import UUID4, BaseModel, Field, field_validator
 
-from tracecat.registry.actions.models import RegistryActionRead
+from tracecat.registry.actions.models import (
+    RegistryActionRead,
+    RegistryActionValidationErrorInfo,
+)
 from tracecat.registry.constants import (
     CUSTOM_REPOSITORY_ORIGIN,
     DEFAULT_LOCAL_REGISTRY_ORIGIN,
@@ -86,3 +89,12 @@ class RegistryRepositoryUpdate(BaseModel):
         min_length=1,
         max_length=255,
     )
+
+
+class RegistryRepositoryErrorDetail(BaseModel):
+    """Error response model for registry sync failures."""
+
+    id: str
+    origin: str
+    message: str
+    errors: dict[str, list[RegistryActionValidationErrorInfo]]

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -30,7 +30,7 @@ from tracecat import config
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.expressions.expectations import create_expectation_model
-from tracecat.expressions.validation import CoreSchemaTemplateValidator
+from tracecat.expressions.validation import TemplateValidator
 from tracecat.git import GitUrl, get_git_repository_sha, parse_git_url
 from tracecat.logger import logger
 from tracecat.parse import safe_url
@@ -458,7 +458,7 @@ class Repository:
         logger.debug("Registering UDF", key=key, name=name)
         # Add validators to the function
         validated_kwargs = RegisterKwargs.model_validate(kwargs)
-        attach_validators(fn, CoreSchemaTemplateValidator())
+        attach_validators(fn, TemplateValidator())
         args_docs = get_signature_docs(fn)
         # Generate the model from the function signature
         args_cls, rtype, rtype_adapter = generate_model_from_function(

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -30,7 +30,7 @@ from tracecat import config
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.expressions.expectations import create_expectation_model
-from tracecat.expressions.validation import TemplateValidator
+from tracecat.expressions.validation import CoreSchemaTemplateValidator
 from tracecat.git import GitUrl, get_git_repository_sha, parse_git_url
 from tracecat.logger import logger
 from tracecat.parse import safe_url
@@ -458,7 +458,7 @@ class Repository:
         logger.debug("Registering UDF", key=key, name=name)
         # Add validators to the function
         validated_kwargs = RegisterKwargs.model_validate(kwargs)
-        attach_validators(fn, TemplateValidator())
+        attach_validators(fn, CoreSchemaTemplateValidator())
         args_docs = get_signature_docs(fn)
         # Generate the model from the function signature
         args_cls, rtype, rtype_adapter = generate_model_from_function(

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -101,7 +101,7 @@ async def check_action_secrets(
     """Check all secrets for a single action."""
     results: list[SecretValidationResult] = []
     secrets = [RegistrySecret(**secret) for secret in action.secrets or []]
-    implicit_secrets = await registry_service.get_action_implicit_secrets(action)
+    implicit_secrets = await registry_service.fetch_all_action_secrets(action)
     secrets.extend(implicit_secrets)
 
     for registry_secret in secrets:


### PR DESCRIPTION
- Adds structural and argument validation for action templates. We're missing validation for expressions.
- Updated how expression template validation works. Previously we had oversimplified - we assumed that if the type under validation is a template string just ignore validation, otherwise validate the type. However this only acts on the root type and not inner nested types. 
- We need to think of the type as a tree -- where at any node in the tree we can have "${{ ... }}", which stops validation for the rest of the current subtree. For this, we replaced the original `TemplateValidator` with `CoreSchemaTemplateValidator`

# Screens

![image](https://github.com/user-attachments/assets/2302cbce-8f0c-4d66-90c7-e73f1fecb7e4)

<img width="1728" alt="Screenshot 2025-02-12 at 16 43 44" src="https://github.com/user-attachments/assets/64f7782b-3497-4239-9e52-b09214400477" />

<img width="1728" alt="Screenshot 2025-02-12 at 16 43 51" src="https://github.com/user-attachments/assets/5b67f804-88b5-42d7-872f-f10d06d63f3d" />

