### PR TITLE
chore(infra): Increase defaults for api_cpu to 1024 and api_memory to 2048

### DIFF
--- a/deployments/aws/ecs/variables.tf
+++ b/deployments/aws/ecs/variables.tf
@@ -296,12 +296,12 @@ variable "remote_repository_url" {
 
 variable "api_cpu" {
   type    = string
-  default = "512"
+  default = "1024"
 }
 
 variable "api_memory" {
   type    = string
-  default = "1024"
+  default = "2048"
 }
 
 variable "worker_cpu" {

--- a/deployments/aws/variables.tf
+++ b/deployments/aws/variables.tf
@@ -265,12 +265,12 @@ variable "remote_repository_url" {
 
 variable "api_cpu" {
   type    = string
-  default = "512"
+  default = "1024"
 }
 
 variable "api_memory" {
   type    = string
-  default = "1024"
+  default = "2048"
 }
 
 variable "worker_cpu" {


### PR DESCRIPTION
In cloud, UI appears very sluggish because API service is only using 0.5vCPU and 1GB mem. Doubling this makes the UI appear more responsive as data loads faster.

This should also help avoiding timeouts during repo sync (likely caused by resource constraints)