### PR TITLE
feat(integrations)!: Extend Jira create case with labels

### DIFF
--- a/registry/tracecat_registry/schemas/notify/create_case.yml
+++ b/registry/tracecat_registry/schemas/notify/create_case.yml
@@ -2,6 +2,7 @@
 # https://support.pagerduty.com/main/docs/pd-cef
 # https://www.servicenow.com/docs/bundle/xanadu-it-operations-management/page/product/event-management/concept/c_EMIntegrateRequirementEvent.html
 # https://confluence.atlassian.com/adminjiraserver/issue-fields-and-statuses-938847116.html
+# https://medium.com/brexeng/elevating-security-alert-management-using-automation-828004ad596c
 # NOTE: Should only be used to create a new case, not to update an existing case.
 # If this is a retrospective case, use the `update_case_status` action after creating the case.
 summary:
@@ -22,9 +23,9 @@ priority:
   type: str | None
   description: Priority of the incident.
   default: null
-tags:
+labels:
   type: list[str]
-  description: Tags to categorize the incident.
+  description: Labels to categorize the incident.
   default: []
 metadata:
   type: list[dict[str, any]]

--- a/registry/tracecat_registry/schemas/notify/create_case.yml
+++ b/registry/tracecat_registry/schemas/notify/create_case.yml
@@ -10,10 +10,12 @@ summary:
   description: Brief one-line summary of the incident.
 description:
   type: str
-  description: A detailed description of the incident.
+  description: Detailed description of the incident.
 # NOTE: Not all integrations support both severity and priority.
 # If the integration only supports severity, use the `severity` field.
 # If the integration only supports priority, use the `priority` field.
+# If the integration only supports a ID field (e.g. Jira), call the field:
+# `severity_id` or `priority_id` and set the value to the ID.
 severity:
   type: str
   description: Severity of the incident.

--- a/registry/tracecat_registry/schemas/notify/create_case.yml
+++ b/registry/tracecat_registry/schemas/notify/create_case.yml
@@ -12,20 +12,21 @@ description:
   type: str
   description: A detailed description of the incident.
 status:
-  type: str | None
+  type: str
   description: Status of the incident.
-  default: null
+# NOTE: Not all integrations support both severity and priority.
+# If the integration only supports severity, use the `severity` field.
+# If the integration only supports priority, use the `priority` field.
 severity:
-  type: str | None
+  type: str
   description: Severity of the incident.
-  default: null
 priority:
-  type: str | None
+  type: str
   description: Priority of the incident.
-  default: null
-labels:
+# NOTE: We normalize labels and tags to `tags`.
+tags:
   type: list[str]
-  description: Labels to categorize the incident.
+  description: Tags or labels to categorize the incident.
   default: []
 metadata:
   type: list[dict[str, any]]

--- a/registry/tracecat_registry/schemas/notify/create_case.yml
+++ b/registry/tracecat_registry/schemas/notify/create_case.yml
@@ -4,16 +4,13 @@
 # https://confluence.atlassian.com/adminjiraserver/issue-fields-and-statuses-938847116.html
 # https://medium.com/brexeng/elevating-security-alert-management-using-automation-828004ad596c
 # NOTE: Should only be used to create a new case, not to update an existing case.
-# If this is a retrospective case, use the `update_case_status` action after creating the case.
+# NOTE: If this is a retrospective case, use the `update_case_status` action after creating the case.
 summary:
   type: str
   description: Brief one-line summary of the incident.
 description:
   type: str
   description: A detailed description of the incident.
-status:
-  type: str
-  description: Status of the incident.
 # NOTE: Not all integrations support both severity and priority.
 # If the integration only supports severity, use the `severity` field.
 # If the integration only supports priority, use the `priority` field.

--- a/registry/tracecat_registry/templates/notify/create_case/jira.yml
+++ b/registry/tracecat_registry/templates/notify/create_case/jira.yml
@@ -16,52 +16,87 @@ definition:
     description:
       type: str
       description: A detailed description of the incident.
-    severity:
+    priority:
       type: str
-      description: Severity of the incident.
-    labels:
+      description: |
+        Priority of the incident.
+        This is the priority name, not the priority ID.
+    tags:
       type: list[str]
-      description: Labels to categorize the incident.
+      description: Tags to categorize the incident. Added as Jira labels.
       default: []
