### PR TITLE
feat(ui): Make no node display less intimidating

### DIFF
--- a/frontend/src/components/workbench/panel/workbench-panel.tsx
+++ b/frontend/src/components/workbench/panel/workbench-panel.tsx
@@ -44,7 +44,7 @@ export const WorkbenchPanel = React.forwardRef<ActionPanelRef>((_, ref) => {
               {selectedNodeId}
             </code>
             <p className="text-sm leading-relaxed text-muted-foreground">
-              This can happen if you&apos;ve deleted the node or renamed it
+              This can happen if you&apos;ve deleted the action or renamed it
               without saving the workflow.
             </p>
           </div>

--- a/frontend/src/components/workbench/panel/workbench-panel.tsx
+++ b/frontend/src/components/workbench/panel/workbench-panel.tsx
@@ -38,7 +38,7 @@ export const WorkbenchPanel = React.forwardRef<ActionPanelRef>((_, ref) => {
           </div>
           <div className="flex flex-col space-y-3">
             <h4 className="text-base font-semibold tracking-tight">
-              Node not found
+              Action not found
             </h4>
             <code className="rounded bg-muted px-0 py-1 font-mono text-sm tracking-tighter text-muted-foreground">
               {selectedNodeId}

--- a/frontend/src/components/workbench/panel/workbench-panel.tsx
+++ b/frontend/src/components/workbench/panel/workbench-panel.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { WorkflowRead } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
+import { AlertCircle, Search } from "lucide-react"
 
 import { FormLoading } from "@/components/loading/form"
 import { AlertNotification } from "@/components/notifications"
@@ -30,11 +31,24 @@ export const WorkbenchPanel = React.forwardRef<ActionPanelRef>((_, ref) => {
   }
   if (selectedNodeId && !selectedNode) {
     return (
-      <div className="flex size-full items-center justify-center">
-        <AlertNotification
-          level="error"
-          message={`Node ${selectedNodeId} not found`}
-        />
+      <div className="flex size-full flex-col items-center justify-center">
+        <div className="flex max-w-[50%] flex-col items-center gap-6 p-8 text-center">
+          <div className="rounded-full bg-muted/80 p-4">
+            <Search className="size-8 text-muted-foreground/80" />
+          </div>
+          <div className="flex flex-col space-y-3">
+            <h4 className="text-base font-semibold tracking-tight">
+              Node not found
+            </h4>
+            <code className="rounded bg-muted px-0 py-1 font-mono text-sm tracking-tighter text-muted-foreground">
+              {selectedNodeId}
+            </code>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              This can happen if you've deleted the node or renamed it without
+              saving.
+            </p>
+          </div>
+        </div>
       </div>
     )
   }

--- a/frontend/src/components/workbench/panel/workbench-panel.tsx
+++ b/frontend/src/components/workbench/panel/workbench-panel.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { WorkflowRead } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
-import { AlertCircle, Search } from "lucide-react"
+import { Search } from "lucide-react"
 
 import { FormLoading } from "@/components/loading/form"
 import { AlertNotification } from "@/components/notifications"
@@ -44,8 +44,8 @@ export const WorkbenchPanel = React.forwardRef<ActionPanelRef>((_, ref) => {
               {selectedNodeId}
             </code>
             <p className="text-sm leading-relaxed text-muted-foreground">
-              This can happen if you've deleted the node or renamed it without
-              saving the workflow.
+              This can happen if you&apos;ve deleted the node or renamed it
+              without saving the workflow.
             </p>
           </div>
         </div>

--- a/frontend/src/components/workbench/panel/workbench-panel.tsx
+++ b/frontend/src/components/workbench/panel/workbench-panel.tsx
@@ -45,7 +45,7 @@ export const WorkbenchPanel = React.forwardRef<ActionPanelRef>((_, ref) => {
             </code>
             <p className="text-sm leading-relaxed text-muted-foreground">
               This can happen if you've deleted the node or renamed it without
-              saving.
+              saving the workflow.
             </p>
           </div>
         </div>

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -88,8 +88,8 @@ from tracecat.expressions.functions import (
     to_timestamp,
     unset_timezone,
     uppercase,
-    url_encode,
     url_decode,
+    url_encode,
     weeks_between,
     zip_iterables,
 )


### PR DESCRIPTION
# Screens
Before
<img width="1728" alt="Screenshot 2025-02-15 at 03 27 21" src="https://github.com/user-attachments/assets/4c95fcec-b677-49d1-86c3-75ac8990e793" />


Afterß
<img width="1728" alt="Screenshot 2025-02-15 at 03 28 44" src="https://github.com/user-attachments/assets/851281f1-58fb-4534-839d-a123be1fa8c7" />
