### PR TITLE
fix(ui): Add missing page titles and small nits

### DIFF
--- a/docs/quickstart/expressions.mdx
+++ b/docs/quickstart/expressions.mdx
@@ -67,7 +67,7 @@ Actions are referenced by a sluggified version of their name.
   Check out the [workflow triggers](/tutorials/workflow-triggers.mdx) tutorial for a detailed guide setting up webhooks for workflows.
 </Info>
 
-Workflows can be triggered via webhook, manual UI trigger, or the `Execute Child Workflow` action.
+Workflows can be triggered via webhook, manual UI trigger, or the `Execute child workflow` action.
 Use the `TRIGGER` context to reference the data from the trigger as a JSON object.
 
 

--- a/docs/quickstart/tutorial.mdx
+++ b/docs/quickstart/tutorial.mdx
@@ -89,7 +89,7 @@ By the end of this tutorial, you'll learn how to:
     </Tabs>
   </Accordion>
   <Accordion title="View supported action inputs" icon="list">
-    You can view the required and optional inputs for an action under the `Input Schema` section.
+    You can view the required and optional inputs for an action under the `Input schema` section.
     ![View input schema](/img/quickstart/tutorial/view-input-schema.png)
   </Accordion>
 </AccordionGroup>

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/organization/members/layout.tsx
+++ b/frontend/src/app/organization/members/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Members | Organization",
+}
+
+export default function MembersLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/sessions/layout.tsx
+++ b/frontend/src/app/organization/sessions/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Sessions | Organization",
+}
+
+export default function SessionsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/app/layout.tsx
+++ b/frontend/src/app/organization/settings/app/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Application | Organization",
+}
+
+export default function AppSettingsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/app/page.tsx
+++ b/frontend/src/app/organization/settings/app/page.tsx
@@ -23,7 +23,7 @@ export default function AppSettingsPage() {
 
         <div className="mb-4 flex flex-row items-center justify-between rounded-lg border p-4">
           <div className="space-y-0.5">
-            <Label>Application Version</Label>
+            <Label>Application version</Label>
           </div>
           <Badge variant="secondary" className="text-xs text-muted-foreground">
             {appInfo?.version ?? "Unknown"}

--- a/frontend/src/app/organization/settings/auth/layout.tsx
+++ b/frontend/src/app/organization/settings/auth/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Email authentication | Organization",
+}
+
+export default function EmailAuthenticationLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/git/layout.tsx
+++ b/frontend/src/app/organization/settings/git/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Git repository | Organization",
+}
+
+export default function GitLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/git/layout.tsx
+++ b/frontend/src/app/organization/settings/git/layout.tsx
@@ -4,10 +4,6 @@ export const metadata: Metadata = {
   title: "Git repository | Organization",
 }
 
-export default function GitLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function GitLayout({ children }: { children: React.ReactNode }) {
   return children
 }

--- a/frontend/src/app/organization/settings/oauth/layout.tsx
+++ b/frontend/src/app/organization/settings/oauth/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "OAuth | Organization",
+}
+
+export default function OAuthLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/sso/layout.tsx
+++ b/frontend/src/app/organization/settings/sso/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "SSO | Organization",
+}
+
+export default function SSOLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/sso/layout.tsx
+++ b/frontend/src/app/organization/settings/sso/layout.tsx
@@ -4,10 +4,6 @@ export const metadata: Metadata = {
   title: "SSO | Organization",
 }
 
-export default function SSOLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function SSOLayout({ children }: { children: React.ReactNode }) {
   return children
 }

--- a/frontend/src/app/organization/ssh-keys/layout.tsx
+++ b/frontend/src/app/organization/ssh-keys/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "SSH keys | Organization",
+}
+
+export default function SSHKeysLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/registry/actions/layout.tsx
+++ b/frontend/src/app/registry/actions/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Actions | Registry",
+}
+
+export default function ActionsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/registry/repositories/layout.tsx
+++ b/frontend/src/app/registry/repositories/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Repositories | Registry",
+}
+
+export default function ActionsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -1,7 +1,7 @@
+import { Metadata } from "next"
 import CasePanelProvider from "@/providers/case-panel"
 
 import CaseTable from "@/components/cases/case-table"
