### PR TITLE
fix(engine): More extensive error path handling and avoid null ActionErrorInfo

### DIFF
--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -243,4 +243,4 @@ class DSLExecutionError(TypedDict, total=False):
 @dataclass(frozen=True)
 class TaskExceptionInfo:
     exception: Exception
-    details: ActionErrorInfo | None = None
+    details: ActionErrorInfo


### PR DESCRIPTION
When we handle the error path sometimes the `details` becomes `None`. We weren't handling this correctly which led to the TypeAdapter(ActionErrorInfo) failing to parse None values