### PR TITLE
feat(ui): Add action panel ref + expand action panel on node click

### DIFF
--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -13,21 +13,31 @@ const PopoverAnchor = PopoverPrimitive.Anchor
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-))
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    portal?: boolean
+  }
+>(
+  (
+    { className, align = "center", sideOffset = 4, portal = false, ...props },
+    ref
+  ) => {
+    const Wrapper = portal ? PopoverPrimitive.Portal : React.Fragment
+    return (
+      <Wrapper>
+        <PopoverPrimitive.Content
+          ref={ref}
+          align={align}
+          sideOffset={sideOffset}
+          className={cn(
+            "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            className
+          )}
+          {...props}
+        />
+      </Wrapper>
+    )
+  }
+)
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
 export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -123,6 +123,12 @@ export default React.memo(function ActionNode({
   const { breakpoint, style } = useActionNodeZoomBreakpoint()
   const { actionPanelRef } = useWorkflowBuilder()
   // Clear timeout on unmount
+  const expandActionPanel = useCallback(() => {
+    if (actionPanelRef.current?.isCollapsed()) {
+      actionPanelRef.current?.expand()
+    }
+  }, [actionPanelRef])
+
   useEffect(() => {
     return () => {
       if (hideTimeoutRef.current) {
@@ -130,12 +136,6 @@ export default React.memo(function ActionNode({
       }
     }
   }, [])
-
-  useEffect(() => {
-    if (selected && actionPanelRef.current?.isCollapsed()) {
-      actionPanelRef.current?.expand()
-    }
-  }, [selected])
 
   // Handle combined mouse over state
   useEffect(() => {
@@ -297,6 +297,7 @@ export default React.memo(function ActionNode({
             )}
             onMouseEnter={handleNodeMouseEnter}
             onMouseLeave={handleNodeMouseLeave}
+            onClick={expandActionPanel}
           >
             <ActionNodeContent
               workspaceId={workspaceId}

--- a/frontend/src/components/workbench/canvas/action-node.tsx
+++ b/frontend/src/components/workbench/canvas/action-node.tsx
@@ -121,7 +121,7 @@ export default React.memo(function ActionNode({
   const nodeRef = useRef<HTMLDivElement>(null)
   const hideTimeoutRef = useRef<number>()
   const { breakpoint, style } = useActionNodeZoomBreakpoint()
-
+  const { actionPanelRef } = useWorkflowBuilder()
   // Clear timeout on unmount
   useEffect(() => {
     return () => {
@@ -130,6 +130,12 @@ export default React.memo(function ActionNode({
       }
     }
   }, [])
+
+  useEffect(() => {
+    if (selected && actionPanelRef.current?.isCollapsed()) {
+      actionPanelRef.current?.expand()
+    }
+  }, [selected])
 
   // Handle combined mouse over state
   useEffect(() => {

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -169,9 +169,14 @@ const parseYaml = (str: string | undefined) =>
 const stringifyYaml = (obj: unknown | undefined) =>
   obj ? YAML.stringify(obj) : ""
 
+export type ActionPanelTabs =
+  | "inputs"
+  | "control-flow"
+  | "retry-policy"
+  | "template-inputs"
 export interface ActionPanelRef extends ImperativePanelHandle {
-  setActiveTab: (tab: string) => void
-  getActiveTab: () => string
+  setActiveTab: (tab: ActionPanelTabs) => void
+  getActiveTab: () => ActionPanelTabs
   setOpen: (open: boolean) => void
   isOpen: () => boolean
 }
@@ -217,7 +222,7 @@ export function ActionPanel({
     RegistryActionValidateResponse[]
   >([])
   const [saveState, setSaveState] = useState<SaveState>(SaveState.IDLE)
-  const [activeTab, setActiveTab] = useState("inputs")
+  const [activeTab, setActiveTab] = useState<ActionPanelTabs>("inputs")
   const [open, setOpen] = useState(false)
 
   useEffect(() => {
@@ -403,7 +408,7 @@ export function ActionPanel({
       <Tabs
         defaultValue="inputs"
         value={activeTab}
-        onValueChange={setActiveTab}
+        onValueChange={(value) => setActiveTab(value as ActionPanelTabs)}
         className="w-full"
       >
         <FormProvider {...methods}>

--- a/frontend/src/components/workbench/panel/action-panel.tsx
+++ b/frontend/src/components/workbench/panel/action-panel.tsx
@@ -9,6 +9,7 @@ import {
   ApiError,
   RegistryActionValidateResponse,
 } from "@/client"
+import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspace } from "@/providers/workspace"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -168,7 +169,12 @@ const parseYaml = (str: string | undefined) =>
 const stringifyYaml = (obj: unknown | undefined) =>
   obj ? YAML.stringify(obj) : ""
 
-export interface ActionPanelRef extends ImperativePanelHandle {}
+export interface ActionPanelRef extends ImperativePanelHandle {
+  setActiveTab: (tab: string) => void
+  getActiveTab: () => string
+  setOpen: (open: boolean) => void
+  isOpen: () => boolean
+}
 
 export function ActionPanel({
   actionId,
@@ -185,6 +191,7 @@ export function ActionPanel({
     workspaceId,
     workflowId
   )
+  const { actionPanelRef } = useWorkflowBuilder()
   const { registryAction, registryActionIsLoading, registryActionError } =
     useGetRegistryAction(action?.type)
   const { for_each, run_if, retry_policy, ...options } =
@@ -211,12 +218,34 @@ export function ActionPanel({
   >([])
   const [saveState, setSaveState] = useState<SaveState>(SaveState.IDLE)
   const [activeTab, setActiveTab] = useState("inputs")
+  const [open, setOpen] = useState(false)
 
   useEffect(() => {
     setActiveTab("inputs")
     setSaveState(SaveState.IDLE)
     setActionValidationErrors([])
   }, [actionId])
+
+  // Set up the ref methods
+  useEffect(() => {
+    if (actionPanelRef.current) {
+      actionPanelRef.current.setActiveTab = setActiveTab
+      actionPanelRef.current.getActiveTab = () => activeTab
+      actionPanelRef.current.setOpen = (newOpen: boolean) => {
+        setOpen(newOpen)
+        // If the panel has a collapse method, use it
+        if (
+          actionPanelRef.current?.collapse &&
+          actionPanelRef.current?.expand
+        ) {
+          newOpen
+            ? actionPanelRef.current.expand()
+            : actionPanelRef.current.collapse()
+        }
+      }
+      actionPanelRef.current.isOpen = () => open
+    }
+  }, [actionPanelRef, activeTab, setOpen, open])
 
   const handleSave = useCallback(
     async (values: ActionFormSchema) => {


### PR DESCRIPTION
- **Expand action panel on node select if collapsed**
- **Expand action panel when node clicked**
- **Add portal prop to popover**
- **Add types for tab names**
