### PR TITLE
fix: Change bitbucket domain from .com to .org

### DIFF
--- a/tracecat/settings/models.py
+++ b/tracecat/settings/models.py
@@ -24,7 +24,7 @@ class GitSettingsRead(BaseSettingsGroup):
 
 class GitSettingsUpdate(BaseSettingsGroup):
     git_allowed_domains: list[str] = Field(
-        default_factory=lambda: ["github.com", "gitlab.com", "bitbucket.com"],
+        default_factory=lambda: ["github.com", "gitlab.com", "bitbucket.org"],
         description="Allowed git domains for authentication.",
     )
     git_repo_url: str | None = Field(default=None)


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

Sorry for wasting time for this very simple PR, we promised to make it and could be worth for someone else since we spent few minutes figuring out that the domain is a different one!


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)? I sincerely don't think it's needed
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description
Default models for git repositories has bitbucket.com, currently not working anymore since it has moved to .org


## Related Issues
Discussed on discord directly



