### PR TITLE
fix: Fix  deadlock issue when unexpected keyword in error info + add more metrics

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,8 @@
 {$BASE_DOMAIN} {
 	bind {$ADDRESS} # Binds to all available network interfaces if not specified
+	handle_path /metrics* {
+		reverse_proxy http://worker:9000
+	}
 	handle_path /api* {
 		reverse_proxy http://api:8000
 	}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,5 @@
 {$BASE_DOMAIN} {
 	bind {$ADDRESS} # Binds to all available network interfaces if not specified
-	handle_path /metrics* {
-		reverse_proxy http://worker:9000
-	}
 	handle_path /api* {
 		reverse_proxy http://api:8000
 	}

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -38,7 +38,7 @@ cat <<EOF > /etc/caddy/Caddyfile
   }
 %{if var.enable_metrics}
   handle_path /metrics* {
-    basicauth {
+    basic_auth {
       {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
     }
     reverse_proxy http://metrics-service:9000

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -28,16 +28,7 @@ resource "aws_ecs_task_definition" "caddy_task_definition" {
         "/bin/sh",
         "-c",
         <<EOT
-# Write the username and password hash to files for Caddy to use
-if [ "${var.enable_metrics}" = "true" ]; then
-  echo "Setting up metrics authentication" >&2
-  echo "${var.metrics_auth_username}" > /etc/caddy/metrics_username
-  echo "${var.metrics_auth_password_hash}" > /etc/caddy/metrics_password_hash
-fi
-
-# Create the Caddyfile with conditional metrics section
-echo "Creating Caddyfile" >&2
-cat > /etc/caddy/Caddyfile <<EOF
+cat <<EOF > /etc/caddy/Caddyfile
 :80 {
   handle_path /api* {
     reverse_proxy http://api-service:8000
@@ -45,29 +36,17 @@ cat > /etc/caddy/Caddyfile <<EOF
   handle_path /temporal-admin* {
     reverse_proxy http://temporal-ui-service:8080
   }
-EOF
-
-# Conditionally add metrics section with basic auth
-if [ "${var.enable_metrics}" = "true" ]; then
-  cat >> /etc/caddy/Caddyfile <<EOF
+%{if var.enable_metrics}
   handle_path /metrics* {
     basicauth {
-      \$(cat /etc/caddy/metrics_username) \$(cat /etc/caddy/metrics_password_hash)
+      {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
     }
     reverse_proxy http://metrics-service:9000
   }
-EOF
-fi
-
-# Complete the Caddyfile
-cat >> /etc/caddy/Caddyfile <<EOF
+%{endif}
   reverse_proxy http://ui-service:3000
 }
 EOF
-
-echo "Caddyfile created:" >&2
-cat /etc/caddy/Caddyfile >&2
-echo "Starting Caddy" >&2
 caddy run --config /etc/caddy/Caddyfile
 EOT
       ]

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -43,7 +43,7 @@ BASECONFIG
 if [ "${var.enable_metrics}" = "true" ]; then
   cat >> /etc/caddy/Caddyfile <<'METRICSCONFIG'
   handle_path /metrics* {
-    basicauth {
+    basic_auth {
       {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
     }
     reverse_proxy http://metrics-service:9000

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -44,6 +44,7 @@ cat <<EOF > /etc/caddy/Caddyfile
     reverse_proxy http://metrics-service:9000
   }
 %{endif}
+  reverse_proxy http://ui-service:3000
 }
 EOF
 caddy run --config /etc/caddy/Caddyfile

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -28,7 +28,8 @@ resource "aws_ecs_task_definition" "caddy_task_definition" {
         "/bin/sh",
         "-c",
         <<EOT
-cat <<EOF > /etc/caddy/Caddyfile
+# Write base Caddyfile
+cat > /etc/caddy/Caddyfile <<'BASECONFIG'
 :80 {
   handle_path /api* {
     reverse_proxy http://api-service:8000
@@ -36,17 +37,32 @@ cat <<EOF > /etc/caddy/Caddyfile
   handle_path /temporal-admin* {
     reverse_proxy http://temporal-ui-service:8080
   }
+BASECONFIG
+
+# Conditionally append metrics config
+if [ "${var.enable_metrics}" = "true" ]; then
+  cat >> /etc/caddy/Caddyfile <<'METRICSCONFIG'
   handle_path /metrics* {
+    basic_auth {
+      {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
+    }
     reverse_proxy http://metrics-service:9000
   }
+METRICSCONFIG
+fi
+
+# Append final UI config
+cat >> /etc/caddy/Caddyfile <<'UICONFIG'
   reverse_proxy http://ui-service:3000
 }
-EOF
+UICONFIG
+
+# Run Caddy
 caddy run --config /etc/caddy/Caddyfile
 EOT
       ]
 
-      environment = [
+      environment = var.enable_metrics ? [
         {
           name  = "METRICS_AUTH_USERNAME"
           value = var.metrics_auth_username
@@ -55,7 +71,7 @@ EOT
           name  = "METRICS_AUTH_PASSWORD_HASH"
           value = var.metrics_auth_password_hash
         }
-      ]
+      ] : []
       logConfiguration = {
         logDriver = "awslogs"
         options = {

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -36,12 +36,30 @@ cat <<EOF > /etc/caddy/Caddyfile
   handle_path /temporal-admin* {
     reverse_proxy http://temporal-ui-service:8080
   }
-  reverse_proxy http://ui-service:3000
+%{if var.enable_metrics}
+  handle_path /metrics* {
+    basicauth {
+      {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
+    }
+    reverse_proxy http://metrics-service:9000
+  }
+%{endif}
 }
 EOF
 caddy run --config /etc/caddy/Caddyfile
 EOT
       ]
+
+      environment = var.enable_metrics ? [
+        {
+          name  = "METRICS_AUTH_USERNAME"
+          value = var.metrics_auth_username
+        },
+        {
+          name  = "METRICS_AUTH_PASSWORD_HASH"
+          value = var.metrics_auth_password_hash
+        }
+      ] : []
 
       logConfiguration = {
         logDriver = "awslogs"

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -39,7 +39,7 @@ cat <<EOF > /etc/caddy/Caddyfile
 %{if var.enable_metrics}
   handle_path /metrics* {
     basicauth {
-      {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
+      $METRICS_AUTH_USERNAME $METRICS_AUTH_PASSWORD_HASH
     }
     reverse_proxy http://metrics-service:9000
   }

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -28,7 +28,8 @@ resource "aws_ecs_task_definition" "caddy_task_definition" {
         "/bin/sh",
         "-c",
         <<EOT
-cat <<'EOF' > /etc/caddy/Caddyfile
+# Write base Caddyfile
+cat > /etc/caddy/Caddyfile <<'BASECONFIG'
 :80 {
   handle_path /api* {
     reverse_proxy http://api-service:8000
@@ -36,16 +37,27 @@ cat <<'EOF' > /etc/caddy/Caddyfile
   handle_path /temporal-admin* {
     reverse_proxy http://temporal-ui-service:8080
   }
-  # Metrics configuration - uncomment if needed
+BASECONFIG
+
+# Conditionally append metrics config
+if [ "${var.enable_metrics}" = "true" ]; then
+  cat >> /etc/caddy/Caddyfile <<'METRICSCONFIG'
   handle_path /metrics* {
     basic_auth {
       {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
     }
     reverse_proxy http://metrics-service:9000
   }
+METRICSCONFIG
+fi
+
+# Append final UI config
+cat >> /etc/caddy/Caddyfile <<'UICONFIG'
   reverse_proxy http://ui-service:3000
 }
-EOF
+UICONFIG
+
+# Run Caddy
 caddy run --config /etc/caddy/Caddyfile
 EOT
       ]

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -36,47 +36,45 @@ cat <<'EOF' > /etc/caddy/Caddyfile
   handle_path /temporal-admin* {
     reverse_proxy http://temporal-ui-service:8080
   }
-${var.enable_metrics ? <<METRICS
+  # Metrics configuration - uncomment if needed
   handle_path /metrics* {
     basic_auth {
       {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
     }
     reverse_proxy http://metrics-service:9000
   }
-METRICS
-      : ""}
   reverse_proxy http://ui-service:3000
 }
 EOF
 caddy run --config /etc/caddy/Caddyfile
 EOT
-    ]
+      ]
 
-    environment = var.enable_metrics ? [
-      {
-        name  = "METRICS_AUTH_USERNAME"
-        value = var.metrics_auth_username
-      },
-      {
-        name  = "METRICS_AUTH_PASSWORD_HASH"
-        value = var.metrics_auth_password_hash
-      }
-    ] : []
+      environment = var.enable_metrics ? [
+        {
+          name  = "METRICS_AUTH_USERNAME"
+          value = var.metrics_auth_username
+        },
+        {
+          name  = "METRICS_AUTH_PASSWORD_HASH"
+          value = var.metrics_auth_password_hash
+        }
+      ] : []
 
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
-        awslogs-region        = var.aws_region
-        awslogs-stream-prefix = "caddy"
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "caddy"
+        }
+      }
+      dockerPullConfig = {
+        maxAttempts = 3
+        backoffTime = 10
       }
     }
-    dockerPullConfig = {
-      maxAttempts = 3
-      backoffTime = 10
-    }
-    }
-])
+  ])
 }
 
 resource "aws_ecs_service" "tracecat_caddy" {

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -28,8 +28,16 @@ resource "aws_ecs_task_definition" "caddy_task_definition" {
         "/bin/sh",
         "-c",
         <<EOT
-# Write base Caddyfile
-cat > /etc/caddy/Caddyfile <<'BASECONFIG'
+# Write the username and password hash to files for Caddy to use
+if [ "${var.enable_metrics}" = "true" ]; then
+  echo "Setting up metrics authentication" >&2
+  echo "${var.metrics_auth_username}" > /etc/caddy/metrics_username
+  echo "${var.metrics_auth_password_hash}" > /etc/caddy/metrics_password_hash
+fi
+
+# Create the Caddyfile with conditional metrics section
+echo "Creating Caddyfile" >&2
+cat > /etc/caddy/Caddyfile <<EOF
 :80 {
   handle_path /api* {
     reverse_proxy http://api-service:8000
@@ -37,27 +45,29 @@ cat > /etc/caddy/Caddyfile <<'BASECONFIG'
   handle_path /temporal-admin* {
     reverse_proxy http://temporal-ui-service:8080
   }
-BASECONFIG
+EOF
 
-# Conditionally append metrics config
+# Conditionally add metrics section with basic auth
 if [ "${var.enable_metrics}" = "true" ]; then
-  cat >> /etc/caddy/Caddyfile <<'METRICSCONFIG'
+  cat >> /etc/caddy/Caddyfile <<EOF
   handle_path /metrics* {
-    basic_auth {
-      {$METRICS_AUTH_USERNAME} {$METRICS_AUTH_PASSWORD_HASH}
+    basicauth {
+      \$(cat /etc/caddy/metrics_username) \$(cat /etc/caddy/metrics_password_hash)
     }
     reverse_proxy http://metrics-service:9000
   }
-METRICSCONFIG
+EOF
 fi
 
-# Append final UI config
-cat >> /etc/caddy/Caddyfile <<'UICONFIG'
+# Complete the Caddyfile
+cat >> /etc/caddy/Caddyfile <<EOF
   reverse_proxy http://ui-service:3000
 }
-UICONFIG
+EOF
 
-# Run Caddy
+echo "Caddyfile created:" >&2
+cat /etc/caddy/Caddyfile >&2
+echo "Starting Caddy" >&2
 caddy run --config /etc/caddy/Caddyfile
 EOT
       ]

--- a/deployments/aws/ecs/ecs-caddy.tf
+++ b/deployments/aws/ecs/ecs-caddy.tf
@@ -134,6 +134,7 @@ resource "aws_ecs_service" "tracecat_caddy" {
 
   depends_on = [
     aws_ecs_service.tracecat_api,
-    aws_ecs_service.tracecat_ui
+    aws_ecs_service.tracecat_ui,
+    aws_ecs_service.tracecat_worker
   ]
 }

--- a/deployments/aws/ecs/ecs-worker.tf
+++ b/deployments/aws/ecs/ecs-worker.tf
@@ -73,6 +73,17 @@ resource "aws_ecs_service" "tracecat_worker" {
         dns_name = "worker-service"
       }
     }
+    service {
+      port_name      = "metrics"
+      discovery_name = "metrics-service"
+      timeout {
+        per_request_timeout_seconds = 120
+      }
+      client_alias {
+        port     = 9000
+        dns_name = "metrics-service"
+      }
+    }
 
     log_configuration {
       log_driver = "awslogs"

--- a/deployments/aws/ecs/ecs-worker.tf
+++ b/deployments/aws/ecs/ecs-worker.tf
@@ -24,6 +24,12 @@ resource "aws_ecs_task_definition" "worker_task_definition" {
           hostPort      = 8001
           name          = "worker"
           appProtocol   = "http"
+        },
+        {
+          containerPort = 9000
+          hostPort      = 9000
+          name          = "metrics"
+          appProtocol   = "http"
         }
       ]
       logConfiguration = {

--- a/deployments/aws/ecs/ecs-worker.tf
+++ b/deployments/aws/ecs/ecs-worker.tf
@@ -62,12 +62,14 @@ resource "aws_ecs_service" "tracecat_worker" {
     security_groups = [
       aws_security_group.core.id,
       aws_security_group.core_db.id,
+      aws_security_group.caddy.id
     ]
   }
 
   service_connect_configuration {
     enabled   = true
     namespace = local.local_dns_namespace
+
     service {
       port_name      = "worker"
       discovery_name = "worker-service"
@@ -79,6 +81,7 @@ resource "aws_ecs_service" "tracecat_worker" {
         dns_name = "worker-service"
       }
     }
+
     service {
       port_name      = "metrics"
       discovery_name = "metrics-service"

--- a/deployments/aws/ecs/ecs.tf
+++ b/deployments/aws/ecs/ecs.tf
@@ -10,6 +10,12 @@ resource "aws_ecs_cluster" "tracecat_cluster" {
   service_connect_defaults {
     namespace = aws_service_discovery_http_namespace.namespace.arn
   }
+
+  # Enable Container Insights
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 locals {

--- a/deployments/aws/ecs/security_groups.tf
+++ b/deployments/aws/ecs/security_groups.tf
@@ -138,11 +138,11 @@ resource "aws_security_group" "core" {
   }
 
   ingress {
-    description     = "Allow traffic to metrics endpoint on port 9000"
-    from_port       = 9000
-    to_port         = 9000
-    protocol        = "tcp"
-    security_groups = [aws_security_group.caddy.id]
+    description = "Allow inbound traffic for metrics service"
+    from_port   = 9000
+    to_port     = 9000
+    protocol    = "tcp"
+    self        = true
   }
 
   egress {

--- a/deployments/aws/ecs/security_groups.tf
+++ b/deployments/aws/ecs/security_groups.tf
@@ -72,6 +72,14 @@ resource "aws_security_group" "caddy" {
     self        = true
   }
 
+  ingress {
+    description = "Allow Caddy to forward traffic to Metrics service"
+    protocol    = "tcp"
+    from_port   = 9000
+    to_port     = 9000
+    self        = true
+  }
+
   egress {
     protocol    = "-1"
     from_port   = 0
@@ -127,6 +135,14 @@ resource "aws_security_group" "core" {
     to_port     = 7233
     protocol    = "tcp"
     self        = true
+  }
+
+  ingress {
+    description     = "Allow traffic to metrics endpoint on port 9000"
+    from_port       = 9000
+    to_port         = 9000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.caddy.id]
   }
 
   egress {

--- a/deployments/aws/ecs/variables.tf
+++ b/deployments/aws/ecs/variables.tf
@@ -430,3 +430,29 @@ variable "rds_auto_minor_version_upgrade" {
   description = "Enable auto minor version upgrades for RDS instances"
   default     = false
 }
+
+### Prometheus Metrics
+
+variable "metrics_auth_username" {
+  description = "Username for basic auth on metrics endpoints"
+  type        = string
+  default     = "metrics"
+}
+
+variable "metrics_auth_password_hash" {
+  description = "Bcrypt hash of the password for basic auth on metrics endpoints (required when enable_metrics is true)"
+  type        = string
+  default     = null
+  sensitive   = true
+
+  validation {
+    condition     = var.metrics_auth_password_hash != null || var.enable_metrics == false
+    error_message = "metrics_auth_password_hash must be set when enable_metrics is true."
+  }
+}
+
+variable "enable_metrics" {
+  description = "Whether to expose metrics endpoints with basic auth protection"
+  type        = bool
+  default     = true
+}

--- a/deployments/aws/main.tf
+++ b/deployments/aws/main.tf
@@ -114,4 +114,9 @@ module "ecs" {
   caddy_memory                = var.caddy_memory
   db_instance_class           = var.db_instance_class
   db_instance_size            = var.db_instance_size
+
+  # Metrics configuration
+  enable_metrics             = var.enable_metrics
+  metrics_auth_username      = var.metrics_auth_username
+  metrics_auth_password_hash = var.metrics_auth_password_hash
 }

--- a/deployments/aws/variables.tf
+++ b/deployments/aws/variables.tf
@@ -363,3 +363,25 @@ variable "rds_backup_retention_period" {
   description = "The number of days to retain backups for RDS instances"
   default     = 7
 }
+
+
+### Prometheus Metrics
+
+variable "metrics_auth_username" {
+  description = "Username for basic auth on metrics endpoints"
+  type        = string
+  default     = "metrics"
+}
+
+variable "metrics_auth_password_hash" {
+  description = "Bcrypt hash of the password for basic auth on metrics endpoints (required when enable_metrics_auth is true)"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "enable_metrics" {
+  description = "Whether to expose metrics endpoints with basic auth protection"
+  type        = bool
+  default     = false
+}

--- a/tracecat/dsl/client.py
+++ b/tracecat/dsl/client.py
@@ -125,6 +125,6 @@ def init_runtime_with_prometheus(port: int) -> Runtime:
     # Create runtime for use with Prometheus metrics
     return Runtime(
         telemetry=TelemetryConfig(
-            metrics=PrometheusConfig(bind_address=f"127.0.0.1:{port}")
+            metrics=PrometheusConfig(bind_address=f"0.0.0.0:{port}")
         )
     )

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -93,19 +93,7 @@ class DSLScheduler:
         else:
             self.logger.error("Task failed with no error paths", ref=ref)
             if isinstance(exc, ApplicationError) and exc.details:
-                self.logger.warning(
-                    "Task failed with application error",
-                    ref=ref,
-                    exc=exc,
-                    details=exc.details,
-                )
-                try:
-                    details = ActionErrorInfo(**exc.details[0])
-                except Exception as e:
-                    self.logger.warning(
-                        "Failed to parse application error details", ref=ref, error=e
-                    )
-                    details = None
+                details = ActionErrorInfo(**exc.details[0])
             else:
                 details = None
 

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -93,7 +93,19 @@ class DSLScheduler:
         else:
             self.logger.error("Task failed with no error paths", ref=ref)
             if isinstance(exc, ApplicationError) and exc.details:
-                details = ActionErrorInfo(**exc.details[0])
+                self.logger.warning(
+                    "Task failed with application error",
+                    ref=ref,
+                    exc=exc,
+                    details=exc.details,
+                )
+                try:
+                    details = ActionErrorInfo(**exc.details[0])
+                except Exception as e:
+                    self.logger.warning(
+                        "Failed to parse application error details", ref=ref, error=e
+                    )
+                    details = None
             else:
                 details = None
 

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -92,6 +92,7 @@ class DSLScheduler:
             await self._queue_tasks(ref, unreachable=non_err_edges)
         else:
             self.logger.error("Task failed with no error paths", ref=ref)
+            details = None
             if isinstance(exc, ApplicationError) and exc.details:
                 self.logger.warning(
                     "Task failed with application error",
@@ -99,16 +100,41 @@ class DSLScheduler:
                     exc=exc,
                     details=exc.details,
                 )
-                try:
-                    details = ActionErrorInfo(**exc.details[0])
-                except Exception as e:
+                details = exc.details[0]
+                if not isinstance(details, dict):
                     self.logger.warning(
-                        "Failed to parse application error details", ref=ref, error=e
+                        "Application error details are not a dictionary",
+                        ref=ref,
+                        details=details,
                     )
                     details = None
-            else:
-                details = None
-
+                elif all(k in details for k in ("ref", "message", "type")):
+                    # Regular action error
+                    # it's of shape ActionErrorInfo()
+                    try:
+                        # This is normal action error
+                        details = ActionErrorInfo(**details)
+                    except Exception as e:
+                        self.logger.warning(
+                            "Failed to parse regular application error details",
+                            ref=ref,
+                            error=e,
+                        )
+                        details = None
+                else:
+                    # Child workflow error
+                    # it's of shape {ref: ActionErrorInfo(), ...}
+                    # try get the first element
+                    try:
+                        val = list(details.values())[0]
+                        details = ActionErrorInfo(**val)
+                    except Exception as e:
+                        self.logger.warning(
+                            "Failed to parse child wf application error details",
+                            ref=ref,
+                            error=e,
+                        )
+                        details = None
             self.task_exceptions[ref] = TaskExceptionInfo(
                 exception=exc, details=details
             )


### PR DESCRIPTION
- **Add prometheus to worker**
- **Bind to 0.0.0.0 and expose /metrics in caddy**
- **Catch exception for ActionErrorInfo**
- **ci: Add prom metrics to fargate (#981)**
- **Expose metrics port**
- **ci(fix): Cursor overwrote ui reverse proxy**
- **fix env vars injection in ecs-caddy**
- **Another try**
- **caddy depend on worker**
- **fix deprecated basic auth directive**
- **anoher attempt**
- **revert caddy changes**
- **deprecated directive**
- **Caddyfile again**
- **hardcode**
- **try again but with the working script**
- **test without basic auth**
- **Update security groups**
- **missing caddy security group in ecs worker**
- **Add basic auth**
- **Revert "Catch exception for ActionErrorInfo"**
- **Revert "Revert "Catch exception for ActionErrorInfo""**
- **Try parse errors nicely**
