### PR TITLE
fix(app): Try fix first builder run not showing up (again)

### DIFF
--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -566,11 +566,7 @@ export function useManualWorkflowExecution(
       onSuccess: async () => {
         // NOTE(daryl): This is a hack to ensure that the last execution is refetched
         // and the UI is updated.
-        await new Promise((resolve) => setTimeout(resolve, 50))
-        await queryClient.refetchQueries({
-          queryKey: ["last-manual-execution"],
-          type: "all",
-        })
+        await new Promise((resolve) => setTimeout(resolve, 200))
         await queryClient.refetchQueries({
           queryKey: ["last-manual-execution"],
           type: "all",

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -146,7 +146,7 @@ class WorkflowExecutionsService:
                 legacy_wf_exec_id = f"{legacy_wf_id}:{legacy_ex_id}"
                 parts.append(f"WorkflowId = '{legacy_wf_exec_id}'")
         query = " OR ".join(parts)
-        self.logger.info("Querying executions", query=query)
+        self.logger.debug("Querying executions", query=query)
         it = self._client.list_workflows(query=query)
         return await anext(it, None)
 


### PR DESCRIPTION
Not the most glamorous approach but bumped the `onSuccess` delay to 200ms (from 50ms). Seems to handle the race condition ok. We'll see. Now we also just refetch once.