### PR TITLE
feat(ui): Add toggle to group case fields in trigger input

### DIFF
--- a/frontend/src/components/cases/case-workflow-trigger.tsx
+++ b/frontend/src/components/cases/case-workflow-trigger.tsx
@@ -24,7 +24,6 @@ import {
 } from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -34,6 +33,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import { JsonViewWithControls } from "@/components/json-viewer"
@@ -57,7 +57,7 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
   // Use the useLocalStorage hook
   const [flattenCaseFields, setFlattenCaseFields] = useLocalStorage(
     "flattenCaseFields",
-    false
+    true
   )
 
   const { createExecution, createExecutionIsPending } =
@@ -191,7 +191,7 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
                   />
                 </TooltipProvider>
                 <div className="mt-4 flex items-center space-x-2">
-                  <Checkbox
+                  <Switch
                     id="flatten-fields-toggle"
                     checked={flattenCaseFields}
                     onCheckedChange={setFlattenCaseFields}

--- a/frontend/src/components/cases/case-workflow-trigger.tsx
+++ b/frontend/src/components/cases/case-workflow-trigger.tsx
@@ -195,6 +195,7 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
                     id="group-fields-toggle"
                     checked={groupCaseFields}
                     onCheckedChange={setGroupCaseFields}
+                    className="ring-0 focus:ring-0 focus-visible:ring-0"
                   />
                   <Label htmlFor="group-fields-toggle" className="text-xs">
                     Group case fields

--- a/frontend/src/components/cases/case-workflow-trigger.tsx
+++ b/frontend/src/components/cases/case-workflow-trigger.tsx
@@ -55,9 +55,9 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
     null
   )
   // Use the useLocalStorage hook
-  const [flattenCaseFields, setFlattenCaseFields] = useLocalStorage(
-    "flattenCaseFields",
-    true
+  const [groupCaseFields, setGroupCaseFields] = useLocalStorage(
+    "groupCaseFields",
+    false
   )
 
   const { createExecution, createExecutionIsPending } =
@@ -68,17 +68,17 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
         .filter((field) => !field.reserved)
         .map((field) => [field.id, field.value])
     )
-    if (flattenCaseFields) {
+    if (groupCaseFields) {
       return {
         case_id: caseData.id,
-        ...fields,
+        case_fields: fields,
       }
     }
     return {
       case_id: caseData.id,
-      case_fields: fields,
+      ...fields,
     }
-  }, [caseData, flattenCaseFields])
+  }, [caseData, groupCaseFields])
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
 
   const selectedWorkflowUrl = `/workspaces/${workspaceId}/workflows/${selectedWorkflowId}`
@@ -192,12 +192,12 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
                 </TooltipProvider>
                 <div className="mt-4 flex items-center space-x-2">
                   <Switch
-                    id="flatten-fields-toggle"
-                    checked={flattenCaseFields}
-                    onCheckedChange={setFlattenCaseFields}
+                    id="group-fields-toggle"
+                    checked={groupCaseFields}
+                    onCheckedChange={setGroupCaseFields}
                   />
-                  <Label htmlFor="flatten-fields-toggle" className="text-xs">
-                    Pass case fields as top-level keys
+                  <Label htmlFor="group-fields-toggle" className="text-xs">
+                    Group case fields
                   </Label>
                 </div>
               </AlertDialogDescription>


### PR DESCRIPTION
# Description
- Add ~checkbox~ toggle in case workflow trigger to allow passing case fields at the trigger input root.
- This is saved to localstorage

# Impact
Allows direct invocation of workflows designed to receive arguments directly from the trigger root. i.e. `TRIGGER.<field>`

# Screens

<img width="557" alt="Screenshot 2025-05-07 at 17 11 14" src="https://github.com/user-attachments/assets/4dc137a4-e15d-4897-bbb9-4323198261cf" />

<img width="574" alt="Screenshot 2025-05-07 at 17 11 10" src="https://github.com/user-attachments/assets/4b38bfc1-679d-4949-9256-2261352d59d1" />
