### PR TITLE
chore: Updated `env.sh` prompt

### DIFF
--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -62,25 +62,22 @@ chmod +x env.sh && ./env.sh
 
 You should see the following instructions after executing `env.sh`.
 
-<Info>
 You'll be prompted to input the following:
-- `y` (yes to production mode)
-- `localhost` (default host)
-- `n` (no to postgres SSL mode)
+- Use production mode? - `y` (use `yes` unless you are a Tracecat developer)
+- Enter the IP address or domain - `localhost` (or IP you want Tracecat to be accessible at)
+- Require PostgreSQL SSL mode? - `n`
 
-Otherwise, if you're deploying Tracecat into an external / Cloud VM, input:
-
-- `y` (yes to production mode)
-- `<host-where-tracecat-is-exposed>` (e.g. `localhost:8080`)
-- `n` (no to postgres SSL mode)
+<Info>
+  When installing Tracecat on a local workstation, use `localhost` as the IP address.
+  For installations on a remote server or any external/cloud VM, be sure to use the server's external IP address.
+  Avoid using `0.0.0.0`, as the frontend will attempt to use this address when making requests to the backend API, causing connection issues.
 </Info>
-
 <Note>
   Setting production mode to `n` changes where Tracecat's remote repository is installed.
   Do not set production mode to `n` unless you are a Tracecat developer.
 
-By default, Tracecat will install the remote repository to the user's home directory at `~/.local/lib/python3.12/site-packages/`.
-Setting production mode to `y` will install the remote repository to the `PYTHONUSERBASE` directory specified in enviroment variables.
+  By default, Tracecat will install the remote repository to the user's home directory at `~/.local/lib/python3.12/site-packages/`.
+  Setting production mode to `y` will install the remote repository to the `PYTHONUSERBASE` directory specified in enviroment variables.
 
 </Note>
 

--- a/env.sh
+++ b/env.sh
@@ -106,9 +106,18 @@ while true; do
 done
 
 # Prompt user for new IP address and strip http:// or https://
-read -p "Enter the new IP address or domain (default: localhost): " new_ip
-new_ip=$(sed -E 's/^\s*.*:\/\///g' <<< $new_ip)
-new_ip=${new_ip:-localhost}
+
+while true; do
+    read -p "Enter the IP address or domain the server should listen on (default: localhost): " new_ip
+    new_ip=$(sed -E 's/^\s*.*:\/\///g' <<< $new_ip)
+    new_ip=${new_ip:-localhost}
+
+    if [ "$new_ip" != "0.0.0.0" ]; then
+        break
+    fi
+    echo -e "${RED}Cannot use 0.0.0.0 as address. You need to enter external IP address / domain name of your server (or use localhost)\nSee https://docs.tracecat.com/self-hosting/deployment-options/docker-compose#download-configuration-files ${NC}"
+done
+
 
 # Prompt user for PostgreSQL SSL mode
 while true; do


### PR DESCRIPTION
## Description
This PR rephrases second question in `env.sh` to make it more clear and adds warning when user tries to use `0.0.0.0` as address (see #887 )
Also updated installation docs for docker compose, reflecting changes in `env.sh` and adding note about IP addresses

## Related Issues
Adds a variable check preventing user from encountering #887 

## Steps to QA
1. Clone repo - git clone https://github.com/TracecatHQ/tracecat.git
2. Run env.sh, leave first and third option default, but in second (where you are asked to specify server ip address) set it to 0.0.0.0
3. You will see an error message pointing to the documentation and script will ask you to enter IP again
4. Then if you enter valid address or domain, installation will continue as before
