### PR TITLE
feat(engine): Implement detached child workflows

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5816,6 +5816,7 @@ export const $WorkflowExecutionEventStatus = {
     "TERMINATED",
     "TIMED_OUT",
     "UNKNOWN",
+    "DETACHED",
   ],
   title: "WorkflowExecutionEventStatus",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1875,6 +1875,7 @@ export type WorkflowExecutionEventStatus =
   | "TERMINATED"
   | "TIMED_OUT"
   | "UNKNOWN"
+  | "DETACHED"
 
 export type WorkflowExecutionRead = {
   /**

--- a/frontend/src/components/workbench/events/events-workflow.tsx
+++ b/frontend/src/components/workbench/events/events-workflow.tsx
@@ -22,6 +22,7 @@ import {
   CirclePlayIcon,
   CircleX,
   EyeOffIcon,
+  GitForkIcon,
   LayoutListIcon,
   LoaderIcon,
   ScanEyeIcon,
@@ -266,7 +267,7 @@ export function WorkflowEvents({
                   </div>
 
                   <div className="flex flex-1 items-center justify-between">
-                    <div className="max-w-28 truncate text-foreground/70">
+                    <div className="w-full truncate text-foreground/70">
                       {event.action_ref}
                     </div>
 
@@ -414,6 +415,15 @@ export function getWorkflowEventIcon(
           strokeWidth={2.5}
         />
       )
+    case "DETACHED":
+      return (
+        <GitForkIcon
+          className={cn("!size-3 stroke-emerald-500", className)}
+          strokeWidth={2.5}
+        />
+      )
+    case "UNKNOWN":
+      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
     default:
       throw new Error("Invalid status")
   }

--- a/registry/tracecat_registry/core/workflow.py
+++ b/registry/tracecat_registry/core/workflow.py
@@ -68,7 +68,7 @@ async def execute(
             "In `wait` mode, this action will wait for all child workflows to complete before returning. "
             "Any child workflow failures will be reported as an error. "
             "In `detach` mode, this action will return immediately after the child workflows are created. "
-            "A fialing child workflow will not affect the parent. "
+            "A failing child workflow will not affect the parent. "
         ),
     ] = "wait",
 ) -> Any:

--- a/registry/tracecat_registry/core/workflow.py
+++ b/registry/tracecat_registry/core/workflow.py
@@ -61,5 +61,15 @@ async def execute(
         Literal["isolated", "all"],
         Doc("Fail strategy to use when a child workflow fails."),
     ] = "isolated",
+    wait_strategy: Annotated[
+        Literal["wait", "detach"],
+        Doc(
+            "Wait strategy to use when waiting for child workflows to complete. "
+            "In `wait` mode, this action will wait for all child workflows to complete before returning. "
+            "Any child workflow failures will be reported as an error. "
+            "In `detach` mode, this action will return immediately after the child workflows are created. "
+            "A fialing child workflow will not affect the parent. "
+        ),
+    ] = "wait",
 ) -> Any:
     raise ActionIsInterfaceError()

--- a/tracecat/dsl/enums.py
+++ b/tracecat/dsl/enums.py
@@ -16,6 +16,19 @@ class LoopStrategy(StrEnum):
     SEQUENTIAL = "sequential"
 
 
+class WaitStrategy(StrEnum):
+    WAIT = "wait"
+    """
+    In `wait` mode, this action will wait for all child workflows to complete before returning.
+    Any child workflow failures will be reported as an error.
+    """
+    DETACH = "detach"
+    """
+    In `detach` mode, this action will return immediately after the child workflows are created.
+    A fialing child workflow will not affect the parent.
+    """
+
+
 class SkipStrategy(StrEnum):
     ISOLATE = auto()
     PROPAGATE = auto()

--- a/tracecat/workflow/executions/enums.py
+++ b/tracecat/workflow/executions/enums.py
@@ -14,6 +14,7 @@ class WorkflowExecutionEventStatus(StrEnum):
     TERMINATED = "TERMINATED"
     TIMED_OUT = "TIMED_OUT"
     UNKNOWN = "UNKNOWN"
+    DETACHED = "DETACHED"
 
 
 class WorkflowEventType(StrEnum):

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -56,6 +56,7 @@ from tracecat.workflow.executions.enums import (
     TemporalSearchAttr,
     TriggerType,
     WorkflowEventType,
+    WorkflowExecutionEventStatus,
 )
 from tracecat.workflow.executions.models import (
     EventFailure,
@@ -206,7 +207,10 @@ class WorkflowExecutionsService:
                     continue
                 wf_event_type = HISTORY_TO_WF_EVENT_TYPE[event.event_type]
                 source.curr_event_type = wf_event_type
-                source.status = wf_event_type.to_status()
+                if source.status != WorkflowExecutionEventStatus.DETACHED:
+                    # Only overwrite the status if it's not already set to DETACHED
+                    # If it's DETACHED the status remains unchanged
+                    source.status = wf_event_type.to_status()
                 if is_start_event(event):
                     source.start_time = event.event_time.ToDatetime(datetime.UTC)
                 if is_close_event(event):


### PR DESCRIPTION
# Description
- Add fire-and-forget style child workflow execution. 
- If the parent completes or fails, the child will remain unaffected. Its timeout can be independently set as well.

# Screens
The first run is the original behavior of child workflows "wait" mode. I show the completions of the child workflows here.
The second run is "detached" mode. I show that there are no completions here.

https://github.com/user-attachments/assets/a9ffcb67-6157-455c-8963-80c58a521a98

Here, see that the workflows did complete -- just not observed by the parent.

https://github.com/user-attachments/assets/7cde851c-49df-435e-919f-7337b54d8833


