### PR TITLE
fix(app): Remove default graph edge source handle value

### DIFF
--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -197,7 +197,13 @@ class DSLInput(BaseModel):
                 if not action.depends_on:
                     # If there are no dependencies, this is an entrypoint
                     entrypoint_id = ref2id[action.ref]
-                    edges.append(RFEdge(source=trigger_node.id, target=entrypoint_id))
+                    edges.append(
+                        RFEdge(
+                            source=trigger_node.id,
+                            target=entrypoint_id,
+                            label="⚡ Trigger",
+                        )
+                    )
                 else:
                     # Otherwise, add edges for all dependencies
                     for dep_ref in action.depends_on:

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -101,7 +101,7 @@ NodeValidator: TypeAdapter[NodeVariant] = TypeAdapter(AnnotatedNodeVariant)
 class RFEdge(TSObject):
     """React Flow Graph Edge."""
 
-    id: str = Field(default=None)
+    id: str | None = Field(default=None, description="RF Graph Edge ID")
     """RF Graph Edge ID. Not used in this context."""
 
     source: str

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -113,7 +113,7 @@ class RFEdge(TSObject):
     label: str | None = Field(default=None, description="Edge label")
 
     source_handle: EdgeType | None = Field(
-        default=EdgeType.SUCCESS, description="Edge source handle type"
+        default=None, description="Edge source handle type"
     )
 
     @model_validator(mode="before")


### PR DESCRIPTION
# Related issues
https://github.com/xyflow/xyflow/pull/4429
> New edges created by the library only have sourceHandle and targetHandle attributes when those attributes are set. (We used to pass sourceHandle: null and targetHandle: null)

https://github.com/xyflow/xyflow/issues/3409
>Edge Behavior with Missing Handles: There was an issue where edges with a specified sourceHandle or targetHandle would behave inconsistently if the corresponding handle was missing. The system would default to another handle, leading to unexpected connections. To resolve this, the behavior was modified so that if a specific handle ID is provided, the system will only connect to that handle. If the specified handle is missing, the edge will not render, ensuring more predictable and controlled connections. ​

# Description
Since we updated to xyflow v12, workflows imported don't display correctly if no matching `sourceHandle` is found. We had set the default sourceHandle to be 'success', which doesn't exist on the trigger node.

# Solution
Don't set the sourceHandle if it's a trigger edge.  For all other edges, we still apply the source handle as done previously.

# Additional changes
- Fixed type hints
- Add Trigger edge marker on trigger edges

# Screens

https://github.com/user-attachments/assets/95f759b5-1d04-456e-b2a2-6a03def54575

