### PR TITLE
fix(ui): Add delete keypress back

### DIFF
--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -506,7 +506,7 @@ export const WorkflowCanvas = React.forwardRef<
         defaultEdgeOptions={defaultEdgeOptions}
         nodeTypes={nodeTypes}
         proOptions={{ hideAttribution: true }}
-        deleteKeyCode={[]}
+        deleteKeyCode={["Backspace", "Delete"]}
         fitView
         fitViewOptions={fitViewOptions}
         nodeDragThreshold={4}


### PR DESCRIPTION
# Description
- Removing the delete keypress in the react flow canvas makes it so you can't delete edges either.
