### PR TITLE
fix(app): Try fix first execution no load bug again

### DIFF
--- a/frontend/src/components/workbench/events/events-sidebar.tsx
+++ b/frontend/src/components/workbench/events/events-sidebar.tsx
@@ -80,15 +80,27 @@ function WorkbenchSidebarEventsList({
   const { execution, executionIsLoading, executionError } =
     useCompactWorkflowExecution(lastExecution?.id)
 
-  if (lastExecutionIsLoading || executionIsLoading) return <CenteredSpinner />
-  if (lastExecutionError || executionError)
+  // Show loading state if either query is loading
+  if (lastExecutionIsLoading || (lastExecution?.id && executionIsLoading)) {
+    return <CenteredSpinner />
+  }
+
+  // Only show error if we have a real error (not just missing execution)
+  if (lastExecutionError || (lastExecution?.id && executionError)) {
     return (
       <AlertNotification
         level="error"
-        message={`Error loading execution: ${lastExecutionError?.message || executionError?.message || "Error loading last execution"}`}
+        message={`Error loading execution: ${
+          lastExecutionError?.message ||
+          executionError?.message ||
+          "Error loading last execution"
+        }`}
       />
     )
-  if (!execution)
+  }
+
+  // Show empty state if we have no execution data
+  if (!lastExecution || !execution) {
     return (
       <EventsSidebarEmpty
         title="No workflow runs"
@@ -96,6 +108,7 @@ function WorkbenchSidebarEventsList({
         actionLabel="New workflow"
       />
     )
+  }
 
   const tabItems = [
     {


### PR DESCRIPTION
Instead of trying to use a timer, we eagerly set the query data with only the important fields (and the rest filler info). Then we force refetch the queries.