### PR TITLE
fix(integrations): Steps and API naming in anomali lookups

### DIFF
--- a/registry/tracecat_registry/templates/detect/lookup_domain/threatstream.yml
+++ b/registry/tracecat_registry/templates/detect/lookup_domain/threatstream.yml
@@ -8,8 +8,8 @@ definition:
   secrets:
     - name: threatstream
       keys:
-        - USERNAME
-        - API_KEY
+        - ANOMALI_USERNAME
+        - ANOMALI_API_KEY
   expects:
     domain:
       type: str
@@ -22,10 +22,10 @@ definition:
         method: GET
         headers:
           Accept: application/json
-          Authorization: apikey ${{ SECRETS.threatstream.USERNAME}}:${{ SECRETS.threatstream.API_KEY }}
+          Authorization: apikey ${{ SECRETS.threatstream.ANOMALI_USERNAME}}:${{ SECRETS.threatstream.ANOMALI_API_KEY }}
         params:
           value: ${{ inputs.domain }}
           type: domain
           status: active
           limit: 0
-  returns: ${{ steps.make_request.result.data }}
+  returns: ${{ steps.get_reputation.result.data }}

--- a/registry/tracecat_registry/templates/detect/lookup_email/threatstream.yml
+++ b/registry/tracecat_registry/templates/detect/lookup_email/threatstream.yml
@@ -3,13 +3,13 @@ definition:
   name: lookup_email
   namespace: tools.threatstream
   title: Lookup Email
-  description: Search Anomali ThreatStream for reputation of an email address
+  description: Search Anomali ThreatStream for reputation of an email address.
   display_group: Anomali ThreatStream
   secrets:
     - name: threatstream
       keys:
-        - USERNAME
-        - API_KEY
+        - ANOMALI_USERNAME
+        - ANOMALI_API_KEY
   expects:
     email:
       type: str
@@ -22,10 +22,10 @@ definition:
         method: GET
         headers:
           Accept: application/json
-          Authorization: apikey ${{ SECRETS.threatstream.USERNAME}}:${{ SECRETS.threatstream.API_KEY }}
+          Authorization: apikey ${{ SECRETS.threatstream.ANOMALI_USERNAME}}:${{ SECRETS.threatstream.ANOMALI_API_KEY }}
         params:
           value: ${{ inputs.email }}
           type: email
           status: active
           limit: 0
-  returns: ${{ steps.make_request.result.data }}
+  returns: ${{ steps.get_reputation.result.data }}

--- a/registry/tracecat_registry/templates/detect/lookup_file_hash/threatstream.yml
+++ b/registry/tracecat_registry/templates/detect/lookup_file_hash/threatstream.yml
@@ -3,13 +3,13 @@ definition:
   name: lookup_file_hash
   namespace: tools.threatstream
   title: Lookup File Hash
-  description: Search Anomali ThreatStream for reputation of a file hash
+  description: Search Anomali ThreatStream for reputation of a file hash.
   display_group: Anomali ThreatStream
   secrets:
     - name: threatstream
       keys:
-        - USERNAME
-        - API_KEY
+        - ANOMALI_USERNAME
+        - ANOMALI_API_KEY
   expects:
     file_hash:
       type: str
@@ -22,10 +22,10 @@ definition:
         method: GET
         headers:
           Accept: application/json
-          Authorization: apikey ${{ SECRETS.threatstream.USERNAME}}:${{ SECRETS.threatstream.API_KEY }}
+          Authorization: apikey ${{ SECRETS.threatstream.ANOMALI_USERNAME}}:${{ SECRETS.threatstream.ANOMALI_API_KEY }}
         params:
           value: ${{ inputs.file_hash }}
           type: md5
           status: active
           limit: 0
-  returns: ${{ steps.make_request.result.data }}
+  returns: ${{ steps.get_reputation.result.data }}

--- a/registry/tracecat_registry/templates/detect/lookup_ip_address/threatstream.yml
+++ b/registry/tracecat_registry/templates/detect/lookup_ip_address/threatstream.yml
@@ -3,13 +3,13 @@ definition:
   name: lookup_ip_address
   namespace: tools.threatstream
   title: Lookup IP address
-  description: Search Anomali ThreatStream for reputation of an IP address
+  description: Search Anomali ThreatStream for reputation of an IP address.
   display_group: Anomali ThreatStream
   secrets:
     - name: threatstream
       keys:
-        - USERNAME
-        - API_KEY
+        - ANOMALI_USERNAME
+        - ANOMALI_API_KEY
   expects:
     ip_address:
       type: str
@@ -22,10 +22,10 @@ definition:
         method: GET
         headers:
           Accept: application/json
-          Authorization: apikey ${{ SECRETS.threatstream.USERNAME}}:${{ SECRETS.threatstream.API_KEY }}
+          Authorization: apikey ${{ SECRETS.threatstream.ANOMALI_USERNAME}}:${{ SECRETS.threatstream.ANOMALI_API_KEY }}
         params:
           value: ${{ inputs.ip_address }}
           type: ip
           status: active
           limit: 0
-  returns: ${{ steps.make_request.result.data }}
+  returns: ${{ steps.get_reputation.result.data }}

--- a/registry/tracecat_registry/templates/detect/lookup_url/threatstream.yml
+++ b/registry/tracecat_registry/templates/detect/lookup_url/threatstream.yml
@@ -3,13 +3,13 @@ definition:
   name: lookup_url
   namespace: tools.threatstream
   title: Lookup URL
-  description: Search Anomali ThreatStream for reputation of an URL
+  description: Search Anomali ThreatStream for reputation of an URL.
   display_group: Anomali ThreatStream
   secrets:
     - name: threatstream
       keys:
-        - USERNAME
-        - API_KEY
+        - ANOMALI_USERNAME
+        - ANOMALI_API_KEY
   expects:
     url:
       type: str
@@ -22,10 +22,10 @@ definition:
         method: GET
         headers:
           Accept: application/json
-          Authorization: apikey ${{ SECRETS.threatstream.USERNAME}}:${{ SECRETS.threatstream.API_KEY }}
+          Authorization: apikey ${{ SECRETS.threatstream.ANOMALI_USERNAME}}:${{ SECRETS.threatstream.ANOMALI_API_KEY }}
         params:
           value: ${{ inputs.url }}
           type: url
           status: active
           limit: 0
-  returns: ${{ steps.make_request.result.data }}
+  returns: ${{ steps.get_reputation.result.data }}


### PR DESCRIPTION
Merged #847 too eagerly.

## What changed
- Added `ANOMALI` prefix to secret keys
- Fixed steps ref `make_request` (old) -> `get_reputation` (new) which was not updated after naming change

## Future considerations
- We've merged a CLI for action template validation here: https://github.com/TracecatHQ/tracecat/pull/856
- Will create `CONTRIBUTIONS.md` by today 16th Feb to describe steps to validating templates locally
- Add validation with CLI to CICD in `test_registry` so action template tests fail quicker