### PR TITLE
feat(engine): Support expressions in dictionary keys

### DIFF
--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1122,7 +1122,7 @@ async def test_extract_expressions_errors(expr, expected, test_role, env_sandbox
             _expr.validate(visitor)
 
     # NOTE: We are using results to get ALL validation results
-    errors = list(visitor.results())
+    errors = list(visitor.errors())
 
     for actual, ex in zip(errors, expected, strict=True):
         assert_validation_result(actual, **ex)
@@ -1322,7 +1322,6 @@ async def test_template_action_validator_unsupported_expressions(expr, expected_
     assert found_err is not None, f"Expected {expected_error}, got {val_results}"
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize(
     "test_name,data,template,expected",
     [

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1122,7 +1122,7 @@ async def test_extract_expressions_errors(expr, expected, test_role, env_sandbox
             _expr.validate(visitor)
 
     # NOTE: We are using results to get ALL validation results
-    errors = list(visitor.errors())
+    errors = list(visitor.results())
 
     for actual, ex in zip(errors, expected, strict=True):
         assert_validation_result(actual, **ex)
@@ -1306,7 +1306,6 @@ async def test_template_action_validator_unsupported_expressions(expr, expected_
 
     val_results = list(visitor.results())
 
-    # Expect that in the validation results, the expected error is present
     found_err = next(
         (
             r
@@ -1321,3 +1320,201 @@ async def test_template_action_validator_unsupported_expressions(expr, expected_
     )
 
     assert found_err is not None, f"Expected {expected_error}, got {val_results}"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "test_name,data,template,expected",
+    [
+        (
+            "basic_template_key",
+            {
+                ExprContext.ACTIONS: {
+                    "input_action": {
+                        "result": {"key_name": "dynamic_key", "value": "dynamic_value"}
+                    }
+                }
+            },
+            {
+                "${{ ACTIONS.input_action.result.key_name }}": "${{ ACTIONS.input_action.result.value }}",
+                "static_key": {
+                    "${{ ACTIONS.input_action.result.key_name }}_nested": "${{ ACTIONS.input_action.result.value }}"
+                },
+            },
+            {
+                "dynamic_key": "dynamic_value",
+                "static_key": {"dynamic_key_nested": "dynamic_value"},
+            },
+        ),
+        (
+            "multiple_expressions_in_key",
+            {
+                ExprContext.ACTIONS: {
+                    "prefix_action": {"result": "test"},
+                    "suffix_action": {"result": "key"},
+                    "value_action": {"result": "result"},
+                }
+            },
+            {
+                "${{ ACTIONS.prefix_action.result }}_${{ ACTIONS.suffix_action.result }}": "${{ ACTIONS.value_action.result }}"
+            },
+            {"test_key": "result"},
+        ),
+        (
+            "non_string_key_evaluation",
+            {
+                ExprContext.ACTIONS: {
+                    "key_action": {"result": 123},
+                    "value_action": {"result": "numeric_key"},
+                }
+            },
+            {"${{ ACTIONS.key_action.result }}": "${{ ACTIONS.value_action.result }}"},
+            {123: "numeric_key"},
+        ),
+        (
+            "deeply_nested_key_expressions",
+            {
+                ExprContext.ACTIONS: {
+                    "level1_action": {"result": "outer"},
+                    "level2_action": {"result": "inner"},
+                    "value_action": {"result": "nested_value"},
+                }
+            },
+            {
+                "${{ ACTIONS.level1_action.result }}": {
+                    "${{ ACTIONS.level2_action.result }}": {
+                        "${{ ACTIONS.level1_action.result }}_${{ ACTIONS.level2_action.result }}": "${{ ACTIONS.value_action.result }}"
+                    }
+                }
+            },
+            {"outer": {"inner": {"outer_inner": "nested_value"}}},
+        ),
+    ],
+    ids=lambda x: x if isinstance(x, str) else "data",
+)
+def test_eval_templated_object_with_key_expressions(
+    test_name, data, template, expected
+):
+    """Test that expressions in dictionary keys are properly evaluated."""
+    result = eval_templated_object(template, operand=data)
+    assert result == expected
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        # Test valid workflow action keys
+        (
+            {
+                "${{ ACTIONS.my_action.result.key }}": "value",
+            },
+            [{"type": ExprType.ACTION, "status": "success"}],
+        ),
+        # Test invalid workflow action reference
+        (
+            {"${{ ACTIONS.invalid_action.result }}": "value"},
+            [
+                {
+                    "type": ExprType.ACTION,
+                    "status": "error",
+                    "contains_msg": "Invalid action reference",
+                },
+                {
+                    "type": ExprType.ACTION,
+                    "status": "success",  # The validator also returns a success result for the full path
+                },
+            ],
+        ),
+        # Test nested expressions in keys
+        (
+            {"parent": {"${{ ACTIONS.my_action.result }}": "value"}},
+            [{"type": ExprType.ACTION, "status": "success"}],
+        ),
+    ],
+)
+async def test_validate_workflow_key_expressions(expr, expected):
+    """Test validation of expressions in workflow dictionary keys."""
+    validation_context = ExprValidationContext(
+        action_refs={"my_action"},  # Only my_action is valid
+        inputs_context={},
+    )
+    validators = get_validators()
+
+    async with GatheringTaskGroup() as tg:
+        visitor = ExprValidator(
+            task_group=tg,
+            validation_context=validation_context,
+            validators=validators,  # type: ignore
+        )
+        exprs = extract_expressions(expr)
+        for expr in exprs:
+            expr.validate(visitor)
+
+    validation_results = list(visitor.results())
+
+    # Sort both lists by type and status to ensure consistent comparison
+    validation_results.sort(key=lambda x: (x.expression_type, x.status))
+    expected.sort(key=lambda x: (x["type"], x["status"]))
+
+    assert len(validation_results) == len(expected), (
+        f"Expected {len(expected)} validation results, got {len(validation_results)}"
+    )
+
+    for actual, ex in zip(validation_results, expected, strict=True):
+        assert_validation_result(actual, **ex)
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        # Test valid template keys
+        (
+            {
+                "${{ inputs.key_name }}": "value",
+            },
+            [{"type": ExprType.TEMPLATE_ACTION_INPUT, "status": "success"}],
+        ),
+        # Test valid step reference in key
+        (
+            {"${{ steps.step1.result }}": "value"},
+            [{"type": ExprType.TEMPLATE_ACTION_STEP, "status": "success"}],
+        ),
+        # Test invalid input reference
+        (
+            {"${{ inputs.invalid }}": "value"},
+            [
+                {
+                    "type": ExprType.TEMPLATE_ACTION_INPUT,
+                    "status": "error",
+                    "contains_msg": "Invalid input reference 'invalid'",
+                }
+            ],
+        ),
+        # Test unsupported expression type in key
+        (
+            {"${{ ACTIONS.some_action.result }}": "value"},
+            [
+                {
+                    "type": ExprType.ACTION,
+                    "status": "error",
+                    "contains_msg": "ACTIONS expressions are not supported in Template Actions",
+                }
+            ],
+        ),
+    ],
+)
+def test_validate_template_action_key_expressions(expr, expected):
+    """Test validation of expressions in template action dictionary keys."""
+    validation_context = TemplateActionValidationContext(
+        expects={"key_name": ExpectedField(type="str")}, step_refs={"step1"}
+    )
+
+    visitor = TemplateActionExprValidator(validation_context=validation_context)
+    exprs = extract_expressions(expr)
+    for expr in exprs:
+        expr.validate(visitor)
+
+    validation_results = list(visitor.results())
+    for actual, ex in zip(validation_results, expected, strict=True):
+        assert_validation_result(actual, **ex)

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1306,6 +1306,7 @@ async def test_template_action_validator_unsupported_expressions(expr, expected_
 
     val_results = list(visitor.results())
 
+    # Expect that in the validation results, the expected error is present
     found_err = next(
         (
             r

--- a/tracecat/expressions/eval.py
+++ b/tracecat/expressions/eval.py
@@ -18,7 +18,12 @@ def _eval_templated_obj_rec(obj: T, operator: Callable[[str], Any]) -> T:
         case list():
             return [_eval_templated_obj_rec(item, operator) for item in obj]
         case dict():
-            return {k: _eval_templated_obj_rec(v, operator) for k, v in obj.items()}
+            return {
+                operator(k) if isinstance(k, str) else k: _eval_templated_obj_rec(
+                    v, operator
+                )
+                for k, v in obj.items()
+            }
         case _:
             return obj
 


### PR DESCRIPTION
## Use-case
Example: JSON Schema properties names are keys. I might want a template action where the name of the property is an argument.

## Changes
This PR introduces support for dynamic dictionary keys using template expressions, along with corresponding validation logic. The changes include:

1. Enhanced the template object evaluation to support expressions in dictionary keys
2. Added comprehensive test coverage for dynamic key evaluation scenarios
3. Updated validation logic to properly handle expressions in dictionary keys
4. Fixed a minor inconsistency in validation result handling

## Key Implementation Details
- Modified `_eval_templated_obj_rec` to evaluate string dictionary keys using the provided operator
- Added test cases covering various scenarios for dynamic keys:
  - Basic template key evaluation
  - Multiple expressions within a single key
  - Non-string key evaluation
  - Deeply nested key expressions
- Added validation tests for both workflow and template action expressions in dictionary keys

## Testing
Added comprehensive test coverage including:
- Basic template key evaluation
- Multiple expressions in keys
- Non-string key evaluation
- Deeply nested key expressions
- Validation for both workflow and template action expressions
- Error cases and invalid expression handling