-import { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: "Cases",

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -1,6 +1,11 @@
 import CasePanelProvider from "@/providers/case-panel"
 
 import CaseTable from "@/components/cases/case-table"
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Cases",
+}
 
 export default function CasesPage() {
   return (

--- a/frontend/src/app/workspaces/[workspaceId]/settings/credentials/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/settings/credentials/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Credentials | Workspace",
+}
+
+export default function CredentialsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/settings/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/settings/layout.tsx
@@ -5,8 +5,7 @@ import { CenteredSpinner } from "@/components/loading/spinner"
 import { SidebarNav } from "@/app/workspaces/[workspaceId]/settings/sidebar-nav"
 
 export const metadata: Metadata = {
-  title: "Workspace Settings",
-  description: "Workspace Settings",
+  title: "Settings | Workspace",
 }
 
 export default async function WorkspaceSettingsLayout({

--- a/frontend/src/app/workspaces/[workspaceId]/settings/members/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/settings/members/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Members | Workspace",
+}
+
+export default function MembersLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/settings/profile/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/settings/profile/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Profile | Workspace",
+}
+
+export default function ProfileLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/settings/security/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/settings/security/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Security | Workspace",
+}
+
+export default function SecurityLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/tables/[tableId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/tables/[tableId]/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Tables",
+}
+
+export default function TablesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <div>{children}</div>
+}

