### PR TITLE
feat(ui): Collapse text with 25 chars plus in lookup tables

### DIFF
--- a/frontend/src/components/tables/table-view.tsx
+++ b/frontend/src/components/tables/table-view.tsx
@@ -13,6 +13,50 @@ import { JsonViewWithControls } from "@/components/json-viewer"
 import { TableViewAction } from "@/components/tables/table-view-action"
 import { TableViewColumnMenu } from "@/components/tables/table-view-column-menu"
 
+import { Button } from "@/components/ui/button"
+
+function CollapsibleText({ text }: { text: string }) {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  if (!isExpanded) {
+    return (
+      <div className="flex items-center">
+        <span className="text-xs truncate">
+          {text.substring(0, 25)}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setIsExpanded(true)}
+          className="h-6 px-1 text-xs text-muted-foreground hover:bg-transparent"
+        >
+          ...
+        </Button>
+      </div>
+    );
+  }
+
+  // Format the text into chunks when expanded
+  const chunks = [];
+  for (let i = 0; i < text.length; i += 25) {
+    chunks.push(text.substring(i, i + 25));
+  }
+
+  return (
+    <div className="space-y-1">
+      <pre className="text-xs whitespace-pre-wrap">{chunks.join('\n')}</pre>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setIsExpanded(false)}
+        className="h-6 px-2 text-xs text-muted-foreground"
+      >
+        Collapse
+      </Button>
+    </div>
+  );
+}
+
 export function DatabaseTable({ table: { columns } }: { table: TableRead }) {
   const { tableId } = useParams<{ tableId: string }>()
   const { workspaceId } = useWorkspace()
@@ -35,15 +79,19 @@ export function DatabaseTable({ table: { columns } }: { table: TableRead }) {
         </div>
       ),
       cell: ({ row }: CellT) => {
-        const value = row.original[column.name as keyof TableRowRead]
+        const value = row.original[column.name as keyof TableRowRead];
         return (
-          <div className="w-full text-xs">
+          <div className="text-xs w-full">
             {typeof value === "object" && value ? (
               <div onClick={(e) => e.stopPropagation()} className="w-full">
                 <TooltipProvider>
-                  <JsonViewWithControls src={value} />
+                  <JsonViewWithControls
+                    src={value}
+                  />
                 </TooltipProvider>
               </div>
+            ) : typeof value === "string" && value.length > 25 ? (
+              <CollapsibleText text={String(value)} />
             ) : (
               <pre className="text-xs">{String(value)}</pre>
             )}


### PR DESCRIPTION
## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [X] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [X] PR only implements a single feature or fixes a single bug.
- [X] Tests passing (`uv run pytest tests`)?
- [X] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

When text values got too long, the table became a little too cluttered 

## Related Issues

#975 

## Screenshots / Recordings

![Screenshot_115](https://github.com/user-attachments/assets/fc33f7ab-26a1-46af-aefe-6c991766e831)
![Screenshot_116](https://github.com/user-attachments/assets/13e2a1fc-1450-4fef-b70c-91b5d2652fa3)


## Steps to QA

1. Create a table with a text column
2. Add a value with more then 25 characters
