### PR TITLE
fix(ui): Add defensive graph pruning on canvas init + layout

### DIFF
--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -40,7 +40,7 @@ import Dagre from "@dagrejs/dagre"
 import { MoveHorizontalIcon, MoveVerticalIcon, PlusIcon } from "lucide-react"
 
 import { useDeleteAction } from "@/lib/hooks"
-import { pruneGraphObject } from "@/lib/workflow"
+import { pruneReactFlowInstance } from "@/lib/workflow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -359,7 +359,7 @@ export const WorkflowCanvas = React.forwardRef<
       )
 
       await updateWorkflow({
-        object: pruneGraphObject(reactFlowInstance),
+        object: pruneReactFlowInstance(reactFlowInstance),
       })
 
       console.log("Workflow updated successfully")
@@ -462,13 +462,13 @@ export const WorkflowCanvas = React.forwardRef<
   // Saving react flow instance state
   useEffect(() => {
     if (workflowId && reactFlowInstance) {
-      updateWorkflow({ object: pruneGraphObject(reactFlowInstance) })
+      updateWorkflow({ object: pruneReactFlowInstance(reactFlowInstance) })
     }
   }, [edges])
 
   const onNodesDragStop = () => {
     if (workflowId && reactFlowInstance) {
-      updateWorkflow({ object: pruneGraphObject(reactFlowInstance) })
+      updateWorkflow({ object: pruneReactFlowInstance(reactFlowInstance) })
     }
   }
 

