### PR TITLE
perf(app): Return only 1 workflow definition in webhook fastapi dependency

### DIFF
--- a/tracecat/webhooks/dependencies.py
+++ b/tracecat/webhooks/dependencies.py
@@ -83,6 +83,7 @@ async def validate_workflow_definition(
             select(WorkflowDefinition)
             .where(WorkflowDefinition.workflow_id == workflow_id)
             .order_by(col(WorkflowDefinition.version).desc())
+            .limit(1)
         )
         defn = result.first()
         if not defn:


### PR DESCRIPTION
add .limit(1) when querying for the latest workflow definition