### PR TITLE
test(fix): Skip podman tests if not running

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Start Docker services
         env:
           TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
-        run: docker compose -f docker-compose.dev.yml up --build -d temporal api worker executor postgres_db caddy
+        run: docker compose -f docker-compose.dev.yml up --build -d temporal api worker executor postgres_db caddy ee-container-runner
 
       - name: Install dependencies
         run: |
@@ -117,4 +117,5 @@ jobs:
       - name: Run tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: uv run pytest tests/${{ matrix.test_type }} -k "not test_podman" -ra
+          TEST_PODMAN_URI: tcp://host.docker.internal:8080
+        run: uv run pytest tests/${{ matrix.test_type }} -ra

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -45,7 +45,7 @@ def is_container_running(container_name):
 # Skip all tests if Podman container runner is not running
 skipif_no_container_runner = pytest.mark.skipif(
     not is_container_running("ee-container-runner"),
-    reason="Podman container-runner from docker-compose.dev.yml is not running or not accessible at the configured URI",
+    reason="No ee-container-runner Docker container found",
 )
 
 

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -44,8 +44,8 @@ def is_container_running(container_name):
 
 # Skip all tests if Podman container runner is not running
 skipif_no_container_runner = pytest.mark.skipif(
-    not is_container_running("ee-container-runner"),
-    reason="No ee-container-runner Docker container found",
+    not is_container_running("container-runner"),
+    reason="No container-runner Docker container found",
 )
 
 

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 import pytest
 
@@ -18,29 +19,44 @@ TEST_TRUSTED_IMAGES = [
 ]
 
 
-def is_podman_running():
-    """Check if Podman is accessible at the configured URI."""
+def is_container_running(container_name):
+    """Check if a Docker container is running."""
     try:
-        get_podman_version(base_url=TEST_PODMAN_URI)
-        return True
+        # Run docker ps command to check if container is running
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                f"name={container_name}",
+                "--format",
+                "{{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # If the container name is in the output, it's running
+        return container_name in result.stdout
     except Exception:
         return False
 
 
