### PR TITLE
feat(engine+integrations): Add interaction metadata

### DIFF
--- a/registry/tracecat_registry/templates/tools/slack/chat/post_message.yml
+++ b/registry/tracecat_registry/templates/tools/slack/chat/post_message.yml
@@ -48,7 +48,7 @@ definition:
           unfurl_media: ${{ inputs.unfurl_media }}
           thread_ts: ${{ inputs.thread_ts }}
           metadata:
-            event_type: post_message
+            event_type: interaction_created
             event_payload:
-              interaction_context: ${{ FN.get_interaction() }}
+              interaction: ${{ FN.get_interaction() }}
   returns: ${{ steps.post_message.result }}

--- a/registry/tracecat_registry/templates/tools/slack/custom/post_notification.yml
+++ b/registry/tracecat_registry/templates/tools/slack/custom/post_notification.yml
@@ -83,4 +83,8 @@ definition:
           text: ${{ inputs.summary }}
           thread_ts: ${{ inputs.thread_ts }}
           unfurl_links: false
+          metadata:
+            event_type: interaction_created
+            event_payload:
+              interaction: ${{ FN.get_interaction() }}
   returns: ${{ steps.post_message.result }}

--- a/registry/tracecat_registry/templates/tools/slack/custom/post_update.yml
+++ b/registry/tracecat_registry/templates/tools/slack/custom/post_update.yml
@@ -54,4 +54,8 @@ definition:
           channel: ${{ inputs.channel }}
           text: ${{ inputs.summary }}
           thread_ts: ${{ inputs.thread_ts }}
+          metadata:
+            event_type: interaction_created
+            event_payload:
+              interaction: ${{ FN.get_interaction() }}
   returns: ${{ steps.post_message.result }}

--- a/tracecat/ee/interactions/connectors.py
+++ b/tracecat/ee/interactions/connectors.py
@@ -6,13 +6,12 @@ from tracecat.ee.interactions.models import InteractionInput
 def parse_slack_interaction_input(payload: dict[str, Any]) -> InteractionInput:
     """Extract event payload from various Slack payloads"""
     match payload:
-        # Block actions
         case {
-            "type": "block_actions",
+            "type": "interaction_created",
             "message": {
                 "metadata": {
                     "event_payload": {
-                        "interaction_context": {
+                        "interaction": {
                             "interaction_id": interaction_id,
                             "execution_id": execution_id,
                             "action_ref": action_ref,

--- a/tracecat/ee/interactions/connectors.py
+++ b/tracecat/ee/interactions/connectors.py
@@ -7,9 +7,9 @@ def parse_slack_interaction_input(payload: dict[str, Any]) -> InteractionInput:
     """Extract event payload from various Slack payloads"""
     match payload:
         case {
-            "type": "interaction_created",
             "message": {
                 "metadata": {
+                    "event_type": "interaction_created",
                     "event_payload": {
                         "interaction": {
                             "interaction_id": interaction_id,


### PR DESCRIPTION
- Rename `interaction_context` in slack metadata to just `context`
- Add interaction context back into other slack post message calls