### PR TITLE
feat(engine): Implement `core.table.lookup` action

### DIFF
--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -9,6 +9,7 @@ import {
   Send,
   ShieldAlert,
   Sparkles,
+  Table,
   WandSparkles,
   WorkflowIcon,
   ZapIcon,
@@ -243,11 +244,6 @@ export const UDFIcons: Record<string, (props: CustomIconProps) => JSX.Element> =
         <Send {...rest} />
       </div>
     ),
-    "integrations.email.send_email_resend": ({ className, ...rest }) => (
-      <div className={cn("bg-lime-100", basicIconsCommon, className)}>
-        <Send {...rest} />
-      </div>
-    ),
     "core.send_email_smtp": ({ className, ...rest }) => (
       <div className={cn("bg-lime-100", basicIconsCommon, className)}>
         <Send {...rest} />
@@ -274,6 +270,11 @@ export const UDFIcons: Record<string, (props: CustomIconProps) => JSX.Element> =
     "core.workflow": ({ className, ...rest }) => (
       <div className={cn("bg-violet-200/70", basicIconsCommon, className)}>
         <WorkflowIcon {...rest} />
+      </div>
+    ),
+    "core.table": ({ className, ...rest }) => (
+      <div className={cn("bg-sky-200/50", basicIconsCommon, className)}>
+        <Table {...rest} />
       </div>
     ),
     // AWS namespace

--- a/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
+++ b/frontend/src/components/workbench/panel/action-panel-tooltips.tsx
@@ -40,7 +40,9 @@ export function RunIfTooltip() {
             <span className="text-xs text-muted-foreground">
               # Search logs for error patterns
             </span>
-            <p>{"${{ FN.regex_match('error|failed', ACTIONS.get_logs.result) }}"}</p>
+            <p>
+              {"${{ FN.regex_match('error|failed', ACTIONS.get_logs.result) }}"}
+            </p>
             {"\n"}
             <span className="text-xs text-muted-foreground">
               # Verify logs are not empty

--- a/registry/tracecat_registry/base/core/table.py
+++ b/registry/tracecat_registry/base/core/table.py
@@ -1,0 +1,31 @@
+from typing import Annotated, Any
+
+from typing_extensions import Doc
+
+from tracecat_registry import RegistryActionError, registry
+
+
+@registry.register(
+    default_title="Lookup Table",
+    description="Get a row from a table corresponding to the given column and value.",
+    display_group="Tables",
+    namespace="core.table",
+)
+async def lookup(
+    table: Annotated[
+        str,
+        Doc("The table to lookup the value in."),
+    ],
+    column: Annotated[
+        str,
+        Doc("The column to lookup the value in."),
+    ],
+    value: Annotated[
+        str,
+        Doc("The value to lookup."),
+    ],
+) -> Any:
+    raise RegistryActionError(
+        "This UDF only defines an interface and cannot be invoked directly."
+        "If you are seeing this error, please contact your administrator."
+    )

--- a/registry/tracecat_registry/base/core/transform.py
+++ b/registry/tracecat_registry/base/core/transform.py
@@ -1,15 +1,8 @@
-from builtins import (
-    filter as filter_,
-)
-from builtins import (
-    map as map_,
-)
+from builtins import filter as filter_
+from builtins import map as map_
 from typing import Annotated, Any
 
-from tracecat.expressions.common import (
-    build_safe_lambda,
-    eval_jsonpath,
-)
+from tracecat.expressions.common import build_safe_lambda, eval_jsonpath
 from tracecat.expressions.functions import flatten as flatten_
 from typing_extensions import Doc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,19 @@ def test_role(test_workspace, mock_org_id):
 
 
 @pytest.fixture(scope="session")
+def test_admin_role(test_workspace, mock_org_id):
+    """Create a test role for the test session and set `ctx_role`."""
+    admin_role = Role(
+        type="user",
+        user_id=mock_org_id,
+        workspace_id=test_workspace.id,
+        access_level=AccessLevel.ADMIN,
+        service_id="tracecat-runner",
+    )
+    return admin_role
+
+
+@pytest.fixture(scope="session")
 def test_config_path(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
     tmp_path = tmp_path_factory.mktemp("config")
     config_path = tmp_path / "test_config.json"

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -10,10 +10,14 @@ from temporalio.exceptions import ApplicationError
 
 from tracecat.contexts import ctx_logger, ctx_run
 from tracecat.db.engine import get_async_session_context_manager
+from tracecat.dsl.common import RunTableLookupArgs
+from tracecat.dsl.enums import CoreActions
 from tracecat.dsl.models import ActionErrorInfo, ActionStatement, RunActionInput
 from tracecat.executor.client import ExecutorClient
+from tracecat.expressions.eval import eval_templated_object
 from tracecat.logger import logger
 from tracecat.registry.actions.models import RegistryActionValidateResponse
+from tracecat.tables.service import TablesService
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import ExecutorClientError, RegistryError
 from tracecat.validation.service import validate_registry_action_args
@@ -102,11 +106,24 @@ class DSLActivities:
             attempt=attempt,
             retry_policy=task.retry_policy,
         )
-
         try:
-            # Delegate to the registry client
-            client = ExecutorClient(role=role)
-            return await client.run_action_memory_backend(input)
+            if task.action == CoreActions.TABLE_LOOKUP:
+                # Do a table lookup
+                resolved_args = eval_templated_object(
+                    task.args, operand=input.exec_context
+                )
+                args = RunTableLookupArgs.model_validate(resolved_args)
+                async with TablesService.with_session(role=role) as service:
+                    rows = await service.lookup_row(
+                        table_name=args.table,
+                        columns=[args.column],
+                        values=[args.value],
+                    )
+                return rows[0] if rows else None
+            else:
+                # Run other actions in the executor
+                client = ExecutorClient(role=role)
+                return await client.run_action_memory_backend(input)
         except ExecutorClientError as e:
             # We only expect ExecutorClientError to be raised from the executor client
             kind = e.__class__.__name__

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -302,7 +302,7 @@ class ChildWorkflowMemo(BaseModel):
 class RunTableLookupArgs(BaseModel):
     table: str
     column: str
-    value: str
+    value: Any
 
 
 AdjDst = tuple[str, EdgeType]

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -299,6 +299,12 @@ class ChildWorkflowMemo(BaseModel):
             raise e
 
 
+class RunTableLookupArgs(BaseModel):
+    table: str
+    column: str
+    value: str
+
+
 AdjDst = tuple[str, EdgeType]
 
 

--- a/tracecat/dsl/constants.py
+++ b/tracecat/dsl/constants.py
@@ -1,2 +1,1 @@
 DEFAULT_ACTION_TIMEOUT = 300  # Seconds
-CHILD_WORKFLOW_EXECUTE_ACTION = "core.workflow.execute"

--- a/tracecat/dsl/enums.py
+++ b/tracecat/dsl/enums.py
@@ -1,6 +1,11 @@
 from enum import StrEnum, auto
 
 
+class CoreActions(StrEnum):
+    CHILD_WORKFLOW_EXECUTE = "core.workflow.execute"
+    TABLE_LOOKUP = "core.table.lookup"
+
+
 class FailStrategy(StrEnum):
     ISOLATED = "isolated"
     ALL = "all"

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -75,13 +75,12 @@ async def get_table(
             detail=str(e),
         ) from e
 
-    cols = table.columns
     return TableRead(
         id=table.id,
         name=table.name,
         columns=[
             TableColumnRead.model_validate(column, from_attributes=True)
-            for column in cols
+            for column in table.columns
         ],
     )
 

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -10,8 +10,13 @@ from tracecat_registry import RegistrySecret
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import RegistryAction
-from tracecat.dsl.common import DSLInput, ExecuteChildWorkflowArgs, context_locator
-from tracecat.dsl.constants import CHILD_WORKFLOW_EXECUTE_ACTION
+from tracecat.dsl.common import (
+    DSLInput,
+    ExecuteChildWorkflowArgs,
+    RunTableLookupArgs,
+    context_locator,
+)
+from tracecat.dsl.enums import CoreActions
 from tracecat.expressions.common import ExprType
 from tracecat.expressions.eval import extract_expressions, is_template_only
 from tracecat.expressions.parser.validator import ExprValidationContext, ExprValidator
@@ -161,8 +166,10 @@ async def validate_registry_action_args(
     # 3. validate the args against the pydantic model
     try:
         try:
-            if action_name == CHILD_WORKFLOW_EXECUTE_ACTION:
+            if action_name == CoreActions.CHILD_WORKFLOW_EXECUTE:
                 validated = ExecuteChildWorkflowArgs.model_validate(args)
+            elif action_name == CoreActions.TABLE_LOOKUP:
+                validated = RunTableLookupArgs.model_validate(args)
             else:
                 service = RegistryActionsService(session)
                 action = await service.get_action(action_name=action_name)

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -13,8 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 
 from tracecat.dsl.common import ChildWorkflowMemo, DSLRunArgs
-from tracecat.dsl.constants import CHILD_WORKFLOW_EXECUTE_ACTION
-from tracecat.dsl.enums import JoinStrategy
+from tracecat.dsl.enums import CoreActions, JoinStrategy
 from tracecat.dsl.models import (
     ActionErrorInfo,
     ActionRetryPolicy,
@@ -363,7 +362,7 @@ class WorkflowExecutionEventCompact(BaseModel):
             schedule_time=event.event_time.ToDatetime(UTC),
             curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
             status=WorkflowExecutionEventStatus.SCHEDULED,
-            action_name=CHILD_WORKFLOW_EXECUTE_ACTION,
+            action_name=CoreActions.CHILD_WORKFLOW_EXECUTE.value,
             action_ref=memo.action_ref,
             action_input=dsl_run_args.trigger_inputs,
             child_wf_exec_id=wf_exec_id,


### PR DESCRIPTION
# Description
- Implement table lookup from workflows. We expose a `core.table.lookup` interface that's handled by native `DSLWorkflow` logic, as opposed to a udf implementation. See `core.workflow.execute` for reference.
- Update action node icon

# Testing
- Added integration tests for calling in workflows