### PR TITLE
fix(engine): Pass memo into error workflow

### DIFF
--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -296,14 +296,14 @@ class ChildWorkflowMemo(BaseModel):
     def from_temporal(memo: temporalio.api.common.v1.Memo) -> ChildWorkflowMemo:
         try:
             action_ref = orjson.loads(memo.fields["action_ref"].data)
-            if loop_index_data := memo.fields["loop_index"].data:
-                loop_index = orjson.loads(loop_index_data)
-            else:
-                loop_index = None
-            return ChildWorkflowMemo(action_ref=action_ref, loop_index=loop_index)
         except Exception as e:
-            logger.opt(exception=e).error("Error parsing child workflow memo")
-            raise e
+            logger.warning("Error parsing child workflow memo action ref", error=e)
+            action_ref = "Unknown Child Workflow"
+        if loop_index_data := memo.fields["loop_index"].data:
+            loop_index = orjson.loads(loop_index_data)
+        else:
+            loop_index = None
+        return ChildWorkflowMemo(action_ref=action_ref, loop_index=loop_index)
 
 
 AdjDst = tuple[str, EdgeType]

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -401,7 +401,11 @@ class WorkflowExecutionEventCompact(BaseModel):
 
         attrs = event.start_child_workflow_execution_initiated_event_attributes
         wf_exec_id = cast(WorkflowExecutionID, attrs.workflow_id)
-        memo = ChildWorkflowMemo.from_temporal(attrs.memo)
+        try:
+            memo = ChildWorkflowMemo.from_temporal(attrs.memo)
+        except Exception as e:
+            logger.error("Error parsing child workflow memo", error=e)
+            raise e
         input_data = extract_first(attrs.input)
         dsl_run_args = DSLRunArgs(**input_data)
 


### PR DESCRIPTION
# Description
We weren't passing memo into the child workflow, which led to unexpected API errors as the error workflow's action ref would be blank and break the UI.
