### PR TITLE
fix(app): Exclude registry cli files during sync + expire registry repo before updating

### DIFF
--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -100,6 +100,7 @@ async def sync_registry_repository(
             commit_sha=commit_sha,
             last_synced_at=last_synced_at,
         )
+        session.expire(repo)
         # Update the registry repository table
         await repos_service.update_repository(
             repo,

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -519,11 +519,19 @@ class Repository:
         base_path = module.__path__[0]
         base_package = module.__name__
         num_udfs = 0
-        # Ignore __init__.py
-        module_paths = [
-            path for path in Path(base_path).rglob("*.py") if path.stem != "__init__"
-        ]
-        for path in module_paths:
+        # Ignore __init__.py and __main__.py
+        exclude_filenames = ("__init__", "__main__")
+        # Ignore CLI files
+        exclude_prefixes = (f"{base_path}/cli",)
+
+        for path in Path(base_path).rglob("*.py"):
+            if path.stem in exclude_filenames:
+                logger.debug("Skipping excluded filename", path=path)
+                continue
+            p_str = path.as_posix()
+            if any(p_str.startswith(prefix) for prefix in exclude_prefixes):
+                logger.debug("Skipping excluded prefix", path=path)
+                continue
             logger.info(f"Loading UDFs from {path!s}")
             # Convert path to relative path
             relative_path = path.relative_to(base_path)


### PR DESCRIPTION
# Description
- **Ignore "\_\_main\_\_" during udf registration**: 
  - It seems like the registry CLI was causing the sync to stop prematurely because the filename is "\_\_main\_\_", so we'd actually trigger the entrypoint. Ignoring "\_\_main\_\_" lets the sync properly complete.
- **Expire RegistryRepository object before performing update**
  - This was the source of all the RegistryAction errors users faced during registry sync. It happens when a template has been deleted (can happen if renamed), and when we proceed to run `RegistryActionsService.update_repository()` with a stale `RegistryRepository` SQLAlchemy object. The fix is to call `session.expire(repo)` to clear out the deleted `RegistryAction` objects.
  
  
  # Screens
Before, deleting the test action template with no expire

https://github.com/user-attachments/assets/b2657077-ff1e-4c8b-86bc-9b7bd5783d71

After, deleting the test action template with expire

https://github.com/user-attachments/assets/33f49db6-19af-42fc-9839-3daca22592d1


