### PR TITLE
feat(ui): Add tables UI

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/tables/[tableId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/tables/[tableId]/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { useWorkspace } from "@/providers/workspace"
+import { ArrowLeftIcon } from "lucide-react"
+
+import { useGetTable } from "@/lib/hooks"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import { TableInsertButton } from "@/components/tables/table-insert-button"
+import { DatabaseTable } from "@/components/tables/table-view"
+
+export default function TablePage() {
+  const { tableId } = useParams<{ tableId: string }>()
+  const { workspaceId } = useWorkspace()
+  const { table, tableIsLoading, tableError } = useGetTable({
+    tableId,
+    workspaceId,
+  })
+  if (tableIsLoading) return <CenteredSpinner />
+  if (tableError || !table)
+    return (
+      <AlertNotification
+        message={tableError?.message ?? "Error loading table"}
+        variant="error"
+      />
+    )
+
+  return (
+    <div className="flex size-full flex-col space-y-8">
+      <div className="flex w-full items-center justify-between">
+        <div className="items-start space-y-3 text-left">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  href={`/workspaces/${workspaceId}/tables`}
+                  className="flex items-center"
+                >
+                  <ArrowLeftIcon className="mr-2 size-4" />
+                  Tables
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator>{"/"}</BreadcrumbSeparator>
+              <BreadcrumbItem>
+                <BreadcrumbLink>{table.name}</BreadcrumbLink>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </div>
+        <TableInsertButton />
+      </div>
+      <DatabaseTable table={table} />
+    </div>
+  )
+}

--- a/frontend/src/app/workspaces/[workspaceId]/tables/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/tables/layout.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Suspense } from "react"
+import { useWorkspace } from "@/providers/workspace"
+
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { TablesSidebar } from "@/components/tables/tables-side-nav"
+
+export default function TablesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { workspaceId } = useWorkspace()
+  return (
+    <div className="container grid h-full grid-cols-6 gap-8 py-16">
+      <div className="col-span-1">
+        <TablesSidebar workspaceId={workspaceId} />
+      </div>
+      <div className="no-scrollbar col-span-5 flex size-full flex-col overflow-auto">
+        <Suspense fallback={<CenteredSpinner />}>{children}</Suspense>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/workspaces/[workspaceId]/tables/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/tables/page.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { TablesDashboard } from "@/components/tables/tables-dashboard"
+
+export default function TablesPage() {
+  return (
+    <div className="flex size-full flex-col space-y-12">
+      <div className="flex w-full items-center justify-between">
+        <div className="items-start space-y-3 text-left">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            Database Tables
+          </h2>
+          <p className="text-md text-muted-foreground">
+            View your workspace&apos;s tables here.
+          </p>
+        </div>
+      </div>
+      <TablesDashboard />
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -113,7 +113,7 @@ export function CreateWorkflowButton() {
         <DropdownMenuTrigger asChild>
           <Button
             role="combobox"
-            className="items-center space-x-2 bg-emerald-500 tracking-wide text-white shadow-sm hover:bg-emerald-500"
+            className="items-center space-x-2 bg-emerald-500 text-white shadow-sm hover:bg-emerald-500"
           >
             <span>Create new</span>
             <ChevronDownIcon className="size-4" />

--- a/frontend/src/components/dashboard/workflow-tags-sidebar.tsx
+++ b/frontend/src/components/dashboard/workflow-tags-sidebar.tsx
@@ -435,7 +435,9 @@ function TagItem({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" side="right">
-              <DropdownMenuLabel className="text-xs">Actions</DropdownMenuLabel>
+              <DropdownMenuLabel className="py-0 text-xs text-muted-foreground">
+                Actions
+              </DropdownMenuLabel>
               <DropdownMenuSeparator />
               <AlertDialogTrigger asChild>
                 <DropdownMenuItem

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -3,9 +3,7 @@
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useWorkspace } from "@/providers/workspace"
-import { ConeIcon } from "lucide-react"
 
-import { siteConfig } from "@/config/site"
 import { useTags } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import {
@@ -15,7 +13,6 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
-import { Button } from "@/components/ui/button"
 import { CreateWorkflowButton } from "@/components/dashboard/create-workflow-button"
 import { WorkflowsDashboardTable } from "@/components/dashboard/dashboard-table"
 import { WorkflowTagsSidebar } from "@/components/dashboard/workflow-tags-sidebar"
@@ -77,12 +74,6 @@ export function WorkflowsDashboard() {
               </p>
             </div>
             <div className="ml-auto flex items-center space-x-2">
-              <Link href={siteConfig.links.playbooks} target="_blank">
-                <Button variant="outline" role="combobox" className="space-x-2">
-                  <ConeIcon className="size-4 text-emerald-600" />
-                  <span>Find playbook</span>
-                </Button>
-              </Link>
               <CreateWorkflowButton />
             </div>
           </div>

--- a/frontend/src/components/nav/dynamic-nav.tsx
+++ b/frontend/src/components/nav/dynamic-nav.tsx
@@ -17,6 +17,9 @@ type DynamicNavbarParams = {
 export function DynamicNavbar() {
   const pathname = usePathname()
   const params = useParams<DynamicNavbarParams>()
+  if (!pathname) {
+    return null
+  }
   return <Navbar>{getNavBar(pathname, params)}</Navbar>
 }
 

--- a/frontend/src/components/nav/workspace-nav.tsx
+++ b/frontend/src/components/nav/workspace-nav.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useWorkspace } from "@/providers/workspace"
-import { WorkflowIcon } from "lucide-react"
+import { Table2Icon, WorkflowIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import {
@@ -16,20 +16,33 @@ import { WorkspaceSelector } from "@/components/workspaces/workspace-selector"
 export function WorkspaceNav() {
   const { workspaceId } = useWorkspace()
   const pathname = usePathname()
+  const basePath = `/workspaces/${workspaceId}`
+  const workflowsPath = `${basePath}/workflows`
+  const tablesPath = `${basePath}/tables`
   return (
     <nav className="flex space-x-4 lg:space-x-6">
       <div className="md:min-w-[150px] md:max-w-[200px] lg:min-w-[250px] lg:max-w-[300px]">
         <WorkspaceSelector />
       </div>
       <Link
-        href={`/workspaces/${workspaceId}/workflows`}
+        href={workflowsPath}
         className={cn(
           "flex-cols flex items-center text-sm font-medium text-muted-foreground transition-colors hover:text-primary",
-          pathname.endsWith("/workflows") && "text-primary"
+          pathname === workflowsPath && "text-primary"
         )}
       >
         <WorkflowIcon className="mr-2 size-4" />
         <span>Workflows</span>
+      </Link>
+      <Link
+        href={tablesPath}
+        className={cn(
+          "flex-cols flex items-center text-sm font-medium text-muted-foreground transition-colors hover:text-primary",
+          pathname === tablesPath && "text-primary"
+        )}
+      >
+        <Table2Icon className="mr-2 size-4" />
+        <span>Tables</span>
       </Link>
       <RegistryNavButton />
       <OrganizationNavButton />

--- a/frontend/src/components/tables/table-create-dialog.tsx
+++ b/frontend/src/components/tables/table-create-dialog.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import { ApiError } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { PlusCircle, Trash2Icon } from "lucide-react"
+import { useFieldArray, useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useCreateTable } from "@/lib/hooks"
+import { SqlType } from "@/lib/tables"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const createTableSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(100, "Name cannot exceed 100 characters")
+    .regex(
+      /^[a-zA-Z0-9_]+$/,
+      "Name must contain only letters, numbers, and underscores"
+    ),
+  columns: z.array(
+    z.object({
+      name: z.string().min(1, "Column name is required"),
+      type: z.enum(SqlType),
+    })
+  ),
+})
+
+type CreateTableSchema = z.infer<typeof createTableSchema>
+
+interface SelectItem {
+  label: string
+  value: string
+}
+
+export function CreateTableDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { workspaceId } = useWorkspace()
+  const { createTable, createTableIsPending } = useCreateTable()
+
+  const form = useForm<CreateTableSchema>({
+    resolver: zodResolver(createTableSchema),
+    defaultValues: {
+      name: "",
+      columns: [],
+    },
+  })
+  const { fields, append, remove } = useFieldArray<CreateTableSchema>({
+    control: form.control,
+    name: "columns",
+  })
+
+  const onSubmit = async (data: CreateTableSchema) => {
+    try {
+      await createTable({
+        requestBody: {
+          name: data.name,
+          columns: data.columns,
+        },
+        workspaceId,
+      })
+      onOpenChange(false)
+      form.reset()
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.status === 409) {
+          form.setError("name", {
+            type: "manual",
+            message: "A table with this name already exists",
+          })
+        } else {
+          form.setError("root", {
+            type: "manual",
+            message: error.message,
+          })
+        }
+      } else {
+        form.setError("root", {
+          type: "manual",
+          message:
+            error instanceof Error ? error.message : "Failed to create table",
+        })
+        console.error("Error creating table:", error)
+        return
+      }
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[625px]">
+        <DialogHeader>
+          <DialogTitle>Create New Table</DialogTitle>
+          <DialogDescription>
+            Define your table structure by adding columns and their data types.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Enter table name..."
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Name of the table. Must be unique within the workspace.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="space-y-4">
+              <FormField
+                control={form.control}
+                name="columns"
+                render={() => (
+                  <FormItem>
+                    <FormLabel>Columns</FormLabel>
+                    <FormDescription>
+                      Define the columns of the table.
+                    </FormDescription>
+                    {fields.map((field, index) => (
+                      <div key={field.id} className="flex items-center">
+                        <div className="grid flex-1 grid-cols-3 gap-2">
+                          <FormField
+                            control={form.control}
+                            name={`columns.${index}.name`}
+                            render={({ field }) => (
+                              <FormControl className="col-span-2">
+                                <Input
+                                  placeholder="Enter column name..."
+                                  {...field}
+                                  value={field.value ?? ""}
+                                />
+                              </FormControl>
+                            )}
+                          />
+                          <FormField
+                            control={form.control}
+                            name={`columns.${index}.type`}
+                            render={({ field }) => (
+                              <FormControl className="col-span-1">
+                                <Select
+                                  value={field.value}
+                                  onValueChange={field.onChange}
+                                >
+                                  <SelectTrigger>
+                                    <SelectValue
+                                      placeholder="Select column type"
+                                      className="w-full"
+                                    />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {SqlType.map((type) => (
+                                      <SelectItem key={type} value={type}>
+                                        {type}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </FormControl>
+                            )}
+                          />
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="ml-2"
+                          onClick={() => remove(index)}
+                          aria-label="Remove column"
+                        >
+                          <Trash2Icon className="size-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => append({ name: "", type: SqlType[0] })}
+                className="space-x-2 text-xs"
+                aria-label="Add new column"
+              >
+                <PlusCircle className="mr-2 size-4" />
+                Add Column
+              </Button>
+            </div>
+            <DialogFooter>
+              <Button type="submit" disabled={createTableIsPending}>
+                Create Table
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/tables/table-delete-dialog.tsx
+++ b/frontend/src/components/tables/table-delete-dialog.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { TableReadMinimal } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+
+import { useDeleteTable } from "@/lib/hooks"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Input } from "@/components/ui/input"
+import { toast } from "@/components/ui/use-toast"
+
+export function DeleteTableDialog({
+  table,
+  open,
+  onOpenChange,
+}: {
+  table: TableReadMinimal
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const router = useRouter()
+  const { workspaceId } = useWorkspace()
+  const { deleteTable } = useDeleteTable()
+  const [confirmName, setConfirmName] = useState("")
+  if (!workspaceId) {
+    return null
+  }
+
+  const handleDeleteTable = async () => {
+    if (confirmName !== table.name) {
+      toast({
+        title: "Table name does not match",
+        description: "Please type the exact table name to confirm deletion",
+      })
+      return
+    }
+    try {
+      await deleteTable({
+        tableId: table.id,
+        workspaceId,
+      })
+      onOpenChange(false)
+      router.push(`/workspaces/${workspaceId}/tables`)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Table</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete the table {table.name}? This action
+            cannot be undone.
+          </AlertDialogDescription>
+          <AlertDialogDescription>Table ID: {table.id}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="my-4">
+          <Input
+            placeholder={`Type "${table.name}" to confirm`}
+            value={confirmName}
+            onChange={(e) => setConfirmName(e.target.value)}
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDeleteTable}
+            variant="destructive"
+            disabled={confirmName !== table.name}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/tables/table-edit-dialog.tsx
+++ b/frontend/src/components/tables/table-edit-dialog.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import { ApiError, TableReadMinimal } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2, PlusCircle } from "lucide-react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useUpdateTable } from "@/lib/hooks"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+const updateTableSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(100, "Name cannot exceed 100 characters")
+    .regex(
+      /^[a-zA-Z0-9_]+$/,
+      "Name must contain only letters, numbers, and underscores"
+    ),
+})
+
+type UpdateTableSchema = z.infer<typeof updateTableSchema>
+
+export function TableEditDialog({
+  table,
+  open,
+  onOpenChange,
+}: {
+  table: TableReadMinimal
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { workspaceId } = useWorkspace()
+  const { updateTable, updateTableIsPending } = useUpdateTable()
+
+  const form = useForm<UpdateTableSchema>({
+    resolver: zodResolver(updateTableSchema),
+    defaultValues: {
+      name: "",
+    },
+  })
+
+  const onSubmit = async (data: UpdateTableSchema) => {
+    try {
+      await updateTable({
+        requestBody: data,
+        tableId: table.id,
+        workspaceId,
+      })
+      form.reset()
+      onOpenChange(false)
+    } catch (error) {
+      console.error(error)
+      if (error instanceof ApiError) {
+        if (error.status === 409) {
+          form.setError("name", {
+            message: "A table with this name already exists",
+          })
+        } else {
+          form.setError("root", { message: error.message })
+        }
+      }
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader className="space-y-4">
+          <DialogTitle>Edit Table</DialogTitle>
+          <DialogDescription>Edit the {table.name} table.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="flex items-center gap-2 text-xs">
+                    Name
+                  </FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>The new name for the table.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={updateTableIsPending}>
+                {updateTableIsPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <PlusCircle className="mr-2 size-4" />
+                )}
+                Update Table
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/tables/table-insert-button.tsx
+++ b/frontend/src/components/tables/table-insert-button.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useState } from "react"
+import {
+  BetweenHorizonalStartIcon,
+  BetweenVerticalStartIcon,
+  ChevronDownIcon,
+  FileUpIcon,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { TableInsertColumnDialog } from "@/components/tables/table-insert-column-dialog"
+import { TableInsertRowDialog } from "@/components/tables/table-insert-row-dialog"
+
+type DialogType = "row" | "column" | "csv" | null
+
+export function TableInsertButton() {
+  const [activeDialog, setActiveDialog] = useState<DialogType>(null)
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            role="combobox"
+            className="h-7 items-center space-x-1 bg-emerald-500/80 px-3 py-1 text-xs text-white shadow-sm hover:border-emerald-500 hover:bg-emerald-400/80"
+          >
+            <ChevronDownIcon className="size-3" />
+            <span>Insert</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="flex items-center gap-2"
+            onSelect={() => setActiveDialog("row")}
+          >
+            <BetweenHorizonalStartIcon className="size-4 text-foreground/80" />
+            <div className="flex flex-col text-xs">
+              <span>Insert Row</span>
+              <span className="text-xs text-muted-foreground">
+                Insert a new row into the table
+              </span>
+            </div>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="flex items-center gap-2"
+            onSelect={() => setActiveDialog("column")}
+          >
+            <BetweenVerticalStartIcon className="size-4 text-foreground/80" />
+            <div className="flex flex-col text-xs">
+              <span>Insert Column</span>
+              <span className="text-xs text-muted-foreground">
+                Insert a new column into the table
+              </span>
+            </div>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="flex items-center gap-2"
+            onSelect={() => setActiveDialog("csv")}
+          >
+            <FileUpIcon className="size-4 text-foreground/80" />
+            <div className="flex flex-col text-xs">
+              <span>Add Rows from CSV</span>
+              <span className="text-xs text-muted-foreground">
+                Add rows from a CSV file
+              </span>
+            </div>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <TableInsertRowDialog
+        open={activeDialog === "row"}
+        onOpenChange={() => setActiveDialog(null)}
+      />
+
+      <TableInsertColumnDialog
+        open={activeDialog === "column"}
+        onOpenChange={() => setActiveDialog(null)}
+      />
+
+      <Dialog
+        open={activeDialog === "csv"}
+        onOpenChange={() => setActiveDialog(null)}
+      >
+        <DialogContent>
+          <div>CSV</div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/components/tables/table-insert-column-dialog.tsx
+++ b/frontend/src/components/tables/table-insert-column-dialog.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { ApiError } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2, PlusCircle } from "lucide-react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { TracecatApiError } from "@/lib/errors"
+import { useGetTable, useInsertColumn } from "@/lib/hooks"
+import { SqlType } from "@/lib/tables"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+// Update schema for column creation
+const createInsertTableColumnSchema = z.object({
+  name: z.string().min(1, "Column name is required"),
+  type: z.enum(SqlType),
+})
+
+type ColumnFormData = z.infer<typeof createInsertTableColumnSchema>
+
+export function TableInsertColumnDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { tableId } = useParams<{ tableId: string }>()
+  const { workspaceId } = useWorkspace()
+  const { table } = useGetTable({ tableId, workspaceId })
+  const { insertColumn, insertColumnIsPending, insertColumnError } =
+    useInsertColumn()
+
+  const form = useForm<ColumnFormData>({
+    resolver: zodResolver(createInsertTableColumnSchema),
+    defaultValues: {
+      name: "",
+    },
+  })
+
+  const onSubmit = async (data: ColumnFormData) => {
+    try {
+      await insertColumn({
+        requestBody: data,
+        tableId,
+        workspaceId,
+      })
+      form.reset()
+      onOpenChange(false)
+    } catch (error) {
+      console.error(error)
+      if (error instanceof ApiError) {
+        const apiError = error as TracecatApiError
+        if (apiError.status === 422) {
+          form.setError("type", {
+            message: JSON.stringify(apiError.body.detail, null, 2),
+          })
+        } else if (apiError.status === 409) {
+          form.setError("name", {
+            message: "A column with this name already exists",
+          })
+        } else {
+          form.setError("root", { message: error.message })
+        }
+      }
+    }
+  }
+
+  if (!table) {
+    return null
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Column</DialogTitle>
+          <DialogDescription>
+            Add a new column to the {table.name} table.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Column Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="flex items-center gap-2 text-xs">
+                    <span>Data Type</span>
+                    <span className="text-xs text-muted-foreground">
+                      (required)
+                    </span>
+                  </FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a type..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SqlType.map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {type}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={insertColumnIsPending}>
+                {insertColumnIsPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <PlusCircle className="mr-2 size-4" />
+                )}
+                Add Column
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/tables/table-insert-row-dialog.tsx
+++ b/frontend/src/components/tables/table-insert-row-dialog.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { TableColumnRead, TableRead } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Checkbox } from "@radix-ui/react-checkbox"
+import { Loader2, PlusCircle } from "lucide-react"
+import { ControllerRenderProps, useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useGetTable, useInsertRow } from "@/lib/hooks"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+// Update the schema to be dynamic based on table columns
+const createInsertTableRowSchema = (table: TableRead) => {
+  const columnValidations: Record<string, z.ZodType> = {}
+
+  table.columns.forEach((column) => {
+    // Add validation based on SQL type
+    switch (column.type.toLowerCase()) {
+      case "text":
+      case "varchar":
+      case "char":
+        columnValidations[column.name] = z
+          .string()
+          .min(1, `${column.name} is required`)
+        break
+      case "integer":
+      case "bigint":
+      case "smallint":
+      case "decimal":
+      case "numeric":
+      case "real":
+      case "double precision":
+        columnValidations[column.name] = z
+          .number()
+          .min(-Infinity, `${column.name} must be a number`)
+        break
+      case "boolean":
+        columnValidations[column.name] = z.boolean()
+        break
+      case "date":
+      case "timestamp":
+        columnValidations[column.name] = z.date()
+        break
+      case "json":
+      case "jsonb":
+        columnValidations[column.name] = z.object({}).passthrough()
+        break
+      default:
+        columnValidations[column.name] = z
+          .string()
+          .min(1, `${column.name} is required`)
+    }
+  })
+
+  return z.object(columnValidations)
+}
+
+type DynamicFormData = Record<string, string | number | boolean>
+
+export function TableInsertRowDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { tableId } = useParams<{ tableId: string }>()
+  const { workspaceId } = useWorkspace()
+  const { table } = useGetTable({ tableId, workspaceId })
+  const { insertRow, insertRowIsPending, insertRowError } = useInsertRow()
+
+  // Create form schema once table data is available
+  const schema = table ? createInsertTableRowSchema(table) : z.object({})
+
+  const form = useForm<DynamicFormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {},
+  })
+
+  const onSubmit = async (data: DynamicFormData) => {
+    try {
+      await insertRow({
+        requestBody: {
+          data,
+        },
+        tableId,
+        workspaceId,
+      })
+      onOpenChange(false)
+      form.reset()
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  if (!table) {
+    return null
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add New Row</DialogTitle>
+          <DialogDescription>
+            Add a new row to the {table.name} table.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {table.columns.map((column) => (
+              <FormField
+                key={column.name}
+                control={form.control}
+                name={column.name}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="flex items-center gap-2 text-xs lowercase">
+                      <span className="font-semibold">{column.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {column.type}
+                      </span>
+                    </FormLabel>
+                    <FormControl>
+                      <DynamicInput column={column} field={field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ))}
+            <DialogFooter>
+              <Button type="submit" disabled={insertRowIsPending}>
+                {insertRowIsPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <PlusCircle className="mr-2 size-4" />
+                )}
+                Insert Row
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DynamicInput({
+  column,
+  field,
+}: {
+  column: TableColumnRead
+  field: ControllerRenderProps<DynamicFormData, string>
+}) {
+  switch (column.type.toLowerCase()) {
+    case "boolean":
+      return (
+        <Checkbox
+          checked={field.value as boolean}
+          onCheckedChange={field.onChange}
+        />
+      )
+    case "integer":
+    case "bigint":
+    case "smallint":
+    case "decimal":
+    case "numeric":
+    case "real":
+    case "double precision":
+      return (
+        <Input
+          type="number"
+          value={field.value as number}
+          onChange={(e) => field.onChange(Number(e.target.value))}
+        />
+      )
+    default:
+      return (
+        <Input
+          type="text"
+          value={field.value as string}
+          onChange={(e) => field.onChange(e.target.value)}
+        />
+      )
+  }
+}

--- a/frontend/src/components/tables/table-view-action-delete-dialog.tsx
+++ b/frontend/src/components/tables/table-view-action-delete-dialog.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { TableRowRead } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+import { Row } from "@tanstack/react-table"
+
+import { useDeleteRow } from "@/lib/hooks"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+export function TableViewActionDeleteDialog({
+  row,
+  open,
+  onOpenChange,
+}: {
+  row: Row<TableRowRead>
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { tableId } = useParams<{ tableId?: string }>()
+  const { workspaceId } = useWorkspace()
+  const { deleteRow } = useDeleteRow()
+  if (!tableId || !workspaceId) {
+    return null
+  }
+
+  const handleDeleteRow = async () => {
+    try {
+      await deleteRow({
+        tableId,
+        workspaceId,
+        rowId: row.original.id,
+      })
+      onOpenChange(false)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Row</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete this row from the table? This action
+            cannot be undone.
+          </AlertDialogDescription>
+          <AlertDialogDescription>
+            Row ID: {row.original.id}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleDeleteRow}>
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/tables/table-view-action.tsx
+++ b/frontend/src/components/tables/table-view-action.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import React, { useState } from "react"
+import { TableRowRead } from "@/client"
+import { useAuth } from "@/providers/auth"
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { Row } from "@tanstack/react-table"
+import { CopyIcon, Trash2Icon } from "lucide-react"
+
+import { userIsPrivileged } from "@/lib/auth"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { TableViewActionDeleteDialog } from "@/components/tables/table-view-action-delete-dialog"
+
+type TableViewActionType = "delete" | "insert" | null
+
+export function TableViewAction({ row }: { row: Row<TableRowRead> }) {
+  const { user } = useAuth()
+  const [activeType, setActiveType] = useState<TableViewActionType>(null)
+  const onOpenChange = () => setActiveType(null)
+
+  const isPrivileged = userIsPrivileged(user)
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="size-4 p-0">
+            <span className="sr-only">Open menu</span>
+            <DotsHorizontalIcon className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="py-1 text-xs text-foreground/80"
+            onClick={(e) => {
+              e.stopPropagation()
+              navigator.clipboard.writeText(String(row.original.id))
+            }}
+          >
+            <CopyIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+            Copy ID
+          </DropdownMenuItem>
+          {isPrivileged && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="py-1 text-xs text-destructive"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setActiveType("delete")
+                }}
+              >
+                <Trash2Icon className="mr-2 size-3 group-hover/item:text-destructive" />
+                Delete
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <TableViewActionDeleteDialog
+        row={row}
+        open={activeType === "delete"}
+        onOpenChange={onOpenChange}
+      />
+
+      <TableViewActionDeleteDialog
+        row={row}
+        open={activeType === "delete"}
+        onOpenChange={onOpenChange}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/tables/table-view-column-menu.tsx
+++ b/frontend/src/components/tables/table-view-column-menu.tsx
@@ -1,0 +1,389 @@
+"use client"
+
+import { useState } from "react"
+import { useParams } from "next/navigation"
+import { ApiError, TableColumnRead } from "@/client"
+import { useAuth } from "@/providers/auth"
+import { useWorkspace } from "@/providers/workspace"
+import { zodResolver } from "@hookform/resolvers/zod"
+import {
+  ChevronDownIcon,
+  CopyIcon,
+  Loader2,
+  Pencil,
+  Trash2Icon,
+} from "lucide-react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { userIsPrivileged } from "@/lib/auth"
+import { useDeleteColumn, useUpdateColumn } from "@/lib/hooks"
+import { SqlType } from "@/lib/tables"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+
+type TableViewColumnMenuType = "delete" | "edit" | null
+
+export function TableViewColumnMenu({ column }: { column: TableColumnRead }) {
+  const { user } = useAuth()
+  const { tableId } = useParams<{ tableId?: string }>()
+  const [activeType, setActiveType] = useState<TableViewColumnMenuType>(null)
+  const onOpenChange = () => setActiveType(null)
+  const isPrivileged = userIsPrivileged(user)
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="size-4 p-0 !ring-0">
+            <span className="sr-only">Edit column</span>
+            <ChevronDownIcon className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="py-1 text-xs text-foreground/80"
+            onClick={(e) => {
+              e.stopPropagation()
+              navigator.clipboard.writeText(String(column.id))
+            }}
+          >
+            <CopyIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+            Copy ID
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="py-1 text-xs text-foreground/80"
+            onClick={(e) => {
+              e.stopPropagation()
+              navigator.clipboard.writeText(String(column.name))
+            }}
+          >
+            <CopyIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+            Copy Name
+          </DropdownMenuItem>
+          {isPrivileged && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="py-1 text-xs text-foreground/80"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setActiveType("edit")
+                }}
+              >
+                <Pencil className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="py-1 text-xs text-destructive"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setActiveType("delete")
+                }}
+              >
+                <Trash2Icon className="mr-2 size-3 group-hover/item:text-destructive" />
+                Delete
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <TableColumnDeleteDialog
+        tableId={tableId}
+        column={column}
+        open={activeType === "delete"}
+        onOpenChange={onOpenChange}
+      />
+      <TableColumnEditDialog
+        tableId={tableId}
+        column={column}
+        open={activeType === "edit"}
+        onOpenChange={onOpenChange}
+      />
+    </>
+  )
+}
+
+function TableColumnDeleteDialog({
+  tableId,
+  column,
+  open,
+  onOpenChange,
+}: {
+  tableId?: string
+  column: TableColumnRead
+  open: boolean
+  onOpenChange: () => void
+}) {
+  const { workspaceId } = useWorkspace()
+  const { deleteColumn } = useDeleteColumn()
+  const [confirmName, setConfirmName] = useState("")
+
+  if (!tableId || !workspaceId) {
+    return null
+  }
+
+  const handleDeleteColumn = async () => {
+    if (confirmName !== column.name) {
+      toast({
+        title: "Column name does not match",
+        description: "Please type the exact column name to confirm deletion",
+      })
+      return
+    }
+
+    try {
+      await deleteColumn({
+        tableId,
+        workspaceId,
+        columnId: column.id,
+      })
+      onOpenChange()
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Column</AlertDialogTitle>
+          <AlertDialogDescription>
+            To confirm deletion, type the column name <b>{column.name}</b>{" "}
+            below. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="my-4">
+          <Input
+            placeholder={`Type "${column.name}" to confirm`}
+            value={confirmName}
+            onChange={(e) => setConfirmName(e.target.value)}
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDeleteColumn}
+            variant="destructive"
+            disabled={confirmName !== column.name}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+const updateColumnSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name must be at least 1 character" })
+    .max(255, { message: "Name must be less than 255 characters" })
+    .regex(/^[a-zA-Z0-9_]+$/, {
+      message: "Name must contain only letters, numbers, and underscores",
+    }),
+  type: z.enum(SqlType),
+  nullable: z.boolean(),
+})
+
+type UpdateColumnSchema = z.infer<typeof updateColumnSchema>
+
+function TableColumnEditDialog({
+  tableId,
+  column,
+  open,
+  onOpenChange,
+}: {
+  tableId?: string
+  column: TableColumnRead
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { workspaceId } = useWorkspace()
+  const { updateColumn, updateColumnIsPending } = useUpdateColumn()
+
+  const form = useForm<UpdateColumnSchema>({
+    resolver: zodResolver(updateColumnSchema),
+    defaultValues: {
+      name: column.name,
+      type: column.type,
+      nullable: column.nullable,
+    },
+  })
+
+  if (!tableId || !workspaceId) {
+    return null
+  }
+
+  const onSubmit = async (data: UpdateColumnSchema) => {
+    try {
+      const updates: Partial<UpdateColumnSchema> = {}
+      if (data.name !== column.name) {
+        updates.name = data.name
+      }
+      if (data.type !== column.type) {
+        updates.type = data.type
+      }
+      if (data.nullable !== column.nullable) {
+        updates.nullable = data.nullable
+      }
+
+      await updateColumn({
+        requestBody: updates,
+        tableId,
+        columnId: column.id,
+        workspaceId,
+      })
+      form.reset()
+      onOpenChange(false)
+    } catch (error) {
+      console.error(error)
+      if (error instanceof ApiError) {
+        if (error.status === 409) {
+          form.setError("name", {
+            message: "A column with this name already exists",
+          })
+        } else {
+          form.setError("root", { message: error.message })
+        }
+      }
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader className="space-y-4">
+          <DialogTitle>Edit Column</DialogTitle>
+          <DialogDescription>Edit the {column.name} column.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="flex items-center gap-2 text-xs">
+                    Name
+                  </FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    The new name for the column.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="flex items-center gap-2 text-xs">
+                    Type
+                  </FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a type..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SqlType.map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {type}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormDescription>
+                    The data type for this column.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="nullable"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="flex items-center gap-2">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled
+                      />
+                    </FormControl>
+                    <FormLabel className="text-xs">Allow null values</FormLabel>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={updateColumnIsPending}>
+                {updateColumnIsPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <Pencil className="mr-2 size-4" />
+                )}
+                Update Column
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/tables/table-view.tsx
+++ b/frontend/src/components/tables/table-view.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import React from "react"
+import { useParams } from "next/navigation"
+import { TableColumnRead, TableRead, TableRowRead } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+import { CellContext, ColumnDef } from "@tanstack/react-table"
+
+import { useListRows } from "@/lib/hooks"
+import { DataTable } from "@/components/data-table"
+import { TableViewAction } from "@/components/tables/table-view-action"
+import { TableViewColumnMenu } from "@/components/tables/table-view-column-menu"
+
+export function DatabaseTable({ table: { columns } }: { table: TableRead }) {
+  const { tableId } = useParams<{ tableId: string }>()
+  const { workspaceId } = useWorkspace()
+  const { rows, rowsIsLoading, rowsError } = useListRows({
+    tableId,
+    workspaceId,
+  })
+
+  type CellT = CellContext<TableRowRead, TableColumnRead>
+  const allColumns: ColumnDef<TableRowRead, TableColumnRead>[] = [
+    ...columns.map((column) => ({
+      accessorKey: column.name,
+      header: () => (
+        <div className="flex items-center gap-2 text-xs">
+          <span className="font-semibold text-foreground/90">
+            {column.name}
+          </span>
+          <span className="lowercase text-muted-foreground">{column.type}</span>
+          <TableViewColumnMenu column={column} />
+        </div>
+      ),
+      cell: ({ row }: CellT) => {
+        const value = row.original[column.name as keyof TableRowRead]
+        return (
+          <div className="flex items-center gap-2 text-xs">
+            {typeof value === "object" ? (
+              <pre className="text-xs">{JSON.stringify(value, null, 2)}</pre>
+            ) : (
+              <pre className="text-xs">{String(value)}</pre>
+            )}
+          </div>
+        )
+      },
+      enableSorting: true,
+      enableHiding: true,
+    })),
+    {
+      id: "actions",
+      enableSorting: false,
+      enableHiding: false,
+      cell: ({ row }: CellT) => <TableViewAction row={row} />,
+    },
+  ]
+
+  return (
+    <DataTable<TableRowRead, TableColumnRead>
+      isLoading={rowsIsLoading}
+      error={rowsError ?? undefined}
+      data={rows}
+      emptyMessage="No rows found."
+      errorMessage="Error loading rows."
+      columns={allColumns}
+    />
+  )
+}

--- a/frontend/src/components/tables/tables-dashboard.tsx
+++ b/frontend/src/components/tables/tables-dashboard.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import React, { useCallback } from "react"
+import { useRouter } from "next/navigation"
+import { TableReadMinimal } from "@/client"
+import { useWorkspace } from "@/providers/workspace"
+import { Row } from "@tanstack/react-table"
+
+import { useListTables } from "@/lib/hooks"
+import {
+  DataTable,
+  DataTableColumnHeader,
+  DataTableToolbarProps,
+} from "@/components/data-table"
+
+export function TablesDashboard() {
+  const router = useRouter()
+  const { workspaceId } = useWorkspace()
+  const { tables, tablesIsLoading, tablesError } = useListTables({
+    workspaceId,
+  })
+  const basePath = `/workspaces/${workspaceId}/tables`
+  const handleOnClickRow = useCallback(
+    (row: Row<TableReadMinimal>) => () =>
+      router.push(`${basePath}/${row.original.id}`),
+    [router, basePath]
+  )
+
+  return (
+    <DataTable
+      isLoading={tablesIsLoading}
+      error={tablesError ?? undefined}
+      data={tables}
+      emptyMessage="No tables found."
+      errorMessage="Error loading tables."
+      onClickRow={handleOnClickRow}
+      columns={[
+        {
+          accessorKey: "name",
+          header: ({ column }) => (
+            <DataTableColumnHeader
+              className="text-xs"
+              column={column}
+              title="Name"
+            />
+          ),
+          cell: ({ row }) => (
+            <div className="text-xs text-foreground/80">
+              {row.getValue<TableReadMinimal["name"]>("name")}
+            </div>
+          ),
+          enableSorting: true,
+          enableHiding: false,
+        },
+      ]}
+      toolbarProps={defaultToolbarProps}
+    />
+  )
+}
+
+const defaultToolbarProps: DataTableToolbarProps = {
+  filterProps: {
+    placeholder: "Search tables...",
+    column: "name",
+  },
+}

--- a/frontend/src/components/tables/tables-side-nav.tsx
+++ b/frontend/src/components/tables/tables-side-nav.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import { useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { TableReadMinimal } from "@/client"
+import { useAuth } from "@/providers/auth"
+import {
+  CopyIcon,
+  EllipsisIcon,
+  PencilIcon,
+  Plus,
+  Table2Icon,
+  Trash2Icon,
+} from "lucide-react"
+
+import { userIsPrivileged } from "@/lib/auth"
+import { useListTables } from "@/lib/hooks"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { CreateTableDialog } from "@/components/tables/table-create-dialog"
+import { DeleteTableDialog } from "@/components/tables/table-delete-dialog"
+import { TableEditDialog } from "@/components/tables/table-edit-dialog"
+
+export function TablesSidebar({ workspaceId }: { workspaceId: string }) {
+  const router = useRouter()
+  const { tables, tablesIsLoading, tablesError } = useListTables({
+    workspaceId,
+  })
+  const [showTableDialog, setShowTableDialog] = useState(false)
+  const { tableId: selectedTableId } = useParams<{ tableId?: string }>()
+
+  if (tablesIsLoading || tablesError) return null
+
+  return (
+    <div className="shrink-0 overflow-auto rounded-lg text-muted-foreground">
+      <div className="sticky top-0 flex items-center justify-between bg-background p-2">
+        <h2 className="text-xs font-semibold text-muted-foreground">Tables</h2>
+        <div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={() => setShowTableDialog(true)}
+          >
+            <Plus className="size-4" />
+            <span className="sr-only">Add table</span>
+          </Button>
+        </div>
+      </div>
+      <div className="flex h-full flex-col space-y-1 p-2">
+        {tables && tables.length > 0 ? (
+          tables.map((table) => (
+            <TableItem
+              key={table.id}
+              table={table}
+              selectedTableId={selectedTableId}
+              onSelect={() => {
+                router.push(`/workspaces/${workspaceId}/tables/${table.id}`)
+              }}
+            />
+          ))
+        ) : (
+          <div className="flex aspect-square h-full items-center justify-center rounded-lg border border-dashed border-muted-foreground/25 bg-muted-foreground/5 p-8">
+            <div className="text-center text-xs text-muted-foreground/60">
+              Create a table to get started
+            </div>
+          </div>
+        )}
+      </div>
+      <CreateTableDialog
+        open={showTableDialog}
+        onOpenChange={setShowTableDialog}
+      />
+    </div>
+  )
+}
+type TableSideNavActionType = "edit" | "delete" | null
+
+function TableItem({
+  table,
+  selectedTableId,
+  onSelect,
+}: {
+  table: TableReadMinimal
+  selectedTableId?: string
+  onSelect: (table: TableReadMinimal) => void
+}) {
+  const { user } = useAuth()
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [activeType, setActiveType] = useState<TableSideNavActionType>(null)
+  const onOpenChange = () => setActiveType(null)
+  const isSelected = selectedTableId === table.id
+  const isPrivileged = userIsPrivileged(user)
+  return (
+    <>
+      <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+        <div className="group relative">
+          <div
+            onClick={() => onSelect(table)}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-1 text-sm hover:cursor-pointer hover:bg-accent hover:text-accent-foreground",
+              (isSelected || isDropdownOpen) &&
+                "bg-accent text-accent-foreground"
+            )}
+          >
+            <Table2Icon
+              className={cn(
+                "mr-2 size-3.5 shrink-0 text-muted-foreground/70",
+                isSelected && "text-accent-foreground"
+              )}
+            />
+            <span className="min-w-0 flex-1 truncate">{table.name}</span>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className={cn(
+                  "absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1",
+                  "opacity-0 group-hover:opacity-100",
+                  isDropdownOpen && "opacity-100",
+                  "hover:bg-transparent focus:ring-0 focus-visible:ring-0"
+                )}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <EllipsisIcon className="size-3 text-muted-foreground" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" side="right">
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation()
+                  navigator.clipboard.writeText(table.name)
+                }}
+                className="py-1 text-xs text-foreground/80"
+              >
+                <CopyIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+                Copy Name
+              </DropdownMenuItem>
+              {isPrivileged && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setActiveType("edit")
+                    }}
+                    className="py-1 text-xs text-foreground/80"
+                  >
+                    <PencilIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+                    Edit
+                  </DropdownMenuItem>
+
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="py-1 text-xs text-destructive/80"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setActiveType("delete")
+                    }}
+                  >
+                    <Trash2Icon className="mr-2 size-3 group-hover/item:text-destructive" />
+                    Delete
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </div>
+        </div>
+      </DropdownMenu>
+      <TableEditDialog
+        table={table}
+        open={activeType === "edit"}
+        onOpenChange={onOpenChange}
+      />
+      <DeleteTableDialog
+        table={table}
+        open={activeType === "delete"}
+        onOpenChange={onOpenChange}
+      />
+    </>
+  )
+}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -74,6 +74,32 @@ import {
   SettingsUpdateOauthSettingsData,
   settingsUpdateSamlSettings,
   SettingsUpdateSamlSettingsData,
+  TableRead,
+  TableReadMinimal,
+  TableRowRead,
+  tablesCreateColumn,
+  TablesCreateColumnData,
+  tablesCreateTable,
+  TablesCreateTableData,
+  TablesCreateTableResponse,
+  tablesDeleteColumn,
+  TablesDeleteColumnData,
+  tablesDeleteRow,
+  TablesDeleteRowData,
+  tablesDeleteTable,
+  TablesDeleteTableData,
+  tablesGetTable,
+  TablesGetTableData,
+  tablesInsertRow,
+  TablesInsertRowData,
+  tablesListRows,
+  TablesListRowsData,
+  tablesListTables,
+  TablesListTablesData,
+  tablesUpdateColumn,
+  TablesUpdateColumnData,
+  tablesUpdateTable,
+  TablesUpdateTableData,
   TagRead,
   tagsCreateTag,
   TagsCreateTagData,
@@ -1858,5 +1884,304 @@ export function useOrgOAuthSettings() {
     updateOAuthSettings,
     updateOAuthSettingsIsPending,
     updateOAuthSettingsError,
+  }
+}
+
+export function useListTables({ workspaceId }: TablesListTablesData) {
+  const {
+    data: tables,
+    isLoading: tablesIsLoading,
+    error: tablesError,
+  } = useQuery<TableReadMinimal[], ApiError>({
+    queryKey: ["tables", workspaceId],
+    queryFn: async () => await tablesListTables({ workspaceId }),
+  })
+
+  return {
+    tables,
+    tablesIsLoading,
+    tablesError,
+  }
+}
+
+export function useGetTable({ tableId, workspaceId }: TablesGetTableData) {
+  const {
+    data: table,
+    isLoading: tableIsLoading,
+    error: tableError,
+  } = useQuery<TableRead, ApiError>({
+    queryKey: ["table", tableId],
+    queryFn: async () => await tablesGetTable({ tableId, workspaceId }),
+  })
+
+  return {
+    table,
+    tableIsLoading,
+    tableError,
+  }
+}
+
+export function useCreateTable() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: createTable,
+    isPending: createTableIsPending,
+    error: createTableError,
+  } = useMutation<
+    TablesCreateTableResponse,
+    TracecatApiError,
+    TablesCreateTableData
+  >({
+    mutationFn: async (params: TablesCreateTableData) =>
+      await tablesCreateTable(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["tables", variables.workspaceId],
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      switch (error.status) {
+        case 403:
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+          break
+        default:
+          console.error("Error creating table", error)
+          break
+      }
+    },
+  })
+
+  return {
+    createTable,
+    createTableIsPending,
+    createTableError,
+  }
+}
+
+export function useUpdateTable() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: updateTable,
+    isPending: updateTableIsPending,
+    error: updateTableError,
+  } = useMutation({
+    mutationFn: async (params: TablesUpdateTableData) =>
+      await tablesUpdateTable(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["tables", variables.workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["table", variables.tableId],
+      })
+    },
+  })
+
+  return {
+    updateTable,
+    updateTableIsPending,
+    updateTableError,
+  }
+}
+
+export function useDeleteTable() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: deleteTable,
+    isPending: deleteTableIsPending,
+    error: deleteTableError,
+  } = useMutation({
+    mutationFn: async (params: TablesDeleteTableData) =>
+      await tablesDeleteTable(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["tables", variables.workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["table", variables.tableId],
+      })
+    },
+  })
+
+  return {
+    deleteTable,
+    deleteTableIsPending,
+    deleteTableError,
+  }
+}
+
+export function useListRows({ tableId, workspaceId }: TablesListRowsData) {
+  const {
+    data: rows,
+    isLoading: rowsIsLoading,
+    error: rowsError,
+  } = useQuery<TableRowRead[], TracecatApiError>({
+    queryKey: ["rows", tableId],
+    queryFn: async () => await tablesListRows({ tableId, workspaceId }),
+  })
+
+  return {
+    rows,
+    rowsIsLoading,
+    rowsError,
+  }
+}
+
+export function useInsertColumn() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: insertColumn,
+    isPending: insertColumnIsPending,
+    error: insertColumnError,
+  } = useMutation({
+    mutationFn: async (params: TablesCreateColumnData) =>
+      await tablesCreateColumn(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["tables", variables.workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["table", variables.tableId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["rows", variables.tableId],
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      switch (error.status) {
+        case 403:
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+          break
+        default:
+          console.error("Error inserting column", error)
+          break
+      }
+    },
+  })
+
+  return {
+    insertColumn,
+    insertColumnIsPending,
+    insertColumnError,
+  }
+}
+
+export function useUpdateColumn() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: updateColumn,
+    isPending: updateColumnIsPending,
+    error: updateColumnError,
+  } = useMutation({
+    mutationFn: async (params: TablesUpdateColumnData) =>
+      await tablesUpdateColumn(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["rows", variables.tableId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["table", variables.tableId],
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      switch (error.status) {
+        case 403:
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+          break
+        default:
+          console.error("Error updating column", error)
+          break
+      }
+    },
+  })
+
+  return {
+    updateColumn,
+    updateColumnIsPending,
+    updateColumnError,
+  }
+}
+
+export function useDeleteColumn() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: deleteColumn,
+    isPending: deleteColumnIsPending,
+    error: deleteColumnError,
+  } = useMutation({
+    mutationFn: async (params: TablesDeleteColumnData) =>
+      await tablesDeleteColumn(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["rows", variables.tableId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["table", variables.tableId],
+      })
+    },
+  })
+
+  return {
+    deleteColumn,
+    deleteColumnIsPending,
+    deleteColumnError,
+  }
+}
+
+export function useInsertRow() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: insertRow,
+    isPending: insertRowIsPending,
+    error: insertRowError,
+  } = useMutation({
+    mutationFn: async (params: TablesInsertRowData) =>
+      await tablesInsertRow(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["rows", variables.tableId],
+      })
+    },
+  })
+
+  return {
+    insertRow,
+    insertRowIsPending,
+    insertRowError,
+  }
+}
+
+export function useDeleteRow() {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: deleteRow,
+    isPending: deleteRowIsPending,
+    error: deleteRowError,
+  } = useMutation({
+    mutationFn: async (params: TablesDeleteRowData) =>
+      await tablesDeleteRow(params),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["rows", variables.tableId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["table", variables.tableId],
+      })
+    },
+  })
+
+  return {
+    deleteRow,
+    deleteRowIsPending,
+    deleteRowError,
   }
 }

--- a/frontend/src/lib/tables.ts
+++ b/frontend/src/lib/tables.ts
@@ -1,0 +1,3 @@
+import { $tracecat__tables__enums__SqlType__1 } from "@/client"
+
+export const SqlType = $tracecat__tables__enums__SqlType__1.enum


### PR DESCRIPTION
# Description
- Implement tables UI. We can now CRUD tables, columns, and rows from the UI.
- Remove "Find Playbook" button from workflows dashboard. Closes #886
- Added null check in `DynamicNav` if pathname is falsy. Hoping this addresses `Cannot read property 'useContext' of null` type of errors