### PR TITLE
fix(ui): Further decouple events sidebar from canvas action

### DIFF
--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -70,7 +70,7 @@ export default React.memo(function ActionNode({
     workspaceId,
     reactFlow,
     sidebarRef,
-    setSelectedNodeEventId,
+    setSelectedActionEventRef,
   } = useWorkflowBuilder()
   const { toast } = useToast()
   // SAFETY: Node only exists if it's in the workflow
@@ -223,7 +223,7 @@ export default React.memo(function ActionNode({
                     onClick={(e) => {
                       e.stopPropagation()
                       sidebarRef.current?.setActiveTab("action-input")
-                      setSelectedNodeEventId(action.id)
+                      setSelectedActionEventRef(slugify(action.title))
                     }}
                   >
                     <LayoutListIcon className="mr-2 size-4" />
@@ -233,7 +233,7 @@ export default React.memo(function ActionNode({
                     onClick={(e) => {
                       e.stopPropagation()
                       sidebarRef.current?.setActiveTab("action-result")
-                      setSelectedNodeEventId(action.id)
+                      setSelectedActionEventRef(slugify(action.title))
                     }}
                   >
                     <CircleCheckBigIcon className="mr-2 size-4" />

--- a/frontend/src/components/workbench/events/events-selected-action.tsx
+++ b/frontend/src/components/workbench/events/events-selected-action.tsx
@@ -1,20 +1,17 @@
 "use client"
 
-import React, { useMemo } from "react"
+import React from "react"
 import {
   EventFailure,
   WorkflowExecutionEventCompact,
   WorkflowExecutionReadCompact,
 } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
-import { useWorkflow } from "@/providers/workflow"
 import { CheckCheckIcon, CircleDot, CopyIcon, LoaderIcon } from "lucide-react"
 import JsonView from "react18-json-view"
 import { NodeMeta } from "react18-json-view/dist/types"
 
-import { useAction } from "@/lib/hooks"
-import { cn, slugify } from "@/lib/utils"
-import { ref2id } from "@/lib/workflow"
+import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import {
   Select,
@@ -33,7 +30,6 @@ import {
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import { CodeBlock } from "@/components/code-block"
-import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { getWorkflowEventIcon } from "@/components/workbench/events/events-workflow"
 
@@ -44,18 +40,8 @@ export function ActionEvent({
   execution: WorkflowExecutionReadCompact
   type: "input" | "result"
 }) {
-  const {
-    workflowId,
-    selectedNodeEventId,
-    setSelectedNodeEventId,
-    workspaceId,
-  } = useWorkflowBuilder()
-  const { workflow } = useWorkflow()
-  const selectedNodeEventRef = useMemo(() => {
-    return selectedNodeEventId
-      ? slugify(workflow?.actions[selectedNodeEventId]?.title || "")
-      : undefined
-  }, [selectedNodeEventId, workflow])
+  const { workflowId, selectedActionEventRef, setSelectedActionEventRef } =
+    useWorkflowBuilder()
 
   if (!workflowId)
     return <AlertNotification level="error" message="No workflow in context" />
@@ -63,17 +49,8 @@ export function ActionEvent({
   return (
     <div className="flex flex-col gap-4 p-4">
       <Select
-        value={selectedNodeEventRef}
-        onValueChange={(actionRef: string | undefined) => {
-          if (!actionRef) {
-            setSelectedNodeEventId(undefined)
-          } else {
-            const id = ref2id(actionRef, workflow)
-            if (id) {
-              setSelectedNodeEventId(id)
-            }
-          }
-        }}
+        value={selectedActionEventRef}
+        onValueChange={setSelectedActionEventRef}
       >
         <SelectTrigger className="h-8 text-xs text-foreground/70 focus:ring-0 focus:ring-offset-0">
           <SelectValue placeholder="Select an event" />
@@ -92,53 +69,29 @@ export function ActionEvent({
           </SelectGroup>
         </SelectContent>
       </Select>
-      <div>
-        {selectedNodeEventId && (
-          <ActionEventDetails
-            actionId={selectedNodeEventId}
-            workflowId={workflowId}
-            workspaceId={workspaceId}
-            status={execution.status}
-            events={execution.events}
-            type={type}
-          />
-        )}
-      </div>
+      {selectedActionEventRef && (
+        <ActionEventDetails
+          eventRef={selectedActionEventRef}
+          status={execution.status}
+          events={execution.events}
+          type={type}
+        />
+      )}
     </div>
   )
 }
 export function ActionEventDetails({
-  actionId,
-  workflowId,
-  workspaceId,
+  eventRef,
   status,
   events,
   type,
 }: {
-  actionId: string
-  workflowId: string
-  workspaceId: string
+  eventRef: string
   status: WorkflowExecutionReadCompact["status"]
   events: WorkflowExecutionEventCompact[]
   type: "input" | "result"
 }) {
-  const { action, actionIsLoading, actionError } = useAction(
-    actionId,
-    workspaceId,
-    workflowId!
-  )
-  // Filter only the events for this action
-  if (actionIsLoading) return <CenteredSpinner />
-  if (actionError || !action)
-    return (
-      <AlertNotification
-        level="error"
-        message={`Error loading action: ${actionError?.message || "Action undefined"}`}
-      />
-    )
-
-  const actionRef = slugify(action.title)
-  const actionEventsForRef = events.filter((e) => e.action_ref === actionRef)
+  const actionEventsForRef = events.filter((e) => e.action_ref === eventRef)
   // No events for ref, either the action has not executed or there was no event for the action.
   if (actionEventsForRef.length === 0) {
     return (
@@ -160,7 +113,7 @@ export function ActionEventDetails({
   // More than 1, error
   if (actionEventsForRef.length > 1) {
     console.error(
-      `More than 1 event for action ${action.title}: ${JSON.stringify(
+      `More than 1 event for action reference ${eventRef}: ${JSON.stringify(
         actionEventsForRef
       )}`
     )
@@ -194,7 +147,7 @@ export function ActionEventDetails({
               : actionEvent.action_result
           }
           defaultExpanded={true}
-          copyPrefix={`ACTIONS.${actionRef}.result`}
+          copyPrefix={`ACTIONS.${eventRef}.result`}
         />
       )}
     </div>

--- a/frontend/src/components/workbench/events/events-workflow.tsx
+++ b/frontend/src/components/workbench/events/events-workflow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react"
+import { useCallback } from "react"
 import Link from "next/link"
 import {
   WorkflowExecutionEventCompact,
@@ -28,7 +28,6 @@ import {
 
 import { executionId } from "@/lib/event-history"
 import { cn, slugify, undoSlugify } from "@/lib/utils"
-import { ref2id } from "@/lib/workflow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -188,8 +187,12 @@ export function WorkflowEvents({
 }: {
   events: WorkflowExecutionEventCompact[]
 }) {
-  const { selectedNodeEventId, setSelectedNodeEventId, setNodes, canvasRef } =
-    useWorkflowBuilder()
+  const {
+    selectedActionEventRef,
+    setSelectedActionEventRef,
+    setNodes,
+    canvasRef,
+  } = useWorkflowBuilder()
   const { workflow } = useWorkflow()
 
   const centerNode = useCallback((actionRef: string) => {
@@ -209,22 +212,14 @@ export function WorkflowEvents({
   }, [])
   const handleRowClick = useCallback(
     (actionRef: string) => {
-      const id = ref2id(actionRef, workflow)
-      if (!id) return
-      if (selectedNodeEventId === id) {
-        setSelectedNodeEventId(undefined)
+      if (selectedActionEventRef === actionRef) {
+        setSelectedActionEventRef(undefined)
       } else {
-        setSelectedNodeEventId(id)
+        setSelectedActionEventRef(actionRef)
       }
     },
-    [selectedNodeEventId, setSelectedNodeEventId, workflow, canvasRef.current]
+    [selectedActionEventRef, setSelectedActionEventRef]
   )
-
-  const selectedNodeRef = useMemo(() => {
-    return selectedNodeEventId
-      ? slugify(workflow?.actions[selectedNodeEventId]?.title || "")
-      : null
-  }, [selectedNodeEventId, workflow])
 
   return (
     <ScrollArea className="p-4 pt-0">
@@ -250,7 +245,7 @@ export function WorkflowEvents({
                   key={event.source_event_id}
                   className={cn(
                     "cursor-pointer hover:bg-muted/50",
-                    selectedNodeRef === event.action_ref &&
+                    selectedActionEventRef === event.action_ref &&
                       "bg-muted-foreground/10"
                   )}
                   onClick={() => handleRowClick(event.action_ref)}

--- a/frontend/src/components/workbench/events/events-workflow.tsx
+++ b/frontend/src/components/workbench/events/events-workflow.tsx
@@ -19,6 +19,7 @@ import {
   CircleMinusIcon,
   CirclePlayIcon,
   CircleX,
+  EyeOffIcon,
   Loader2,
   LoaderIcon,
   ScanEyeIcon,
@@ -221,6 +222,16 @@ export function WorkflowEvents({
     [selectedActionEventRef, setSelectedActionEventRef]
   )
 
+  const isActionRefValid = useCallback(
+    (actionRef: string) => {
+      const action = Object.values(workflow?.actions || {}).find(
+        (act) => slugify(act.title) === actionRef
+      )
+      return action !== undefined
+    },
+    [workflow]
+  )
+
   return (
     <ScrollArea className="p-4 pt-0">
       <div className="rounded-md border">
@@ -281,13 +292,19 @@ export function WorkflowEvents({
                         </DropdownMenuLabel>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
+                          // Disable if the action reference is not present in the current workflow
+                          disabled={!isActionRefValid(event.action_ref)}
                           onClick={(e) => {
                             e.stopPropagation()
                             centerNode(event.action_ref)
                           }}
                           className="flex items-center gap-2 text-xs"
                         >
-                          <ScanEyeIcon className="size-4" />
+                          {!isActionRefValid(event.action_ref) ? (
+                            <EyeOffIcon className="size-4" />
+                          ) : (
+                            <ScanEyeIcon className="size-4" />
+                          )}
                           <span>Focus Action</span>
                         </DropdownMenuItem>
                       </DropdownMenuContent>

--- a/frontend/src/components/workbench/events/events-workflow.tsx
+++ b/frontend/src/components/workbench/events/events-workflow.tsx
@@ -288,7 +288,7 @@ export function WorkflowEvents({
                           className="flex items-center gap-2 text-xs"
                         >
                           <ScanEyeIcon className="size-4" />
-                          <span>Focus node</span>
+                          <span>Focus Action</span>
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -1,7 +1,5 @@
-import { WorkflowRead } from "@/client"
 import { ReactFlowInstance } from "reactflow"
 
-import { slugify } from "@/lib/utils"
 import { isEphemeral } from "@/components/workbench/canvas/canvas"
 
 export const CHILD_WORKFLOW_ACTION_TYPE = "core.workflow.execute" as const
@@ -31,13 +29,4 @@ export function pruneGraphObject(reactFlowInstance: ReactFlowInstance) {
     throw new Error("Workflow cannot be saved without a trigger node")
   }
   return object
-}
-export function ref2id(
-  ref: string,
-  workflow: WorkflowRead | null
-): string | undefined {
-  const action = Object.values(workflow?.actions || {}).find(
-    (act) => slugify(act.title) === ref
-  )
-  return action?.id
 }

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -44,8 +44,8 @@ interface ReactFlowContextType {
   toggleSidebar: () => void
   toggleActionPanel: () => void
   expandSidebarAndFocusEvents: () => void
-  selectedNodeEventId?: string
-  setSelectedNodeEventId: React.Dispatch<SetStateAction<string | undefined>>
+  selectedActionEventRef?: string
+  setSelectedActionEventRef: React.Dispatch<SetStateAction<string | undefined>>
 }
 
 const ReactFlowInteractionsContext = createContext<
@@ -63,7 +63,7 @@ export const WorkflowBuilderProvider: React.FC<
   const { workspaceId, workflowId, error, updateWorkflow } = useWorkflow()
 
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
-  const [selectedNodeEventId, setSelectedNodeEventId] = useState<
+  const [selectedActionEventRef, setSelectedActionEventRef] = useState<
     string | undefined
   >(undefined)
   const [isSidebarCollapsed, setIsSidebarCollapsed] = React.useState(false)
@@ -145,12 +145,12 @@ export const WorkflowBuilderProvider: React.FC<
       workflowId,
       workspaceId,
       selectedNodeId,
-      selectedNodeEventId,
+      selectedActionEventRef,
       getNode: reactFlowInstance.getNode,
       setNodes: setReactFlowNodes,
       setEdges: setReactFlowEdges,
       setSelectedNodeId,
-      setSelectedNodeEventId,
+      setSelectedActionEventRef,
       reactFlow: reactFlowInstance,
       canvasRef,
       sidebarRef,
@@ -169,8 +169,8 @@ export const WorkflowBuilderProvider: React.FC<
       setReactFlowNodes,
       setReactFlowEdges,
       setSelectedNodeId,
-      selectedNodeEventId,
-      setSelectedNodeEventId,
+      selectedActionEventRef,
+      setSelectedActionEventRef,
       canvasRef,
       sidebarRef,
       isSidebarCollapsed,


### PR DESCRIPTION
We had previously coupled the events sidebar with actions on the page. This meant that when an action was deleted from the canvas, you couldn't view the event in the sidebar. This PR fixes this behavior. We also disable focusing the canvas on the action if we can't find a matching action ref in the workflow.