### PR TITLE
fix(ui): Add error handling for duplicate workflow alias

### DIFF
--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -20,11 +20,23 @@ export function retryHandler(failureCount: number, error: ApiError) {
  * Type for request validation errors
  * Returned with 422 status code
  */
-export type RequestValidationError = {
+export interface RequestValidationError {
   loc: string[]
   ctx: {
     [key: string]: unknown
   }
   msg: string
   type: string
+}
+
+export function isRequestValidationError(
+  obj: unknown
+): obj is RequestValidationError {
+  return typeof obj === "object" && obj !== null && "loc" in obj && "msg" in obj
+}
+
+export function isRequestValidationErrorArray(
+  obj: unknown
+): obj is RequestValidationError[] {
+  return Array.isArray(obj) && obj.every((o) => isRequestValidationError(o))
 }

--- a/frontend/src/providers/workflow.tsx
+++ b/frontend/src/providers/workflow.tsx
@@ -27,6 +27,7 @@ import {
 } from "@tanstack/react-query"
 import { AlertTriangleIcon } from "lucide-react"
 
+import { TracecatApiError } from "@/lib/errors"
 import { toast } from "@/components/ui/use-toast"
 
 type WorkflowContextType = {
@@ -147,15 +148,25 @@ export function WorkflowProvider({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
     },
-    onError: (error: ApiError) => {
+    onError: (error: TracecatApiError) => {
       console.error("Failed to update workflow:", error)
-      toast({
-        title: "Error updating workflow",
-        description:
-          (error.body as TracecatErrorMessage).message ||
-          "Could not update workflow. Please try again.",
-        variant: "destructive",
-      })
+      switch (error.status) {
+        case 409:
+          toast({
+            title: "Failed to update workflow",
+            description:
+              String(error.body.detail) ||
+              "There was a conflict updating the workflow. Please try again.",
+          })
+          break
+        default:
+          toast({
+            title: "Failed to update workflow",
+            description:
+              String(error.body.detail) ||
+              "Could not update workflow. Please the logs for more details.",
+          })
+      }
     },
   })
 

--- a/tracecat/db/common.py
+++ b/tracecat/db/common.py
@@ -1,0 +1,13 @@
+from enum import StrEnum
+
+
+class DBConstraints(StrEnum):
+    WORKFLOW_ALIAS_UNIQUE_IN_WORKSPACE = "uq_workflow_alias_owner_id"
+
+    def msg(self) -> str:
+        return CONSTRAINT_TO_MSG[self.value]
+
+
+CONSTRAINT_TO_MSG = {
+    "uq_workflow_alias_owner_id": "Workflow alias must be unique within the workspace.",
+}


### PR DESCRIPTION
- Start to build a system to catch and report specific violations of backend state (like db unique constraints). This design is a WIP, experimenting with mapping sqlalchemy `UniqueConstraints` to error messages.