### PR TITLE
feat(engine): Add Temporal search attributes in FastAPI lifespan for API

### DIFF
--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -13,6 +13,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from tracecat import __version__ as APP_VERSION
 from tracecat import config
 from tracecat.api.common import (
+    add_temporal_search_attributes,
     bootstrap_role,
     custom_generate_unique_id,
     generic_exception_handler,
@@ -62,6 +63,10 @@ from tracecat.workspaces.service import WorkspaceService
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Temporal
+    await add_temporal_search_attributes()
+
+    # App
     role = bootstrap_role()
     async with get_async_session_context_manager() as session:
         # Org

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -1,8 +1,21 @@
 from fastapi import Request, status
 from fastapi.responses import ORJSONResponse
 from fastapi.routing import APIRoute
+from temporalio.api.enums.v1 import IndexedValueType
+from temporalio.api.operatorservice.v1 import (
+    AddSearchAttributesRequest,
+    RemoveSearchAttributesRequest,
+)
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
+from tracecat.config import TEMPORAL__CLUSTER_NAMESPACE
 from tracecat.contexts import ctx_role
+from tracecat.dsl.client import get_temporal_client
 from tracecat.logger import logger
 from tracecat.types.auth import AccessLevel, Role
 from tracecat.types.exceptions import TracecatException
@@ -54,3 +67,77 @@ def custom_generate_unique_id(route: APIRoute):
     if route.tags:
         return f"{route.tags[0]}-{route.name}"
     return route.name
+
+
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=5, min=5, max=20),
+    retry=retry_if_exception_type(Exception),
+    reraise=True,
+)
+async def add_temporal_search_attributes():
+    """Add search attributes to the Temporal cluster.
+
+    This is an idempotent operation and is safe to run multiple times.
+    """
+    client = await get_temporal_client()
+    namespace = TEMPORAL__CLUSTER_NAMESPACE
+    try:
+        await client.operator_service.add_search_attributes(
+            AddSearchAttributesRequest(
+                search_attributes={
+                    "TracecatTriggerType": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+                    "TracecatTriggeredByUserId": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+                },
+                namespace=namespace,
+            )
+        )
+    except Exception as e:
+        logger.error(
+            "Error adding temporal search attributes",
+            exc=e,
+            namespace=namespace,
+        )
+    else:
+        logger.info(
+            "Temporal search attributes added",
+            namespace=namespace,
+            search_attributes=["TracecatTriggerType", "TracecatTriggeredByUserId"],
+        )
+
+
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=5, min=5, max=20),
+    retry=retry_if_exception_type(Exception),
+    reraise=True,
+)
+async def remove_temporal_search_attributes():
+    """Remove search attributes from the Temporal cluster.
+
+    This is an idempotent operation and is safe to run multiple times.
+    """
+    client = await get_temporal_client()
+    namespace = TEMPORAL__CLUSTER_NAMESPACE
+    try:
+        await client.operator_service.remove_search_attributes(
+            RemoveSearchAttributesRequest(
+                search_attributes=[
+                    "TracecatTriggerType",
+                    "TracecatTriggeredByUserId",
+                ],
+                namespace=namespace,
+            )
+        )
+    except Exception as e:
+        logger.error(
+            "Error removing temporal search attributes",
+            exc=e,
+            namespace=namespace,
+        )
+    else:
+        logger.info(
+            "Temporal search attributes removed",
+            namespace=namespace,
+            search_attributes=["TracecatTriggerType", "TracecatTriggeredByUserId"],
+        )

--- a/tracecat/api/executor.py
+++ b/tracecat/api/executor.py
@@ -6,6 +6,7 @@ from fastapi.responses import ORJSONResponse
 
 from tracecat import config
 from tracecat.api.common import (
+    add_temporal_search_attributes,
     custom_generate_unique_id,
     generic_exception_handler,
     tracecat_exception_handler,
@@ -19,6 +20,10 @@ from tracecat.types.exceptions import TracecatException
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Temporal
+    await add_temporal_search_attributes()
+
+    # App
     with setup_ray():
         yield
 

--- a/tracecat/api/executor.py
+++ b/tracecat/api/executor.py
@@ -6,7 +6,6 @@ from fastapi.responses import ORJSONResponse
 
 from tracecat import config
 from tracecat.api.common import (
-    add_temporal_search_attributes,
     custom_generate_unique_id,
     generic_exception_handler,
     tracecat_exception_handler,
@@ -20,10 +19,6 @@ from tracecat.types.exceptions import TracecatException
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Temporal
-    await add_temporal_search_attributes()
-
-    # App
     with setup_ray():
         yield
 


### PR DESCRIPTION
# Description
Sometimes we need to destroy Temporal's volumes and thus destroy any custom search attributes.
Currently we've added search attributes in alembic migration. From the DB's POV it has already
applied the migration. To address this, we add search attributes in FastAPI lifespan in API ~and executor services~ (update: remove this in executor, executor doesn't know about the existence of Temporal). Ideally this should run in a shell script before any services start.
