### PR TITLE
fix(engine):: Optional secrets not handled correctly

### DIFF
--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -2,13 +2,19 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from tracecat_registry import RegistrySecret
 
 from tracecat.dsl.models import ActionStatement, RunActionInput, RunContext
 from tracecat.executor.models import DispatchActionContext
-from tracecat.executor.service import _dispatch_action, dispatch_action_on_cluster
+from tracecat.executor.service import (
+    _dispatch_action,
+    dispatch_action_on_cluster,
+    run_action_from_input,
+)
 from tracecat.expressions.common import ExprContext
 from tracecat.git import GitUrl
 from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.types.auth import Role
 
 
@@ -144,3 +150,109 @@ async def test_dispatch_action_with_git_url(mock_session, basic_task_input):
         assert result == {"result": "success"}
         mock_git_url.assert_called_once()
         mock_key_file.return_value.__aenter__.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_run_action_from_input_secrets_handling(mocker, test_role):
+    """Test that run_action_from_input correctly handles secrets as sets without converting to lists."""
+    # Mock the registry action service
+    mock_reg_service = mocker.AsyncMock(spec=RegistryActionsService)
+    mock_reg_service.get_action.return_value = mocker.MagicMock()
+    mock_reg_service.get_bound.return_value = mocker.MagicMock()
+
+    # Create some registry secrets
+    registry_secrets = [
+        RegistrySecret(name="required_secret1", keys=["REQ_KEY1"], optional=False),
+        RegistrySecret(name="required_secret2", keys=["REQ_KEY2"], optional=False),
+        RegistrySecret(name="optional_secret1", keys=["OPT_KEY1"], optional=True),
+        RegistrySecret(name="optional_secret2", keys=["OPT_KEY2"], optional=True),
+    ]
+    mock_reg_service.fetch_all_action_secrets.return_value = registry_secrets
+
+    # Mock the with_session context manager
+    mocker.patch(
+        "tracecat.registry.actions.service.RegistryActionsService.with_session",
+        return_value=mocker.AsyncMock(
+            __aenter__=mocker.AsyncMock(return_value=mock_reg_service)
+        ),
+    )
+
+    # Mock the task args with templated secrets
+    task_args = {
+        "param1": "{{ secrets.args_secret1 }}",
+        "param2": {"nested": "{{ secrets.args_secret2 }}"},
+    }
+
+    # Create a run action input
+    wf_id = WorkflowUUID.new_uuid4()
+    wf_exec_id = wf_id.short() + "/exec_test"
+    wf_run_id = uuid.uuid4()
+
+    task = ActionStatement(ref="test_task", action="test_action", args=task_args)
+    input = RunActionInput(
+        task=task,
+        exec_context={},
+        run_context=RunContext(
+            wf_id=wf_id,
+            wf_exec_id=wf_exec_id,
+            wf_run_id=wf_run_id,
+            environment="test-env",
+        ),
+    )
+
+    # Mock extract_templated_secrets to return some args secrets
+    mocker.patch(
+        "tracecat.executor.service.extract_templated_secrets",
+        return_value=["args_secret1", "args_secret2"],
+    )
+
+    # Mock get_runtime_env
+    mocker.patch("tracecat.executor.service.get_runtime_env", return_value="test_env")
+
+    # Mock the AuthSandbox
+    mock_sandbox = mocker.MagicMock()
+    mock_sandbox.secrets = {}
+    mock_sandbox.__aenter__.return_value = mock_sandbox
+    mock_sandbox.__aexit__.return_value = None
+
+    auth_sandbox_mock = mocker.patch("tracecat.executor.service.AuthSandbox")
+    auth_sandbox_mock.return_value = mock_sandbox
+
+    # Mock run_single_action to avoid actually running the action
+    mocker.patch("tracecat.executor.service.run_single_action", return_value="result")
+
+    # Mock evaluate_templated_args
+    mocker.patch("tracecat.executor.service.evaluate_templated_args", return_value={})
+
+    # Mock env_sandbox
+    mocker.patch("tracecat.executor.service.env_sandbox")
+
+    # Mock flatten_secrets
+    mocker.patch("tracecat.executor.service.flatten_secrets", return_value={})
+
+    # Run the function
+    await run_action_from_input(input, test_role)
+
+    # Check that AuthSandbox was called with sets, not lists
+    auth_sandbox_mock.assert_called_once()
+    call_args, call_kwargs = auth_sandbox_mock.call_args
+
+    # Verify that secrets parameter is a set
+    assert isinstance(call_kwargs["secrets"], set)
+    expected_secrets = {
+        "required_secret1",
+        "required_secret2",
+        "optional_secret1",
+        "optional_secret2",
+        "args_secret1",
+        "args_secret2",
+    }
+    assert call_kwargs["secrets"] == expected_secrets
+
+    # Verify that optional_secrets parameter is a set
+    assert isinstance(call_kwargs["optional_secrets"], set)
+    expected_optional_secrets = {"optional_secret1", "optional_secret2"}
+    assert call_kwargs["optional_secrets"] == expected_optional_secrets
+
+    # Verify environment parameter
+    assert call_kwargs["environment"] == "test_env"

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 import pytest_mock
+from pydantic import SecretStr
 
 from tracecat.auth.credentials import TemporaryRole
 from tracecat.auth.sandbox import AuthSandbox
