### PR TITLE
feat: Enable enums in UDF decorators

### DIFF
--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tracecat.expressions.common import eval_jsonpath
 from tracecat.parse import (
     get_pyproject_toml_required_deps,
+    resolve_jsonschema_refs,
     traverse_expressions,
     traverse_leaves,
     unescape_string,
@@ -219,3 +220,146 @@ def test_unescape_string_no_escapes() -> None:
 def test_unescape_string_empty() -> None:
     """Test that empty strings are handled correctly."""
     assert unescape_string("") == ""
+
+
+def test_resolve_jsonschema_refs_basic():
+    """Test basic reference resolution in a JSON schema."""
+    schema = {
+        "$defs": {
+            "person": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            }
+        },
+        "properties": {"employee": {"$ref": "#/$defs/person"}},
+    }
+
+    resolved = resolve_jsonschema_refs(schema)
+
+    # Check that $defs is no longer in the resolved schema
+    assert "$defs" not in resolved
+
+    # Check that the reference was properly resolved
+    assert resolved["properties"]["employee"]["type"] == "object"
+    assert "name" in resolved["properties"]["employee"]["properties"]
+    assert "age" in resolved["properties"]["employee"]["properties"]
+    assert resolved["properties"]["employee"]["properties"]["name"]["type"] == "string"
+    assert resolved["properties"]["employee"]["properties"]["age"]["type"] == "integer"
+
+
+def test_resolve_jsonschema_refs_with_additional_props():
+    """Test reference resolution when the reference property has additional fields."""
+    schema = {
+        "$defs": {
+            "person": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                },
+            }
+        },
+        "properties": {
+            "employee": {
+                "$ref": "#/$defs/person",
+                "description": "An employee record",
+                "required": True,
+            }
+        },
+    }
+
+    resolved = resolve_jsonschema_refs(schema)
+
+    # Check that additional properties are preserved
+    assert resolved["properties"]["employee"]["type"] == "object"
+    assert resolved["properties"]["employee"]["description"] == "An employee record"
+    assert resolved["properties"]["employee"]["required"] is True
+    assert "name" in resolved["properties"]["employee"]["properties"]
+
+
+def test_resolve_jsonschema_refs_with_missing_ref():
+    """Test handling of references to undefined definitions."""
+    schema = {
+        "$defs": {
+            "person": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                },
+            }
+        },
+        "properties": {"employee": {"$ref": "#/$defs/nonexistent"}},
+    }
+
+    resolved = resolve_jsonschema_refs(schema)
+
+    # The reference should remain unresolved since the definition doesn't exist
+    assert resolved["properties"]["employee"]["$ref"] == "#/$defs/nonexistent"
+
+
+def test_resolve_jsonschema_refs_with_external_refs():
+    """Test that external references are not resolved."""
+    schema = {
+        "properties": {"employee": {"$ref": "https://example.com/schemas/person.json"}}
+    }
+
+    resolved = resolve_jsonschema_refs(schema)
+
+    # External references should remain unchanged
+    assert (
+        resolved["properties"]["employee"]["$ref"]
+        == "https://example.com/schemas/person.json"
+    )
+
+
+def test_resolve_jsonschema_refs_with_no_refs():
+    """Test a schema with no references to resolve."""
+    schema = {
+        "properties": {
+            "employee": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            }
+        }
+    }
+
+    resolved = resolve_jsonschema_refs(schema)
+
+    # The schema should remain unchanged
+    assert resolved == schema
+
+
+def test_resolve_jsonschema_refs_nested_properties():
+    """Test reference resolution in nested properties."""
+    schema = {
+        "$defs": {
+            "address": {
+                "type": "object",
+                "properties": {
+                    "street": {"type": "string"},
+                    "city": {"type": "string"},
+                },
+            }
+        },
+        "properties": {
+            "person": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "home_address": {"$ref": "#/$defs/address"},
+                },
+            }
+        },
+    }
+
+    # The current implementation doesn't resolve nested references
+    # This test documents this limitation
+    resolved = resolve_jsonschema_refs(schema)
+
+    # The top-level properties are processed, but nested refs remain
+    assert "$defs" not in resolved
+    assert "person" in resolved["properties"]
+    # The nested reference remains unresolved
+    assert (
+        resolved["properties"]["person"]["properties"]["home_address"]["$ref"]
+        == "#/$defs/address"
+    )

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -22,6 +22,7 @@ from tracecat_registry import RegistrySecret
 from tracecat.db.schemas import RegistryAction
 from tracecat.expressions.expectations import ExpectedField, create_expectation_model
 from tracecat.logger import logger
+from tracecat.parse import resolve_jsonschema_refs
 from tracecat.registry.actions.enums import TemplateActionValidationErrorType
 from tracecat.types.exceptions import (
     RegistryActionError,
@@ -87,13 +88,15 @@ class BoundRegistryAction(BaseModel):
                 self.template_action.definition.expects,
                 self.template_action.definition.action.replace(".", "__"),
             )
+            schema = expects.model_json_schema()
             return RegistryActionInterface(
-                expects=expects.model_json_schema(),
+                expects=resolve_jsonschema_refs(schema),
                 returns=self.template_action.definition.returns,
             )
         elif self.type == "udf":
+            schema = self.args_cls.model_json_schema()
             return RegistryActionInterface(
-                expects=self.args_cls.model_json_schema(),
+                expects=resolve_jsonschema_refs(schema),
                 returns=None
                 if not self.rtype_adapter
                 else self.rtype_adapter.json_schema(),


### PR DESCRIPTION
# Description
- Add function to resolve jsonschema refs
  - This enables using `Enum` types in udf args. 