-    custom_fields:
+    metadata:
       type: list[dict[str, any]]
-      description: Custom fields to add to the incident.
+      description: >-
+        Context related to the incident, where the keys are Jira custom field names.
+        Field names are automatically mapped to Jira custom field IDs.
       default: []
-    severity_to_priority_id:
-      type: dict[str, str]
-      description: Mapping of severity to priority ID.
-    base_url:
-      type: str
-      description: Jira tenant URL (e.g. https://tracecat.atlassian.net).
     project_id:
       type: str
       description: Jira project ID.
+    scheme_id:
+      type: str
+      description: Jira priority scheme ID.
     issue_type_id:
       type: str
       description: Jira issue type ID.
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net).
   steps:
+    # Map priority name to ID
+    - ref: get_priorities
+      action: tools.jira.get_priorities
+      args:
+        priority_scheme_id: ${{ inputs.priority_scheme_id }}
+        base_url: ${{ inputs.base_url }}
+    - ref: priority_name_to_id
+      action: core.transform.reshape
+      args:
+        value: ${{ FN.index_by_key(steps.get_priorities.result, "name", "id") }}
+    # Format the required fields
+    - ref: required_fields
+      action: core.transform.reshape
+      args:
+        value:
+          summary: ${{ inputs.summary }}
+          description:
+            type: doc
+            version: 1
+            content:
+              - type: paragraph
+                content:
+                  - text: ${{ inputs.description }}
+                    type: text
+          labels: ${{ inputs.tags }}
+          priority:
+            id: ${{ FN.lookup(steps.priority_name_to_id.result, inputs.priority) }}
+          project:
+            id: ${{ inputs.project_id }}
+          issuetype:
+            id: ${{ inputs.issue_type_id }}
+    # Map custom field names to IDs
+    - ref: get_custom_fields
+      action: tools.jira.get_custom_fields
+      args:
+        base_url: ${{ inputs.base_url }}
+    - ref: custom_field_name_to_id
+      action: core.transform.reshape
+      args:
+        value: ${{ FN.index_by_key(steps.get_custom_fields.result, "name", "id") }}
+    - ref: custom_fields
+      action: core.transform.reshape
+      args:
+        value: ${{ FN.map_keys(inputs.metadata, steps.custom_field_name_to_id.result) }}
+    # Create the issue
     - ref: create_issue
       action: core.http_request
       args:
         url: ${{ inputs.base_url }}/rest/api/3/issue/
         method: POST
         headers:
