### PR TITLE
feat(app): Allow all org users to read app settings

### DIFF
--- a/tracecat/settings/router.py
+++ b/tracecat/settings/router.py
@@ -35,6 +35,15 @@ OrgAdminUserRole = Annotated[
     ),
 ]
 
+OrgUserRole = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="no",
+    ),
+]
+
 # NOTE: We expose settings groups
 # We don't need create or delete endpoints as we only need to read/update settings.
 # For M2M, we use the service directly.
@@ -167,7 +176,7 @@ async def update_oauth_settings(
 @router.get("/app", response_model=AppSettingsRead)
 async def get_app_settings(
     *,
-    role: OrgAdminUserRole,
+    role: OrgUserRole,
     session: AsyncDBSession,
 ) -> AppSettingsRead:
     service = SettingsService(session, role)


### PR DESCRIPTION
# Description
All user roles need to be able to read organization app settings to conditionally render UI (e.g. disable exports). This contains non-sensitive values so it's safe