### PR TITLE
feat(core)! Rename exprs to conditions in `core.require` node

### DIFF
--- a/registry/tracecat_registry/base/core/require.py
+++ b/registry/tracecat_registry/base/core/require.py
@@ -11,26 +11,26 @@ from tracecat_registry import registry
     namespace="core",
 )
 def require(
-    exprs: Annotated[
+    conditions: Annotated[
         Any | list[Any],
         Doc(
             "Conditional expression(s) to evaluate. All must be true for the result to be true."
         ),
     ],
 ) -> bool:
-    if not isinstance(exprs, list):
-        exprs = [exprs]
+    if not isinstance(conditions, list):
+        conditions = [conditions]
 
-    if not all(isinstance(expr, bool) for expr in exprs):
+    if not all(isinstance(condition, bool) for condition in conditions):
         raise ValueError(
-            "All expressions must evaluate to a boolean. Got types: "
-            + ", ".join(type(expr).__name__ for expr in exprs)
+            "All conditions must evaluate to a boolean. Got types: "
+            + ", ".join(type(condition).__name__ for condition in conditions)
         )
 
-    if not all(exprs):
+    if not all(conditions):
         raise AssertionError(
-            "All expressions must evaluate to true. Got values: "
-            + ", ".join(str(expr) for expr in exprs)
+            "All conditions must evaluate to true. Got values: "
+            + ", ".join(str(condition) for condition in conditions)
         )
 
     return True

--- a/tests/registry/test_core_require.py
+++ b/tests/registry/test_core_require.py
@@ -7,25 +7,25 @@ from tracecat_registry.base.core.require import require
 
 
 @pytest.mark.parametrize(
-    "exprs",
+    "conditions",
     [
         True,
         [True, True],
         [True, True, True],
     ],
 )
-def test_require_all(exprs):
-    assert require(exprs) is True
+def test_require_all(conditions):
+    assert require(conditions) is True
 
 
 @pytest.mark.parametrize(
-    "exprs",
+    "conditions",
     [
         False,
         [True, False],
         [False, True],
     ],
 )
-def test_require_all_fail(exprs):
+def test_require_all_fail(conditions):
     with pytest.raises(AssertionError):
-        require(exprs)
+        require(conditions)


### PR DESCRIPTION
## Why
`conditions` is a more human-readable and meaningful name. Easier to understand when reading a template file.