### PR TITLE
Add Anthropic support via Bedrock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "uv==0.4.10",
     "uvicorn==0.29.0",
     "virtualenv==20.27.0",
+    "anthropic[bedrock]==0.49.0",
 ]
 dynamic = ["version"]
 

--- a/registry/tracecat_registry/llm/anthropic_bedrock.py
+++ b/registry/tracecat_registry/llm/anthropic_bedrock.py
@@ -1,0 +1,52 @@
+from typing import Annotated, Any
+
+from typing_extensions import Doc
+
+from tracecat.llm.anthropic_bedrock import (
+    async_anthropic_bedrock_call,
+    DEFAULT_ANTHROPIC_MODEL,
+)
+from tracecat_registry import registry
+
+
+@registry.register(
+    default_title="Call Anthropic Bedrock (messages)",
+    description="Call an LLM via Anthropic Bedrock messages API.",
+    display_group="Anthropic",
+    doc_url="https://docs.anthropic.com/claude/reference/bedrock-python-sdk",
+    namespace="llm.anthropic_bedrock",
+)
+async def call(
+    prompt: Annotated[
+        str,
+        Doc("Prompt or conversation history to send to the LLM"),
+    ],
+    completion: Annotated[
+        str | None,
+        Doc("Optionally prefix the LLM's response"),
+    ] = None,
+    model: Annotated[
+        str,
+        Doc("Model to use"),
+    ] = DEFAULT_ANTHROPIC_MODEL,
+    memory: Annotated[
+        list[dict[str, Any]] | None,
+        Doc("Past messages to include in the conversation."),
+    ] = None,
+    system_prompt: Annotated[
+        str | None, Doc("Insert a system message at the beginning of the conversation.")
+    ] = None,
+    max_tokens: Annotated[
+        int,
+        Doc("Maximum number of tokens to generate. 1024 by default."),
+    ] = 1024,
+) -> dict[str, Any]:
+    response = await async_anthropic_bedrock_call(
+        prompt=prompt,
+        completion=completion,
+        model=model,
+        memory=memory,
+        system_prompt=system_prompt,
+        max_tokens=max_tokens
+    )
+    return response.model_dump()

--- a/tracecat/llm/__init__.py
+++ b/tracecat/llm/__init__.py
@@ -1,12 +1,12 @@
+from .anthropic_bedrock import (
+    DEFAULT_ANTHROPIC_MODEL,
+    async_anthropic_bedrock_call,
+)
 from .ollama import async_ollama_call
 from .openai import (
     DEFAULT_OPENAI_MODEL,
     async_openai_call,
     async_openai_chat_completion,
-)
-from .anthropic_bedrock import (
-    DEFAULT_ANTHROPIC_MODEL,
-    async_anthropic_bedrock_call,
 )
 
 __all__ = [

--- a/tracecat/llm/__init__.py
+++ b/tracecat/llm/__init__.py
@@ -4,10 +4,16 @@ from .openai import (
     async_openai_call,
     async_openai_chat_completion,
 )
+from .anthropic_bedrock import (
+    DEFAULT_ANTHROPIC_MODEL,
+    async_anthropic_bedrock_call,
+)
 
 __all__ = [
     "async_ollama_call",
     "async_openai_call",
     "async_openai_chat_completion",
     "DEFAULT_OPENAI_MODEL",
+    "async_anthropic_bedrock_call",
+    "DEFAULT_ANTHROPIC_MODEL",
 ]

--- a/tracecat/llm/anthropic_bedrock.py
+++ b/tracecat/llm/anthropic_bedrock.py
@@ -1,0 +1,47 @@
+"""Anthropic Bedrock LLM client.
+
+Docs: https://docs.anthropic.com/claude/reference/bedrock-python-sdk
+"""
+
+from typing import Any, overload
+
+from anthropic import AsyncAnthropicBedrock
+from anthropic.types import Message, MessageParam
+
+from tracecat.logger import logger
+
+DEFAULT_ANTHROPIC_MODEL = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+
+
+async def async_anthropic_bedrock_call(
+    prompt: str,
+    completion: str | None = None,
+    *,
+    model: str = DEFAULT_ANTHROPIC_MODEL,
+    memory: list[MessageParam] | None = None,
+    system_prompt: str | None = None,
+    max_tokens: int
+) -> Message:
+    """Call the Anthropic Bedrock API with the given prompt and return the response."""
+    client = AsyncAnthropicBedrock()
+    logger.debug(
+        "🧠 Calling LLM chat completion",
+        provider="anthropic_bedrock",
+        model=model,
+        prompt=prompt,
+    )
+
+    messages = []
+    if memory:
+        messages.extend(memory)
+
+    messages.append({"role": "user", "content": prompt})
+    if completion:
+        messages.append({"role": "assistant", "content": completion})
+    kwargs = {"model": model, "messages": messages, "max_tokens": max_tokens}
+
+    if system_prompt:
+        kwargs["system"] = system_prompt
+
+    response = await client.messages.create(**kwargs)
+    return response

--- a/tracecat/llm/anthropic_bedrock.py
+++ b/tracecat/llm/anthropic_bedrock.py
@@ -3,7 +3,6 @@
 Docs: https://docs.anthropic.com/claude/reference/bedrock-python-sdk
 """
 
-from typing import Any, overload
 
 from anthropic import AsyncAnthropicBedrock
 from anthropic.types import Message, MessageParam


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

I wanted to use Claude via Bedrock in a way similar to how tracecat supports Ollama/OpenAI, so I implemented that. It only supports role-based/environment variable based auth; I'm not sure if others would want to store keys as secrets (AWS doesn't recommend this). 

Sorry, couldn't get tests to run. Not sure if the registry directory structured changed or what, but I don't _think_ this will break any tests

```    from tracecat.registry.actions.models import (
tracecat/registry/actions/models.py:20: in <module>
    from tracecat_registry import RegistrySecret
E   ModuleNotFoundError: No module named 'tracecat_registry'```


## Screenshots / Recordings
![Screenshot 2025-04-17 at 11 44 28 AM](https://github.com/user-attachments/assets/1e454dbf-84df-4a5b-85a0-072570763011)

