### PR TITLE
chore(infra): Standardized restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,7 @@ services:
   postgres_db:
     image: postgres:16
     container_name: postgres_db
-    restart: always
+    restart: unless-stopped
     networks:
       - core-db
     shm_size: 128mb
@@ -169,7 +169,7 @@ services:
   temporal_postgres_db:
     image: postgres:13
     container_name: temporal_postgres_db
-    restart: always
+    restart: unless-stopped
     networks:
       - temporal-db
     environment:
@@ -181,7 +181,7 @@ services:
   temporal:
     image: temporalio/auto-setup:${TEMPORAL__VERSION}
     container_name: temporal
-    restart: always
+    restart: unless-stopped
     networks:
       - core
       - temporal
@@ -199,6 +199,7 @@ services:
   temporal_ui:
     image: temporalio/ui:${TEMPORAL__UI_VERSION}
     container_name: temporal_ui
+    restart: unless-stopped
     networks:
       - temporal
     # ports:


### PR DESCRIPTION
## Description
In `docker-compose.yml` different services had different `restart_policy` set
This is small fix that standardizes them all to `unless-stopped`

**Before:**
```caddy - unless-stopped  
api - unless-stopped  
worker - unless-stopped  
executor - unless-stopped  
ui - unless-stopped  
postgres_db - always  
temporal_postgres_db - always  
temporal - always  
temporal_ui - not specified, defaults to no
```

## Steps to QA

Follow default installation steps

1. `git clone https://github.com/TracecatHQ/tracecat.git`
2. `./env.sh`
3. `docker compose up -d`