### PR TITLE
feat(integrations): Add URLScan template with polling

### DIFF
--- a/registry/tracecat_registry/templates/detect/lookup_url/urlscan.yml
+++ b/registry/tracecat_registry/templates/detect/lookup_url/urlscan.yml
@@ -1,0 +1,41 @@
+type: action
+definition:
+  title: Lookup URL
+  description: Lookup a URL using URLScan.
+  display_group: URLScan
+  doc_url: https://urlscan.io/docs/api/
+  name: lookup_url
+  namespace: tools.urlscan
+  secrets:
+    - name: urlscan
+      keys:
+        - URLSCAN_API_KEY
+  expects:
+    url:
+      type: str
+      description: URL to lookup.
+    visibility:
+      type: str
+      description: Visibility of the scan.
+      default: private
+  steps:
+    - ref: scan_url
+      action: core.http_request
+      args:
+        url: https://urlscan.io/api/v1/scan/
+        method: POST
+        headers:
+          API-key: ${{ SECRETS.urlscan.URLSCAN_API_KEY }}
+        payload:
+          url: ${{ inputs.url }}
+          visibility: ${{ inputs.visibility }}
+    - ref: get_scan_result
+      action: core.http_polling
+      args:
+        url: https://urlscan.io/api/v1/result/${{ steps.scan_url.result.data.uuid }}
+        method: GET
+        headers:
+          API-key: ${{ SECRETS.urlscan.URLSCAN_API_KEY }}
+        poll_retry_codes:
+          - 400
+  returns: ${{ steps.get_scan_result.result }}

--- a/registry/tracecat_registry/templates/detect/lookup_url/urlscan.yml
+++ b/registry/tracecat_registry/templates/detect/lookup_url/urlscan.yml
@@ -30,12 +30,12 @@ definition:
           url: ${{ inputs.url }}
           visibility: ${{ inputs.visibility }}
     - ref: get_scan_result
-      action: core.http_polling
+      action: core.http_poll
       args:
         url: https://urlscan.io/api/v1/result/${{ steps.scan_url.result.data.uuid }}
         method: GET
         headers:
           API-key: ${{ SECRETS.urlscan.URLSCAN_API_KEY }}
         poll_retry_codes:
-          - 400
+          - 404
   returns: ${{ steps.get_scan_result.result }}


### PR DESCRIPTION
## What changed
With the introduction of #810 we can only easily implement async POST query then GET poll until result complete integrations. URLScan is one such canonical example.

<img width="701" alt="Screenshot 2025-02-23 at 11 03 12 PM" src="https://github.com/user-attachments/assets/fab7c814-f577-45ec-a38e-71621fb8e4b3" />
