### PR TITLE
fix(ui): Fix action ref copy and don't select node when clicking on toolbar

### DIFF
--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -509,6 +509,7 @@ function ActionNodeToolbar({
       align="start"
       onMouseEnter={handleToolbarMouseEnter}
       onMouseLeave={handleToolbarMouseLeave}
+      onClick={(e) => e.stopPropagation()}
     >
       <Command
         value={commandValue}
@@ -520,8 +521,8 @@ function ActionNodeToolbar({
           {/* Actions */}
           <CommandGroup>
             <CommandItem
-              value={`ACTIONS.${slugify(action.title)}.result`}
-              onSelect={(value) => {
+              onSelect={() => {
+                const value = `ACTIONS.${slugify(action.title)}.result`
                 navigator.clipboard.writeText(value)
                 toast({
                   title: "Copied action reference",


### PR DESCRIPTION
This is useful for when a user is working on a node that requires other action refs

# Screens

https://github.com/user-attachments/assets/db575936-445a-4516-86b7-0bc1b2102bd6

