### PR TITLE
feat(engine): Add unescape string for `FN.join()` separator

### DIFF
--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -5,6 +5,7 @@ from tracecat.parse import (
     get_pyproject_toml_required_deps,
     traverse_expressions,
     traverse_leaves,
+    unescape_string,
 )
 
 
@@ -172,3 +173,49 @@ invalid toml content
     # Test parsing
     deps = get_pyproject_toml_required_deps(pyproject)
     assert deps == []
+
+
+def test_unescape_string_newlines() -> None:
+    """Test that backslash-n sequences are converted to actual newlines."""
+    input_str = "Hello\\nWorld"
+    expected = "Hello\nWorld"
+    assert unescape_string(input_str) == expected
+
+
+def test_unescape_string_tabs() -> None:
+    """Test that backslash-t sequences are converted to actual tabs."""
+    input_str = "Hello\\tWorld"
+    expected = "Hello\tWorld"
+    assert unescape_string(input_str) == expected
+
+
+def test_unescape_string_carriage_returns() -> None:
+    """Test that backslash-r sequences are converted to actual carriage returns."""
+    input_str = "Hello\\rWorld"
+    expected = "Hello\rWorld"
+    assert unescape_string(input_str) == expected
+
+
+def test_unescape_string_backslashes() -> None:
+    """Test that double backslashes are converted to a single backslash."""
+    input_str = "Hello\\\\World"
+    expected = "Hello\\World"
+    assert unescape_string(input_str) == expected
+
+
+def test_unescape_string_multiple_escapes() -> None:
+    """Test that multiple escape sequences in a string are all converted."""
+    input_str = "Line1\\nLine2\\tTabbed\\r\\\\Backslash"
+    expected = "Line1\nLine2\tTabbed\r\\Backslash"
+    assert unescape_string(input_str) == expected
+
+
+def test_unescape_string_no_escapes() -> None:
+    """Test that strings without escape sequences remain unchanged."""
+    input_str = "Regular string with no escapes"
+    assert unescape_string(input_str) == input_str
+
+
+def test_unescape_string_empty() -> None:
+    """Test that empty strings are handled correctly."""
+    assert unescape_string("") == ""

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -26,6 +26,7 @@ from tracecat.ee.interactions.models import InteractionContext
 from tracecat.expressions.formatters import tabulate
 from tracecat.expressions.ioc_extractors.email import extract_emails
 from tracecat.expressions.ioc_extractors.ip import extract_ipv4
+from tracecat.parse import unescape_string
 
 
 def _bool(x: Any) -> bool:
@@ -336,7 +337,8 @@ def unique(items: Sequence[Any]) -> list[Any]:
 
 def join_strings(items: Sequence[str], sep: str) -> str:
     """Join sequence of strings with separator."""
-    return sep.join(items)
+    excaped_sep = unescape_string(sep)
+    return excaped_sep.join(items)
 
 
 def concat_strings(*items: str) -> str:

--- a/tracecat/parse.py
+++ b/tracecat/parse.py
@@ -80,3 +80,20 @@ def get_pyproject_toml_required_deps(pyproject_path: Path) -> list[str]:
     except Exception as e:
         logger.error("Error parsing pyproject.toml", error=e)
         return []
+
+
+def unescape_string(s: str) -> str:
+    """Convert string escape sequences to their actual characters.
+
+    Handles common escape sequences:
+    - "\\n" becomes a newline
+    - "\\t" becomes a tab
+    - "\\r" becomes a carriage return
+    - "\\\\" becomes a backslash
+    """
+    # Use a single regex substitution instead of multiple string replacements
+    return re.sub(
+        r"\\([\\nrt])",
+        lambda m: {"n": "\n", "t": "\t", "r": "\r", "\\": "\\"}[m.group(1)],
+        s,
+    )


### PR DESCRIPTION
# Description
- Allows passing of `\n \t \r` etc (any number) into expressions as plain strings. The python functions see the escaped versions `\\n \\t \\r` etc, and replace them with the unescaped versions
- We currently only apply this onto `FN.join`