### PR TITLE
refactor(ui): Lift up workflowId parsing outside of WorkflowProvider

### DIFF
--- a/frontend/src/app/workspaces/layout.tsx
+++ b/frontend/src/app/workspaces/layout.tsx
@@ -22,36 +22,61 @@ export default function WorkspaceLayout({
 }) {
   const { workspaces, workspacesLoading, workspacesError } =
     useWorkspaceManager()
-  const { workspaceId } = useParams<{ workspaceId?: string }>()
+  const params = useParams<{ workspaceId?: string; workflowId?: string }>()
+  const { workspaceId, workflowId } = params
   if (workspacesLoading) {
     return <CenteredSpinner />
   }
   if (workspacesError || !workspaces) {
     throw workspacesError
   }
-  let wsId: string
+  let selectedWorkspaceId: string
   if (workspaceId) {
-    wsId = workspaceId
+    selectedWorkspaceId = workspaceId
   } else if (workspaces.length > 0) {
-    wsId = workspaces[0].id
+    selectedWorkspaceId = workspaces[0].id
   } else {
     return <NoWorkspaces />
   }
 
   return (
-    <WorkspaceProvider workspaceId={wsId}>
-      <WorkflowProvider workspaceId={wsId}>
-        <ReactFlowProvider>
-          <WorkflowBuilderProvider>
-            <div className="no-scrollbar flex h-screen max-h-screen flex-col overflow-hidden">
-              {/* DynamicNavbar needs a WorkflowProvider and a WorkspaceProvider */}
-              <DynamicNavbar />
-              <div className="grow overflow-auto">{children}</div>
-            </div>
-          </WorkflowBuilderProvider>
-        </ReactFlowProvider>
-      </WorkflowProvider>
+    <WorkspaceProvider workspaceId={selectedWorkspaceId}>
+      {workflowId ? (
+        <WorkflowView workspaceId={selectedWorkspaceId} workflowId={workflowId}>
+          <WorkspaceChildren>{children}</WorkspaceChildren>
+        </WorkflowView>
+      ) : (
+        <WorkspaceChildren>{children}</WorkspaceChildren>
+      )}
     </WorkspaceProvider>
+  )
+}
+
+function WorkspaceChildren({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="no-scrollbar flex h-screen max-h-screen flex-col overflow-hidden">
+      {/* DynamicNavbar needs a WorkflowProvider and a WorkspaceProvider */}
+      <DynamicNavbar />
+      <div className="grow overflow-auto">{children}</div>
+    </div>
+  )
+}
+
+function WorkflowView({
+  children,
+  workspaceId,
+  workflowId,
+}: {
+  children: React.ReactNode
+  workspaceId: string
+  workflowId: string
+}) {
+  return (
+    <WorkflowProvider workspaceId={workspaceId} workflowId={workflowId}>
+      <ReactFlowProvider>
+        <WorkflowBuilderProvider>{children}</WorkflowBuilderProvider>
+      </ReactFlowProvider>
+    </WorkflowProvider>
   )
 }
 

--- a/frontend/src/providers/workflow.tsx
+++ b/frontend/src/providers/workflow.tsx
@@ -9,7 +9,6 @@ import React, {
   useEffect,
   useState,
 } from "react"
-import { useParams } from "next/navigation"
 import {
   ApiError,
   RegistryActionValidateResponse,
@@ -60,14 +59,15 @@ const WorkflowContext = createContext<WorkflowContextType | undefined>(
 )
 
 export function WorkflowProvider({
+  workflowId,
   workspaceId,
   children,
 }: {
+  workflowId: string
   workspaceId: string
   children: ReactNode
 }) {
   const queryClient = useQueryClient()
-  const { workflowId } = useParams<{ workflowId: string }>()
   const [validationErrors, setValidationErrors] = useState<
     RegistryActionValidateResponse[] | null
   >(null)


### PR DESCRIPTION
Hoping this fixes the issue where useParams tries to read `property null of useContext`. I've noticed that this often happens most when we go back from the builder view to workspaces (when workspaceId suddenly becomes null). This does only happen in dev mode but it's net positive change.