### PR TITLE
feat(engine): Update sentry fingerprinting, add more tags, alert on webhook events

### DIFF
--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -27,24 +27,56 @@ def _set_common_workflow_tags(info: workflow.Info | activity.Info) -> None:
 
 
 def _set_fingerprint(
-    scope: sentry.Scope, input: ExecuteWorkflowInput, info: workflow.Info
+    scope: sentry.Scope,
+    input: ExecuteWorkflowInput,
+    info: workflow.Info,
+    trigger_type: TriggerType,
 ) -> None:
     if len(input.args) > 0 and isinstance(input.args[0], DSLRunArgs):
         arg = input.args[0]
         wf_id = arg.wf_id.short()
         logger.info("Using workflow ID for fingerprint", workflow_id=wf_id)
-        scope.fingerprint = [wf_id]
+        scope.fingerprint = [wf_id, trigger_type.value]
+        sentry.set_tag("tracecat.workflow_id", wf_id)
+
+        # Set additional tags for the workflow from its DSLRunArgs
+        if parent_run_context := arg.parent_run_context:
+            sentry.set_tag("tracecat.parent.workflow_id", parent_run_context.wf_id)
+            sentry.set_tag(
+                "tracecat.parent.workflow_exec_id", parent_run_context.wf_exec_id
+            )
+        if dsl := arg.dsl:
+            sentry.set_tag("tracecat.dsl.title", dsl.title)
+            sentry.set_tag("tracecat.dsl.description", dsl.description)
+            sentry.set_tag("tracecat.dsl.error_handler", dsl.error_handler)
+            sentry.set_tag("tracecat.dsl.config.timeout", dsl.config.timeout)
     else:
-        logger.info("Deriving workflow ID from execution ID for fingerprint")
+        logger.warning(
+            "Couldn't find DSLRunArgs, deriving workflow ID from execution ID for fingerprint"
+        )
         wf_exec_id = info.workflow_id
         try:
-            scope.fingerprint = [wf_exec_id.split("/")[0]]
+            scope.fingerprint = [wf_exec_id.split("/")[0], trigger_type.value]
         except Exception as e:
             logger.warning(
                 "Failed to derive workflow ID for fingerprint, falling back to execution ID",
                 error=str(e),
             )
-            scope.fingerprint = [wf_exec_id]
+            scope.fingerprint = [wf_exec_id, trigger_type.value]
+
+
+def _get_trigger_type(info: workflow.Info) -> TriggerType:
+    search_attributes = info.typed_search_attributes
+    trigger_type = search_attributes.get(
+        SearchAttributeKey.for_keyword(TemporalSearchAttr.TRIGGER_TYPE.value)
+    )
+    if trigger_type is None:
+        logger.warning(
+            "Couldn't find trigger type, using manual as fallback",
+            workflow_id=info.workflow_id,
+        )
+        trigger_type = TriggerType.MANUAL
+    return TriggerType(trigger_type)
 
 
 class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
@@ -55,19 +87,16 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
             sentry.set_tag(
                 "module", input.run_fn.__module__ + "." + input.run_fn.__qualname__
             )
-            workflow_info = workflow.info()
-            _set_common_workflow_tags(workflow_info)
-            sentry.set_tag("temporal.workflow.task_queue", workflow_info.task_queue)
-            sentry.set_tag("temporal.workflow.namespace", workflow_info.namespace)
-            sentry.set_tag("temporal.workflow.run_id", workflow_info.run_id)
-            search_attributes = workflow_info.typed_search_attributes
-            trigger_type = search_attributes.get(
-                SearchAttributeKey.for_keyword(TemporalSearchAttr.TRIGGER_TYPE.value)
-            )
+            info = workflow.info()
+            _set_common_workflow_tags(info)
+            sentry.set_tag("temporal.workflow.task_queue", info.task_queue)
+            sentry.set_tag("temporal.workflow.namespace", info.namespace)
+            sentry.set_tag("temporal.workflow.run_id", info.run_id)
+            trigger_type = _get_trigger_type(info)
             if (role := ctx_role.get()) and role.workspace_id:
                 sentry.set_tag("tracecat.workspace_id", str(role.workspace_id))
             # Fingerprint to each workflow ID
-            _set_fingerprint(scope, input, workflow_info)
+            _set_fingerprint(scope, input, info, trigger_type)
             try:
                 return await super().execute_workflow(input)
             except ApplicationError as e:
@@ -75,14 +104,20 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
                 # We want to raise the error so that the workflow can be retried
                 # We want to log the error if this is a scheduled workflow
                 # Get the temporal search attribute for TracecatTriggerType
-                if trigger_type == TriggerType.SCHEDULED:
-                    logger.info("Reporting scheduled workflow error")
-                    if not workflow.unsafe.is_replaying():
-                        # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
-                        # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
-                        logger.error("Scheduled workflow error", error=str(e))
-                else:
-                    logger.info("Not a scheduled workflow, skipping reporting")
+                match trigger_type:
+                    case TriggerType.SCHEDULED:
+                        logger.info("Reporting scheduled workflow error")
+                        if not workflow.unsafe.is_replaying():
+                            # NOTE: We log here instead of capturing the exception because of metaclass issues with ApplicationError
+                            # Related issue: https://temporalio.slack.com/archives/CTT84RS0P/p1720730740608279?thread_ts=1720727238.727909&cid=CTT84RS0P
+                            logger.error("Scheduled workflow error", error=str(e))
+                    case TriggerType.WEBHOOK:
+                        logger.info("Reporting webhook workflow error")
+                        if not workflow.unsafe.is_replaying():
+                            # See note above
+                            logger.error("Webhook workflow error", error=str(e))
+                    case _:
+                        logger.info("Not a scheduled workflow, skipping reporting")
                 raise e
             except Exception as e:
                 logger.warning("Caught platform level workflow error", error=str(e))


### PR DESCRIPTION
Update sentry alert fingerprints to be `[<workflow ID>, <trigger type>]` so that alerts are grouped separately. See sentry for examples.

Also alert on webhook events.
