### PR TITLE
fix(engine): Address loop recursion error issues

### DIFF
--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from tracecat.expressions.common import eval_jsonpath
 from tracecat.parse import (
     get_pyproject_toml_required_deps,
-    to_flat_dict,
     traverse_expressions,
     traverse_leaves,
 )
@@ -173,27 +172,3 @@ invalid toml content
     # Test parsing
     deps = get_pyproject_toml_required_deps(pyproject)
     assert deps == []
-
-
-def test_to_flat_dict_basic() -> None:
-    """Test basic dictionary flattening."""
-    result = to_flat_dict({"a": [{"b": 1}, {"b": 2}]})
-    assert result == {"a[0].b": 1, "a[1].b": 2}
-
-
-def test_to_flat_dict_with_dots() -> None:
-    """Test flattening dictionary with dots in keys."""
-    result = to_flat_dict({"a.b": {"c": 1}})
-    assert result == {"'a.b'.c": 1}
-
-
-def test_to_flat_dict_nested() -> None:
-    """Test flattening deeply nested dictionary."""
-    result = to_flat_dict({"a": {"b": {"c": 1, "d": 2}}})
-    assert result == {"a.b.c": 1, "a.b.d": 2}
-
-
-def test_to_flat_dict_with_prefix() -> None:
-    """Test flattening dictionary with prefix."""
-    result = to_flat_dict({"a": {"b": {"c": 1, "d": 2}}, "e": 3}, prefix="var")
-    assert result == {"var.a.b.c": 1, "var.a.b.d": 2, "var.e": 3}

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -115,7 +115,7 @@ class AuthSandbox:
             self._context[name][kv.key] = kv.value.get_secret_value()
 
     def _unset_secrets(self) -> None:
-        logger.debug("Cleaning up secrets")
+        logger.trace("Cleaning up secrets")
         for secret in self._secret_objs:
             if secret.name in self._context:
                 del self._context[secret.name]

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -547,7 +547,7 @@ class DSLWorkflow:
             task_result.update(error=msg, error_typename=err_type)
             raise ApplicationError(msg, non_retryable=True, type=err_type) from e
         finally:
-            logger.debug("Setting action result", task_result=task_result)
+            logger.trace("Setting action result", task_result=task_result)
             self.context[ExprContext.ACTIONS][task.ref] = task_result  # type: ignore
         return task_result
 
@@ -845,7 +845,7 @@ class DSLWorkflow:
         arg = RunActionInput(
             task=task, run_context=self.run_context, exec_context=self.context
         )
