### PR TITLE
fix: Drop multiindex support

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4535,14 +4535,6 @@ export const $TableRowInsert = {
       title: "Upsert",
       default: false,
     },
-    natural_keys: {
-      items: {
-        type: "string",
-      },
-      type: "array",
-      title: "Natural Keys",
-      description: "The columns of the table to use for upsert",
-    },
   },
   type: "object",
   required: ["data"],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1484,10 +1484,6 @@ export type TableRowInsert = {
     [key: string]: unknown
   }
   upsert?: boolean
-  /**
-   * The columns of the table to use for upsert
-   */
-  natural_keys?: Array<string>
 }
 
 /**

--- a/frontend/src/components/tables/table-view-column-menu.tsx
+++ b/frontend/src/components/tables/table-view-column-menu.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   ChevronDownIcon,
   CopyIcon,
-  KeyIcon,
+  DatabaseIcon,
   Pencil,
   Trash2Icon,
 } from "lucide-react"
@@ -114,8 +114,8 @@ export function TableViewColumnMenu({ column }: { column: TableColumnRead }) {
                 }}
                 disabled={column.is_index}
               >
-                <KeyIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
-                {column.is_index ? "Natural Key" : "Make natural key"}
+                <DatabaseIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+                {column.is_index ? "Unique index" : "Create unique index"}
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="py-1 text-xs text-foreground/80"
@@ -426,10 +426,9 @@ function TableColumnIndexDialog({
       <AlertDialog open={open} onOpenChange={onOpenChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Column is already a Natural Key</AlertDialogTitle>
+            <AlertDialogTitle>Column is already a unique index</AlertDialogTitle>
             <AlertDialogDescription>
-              Column <b>{column.name}</b> is already a natural key with a unique
-              index.
+              Column <b>{column.name}</b> is already a unique index.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -454,13 +453,13 @@ function TableColumnIndexDialog({
       })
 
       toast({
-        title: "Natural key created",
-        description: "Column is now a natural key.",
+        title: "Created unique index",
+        description: "Column is now a unique index.",
       })
 
       onOpenChange()
     } catch (error) {
-      console.error("Error creating natural key:", error)
+      console.error("Error creating unique index:", error)
     }
   }
 
@@ -475,11 +474,10 @@ function TableColumnIndexDialog({
     >
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Create Natural Key</AlertDialogTitle>
+          <AlertDialogTitle>Create unique index</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to make column <b>{column.name}</b> a natural
-            key? This will create a unique index on the column, making it usable
-            for upsert operations.
+            Are you sure you want to make column <b>{column.name}</b> a unique
+            index? This enables upsert operations on the table.
             <br />
             <br />
             <strong>Requirements:</strong>
@@ -504,8 +502,8 @@ function TableColumnIndexDialog({
               </>
             ) : (
               <>
-                <KeyIcon className="mr-2 size-4" />
-                Create Natural Key
+                <DatabaseIcon className="mr-2 size-4" />
+                Create unique index
               </>
             )}
           </AlertDialogAction>

--- a/frontend/src/components/tables/table-view-column-menu.tsx
+++ b/frontend/src/components/tables/table-view-column-menu.tsx
@@ -426,7 +426,9 @@ function TableColumnIndexDialog({
       <AlertDialog open={open} onOpenChange={onOpenChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Column is already a unique index</AlertDialogTitle>
+            <AlertDialogTitle>
+              Column is already a unique index
+            </AlertDialogTitle>
             <AlertDialogDescription>
               Column <b>{column.name}</b> is already a unique index.
             </AlertDialogDescription>

--- a/frontend/src/components/tables/table-view-column-menu.tsx
+++ b/frontend/src/components/tables/table-view-column-menu.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   ChevronDownIcon,
   CopyIcon,
-  DatabaseIcon,
+  DatabaseZapIcon,
   Pencil,
   Trash2Icon,
 } from "lucide-react"
@@ -114,7 +114,7 @@ export function TableViewColumnMenu({ column }: { column: TableColumnRead }) {
                 }}
                 disabled={column.is_index}
               >
-                <DatabaseIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+                <DatabaseZapIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
                 {column.is_index ? "Unique index" : "Create unique index"}
               </DropdownMenuItem>
               <DropdownMenuItem
@@ -502,7 +502,7 @@ function TableColumnIndexDialog({
               </>
             ) : (
               <>
-                <DatabaseIcon className="mr-2 size-4" />
+                <DatabaseZapIcon className="mr-2 size-4" />
                 Create unique index
               </>
             )}

--- a/frontend/src/components/tables/table-view.tsx
+++ b/frontend/src/components/tables/table-view.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation"
 import { TableColumnRead, TableRead, TableRowRead } from "@/client"
 import { useWorkspace } from "@/providers/workspace"
 import { CellContext, ColumnDef } from "@tanstack/react-table"
-import { KeyIcon } from "lucide-react"
+import { DatabaseIcon } from "lucide-react"
 
 import { useListRows } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
@@ -96,7 +96,7 @@ export function DatabaseTable({ table: { columns } }: { table: TableRead }) {
           <span className="lowercase text-muted-foreground">{column.type}</span>
           {column.is_index && (
             <span className="inline-flex items-center rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100">
-              <KeyIcon className="mr-1 size-3" />
+              <DatabaseIcon className="mr-1 size-3" />
               Key
             </span>
           )}

--- a/frontend/src/components/tables/table-view.tsx
+++ b/frontend/src/components/tables/table-view.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation"
 import { TableColumnRead, TableRead, TableRowRead } from "@/client"
 import { useWorkspace } from "@/providers/workspace"
 import { CellContext, ColumnDef } from "@tanstack/react-table"
-import { DatabaseIcon } from "lucide-react"
+import { DatabaseZapIcon } from "lucide-react"
 
 import { useListRows } from "@/lib/hooks"
 import { Button } from "@/components/ui/button"
@@ -96,8 +96,8 @@ export function DatabaseTable({ table: { columns } }: { table: TableRead }) {
           <span className="lowercase text-muted-foreground">{column.type}</span>
           {column.is_index && (
             <span className="inline-flex items-center rounded-full bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-100">
-              <DatabaseIcon className="mr-1 size-3" />
-              Key
+              <DatabaseZapIcon className="mr-1 size-3" />
+              Index
             </span>
           )}
           <TableViewColumnMenu column={column} />

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -2207,6 +2207,12 @@ export function useUpdateColumn() {
               "Column contains duplicate values. All values must be unique.",
             variant: "destructive",
           })
+        } else if (error.status === 400) {
+          toast({
+            title: "Error creating natural key",
+            description: error.message,
+            variant: "destructive",
+          })
         } else {
           toast({
             title: "Error creating natural key",

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -2205,19 +2205,16 @@ export function useUpdateColumn() {
             title: "Error creating natural key",
             description:
               "Column contains duplicate values. All values must be unique.",
-            variant: "destructive",
           })
         } else if (error.status === 400) {
           toast({
             title: "Error creating natural key",
-            description: error.message,
-            variant: "destructive",
+            description: String(error.body.detail),
           })
         } else {
           toast({
             title: "Error creating natural key",
             description: error.message || "An unexpected error occurred",
-            variant: "destructive",
           })
         }
       } else {
@@ -2234,7 +2231,6 @@ export function useUpdateColumn() {
             toast({
               title: "Error updating column",
               description: error.message || "An unexpected error occurred",
-              variant: "destructive",
             })
             break
         }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -2195,25 +2195,25 @@ export function useUpdateColumn() {
       })
     },
     onError: (error: TracecatApiError, variables) => {
-      // Check if this was a natural key operation
+      // Check if this was a unique index operation
       const isIndexOperation = !!variables.requestBody?.is_index
 
       if (isIndexOperation) {
-        // Handle natural key specific errors
+        // Handle unique index specific errors
         if (error.status === 409) {
           toast({
-            title: "Error creating natural key",
+            title: "Error creating unique index",
             description:
               "Column contains duplicate values. All values must be unique.",
           })
         } else if (error.status === 400) {
           toast({
-            title: "Error creating natural key",
+            title: "Error creating unique index",
             description: String(error.body.detail),
           })
         } else {
           toast({
-            title: "Error creating natural key",
+            title: "Error creating unique index",
             description: error.message || "An unexpected error occurred",
           })
         }

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -314,9 +314,7 @@ class TestTableRows:
 
         # Upsert using name as natural key
         upsert_data = {"name": "John", "age": 35}
-        upsert_insert = TableRowInsert(
-            data=upsert_data, upsert=True, natural_keys=["name"]
-        )
+        upsert_insert = TableRowInsert(data=upsert_data, upsert=True)
         upserted = await tables_service.insert_row(table, upsert_insert)
 
         # Verify row was updated
@@ -372,9 +370,7 @@ class TestTableRows:
 
         # Upsert with compound key
         compound_upsert = TableRowInsert(
-            data={"name": "Alice", "age": 26, "email": "alice@example.com"},
-            upsert=True,
-            natural_keys=["name", "email"],
+            data={"name": "Alice", "age": 26, "email": "alice@example.com"}, upsert=True
         )
         updated = await tables_service.insert_row(compound_table, compound_upsert)
 
@@ -408,7 +404,7 @@ class TestTableRows:
         # Attempt upsert without index
         with pytest.raises(ValueError) as exc_info:
             upsert_insert = TableRowInsert(
-                data={"name": "TestUser", "age": 41}, upsert=True, natural_keys=["name"]
+                data={"name": "TestUser", "age": 41}, upsert=True
             )
             await tables_service.insert_row(table, upsert_insert)
 

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -264,7 +264,7 @@ class TestTableRows:
         # Create unique index on name column
         await tables_service.create_unique_index(table, "name")
 
-        # Upsert using name as natural key
+        # Upsert using name as unique index
         upsert_data = {"name": "John", "age": 35}
         upsert_insert = TableRowInsert(data=upsert_data, upsert=True)
         upserted = await tables_service.insert_row(table, upsert_insert)

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -354,7 +354,23 @@ class TestTableRows:
             await tables_service.insert_row(table, upsert_insert)
 
         # Verify error message
-        assert "Create a unique index first" in str(exc_info.value)
+        assert "Table must have at least one unique index for upsert" in str(
+            exc_info.value
+        )
+
+    async def test_index_field_required_for_upsert(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Test that upsert fails if the field is not in the index."""
+        await tables_service.create_unique_index(table, "name")
+
+        with pytest.raises(ValueError) as exc_info:
+            upsert_insert = TableRowInsert(data={"age": 41}, upsert=True)
+            await tables_service.insert_row(table, upsert_insert)
+
+        assert "Data to upsert must contain the unique index column" in str(
+            exc_info.value
+        )
 
     async def test_update_row(
         self, tables_service: TablesService, table: Table

--- a/tracecat/tables/models.py
+++ b/tracecat/tables/models.py
@@ -92,10 +92,6 @@ class TableRowInsert(BaseModel):
 
     data: dict[str, Any]
     upsert: bool = False
-    natural_keys: list[str] = Field(
-        default_factory=list,
-        description="The columns of the table to use for upsert",
-    )
 
 
 class TableRowInsertBatch(BaseModel):

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -134,7 +134,7 @@ async def get_table(
         ) from e
 
     # Get natural key info or default to empty dict if not present
-    natural_key_info = await service.get_index(table)
+    index_columns = await service.get_index(table)
 
     # Convert to response model (includes is_index field)
     return TableRead(
@@ -147,7 +147,7 @@ async def get_table(
                 type=SqlType(column.type),
                 nullable=column.nullable,
                 default=column.default,
-                is_index=natural_key_info.get(column.name, False),
+                is_index=column.name in index_columns,
             )
             for column in table.columns
         ],

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -133,7 +133,7 @@ async def get_table(
             detail=str(e),
         ) from e
 
-    # Get natural key info or default to empty dict if not present
+    # Get unique index info or default to empty dict if not present
     index_columns = await service.get_index(table)
 
     # Convert to response model (includes is_index field)

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -261,6 +261,11 @@ async def update_column(
         ) from e
     try:
         await service.update_column(column, params)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except ProgrammingError as e:
         # Drill down to the root cause
         while (cause := e.__cause__) is not None:

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -438,22 +438,6 @@ class BaseTablesService(BaseService):
         await self.session.flush()
 
     @require_access_level(AccessLevel.ADMIN)
-    async def create_multi_unique_index(
-        self, table: Table, column_names: list[str]
-    ) -> None:
-        """Create a unique index on multiple columns."""
-        full_table_name = self._full_table_name(table.name)
-        index_name = f"uq_{table.name}_{'_'.join(column_names)}"
-        conn = await self.session.connection()
-        await conn.execute(
-            sa.DDL(
-                "CREATE UNIQUE INDEX %s ON %s (%s)",
-                (index_name, full_table_name, ", ".join(column_names)),
-            )
-        )
-        await self.session.flush()
-
-    @require_access_level(AccessLevel.ADMIN)
     async def delete_column(self, column: TableColumn) -> None:
         """Remove a column from an existing table."""
         full_table_name = self._full_table_name(column.table.name)


### PR DESCRIPTION
## What changed
- Only support single index now
- Use sqlalchemy inspect to get indexes
- Renamed "natural key" to "unique index"
- Changed key icon to database spark
- Added ValueError (reraised as HTTP 400 error at router) exception to table service if update column with `is_index=True` and an index already exists
- Catch 400 exception in frontend updateColumn use effect

## Fixes
Silent bug where multi index path was reachable by user.

## QA
- Create new table
- Create index
- Create another index (errors as notification)

<img width="1331" alt="Screenshot 2025-04-22 at 5 46 36 PM" src="https://github.com/user-attachments/assets/41d12e88-25dc-473d-8178-335e2663aea0" />