### PR TITLE
fix(engine): Ignore prom address already in use

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -141,7 +141,7 @@ TEMPORAL__CLIENT_RPC_TIMEOUT = os.environ.get("TEMPORAL__CLIENT_RPC_TIMEOUT")
 TEMPORAL__TASK_TIMEOUT = os.environ.get("TEMPORAL__TASK_TIMEOUT")
 """Temporal workflow task timeout in seconds (default 10 seconds)."""
 
-TEMPORAL__METRICS_PORT = int(os.environ.get("TEMPORAL__METRICS_PORT", 9000))
+TEMPORAL__METRICS_PORT = os.environ.get("TEMPORAL__METRICS_PORT")
 """Port for the Temporal metrics server."""
 
 # Secrets manager config

--- a/tracecat/dsl/client.py
+++ b/tracecat/dsl/client.py
@@ -53,8 +53,15 @@ async def connect_to_temporal() -> Client:
         tls_config = True
         rpc_metadata["temporal-namespace"] = TEMPORAL__CLUSTER_NAMESPACE
 
+    runtime = None
+    # TODO: fix https://github.com/prometheus/client_python/issues/155
     if TEMPORAL__METRICS_PORT:
-        runtime = init_runtime_with_prometheus(port=TEMPORAL__METRICS_PORT)
+        try:
+            runtime = init_runtime_with_prometheus(port=int(TEMPORAL__METRICS_PORT))
+        except Exception as e:
+            logger.warning(
+                "Failed to initialize Prometheus runtime: %s", e, exc_info=True
+            )
     client = await Client.connect(
         target_host=TEMPORAL__CLUSTER_URL,
         namespace=TEMPORAL__CLUSTER_NAMESPACE,


### PR DESCRIPTION
Seems to be a bug in the prom python client side: https://github.com/prometheus/client_python/issues/155

Just going to ignore the error for now