### PR TITLE
feat(registry): Add CLI for template validation

### DIFF
--- a/registry/pyproject.toml
+++ b/registry/pyproject.toml
@@ -43,10 +43,16 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+cli = ["typer>=0.15.1", "rich>=13.7.0"]
+
 [project.urls]
 Homepage = "https://tracecat.com"
 Documentation = "https://docs.tracecat.com"
 Repository = "https://github.com/TracecatHQ/tracecat"
+
+[project.scripts]
+tc = "tracecat_registry.__main__:main"
 
 [tool.hatch.version]
 path = "tracecat_registry/__init__.py"

--- a/registry/tracecat_registry/__main__.py
+++ b/registry/tracecat_registry/__main__.py
@@ -1,0 +1,9 @@
+from .cli import entrypoint
+
+
+def main():
+    return entrypoint.app()
+
+
+if __name__ == "__main__":
+    main()

--- a/registry/tracecat_registry/cli/entrypoint.py
+++ b/registry/tracecat_registry/cli/entrypoint.py
@@ -1,0 +1,34 @@
+import typer
+from tracecat.logger import logger
+
+from . import validate
+
+logger.remove()
+
+# Set logger log level
+
+
+app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
+
+
+def version_callback(value: bool):
+    if value:
+        from tracecat_registry import __version__
+
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
+@app.callback()
+def tc(
+    ctx: typer.Context,
+    version: bool = typer.Option(None, "--version", callback=version_callback),
+):
+    pass
+
+
+app.add_typer(validate.app, name="validate")
+
+
+if __name__ == "__main__":
+    typer.run(app)

--- a/registry/tracecat_registry/cli/entrypoint.py
+++ b/registry/tracecat_registry/cli/entrypoint.py
@@ -1,11 +1,15 @@
+import warnings
+
 import typer
 from tracecat.logger import logger
 
 from . import validate
 
+# Silence loggers
 logger.remove()
 
-# Set logger log level
+# Filter out Pydantic serializer warnings
+warnings.filterwarnings("ignore", message="Pydantic serializer warning*")
 
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)

--- a/registry/tracecat_registry/cli/validate.py
+++ b/registry/tracecat_registry/cli/validate.py
@@ -1,0 +1,75 @@
+import asyncio
+from collections import defaultdict
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from tracecat.registry.actions.models import RegistryActionValidationErrorInfo
+from tracecat.registry.actions.service import validate_action_template
+from tracecat.registry.repository import Repository
+
+app = typer.Typer(name="tc", help="Validate action templates", no_args_is_help=True)
+console = Console()
+
+
+async def validate_action_templates(path: Path, check_db: bool = False) -> None:
+    # We need bound registry action
+    origin = f"file://{path.as_posix()}"
+    repo = Repository(origin=origin)
+    if path.is_dir():
+        n_loaded = repo.load_template_actions_from_path(path=path, origin=origin)
+    else:
+        repo.load_template_action_from_file(path, origin)
+        n_loaded = 1
+    console.print(f"Loaded {n_loaded} template actions from {path}", style="bold green")
+    # Show the loaded actions
+    for action in repo.store.keys():
+        console.print(f"  {action}", style="bold yellow")
+    console.print(f"Checking db: {check_db}", style="bold yellow")
+    val_errs: dict[str, list[RegistryActionValidationErrorInfo]] = defaultdict(list)
+    for action in repo.store.values():
+        if not action.is_template:
+            continue
+        if errs := await validate_action_template(action, repo):
+            val_errs[action.action].extend(errs)
+    if val_errs:
+        # Show this in a table
+        table = Table(title="Validation Errors")
+        table.add_column("Action")
+        table.add_column("Details")
+        table.add_column("Location [dim](Details)[/dim]")
+        for action, errs in val_errs.items():
+            for err in errs:
+                table.add_row(
+                    action,
+                    "\n".join(err.details),
+                    f"{err.loc_primary} [dim]({err.loc_secondary})[/dim]"
+                    if err.loc_secondary
+                    else err.loc_primary,
+                )
+        console.print(table)
+    else:
+        console.print("No validation errors found", style="bold green")
+
+
+@app.command(name="template", help="Validate action template(s)")
+def template(
+    path: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to template YAML file or directory containing templates",
+            exists=True,
+        ),
+    ],
+    check_db: Annotated[
+        bool,
+        typer.Option(
+            "--db",
+            help="Check against the database to ensure the action is registered",
+        ),
+    ] = False,
+) -> None:
+    """Validate action template YAML files."""
+    asyncio.run(validate_action_templates(path, check_db=check_db))

