### PR TITLE
feat(ui): Decouple left sidebar from action panel config

### DIFF
--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -28,6 +28,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
@@ -62,7 +64,14 @@ export default React.memo(function ActionNode({
   id,
 }: NodeProps<ActionNodeData>) {
   const [error, setError] = useState<string | null>(null)
-  const { workflowId, getNode, workspaceId, reactFlow } = useWorkflowBuilder()
+  const {
+    workflowId,
+    getNode,
+    workspaceId,
+    reactFlow,
+    sidebarRef,
+    setSelectedNodeEventId,
+  } = useWorkflowBuilder()
   const { toast } = useToast()
   // SAFETY: Node only exists if it's in the workflow
   const { action, actionIsLoading } = useAction(id, workspaceId, workflowId!)
@@ -206,6 +215,30 @@ export default React.memo(function ActionNode({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
+                  <DropdownMenuLabel className="py-0 text-xs text-muted-foreground">
+                    Quick Actions
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      sidebarRef.current?.setActiveTab("action-input")
+                      setSelectedNodeEventId(action.id)
+                    }}
+                  >
+                    <LayoutListIcon className="mr-2 size-4" />
+                    <span className="text-xs">View Last Input</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      sidebarRef.current?.setActiveTab("action-result")
+                      setSelectedNodeEventId(action.id)
+                    }}
+                  >
+                    <CircleCheckBigIcon className="mr-2 size-4" />
+                    <span className="text-xs">View Last Result</span>
+                  </DropdownMenuItem>
                   <DropdownMenuItem onClick={handleDeleteNode}>
                     <Trash2Icon className="mr-2 size-4 text-red-600" />
                     <span className="text-xs text-red-600">Delete</span>

--- a/frontend/src/components/workbench/events/events-selected-action.tsx
+++ b/frontend/src/components/workbench/events/events-selected-action.tsx
@@ -5,7 +5,6 @@ import {
   EventFailure,
   WorkflowExecutionEventCompact,
   WorkflowExecutionReadCompact,
-  WorkflowRead,
 } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
@@ -15,6 +14,7 @@ import { NodeMeta } from "react18-json-view/dist/types"
 
 import { useAction } from "@/lib/hooks"
 import { cn, slugify } from "@/lib/utils"
+import { ref2id } from "@/lib/workflow"
 import { Badge } from "@/components/ui/badge"
 import {
   Select,
@@ -37,15 +37,6 @@ import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { getWorkflowEventIcon } from "@/components/workbench/events/events-workflow"
 
-function ref2id(
-  ref: string,
-  workflow: WorkflowRead | null
-): string | undefined {
-  const action = Object.values(workflow?.actions || {}).find(
-    (act) => slugify(act.title) === ref
-  )
-  return action?.id
-}
 export function ActionEvent({
   execution,
   type,

--- a/frontend/src/components/workbench/events/events-sidebar.tsx
+++ b/frontend/src/components/workbench/events/events-sidebar.tsx
@@ -22,7 +22,10 @@ import {
   WorkflowEventsHeader,
 } from "@/components/workbench/events/events-workflow"
 
-export type EventsSidebarTabs = "workflow-events" | "action-event"
+export type EventsSidebarTabs =
+  | "workflow-events"
+  | "action-input"
+  | "action-result"
 /**
  * Interface for controlling the events sidebar through a ref
  */

--- a/frontend/src/components/workbench/events/events-workflow.tsx
+++ b/frontend/src/components/workbench/events/events-workflow.tsx
@@ -8,6 +8,7 @@ import {
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspace } from "@/providers/workspace"
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import {
   AlarmClockCheckIcon,
   AlarmClockOffIcon,
@@ -20,6 +21,7 @@ import {
   CircleX,
   Loader2,
   LoaderIcon,
+  ScanEyeIcon,
   SquareArrowOutUpRightIcon,
   WorkflowIcon,
 } from "lucide-react"
@@ -27,6 +29,14 @@ import {
 import { executionId } from "@/lib/event-history"
 import { cn, slugify, undoSlugify } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   Table,
@@ -176,34 +186,46 @@ export function WorkflowEvents({
 }: {
   events: WorkflowExecutionEventCompact[]
 }) {
-  const { selectedNodeId, setSelectedNodeId, setNodes, canvasRef } =
+  const { selectedNodeEventId, setSelectedNodeEventId, setNodes, canvasRef } =
     useWorkflowBuilder()
   const { workflow } = useWorkflow()
 
+  const centerNode = useCallback((actionRef: string) => {
+    const action = Object.values(workflow?.actions || {}).find(
+      (act) => slugify(act.title) === actionRef
+    )
+    const id = action?.id
+    if (id) {
+      setNodes((nodes) =>
+        nodes.map((node) => ({
+          ...node,
+          selected: Boolean(node.id === action.id),
+        }))
+      )
+      canvasRef.current?.centerOnNode(id)
+    }
+  }, [])
   const handleRowClick = useCallback(
     (actionRef: string) => {
-      setSelectedNodeId(actionRef)
       const action = Object.values(workflow?.actions || {}).find(
         (act) => slugify(act.title) === actionRef
       )
-      if (action) {
-        console.log("action", action, canvasRef.current)
-        const id = action.id
-        setSelectedNodeId(id)
-        setNodes((nodes) =>
-          nodes.map((node) => ({ ...node, selected: Boolean(node.id === id) }))
-        )
-        canvasRef.current?.centerOnNode(id)
+      const id = action?.id
+      if (!id) return
+      if (selectedNodeEventId === id) {
+        setSelectedNodeEventId(undefined)
+      } else {
+        setSelectedNodeEventId(id)
       }
     },
-    [setSelectedNodeId, workflow, canvasRef.current]
+    [selectedNodeEventId, setSelectedNodeEventId, workflow, canvasRef.current]
   )
 
   const selectedNodeRef = useMemo(() => {
-    return selectedNodeId
-      ? slugify(workflow?.actions[selectedNodeId]?.title || "")
+    return selectedNodeEventId
+      ? slugify(workflow?.actions[selectedNodeEventId]?.title || "")
       : null
-  }, [selectedNodeId, workflow])
+  }, [selectedNodeEventId, workflow])
 
   return (
     <ScrollArea className="p-4 pt-0">
@@ -251,6 +273,30 @@ export function WorkflowEvents({
                         ? new Date(event.start_time).toLocaleTimeString()
                         : "-"}
                     </Badge>
+                  </TableCell>
+                  <TableCell className="max-w-10 text-xs">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button className="size-6 p-0" variant="ghost">
+                          <DotsHorizontalIcon className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuLabel className="py-0 text-xs text-muted-foreground">
+                          Actions
+                        </DropdownMenuLabel>
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            centerNode(event.action_ref)
+                          }}
+                          className="flex items-center gap-2 text-xs"
+                        >
+                          <ScanEyeIcon className="size-4" />
+                          <span>Focus node</span>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </TableCell>
                 </TableRow>
               ))

--- a/frontend/src/components/workbench/events/events-workflow.tsx
+++ b/frontend/src/components/workbench/events/events-workflow.tsx
@@ -28,6 +28,7 @@ import {
 
 import { executionId } from "@/lib/event-history"
 import { cn, slugify, undoSlugify } from "@/lib/utils"
+import { ref2id } from "@/lib/workflow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -207,10 +208,7 @@ export function WorkflowEvents({
   }, [])
   const handleRowClick = useCallback(
     (actionRef: string) => {
-      const action = Object.values(workflow?.actions || {}).find(
-        (act) => slugify(act.title) === actionRef
-      )
-      const id = action?.id
+      const id = ref2id(actionRef, workflow)
       if (!id) return
       if (selectedNodeEventId === id) {
         setSelectedNodeEventId(undefined)

--- a/frontend/src/components/workbench/events/events-workflow.tsx
+++ b/frontend/src/components/workbench/events/events-workflow.tsx
@@ -36,6 +36,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -283,6 +284,7 @@ export function WorkflowEvents({
                         <DropdownMenuLabel className="py-0 text-xs text-muted-foreground">
                           Actions
                         </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
                         <DropdownMenuItem
                           onClick={(e) => {
                             e.stopPropagation()

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -1,5 +1,7 @@
+import { WorkflowRead } from "@/client"
 import { ReactFlowInstance } from "reactflow"
 
+import { slugify } from "@/lib/utils"
 import { isEphemeral } from "@/components/workbench/canvas/canvas"
 
 export const CHILD_WORKFLOW_ACTION_TYPE = "core.workflow.execute" as const
@@ -29,4 +31,13 @@ export function pruneGraphObject(reactFlowInstance: ReactFlowInstance) {
     throw new Error("Workflow cannot be saved without a trigger node")
   }
   return object
+}
+export function ref2id(
+  ref: string,
+  workflow: WorkflowRead | null
+): string | undefined {
+  const action = Object.values(workflow?.actions || {}).find(
+    (act) => slugify(act.title) === ref
+  )
+  return action?.id
 }

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -44,6 +44,8 @@ interface ReactFlowContextType {
   toggleSidebar: () => void
   toggleActionPanel: () => void
   expandSidebarAndFocusEvents: () => void
+  selectedNodeEventId?: string
+  setSelectedNodeEventId: React.Dispatch<SetStateAction<string | undefined>>
 }
 
 const ReactFlowInteractionsContext = createContext<
@@ -61,6 +63,9 @@ export const WorkflowBuilderProvider: React.FC<
   const { workspaceId, workflowId, error, updateWorkflow } = useWorkflow()
 
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
+  const [selectedNodeEventId, setSelectedNodeEventId] = useState<
+    string | undefined
+  >(undefined)
   const [isSidebarCollapsed, setIsSidebarCollapsed] = React.useState(false)
   const [isActionPanelCollapsed, setIsActionPanelCollapsed] =
     React.useState(false)
@@ -140,10 +145,12 @@ export const WorkflowBuilderProvider: React.FC<
       workflowId,
       workspaceId,
       selectedNodeId,
+      selectedNodeEventId,
       getNode: reactFlowInstance.getNode,
       setNodes: setReactFlowNodes,
       setEdges: setReactFlowEdges,
-      setSelectedNodeId: setSelectedNodeId,
+      setSelectedNodeId,
+      setSelectedNodeEventId,
       reactFlow: reactFlowInstance,
       canvasRef,
       sidebarRef,
@@ -162,6 +169,8 @@ export const WorkflowBuilderProvider: React.FC<
       setReactFlowNodes,
       setReactFlowEdges,
       setSelectedNodeId,
+      selectedNodeEventId,
+      setSelectedNodeEventId,
       canvasRef,
       sidebarRef,
       isSidebarCollapsed,


### PR DESCRIPTION
- Clicking on row in sidebar events no longer focuses node, only selects it
- Add ellipsis dropdown menu for left sidebar events with focus on node option
- Add selectors to inputs/results tabs for easy cycling between events
- Upgraded action node dropdown actions with `View Last Input` and `View Last Result`

# Screens
## Decoupled
https://github.com/user-attachments/assets/c3b2aa1f-3c9a-43dd-b267-24230ec07d32

## Updated node quick actions
https://github.com/user-attachments/assets/fb35da3e-5814-4a2f-94e6-67332cad0230





