### PR TITLE
fix(ui): Prevent trackpad overscroll on macos

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -57,6 +57,11 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  html,
+  body {
+    overscroll-behavior-x: none; /* Prevents back/forward swipe navigation */
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
# Screens
On staging, horizontal scrolling to the left navigates the browser back.
In localhost, trying to horizontal scroll to the left no longer navigates back.

https://github.com/user-attachments/assets/2b5462b0-0c56-45e9-bb47-5480fb3315ea

