### PR TITLE
feat(engine): Add url to error workflow info and return errors as list

### DIFF
--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, TypedDict
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, TypeAdapter, field_validator, model_validator
 
 from tracecat.dsl.constants import DEFAULT_ACTION_TIMEOUT
 from tracecat.dsl.enums import JoinStrategy
@@ -60,6 +60,9 @@ class ActionErrorInfo:
     def format(self, loc: str = "run_action") -> str:
         locator = f"{self.expr_context}.{self.ref} -> {loc}"
         return f"[{locator}] (Attempt {self.attempt})\n\n{self.message}"
+
+
+ActionErrorInfoAdapter = TypeAdapter(ActionErrorInfo)
 
 
 class ActionRetryPolicy(BaseModel):

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -994,8 +994,8 @@ class DSLWorkflow:
                 handler_wf_id=wf_id,
                 orig_wf_id=orig_wf_id,
                 orig_wf_exec_id=orig_wf_exec_id,
+                orig_wf_exec_url=url,
                 errors=errors,
-                url=url,
             ),
             runtime_config=runtime_config,
         )

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -228,15 +228,25 @@ class DSLWorkflow:
                 err_info_map = e.details[0]
                 self.logger.info("Raising error info", err_info_data=err_info_map)
                 if not isinstance(err_info_map, dict):
-                    raise ApplicationError(
-                        "Error info map is not a dictionary",
-                        non_retryable=True,
-                        type=e.__class__.__name__,
-                    ) from e
-                errors = [
-                    ActionErrorInfoAdapter.validate_python(data)
-                    for data in err_info_map.values()
-                ]
+                    logger.error(
+                        "Unexpected error info object",
+                        err_info_map=err_info_map,
+                        type=type(err_info_map).__name__,
+                    )
+                    # TODO: There's likely a nicer way to gracefully handle this
+                    # instead of a sentinel error value
+                    errors = [
+                        ActionErrorInfo(
+                            ref="N/A",
+                            message=f"Unexpected error info object of type {type(err_info_map).__name__}: {err_info_map}",
+                            type=type(err_info_map).__name__,
+                        )
+                    ]
+                else:
+                    errors = [
+                        ActionErrorInfoAdapter.validate_python(data)
+                        for data in err_info_map.values()
+                    ]
             else:
                 errors = None
 

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -473,7 +473,7 @@ class ErrorHandlerWorkflowInput:
     handler_wf_id: WorkflowID
     orig_wf_id: WorkflowID
     orig_wf_exec_id: WorkflowExecutionID
-    errors: dict[str, ActionErrorInfo] | None
+    errors: list[ActionErrorInfo] | None = None
     orig_wf_exec_url: str | None = None
 
 

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -474,6 +474,7 @@ class ErrorHandlerWorkflowInput:
     orig_wf_id: WorkflowID
     orig_wf_exec_id: WorkflowExecutionID
     errors: dict[str, ActionErrorInfo] | None
+    url: str | None = None
 
 
 class ReceiveInteractionResponse(BaseModel):

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -474,7 +474,7 @@ class ErrorHandlerWorkflowInput:
     orig_wf_id: WorkflowID
     orig_wf_exec_id: WorkflowExecutionID
     errors: dict[str, ActionErrorInfo] | None
-    url: str | None = None
+    orig_wf_exec_url: str | None = None
 
 
 class ReceiveInteractionResponse(BaseModel):


### PR DESCRIPTION
- **Add passing child workflow memo into error workflow**
- **Add url to error workflow info**
- **Rename url**
- **Return a list of errors instead of dict**

# Note
Any workflow exceptions are caught gracefully in the DSLScheduler and handled [here](https://github.com/TracecatHQ/tracecat/blob/e8e1bd9ce58e151bc49dd1232104f5765469f731/tracecat/dsl/workflow.py#L404).  In this [part of the PR](https://github.com/TracecatHQ/tracecat/pull/1091/files#diff-2079223e69c50358b1cca8d442dc92a6a030ecf15a15c8d995c7406b221441f9R230-R244) we handle the unexpected case where this isn't a dictionary and return an error instead of crashing the workflow.


# Screens

https://github.com/user-attachments/assets/0b35b433-238d-45ad-839e-2c090771fbae