--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -42,11 +42,6 @@ import { useDeleteAction } from "@/lib/hooks"
 import { pruneGraphObject, pruneReactFlowInstance } from "@/lib/workflow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { useToast } from "@/components/ui/use-toast"
 import actionNode, {
   ActionNodeData,
@@ -553,18 +548,13 @@ export const WorkflowCanvas = React.forwardRef<
           >
             Layout
           </Badge>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                className="m-0 size-6 p-0 text-xs"
-                onClick={() => onLayout("TB")}
-              >
-                <MoveVerticalIcon className="size-3" strokeWidth={2} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Vertical layout</TooltipContent>
-          </Tooltip>
+          <Button
+            variant="outline"
+            className="m-0 size-6 p-0 text-xs"
+            onClick={() => onLayout("TB")}
+          >
+            <MoveVerticalIcon className="size-3" strokeWidth={2} />
+          </Button>
           <Button
             variant="outline"
             className="m-0 hidden size-6 p-0 text-xs"

--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -179,7 +179,6 @@ export const WorkflowCanvas = React.forwardRef<
   const [pendingDeleteNodes, setPendingDeleteNodes] = useState<
     NodeRemoveChange[]
   >([])
-  const [pendingDeleteEdges, setPendingDeleteEdges] = useState<EdgeChange[]>([])
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const { deleteAction } = useDeleteAction()
   /**
@@ -334,7 +333,6 @@ export const WorkflowCanvas = React.forwardRef<
     if (!workflowId || !reactFlowInstance) return
     console.log("HANDLE CONFIRMED DELETION", {
       pendingDeleteNodes,
-      pendingDeleteEdges,
     })
 
     try {
@@ -370,11 +368,9 @@ export const WorkflowCanvas = React.forwardRef<
     } finally {
       setShowDeleteDialog(false)
       setPendingDeleteNodes([])
-      setPendingDeleteEdges([])
     }
   }, [
     pendingDeleteNodes,
-    pendingDeleteEdges,
     workflowId,
     reactFlowInstance,
     workspaceId,
@@ -385,7 +381,6 @@ export const WorkflowCanvas = React.forwardRef<
 
   const handleEdgesChange = useCallback(
     (changes: EdgeChange[]) => {
-      const pendingDeletes: EdgeRemoveChange[] = []
       const nextChanges = changes.reduce((acc, change) => {
         if (change.type === "remove") {
           // Add pending deletes
@@ -403,13 +398,9 @@ export const WorkflowCanvas = React.forwardRef<
         }
         return [...acc, change]
       }, [] as EdgeChange[])
-      if (pendingDeletes.length > 0) {
-        console.log("Pending delete edges:", pendingDeletes)
-        setPendingDeleteEdges(pendingDeletes)
-      }
       onEdgesChange(nextChanges)
     },
-    [edges, setEdges, pendingDeleteEdges]
+    [edges, setEdges]
   )
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
@@ -577,7 +568,6 @@ export const WorkflowCanvas = React.forwardRef<
           onOpenChange={(open) => {
             if (!open) {
               setPendingDeleteNodes([])
-              setPendingDeleteEdges([])
             }
           }}
           onConfirm={handleConfirmedDeletion}

--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -14,7 +14,6 @@ import {
   Controls,
   Edge,
   EdgeChange,
-  EdgeRemoveChange,
   FitViewOptions,
   MarkerType,
   NodeChange,

--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -40,7 +40,7 @@ import Dagre from "@dagrejs/dagre"
 import { MoveHorizontalIcon, MoveVerticalIcon, PlusIcon } from "lucide-react"
 
 import { useDeleteAction } from "@/lib/hooks"
-import { pruneReactFlowInstance } from "@/lib/workflow"
+import { pruneGraphObject, pruneReactFlowInstance } from "@/lib/workflow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -199,9 +199,11 @@ export const WorkflowCanvas = React.forwardRef<
         if (!graph) {
           throw new Error("No workflow data found")
         }
+        // Defensive
+        const prunedGraph = pruneGraphObject(graph)
         const { nodes: layoutNodes, edges: layoutEdges } = getLayoutedElements(
-          graph.nodes,
-          graph.edges,
+          prunedGraph.nodes,
+          prunedGraph.edges,
           "TB"
         )
         setNodes((currNodes) => [...currNodes, ...layoutNodes])
@@ -448,9 +450,13 @@ export const WorkflowCanvas = React.forwardRef<
 
   const onLayout = useCallback(
     (direction: "TB" | "LR") => {
-      const { nodes: newNodes, edges: newEdges } = getLayoutedElements(
+      const prundGraph = pruneGraphObject({
         nodes,
         edges,
+      })
+      const { nodes: newNodes, edges: newEdges } = getLayoutedElements(
+        prundGraph.nodes,
+        prundGraph.edges,
         direction
       )
       setNodes(newNodes)

--- a/frontend/src/components/workbench/canvas/canvas.tsx
+++ b/frontend/src/components/workbench/canvas/canvas.tsx
@@ -43,6 +43,11 @@ import { useDeleteAction } from "@/lib/hooks"
 import { pruneGraphObject } from "@/lib/workflow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { useToast } from "@/components/ui/use-toast"
 import actionNode, {
   ActionNodeData,
@@ -543,13 +548,18 @@ export const WorkflowCanvas = React.forwardRef<
           >
             Layout
           </Badge>
-          <Button
-            variant="outline"
-            className="m-0 size-6 p-0 text-xs"
-            onClick={() => onLayout("TB")}
-          >
-            <MoveVerticalIcon className="size-3" strokeWidth={2} />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                className="m-0 size-6 p-0 text-xs"
+                onClick={() => onLayout("TB")}
+              >
+                <MoveVerticalIcon className="size-3" strokeWidth={2} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Vertical layout</TooltipContent>
+          </Tooltip>
           <Button
             variant="outline"
             className="m-0 hidden size-6 p-0 text-xs"

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -19,9 +19,18 @@ export function pruneGraphObject(reactFlowInstance: ReactFlowInstance) {
 
   // Keep nodes that are NOT ephemeral
   object.nodes = object.nodes.filter((node) => !ephemeralNodeIds.has(node.id))
-  // Keep edges that are NOT connected to ephemeral nodes
+
+  // Create a Set of all valid node IDs for quick lookups
+  const validNodeIds = new Set(object.nodes.map((node) => node.id))
+
+  // Keep edges that:
+  // 1. Are NOT connected to ephemeral nodes
+  // 2. Have both source and target nodes that exist in the graph
   object.edges = object.edges.filter(
-    (edge) => !ephemeralNodeIds.has(edge.target)
+    (edge) =>
+      !ephemeralNodeIds.has(edge.target) &&
+      validNodeIds.has(edge.source) &&
+      validNodeIds.has(edge.target)
   )
 
   // Check that the object at least contains the trigger node

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -1,17 +1,26 @@
-import { ReactFlowInstance } from "@xyflow/react"
+import type { ReactFlowInstance, ReactFlowJsonObject } from "@xyflow/react"
 
 import { isEphemeral } from "@/components/workbench/canvas/canvas"
 
 export const CHILD_WORKFLOW_ACTION_TYPE = "core.workflow.execute" as const
 
 /**
+ * Prune the React Flow instance to remove ephemeral nodes and edges.
+ * @param reactFlowInstance - The React Flow instance.
+ * @returns The pruned React Flow instance.
+ */
+export function pruneReactFlowInstance(reactFlowInstance: ReactFlowInstance) {
+  return pruneGraphObject(reactFlowInstance.toObject())
+}
+
+/**
  * Prune the graph object to remove ephemeral nodes and edges.
  * @param reactFlowInstance - The React Flow instance.
  * @returns The pruned graph object.
  */
-export function pruneReactFlowInstance(reactFlowInstance: ReactFlowInstance) {
-  const object = reactFlowInstance.toObject()
-
+export function pruneGraphObject(
+  object: Omit<ReactFlowJsonObject, "viewport">
+) {
   // Keep nodes that are NOT ephemeral
   object.nodes = object.nodes.filter((node) => !isEphemeral(node))
 

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -12,25 +12,16 @@ export const CHILD_WORKFLOW_ACTION_TYPE = "core.workflow.execute" as const
 export function pruneGraphObject(reactFlowInstance: ReactFlowInstance) {
   const object = reactFlowInstance.toObject()
 
-  // Filter out non-ephemeral nodes and their associated edges
-  const ephemeralNodeIds = new Set(
-    object.nodes.filter(isEphemeral).map((node) => node.id)
-  )
-
   // Keep nodes that are NOT ephemeral
-  object.nodes = object.nodes.filter((node) => !ephemeralNodeIds.has(node.id))
+  object.nodes = object.nodes.filter((node) => !isEphemeral(node))
 
   // Create a Set of all valid node IDs for quick lookups
   const validNodeIds = new Set(object.nodes.map((node) => node.id))
 
-  // Keep edges that:
-  // 1. Are NOT connected to ephemeral nodes
-  // 2. Have both source and target nodes that exist in the graph
+  // Keep edges that have both source and target nodes that exist in the graph
+  // This is true for all well-formed workflow graphs
   object.edges = object.edges.filter(
-    (edge) =>
-      !ephemeralNodeIds.has(edge.target) &&
-      validNodeIds.has(edge.source) &&
-      validNodeIds.has(edge.target)
+    (edge) => validNodeIds.has(edge.source) && validNodeIds.has(edge.target)
   )
 
   // Check that the object at least contains the trigger node

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -9,7 +9,7 @@ export const CHILD_WORKFLOW_ACTION_TYPE = "core.workflow.execute" as const
  * @param reactFlowInstance - The React Flow instance.
  * @returns The pruned graph object.
  */
-export function pruneGraphObject(reactFlowInstance: ReactFlowInstance) {
+export function pruneReactFlowInstance(reactFlowInstance: ReactFlowInstance) {
   const object = reactFlowInstance.toObject()
 
   // Keep nodes that are NOT ephemeral

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -19,7 +19,7 @@ import {
   useReactFlow,
 } from "@xyflow/react"
 
-import { pruneGraphObject } from "@/lib/workflow"
+import { pruneReactFlowInstance } from "@/lib/workflow"
 import {
   NodeType,
   WorkflowCanvasRef,
@@ -86,14 +86,14 @@ export const WorkflowBuilderProvider: React.FC<
   const setReactFlowNodes = useCallback(
     (nodes: Node[] | ((nodes: Node[]) => Node[])) => {
       reactFlowInstance.setNodes(nodes)
-      updateWorkflow({ object: pruneGraphObject(reactFlowInstance) })
+      updateWorkflow({ object: pruneReactFlowInstance(reactFlowInstance) })
     },
     [workflowId, reactFlowInstance]
   )
   const setReactFlowEdges = useCallback(
     (edges: Edge[] | ((edges: Edge[]) => Edge[])) => {
       reactFlowInstance.setEdges(edges)
-      updateWorkflow({ object: pruneGraphObject(reactFlowInstance) })
+      updateWorkflow({ object: pruneReactFlowInstance(reactFlowInstance) })
     },
     [workflowId, reactFlowInstance]
   )

--- a/frontend/tests/workflow.test.ts
+++ b/frontend/tests/workflow.test.ts
@@ -1,13 +1,13 @@
 import { ReactFlowInstance } from "@xyflow/react"
 
-import { pruneGraphObject } from "@/lib/workflow"
+import { pruneReactFlowInstance } from "@/lib/workflow"
 
 // Mock the canvas module to avoid circular dependencies
 jest.mock("@/components/workbench/canvas/canvas", () => ({
   isEphemeral: jest.fn((node: { type: string }) => node.type === "selector"),
 }))
 
-describe("pruneGraphObject", () => {
+describe("pruneReactFlowInstance", () => {
   let mockReactFlowInstance: ReactFlowInstance
 
   beforeEach(() => {
@@ -28,7 +28,7 @@ describe("pruneGraphObject", () => {
       viewport: { x: 0, y: 0, zoom: 1 },
     })
 
-    const result = pruneGraphObject(mockReactFlowInstance)
+    const result = pruneReactFlowInstance(mockReactFlowInstance)
 
     expect(result.nodes).toHaveLength(2)
     expect(result.edges).toHaveLength(1)
@@ -49,7 +49,7 @@ describe("pruneGraphObject", () => {
       viewport: { x: 0, y: 0, zoom: 1 },
     })
 
-    const result = pruneGraphObject(mockReactFlowInstance)
+    const result = pruneReactFlowInstance(mockReactFlowInstance)
 
     expect(result.nodes).toHaveLength(2)
     expect(result.edges).toHaveLength(1)
@@ -71,7 +71,7 @@ describe("pruneGraphObject", () => {
       viewport: { x: 0, y: 0, zoom: 1 },
     })
 
-    const result = pruneGraphObject(mockReactFlowInstance)
+    const result = pruneReactFlowInstance(mockReactFlowInstance)
 
     expect(result.nodes).toHaveLength(2)
     expect(result.edges).toHaveLength(1)
@@ -89,7 +89,7 @@ describe("pruneGraphObject", () => {
       viewport: { x: 0, y: 0, zoom: 1 },
     })
 
-    expect(() => pruneGraphObject(mockReactFlowInstance)).toThrow(
+    expect(() => pruneReactFlowInstance(mockReactFlowInstance)).toThrow(
       "Workflow cannot be saved without a trigger node"
     )
   })

--- a/frontend/tests/workflow.test.ts
+++ b/frontend/tests/workflow.test.ts
@@ -1,0 +1,96 @@
+import { ReactFlowInstance } from "@xyflow/react"
+
+import { pruneGraphObject } from "@/lib/workflow"
+
+// Mock the canvas module to avoid circular dependencies
+jest.mock("@/components/workbench/canvas/canvas", () => ({
+  isEphemeral: jest.fn((node: { type: string }) => node.type === "selector"),
+}))
+
+describe("pruneGraphObject", () => {
+  let mockReactFlowInstance: ReactFlowInstance
+
+  beforeEach(() => {
+    // Create a mock ReactFlowInstance for testing
+    mockReactFlowInstance = {
+      toObject: jest.fn(),
+    } as unknown as ReactFlowInstance
+  })
+
+  it("preserves valid nodes and edges", () => {
+    // Set up test data with valid nodes and edges
+    mockReactFlowInstance.toObject = jest.fn().mockReturnValue({
+      nodes: [
+        { id: "node1", type: "trigger" },
+        { id: "node2", type: "udf" },
+      ],
+      edges: [{ id: "edge1", source: "node1", target: "node2" }],
+      viewport: { x: 0, y: 0, zoom: 1 },
+    })
+
+    const result = pruneGraphObject(mockReactFlowInstance)
+
+    expect(result.nodes).toHaveLength(2)
+    expect(result.edges).toHaveLength(1)
+  })
+
+  it("removes ephemeral nodes and their connected edges", () => {
+    // Set up test data with ephemeral nodes
+    mockReactFlowInstance.toObject = jest.fn().mockReturnValue({
+      nodes: [
+        { id: "node1", type: "trigger" },
+        { id: "node2", type: "udf" },
+        { id: "ephemeral1", type: "selector" }, // ephemeral node
+      ],
+      edges: [
+        { id: "edge1", source: "node1", target: "node2" },
+        { id: "edge2", source: "node2", target: "ephemeral1" }, // connected to ephemeral
+      ],
+      viewport: { x: 0, y: 0, zoom: 1 },
+    })
+
+    const result = pruneGraphObject(mockReactFlowInstance)
+
+    expect(result.nodes).toHaveLength(2)
+    expect(result.edges).toHaveLength(1)
+    expect(result.edges.find((e) => e.id === "edge2")).toBeUndefined()
+  })
+
+  it("removes orphaned edges with missing source or target nodes", () => {
+    // Set up test data with orphaned edges
+    mockReactFlowInstance.toObject = jest.fn().mockReturnValue({
+      nodes: [
+        { id: "node1", type: "trigger" },
+        { id: "node2", type: "udf" },
+      ],
+      edges: [
+        { id: "edge1", source: "node1", target: "node2" }, // valid edge
+        { id: "edge2", source: "node1", target: "missing_node" }, // orphaned edge
+        { id: "edge3", source: "missing_node", target: "node2" }, // orphaned edge
+      ],
+      viewport: { x: 0, y: 0, zoom: 1 },
+    })
+
+    const result = pruneGraphObject(mockReactFlowInstance)
+
+    expect(result.nodes).toHaveLength(2)
+    expect(result.edges).toHaveLength(1)
+    expect(result.edges[0].id).toBe("edge1")
+  })
+
+  it("throws error when there's no trigger node", () => {
+    // Set up test data without a trigger node
+    mockReactFlowInstance.toObject = jest.fn().mockReturnValue({
+      nodes: [
+        { id: "node1", type: "udf" },
+        { id: "node2", type: "udf" },
+      ],
+      edges: [{ id: "edge1", source: "node1", target: "node2" }],
+      viewport: { x: 0, y: 0, zoom: 1 },
+    })
+
+    expect(() => pruneGraphObject(mockReactFlowInstance)).toThrow(
+      "Workflow cannot be saved without a trigger node"
+    )
+  })
+})


### PR DESCRIPTION
# Motivaiton
Aim to eliminate ghost edges which makes UX awkward. Solving at the root cause would be much more challenging and involved than retroactively patching the graph object.
# Changes
- **We don't actually use pendingDeleteEdges**
- **Drop ghost edges in graph prune step**
- **Simplify ephemeral node pruning logic**
- **pruneGraphObject -> pruneReactFlowInstance**
- **Defensive graph prune on layout + initialize**

# Description
- Update graph pruning logic to drop ghost edges
- Add tests for grpah pruning logic (TODO: Add to CI)
- Run pruning on canvas initialization and onLayout handler
- Simplify `isEphemeral` check in prune step