### PR TITLE
feat(ui): Merge child workflow compact runs

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4336,6 +4336,11 @@ export const $WorkflowExecutionEventCompact = {
       ],
       title: "Child Wf Exec Id",
     },
+    child_wf_count: {
+      type: "integer",
+      title: "Child Wf Count",
+      default: 0,
+    },
   },
   type: "object",
   required: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1347,6 +1347,7 @@ export type WorkflowExecutionEventCompact = {
   action_result?: unknown | null
   action_error?: EventFailure | null
   child_wf_exec_id?: string | null
+  child_wf_count?: number
 }
 
 export type WorkflowExecutionEventStatus =

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -280,12 +280,20 @@ class ChildWorkflowMemo(BaseModel):
     action_ref: str = Field(
         ..., description="The action ref that initiated the child workflow."
     )
+    loop_index: int | None = Field(
+        default=None,
+        description="The loop index of the child workflow, if any.",
+    )
 
     @staticmethod
     def from_temporal(memo: temporalio.api.common.v1.Memo) -> ChildWorkflowMemo:
         try:
             action_ref = orjson.loads(memo.fields["action_ref"].data)
-            return ChildWorkflowMemo(action_ref=action_ref)
+            if loop_index_data := memo.fields["loop_index"].data:
+                loop_index = orjson.loads(loop_index_data)
+            else:
+                loop_index = None
+            return ChildWorkflowMemo(action_ref=action_ref, loop_index=loop_index)
         except Exception as e:
             logger.opt(exception=e).error("Error parsing child workflow memo")
             raise e

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -286,6 +286,7 @@ class WorkflowExecutionEventCompact(BaseModel):
     action_error: EventFailure | None = None
     child_wf_exec_id: WorkflowExecutionID | None = None
     child_wf_count: int = 0
+    loop_index: int | None = None
 
     @staticmethod
     def from_source_event(
@@ -366,6 +367,7 @@ class WorkflowExecutionEventCompact(BaseModel):
             action_ref=memo.action_ref,
             action_input=dsl_run_args.trigger_inputs,
             child_wf_exec_id=wf_exec_id,
+            loop_index=memo.loop_index,
         )
 
 

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -285,6 +285,7 @@ class WorkflowExecutionEventCompact(BaseModel):
     action_result: Any | None = None
     action_error: EventFailure | None = None
     child_wf_exec_id: WorkflowExecutionID | None = None
+    child_wf_count: int = 0
 
     @staticmethod
     def from_source_event(


### PR DESCRIPTION
# Description
- Group up looped child workflow runs
- Add `child_wf_count` to track number of instances
- Add `loop_index`. Track this in `ChildWorkflowMemo` (need to distinguish between single loop iteration vs direct invocation)

# Screens
## Before
<img width="1728" alt="Screenshot 2025-02-17 at 14 18 22" src="https://github.com/user-attachments/assets/609f354f-ee8c-4307-b4f6-68b8dc04ef32" />

<img width="1728" alt="Screenshot 2025-02-17 at 14 18 30" src="https://github.com/user-attachments/assets/aba6a664-819f-429f-a222-3f0338204d48" />

## After
<img width="1728" alt="Screenshot 2025-02-17 at 14 18 12" src="https://github.com/user-attachments/assets/22da8f5e-6b9d-456c-8dd8-022dd8ff7689" />

<img width="1588" alt="Screenshot 2025-02-17 at 3 53 11 PM" src="https://github.com/user-attachments/assets/1ef608dd-644a-4a07-a18a-93747fdb89f8" />

