### PR TITLE
chore(functions)!: Drop non-python lambda `core.transform` actions

### DIFF
--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -21,13 +21,10 @@ Core action namespaces are prefixed with `core.`.
 | core.transform | apply | - |
 | core.transform | deduplicate | - |
 | core.transform | filter | - |
-| core.transform | flatten | - |
 | core.transform | is_in | - |
 | core.transform | is_not_in | - |
 | core.transform | map | - |
-| core.transform | merge | - |
 | core.transform | reshape | - |
-| core.transform | unique | - |
 | core.workflow | execute | - |
 
 ## Integrations

--- a/registry/tracecat_registry/base/core/transform.py
+++ b/registry/tracecat_registry/base/core/transform.py
@@ -3,7 +3,6 @@ from builtins import map as map_
 from typing import Annotated, Any
 
 from tracecat.expressions.common import build_safe_lambda, eval_jsonpath
-from tracecat.expressions.functions import flatten as flatten_
 from typing_extensions import Doc
 
 from tracecat_registry import registry
@@ -109,38 +108,6 @@ def is_not_in(
 
 
 @registry.register(
-    default_title="Flatten",
-    description="Flatten a list of lists into a single list.",
-    display_group="Data Transform",
-    namespace="core.transform",
-)
-def flatten(
-    items: Annotated[
-        list[list[Any]],
-        Doc("List of lists to flatten."),
-    ],
-) -> list[Any]:
-    return flatten_(items)
-
-
-@registry.register(
-    default_title="Unique",
-    description="Remove duplicate items from a list. Items must be hashable.",
-    display_group="Data Transform",
-    namespace="core.transform",
-)
-def unique(
-    items: Annotated[
-        list[Any],
-        Doc(
-            "List of hashable items (e.g. strings, numbers) to remove duplicates from."
-        ),
-    ],
-) -> list[Any]:
-    return list(set(items))
-
-
-@registry.register(
     default_title="Deduplicate",
     description="Deduplicate list of JSON objects given a list of keys.",
     display_group="Data Transform",
@@ -216,17 +183,3 @@ def map(
 ) -> list[Any]:
     fn = build_safe_lambda(python_lambda)
     return list(map_(fn, items))
-
-
-@registry.register(
-    default_title="Merge JSON objects",
-    description="Merge two JSON objects into a single JSON object.",
-    display_group="Data Transform",
-    namespace="core.transform",
-)
-def merge(
-    left: Annotated[dict[str, Any], Doc("Left JSON object")],
-    right: Annotated[dict[str, Any], Doc("Right JSON object")],
-) -> dict[str, Any]:
-    """Merge two JSON objects into a single JSON object."""
-    return {**left, **right}

--- a/tests/registry/test_core_transform.py
+++ b/tests/registry/test_core_transform.py
@@ -8,7 +8,6 @@ from tracecat_registry.base.core.transform import (
     is_in,
     is_not_in,
     map,
-    unique,
 )
 
 
@@ -227,17 +226,6 @@ def test_is_not_in(
     """Test filtering items not in the collection."""
     result = is_not_in(items, collection, python_lambda)
     assert result == expected
-
-
-@pytest.mark.parametrize(
-    "items,expected",
-    [
-        ([1, 2, 3, 2, 1], [1, 2, 3]),
-        (["a", "b", "b", "c"], ["a", "b", "c"]),
-    ],
-)
-def test_unique(items: list[Any], expected: list[Any]) -> None:
-    assert sorted(unique(items)) == sorted(expected)
 
 
 @pytest.mark.parametrize(

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -312,7 +312,7 @@ def flatten(iterables: Sequence[Sequence[Any]]) -> list[Any]:
 
 
 def unique(items: Sequence[Any]) -> list[Any]:
-    """Return unique items from sequence."""
+    """List of hashable items (e.g. strings, numbers) to remove duplicates from."""
     return list(set(items))
 
 


### PR DESCRIPTION
For consistency, we only have transforms as actions IF it requires python lambda:
- `core.transform.merge`, `core.transform.flatten` and `core.transform.unique` violate this.
- In templates, I always go for `FN.flatten` and `FN.merge`