### PR TITLE
fix(engine): Use UDF for table actions

### DIFF
--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -5,21 +5,15 @@ from typing import Any
 
 import dateparser
 from pydantic import BaseModel
-from sqlalchemy.exc import DBAPIError
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from tracecat.contexts import ctx_logger, ctx_run
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.dsl.common import RunTableInsertRowArgs, RunTableLookupArgs
-from tracecat.dsl.enums import CoreActions
 from tracecat.dsl.models import ActionErrorInfo, ActionStatement, RunActionInput
 from tracecat.executor.client import ExecutorClient
-from tracecat.expressions.eval import eval_templated_object
 from tracecat.logger import logger
 from tracecat.registry.actions.models import RegistryActionValidateResponse
-from tracecat.tables.models import TableRowInsert
-from tracecat.tables.service import TablesService
 from tracecat.types.auth import Role
 from tracecat.types.exceptions import ExecutorClientError, RegistryError
 from tracecat.validation.service import validate_registry_action_args
@@ -109,43 +103,8 @@ class DSLActivities:
             retry_policy=task.retry_policy,
         )
         try:
-            if task.action == CoreActions.TABLE_LOOKUP:
-                # Do a table lookup
-                resolved_args = eval_templated_object(
-                    task.args, operand=input.exec_context
-                )
-                args = RunTableLookupArgs.model_validate(resolved_args)
-                async with TablesService.with_session(role=role) as service:
-                    rows = await service.lookup_row(
-                        table_name=args.table,
-                        columns=[args.column],
-                        values=[args.value],
-                    )
-                return rows[0] if rows else None
-            elif task.action == CoreActions.TABLE_INSERT_ROW:
-                args = RunTableInsertRowArgs.model_validate(task.args)
-                params = TableRowInsert(data=args.row_data)
-                async with TablesService.with_session(role=role) as service:
-                    table = await service.get_table_by_name(args.table)
-                    row = await service.insert_row(table=table, params=params)
-                return row
-            else:
-                # Run other actions in the executor
-                client = ExecutorClient(role=role)
-                return await client.run_action_memory_backend(input)
-        except DBAPIError as e:
-            # We only expect DBAPIError to be raised from the tables service
-            kind = e.__class__.__name__
-            msg = str(e)
-            act_logger.error("Database exception occurred", error=msg, detail=e.detail)
-            err_info = ActionErrorInfo(
-                ref=task.ref,
-                message=msg,
-                type=kind,
-                attempt=attempt,
-            )
-            err_msg = err_info.format("run_action")
-            raise ApplicationError(err_msg, err_info, type=kind) from e
+            client = ExecutorClient(role=role)
+            return await client.run_action_memory_backend(input)
         except ExecutorClientError as e:
             # We only expect ExecutorClientError to be raised from the executor client
             kind = e.__class__.__name__

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -299,17 +299,6 @@ class ChildWorkflowMemo(BaseModel):
             raise e
 
 
-class RunTableLookupArgs(BaseModel):
-    table: str
-    column: str
-    value: Any
-
-
-class RunTableInsertRowArgs(BaseModel):
-    table: str
-    row_data: dict[str, Any]
-
-
 AdjDst = tuple[str, EdgeType]
 
 

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -10,13 +10,7 @@ from tracecat_registry import RegistrySecret
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import RegistryAction
-from tracecat.dsl.common import (
-    DSLInput,
-    ExecuteChildWorkflowArgs,
-    RunTableInsertRowArgs,
-    RunTableLookupArgs,
-    context_locator,
-)
+from tracecat.dsl.common import DSLInput, ExecuteChildWorkflowArgs, context_locator
 from tracecat.dsl.enums import CoreActions
 from tracecat.expressions.common import ExprType
 from tracecat.expressions.eval import extract_expressions, is_template_only
@@ -169,10 +163,6 @@ async def validate_registry_action_args(
         try:
             if action_name == CoreActions.CHILD_WORKFLOW_EXECUTE:
                 validated = ExecuteChildWorkflowArgs.model_validate(args)
-            elif action_name == CoreActions.TABLE_LOOKUP:
-                validated = RunTableLookupArgs.model_validate(args)
-            elif action_name == CoreActions.TABLE_INSERT_ROW:
-                validated = RunTableInsertRowArgs.model_validate(args)
             else:
                 service = RegistryActionsService(session)
                 action = await service.get_action(action_name=action_name)


### PR DESCRIPTION
- Tables weren't working with loops
- Fix incorrect type `str` for value field
- Remove special treatment for core.tables actions, treat as UDF. we just use TablesService directly from tracecat_registry