### PR TITLE
fix(engine): Ignore action delete if not found

### DIFF
--- a/tracecat/workflow/actions/router.py
+++ b/tracecat/workflow/actions/router.py
@@ -9,6 +9,7 @@ from tracecat.db.schemas import Action
 from tracecat.ee.interactions.models import ActionInteractionValidator
 from tracecat.identifiers.action import ActionID
 from tracecat.identifiers.workflow import AnyWorkflowIDPath, WorkflowUUID
+from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.types.exceptions import RegistryError
 from tracecat.workflow.actions.models import (
@@ -213,10 +214,9 @@ async def delete_action(
     result = await session.exec(statement)
     try:
         action = result.one()
-    except NoResultFound as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
-        ) from e
+    except NoResultFound:
+        logger.error(f"Action not found: {action_id}. Ignore delete.")
+        return
     # If the user doesn't own this workflow, they can't delete the action
     await session.delete(action)
     await session.commit()


### PR DESCRIPTION
## Explain the bug

- Race condition
- Action in table gets deleted before the action in the workflow definition.
- When this happens, causes unrecoverable error. No longer able to SAVE the workflow (action not found) NOR delete the action (action not found).

## How to reproduce
Hard to reproduce. But this happened only when I started deleting a bunch of nodes in rapid succession.

## Proposed fix
- Do not raise "resource not found" error if action delete finds no action.

## Is this a breaking change
Not to my knowledge. It seems safe to ignore a delete if it doesn't exist.

## Before

<img width="871" alt="Screenshot 2025-05-11 at 4 47 31 PM" src="https://github.com/user-attachments/assets/8552312b-8078-4e24-8931-ad0756fa59b6" />
<img width="871" alt="Screenshot 2025-05-11 at 4 32 00 PM" src="https://github.com/user-attachments/assets/4350aa96-5120-4b56-9f09-0552042bb186" />
<img width="1001" alt="Screenshot 2025-05-11 at 5 10 46 PM" src="https://github.com/user-attachments/assets/3086d0d6-ffbd-48bd-b3f1-2102f9c1603e" />

## After
Can delete node then save workflow.
