### PR TITLE
feat(ui): Split run if by operators

### DIFF
--- a/frontend/src/components/builder/canvas/custom-handle.tsx
+++ b/frontend/src/components/builder/canvas/custom-handle.tsx
@@ -20,7 +20,7 @@ import {
   Repeat,
 } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn, splitConditionalExpression } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
 import {
@@ -271,7 +271,7 @@ export function ActionTargetHandle({
                 <span className="flex items-center space-x-1">
                   <GitBranch className="size-3" strokeWidth={2.5} />
                   <pre className="text-xs tracking-tighter">
-                    {runIf.slice(3, -2).trim()}
+                    {splitConditionalExpression(runIf.slice(3, -2).trim(), 50)}
                   </pre>
                 </span>
               </Badge>

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -70,3 +70,51 @@ export function itemOrEmptyString(item: unknown | undefined) {
 export function capitalizeFirst(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
+
+export function splitConditionalExpression(
+  s: string,
+  maxLength: number = 30,
+  operators: string[] = ["&&", "||", "=="]
+): string {
+  // 1) Tokenize on operators (keeping the delimiters)
+  const operatorPattern = new RegExp(
+    `(${operators.map((op) => op.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})`
+  )
+  const parts = s
+    .split(operatorPattern)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  if (parts.length === 0) {
+    return ""
+  }
+
+  // 2) Build lines greedily
+  const lines: string[] = []
+  let currentLine = parts[0] // start with the first operand
+
+  for (let i = 1; i < parts.length; i += 2) {
+    const op = parts[i]
+    const operand = parts[i + 1] ?? ""
+    const chunk = `${op} ${operand}`
+
+    // If adding this chunk would exceed maxLength, emit the current line…
+    if (currentLine.length + 1 + chunk.length > maxLength) {
+      lines.push(currentLine)
+      currentLine = chunk
+    } else {
+      // …otherwise, tack it on
+      currentLine += " " + chunk
+    }
+  }
+
+  // push whatever's left
+  lines.push(currentLine)
+
+  // 3) If we ended up with exactly one line and it's ≤ maxLength, return the original
+  if (lines.length === 1 && lines[0].length <= maxLength) {
+    return s
+  }
+
+  return lines.join("\n")
+}

--- a/frontend/tests/utils.test.ts
+++ b/frontend/tests/utils.test.ts
@@ -1,4 +1,9 @@
-import { isServer, slugify, undoSlugify } from "@/lib/utils"
+import {
+  isServer,
+  slugify,
+  splitConditionalExpression,
+  undoSlugify,
+} from "@/lib/utils"
 
 describe("slugify", () => {
   it("should convert a string to a slug", () => {
@@ -18,5 +23,62 @@ describe("isServer", () => {
   it("should return true if the code is running on the server", () => {
     const result = isServer()
     expect(result).toBe(true)
+  })
+})
+
+describe("splitConditionalExpression", () => {
+  it("should return empty string for empty input", () => {
+    const result = splitConditionalExpression("")
+    expect(result).toBe("")
+  })
+
+  it("should return the input as is if no operators are present", () => {
+    const result = splitConditionalExpression("ACTIONS.test.result")
+    expect(result).toBe("ACTIONS.test.result")
+  })
+
+  it("should return the input as is if it's short enough", () => {
+    const result = splitConditionalExpression("a && b", 10)
+    expect(result).toBe("a && b")
+  })
+
+  it("should split expressions with AND operator when they exceed maxLength", () => {
+    const result = splitConditionalExpression(
+      "ACTIONS.test.result && ACTIONS.another.result",
+      20
+    )
+    expect(result).toBe("ACTIONS.test.result\n&& ACTIONS.another.result")
+  })
+
+  it("should split expressions with OR operator when they exceed maxLength", () => {
+    const result = splitConditionalExpression(
+      "ACTIONS.test.result || ACTIONS.another.result",
+      20
+    )
+    expect(result).toBe("ACTIONS.test.result\n|| ACTIONS.another.result")
+  })
+
+  it("should handle multiple operators and add line breaks at appropriate positions", () => {
+    const result = splitConditionalExpression(
+      "ACTIONS.a.result && ACTIONS.b.result || ACTIONS.c.result",
+      15
+    )
+    expect(result).toBe(
+      "ACTIONS.a.result\n&& ACTIONS.b.result\n|| ACTIONS.c.result"
+    )
+  })
+
+  it("should keep short expressions on the same line even with operators", () => {
+    const result = splitConditionalExpression("a && b || c", 30)
+    expect(result).toBe("a && b || c")
+  })
+
+  it("should handle custom operators", () => {
+    const result = splitConditionalExpression(
+      "field1 > 10 AND field2 < 20",
+      15,
+      ["AND", ">", "<"]
+    )
+    expect(result).toBe("field1 > 10\nAND field2 < 20")
   })
 })


### PR DESCRIPTION
We're blocked by our inability to handle multiline action node handles well. It'll look bad until this is resolved.

# Vision
The pill overflows past the incoming edge arrowhead and the node body.
<img width="459" alt="image" src="https://github.com/user-attachments/assets/22c1c22d-01fb-4182-b88b-ab8a3339b394" />

