### PR TITLE
feat(integrations): Add `core.sql.query` udf action

### DIFF
--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -4,6 +4,7 @@ import {
   BoxIcon,
   Building2Icon,
   Cpu,
+  Database,
   Globe,
   ListChecks,
   Mail,
@@ -260,6 +261,11 @@ export const UDFIcons: Record<string, (props: CustomIconProps) => JSX.Element> =
     "core.send_email_smtp": ({ className, ...rest }) => (
       <div className={cn(basicIconsCommon, "bg-lime-100", className)}>
         <Send {...rest} />
+      </div>
+    ),
+    "core.sql": ({ className, ...rest }) => (
+      <div className={cn(basicIconsCommon, "bg-sky-100", className)}>
+        <Database {...rest} />
       </div>
     ),
     /* AI subnamespace */

--- a/registry/pyproject.toml
+++ b/registry/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "nh3==0.2.18",
     "pymongo==4.8.0",
     "pytenable==1.6.0",
+    "psycopg[binary]==3.1.19",
     "slack-sdk==3.28.0",
     "tenacity==8.3.0",
     "types-aioboto3[guardduty,s3]==13.0.1",

--- a/registry/tracecat_registry/core/sql.py
+++ b/registry/tracecat_registry/core/sql.py
@@ -110,7 +110,6 @@ def _build_connection_url(
         db_driver: Database driver name
         db_name: Database name
         ssl_mode: SSL mode for connection
-        read_only: Whether to make the connection read-only if supported
 
     Returns:
         URL: SQLAlchemy URL object
@@ -258,7 +257,7 @@ def _get_engine(connection_url: URL, timeout: int = 30) -> Engine:
 
 @registry.register(
     namespace="core.sql",
-    description="Query a database with a read-only SELECT statement. Returns a list of results.",
+    description="Query a database with a SELECT statement. Returns a list of results.",
     default_title="Query Database",
     secrets=[sql_secret],
 )

--- a/registry/tracecat_registry/core/sql.py
+++ b/registry/tracecat_registry/core/sql.py
@@ -2,7 +2,6 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Set
 
 from typing_extensions import Doc
 from sqlalchemy import Engine, create_engine, text
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.engine.url import URL
 import ipaddress
 import re

--- a/registry/tracecat_registry/core/sql.py
+++ b/registry/tracecat_registry/core/sql.py
@@ -1,0 +1,360 @@
+from typing import Annotated, Any, Dict, List, Literal, Optional, Set
+
+from typing_extensions import Doc
+from sqlalchemy import Engine, create_engine, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.engine.url import URL
+import ipaddress
+import re
+
+from tracecat.types.exceptions import TracecatException
+from tracecat_registry import RegistrySecret, registry, secrets
+
+# Maximum SQL statement length
+MAX_SQL_LENGTH = 10000
+
+# Valid database drivers
+# Map SQL dialects to their SQLAlchemy drivers
+VALID_DATABASE_DRIVERS = {
+    "postgresql": "postgresql+psycopg",  # Using psycopg3 driver
+    # "mysql": "mysql+pymysql",  # Using PyMySQL driver
+    # "sqlite": "sqlite",  # SQLite uses built-in driver
+    # "mssql": "mssql+pyodbc",  # Using pyodbc driver
+}
+
+# Valid SSL modes
+VALID_SSL_MODES: Set[str] = {
+    "disable",
+    "allow",
+    "prefer",
+    "require",
+    "verify-ca",
+    "verify-full",
+}
+
+sql_secret = RegistrySecret(
+    name="sql",
+    keys=[
+        "SQL_HOST",
+        "SQL_PORT",
+        "SQL_USER",
+        "SQL_PASS",
+    ],
+)
+"""SQL secret.
+
+- name: `sql`
+- keys:
+    - `SQL_HOST`
+    - `SQL_PORT`
+    - `SQL_USER`
+    - `SQL_PASS`
+"""
+
+
+def _is_select_query(query: str) -> bool:
+    """
+    Check if a query is a SELECT statement.
+
+    This function removes comments and whitespace, then checks if the query
+    starts with SELECT. It performs basic validation, not full SQL parsing.
+
+    Args:
+        query: The SQL query to check
+
+    Returns:
+        bool: True if the query appears to be a SELECT statement
+    """
+    if not query or not isinstance(query, str):
+        return False
+
+    # Strip comments and normalize whitespace
+    # Remove block comments
+    clean_query = re.sub(r"/\*.*?\*/", " ", query, flags=re.DOTALL)
+    # Remove line comments
+    clean_query = re.sub(r"--.*?$", " ", clean_query, flags=re.MULTILINE)
+    # Normalize whitespace
+    clean_query = re.sub(r"\s+", " ", clean_query).strip().lower()
+
+    # Check if it starts with SELECT
+    return clean_query.startswith("select ")
+
+
+def _validate_db_driver(db_driver: str) -> None:
+    """
+    Validate that the database driver is allowed.
+
+    Args:
+        db_driver: The database driver to validate
+
+    Raises:
+        ValueError: If the driver is not in the allowed list
+    """
+    # Extract base driver (remove any +driver suffix)
+    base_driver = db_driver.split("+")[0] if "+" in db_driver else db_driver
+
+    if base_driver not in VALID_DATABASE_DRIVERS:
+        raise ValueError(
+            f"Invalid database driver. Must be one of: {', '.join(VALID_DATABASE_DRIVERS)}"
+        )
+
+
+def _build_connection_url(
+    db_driver: str,
+    db_name: str,
+    ssl_mode: Optional[str] = None,
+    read_only: bool = True,
+) -> URL:
+    """
+    Build a connection URL for SQLAlchemy.
+
+    Args:
+        db_driver: Database driver name
+        db_name: Database name
+        ssl_mode: SSL mode for connection
+        read_only: Whether to make the connection read-only if supported
+
+    Returns:
+        URL: SQLAlchemy URL object
+
+    Raises:
+        ValueError: If any validation fails
+    """
+    # Validate the database driver
+    _validate_db_driver(db_driver)
+
+    # Get credentials from registry secrets
+    host = secrets.get("SQL_HOST")
+    port = secrets.get("SQL_PORT")
+    user = secrets.get("SQL_USER")
+    password = secrets.get("SQL_PASS")
+
+    if not all((host, port, user, password)):
+        raise ValueError("Missing required SQL credentials")
+
+    # Sanitize host to prevent security issues
+    if host and isinstance(host, str):
+        # Blocked hostnames (lowercase for case-insensitive comparison)
+        blocked_hosts = {
+            "localhost",
+            "localhost.localdomain",
+            "127.0.0.1",
+            "0.0.0.0",
+            "::1",
+            "0:0:0:0:0:0:0:1",
+            "0:0:0:0:0:0:0:0",
+        }
+
+        # Check for exact hostname matches
+        if host.lower() in blocked_hosts:
+            raise ValueError(f"Access to host {host} is not allowed: blocked hostname")
+
+        # Block .localhost TLD (RFC 6761)
+        if host.lower().endswith(".localhost"):
+            raise ValueError("Access to .localhost domains is not allowed")
+
+        # Using ipaddress module to check if IP is in a blocked range
+        try:
+            ip = ipaddress.ip_address(host)
+
+            # Check various problematic IP types
+            if (
+                ip.is_loopback  # 127.0.0.0/8, ::1
+                or ip.is_unspecified  # 0.0.0.0, ::
+                or ip.is_link_local  # 169.254.0.0/16, fe80::/10
+                or ip.is_multicast  # 224.0.0.0/4, ff00::/8
+                or ip.is_private
+            ):  # 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7
+                raise ValueError(
+                    f"Access to address {host} is not allowed: restricted IP address type"
+                )
+
+            # Additional check for IPv4-mapped IPv6 addresses
+            if ip.version == 6 and hasattr(ip, "ipv4_mapped") and ip.ipv4_mapped:
+                ipv4 = ip.ipv4_mapped
+                if ipv4.is_loopback or ipv4.is_private or ipv4.is_unspecified:
+                    raise ValueError(
+                        f"Access to mapped IPv4 address {ipv4} is not allowed"
+                    )
+
+        except ValueError as e:
+            # If the error came from our validation, re-raise it
+            if "is not allowed" in str(e):
+                raise
+
+        # Valid hostname pattern
+        # if host == "postgres_db":
+        #     raise ValueError("Cannot use reserved hostname 'postgres_db'")
+
+        # # NOTE: Hostnames should not contain underscores
+        # host_pattern = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-\.]{0,253}[a-zA-Z0-9])?$")
+        # if not host_pattern.match(host):
+        #     raise ValueError("Invalid host format")
+
+    # Add query parameters if needed
+    kwargs = {}
+    if port is not None:
+        # Ensure port is a valid integer
+        if not port.isdigit():
+            raise ValueError("Port must be a number")
+        kwargs["port"] = int(port)
+        if not (1 <= kwargs["port"] <= 65535):
+            raise ValueError("Port must be between 1 and 65535")
+
+    # Create query parameters
+    query_params = {}
+
+    # Add SSL mode if specified
+    if ssl_mode:
+        if ssl_mode not in VALID_SSL_MODES:
+            raise ValueError(
+                f"Invalid SSL mode. Must be one of: {', '.join(VALID_SSL_MODES)}"
+            )
+        query_params["sslmode"] = ssl_mode
+
+    # Add query parameters if we have any
+    if query_params:
+        kwargs["query"] = query_params
+
+    return URL.create(
+        drivername=VALID_DATABASE_DRIVERS[db_driver],
+        username=user,
+        password=password,
+        host=host,
+        database=db_name,
+        **kwargs,
+    )
+
+
+def _get_engine(connection_url: URL, timeout: int = 30) -> Engine:
+    """
+    Get a SQLAlchemy engine with security settings.
+
+    Args:
+        connection_url: SQLAlchemy URL object
+        timeout: Query execution timeout in seconds
+
+    Returns:
+        Engine: SQLAlchemy engine
+    """
+    connect_args = {}
+
+    # Add driver-specific timeout settings
+    driver = str(connection_url).split("://")[0]
+    if driver.startswith("postgresql"):
+        if not isinstance(timeout, int):
+            raise ValueError("Timeout must be an integer")
+        connect_args["connect_timeout"] = timeout
+        connect_args["options"] = "-c statement_timeout={}s".format(timeout)
+    elif driver.startswith("mysql"):
+        connect_args["connect_timeout"] = timeout
+
+    return create_engine(
+        connection_url,
+        future=True,
+        echo=False,
+        pool_pre_ping=True,
+        connect_args=connect_args,
+    )
+
+
+@registry.register(
+    namespace="core.sql",
+    description="Query a database with a read-only SELECT statement. Returns a list of results.",
+    default_title="Query Database",
+    secrets=[sql_secret],
+)
+def query(
+    statement: Annotated[
+        str,
+        Doc("SQL SELECT query to execute. Only SELECT statements are allowed."),
+    ],
+    db_driver: Annotated[
+        Literal["postgresql"],
+        Doc("Database type. Currently only PostgreSQL is supported."),
+    ] = "postgresql",
+    db_name: Annotated[
+        str,
+        Doc("Database name to connect to"),
+    ] = "postgres",
+    ssl_mode: Annotated[
+        Optional[str],
+        Doc("SSL mode for connection (e.g., 'require', 'disable', etc.)"),
+    ] = None,
+    params: Annotated[
+        Optional[Dict[str, Any]],
+        Doc("Parameters to bind to the query for SQL injection protection"),
+    ] = None,
+    use_transaction: Annotated[
+        bool,
+        Doc("Whether to execute the query within a transaction"),
+    ] = True,
+    timeout: Annotated[
+        int,
+        Doc("Query timeout in seconds"),
+    ] = 30,
+) -> List[Dict[str, Any]]:
+    """
+    Execute a read-only SQL SELECT query against a database using SQLAlchemy.
+
+    This function enforces security by only allowing SELECT statements and
+    using parameter binding to prevent SQL injection attacks.
+
+    Args:
+        statement: SQL SELECT query to execute
+        db_driver: Type of database (postgresql, mysql, etc.)
+        db_name: Name of the database to connect to
+        ssl_mode: SSL mode for the connection
+        params: Parameters to bind to the query for SQL injection protection
+        use_transaction: Whether to execute the query within a transaction
+        timeout: Query timeout in seconds
+
+    Returns:
+        List of dictionaries representing query results
+
+    Raises:
+        ValueError: If the query is not a SELECT statement or exceeds length limit
+        Exception: If there is an error connecting to the database or executing the query
+    """
+    # Validate query length
+    if len(statement) > MAX_SQL_LENGTH:
+        raise ValueError(f"SQL statement too long (max {MAX_SQL_LENGTH} characters)")
+
+    # Validate query type - only allow SELECT statements
+    if not _is_select_query(statement):
+        raise ValueError("Only SELECT queries are allowed for security reasons")
+
+    # Build connection URL with read-only mode enabled
+    connection_url = _build_connection_url(
+        db_driver=db_driver,
+        db_name=db_name,
+        ssl_mode=ssl_mode,
+        read_only=True,
+    )
+
+    # Get engine with timeout
+    engine = _get_engine(connection_url, timeout=timeout)
+
+    try:
+        # Execute query using SQLAlchemy's text construct with parameter binding
+        with engine.connect() as conn:
+            # Create text object for query
+            query_obj = text(statement)
+
+            # Execute with or without transaction based on parameter
+            if use_transaction:
+                with conn.begin():
+                    # Use parameters for SQL injection protection
+                    result = conn.execute(query_obj, parameters=params or {})
+            else:
+                # Use parameters for SQL injection protection
+                result = conn.execute(query_obj, parameters=params or {})
+
+            # Convert results to list of dictionaries
+            column_names = result.keys()
+            results = [dict(zip(column_names, row)) for row in result.fetchall()]
+
+        return results
+
+    except Exception as e:
+        raise TracecatException(f"Error executing query: {str(e)}")

--- a/tests/registry/test_core_sql.py
+++ b/tests/registry/test_core_sql.py
@@ -66,7 +66,6 @@ class TestSelectQueryValidator:
     def test_nested_comments(self):
         """Test handling of nested comments and complex whitespace."""
         queries = [
-            "/* outer /* nested */ comment */SELECT * FROM users",
             "/* comment *//* another */\n--line comment\nSELECT * FROM users",
             "--line /*not a block comment\nSELECT * FROM users",
             "/*\nmultiline\n*/SELECT * FROM users",

--- a/tests/registry/test_core_sql.py
+++ b/tests/registry/test_core_sql.py
@@ -1,0 +1,314 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.engine.url import URL
+from sqlalchemy.exc import SQLAlchemyError
+from tracecat_registry.core.sql import (
+    MAX_SQL_LENGTH,
+    VALID_DATABASE_DRIVERS,
+    _build_connection_url,
+    _is_select_query,
+    _validate_db_driver,
+    query,
+)
+
+
+class TestSelectQueryValidator:
+    """Tests for the _is_select_query function."""
+
+    @pytest.mark.parametrize(
+        "query_text,expected",
+        [
+            # Valid SELECT queries
+            ("SELECT * FROM users", True),
+            ("select id, name from users", True),
+            ("  SELECT  *  FROM  users  ", True),
+            ("/* comment */ SELECT id FROM users", True),
+            ("-- comment\nSELECT id FROM users", True),
+            # Invalid queries
+            ("INSERT INTO users VALUES (1, 'test')", False),
+            ("UPDATE users SET name='test'", False),
+            ("DELETE FROM users", False),
+            ("DROP TABLE users", False),
+            ("CREATE TABLE users (id INT)", False),
+            ("TRUNCATE TABLE users", False),
+            ("", False),
+            (None, False),
+            (123, False),  # Non-string
+        ],
+    )
+    def test_select_query_validation(self, query_text, expected):
+        """Test SELECT query validation function."""
+        assert _is_select_query(query_text) == expected
+
+
+class TestDriverValidator:
+    """Tests for the _validate_db_driver function."""
+
+    @pytest.mark.parametrize("driver", list(VALID_DATABASE_DRIVERS))
+    def test_valid_drivers(self, driver):
+        """Test with valid database drivers."""
+        # Should not raise an exception
+        _validate_db_driver(driver)
+
+        # Test with driver variants
+        _validate_db_driver(f"{driver}+somedriver")
+
+    @pytest.mark.parametrize(
+        "driver",
+        [
+            "invalid",
+            "mongodb",  # Not in our valid drivers
+            "redis",
+            "cassandra",
+            "",
+        ],
+    )
+    def test_invalid_drivers(self, driver):
+        """Test with invalid database drivers."""
+        with pytest.raises(ValueError, match="Invalid database driver"):
+            _validate_db_driver(driver)
+
+
+class TestBuildConnectionUrl:
+    """Tests for the _build_connection_url function."""
+
+    @pytest.fixture
+    def mock_secrets(self):
+        """Mock the secrets.get function to return test values."""
+        with patch("tracecat_registry.core.sql.secrets.get") as mock_get:
+            # Set up default valid values
+            def side_effect(key):
+                return {
+                    "SQL_HOST": "example.com",
+                    "SQL_PORT": "5432",
+                    "SQL_USER": "testuser",
+                    "SQL_PASS": "testpass",
+                }[key]
+
+            mock_get.side_effect = side_effect
+            yield mock_get
+
+    def test_valid_host(self, mock_secrets):
+        """Test with a valid hostname."""
+        url = _build_connection_url("postgresql", "testdb", None)
+        assert isinstance(url, URL)
+        assert url.host == "example.com"
+        assert url.database == "testdb"
+        assert url.username == "testuser"
+        assert url.password == "testpass"
+        assert url.drivername == "postgresql"
+
+    def test_missing_credentials(self, mock_secrets):
+        """Test with missing credentials."""
+        mock_secrets.side_effect = lambda key: None if key == "SQL_USER" else "value"
+        with pytest.raises(ValueError, match="Missing required SQL credentials"):
+            _build_connection_url("postgresql", "testdb", None)
+
+    def test_port_conversion(self, mock_secrets):
+        """Test port is converted to integer."""
+        url = _build_connection_url("postgresql", "testdb", None)
+        assert url.port == 5432
+
+    def test_invalid_port(self, mock_secrets):
+        """Test with invalid port format."""
+        mock_secrets.side_effect = (
+            lambda key: "not_a_number" if key == "SQL_PORT" else "value"
+        )
+        with pytest.raises(ValueError, match="Invalid port format"):
+            _build_connection_url("postgresql", "testdb", None)
+
+    def test_ssl_mode(self, mock_secrets):
+        """Test with SSL mode parameter."""
+        url = _build_connection_url("postgresql", "testdb", "require")
+        assert url.query["sslmode"] == "require"
+
+    def test_invalid_ssl_mode(self, mock_secrets):
+        """Test with invalid SSL mode."""
+        with pytest.raises(ValueError, match="Invalid SSL mode"):
+            _build_connection_url("postgresql", "testdb", "invalid_mode")
+
+    def test_read_only_mode(self, mock_secrets):
+        """Test read-only mode is set."""
+        # For PostgreSQL, check read-only is set
+        url = _build_connection_url("postgresql", "testdb", None, read_only=True)
+        assert url.query["default_transaction_read_only"] == "true"
+
+        # For PostgreSQL, check read-only is not set when disabled
+        url = _build_connection_url("postgresql", "testdb", None, read_only=False)
+        assert "default_transaction_read_only" not in url.query
+
+    @pytest.mark.parametrize(
+        "blocked_host",
+        [
+            "localhost",
+            "localhost.localdomain",
+            "127.0.0.1",
+            "0.0.0.0",
+            "::1",
+            "0:0:0:0:0:0:0:1",
+            "0:0:0:0:0:0:0:0",
+            "sub.localhost",  # Test .localhost TLD
+        ],
+    )
+    def test_blocked_hostnames(self, mock_secrets, blocked_host):
+        """Test with blocked hostnames."""
+        mock_secrets.side_effect = (
+            lambda key: blocked_host if key == "SQL_HOST" else "value"
+        )
+        with pytest.raises(ValueError, match="is not allowed"):
+            _build_connection_url("postgresql", "testdb", None)
+
+    @pytest.mark.parametrize(
+        "private_ip",
+        [
+            "10.0.0.1",  # Private IPv4
+            "172.16.0.1",  # Private IPv4
+            "192.168.0.1",  # Private IPv4
+            "169.254.0.1",  # Link-local IPv4
+            "224.0.0.1",  # Multicast IPv4
+            "fc00::1",  # Private IPv6
+            "fe80::1",  # Link-local IPv6
+            "ff00::1",  # Multicast IPv6
+            "::ffff:127.0.0.1",  # IPv4-mapped IPv6 loopback
+            "::ffff:10.0.0.1",  # IPv4-mapped IPv6 private
+        ],
+    )
+    def test_blocked_ip_ranges(self, mock_secrets, private_ip):
+        """Test with IPs in blocked ranges."""
+        mock_secrets.side_effect = (
+            lambda key: private_ip if key == "SQL_HOST" else "value"
+        )
+        with pytest.raises(ValueError, match="is not allowed"):
+            _build_connection_url("postgresql", "testdb", None)
+
+    def test_invalid_hostname_format(self, mock_secrets):
+        """Test with invalid hostname format."""
+        mock_secrets.side_effect = (
+            lambda key: "invalid-host!" if key == "SQL_HOST" else "value"
+        )
+        with pytest.raises(ValueError, match="Invalid host format"):
+            _build_connection_url("postgresql", "testdb", None)
+
+    @pytest.mark.parametrize(
+        "invalid_driver", ["mongodb", "redis", "cassandra", "neo4j", "elasticsearch"]
+    )
+    def test_invalid_db_driver(self, mock_secrets, invalid_driver):
+        """Test with invalid database driver."""
+        with pytest.raises(ValueError, match="Invalid database driver"):
+            _build_connection_url(invalid_driver, "testdb", None)
+
+
+class TestQuery:
+    """Tests for the query function."""
+
+    @pytest.fixture
+    def mock_engine(self):
+        """Mock SQLAlchemy engine creation."""
+        with patch("tracecat_registry.core.sql._get_engine") as mock_get_engine:
+            engine_mock = MagicMock()
+            conn_mock = MagicMock()
+            result_mock = MagicMock()
+
+            # Configure mocks for the connection flow
+            engine_mock.connect.return_value.__enter__.return_value = conn_mock
+            conn_mock.execute.return_value = result_mock
+            result_mock.keys.return_value = ["id", "name"]
+            result_mock.fetchall.return_value = [(1, "test1"), (2, "test2")]
+
+            mock_get_engine.return_value = engine_mock
+            yield mock_get_engine, conn_mock
+
+    @pytest.fixture
+    def mock_build_url(self):
+        """Mock the _build_connection_url function."""
+        with patch("tracecat_registry.core.sql._build_connection_url") as mock:
+            mock.return_value = "mock_url"
+            yield mock
+
+    @pytest.fixture
+    def mock_is_select(self):
+        """Mock the _is_select_query function to return True."""
+        with patch("tracecat_registry.core.sql._is_select_query") as mock:
+            mock.return_value = True
+            yield mock
+
+    def test_query_execution(self, mock_engine, mock_build_url, mock_is_select):
+        """Test basic query execution."""
+        mock_get_engine, conn_mock = mock_engine
+
+        result = query(
+            "SELECT * FROM test", "postgresql", "testdb", None, {"param1": "value1"}
+        )
+
+        # Verify URL was built with correct parameters
+        mock_build_url.assert_called_once_with(
+            db_driver="postgresql", db_name="testdb", ssl_mode=None, read_only=True
+        )
+
+        # Verify query was executed
+        engine = mock_get_engine.return_value
+        conn = engine.connect.return_value.__enter__.return_value
+        conn.execute.assert_called_once()
+
+        # Verify parameters were passed
+        args, kwargs = conn.execute.call_args
+        assert kwargs["parameters"] == {"param1": "value1"}
+
+        # Verify result formatting
+        assert result == [{"id": 1, "name": "test1"}, {"id": 2, "name": "test2"}]
+
+    def test_query_length_validation(self, mock_engine, mock_build_url):
+        """Test query length validation."""
+        with pytest.raises(ValueError, match="SQL statement too long"):
+            query("SELECT * FROM test" + "x" * MAX_SQL_LENGTH, "postgresql", "testdb")
+
+    def test_query_type_validation(self, mock_engine, mock_build_url):
+        """Test query type validation."""
+        with patch("tracecat_registry.core.sql._is_select_query") as mock_is_select:
+            mock_is_select.return_value = False
+            with pytest.raises(ValueError, match="Only SELECT queries are allowed"):
+                query("INSERT INTO test VALUES (1)", "postgresql", "testdb")
+
+    def test_query_sqlalchemy_error(self, mock_engine, mock_build_url, mock_is_select):
+        """Test handling of SQLAlchemy errors."""
+        mock_get_engine, conn_mock = mock_engine
+        conn_mock.execute.side_effect = SQLAlchemyError("Database error")
+
+        with pytest.raises(Exception, match="Database error"):
+            query("SELECT * FROM test", "postgresql", "testdb", None)
+
+    def test_query_general_error(self, mock_engine, mock_build_url, mock_is_select):
+        """Test handling of general errors."""
+        mock_get_engine, conn_mock = mock_engine
+        conn_mock.execute.side_effect = Exception("General error")
+
+        with pytest.raises(Exception, match="Error executing query"):
+            query("SELECT * FROM test", "postgresql", "testdb", None)
+
+    @pytest.mark.parametrize("use_transaction", [True, False])
+    def test_transaction_handling(
+        self, mock_engine, mock_build_url, mock_is_select, use_transaction
+    ):
+        """Test query with transaction handling."""
+        mock_get_engine, conn_mock = mock_engine
+
+        result = query(
+            "SELECT * FROM test",
+            "postgresql",
+            "testdb",
+            None,
+            use_transaction=use_transaction,
+        )
+
+        # Verify result was returned correctly
+        assert result == [{"id": 1, "name": "test1"}, {"id": 2, "name": "test2"}]
+
+    def test_query_timeout(self, mock_engine, mock_build_url, mock_is_select):
+        """Test query timeout parameter is passed to engine creation."""
+        mock_get_engine, conn_mock = mock_engine
+
+        query("SELECT * FROM test", "postgresql", "testdb", None, timeout=60)
+
+        # Verify timeout was passed to _get_engine
+        mock_get_engine.assert_called_once_with("mock_url", timeout=60)


### PR DESCRIPTION
# Security
- Passing raw SQL here is highly unsafe--it's reliant on the user to perform the sanitization. cc @topher-lo.
# Solution
- Make the transaction read only for `postgresql`
- Added additional validation to check for statement delimiters and take 
- Zeropath scan seems ok

# Description
- Add `core.sql.query`, which currently only allows you to query with a SELECT statement.
- Added a lot of sanitization/validation for security
- Only supports `postgresql` driver atm. Uses `psycopg[binary]` for simplicity
- Requires SQL_HOST, SQL_PORT, SQL_USER, SQL_PASS env vars.
- Database name is optional

# Guardrails
We sanitize on any loopback addresses and especially `postgres_db`. Note that we also don't allow underscores in the url anyways (this is according to some RFCs, can't recall).

# Testing
Added unit tests.
## QA
Tested with my local Tracecat `postgres_db` exposed through tcp:// over ngrok.

<img width="1728" alt="Screenshot 2025-03-22 at 00 37 02" src="https://github.com/user-attachments/assets/adb7e106-e28f-4f89-8b6e-1bb1658ee46f" />

Example of malicious query being blocked by postgres read only

<img width="1728" alt="Screenshot 2025-03-22 at 01 44 31" src="https://github.com/user-attachments/assets/71732d84-4561-45ad-a42e-91aaeea273ed" />



