### PR TITLE
feat(engine): Add sentry

### DIFF
--- a/deployments/aws/ecs/locals.tf
+++ b/deployments/aws/ecs/locals.tf
@@ -76,6 +76,7 @@ locals {
       TRACECAT__EXECUTOR_CLIENT_TIMEOUT = var.executor_client_timeout
       TRACECAT__EXECUTOR_URL            = local.internal_executor_url
       TRACECAT__PUBLIC_API_URL          = local.public_api_url
+      SENTRY_DSN                        = var.sentry_dsn
     }, local.tracecat_db_configs) :
     { name = k, value = tostring(v) }
   ]

--- a/deployments/aws/ecs/variables.tf
+++ b/deployments/aws/ecs/variables.tf
@@ -456,3 +456,10 @@ variable "enable_metrics" {
   type        = bool
   default     = true
 }
+
+variable "sentry_dsn" {
+  description = "The Sentry DSN to use for error reporting"
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/deployments/aws/main.tf
+++ b/deployments/aws/main.tf
@@ -119,4 +119,7 @@ module "ecs" {
   enable_metrics             = var.enable_metrics
   metrics_auth_username      = var.metrics_auth_username
   metrics_auth_password_hash = var.metrics_auth_password_hash
+
+  # Sentry configuration
+  sentry_dsn = var.sentry_dsn
 }

--- a/deployments/aws/variables.tf
+++ b/deployments/aws/variables.tf
@@ -385,3 +385,10 @@ variable "enable_metrics" {
   type        = bool
   default     = false
 }
+
+variable "sentry_dsn" {
+  description = "The Sentry DSN to use for error reporting"
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -95,6 +95,8 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
+      # Sentry
+      SENTRY_DSN: ${SENTRY_DSN}
     volumes:
       - ./tracecat:/app/tracecat
       - ./registry:/app/registry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,8 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
+      # Sentry
+      SENTRY_DSN: ${SENTRY_DSN}
     volumes:
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     command: ["python", "tracecat/dsl/worker.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "pysaml2==7.5.0",
     "python-slugify==8.0.4",
     "ray[default]==2.40.0",
+    "sentry-sdk==2.24.1",
     "sqlmodel==0.0.18",
     "temporalio==1.9.0",
     "tenacity==8.3.0",
@@ -126,5 +127,5 @@ markers = [
     "integration: marks tests that perform live network calls and container operations",
     "podman: marks tests that use the Podman container runner",
     "llm: marks tests that perform LLM calls",
-    "ollama: mark tests that require Ollama"
+    "ollama: mark tests that require Ollama",
 ]

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -129,7 +129,7 @@ class DSLActivities:
             # We only expect ExecutorClientError to be raised from the executor client
             kind = e.__class__.__name__
             msg = str(e)
-            log.error("Application exception occurred", error=msg, detail=e.detail)
+            log.info("Executor Client Error", error=msg, detail=e.detail)
             err_info = ActionErrorInfo(
                 ref=task.ref,
                 message=msg,
@@ -154,7 +154,7 @@ class DSLActivities:
         except Exception as e:
             # Unexpected errors - non-retryable
             kind = e.__class__.__name__
-            raw_msg = f"{kind} occurred:\n{e}"
+            raw_msg = f"Unexpected {kind} occurred:\n{e}"
             log.error(raw_msg)
 
             err_info = ActionErrorInfo(

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -129,7 +129,7 @@ class DSLActivities:
             # We only expect ExecutorClientError to be raised from the executor client
             kind = e.__class__.__name__
             msg = str(e)
-            log.info("Executor Client Error", error=msg, detail=e.detail)
+            log.info("Executor client error", error=msg, detail=e.detail)
             err_info = ActionErrorInfo(
                 ref=task.ref,
                 message=msg,

--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -1,0 +1,90 @@
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+from temporalio import activity, workflow
+from temporalio.common import SearchAttributeKey
+from temporalio.exceptions import ApplicationError
+from temporalio.worker import (
+    ExecuteWorkflowInput,
+    Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+)
+
+with workflow.unsafe.imports_passed_through():
+    import sentry_sdk as sentry
+    from pydantic import BaseModel
+
+    from tracecat.contexts import ctx_role
+    from tracecat.logger import logger
+    from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
+
+
+def _set_common_workflow_tags(info: workflow.Info | activity.Info):
+    sentry.set_tag("temporal.workflow.type", info.workflow_type)
+    sentry.set_tag("temporal.workflow.id", info.workflow_id)
+
+
+class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        # https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
+        with sentry.isolation_scope():
+            sentry.set_tag("temporal.execution_type", "workflow")
+            sentry.set_tag(
+                "module", input.run_fn.__module__ + "." + input.run_fn.__qualname__
+            )
+            workflow_info = workflow.info()
+            _set_common_workflow_tags(workflow_info)
+            sentry.set_tag("temporal.workflow.task_queue", workflow_info.task_queue)
+            sentry.set_tag("temporal.workflow.namespace", workflow_info.namespace)
+            sentry.set_tag("temporal.workflow.run_id", workflow_info.run_id)
+            search_attributes = workflow_info.typed_search_attributes
+            trigger_type = search_attributes.get(
+                SearchAttributeKey.for_keyword(TemporalSearchAttr.TRIGGER_TYPE.value)
+            )
+            try:
+                return await super().execute_workflow(input)
+            except ApplicationError as e:
+                logger.warning("Caught application level workflow error", error=str(e))
+                # We want to raise the error so that the workflow can be retried
+                # We want to log the error if this is a scheduled workflow
+                # Get the temporal search attribute for TracecatTriggerType
+                if trigger_type == TriggerType.SCHEDULED:
+                    role = ctx_role.get()
+                    if role and role.workspace_id:
+                        sentry.set_tag("tracecat.workspace_id", str(role.workspace_id))
+                    if not workflow.unsafe.is_replaying():
+                        # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
+                        # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
+                        logger.error("Scheduled Workflow Error", error=str(e))
+                raise e
+            except Exception as e:
+                logger.warning("Caught platform level workflow error", error=str(e))
+                if len(input.args) >= 1:
+                    arg = input.args[0]
+                    if is_dataclass(arg) and not isinstance(arg, type):
+                        sentry.set_context("temporal.workflow.input", asdict(arg))
+                    elif isinstance(arg, BaseModel):
+                        sentry.set_context("temporal.workflow.input", arg.model_dump())
+                sentry.set_context("temporal.workflow.info", workflow.info().__dict__)
+
+                if not workflow.unsafe.is_replaying():
+                    # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
+                    # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
+                    logger.error(
+                        "Unexpected workflow error, likely a platform issue",
+                        error=str(e),
+                    )
+                logger.debug(
+                    "Reraising exception as ApplicationError to fail workflow gracefully"
+                )
+                raise ApplicationError(str(e)) from e
+
+
+class SentryInterceptor(Interceptor):
+    """Temporal Interceptor class which will report workflow & activity exceptions to Sentry"""
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> type[WorkflowInboundInterceptor] | None:
+        return _SentryWorkflowInterceptor

--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -57,7 +57,10 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
                     if not workflow.unsafe.is_replaying():
                         # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
                         # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
-                        logger.error("Application error raised by scheduled workflow", error=str(e))
+                        logger.error(
+                            "Application error raised by scheduled workflow",
+                            error=str(e),
+                        )
                 else:
                     logger.info("Not a scheduled workflow, skipping reporting")
                 raise e

--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -50,6 +50,7 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
                 # We want to log the error if this is a scheduled workflow
                 # Get the temporal search attribute for TracecatTriggerType
                 if trigger_type == TriggerType.SCHEDULED:
+                    logger.info("Reporting scheduled workflow error")
                     role = ctx_role.get()
                     if role and role.workspace_id:
                         sentry.set_tag("tracecat.workspace_id", str(role.workspace_id))
@@ -57,6 +58,8 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
                         # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
                         # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
                         logger.error("Scheduled Workflow Error", error=str(e))
+                else:
+                    logger.info("Not a scheduled workflow, skipping reporting")
                 raise e
             except Exception as e:
                 logger.warning("Caught platform level workflow error", error=str(e))

--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -57,10 +57,7 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
                     if not workflow.unsafe.is_replaying():
                         # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
                         # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
-                        logger.error(
-                            "Application error raised by scheduled workflow",
-                            error=str(e),
-                        )
+                        logger.error("Scheduled workflow error", error=str(e))
                 else:
                     logger.info("Not a scheduled workflow, skipping reporting")
                 raise e

--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -57,7 +57,7 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
                     if not workflow.unsafe.is_replaying():
                         # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
                         # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
-                        logger.error("Scheduled Workflow Error", error=str(e))
+                        logger.error("Application error raised by scheduled workflow", error=str(e))
                 else:
                     logger.info("Not a scheduled workflow, skipping reporting")
                 raise e

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -91,7 +91,7 @@ class DSLScheduler:
         if len(non_err_edges) < len(self.adj[ref]):
             await self._queue_tasks(ref, unreachable=non_err_edges)
         else:
-            self.logger.error("Task failed with no error paths", ref=ref)
+            self.logger.info("Task failed with no error paths", ref=ref)
             details = None
             if isinstance(exc, ApplicationError) and exc.details:
                 self.logger.warning(
@@ -241,7 +241,7 @@ class DSLScheduler:
         except Exception as e:
             kind = e.__class__.__name__
             non_retryable = getattr(e, "non_retryable", True)
-            self.logger.error(
+            self.logger.warning(
                 f"{kind} in DSLScheduler", ref=ref, error=e, non_retryable=non_retryable
             )
             await self._handle_error_path(ref, e)

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -541,7 +541,7 @@ class DSLWorkflow:
             # These are deterministic and expected errors that
             err_type = e.__class__.__name__
             msg = self.ERROR_TYPE_TO_MESSAGE[err_type]
-            self.logger.error(msg, role=self.role, e=e, cause=e.cause, type=err_type)
+            self.logger.warning(msg, role=self.role, e=e, cause=e.cause, type=err_type)
             match cause := e.cause:
                 case ApplicationError(details=details) if details:
                     err_info = details[0]
@@ -562,7 +562,7 @@ class DSLWorkflow:
             raise ApplicationError(detail, non_retryable=True, type=err_type) from e
 
         except ValidationError as e:
-            logger.error("Runtime validation error", error=e.errors())
+            logger.warning("Runtime validation error", error=e.errors())
             task_result.update(
                 error=e.errors(), error_typename=ValidationError.__name__
             )

--- a/tracecat/executor/client.py
+++ b/tracecat/executor/client.py
@@ -146,9 +146,9 @@ class ExecutorClient:
             case _:
                 logger.debug("Looks like unknown error")
                 detail = e.response.text
-        logger.error("Executor returned an error")
+        logger.warning("Executor returned an error", error=detail)
         if e.response.status_code / 100 == 5:
-            logger.error("There was an error in the executor when calling action")
+            logger.warning("There was an error in the executor when calling action")
             raise ExecutorClientError(
                 f"There was an error in the executor when calling action {action_type!r}.\n\n{detail}"
             ) from e


### PR DESCRIPTION
Add sentry interceptor based on https://github.com/temporalio/samples-python/tree/main/sentry. 
If SENTRY_DSN is defiend on a worker, we initialize the `sentry_sdk` and add a `SentryInterceptor` to the temporal worker.

Lowered log level to avoid using `logger.error`, as sentry automatically captures those as issues.

Note that we have issues using `sentry_sdk.capture_exception()`. Some kind of metaclass issue. It works on v1.45.1 of sentry-sdk in Temporal's sample. 

```
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1              |   File "/usr/local/lib/python3.12/site-packages/temporalio/worker/workflow_sandbox/_importer.py", line 234, in _import
worker-1              |     mod = importlib.__import__(name, globals, locals, fromlist, level)
worker-1              |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker-1              |   File "<frozen importlib._bootstrap>", line 1486, in __import__
worker-1              |   File "<frozen importlib._bootstrap>", line 1415, in _handle_fromlist
worker-1              |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
worker-1              |   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
worker-1              |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
worker-1              |   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
worker-1              |   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
worker-1              |   File "<frozen importlib._bootstrap_external>", line 995, in exec_module
worker-1              |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
worker-1              |   File "/usr/local/lib/python3.12/site-packages/urllib3/exceptions.py", line 253, in <module>
worker-1              |     class IncompleteRead(HTTPError, httplib_IncompleteRead):
worker-1              | TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```
Similar issue found in Temporals slack: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P