### PR TITLE
build(deps): Bump fastapi + uvicorn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "dateparser>=1.2.1,<1.3.0",
     "email-validator>=2.0.0",
     "fastapi-users[sqlalchemy,oauth]==13.0.0",
-    "fastapi==0.111.0",
+    "fastapi>=0.115.8",
     "google-auth==2.37.0",
     "greenlet==3.0.3",
     "hatchling==1.27.0",
@@ -61,7 +61,7 @@ dependencies = [
     "tenacity==8.3.0",
     "tomli==2.2.1",
     "uv==0.4.10",
-    "uvicorn==0.29.0",
+    "uvicorn>=0.33.0",
     "virtualenv==20.27.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "dateparser>=1.2.1,<1.3.0",
     "email-validator>=2.0.0",
     "fastapi-users[sqlalchemy,oauth]==13.0.0",
-    "fastapi>=0.115.8",
+    "fastapi>=0.115.8,<0.116",
     "google-auth==2.37.0",
     "greenlet==3.0.3",
     "hatchling==1.27.0",
@@ -61,7 +61,7 @@ dependencies = [
     "tenacity==8.3.0",
     "tomli==2.2.1",
     "uv==0.4.10",
-    "uvicorn>=0.33.0",
+    "uvicorn>=0.33.0,<0.34",
     "virtualenv==20.27.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
# Description
The below issue happens when trying to pip install both `tracecat` and `tracecat_registry` (or the custom integrations starter kit) into the same venv.
```
  × No solution found when resolving script dependencies:
  ╰─▶ Because only tracecat==0.34.2 is available and tracecat==0.34.2 depends on fastapi==0.111.0, we can conclude that
      all versions of tracecat depend on fastapi==0.111.0.
      And because pycti==6.6.3 depends on fastapi>=0.115.8, we can conclude that pycti==6.6.3 and all versions of
      tracecat are incompatible.
      And because tracecat-registry==0.1.0 depends on pycti==6.6.3 and only tracecat-registry==0.1.0 is available, we
      can conclude that all versions of tracecat and all versions of tracecat-registry are incompatible.
      And because you require tracecat and tracecat-registry, we can conclude that your requirements are unsatisfiable.
```
Seems related to https://github.com/TracecatHQ/custom-integrations-starter-kit/issues/1. 

# Solution
Bump fastapi and uvicorn