--- a/registry/tracecat_registry/cli/validate.py
+++ b/registry/tracecat_registry/cli/validate.py
@@ -1,21 +1,29 @@
 import asyncio
+import os
 from collections import defaultdict
 from pathlib import Path
-from typing import Annotated
 
 import typer
 from rich.console import Console
 from rich.table import Table
+from tracecat import config
 from tracecat.registry.actions.models import RegistryActionValidationErrorInfo
-from tracecat.registry.actions.service import validate_action_template
+from tracecat.registry.actions.service import (
+    RegistryActionsService,
+    validate_action_template,
+)
 from tracecat.registry.repository import Repository
 
 app = typer.Typer(name="tc", help="Validate action templates", no_args_is_help=True)
 console = Console()
 
 
-async def validate_action_templates(path: Path, check_db: bool = False) -> None:
-    # We need bound registry action
+async def validate_action_templates(
+    path: Path,
+    *,
+    check_db: bool = False,
+    ra_service: RegistryActionsService | None = None,
+) -> None:
     origin = f"file://{path.as_posix()}"
     repo = Repository(origin=origin)
     if path.is_dir():
@@ -23,17 +31,25 @@ async def validate_action_templates(path: Path, check_db: bool = False) -> None:
     else:
         repo.load_template_action_from_file(path, origin)
         n_loaded = 1
-    console.print(f"Loaded {n_loaded} template actions from {path}", style="bold green")
-    # Show the loaded actions
-    for action in repo.store.keys():
-        console.print(f"  {action}", style="bold yellow")
-    console.print(f"Checking db: {check_db}", style="bold yellow")
+    console.print(f"Loaded {n_loaded} template actions from {path}", style="bold blue")
     val_errs: dict[str, list[RegistryActionValidationErrorInfo]] = defaultdict(list)
-    for action in repo.store.values():
+
+    for action in sorted(repo.store.values(), key=lambda a: a.action):
         if not action.is_template:
             continue
-        if errs := await validate_action_template(action, repo):
+        if errs := await validate_action_template(
+            action,
+            repo,
+            check_db=check_db,
+            ra_service=ra_service,
+        ):
             val_errs[action.action].extend(errs)
+            console.print(
+                f"✗ {action.action} ({len(errs)} errors)",
+                style="bold red",
+            )
+        else:
+            console.print(f"✓ {action.action}", style="bold green")
     if val_errs:
         # Show this in a table
         table = Table(title="Validation Errors")
