### PR TITLE
fix(engine): Use temporal's workflow.uuid4() if we're inside the workflow sandbox

### DIFF
--- a/tracecat/identifiers/common.py
+++ b/tracecat/identifiers/common.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Self, cast
 from uuid import UUID
 
 from pydantic_core import CoreSchema, core_schema
+from temporalio import workflow
 
 from tracecat import base62
 
@@ -32,6 +33,13 @@ def id_from_short(short_id: str, prefix: str) -> UUID:
     prefix_len = len(prefix)
     suffix = short_id[prefix_len:]
     return UUID(int=base62.b62decode(suffix))
+
+
+def safe_uuid4() -> UUID:
+    """Generate a UUID4 safe for use in workflows."""
+    if workflow.unsafe.in_sandbox():
+        return workflow.uuid4()
+    return uuid.uuid4()
 
 
 class TracecatUUID[ShortID: str](UUID):
@@ -122,7 +130,7 @@ class TracecatUUID[ShortID: str](UUID):
 
     @classmethod
     def new_uuid4(cls) -> Self:
-        return cls.from_uuid(uuid.uuid4())
+        return cls.from_uuid(safe_uuid4())
 
     @classmethod
     def new(cls, id: Any) -> Self:


### PR DESCRIPTION
# Issue
When we try to load workflow executions from spawning a list of child workflows, we were seeing this:
```
api                   | temporalio.client.WorkflowQueryFailedError: [TMPRL1100] Nondeterminism error: Child workflow id of scheduled event 'wf_4Va5Yb7xLsIXIXiLjdjNob/exec_2gH9iBkiKfKi7gBiotWVXm' does not match child workflow id of command 'wf_4Va5Yb7xLsIXIXiLjdjNob/exec_07gFQ2ICmvLwVxxrWMfdFH
```
during workflow replay. In particular, it happens when we try to `query` the workflow execution in the workflow executions service, after we added interactions.

# Diagnostic
From kapa.ai:

> 
> You're encountering a non-deterministic error when querying a workflow. This error occurs because there's a mismatch between the child workflow ID that was used during the original workflow execution and the ID that's being generated during replay when you query the workflow.
> Why This Happens
> Temporal requires workflows to be deterministic, meaning they must produce the same sequence of commands every time they're executed with the same input. When you query a workflow, Temporal replays the workflow's event history to rebuild its current state. During this replay, if your workflow code generates different commands than it did during the original execution, you'll get a non-deterministic error [What is a Temporal Workflow?](https://docs.temporal.io/workflows#deterministic-constraints).
> In your case, the error specifically indicates that the child workflow ID being generated during replay doesn't match the one that was used in the original execution.
> See less
> Common Causes
> This typically happens when:
> 1. Your workflow code uses non-deterministic logic to generate child workflow IDs
> 2. You're using Workflow.getInfo().getWorkflowId() or similar methods to dynamically generate child workflow IDs
> 3. The workflow ID available during replay differs from the one available durin…
> See more
> Solution
> When using the WorkflowReplayer (for testing) or when querying workflows, you need to ensure that the workflow ID is properly specified. For example, in Java, you would need to provide the workflow ID when constructing the WorkflowExecutionHistory:
> WorkflowReplayer.replayWorkflowExecution(
>     WorkflowExecutionHistory.WorkflowExecutionHistory(
>         WorkflowHistoryLoader.readHistory(eventHistoryFile), 
>         "YOUR_WORKFLOW_ID"
>     ),
>     YourWorkflowImpl.class
> );
> For your specific case with wf_handle.query(), the issue is that the workflow ID being used during replay (when processing the query) doesn't match the original workflow ID that was used when the child workflow was created.
> To fix this, consider:
> 1. Using a deterministic method to generate child workflow IDs that doesn't depend on runtime information
> 2. If you must use the parent workflow ID as part of the child ID, make sure it's properly available during replay
> 3. Using Workflow Versioning to handle changes in your workflow logic
> Remember that workflow code cannot catch or handle non-deterministic errors - you must recognize and avoid the problems that cause them.
> 

# Solution
Use deterministic uuid4() from `temporalio` when generating the child worklfow execution ID.

# Screens

https://github.com/user-attachments/assets/acfe46c7-96d7-44de-b0e9-c724e9a9f8c0