-          Authorization: Basic ${{ SECRETS.jira.JIRA_BASE64_TOKEN || FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
+          Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
         payload:
-          fields:
-            summary: ${{ inputs.summary }}
-            description:
-              type: doc
-              version: 1
-              content:
-                - type: paragraph
-                  content:
-                    - text: ${{ inputs.description }}
-                      type: text
-            priority:
-              id: ${{ FN.lookup(inputs.severity_to_priority_id, inputs.severity) }}
-            project:
-              id: ${{ inputs.project_id }}
-            issuetype:
-              id: ${{ inputs.issue_type_id }}
+          # Merge required fields with custom fields
+          fields: ${{ FN.merge(steps.required_fields.result, steps.custom_fields.result) }}
   returns: ${{ steps.create_issue.result }}

--- a/registry/tracecat_registry/templates/notify/create_case/jira.yml
+++ b/registry/tracecat_registry/templates/notify/create_case/jira.yml
@@ -34,7 +34,7 @@ definition:
     project_id:
       type: str
       description: Jira project ID.
-    scheme_id:
+    priority_scheme_id:
       type: str
       description: Jira priority scheme ID.
     issue_type_id:
@@ -76,14 +76,14 @@ definition:
           issuetype:
             id: ${{ inputs.issue_type_id }}
     # Map custom field names to IDs
-    - ref: get_custom_fields
-      action: tools.jira.get_custom_fields
+    - ref: get_fields
+      action: tools.jira.get_fields
       args:
         base_url: ${{ inputs.base_url }}
     - ref: custom_field_name_to_id
       action: core.transform.reshape
       args:
-        value: ${{ FN.index_by_key(steps.get_custom_fields.result, "name", "id") }}
+        value: ${{ FN.index_by_key(steps.get_fields.result, "name", "id") }}
     - ref: custom_fields
       action: core.transform.reshape
       args:

--- a/registry/tracecat_registry/templates/notify/create_case/jira.yml
+++ b/registry/tracecat_registry/templates/notify/create_case/jira.yml
@@ -60,14 +60,15 @@ definition:
       args:
         value:
           summary: ${{ inputs.summary }}
+          # See: https://developer.atlassian.com/cloud/jira/platform/apis/document/playground/
           description:
-            type: doc
             version: 1
+            type: doc
             content:
               - type: paragraph
                 content:
-                  - text: ${{ inputs.description }}
-                    type: text
+                  - type: text
+                    text: ${{ inputs.description }}
           labels: ${{ inputs.tags }}
           priority:
             id: ${{ FN.lookup(steps.priority_name_to_id.result, inputs.priority) }}
@@ -87,16 +88,21 @@ definition:
     - ref: custom_fields
       action: core.transform.reshape
       args:
-        value: ${{ FN.map_keys(inputs.metadata, steps.custom_field_name_to_id.result) }}
+        value: ${{ FN.map_keys(FN.merge(inputs.metadata), steps.custom_field_name_to_id.result) }}
+    # Fields
+    - ref: fields
+      action: core.transform.reshape
+      args:
+        value: ${{ FN.merge([steps.required_fields.result, steps.custom_fields.result]) }}
     # Create the issue
     - ref: create_issue
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/rest/api/3/issue/
+        url: ${{ inputs.base_url }}/rest/api/3/issue
         method: POST
         headers:
           Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
         payload:
           # Merge required fields with custom fields
-          fields: ${{ FN.merge(steps.required_fields.result, steps.custom_fields.result) }}
-  returns: ${{ steps.create_issue.result }}
+          fields: ${{ steps.fields.result }}
+  returns: ${{ steps.fields.result }}

--- a/registry/tracecat_registry/templates/notify/create_case/jira.yml
+++ b/registry/tracecat_registry/templates/notify/create_case/jira.yml
@@ -15,12 +15,10 @@ definition:
       description: Brief one-line summary of the incident.
     description:
       type: str
-      description: A detailed description of the incident.
-    priority:
+      description: Detailed description of the incident.
+    priority_id:
       type: str
-      description: |
-        Priority of the incident.
-        This is the priority name, not the priority ID.
+      description: Priority ID. Must be one of the priorities in the priority scheme.
     tags:
       type: list[str]
       description: Tags to categorize the incident. Added as Jira labels.
@@ -28,8 +26,7 @@ definition:
     metadata:
       type: list[dict[str, any]]
       description: >-
-        Context related to the incident, where the keys are Jira custom field names.
-        Field names are automatically mapped to Jira custom field IDs.
+        Context related to the incident. Keys are Jira custom field IDs.
       default: []
     project_id:
       type: str
@@ -44,16 +41,6 @@ definition:
       type: str
       description: Jira tenant URL (e.g. https://tracecat.atlassian.net).
   steps:
-    # Map priority name to ID
-    - ref: get_priorities
-      action: tools.jira.get_priorities
-      args:
-        priority_scheme_id: ${{ inputs.priority_scheme_id }}
-        base_url: ${{ inputs.base_url }}
-    - ref: priority_name_to_id
-      action: core.transform.reshape
-      args:
-        value: ${{ FN.index_by_key(steps.get_priorities.result, "name", "id") }}
     # Format the required fields
     - ref: required_fields
       action: core.transform.reshape
@@ -71,29 +58,16 @@ definition:
                     text: ${{ inputs.description }}
           labels: ${{ inputs.tags }}
           priority:
-            id: ${{ FN.lookup(steps.priority_name_to_id.result, inputs.priority) }}
+            id: ${{ inputs.priority_id }}
           project:
             id: ${{ inputs.project_id }}
           issuetype:
             id: ${{ inputs.issue_type_id }}
-    # Map custom field names to IDs
-    - ref: get_fields
-      action: tools.jira.get_fields
-      args:
-        base_url: ${{ inputs.base_url }}
-    - ref: custom_field_name_to_id
-      action: core.transform.reshape
-      args:
-        value: ${{ FN.index_by_key(steps.get_fields.result, "name", "id") }}
-    - ref: custom_fields
-      action: core.transform.reshape
-      args:
-        value: ${{ FN.map_keys(FN.merge(inputs.metadata), steps.custom_field_name_to_id.result) }}
     # Fields
     - ref: fields
       action: core.transform.reshape
       args:
-        value: ${{ FN.merge([steps.required_fields.result, steps.custom_fields.result]) }}
+        value: ${{ FN.merge([steps.required_fields.result, FN.merge(inputs.metadata)]) }}
     # Create the issue
     - ref: create_issue
       action: core.http_request

--- a/registry/tracecat_registry/templates/notify/create_case/jira.yml
+++ b/registry/tracecat_registry/templates/notify/create_case/jira.yml
@@ -19,9 +19,9 @@ definition:
     severity:
       type: str
       description: Severity of the incident.
-    tags:
+    labels:
       type: list[str]
-      description: Tags to categorize the incident.
+      description: Labels to categorize the incident.
       default: []
     custom_fields:
       type: list[dict[str, any]]

--- a/registry/tracecat_registry/templates/notify/post_todo/slack.yml
+++ b/registry/tracecat_registry/templates/notify/post_todo/slack.yml
@@ -68,6 +68,6 @@ definition:
           attachments:
             - color: ${{ "#22c55e" if inputs.status == "done" else "#eab308" if inputs.status == "in_progress" else "" }}
               blocks:
-                - "${{ FN.merge(steps.summary_block.result, {'accessory': steps.overflow_menu.result}) }}"
+                - "${{ FN.merge([steps.summary_block.result, {'accessory': steps.overflow_menu.result}]) }}"
                 - "${{ steps.metadata_block.result }}"
   returns: ${{ steps.post_message.result.message }}

--- a/registry/tracecat_registry/templates/tools/README.md
+++ b/registry/tracecat_registry/templates/tools/README.md
@@ -1,0 +1,3 @@
+> ![NOTE]
+> Integrations that do not fit into a specific category and capability are placed here.
+> These are typically integrations to vendor-specific data models.

--- a/registry/tracecat_registry/templates/tools/jira/get_fields.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_fields.yml
@@ -1,0 +1,24 @@
+type: action
+definition:
+  title: Get fields
+  description: Get a list of fields from Jira.
+  display_group: Jira
+  doc_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-group-issue-fields
+  namespace: tools.jira
+  name: get_fields
+  secrets:
+    - name: jira
+      keys: ["JIRA_USEREMAIL", "JIRA_API_TOKEN"]
+  expects:
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+  steps:
+    - ref: get_fields
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/rest/api/3/field
+        method: GET
+        headers:
+          Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
+  returns: ${{ steps.get_fields.result }}

--- a/registry/tracecat_registry/templates/tools/jira/get_fields.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_fields.yml
@@ -21,4 +21,4 @@ definition:
         method: GET
         headers:
           Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
-  returns: ${{ steps.get_fields.result }}
+  returns: ${{ steps.get_fields.result.data }}

--- a/registry/tracecat_registry/templates/tools/jira/get_priorities.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_priorities.yml
@@ -16,6 +16,10 @@ definition:
     base_url:
       type: str
       description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+    limit:
+      type: int
+      description: Maximum number of priorities to return.
+      default: 50
   steps:
     - ref: get_priorities
       action: core.http_request
@@ -24,4 +28,6 @@ definition:
         method: GET
         headers:
           Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
+        params:
+          maxResults: ${{ inputs.limit }}
   returns: ${{ steps.get_priorities.result.data.values }}

--- a/registry/tracecat_registry/templates/tools/jira/get_priorities.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_priorities.yml
@@ -20,8 +20,8 @@ definition:
     - ref: get_priorities
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/rest/api/3/priorityscheme/${{ inputs.priority_scheme_id }}/priority
+        url: ${{ inputs.base_url }}/rest/api/3/priorityscheme/${{ inputs.priority_scheme_id }}/priorities
         method: GET
         headers:
           Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
-  returns: ${{ steps.get_priorities.result.values }}
+  returns: ${{ steps.get_priorities.result.data.values }}

--- a/registry/tracecat_registry/templates/tools/jira/get_priorities.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_priorities.yml
@@ -1,0 +1,27 @@
+type: action
+definition:
+  title: Get priorities by scheme
+  description: Get a list of priorities from Jira for a given priority scheme.
+  display_group: Jira
+  doc_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-priority-schemes/#api-rest-api-3-priorityscheme-schemeid-priorities-get
+  namespace: tools.jira
+  name: get_priorities
+  secrets:
+    - name: jira
+      keys: ["JIRA_USEREMAIL", "JIRA_API_TOKEN"]
+  expects:
+    priority_scheme_id:
+      type: str
+      description: Jira priority scheme ID.
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+  steps:
+    - ref: get_priorities
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/rest/api/3/priorityscheme/${{ inputs.priority_scheme_id }}/priority
+        method: GET
+        headers:
+          Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
+  returns: ${{ steps.get_priorities.result.values }}

--- a/registry/tracecat_registry/templates/tools/jira/get_priority_schemes.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_priority_schemes.yml
@@ -13,6 +13,10 @@ definition:
     base_url:
       type: str
       description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+    limit:
+      type: int
+      description: Maximum number of priority schemes to return.
+      default: 50
   steps:
     - ref: get_priority_schemes
       action: core.http_request
@@ -21,4 +25,6 @@ definition:
         method: GET
         headers:
           Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
+        params:
+          maxResults: ${{ inputs.limit }}
   returns: ${{ steps.get_priority_schemes.result.data.values }}

--- a/registry/tracecat_registry/templates/tools/jira/get_priority_schemes.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_priority_schemes.yml
@@ -1,0 +1,24 @@
+type: action
+definition:
+  title: Get priority schemes
+  description: Get a list of priority schemes from Jira.
+  display_group: Jira
+  doc_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-priority-schemes/#api-rest-api-3-priorityscheme-get
+  namespace: tools.jira
+  name: get_priority_schemes
+  secrets:
+    - name: jira
+      keys: ["JIRA_USEREMAIL", "JIRA_API_TOKEN"]
+  expects:
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+  steps:
+    - ref: get_priority_schemes
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/rest/api/3/priorityscheme
+        method: GET
+        headers:
+          Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
+  returns: ${{ steps.get_priority_schemes.result.values }}

--- a/registry/tracecat_registry/templates/tools/jira/get_priority_schemes.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_priority_schemes.yml
@@ -21,4 +21,4 @@ definition:
         method: GET
         headers:
           Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
-  returns: ${{ steps.get_priority_schemes.result.values }}
+  returns: ${{ steps.get_priority_schemes.result.data.values }}

--- a/registry/tracecat_registry/templates/tools/jira/get_projects.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_projects.yml
@@ -1,0 +1,30 @@
+type: action
+definition:
+  title: Get projects
+  description: Get a list of projects from Jira.
+  display_group: Jira
+  doc_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-search-get
+  namespace: tools.jira
+  name: get_projects
+  secrets:
+    - name: jira
+      keys: ["JIRA_USEREMAIL", "JIRA_API_TOKEN"]
+  expects:
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+    limit:
+      type: int
+      description: Maximum number of projects to return.
+      default: 50
+  steps:
+    - ref: get_projects
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/rest/api/3/project/search
+        method: GET
+        headers:
+          Authorization: Basic ${{ FN.to_base64(SECRETS.jira.JIRA_USEREMAIL + ":" + SECRETS.jira.JIRA_API_TOKEN) }}
+        params:
+          maxResults: ${{ inputs.limit }}
+  returns: ${{ steps.get_projects.result.data.values }}

--- a/tests/registry/test_templates.py
+++ b/tests/registry/test_templates.py
@@ -12,13 +12,6 @@ from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.repository import Repository
 
 
-@pytest.fixture(scope="module")
-def registry():
-    registry = Repository()
-    registry.init(include_base=False, include_templates=True)
-    return registry
-
-
 @pytest.mark.anyio
 async def test_base_registry_validate_template_actions():
     origin = DEFAULT_REGISTRY_ORIGIN
@@ -74,12 +67,16 @@ async def test_base_registry_validate_template_actions():
     list(Path("registry/tracecat_registry/templates").rglob("*.yml")),
     ids=lambda path: str(path.parts[-2:]),
 )
-async def test_template_action_validation(file_path, registry):
+async def test_template_action_validation(file_path):
+    # Initialize the repository
+    repo = Repository()
+    repo.init(include_base=False, include_templates=True)
+
     # Test parsing
     action = TemplateAction.from_yaml(file_path)
     assert action.type == "action"
     assert action.definition
 
     # Test registration
-    registry.register_template_action(action)
-    assert action.definition.action in registry
+    repo.register_template_action(action)
+    assert action.definition.action in repo

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -810,33 +810,31 @@ def test_index_by_key(
 
 
 @pytest.mark.parametrize(
-    "input_list,key,expected",
+    "input_dict,key_mapping,expected",
     [
-        # Basic case
+        # Basic key mapping
+        ({"a": 1, "b": 2}, {"a": "x", "b": "y"}, {"x": 1, "y": 2}),
+        # Empty dictionary
+        ({}, {}, {}),
+        # Subset of keys
+        ({"a": 1, "b": 2}, {"a": "x"}, {"x": 1}),
+        # Different value types
         (
-            [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
-            "id",
-            {1: {"id": 1, "name": "Alice"}, 2: {"id": 2, "name": "Bob"}},
-        ),
-        # Empty list
-        ([], "id", {}),
-        # Different key types
-        (
-            [{"num": 1.5, "val": "a"}, {"num": 2.5, "val": "b"}],
-            "num",
-            {1.5: {"num": 1.5, "val": "a"}, 2.5: {"num": 2.5, "val": "b"}},
-        ),
-        # Nested dictionaries
-        (
-            [{"key": "a", "data": {"x": 1}}, {"key": "b", "data": {"x": 2}}],
-            "key",
-            {"a": {"key": "a", "data": {"x": 1}}, "b": {"key": "b", "data": {"x": 2}}},
+            {"a": [1, 2], "b": {"c": 3}},
+            {"a": "x", "b": "y"},
+            {"x": [1, 2], "y": {"c": 3}},
         ),
     ],
 )
-def test_map_dict_keys(input_list: list[dict], key: str, expected: dict) -> None:
-    """Test mapping a list of dictionaries to a dictionary using a specified key."""
-    assert map_dict_keys(input_list, key) == expected
+def test_map_dict_keys(input_dict: dict, key_mapping: dict, expected: dict) -> None:
+    """Test mapping dictionary keys using a key mapping dictionary."""
+    assert map_dict_keys(input_dict, key_mapping) == expected
+
+
+def test_map_dict_keys_missing_key() -> None:
+    """Test that map_dict_keys raises ValueError when key mapping is missing."""
+    with pytest.raises(ValueError, match="Key 'missing' not found in keys mapping"):
+        map_dict_keys({"missing": 1}, {"other": "x"})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -512,7 +512,7 @@ def test_string_boundary_functions(
 
 
 @pytest.mark.parametrize(
-    "func,input_val,expected",
+    "func,dt,expected",
     [
         (get_day, datetime(2024, 3, 1), 1),
         (get_day, datetime(2024, 3, 31), 31),
@@ -522,28 +522,24 @@ def test_string_boundary_functions(
         (get_year, datetime(2024, 3, 15), 2024),
     ],
 )
-def test_date_component_getters(func, input_val: datetime, expected: int) -> None:
+def test_date_component_getters(func, dt: datetime, expected: int) -> None:
     """Test all date/time component getter functions."""
-    assert func(input_val) == expected
+    assert func(dt) == expected
 
 
 @pytest.mark.parametrize(
-    "func,input_val,expected",
+    "dt,format,expected",
     [
-        (get_month, datetime(2024, 1, 1), 1),
-        (get_month, datetime(2024, 12, 1), 12),
-        (get_month, datetime(2024, 1, 1), "number"),
-        (get_month, datetime(2024, 12, 1), "number"),
-        (get_month, datetime(2024, 1, 1), "full"),
-        (get_month, datetime(2024, 12, 1), "full"),
-        (get_month, datetime(2024, 1, 1), "short"),
-        (get_month, datetime(2024, 12, 1), "short"),
+        (datetime(2024, 1, 1), "number", 1),
+        (datetime(2024, 12, 1), "number", 12),
+        (datetime(2024, 1, 1), "full", "January"),
+        (datetime(2024, 12, 1), "full", "December"),
+        (datetime(2024, 1, 1), "short", "Jan"),
+        (datetime(2024, 12, 1), "short", "Dec"),
     ],
 )
-def test_get_month(func, input_val: datetime, expected: int | str) -> None:
-    assert func(input_val, "number") == expected
-    assert func(input_val, "full") == expected
-    assert func(input_val, "short") == expected
+def test_get_month(dt: datetime, format: str, expected: int | str) -> None:
+    assert get_month(dt, format) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -844,29 +844,31 @@ def test_map_dict_keys(input_list: list[dict], key: str, expected: dict) -> None
 
 
 @pytest.mark.parametrize(
-    "dict1,dict2,expected",
+    "dict_list,expected",
     [
         # Basic case
-        ({"a": 1}, {"b": 2}, {"a": 1, "b": 2}),
+        ([{"a": 1}, {"b": 2}], {"a": 1, "b": 2}),
         # Empty dictionaries
-        ({}, {}, {}),
-        ({}, {"a": 1}, {"a": 1}),
-        ({"a": 1}, {}, {"a": 1}),
-        # Overlapping keys (second dict takes precedence)
-        ({"a": 1}, {"a": 2}, {"a": 2}),
+        ([], {}),
+        ([{}], {}),
+        ([{}, {"a": 1}], {"a": 1}),
+        ([{"a": 1}, {}], {"a": 1}),
+        # Overlapping keys (last dict takes precedence)
+        ([{"a": 1}, {"a": 2}], {"a": 2}),
         # Nested dictionaries
-        ({"a": {"x": 1}}, {"b": {"y": 2}}, {"a": {"x": 1}, "b": {"y": 2}}),
+        ([{"a": {"x": 1}}, {"b": {"y": 2}}], {"a": {"x": 1}, "b": {"y": 2}}),
         # Mixed value types
         (
-            {"a": 1, "b": "str"},
-            {"c": [1, 2], "d": {"x": 1}},
+            [{"a": 1, "b": "str"}, {"c": [1, 2], "d": {"x": 1}}],
             {"a": 1, "b": "str", "c": [1, 2], "d": {"x": 1}},
         ),
+        # More than two dictionaries
+        ([{"a": 1}, {"b": 2}, {"c": 3}], {"a": 1, "b": 2, "c": 3}),
     ],
 )
-def test_merge_dicts(dict1: dict, dict2: dict, expected: dict) -> None:
-    """Test merging two dictionaries."""
-    assert merge_dicts(dict1, dict2) == expected
+def test_merge_dicts(dict_list: list[dict], expected: dict) -> None:
+    """Test merging a list of dictionaries."""
+    assert merge_dicts(dict_list) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -816,8 +816,8 @@ def test_index_by_key(
         ({"a": 1, "b": 2}, {"a": "x", "b": "y"}, {"x": 1, "y": 2}),
         # Empty dictionary
         ({}, {}, {}),
-        # Subset of keys
-        ({"a": 1, "b": 2}, {"a": "x"}, {"x": 1}),
+        # All keys must be mapped
+        ({"a": 1}, {"a": "x"}, {"x": 1}),
         # Different value types
         (
             {"a": [1, 2], "b": {"c": 3}},

--- a/tests/unit/test_template_actions.py
+++ b/tests/unit/test_template_actions.py
@@ -530,17 +530,17 @@ async def test_template_action_runs(test_args, expected, should_raise):
     )
 
     # Register the action
-    registry = Repository()
-    registry.init(include_base=True, include_templates=False)
-    registry.register_template_action(action)
+    repo = Repository()
+    repo.init(include_base=True, include_templates=False)
+    repo.register_template_action(action)
 
     # Check that the action is registered
     assert action.definition.action == "integrations.test.wrapper"
-    assert "core.transform.reshape" in registry
-    assert action.definition.action in registry
+    assert "core.transform.reshape" in repo
+    assert action.definition.action in repo
 
     # Get the registered action
-    bound_action = registry.get(action.definition.action)
+    bound_action = repo.get(action.definition.action)
 
     # Run the action
     if should_raise:
@@ -630,12 +630,12 @@ async def test_template_action_with_enums(test_args, expected, should_raise):
     action = TemplateAction.model_validate(data)
 
     # Register the action
-    registry = Repository()
-    registry.init(include_base=True, include_templates=False)
-    registry.register_template_action(action)
+    repo = Repository()
+    repo.init(include_base=True, include_templates=False)
+    repo.register_template_action(action)
 
     # Get the registered action
-    bound_action = registry.get(action.definition.action)
+    bound_action = repo.get(action.definition.action)
 
     # Run the action
     if should_raise:

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -163,7 +163,7 @@ def generate_uuid() -> str:
 
 
 def deserialize_ndjson(x: str) -> list[dict[str, Any]]:
-    """Parse newline-delimited JSON string into list of dictionaries."""
+    """Parse newline-delimited JSON string into list of objects."""
     return [orjson.loads(line) for line in x.splitlines()]
 
 
@@ -342,30 +342,42 @@ def create_range(start: int, end: int, step: int = 1) -> range:
 
 
 # Dictionary functions
+# NOTE: Use "object" in docstrings to align to Javascript / JSON terminology.
+
+
+def index_by_key(
+    x: list[dict[str, Any]],
+    field_key: str,
+    value_key: str | None = None,
+) -> dict[str, Any]:
+    """Convert a list of objects into an object indexed by the specified key."""
+    if value_key:
+        return {item[field_key]: item[value_key] for item in x}
+    return {item[field_key]: item for item in x}
 
 
 def merge_dicts(x: dict[Any, Any], y: dict[Any, Any]) -> dict[Any, Any]:
-    """Merge two dictionaries. Similar to merge function in Terraform."""
+    """Merge two objects. Similar to merge function in Terraform."""
     return {**x, **y}
 
 
 def dict_keys(x: dict[Any, Any]) -> list[Any]:
-    """Extract keys from dictionary."""
+    """Extract keys from an object."""
     return list(x.keys())
 
 
 def dict_lookup(d: dict[Any, Any], k: Any) -> Any:
-    """Safely get value from dictionary."""
+    """Safely get value from an object."""
     return d.get(k)
 
 
 def dict_values(x: dict[Any, Any]) -> list[Any]:
-    """Extract values from dictionary."""
+    """Extract values from an object."""
     return list(x.values())
 
 
 def map_dict_keys(x: dict[str, Any], keys: dict[str, str]) -> dict[str, Any]:
-    """Map keys in dictionary to new keys."""
+    """Map keys in an object to new keys."""
     try:
         return {keys[k]: v for k, v in x.items()}
     except KeyError as e:
@@ -817,6 +829,7 @@ _FUNCTION_MAPPING = {
     # Generators
     "uuid4": generate_uuid,
     # JSON functions
+    "index_by_key": index_by_key,
     "lookup": dict_lookup,
     "map_keys": map_dict_keys,
     "merge": merge_dicts,

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -364,6 +364,14 @@ def dict_values(x: dict[Any, Any]) -> list[Any]:
     return list(x.values())
 
 
+def map_dict_keys(x: dict[str, Any], keys: dict[str, str]) -> dict[str, Any]:
+    """Map keys in dictionary to new keys."""
+    try:
+        return {keys[k]: v for k, v in x.items()}
+    except KeyError as e:
+        raise ValueError(f"Key {e} not found in keys mapping {keys}.") from e
+
+
 def serialize_to_json(x: Any) -> str:
     """Convert object to JSON string."""
     return orjson.dumps(x).decode()
@@ -810,6 +818,7 @@ _FUNCTION_MAPPING = {
     "uuid4": generate_uuid,
     # JSON functions
     "lookup": dict_lookup,
+    "map_keys": map_dict_keys,
     "merge": merge_dicts,
     "to_keys": dict_keys,
     "to_values": dict_values,

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -356,9 +356,9 @@ def index_by_key(
     return {item[field_key]: item for item in x}
 
 
-def merge_dicts(x: dict[Any, Any], y: dict[Any, Any]) -> dict[Any, Any]:
-    """Merge two objects. Similar to merge function in Terraform."""
-    return {**x, **y}
+def merge_dicts(x: list[dict[Any, Any]]) -> dict[Any, Any]:
+    """Merge list of objects. Similar to merge function in Terraform."""
+    return {k: v for d in x for k, v in d.items()}
 
 
 def dict_keys(x: dict[Any, Any]) -> list[Any]:


### PR DESCRIPTION
## What changed
- Fixed `create_case` integration for Jira to support tags and metadata / custom fields.
- Changed `priority` to `priority_id`
- Added templates for get projects, get priorities by scheme, get priority schemes, get fields Jira endpoints (use-case: to populate lookup tables or map priority name to ID)
- Added `index_by_key` (turn list of dicts to dict) and `map_keys` inline functions

## Future considerations
Replace paginated endpoints with `core.http_paginated` (enterprise only?)

## QA
<img width="550" alt="Screenshot 2025-02-23 at 4 37 39 PM" src="https://github.com/user-attachments/assets/83437125-e84b-4ef9-8f9e-aff51ddc855c" />
