### PR TITLE
fix(ui): Fixing csv import window and handling large texts

### DIFF
--- a/frontend/src/components/tables/table-import-csv-dialog.tsx
+++ b/frontend/src/components/tables/table-import-csv-dialog.tsx
@@ -287,7 +287,7 @@ function CsvPreview({ csvData }: CsvPreviewProps) {
   return (
     <div className="space-y-4">
       <div className="text-sm font-medium">Preview (first 5 rows)</div>
-      <div className="max-h-60 overflow-auto rounded border">
+      <div className="max-h-60 overflow-auto overflow-x-auto rounded border">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b bg-muted/50">
@@ -302,9 +302,11 @@ function CsvPreview({ csvData }: CsvPreviewProps) {
             {csvData.preview.map((row, i) => (
               <tr key={i} className="border-b">
                 {csvData.headers.map((header) => (
-                  <td key={header} className="p-2">
-                    {row[header]}
-                  </td>
+                  <td key={header} className="p-2 max-w-xs truncate" title={row[header]}>
+                  {typeof row[header] === 'string' && row[header].length > 100
+                    ? row[header].substring(0, 100) + "..."
+                    : row[header]}
+                </td>
                 ))}
               </tr>
             ))}

--- a/frontend/src/components/tables/table-view.tsx
+++ b/frontend/src/components/tables/table-view.tsx
@@ -16,11 +16,30 @@ import { TableViewColumnMenu } from "@/components/tables/table-view-column-menu"
 
 function CollapsibleText({ text }: { text: string }) {
   const [isExpanded, setIsExpanded] = React.useState(false)
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = React.useState(0)
+
+  // Measure container width on mount and when window resizes
+  React.useEffect(() => {
+    const updateWidth = () => {
+      if (containerRef.current) {
+        setContainerWidth(containerRef.current.clientWidth)
+      }
+    }
+
+    updateWidth()
+    window.addEventListener('resize', updateWidth)
+    return () => window.removeEventListener('resize', updateWidth)
+  }, [])
+
+  // Estimate characters per line based on container width (assumes monospace font)
+  // Adjust the divisor based on your font metrics
+  const charsPerLine = Math.max(25, Math.floor(containerWidth / 7))
 
   if (!isExpanded) {
     return (
-      <div className="flex items-center">
-        <span className="truncate text-xs">{text.substring(0, 25)}</span>
+      <div ref={containerRef} className="flex items-center">
+        <span className="truncate text-xs">{text.substring(0, charsPerLine)}</span>
         <Button
           variant="ghost"
           size="sm"
@@ -33,14 +52,14 @@ function CollapsibleText({ text }: { text: string }) {
     )
   }
 
-  // Format the text into chunks when expanded
+  // Format the text into chunks based on available width
   const chunks = []
-  for (let i = 0; i < text.length; i += 25) {
-    chunks.push(text.substring(i, i + 25))
+  for (let i = 0; i < text.length; i += charsPerLine) {
+    chunks.push(text.substring(i, i + charsPerLine))
   }
 
   return (
-    <div className="space-y-1">
+    <div ref={containerRef} className="space-y-1">
       <pre className="whitespace-pre-wrap text-xs">{chunks.join("\n")}</pre>
       <Button
         variant="ghost"


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [X] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [X] PR only implements a single feature or fixes a single bug.
- [X] Tests passing (`uv run pytest tests`)?
- [X] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes the UI malfunction that has long texts passing boundaries in the csv

## Related Issues

Fixes #1012 

## Screenshots / Recordings

<img width="914" alt="Screenshot_3" src="https://github.com/user-attachments/assets/d58452c7-ccdd-4419-98aa-f0e597eaa629" />
<img width="911" alt="Screenshot_4" src="https://github.com/user-attachments/assets/f6bfffb9-a9ab-4964-b38c-32d62df57547" />
<img width="650" alt="Screenshot_5" src="https://github.com/user-attachments/assets/98e2e6d5-e6c5-434c-aa38-c536788485c2" />


## Steps to QA

CSV:
1. Choose a CSV with large amounts of text
2. The next dialog window should collapse the text

Table View:
1. Add an arbitrary number of text columns to a table
2. Add rows with long text