@@ -56,20 +72,55 @@ async def validate_action_templates(path: Path, check_db: bool = False) -> None:
 
 @app.command(name="template", help="Validate action template(s)")
 def template(
-    path: Annotated[
-        Path,
-        typer.Argument(
-            help="Path to template YAML file or directory containing templates",
-            exists=True,
+    path: Path = typer.Argument(
+        help="Path to template YAML file or directory containing templates",
+        exists=True,
+    ),
+    check_db: bool = typer.Option(
+        False,
+        "--db",
+        help="Check against the database to ensure the action is registered",
+    ),
+    db_uri: str = typer.Option(
+        lambda: os.getenv(
+            "TRACECAT__DB_URI",
+            # Points to a locally running Tracecat DB
+            "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         ),
-    ],
-    check_db: Annotated[
-        bool,
-        typer.Option(
-            "--db",
-            help="Check against the database to ensure the action is registered",
-        ),
-    ] = False,
+        help="The database URI to use for validation. Defaults to TRACECAT__DB_URI if set, otherwise points to a locally running Tracecat DB.",
+    ),
 ) -> None:
     """Validate action template YAML files."""
-    asyncio.run(validate_action_templates(path, check_db=check_db))
+
+    # Needed to override the default database URI used in Docker networking
+    config.TRACECAT__DB_URI = db_uri
+
+    async def main():
+        if check_db:
+            from tracecat.api.common import bootstrap_role
+
+            console.print(
+                f"Checking against database at '{db_uri}'.",
+                style="bold blue",
+            )
+            async with RegistryActionsService.with_session(
+                role=bootstrap_role()
+            ) as service:
+                await validate_action_templates(path, check_db=True, ra_service=service)
+        else:
+            console.print(
+                "Skipping database check.",
+                style="bold blue",
+            )
+            await validate_action_templates(path, check_db=False)
+
+    try:
+        asyncio.run(main())
+    except Exception as e:
+        # Suppress stack trace and exit with error code 1
+        if "nodename nor servname provided, or not known" in str(e):
+            console.print(
+                "The database URI is invalid. Please check your TRACECAT__DB_URI environment variable.",
+                style="bold red",
+            )
+        raise typer.Exit(code=1) from e

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -223,7 +223,10 @@ class Repository:
         self._register_udfs_from_package(tracecat_registry)
 
     async def load_from_origin(self, commit_sha: str | None = None) -> str | None:
-        """Load the registry from the origin and return the commit sha."""
+        """Load the registry from the origin and return the commit sha.
+
+        If we pass a local directory, load the files directly.
+        """
         if self._origin == DEFAULT_REGISTRY_ORIGIN:
             # This is a builtin registry, nothing to load
             logger.info("Loading builtin registry")
@@ -565,6 +568,41 @@ class Repository:
                 "No template actions found in package", package_name=base_package
             )
 
+    def load_template_action_from_file(
+        self, file_path: Path, origin: str
+    ) -> TemplateAction | None:
+        """Load a template action from a YAML file.
+
+        Args:
+            file_path: Path to the YAML file
+
+        Returns:
+            The loaded template action, or None if loading failed
+        """
+        logger.debug("Loading template action from path", path=file_path)
+        try:
+            template_action = TemplateAction.from_yaml(file_path)
+        except ValidationError as e:
+            logger.error(
+                f"Could not parse {file_path!s} as template action, skipped",
+                error=e,
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                "Unexpected error loading template action",
+                error=e,
+                path=file_path,
+            )
+            return None
+        key = template_action.definition.action
+        if key in self._store:
+            logger.debug("Template action already registered, skipping", key=key)
+            return None
+
+        self.register_template_action(template_action, origin=origin)
+        return template_action
+
     def load_template_actions_from_path(
         self, *, path: Path, origin: str, ignore_path: str = "schemas"
     ) -> int:
@@ -574,30 +612,11 @@ class Repository:
         for file_path in all_paths:
             if ignore_path in file_path.parts:
                 continue
-            logger.debug("Loading template action from path", path=file_path)
-            # Load TemplateActionDefinition
-            try:
-                template_action = TemplateAction.from_yaml(file_path)
-            except ValidationError as e:
-                logger.error(
-                    f"Could not parse {file_path!s} as template action, skipped",
-                    error=e,
-                )
-                continue
-            except Exception as e:
-                logger.error(
-                    "Unexpected error loading template action",
-                    error=e,
-                    path=file_path,
-                )
+
+            template_action = self.load_template_action_from_file(file_path, origin)
+            if template_action is None:
                 continue
 
-            key = template_action.definition.action
-            if key in self._store:
-                logger.debug("Template action already registered, skipping", key=key)
-                continue
-
-            self.register_template_action(template_action, origin=origin)
             n_loaded += 1
         return n_loaded
 

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -569,7 +569,7 @@ class Repository:
             )
 
     def load_template_action_from_file(
-        self, file_path: Path, origin: str
+        self, file_path: Path, origin: str, *, overwrite: bool = True
     ) -> TemplateAction | None:
         """Load a template action from a YAML file.
 
@@ -596,15 +596,22 @@ class Repository:
             )
             return None
         key = template_action.definition.action
-        if key in self._store:
+        if key in self._store and not overwrite:
             logger.debug("Template action already registered, skipping", key=key)
             return None
+        else:
+            logger.debug("Overwriting template action", key=key)
 
         self.register_template_action(template_action, origin=origin)
         return template_action
 
     def load_template_actions_from_path(
-        self, *, path: Path, origin: str, ignore_path: str = "schemas"
+        self,
+        *,
+        path: Path,
+        origin: str,
+        ignore_path: str = "schemas",
+        overwrite: bool = True,
     ) -> int:
         """Load template actions from a package."""
         n_loaded = 0
@@ -613,7 +620,9 @@ class Repository:
             if ignore_path in file_path.parts:
                 continue
 
-            template_action = self.load_template_action_from_file(file_path, origin)
+            template_action = self.load_template_action_from_file(
+                file_path, origin, overwrite=overwrite
+            )
             if template_action is None:
                 continue
 


### PR DESCRIPTION
# Description
- `--mode`: Validation mode
  - `default`: Validate actions against actions in `tracecat_registry`. Doesn't need a live Tracecat stack. This is the default.
  - `isolated`: Validate templates only. Doesn't need a live Tracecat stack.
  - `db`: Validate templates and actions against a live Tracecat stack. 
- Pass `--db-uri` to specify the DB. Only relevant if `mode=db`. Otherwise, the CLI tries to read from `TRACECAT__DB_URI`, and falls back to `postgresql+psycopg://postgres:postgres@localhost:5432/postgres`
# Screens
![image](https://github.com/user-attachments/assets/5fc20f12-b0aa-4dca-9d15-4a380fd1191f)

