### PR TITLE
feat(app): Allow editing of existing keys

### DIFF
--- a/frontend/src/components/organization/org-secret-update.tsx
+++ b/frontend/src/components/organization/org-secret-update.tsx
@@ -69,7 +69,18 @@ export function UpdateOrgSecretDialog({
       keys: [],
     },
   })
-  const { control, register } = methods
+  const { control, register, reset } = methods
+
+  React.useEffect(() => {
+    if (selectedSecret) {
+      reset({
+        name: "",
+        description: "",
+        environment: "",
+        keys: selectedSecret.keys.map(keyName => ({ key: keyName, value: "" })),
+      });
+    }
+  }, [selectedSecret, reset]);
 
   const onSubmit = useCallback(
     async (values: SecretUpdate) => {

--- a/frontend/src/components/workspaces/edit-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/edit-workspace-secret.tsx
@@ -69,7 +69,18 @@ export function EditCredentialsDialog({
       keys: [],
     },
   })
-  const { control, register } = methods
+  const { control, register, reset } = methods
+
+  React.useEffect(() => {
+    if (selectedSecret) {
+      reset({
+        name: "",
+        description: "",
+        environment: "",
+        keys: selectedSecret.keys.map(keyName => ({ key: keyName, value: "" })),
+      });
+    }
+  }, [selectedSecret, reset]);
 
   const onSubmit = useCallback(
     async (values: SecretUpdate) => {


### PR DESCRIPTION
## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [X] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [X] PR only implements a single feature or fixes a single bug.
- [X] Tests passing (`uv run pytest tests`)?
- [X] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR enables the user to edit existing keys in both Workspace and Organization edit dialogs.

## Related Issues

Fixes #872 

## Screenshots / Recordings
![Screenshot_88](https://github.com/user-attachments/assets/0277580c-3060-4c57-9be7-633b43070981)
![Screenshot_89](https://github.com/user-attachments/assets/7a76471b-feb3-4df4-b7d1-60b2d1fdadc9)
![Screenshot_90](https://github.com/user-attachments/assets/00a3b3cc-8e95-49c1-bfa5-8ccf23f2c54f)
![Screenshot_91](https://github.com/user-attachments/assets/c2b5ecb4-c7a5-424c-9ef3-cdbc2f5f56f3)
![Screenshot_92](https://github.com/user-attachments/assets/4fa371cb-2b43-4436-9b0b-069dd6b71350)
![Screenshot_93](https://github.com/user-attachments/assets/47247727-5d25-4c69-ba03-cca492b147bf)
![Screenshot_94](https://github.com/user-attachments/assets/76ee2fdd-6371-4504-b7cb-5b0c415f990e)
![Screenshot_95](https://github.com/user-attachments/assets/e75cff6a-893b-48fe-93d4-41f14a4aabe7)



## Steps to QA

1. Add multiple a secret with keys
2. Click the three dots at the end
3. Click edit to open edit dialog