@@ -26,8 +27,11 @@ async def test_auth_sandbox_with_secrets(mocker: pytest_mock.MockFixture, test_r
 
     role = ctx_role.get()
     assert role is not None
+    assert role.workspace_id is not None
 
-    mock_secret_keys = [SecretKeyValue(key="SECRET_KEY", value="my_secret_key")]
+    mock_secret_keys = [
+        SecretKeyValue(key="SECRET_KEY", value=SecretStr("my_secret_key"))
+    ]
 
     mock_secret = BaseSecret(
         name="my_secret",
@@ -42,7 +46,7 @@ async def test_auth_sandbox_with_secrets(mocker: pytest_mock.MockFixture, test_r
 
     mocker.patch.object(AuthSandbox, "_get_secrets", return_value=[mock_secret])
 
-    async with AuthSandbox(secrets=["my_secret"], target="context") as sandbox:
+    async with AuthSandbox(secrets=["my_secret"]) as sandbox:
         assert sandbox.secrets == {"my_secret": {"SECRET_KEY": "my_secret_key"}}
 
     AuthSandbox._get_secrets.assert_called_once()
@@ -64,38 +68,6 @@ async def test_auth_sandbox_without_secrets(test_role, mock_user_id):
 
 
 @pytest.mark.anyio
-@pytest.mark.skip("Deprecating env target")
-async def test_auth_sandbox_env_target(mocker: pytest_mock.MockFixture, test_role):
-    role = ctx_role.get()
-    assert role is not None
-    mock_secret_keys = [SecretKeyValue(key="SECRET_KEY", value="my_secret_key")]
-    mock_secret = BaseSecret(
-        name="my_secret",
-        owner_id=role.workspace_id,
-        environment="default",
-        encrypted_keys=encrypt_keyvalues(
-            mock_secret_keys, key=os.environ["TRACECAT__DB_ENCRYPTION_KEY"]
-        ),
-    )
-
-    # Mock SecretsService
-    mock_secrets_service = mocker.AsyncMock(spec=SecretsService)
-    mock_secrets_service.search_secrets.return_value = [mock_secret]
-    mocker.patch(
-        "tracecat.auth.sandbox.SecretsService.with_session",
-        return_value=mocker.AsyncMock(
-            __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
-        ),
-    )
-
-    async with AuthSandbox(secrets=["my_secret"], target="env"):
-        assert "SECRET_KEY" in os.environ
-        assert os.environ["SECRET_KEY"] == "my_secret_key"
-
-    assert "SECRET_KEY" not in os.environ
-
-
-@pytest.mark.anyio
 async def test_auth_sandbox_missing_secret(mocker: pytest_mock.MockFixture, test_role):
     role = ctx_role.get()
     assert role is not None
@@ -111,14 +83,12 @@ async def test_auth_sandbox_missing_secret(mocker: pytest_mock.MockFixture, test
     )
 
     with pytest.raises(TracecatCredentialsError):
-        async with AuthSandbox(
-            secrets=["missing_secret"], target="context", environment="default"
-        ):
+        async with AuthSandbox(secrets=["missing_secret"], environment="default"):
             pass
 
     # Assert that the SecretsService was called with the correct parameters
     mock_secrets_service.search_secrets.assert_called_once_with(
-        SecretSearch(names=["missing_secret"], environment="default")
+        SecretSearch(names={"missing_secret"}, environment="default")
     )
 
 
@@ -132,21 +102,19 @@ async def test_auth_sandbox_custom_runtime_env_target(
             SecretCreate(
                 name="test_secret",
                 environment="__FIRST__",
-                keys=[SecretKeyValue(key="KEY", value="FIRST_VALUE")],
+                keys=[SecretKeyValue(key="KEY", value=SecretStr("FIRST_VALUE"))],
             )
         )
         await service.create_secret(
             SecretCreate(
                 name="test_secret",
                 environment="__SECOND__",
-                keys=[SecretKeyValue(key="KEY", value="SECOND_VALUE")],
+                keys=[SecretKeyValue(key="KEY", value=SecretStr("SECOND_VALUE"))],
             )
         )
 
     # Verify that the correct secret is picked up
-    async with AuthSandbox(
-        secrets=["test_secret"], target="context", environment="__FIRST__"
-    ) as sandbox:
+    async with AuthSandbox(secrets=["test_secret"], environment="__FIRST__") as sandbox:
         assert "test_secret" in sandbox.secrets
         assert "KEY" in sandbox.secrets["test_secret"]
         assert sandbox.secrets["test_secret"]["KEY"] == "FIRST_VALUE"
@@ -155,7 +123,7 @@ async def test_auth_sandbox_custom_runtime_env_target(
 
     # Verify that if we change the environment, the incorrect secret is picked up
     async with AuthSandbox(
-        secrets=["test_secret"], target="context", environment="__SECOND__"
+        secrets=["test_secret"], environment="__SECOND__"
     ) as sandbox:
         assert "test_secret" in sandbox.secrets
         assert "KEY" in sandbox.secrets["test_secret"]
@@ -246,13 +214,13 @@ async def test_auth_sandbox_optional_secrets(
 
     role = ctx_role.get()
     assert role is not None
-
+    assert role.workspace_id is not None
     # Create mock secrets
     required_secret = BaseSecret(
         name="required_secret",
         owner_id=role.workspace_id,
         encrypted_keys=encrypt_keyvalues(
-            [SecretKeyValue(key="REQ_KEY", value="required_value")],
+            [SecretKeyValue(key="REQ_KEY", value=SecretStr("required_value"))],
             key=os.environ["TRACECAT__DB_ENCRYPTION_KEY"],
         ),
         created_at=datetime.now(),
@@ -273,7 +241,6 @@ async def test_auth_sandbox_optional_secrets(
     # Test with both required and optional secrets
     async with AuthSandbox(
         secrets=["required_secret", "optional_secret"],
-        target="context",
         optional_secrets=["optional_secret"],
     ) as sandbox:
         # Required secret should be present
@@ -295,7 +262,6 @@ async def test_auth_sandbox_optional_secrets(
     with pytest.raises(TracecatCredentialsError) as exc_info:
         async with AuthSandbox(
             secrets=["required_secret", "optional_secret"],
-            target="context",
             optional_secrets=["optional_secret"],
         ):
             pass
@@ -312,15 +278,15 @@ async def test_auth_sandbox_all_secrets_present(
 
     role = ctx_role.get()
     assert role is not None
-
+    assert role.workspace_id is not None
     # Create mock secrets for both required and optional
     required_secret = BaseSecret(
         name="required_secret",
         owner_id=role.workspace_id,
         encrypted_keys=encrypt_keyvalues(
             [
-                SecretKeyValue(key="REQ_KEY1", value="required_value1"),
-                SecretKeyValue(key="REQ_KEY2", value="required_value2"),
+                SecretKeyValue(key="REQ_KEY1", value=SecretStr("required_value1")),
+                SecretKeyValue(key="REQ_KEY2", value=SecretStr("required_value2")),
             ],
             key=os.environ["TRACECAT__DB_ENCRYPTION_KEY"],
         ),
@@ -333,7 +299,7 @@ async def test_auth_sandbox_all_secrets_present(
         name="optional_secret",
         owner_id=role.workspace_id,
         encrypted_keys=encrypt_keyvalues(
-            [SecretKeyValue(key="OPT_KEY", value="optional_value")],
+            [SecretKeyValue(key="OPT_KEY", value=SecretStr("optional_value"))],
             key=os.environ["TRACECAT__DB_ENCRYPTION_KEY"],
         ),
         created_at=datetime.now(),
@@ -357,7 +323,6 @@ async def test_auth_sandbox_all_secrets_present(
     # Test with both secrets present
     async with AuthSandbox(
         secrets=["required_secret", "optional_secret"],
-        target="context",
         optional_secrets=["optional_secret"],
     ) as sandbox:
         # Required secret should be present with all keys
@@ -388,7 +353,7 @@ async def test_auth_sandbox_optional_secret_with_all_keys(
 
     role = ctx_role.get()
     assert role is not None
-
+    assert role.workspace_id is not None
     # Create mock optional secret with all keys
     optional_secret = BaseSecret(
         name="optional_secret",
@@ -417,7 +382,6 @@ async def test_auth_sandbox_optional_secret_with_all_keys(
 
     async with AuthSandbox(
         secrets=["optional_secret"],
-        target="context",
         optional_secrets=["optional_secret"],
     ) as sandbox:
         assert "optional_secret" in sandbox.secrets
@@ -446,7 +410,6 @@ async def test_auth_sandbox_missing_optional_secret(
     # Should not raise error since secret is optional
     async with AuthSandbox(
         secrets=["optional_secret"],
-        target="context",
         optional_secrets=["optional_secret"],
     ) as sandbox:
         assert "optional_secret" not in sandbox.secrets
@@ -463,7 +426,7 @@ async def test_auth_sandbox_optional_secret_missing_optional_key(
 
     role = ctx_role.get()
     assert role is not None
-
+    assert role.workspace_id is not None
     # Create mock optional secret with only required keys
     partial_optional_secret = BaseSecret(
         name="optional_secret",
@@ -491,7 +454,6 @@ async def test_auth_sandbox_optional_secret_missing_optional_key(
 
     async with AuthSandbox(
         secrets=["optional_secret"],
-        target="context",
         optional_secrets=["optional_secret"],
     ) as sandbox:
         assert "optional_secret" in sandbox.secrets

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from datetime import datetime
 
 import pytest
 import pytest_mock
@@ -210,7 +211,6 @@ async def test_auth_sandbox_optional_secrets(
     mocker: pytest_mock.MockFixture, test_role
 ):
     """Test that AuthSandbox handles both required and optional secrets correctly."""
-    from datetime import datetime
 
     role = ctx_role.get()
     assert role is not None
@@ -274,7 +274,6 @@ async def test_auth_sandbox_all_secrets_present(
     mocker: pytest_mock.MockFixture, test_role
 ):
     """Test AuthSandbox when both required and optional secrets are available."""
-    from datetime import datetime
 
     role = ctx_role.get()
     assert role is not None
@@ -347,9 +346,6 @@ async def test_auth_sandbox_optional_secret_with_all_keys(
     mocker: pytest_mock.MockFixture, test_role
 ):
     """Test AuthSandbox when optional secret has all required and optional keys."""
-    from datetime import datetime
-
-    from pydantic import SecretStr
 
     role = ctx_role.get()
     assert role is not None
@@ -420,9 +416,6 @@ async def test_auth_sandbox_optional_secret_missing_optional_key(
     mocker: pytest_mock.MockFixture, test_role
 ):
     """Test AuthSandbox when optional secret has required keys but missing optional keys."""
-    from datetime import datetime
-
-    from pydantic import SecretStr
 
     role = ctx_role.get()
     assert role is not None

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -31,18 +31,14 @@ class AuthSandbox:
     def __init__(
         self,
         role: Role | None = None,
-        secrets: list[str]
-        | None = None,  # This can be either 'my_secret.KEY' or 'my_secret'
-        target: Literal["env", "context"] = "context",
+        # This can be either 'my_secret.KEY' or 'my_secret'
+        secrets: list[str] | None = None,
         environment: str = DEFAULT_SECRETS_ENVIRONMENT,
         optional_secrets: list[str] | None = None,  # Base secret names only
     ):
         self._role = role or ctx_role.get()
         self._secret_paths: list[str] = secrets or []
         self._secret_objs: Sequence[BaseSecret] = []
-        self._target = target
-        if self._target == "env":
-            raise ValueError("Target env is no longer supported.")
         self._context: dict[str, Any] = {}
         self._environment = environment
         self._optional_secrets = set(optional_secrets or [])

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from types import TracebackType
-from typing import Any, Literal, Self
+from typing import Any, Self
 
 from tracecat.contexts import ctx_role
 from tracecat.db.schemas import BaseSecret
@@ -32,12 +32,14 @@ class AuthSandbox:
         self,
         role: Role | None = None,
         # This can be either 'my_secret.KEY' or 'my_secret'
-        secrets: list[str] | None = None,
+        # Keys that are passed here are fetched from the db
+        secrets: Iterable[str] | None = None,
         environment: str = DEFAULT_SECRETS_ENVIRONMENT,
-        optional_secrets: list[str] | None = None,  # Base secret names only
+        # Keys specified here will tell the sandbox to ignore if they are missing
+        optional_secrets: Iterable[str] | None = None,  # Base secret names only
     ):
         self._role = role or ctx_role.get()
-        self._secret_paths: list[str] = secrets or []
+        self._secret_paths = set(secrets or [])
         self._secret_objs: Sequence[BaseSecret] = []
         self._context: dict[str, Any] = {}
         self._environment = environment

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -209,19 +209,21 @@ async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
     args_secrets = set(extract_templated_secrets(task.args))
     optional_secrets = {s.name for s in action_secrets if s.optional}
     required_secrets = {s.name for s in action_secrets if not s.optional}
+    secrets_to_fetch = required_secrets | args_secrets | optional_secrets
 
     logger.info(
-        "Required secrets",
+        "Handling secrets",
         required_secrets=required_secrets,
         optional_secrets=optional_secrets,
         args_secrets=args_secrets,
+        secrets_to_fetch=secrets_to_fetch,
     )
 
     # Get all secrets in one call
     async with AuthSandbox(
-        secrets=list(required_secrets | args_secrets),
+        secrets=secrets_to_fetch,
         environment=get_runtime_env(),
-        optional_secrets=list(optional_secrets),
+        optional_secrets=optional_secrets,
     ) as sandbox:
         secrets = sandbox.secrets.copy()
 


### PR DESCRIPTION
We weren't pulling optional secrets correctly in the executor. Include it in the secrets to fetch.

# Screens
<img width="1728" alt="Screenshot 2025-02-27 at 14 09 14" src="https://github.com/user-attachments/assets/42dbd5c3-2a8f-41bc-b3fe-4b639065860a" />