--- a/frontend/src/app/workspaces/[workspaceId]/tables/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/tables/layout.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
 import { useWorkspace } from "@/providers/workspace"
 
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -12,6 +12,11 @@ export default function TablesLayout({
   children: React.ReactNode
 }) {
   const { workspaceId } = useWorkspace()
+
+  useEffect(() => {
+    document.title = `Tables`
+  }, [])
+
   return (
     <div className="container grid h-full grid-cols-6 gap-8 py-16">
       <div className="col-span-1">

--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/layout.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React from "react"
+import React, { useEffect } from "react"
 import { useWorkflow } from "@/providers/workflow"
 import { ImperativePanelHandle } from "react-resizable-panels"
 

--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/layout.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect } from "react"
+import React from "react"
 import { useWorkflow } from "@/providers/workflow"
 import { ImperativePanelHandle } from "react-resizable-panels"
 

--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/page.tsx
@@ -1,6 +1,15 @@
 "use client"
 
+import { useEffect } from "react"
+import { useWorkflow } from "@/providers/workflow"
+
 export default function WorkflowExecutionsPage() {
+  const { workflow } = useWorkflow()
+
+  useEffect(() => {
+    document.title = `Workflow runs | ${workflow?.title}`
+  }, [workflow])
+
   return (
     <main className="container flex size-full max-w-[400px] flex-col items-center justify-center space-y-4">
       <h1 className="text-xl font-semibold tracking-tight">

--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from "next/headers"
 import { Builder } from "@/components/builder/builder"
 
 export const metadata: Metadata = {
-  title: "Builder | Tracecat",
+  title: "Workflow builder",
 }
 
 export default async function BuilderPage() {

--- a/frontend/src/components/builder/canvas/action-node.tsx
+++ b/frontend/src/components/builder/canvas/action-node.tsx
@@ -391,7 +391,7 @@ function ActionNodeContent({
           <div className="flex w-full flex-1 justify-between">
             <div className="flex flex-col space-y-1">
               <CardTitle className="text-sm font-medium text-muted-foreground">
-                Unknown Action
+                Unknown action
               </CardTitle>
               <CardDescription className="text-xs">
                 Action type not found

--- a/frontend/src/components/builder/canvas/custom-handle.tsx
+++ b/frontend/src/components/builder/canvas/custom-handle.tsx
@@ -243,7 +243,7 @@ export function ActionTargetHandle({
               }
             }}
           >
-            {hasJoin && (
+            {Boolean(hasJoin) && (
               <Badge
                 className={cn(
                   "border-0 px-2 text-xs shadow-none",

--- a/frontend/src/components/builder/canvas/delete-node-dialog.tsx
+++ b/frontend/src/components/builder/canvas/delete-node-dialog.tsx
@@ -24,7 +24,7 @@ export function DeleteActionNodeDialog({
     <AlertDialog {...rest}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete Action Node</AlertDialogTitle>
+          <AlertDialogTitle>Delete action node</AlertDialogTitle>
           <AlertDialogDescription className="space-y-2">
             Are you sure you want to delete this action node? This will remove
             it from the workflow and delete any connections to other nodes.

--- a/frontend/src/components/builder/panel/builder-panel.tsx
+++ b/frontend/src/components/builder/panel/builder-panel.tsx
@@ -21,7 +21,7 @@ export const BuilderPanel = React.forwardRef<ActionPanelRef, object>(() => {
 
   useEffect(() => {
     if (workflow) {
-      document.title = `${workflow.title} | Tracecat`
+      document.title = `Workflow | ${workflow.title}`
     }
   }, [workflow])
 

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -248,7 +248,7 @@ export function WorkflowPanel({
                     value="workflow-static-inputs"
                   >
                     <FileInputIcon className="mr-2 size-4" />
-                    <span>Static Inputs</span>
+                    <span>Static inputs</span>
                   </TabsTrigger>
                 </TabsList>
               </div>
@@ -544,7 +544,7 @@ export function WorkflowPanel({
                       <AccordionTrigger className="px-4 text-xs font-bold">
                         <div className="flex items-center">
                           <Redo2Icon className="mr-3 size-4" />
-                          <span className="capitalize">Input schema</span>
+                          <span>Input schema</span>
                         </div>
                       </AccordionTrigger>
                       <AccordionContent>
@@ -599,7 +599,7 @@ export function WorkflowPanel({
                       <AccordionTrigger className="px-4 text-xs font-bold">
                         <div className="flex items-center">
                           <Undo2Icon className="mr-3 size-4" />
-                          <span className="capitalize">Output Schema</span>
+                          <span>Output schema</span>
                         </div>
                       </AccordionTrigger>
                       <AccordionContent>
@@ -661,7 +661,7 @@ export function WorkflowPanel({
                       <AccordionTrigger className="px-4 text-xs font-bold">
                         <div className="flex items-center">
                           <FileInputIcon className="mr-3 size-4" />
-                          <span>Static Inputs</span>
+                          <span>Static inputs</span>
                         </div>
                       </AccordionTrigger>
                       <AccordionContent>
@@ -723,7 +723,7 @@ function StaticInputTooltip() {
   return (
     <div className="w-full space-y-4">
       <div className="flex w-full items-center justify-between text-muted-foreground ">
-        <span className="font-mono text-sm font-semibold">Static Inputs</span>
+        <span className="font-mono text-sm font-semibold">Static inputs</span>
         <span className="text-xs text-muted-foreground/80">(optional)</span>
       </div>
       <div className="flex w-full flex-col items-center justify-between space-y-4 text-muted-foreground">
@@ -747,7 +747,7 @@ function WorkflowReturnValueTooltip() {
   return (
     <div className="flex w-full flex-col space-y-4">
       <div className="flex w-full items-center justify-between text-muted-foreground">
-        <span className="font-mono text-sm font-semibold">Output Schema</span>
+        <span className="font-mono text-sm font-semibold">Output schema</span>
         <span className="text-xs text-muted-foreground/80">(optional)</span>
       </div>
       <span className="w-full text-muted-foreground">

--- a/frontend/src/components/organization/org-settings-app.tsx
+++ b/frontend/src/components/organization/org-settings-app.tsx
@@ -112,7 +112,7 @@ export function OrgSettingsAppForm() {
           render={({ field }) => (
             <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
               <div className="space-y-0.5">
-                <FormLabel>Workflow Executions Query Limit</FormLabel>
+                <FormLabel>Workflow executions query limit</FormLabel>
                 <FormDescription>
                   Maximum number of executions that can be queried at once.
                 </FormDescription>
@@ -137,7 +137,7 @@ export function OrgSettingsAppForm() {
           render={({ field }) => (
             <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
               <div className="space-y-0.5">
-                <FormLabel>Enable Interactions</FormLabel>
+                <FormLabel>Enable interactions</FormLabel>
                 <FormDescription>
                   Enable application interactions functionality (alpha).
                 </FormDescription>
@@ -158,7 +158,7 @@ export function OrgSettingsAppForm() {
           render={({ field }) => (
             <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
               <div className="space-y-0.5">
-                <FormLabel>Enable Workflow Exports</FormLabel>
+                <FormLabel>Enable workflow exports</FormLabel>
                 <FormDescription>
                   Allow users to export workflows. When disabled, users will be
                   unable to export workflows.
@@ -180,7 +180,7 @@ export function OrgSettingsAppForm() {
           render={({ field }) => (
             <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
               <div className="space-y-0.5">
-                <FormLabel>Create Workspace on Sign-up</FormLabel>
+                <FormLabel>Create workspace on sign-up</FormLabel>
                 <FormDescription>
                   Automatically create a workspace for new users when they sign
                   up.

--- a/frontend/src/components/tables/table-view.tsx
+++ b/frontend/src/components/tables/table-view.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import React from "react"
-import { useParams } from "next/navigation"
+import React, { useEffect } from "react"
 import { TableColumnRead, TableRead, TableRowRead } from "@/client"
 import { useWorkspace } from "@/providers/workspace"
 import { CellContext, ColumnDef } from "@tanstack/react-table"
@@ -76,13 +75,22 @@ function CollapsibleText({ text }: { text: string }) {
   )
 }
 
-export function DatabaseTable({ table: { columns } }: { table: TableRead }) {
-  const { tableId } = useParams<{ tableId: string }>()
+export function DatabaseTable({
+  table: { id, name, columns },
+}: {
+  table: TableRead
+}) {
   const { workspaceId } = useWorkspace()
   const { rows, rowsIsLoading, rowsError } = useListRows({
-    tableId,
+    tableId: id,
     workspaceId,
   })
+
+  useEffect(() => {
+    if (id) {
+      document.title = `${name} | Tables`
+    }
+  }, [id, name])
 
   type CellT = CellContext<TableRowRead, TableColumnRead>
   const allColumns: ColumnDef<TableRowRead, TableColumnRead>[] = [

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -1852,8 +1852,8 @@ export function useOrgAppSettings() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["org-app-settings"] })
       toast({
-        title: "Updated App settings",
-        description: "App settings updated successfully.",
+        title: "Updated application settings",
+        description: "Application settings updated successfully.",
       })
     },
     onError: (error: TracecatApiError) => {
@@ -1865,10 +1865,10 @@ export function useOrgAppSettings() {
           })
           break
         default:
-          console.error("Failed to update App settings", error)
+          console.error("Failed to update application settings", error)
           toast({
-            title: "Failed to update App settings",
-            description: `An error occurred while updating the App settings: ${error.body.detail}`,
+            title: "Failed to update application settings",
+            description: `An error occurred while updating the application settings: ${error.body.detail}`,
           })
       }
     },
@@ -1950,8 +1950,8 @@ export function useOrgAuthSettings() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["org-auth-settings"] })
       toast({
-        title: "Updated Auth settings",
-        description: "Auth settings updated successfully.",
+        title: "Updated authentication settings",
+        description: "Authentication settings updated successfully.",
       })
     },
     onError: (error: TracecatApiError) => {
@@ -1963,10 +1963,10 @@ export function useOrgAuthSettings() {
           })
           break
         default:
-          console.error("Failed to update auth settings", error)
+          console.error("Failed to update authentication settings", error)
           toast({
-            title: "Failed to update auth settings",
-            description: `An error occurred while updating the auth settings: ${error.body.detail}`,
+            title: "Failed to update authentication settings",
+            description: `An error occurred while updating the authentication settings: ${error.body.detail}`,
           })
       }
     },
@@ -2394,7 +2394,7 @@ export function useInsertRow() {
     onError: (error: TracecatApiError, variables) => {
       if (error.status === 409) {
         toast({
-          title: "Duplicate Value Error",
+          title: "Duplicate value error",
           description:
             "Cannot insert duplicate values in a unique column. Please use unique values.",
           variant: "destructive",

--- a/registry/tracecat_registry/core/cases.py
+++ b/registry/tracecat_registry/core/cases.py
@@ -50,7 +50,7 @@ StatusType = Literal[
 
 
 @registry.register(
-    default_title="Create Case",
+    default_title="Create case",
     display_group="Cases",
     description="Create a new case.",
     namespace="core.cases",
@@ -96,7 +96,7 @@ async def create_case(
 
 
 @registry.register(
-    default_title="Update Case",
+    default_title="Update case",
     display_group="Cases",
     description="Update an existing case.",
     namespace="core.cases",
@@ -157,7 +157,7 @@ async def update_case(
 
 
 @registry.register(
-    default_title="Create Case Comment",
+    default_title="Create case comment",
     display_group="Cases",
     description="Add a comment to an existing case.",
     namespace="core.cases",
@@ -193,7 +193,7 @@ async def create_comment(
 
 
 @registry.register(
-    default_title="Update Case Comment",
+    default_title="Update case comment",
     display_group="Cases",
     description="Update an existing case comment.",
     namespace="core.cases",
@@ -229,7 +229,7 @@ async def update_comment(
 
 
 @registry.register(
-    default_title="Get Case",
+    default_title="Get case",
     display_group="Cases",
     description="Get details of a specific case by ID.",
     namespace="core.cases",
@@ -282,7 +282,7 @@ async def get_case(
 
 
 @registry.register(
-    default_title="List Cases",
+    default_title="List cases",
     display_group="Cases",
     description="List all cases.",
     namespace="core.cases",
@@ -319,7 +319,7 @@ async def list_cases(
 
 
 @registry.register(
-    default_title="Search Cases",
+    default_title="Search cases",
     display_group="Cases",
     description="Search cases based on various criteria.",
     namespace="core.cases",
@@ -380,7 +380,7 @@ async def search_cases(
 
 
 @registry.register(
-    default_title="List Case Comments",
+    default_title="List case comments",
     display_group="Cases",
     description="List all comments for a case.",
     namespace="core.cases",

--- a/registry/tracecat_registry/core/email.py
+++ b/registry/tracecat_registry/core/email.py
@@ -97,9 +97,9 @@ def _build_email_message(
 
 
 @registry.register(
-    namespace="core",
+    default_title="Send email (SMTP)",
     description="Perform a send email action using SMTP",
-    default_title="Send Email (SMTP)",
+    namespace="core",
     secrets=[smtp_secret],
 )
 def send_email_smtp(

--- a/registry/tracecat_registry/core/http.py
+++ b/registry/tracecat_registry/core/http.py
@@ -253,7 +253,7 @@ def _http_status_error_to_message(e: httpx.HTTPStatusError) -> str:
 @registry.register(
     namespace="core",
     description="Perform a HTTP request to a given URL.",
-    default_title="HTTP Request",
+    default_title="HTTP request",
     secrets=[ssl_secret],
 )
 async def http_request(
@@ -324,7 +324,7 @@ class PredicateArgs(TypedDict):
 @registry.register(
     namespace="core",
     description="Perform a HTTP request to a given URL with polling.",
-    default_title="HTTP Polling",
+    default_title="HTTP poll",
     secrets=[ssl_secret],
 )
 async def http_poll(

--- a/registry/tracecat_registry/core/table.py
+++ b/registry/tracecat_registry/core/table.py
@@ -10,7 +10,7 @@ from tracecat_registry import registry
 
 
 @registry.register(
-    default_title="Lookup one record",
+    default_title="Lookup record",
     description="Get a single record from a table corresponding to the given column and value.",
     display_group="Tables",
     namespace="core.table",

--- a/registry/tracecat_registry/core/workflow.py
+++ b/registry/tracecat_registry/core/workflow.py
@@ -8,8 +8,8 @@ from tracecat_registry import ActionIsInterfaceError, registry
 
 @registry.register(
     namespace="core.workflow",
-    description="Execute a child workflow. The child workflow inherits the parent's execution context.",
-    default_title="Execute child workflow",
+    description="Execute a child workflow.",
+    default_title="Execute subflow",
     display_group="Workflows",
 )
 async def execute(


### PR DESCRIPTION
## Why is this needed
Hard to keep track tabs as tables. Also small UI consistency

## What this PR does
- Add page titles for tables, cases, settings etc.
- Page titles for tables are dynamically configured as `{table name} | Tables` in /components
- Other "fixed" headers are configured in `page.tsx` or `layout.tsx`
- Fixes the "0" thing with dynamic islands with no connected edge (just needed to cast to bool)
- Make core actions titlized (not capitalized)

<img width="974" alt="Screenshot 2025-05-11 at 9 18 49 PM" src="https://github.com/user-attachments/assets/5d5d2b8b-0aa6-4cca-abbb-fc4a16b09a0d" />

<img width="510" alt="Screenshot 2025-05-11 at 9 14 51 PM" src="https://github.com/user-attachments/assets/44ef21ed-8801-47e3-a171-62c6b403664e" />