### PR TITLE
feat(ui): Use query params for case panel

### DIFF
--- a/frontend/src/components/cases/case-comments-section.tsx
+++ b/frontend/src/components/cases/case-comments-section.tsx
@@ -72,11 +72,10 @@ export function CommentSection({
   caseId: string
   workspaceId: string
 }) {
-  const { caseComments, caseCommentsIsLoading, caseCommentsError } =
-    useCaseComments({
-      caseId,
-      workspaceId,
-    })
+  const { caseComments, caseCommentsIsLoading } = useCaseComments({
+    caseId,
+    workspaceId,
+  })
 
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null)
 

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -1,10 +1,7 @@
 import { CaseCustomFieldRead, CaseUpdate } from "@/client"
-import { useCasePanelContext } from "@/providers/case-panel"
-import { useWorkspace } from "@/providers/workspace"
 import { FormProvider, useForm, useFormContext } from "react-hook-form"
 import { z } from "zod"
 
-import { useUpdateCase } from "@/lib/hooks"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   FormControl,
@@ -23,15 +20,11 @@ type CustomFieldFormSchema = z.infer<typeof customFieldFormSchema>
 
 export function CustomField({
   customField,
+  updateCase,
 }: {
   customField: CaseCustomFieldRead
+  updateCase: (caseUpdate: Partial<CaseUpdate>) => Promise<void>
 }) {
-  const { workspaceId } = useWorkspace()
-  const { panelCase } = useCasePanelContext()
-  const { updateCase } = useUpdateCase({
-    caseId: panelCase?.id ?? "",
-    workspaceId: workspaceId,
-  })
   const form = useForm<CustomFieldFormSchema>({
     defaultValues: {
       id: customField.id,
@@ -39,9 +32,6 @@ export function CustomField({
     },
   })
   const onSubmit = async (data: CustomFieldFormSchema) => {
-    if (!panelCase) {
-      return
-    }
     const caseUpdate: Partial<CaseUpdate> = {
       fields: {
         [customField.id]: data.value,

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -192,7 +192,10 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                       {field.id}
                     </span>
                     <div className="col-span-2">
-                      <CustomField customField={field} />
+                      <CustomField
+                        customField={field}
+                        updateCase={updateCase}
+                      />
                     </div>
                   </div>
                 ))}

--- a/frontend/src/components/cases/case-table.tsx
+++ b/frontend/src/components/cases/case-table.tsx
@@ -21,15 +21,12 @@ export default function CaseTable() {
   const { cases } = useListCases({
     workspaceId,
   })
-  const { setPanelCase, setIsOpen } = useCasePanelContext()
+  const { setCaseId } = useCasePanelContext()
 
   const memoizedColumns = useMemo(() => columns, [])
 
   function handleClickRow(row: Row<CaseReadMinimal>) {
-    return () => {
-      setPanelCase(row.original)
-      setIsOpen(true)
-    }
+    return () => setCaseId(row.original.id)
   }
   return (
     <TooltipProvider>

--- a/frontend/src/components/cases/case-workflow-trigger.tsx
+++ b/frontend/src/components/cases/case-workflow-trigger.tsx
@@ -130,7 +130,7 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
         <AlertDialogTrigger asChild>
           <Button
             size="sm"
-            disabled={!selectedWorkflowId}
+            disabled={!selectedWorkflowId || createExecutionIsPending}
             className="bg-emerald-400 hover:bg-emerald-400/80 hover:text-white"
           >
             <PlayIcon className="size-3 fill-white stroke-white" />

--- a/frontend/src/components/sliding-panel.tsx
+++ b/frontend/src/components/sliding-panel.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { cn } from "@/lib/utils"
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet"
 
 interface SlidingPanelProps
@@ -18,7 +19,7 @@ export function SlidingPanel({
     <Sheet modal={false} open={isOpen} onOpenChange={setIsOpen}>
       <SheetTitle className="sr-only">Sliding Panel</SheetTitle>
       <SheetContent
-        className={className}
+        className={cn("!animate-none !transition-none !duration-0", className)}
         onOpenAutoFocus={(e) => {
           e.preventDefault()
         }} // Prevents the first focusable element from being focused on open


### PR DESCRIPTION
# Description
Use query params to navigate to case panel. This makes it less disorienting when refreshing the page. Also makes it easier to share urls to casees.

# Screens

https://github.com/user-attachments/assets/673e002e-e09a-4ed9-94c6-a775b01b7ddf