-# Skip all tests if Podman is not running
-podman_not_running = pytest.mark.skipif(
-    not is_podman_running(), reason="Podman is not running at the configured URI"
+# Skip all tests if Podman container runner is not running
+skipif_no_container_runner = pytest.mark.skipif(
+    not is_container_running("ee-container-runner"),
+    reason="Podman container-runner from docker-compose.dev.yml is not running or not accessible at the configured URI",
 )
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_podman_version():
     """Smoke test to verify Podman API connectivity."""
     version = get_podman_version(base_url=TEST_PODMAN_URI)
     assert version == "5.4.0"
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_hello_world():
     """Test basic container operation with Alpine Linux."""
     result = run_podman_container(
@@ -56,7 +72,7 @@ def test_hello_world():
     assert any("Hello, World!" in line for line in result.stdout)
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_environment_variables_are_set():
     """Test that environment variables are set."""
     result = run_podman_container(
@@ -70,7 +86,7 @@ def test_environment_variables_are_set():
     assert result.stdout[0].startswith("hello! world! foo!")
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_stratus_red_team_list():
     """Test running list command with Stratus Red Team image."""
     result = run_podman_container(
@@ -89,7 +105,7 @@ def test_stratus_red_team_list():
     )
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_volumes_persist_across_runs():
     """Test that volumes persist across container runs."""
     volume_name = "test-persist-volume"
@@ -137,7 +153,7 @@ def test_volumes_persist_across_runs():
     )
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_untrusted_image():
     """Test that non-allowlisted images are rejected."""
     with pytest.raises(ValueError):
@@ -150,7 +166,7 @@ def test_untrusted_image():
         )
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_http_request_with_bridge_network():
     """Test that HTTP request to google.com works with bridge network."""
     script = """
@@ -176,7 +192,7 @@ except Exception as e:
     assert "200" in " ".join(result.stdout)
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_http_request_with_none_network():
     """Test that HTTP request to google.com fails with no network."""
     script = """
@@ -207,7 +223,7 @@ except Exception as e:
     assert "Error:" in error_message
 
 
-@podman_not_running
+@skipif_no_container_runner
 def test_expected_exit_codes():
     """Test that expected exit codes don't raise errors."""
     # Test a command that exits with code 1

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -18,12 +18,29 @@ TEST_TRUSTED_IMAGES = [
 ]
 
 
+def is_podman_running():
+    """Check if Podman is accessible at the configured URI."""
+    try:
+        get_podman_version(base_url=TEST_PODMAN_URI)
+        return True
+    except Exception:
+        return False
+
+
+# Skip all tests if Podman is not running
+podman_not_running = pytest.mark.skipif(
+    not is_podman_running(), reason="Podman is not running at the configured URI"
+)
+
+
+@podman_not_running
 def test_podman_version():
     """Smoke test to verify Podman API connectivity."""
     version = get_podman_version(base_url=TEST_PODMAN_URI)
     assert version == "5.4.0"
 
 
+@podman_not_running
 def test_hello_world():
     """Test basic container operation with Alpine Linux."""
     result = run_podman_container(
@@ -39,6 +56,7 @@ def test_hello_world():
     assert any("Hello, World!" in line for line in result.stdout)
 
 
+@podman_not_running
 def test_environment_variables_are_set():
     """Test that environment variables are set."""
     result = run_podman_container(
@@ -52,6 +70,7 @@ def test_environment_variables_are_set():
     assert result.stdout[0].startswith("hello! world! foo!")
 
 
+@podman_not_running
 def test_stratus_red_team_list():
     """Test running list command with Stratus Red Team image."""
     result = run_podman_container(
@@ -70,6 +89,7 @@ def test_stratus_red_team_list():
     )
 
 
+@podman_not_running
 def test_volumes_persist_across_runs():
     """Test that volumes persist across container runs."""
     volume_name = "test-persist-volume"
@@ -117,6 +137,7 @@ def test_volumes_persist_across_runs():
     )
 
 
+@podman_not_running
 def test_untrusted_image():
     """Test that non-allowlisted images are rejected."""
     with pytest.raises(ValueError):
@@ -129,6 +150,7 @@ def test_untrusted_image():
         )
 
 
+@podman_not_running
 def test_http_request_with_bridge_network():
     """Test that HTTP request to google.com works with bridge network."""
     script = """
@@ -154,6 +176,7 @@ except Exception as e:
     assert "200" in " ".join(result.stdout)
 
 
+@podman_not_running
 def test_http_request_with_none_network():
     """Test that HTTP request to google.com fails with no network."""
     script = """
@@ -184,6 +207,7 @@ except Exception as e:
     assert "Error:" in error_message
 
 
+@podman_not_running
 def test_expected_exit_codes():
     """Test that expected exit codes don't raise errors."""
     # Test a command that exits with code 1

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from tracecat.ee.sandbox.podman import (
@@ -9,7 +11,7 @@ from tracecat.ee.sandbox.podman import (
     run_podman_container,
 )
 
-TEST_PODMAN_URI = "tcp://localhost:8080"
+TEST_PODMAN_URI = os.environ.get("TEST_PODMAN_URI", "tcp://localhost:8080")
 TEST_TRUSTED_IMAGES = [
     "alpine:latest",
     "ghcr.io/datadog/stratus-red-team:latest",


### PR DESCRIPTION
## What changed
- Add skip condition in the test_podman.py file to check specifically if the "ee-container-runner" service from the docker-compose.dev.yml file is running
- Removed `-k "not test_podman"` in CI

<img width="916" alt="Screenshot 2025-03-15 at 10 30 30 PM" src="https://github.com/user-attachments/assets/1a735e67-68bf-4bcc-b58b-2d7adc8878d6" />

