### PR TITLE
fix(test): Sort pending children by initiated ID

### DIFF
--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -3161,7 +3161,7 @@ async def test_workflow_detached_child_workflow(
         pending_children = desc.raw_description.pending_children
         assert len(pending_children) == 3
         async with GatheringTaskGroup() as tg:
-            for child in pending_children:
+            for child in sorted(pending_children, key=lambda c: c.initiated_id):
                 logger.info("child", child=child)
                 child_handle = temporal_client.get_workflow_handle_for(
                     DSLWorkflow.run, child.workflow_id


### PR DESCRIPTION
# Description
Tests would intermittently fail because `test_workflow_detached_child_workflow` would return pending children out of order.

```
2025-05-09 16:14:36.343833Z [30981] | INFO      test_workflows:test_workflow_detached_child_workflow:3162 - pending_children | {'pending_children': [workflow_id: "wf_37s1zQPZlYqHqIYjsR7K2k/exec_1tjgU3Pk5pP7AVHeVYtcGl"
run_id: "0196b59c-d468-7c5e-9f8b-69ff62f93005"
workflow_type_name: "DSLWorkflow"
initiated_id: 34
parent_close_policy: PARENT_CLOSE_POLICY_ABANDON
, workflow_id: "wf_37s1zQPZlYqHqIYjsR7K2k/exec_2ub7gXEOr7G0Tqg2vIq7Y0"
run_id: "0196b59c-d479-7ab0-8135-5d28005e58bd"
workflow_type_name: "DSLWorkflow"
initiated_id: 32
parent_close_policy: PARENT_CLOSE_POLICY_ABANDON
, workflow_id: "wf_37s1zQPZlYqHqIYjsR7K2k/exec_6eGKhDN7ocFMeZ1ONc1e5y"
run_id: "0196b59c-d487-7ee1-80ae-d42ddbf5a21e"
workflow_type_name: "DSLWorkflow"
initiated_id: 33
parent_close_policy: PARENT_CLOSE_POLICY_ABANDON
]}
```

To remedy, we iterate over the children sorted by initiated id
