### PR TITLE
refactor+fix(app): Add `RegistryActionReadMinimal` and fix duplicate registry secrets

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1800,6 +1800,71 @@ export const $RegistryActionRead = {
   description: "API read model for a registered action.",
 } as const
 
+export const $RegistryActionReadMinimal = {
+  properties: {
+    name: {
+      type: "string",
+      title: "Name",
+      description: "The name of the action",
+    },
+    description: {
+      type: "string",
+      title: "Description",
+      description: "The description of the action",
+    },
+    namespace: {
+      type: "string",
+      title: "Namespace",
+      description: "The namespace of the action",
+    },
+    type: {
+      type: "string",
+      enum: ["udf", "template"],
+      title: "Type",
+      description: "The type of the action",
+    },
+    origin: {
+      type: "string",
+      title: "Origin",
+      description: "The origin of the action as a url",
+    },
+    default_title: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Default Title",
+      description: "The default title of the action",
+    },
+    display_group: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Display Group",
+      description: "The presentation group of the action",
+    },
+    action: {
+      type: "string",
+      title: "Action",
+      description: "The full action identifier.",
+      readOnly: true,
+    },
+  },
+  type: "object",
+  required: ["name", "description", "namespace", "type", "origin", "action"],
+  title: "RegistryActionReadMinimal",
+  description: "API minimal read model for a registered action.",
+} as const
+
 export const $RegistryActionTemplateImpl_Input = {
   properties: {
     type: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -2019,7 +2019,7 @@ export const registryRepositoriesDeleteRegistryRepository = (
 /**
  * List Registry Actions
  * List all actions in a registry.
- * @returns RegistryActionRead Successful Response
+ * @returns RegistryActionReadMinimal Successful Response
  * @throws ApiError
  */
 export const registryActionsListRegistryActions =

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -599,6 +599,44 @@ export type RegistryActionRead = {
   readonly is_template: boolean
 }
 
+/**
+ * API minimal read model for a registered action.
+ */
+export type RegistryActionReadMinimal = {
+  /**
+   * The name of the action
+   */
+  name: string
+  /**
+   * The description of the action
+   */
+  description: string
+  /**
+   * The namespace of the action
+   */
+  namespace: string
+  /**
+   * The type of the action
+   */
+  type: "udf" | "template"
+  /**
+   * The origin of the action as a url
+   */
+  origin: string
+  /**
+   * The default title of the action
+   */
+  default_title?: string | null
+  /**
+   * The presentation group of the action
+   */
+  display_group?: string | null
+  /**
+   * The full action identifier.
+   */
+  readonly action: string
+}
+
 export type RegistryActionTemplateImpl_Input = {
   type?: "template"
   /**
@@ -2115,7 +2153,7 @@ export type RegistryRepositoriesDeleteRegistryRepositoryData = {
 export type RegistryRepositoriesDeleteRegistryRepositoryResponse = void
 
 export type RegistryActionsListRegistryActionsResponse =
-  Array<RegistryActionRead>
+  Array<RegistryActionReadMinimal>
 
 export type RegistryActionsCreateRegistryActionData = {
   requestBody: RegistryActionCreate
@@ -3293,7 +3331,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<RegistryActionRead>
+        200: Array<RegistryActionReadMinimal>
       }
     }
     post: {

--- a/frontend/src/components/registry/delete-registry-action.tsx
+++ b/frontend/src/components/registry/delete-registry-action.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState } from "react"
-import { RegistryActionRead } from "@/client"
+import { RegistryActionReadMinimal } from "@/client"
 
 import { useRegistryActions } from "@/lib/hooks"
 import {
@@ -23,8 +23,8 @@ export function DeleteRegistryActionAlertDialog({
   setSelectedAction,
   children,
 }: React.PropsWithChildren<{
-  selectedAction: RegistryActionRead | null
-  setSelectedAction: (selectedAction: RegistryActionRead | null) => void
+  selectedAction: RegistryActionReadMinimal | null
+  setSelectedAction: (selectedAction: RegistryActionReadMinimal | null) => void
 }>) {
   const { deleteRegistryAction } = useRegistryActions()
   const [confirmationInput, setConfirmationInput] = useState<string>("")

--- a/frontend/src/components/registry/registry-actions-table.tsx
+++ b/frontend/src/components/registry/registry-actions-table.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
-import { RegistryActionRead } from "@/client"
+import { RegistryActionReadMinimal } from "@/client"
 import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import { Row } from "@tanstack/react-table"
@@ -32,7 +32,7 @@ export function RegistryActionsTable() {
   const { registryActions, registryActionsIsLoading, registryActionsError } =
     useRegistryActions()
   const [selectedAction, setSelectedAction] =
-    useState<RegistryActionRead | null>(null)
+    useState<RegistryActionReadMinimal | null>(null)
 
   // Create a memoized version of the toolbar props
   const toolbarProps: DataTableToolbarProps = useMemo(() => {
@@ -88,7 +88,7 @@ export function RegistryActionsTable() {
     }
   }, [registryActions])
 
-  const handleOnClickRow = (row: Row<RegistryActionRead>) => () => {
+  const handleOnClickRow = (row: Row<RegistryActionReadMinimal>) => () => {
     // Link to workflow detail page
     console.debug("Clicked row", row)
     setSelectedAction(row.original)
@@ -117,7 +117,7 @@ export function RegistryActionsTable() {
             ),
             cell: ({ row }) => (
               <div className="text-xs text-foreground/80">
-                {row.getValue<RegistryActionRead["default_title"]>(
+                {row.getValue<RegistryActionReadMinimal["default_title"]>(
                   "default_title"
                 )}
               </div>
@@ -144,7 +144,7 @@ export function RegistryActionsTable() {
             enableColumnFilter: true,
             filterFn: (row, id, value) => {
               return value.includes(
-                row.getValue<RegistryActionRead["namespace"]>(id)
+                row.getValue<RegistryActionReadMinimal["namespace"]>(id)
               )
             },
           },
@@ -160,7 +160,9 @@ export function RegistryActionsTable() {
             cell: ({ row }) => {
               return (
                 <div className="text-xs text-foreground/80">
-                  {row.getValue<RegistryActionRead["origin"]>("origin") || "-"}
+                  {row.getValue<RegistryActionReadMinimal["origin"]>(
+                    "origin"
+                  ) || "-"}
                 </div>
               )
             },
@@ -169,7 +171,7 @@ export function RegistryActionsTable() {
             enableColumnFilter: true,
             filterFn: (row, id, value) => {
               return value.includes(
-                row.getValue<RegistryActionRead["origin"]>(id)
+                row.getValue<RegistryActionReadMinimal["origin"]>(id)
               )
             },
           },
@@ -185,7 +187,7 @@ export function RegistryActionsTable() {
             cell: ({ row }) => {
               return (
                 <div className="text-xs text-foreground/80">
-                  {row.getValue<RegistryActionRead["type"]>("type")}
+                  {row.getValue<RegistryActionReadMinimal["type"]>("type")}
                 </div>
               )
             },
@@ -194,7 +196,7 @@ export function RegistryActionsTable() {
             enableColumnFilter: true,
             filterFn: (row, id, value) => {
               return value.includes(
-                row.getValue<RegistryActionRead["type"]>(id)
+                row.getValue<RegistryActionReadMinimal["type"]>(id)
               )
             },
           },
@@ -215,7 +217,7 @@ export function RegistryActionsTable() {
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    {row.original.is_template && (
+                    {row.original.type === "template" && (
                       <>
                         <DropdownMenuLabel className="p-2 text-xs font-semibold text-muted-foreground">
                           Templates

--- a/frontend/src/components/workbench/canvas/selector-node.tsx
+++ b/frontend/src/components/workbench/canvas/selector-node.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react"
-import { actionsCreateAction, RegistryActionRead } from "@/client"
+import { actionsCreateAction, RegistryActionReadMinimal } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
 import fuzzysort from "fuzzysort"
 import { CloudOffIcon, XIcon } from "lucide-react"
@@ -31,10 +31,10 @@ const SEARCH_KEYS = [
   "action",
   "default_title",
   "display_group",
-] as (keyof RegistryActionRead)[]
+] as (keyof RegistryActionReadMinimal)[]
 
-function filterActions(actions: RegistryActionRead[], search: string) {
-  const results = fuzzysort.go<RegistryActionRead>(search, actions, {
+function filterActions(actions: RegistryActionReadMinimal[], search: string) {
+  const results = fuzzysort.go<RegistryActionReadMinimal>(search, actions, {
     all: true,
     keys: SEARCH_KEYS,
   })
@@ -208,7 +208,7 @@ function ActionCommandGroup({
 }: {
   group: string
   nodeId: string
-  registryActions: RegistryActionRead[]
+  registryActions: RegistryActionReadMinimal[]
   inputValue: string
 }) {
   const { workspaceId, workflowId, reactFlow } = useWorkflowBuilder()
@@ -224,7 +224,7 @@ function ActionCommandGroup({
   }, [sortedActions, inputValue])
 
   const handleSelect = useCallback(
-    async (registryAction: RegistryActionRead) => {
+    async (registryAction: RegistryActionReadMinimal) => {
       if (!workflowId) {
         return
       }
@@ -297,7 +297,7 @@ function ActionCommandGroup({
               acc[key] = currRes.highlight() || String(action[key])
               return acc
             },
-            {} as Record<keyof RegistryActionRead, string>
+            {} as Record<keyof RegistryActionReadMinimal, string>
           )
 
           return (

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -37,7 +37,7 @@ import YAML from "yaml"
 import { z } from "zod"
 
 import { RequestValidationError, TracecatApiError } from "@/lib/errors"
-import { useAction, useWorkbenchRegistryActions } from "@/lib/hooks"
+import { useAction, useGetRegistryAction } from "@/lib/hooks"
 import { cn, slugify } from "@/lib/utils"
 import {
   Accordion,
@@ -174,11 +174,8 @@ export function ActionPanel({
     workspaceId,
     workflowId
   )
-  const { getRegistryAction, registryActionsIsLoading } =
-    useWorkbenchRegistryActions()
-  const registryAction = action?.type
-    ? getRegistryAction(action.type)
-    : undefined
+  const { registryAction, registryActionIsLoading, registryActionError } =
+    useGetRegistryAction(action?.type)
   const { for_each, run_if, retry_policy, ...options } =
     action?.control_flow ?? {}
   const methods = useForm<ActionFormSchema>({
@@ -320,10 +317,10 @@ export function ActionPanel({
     return () => document.removeEventListener("keydown", handleKeyDown)
   }, [methods, onSubmit, action])
 
-  if (actionIsLoading || registryActionsIsLoading) {
+  if (actionIsLoading || registryActionIsLoading) {
     return <CenteredSpinner />
   }
-  if (!registryAction) {
+  if (!registryAction || registryActionError) {
     return (
       <div className="flex h-full items-center justify-center space-x-2 p-4">
         <AlertNotification

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -26,6 +26,7 @@ import {
   OrgMemberRead,
   RegistryActionCreate,
   RegistryActionRead,
+  RegistryActionReadMinimal,
   registryActionsCreateRegistryAction,
   registryActionsDeleteRegistryAction,
   RegistryActionsDeleteRegistryActionData,
@@ -974,14 +975,16 @@ export function useWorkbenchRegistryActions(versions?: string[]) {
     data: registryActions,
     isLoading: registryActionsIsLoading,
     error: registryActionsError,
-  } = useQuery<RegistryActionRead[]>({
+  } = useQuery<RegistryActionReadMinimal[]>({
     queryKey: ["workbench_registry_actions", versions],
     queryFn: async () => {
       return await registryActionsListRegistryActions()
     },
   })
 
-  const getRegistryAction = (key: string): RegistryActionRead | undefined => {
+  const getRegistryAction = (
+    key: string
+  ): RegistryActionReadMinimal | undefined => {
     return registryActions?.find((action) => action.action === key)
   }
 
@@ -991,6 +994,26 @@ export function useWorkbenchRegistryActions(versions?: string[]) {
     registryActionsError,
     getRegistryAction,
   }
+}
+
+export function useGetRegistryAction(actionName?: string) {
+  const {
+    data: registryAction,
+    isLoading: registryActionIsLoading,
+    error: registryActionError,
+  } = useQuery<RegistryActionRead | undefined>({
+    queryKey: ["registry_action", actionName],
+    queryFn: async () => {
+      if (!actionName) {
+        return undefined
+      }
+      return await registryActionsGetRegistryAction({
+        actionName,
+      })
+    },
+  })
+
+  return { registryAction, registryActionIsLoading, registryActionError }
 }
 
 // This is for the action panel in the workbench
@@ -1018,18 +1041,12 @@ export function useRegistryActions(versions?: string[]) {
     data: registryActions,
     isLoading: registryActionsIsLoading,
     error: registryActionsError,
-  } = useQuery<RegistryActionRead[]>({
+  } = useQuery<RegistryActionReadMinimal[]>({
     queryKey: ["registry_actions", versions],
     queryFn: async () => {
       return await registryActionsListRegistryActions()
     },
   })
-
-  const getRegistryAction = (
-    actionName: string
-  ): RegistryActionRead | undefined => {
-    return registryActions?.find((action) => action.action === actionName)
-  }
 
   const {
     mutateAsync: createRegistryAction,
@@ -1143,7 +1160,6 @@ export function useRegistryActions(versions?: string[]) {
     registryActions,
     registryActionsIsLoading,
     registryActionsError,
-    getRegistryAction,
     createRegistryAction,
     createRegistryActionIsPending,
     createRegistryActionError,

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -352,9 +352,9 @@ class RegistryActionRead(RegistryActionBase):
         action: RegistryAction, extra_secrets: list[RegistrySecret] | None = None
     ) -> RegistryActionRead:
         impl = RegistryActionImplValidator.validate_python(action.implementation)
-        secrets = [RegistrySecret(**secret) for secret in action.secrets or []]
+        secrets = {RegistrySecret(**secret) for secret in action.secrets or []}
         if extra_secrets:
-            secrets.extend(extra_secrets)
+            secrets.update(extra_secrets)
         return RegistryActionRead(
             repository_id=action.repository_id,
             name=action.name,
@@ -370,7 +370,7 @@ class RegistryActionRead(RegistryActionBase):
             display_group=action.display_group,
             origin=action.origin,
             options=RegistryActionOptions(**action.options),
-            secrets=secrets,
+            secrets=sorted(secrets, key=lambda x: x.name),
         )
 
 

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -310,6 +310,28 @@ class RegistryActionBase(BaseModel):
     repository_id: UUID4 = Field(..., description="The repository id")
 
 
+class RegistryActionReadMinimal(BaseModel):
+    """API minimal read model for a registered action."""
+
+    name: str = Field(..., description="The name of the action")
+    description: str = Field(..., description="The description of the action")
+    namespace: str = Field(..., description="The namespace of the action")
+    type: RegistryActionType = Field(..., description="The type of the action")
+    origin: str = Field(..., description="The origin of the action as a url")
+    default_title: str | None = Field(
+        None, description="The default title of the action"
+    )
+    display_group: str | None = Field(
+        None, description="The presentation group of the action"
+    )
+
+    @computed_field(return_type=str)
+    @property
+    def action(self) -> str:
+        """The full action identifier."""
+        return f"{self.namespace}.{self.name}"
+
+
 class RegistryActionRead(RegistryActionBase):
     """API read model for a registered action."""
 


### PR DESCRIPTION
We were returning the full read model from the list endpoint. We were also weren't using the GET endpoint so now we are. Also fixed duplicate secrets returned from the get registry action endpoint.