### PR TITLE
fix(app): Include secrets in update params

### DIFF
--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -474,6 +474,7 @@ class RegistryActionUpdate(BaseModel):
             author=action.author,
             deprecated=action.deprecated,
             options=RegistryActionOptions(include_in_schema=action.include_in_schema),
+            secrets=action.secrets,
         )
 
 


### PR DESCRIPTION
Should close #857. We missed including secrets in the update params for registry sync. Note that you have to re-sync for the changes to take place, as the registry actions in the DB must be updated. Simply saving the file locally isn't enough.

# Screens

https://github.com/user-attachments/assets/56713dad-8b68-46ad-98e3-26c4c37a2e5c


