### PR TITLE
infra(fix): Make metrics port configurable via env var

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -138,6 +138,9 @@ TEMPORAL__CLIENT_RPC_TIMEOUT = os.environ.get("TEMPORAL__CLIENT_RPC_TIMEOUT")
 TEMPORAL__TASK_TIMEOUT = os.environ.get("TEMPORAL__TASK_TIMEOUT")
 """Temporal workflow task timeout in seconds (default 10 seconds)."""
 
+TEMPORAL__METRICS_PORT = int(os.environ.get("TEMPORAL__METRICS_PORT", 9000))
+"""Port for the Temporal metrics server."""
+
 # Secrets manager config
 TRACECAT__UNSAFE_DISABLE_SM_MASKING = os.environ.get(
     "TRACECAT__UNSAFE_DISABLE_SM_MASKING",

--- a/tracecat/dsl/client.py
+++ b/tracecat/dsl/client.py
@@ -19,6 +19,7 @@ from tracecat.config import (
     TEMPORAL__CLUSTER_NAMESPACE,
     TEMPORAL__CLUSTER_URL,
     TEMPORAL__CONNECT_RETRIES,
+    TEMPORAL__METRICS_PORT,
     TEMPORAL__MTLS_CERT__ARN,
     TEMPORAL__MTLS_ENABLED,
 )
@@ -84,7 +85,7 @@ async def connect_to_temporal() -> Client:
         tls_config = True
         rpc_metadata["temporal-namespace"] = TEMPORAL__CLUSTER_NAMESPACE
 
-    runtime = init_runtime_with_prometheus(port=9000)
+    runtime = init_runtime_with_prometheus(port=TEMPORAL__METRICS_PORT)
     client = await Client.connect(
         target_host=TEMPORAL__CLUSTER_URL,
         namespace=TEMPORAL__CLUSTER_NAMESPACE,


### PR DESCRIPTION
Why we need this: port 9000 already in use in k8s.