### PR TITLE
fix(app): Use env vars when auth allowed domains list setting is empty list

### DIFF
--- a/frontend/src/components/auth/sign-up.tsx
+++ b/frontend/src/components/auth/sign-up.tsx
@@ -133,7 +133,7 @@ export function BasicRegistrationForm() {
       })
     } catch (error) {
       if (error instanceof ApiError) {
-        console.error("ApiError registering user", error)
+        console.log("ApiError registering user", error)
         const apiError = error as TracecatApiError
 
         // Handle both string and object error details
@@ -172,7 +172,7 @@ export function BasicRegistrationForm() {
             }
           } else {
             // Handle RequestValidationError case
-            console.error("Validation error", detail)
+            console.log("Validation error", detail)
             form.setError("email", {
               message: detail[0].msg || "Unknown error",
             })

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -73,13 +73,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def validate_email(self, email: str) -> None:
         allowed_domains = cast(
             list[str] | None,
-            await get_setting(
-                "auth_allowed_email_domains",
-                role=self.role,
-                # TODO: Deprecate in future version
-                default=list(config.TRACECAT__AUTH_ALLOWED_DOMAINS),
-            ),
-        )
+            await get_setting("auth_allowed_email_domains", role=self.role),
+            # Allow overriding of falsy value (empty list)
+        ) or list(config.TRACECAT__AUTH_ALLOWED_DOMAINS)
+        self.logger.debug("Allowed domains", allowed_domains=allowed_domains)
         validate_email(email=email, allowed_domains=allowed_domains)
 
     async def oauth_callback(

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -74,7 +74,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         allowed_domains = cast(
             list[str] | None,
             await get_setting("auth_allowed_email_domains", role=self.role),
-            # Allow overriding of falsy value (empty list)
+            # Allow overriding of empty list
         ) or list(config.TRACECAT__AUTH_ALLOWED_DOMAINS)
         self.logger.debug("Allowed domains", allowed_domains=allowed_domains)
         validate_email(email=email, allowed_domains=allowed_domains)


### PR DESCRIPTION
# Changes
- **Don't console.error on api error**
- **Handle allowed domains list empty case**

# Description
When I added workspace roles a while back, I changed the handling of default values to compare against an unset sentinel, as null values are considered valid. This change made it no longer treat falsy values as `False`, but only those that are not the unset value.

# Screens

https://github.com/user-attachments/assets/0b4cf27e-0131-47f1-80db-492ceb1e1511