-        self.logger.debug("RUN UDF ACTIVITY", arg=arg)
+        self.logger.debug("RUN UDF ACTIVITY", action=task.action)
 
         return await workflow.execute_activity(
             DSLActivities.run_action_activity,

--- a/tracecat/executor/models.py
+++ b/tracecat/executor/models.py
@@ -8,9 +8,7 @@ from typing import Any
 from pydantic import UUID4, BaseModel
 
 from tracecat.config import TRACECAT__APP_ENV
-from tracecat.expressions.common import ExprContext
 from tracecat.git import GitUrl
-from tracecat.parse import to_flat_dict
 from tracecat.types.auth import Role
 
 
@@ -49,12 +47,9 @@ class ExecutorActionErrorInfo(BaseModel):
         parts = []
         msg = f"\n{self.type}: {self.message}"
         if self.loop_iteration is not None:
-            flattened = to_flat_dict(
-                self.loop_vars or {}, prefix=ExprContext.LOCAL_VARS
-            )
             parts.append(
                 f"\n[for_each] (Iteration {self.loop_iteration})"
-                f"\n\nLoop variables:\n```\n{json.dumps(flattened, indent=2)}\n```"
+                f"\n\nLoop variables:\n```\n{json.dumps(self.loop_vars or {}, indent=2)}\n```"
                 f"\n\n{msg}"
                 "\n\nPlease ensure that the loop is iterable and that the loop variable has the correct type."
             )

--- a/tracecat/executor/router.py
+++ b/tracecat/executor/router.py
@@ -55,7 +55,7 @@ async def run_action(
         ) from e
     except LoopExecutionError as e:
         err_info_list = [e.info.model_dump(mode="json") for e in e.loop_errors]
-        act_logger.error("Error in loop", errors=err_info_list)
+        act_logger.error("Error in loop", n_errors=len(err_info_list))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=err_info_list,

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -254,7 +254,7 @@ async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
     if mask_values:
         result = apply_masks_object(result, masks=mask_values)
 
-    act_logger.debug("Result", result=result)
+    act_logger.trace("Result", result=result)
     return result
 
 
@@ -338,7 +338,7 @@ async def run_action_on_ray_cluster(
 
     runtime_env = RuntimeEnv(env_vars=env_vars, **additional_vars)
 
-    logger.info("Running action on ray cluster", runtime_env=runtime_env)
+    logger.trace("Running action on ray cluster", runtime_env=runtime_env)
     obj_ref = run_action_task.options(runtime_env=runtime_env).remote(input, ctx.role)
     try:
         coro = asyncio.to_thread(ray.get, obj_ref)
@@ -356,7 +356,7 @@ async def run_action_on_ray_cluster(
     # Here, we have some result or error.
     # Reconstruct the error and raise some kind of proxy
     if isinstance(exec_result, ExecutorActionErrorInfo):
-        logger.info("Raising executor error proxy", exec_result=exec_result)
+        logger.trace("Raising executor error proxy", exec_result=exec_result)
         if iteration is not None:
             exec_result.loop_iteration = iteration
             exec_result.loop_vars = input.exec_context[ExprContext.LOCAL_VARS]

--- a/tracecat/parse.py
+++ b/tracecat/parse.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
@@ -80,46 +80,3 @@ def get_pyproject_toml_required_deps(pyproject_path: Path) -> list[str]:
     except Exception as e:
         logger.error("Error parsing pyproject.toml", error=e)
         return []
-
-
-def to_flat_dict(value: Any, parent_key: str = "", prefix: str = "") -> dict[str, Any]:
-    """Flatten a nested dictionary/list into a single level dictionary with path-like keys.
-    Handles dict keys that are already paths by wrapping them in quotes.
-
-    Args:
-        value: The value to flatten, can be a dict, list or primitive
-        parent_key: The parent key path to prepend (used for recursion)
-        prefix: Optional prefix to add to the beginning of all keys
-
-    Returns:
-        A flattened dictionary where nested keys are joined with dots and list indices.
-        Keys containing dots are wrapped in quotes.
-
-    Example:
-        >>> flatten_json({"a": [{"b": 1}, {"b": 2}]})
-        {'a[0].b': 1, 'a[1].b': 2}
-        >>> flatten_json({"a.b": {"c": 1}})
-        {"'a.b'.c": 1}
-        >>> flatten_json({"a": {"b": 1}}, prefix="prefix")
-        {'prefix.a.b': 1}
-    """
-    items: dict[str, Any] = {}
-
-    match value:
-        case Mapping():
-            for k, v in value.items():
-                # Wrap keys containing dots in quotes
-                escaped_key = f"'{k}'" if "." in k else k
-                new_key = (
-                    escaped_key if not parent_key else f"{parent_key}.{escaped_key}"
-                )
-                items.update(to_flat_dict(v, new_key, prefix))
-        case Sequence():
-            for i, item in enumerate(value):
-                new_key = f"{parent_key}[{i}]"
-                items.update(to_flat_dict(item, new_key, prefix))
-        case _:
-            final_key = f"{prefix}.{parent_key}" if prefix else parent_key
-            items[final_key] = value
-
-    return items


### PR DESCRIPTION
Reproduced the error with this setup:
1. Run a local http server that returns 1000 large nested jsons
2. Workflow hits this with `core.http_request` successfully
3. `for_each` over the data, trying to `FN.deserialize_json()`. This causes every single loop iteration to error out because the data is already json.
4. Observe recursion error

When handling executor errors, we were formatting error messages using `to_flat_dict`. This made us hit recursion limits quickly as it processes the entire result (if we looped N times, would return a list of N items). Decided to just show 1 instance of the error.

After removing `to_flat_dict`, we would observe the Temporal just gives up trying to return the error message because it exceeds the size limit. Fair enough. So we just return 1/N items since they're all similar anyways (`for_each` is mostly homogenous)

This might not be the end to it. Tagging @captainJackDnaiel has he's seen this before, though I'm not sure if the cause is the same.