### PR TITLE
test: Add more skip logic for local testing and disable failing llm tests

### DIFF
--- a/tests/unit/test_llms.py
+++ b/tests/unit/test_llms.py
@@ -130,6 +130,10 @@ class BooleanResponse(BaseModel):
     answer: bool = Field(strict=True)
 
 
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") is not None,
+    reason="Skip memory tests in GitHub Actions CI. This is currently brokwn.",
+)
 @pytest.mark.anyio
 async def test_memory(call_llm_params: tuple[str, Callable]):
     """Test conversation memory functionality."""

--- a/tests/unit/test_llms.py
+++ b/tests/unit/test_llms.py
@@ -58,7 +58,7 @@ def load_api_kwargs(provider: str) -> dict[str, Any]:
 
 
 @pytest.fixture(
-    scope="session",
+    scope="function",
     params=[
         pytest.param(
             ("ollama", async_ollama_call),


### PR DESCRIPTION
Disable broken llm test and add more skip logic for local test runs.

See https://github.com/TracecatHQ/tracecat/actions/runs/13705543127. 

Logs:
```
==================================== ERRORS ====================================
________ ERROR at setup of TestTablesService.test_create_and_get_table _________

anyio_backend = 'asyncio'
request = <SubRequest 'svc_workspace' for <Function test_create_and_get_table>>
args = ()
kwargs = {'session': <sqlmodel.ext.asyncio.session.AsyncSession object at 0x7f9b44f696d0>}
local_func = <function svc_workspace at 0x7f9b4f3c5b20>
backend_name = 'asyncio', backend_options = {}
runner = <anyio._backends._asyncio.TestRunner object at 0x7f9b4413d6a0>

    def wrapper(
        *args: Any, anyio_backend: Any, request: SubRequest, **kwargs: Any
    ) -> Any:
        # Rebind any fixture methods to the request instance
        if (
            request.instance
            and ismethod(func)
            and type(func.__self__) is type(request.instance)
        ):
            local_func = func.__func__.__get__(request.instance)
        else:
            local_func = func
    
        backend_name, backend_options = extract_backend_and_options(anyio_backend)
        if has_backend_arg:
            kwargs["anyio_backend"] = anyio_backend
    
        if has_request_arg:
            kwargs["request"] = request
    
        with get_runner(backend_name, backend_options) as runner:
            if isasyncgenfunction(local_func):
>               yield from runner.run_asyncgen_fixture(local_func, kwargs)

/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/pytest_plugin.py:98: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:2237: in run_asyncgen_fixture
    self._raise_async_exceptions()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:2176: in _raise_async_exceptions
    raise exceptions[0]
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpx/_client.py:2018: in aclose
    await self._transport.aclose()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpx/_transports/default.py:385: in aclose
    await self._pool.aclose()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection_pool.py:353: in aclose
    await self._close_connections(closing_connections)
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection_pool.py:345: in _close_connections
    await connection.aclose()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection.py:173: in aclose
    await self._connection.aclose()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/http11.py:258: in aclose
    await self._network_stream.aclose()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_backends/anyio.py:53: in aclose
    await self._stream.aclose()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/streams/tls.py:201: in aclose
    await self.transport_stream.aclose()
/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:1302: in aclose
    self._transport.write_eof()
uvloop/handles/stream.pyx:703: in uvloop.loop.UVStream.write_eof
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   RuntimeError: unable to perform operation on <TCPTransport closed=True reading=False 0x5619e42747d0>; the handler is closed

uvloop/handles/handle.pyx:159: RuntimeError
=================================== FAILURES ===================================
_____________________________ test_memory[openai] ______________________________
  + Exception Group Traceback (most recent call last):
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/runner.py", line 341, in from_call
  |     result: TResult | None = func()
  |                              ^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/runner.py", line 242, in <lambda>
  |     lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
  |     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
  |     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
  |     raise exception.with_traceback(exception.__traceback__)
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/threadexception.py", line 92, in pytest_runtest_call
  |     yield from thread_exception_runtest_hook()
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/threadexception.py", line 68, in thread_exception_runtest_hook
  |     yield
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 95, in pytest_runtest_call
  |     yield from unraisable_exception_runtest_hook()
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 70, in unraisable_exception_runtest_hook
  |     yield
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/logging.py", line 848, in pytest_runtest_call
  |     yield from self._runtest_for(item, "call")
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/logging.py", line 831, in _runtest_for
  |     yield
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/capture.py", line 879, in pytest_runtest_call
  |     return (yield)
  |             ^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/skipping.py", line 257, in pytest_runtest_call
  |     return (yield)
  |             ^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 103, in _multicall
  |     res = hook_impl.function(*args)
  |           ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/runner.py", line 174, in pytest_runtest_call
  |     item.runtest()
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/_pytest/python.py", line 1627, in runtest
  |     self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
  |     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
  |     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
  |     raise exception.with_traceback(exception.__traceback__)
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/pluggy/_callers.py", line 103, in _multicall
  |     res = hook_impl.function(*args)
  |           ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/pytest_plugin.py", line 160, in pytest_pyfunc_call
  |     runner.run_test(pyfuncitem.obj, testargs)
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2272, in run_test
  |     self._raise_async_exceptions()
  |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2178, in _raise_async_exceptions
  |     raise BaseExceptionGroup(
  | ExceptionGroup: Multiple exceptions occurred in asynchronous callbacks (2 sub-exceptions)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpx/_client.py", line 2018, in aclose
    |     await self._transport.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpx/_transports/default.py", line 385, in aclose
    |     await self._pool.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 353, in aclose
    |     await self._close_connections(closing_connections)
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 345, in _close_connections
    |     await connection.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection.py", line 173, in aclose
    |     await self._connection.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/http11.py", line 258, in aclose
    |     await self._network_stream.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 53, in aclose
    |     await self._stream.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/streams/tls.py", line 201, in aclose
    |     await self.transport_stream.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1302, in aclose
    |     self._transport.write_eof()
    |   File "uvloop/handles/stream.pyx", line 703, in uvloop.loop.UVStream.write_eof
    |   File "uvloop/handles/handle.pyx", line 159, in uvloop.loop.UVHandle._ensure_alive
    | RuntimeError: unable to perform operation on <TCPTransport closed=True reading=False 0x5619e3a62420>; the handler is closed
    +---------------- 2 ----------------
    | Traceback (most recent call last):
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpx/_client.py", line 2018, in aclose
    |     await self._transport.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpx/_transports/default.py", line 385, in aclose
    |     await self._pool.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 353, in aclose
    |     await self._close_connections(closing_connections)
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 345, in _close_connections
    |     await connection.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/connection.py", line 173, in aclose
    |     await self._connection.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_async/http11.py", line 258, in aclose
    |     await self._network_stream.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 53, in aclose
    |     await self._stream.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/streams/tls.py", line 201, in aclose
    |     await self.transport_stream.aclose()
    |   File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1302, in aclose
    |     self._transport.write_eof()
    |   File "uvloop/handles/stream.pyx", line 703, in uvloop.loop.UVStream.write_eof
    |   File "uvloop/handles/handle.pyx", line 159, in uvloop.loop.UVHandle._ensure_alive
    | RuntimeError: unable to perform operation on <TCPTransport closed=True reading=False 0x5619e4092960>; the handler is closed
    +------------------------------------
    ```