### PR TITLE
fix(ui): CSV importer dialog width overflow

### DIFF
--- a/frontend/src/components/tables/table-import-csv-dialog.tsx
+++ b/frontend/src/components/tables/table-import-csv-dialog.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
 import { Spinner } from "@/components/loading/spinner"
+import { Table, TableCell, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 
 const BYTES_PER_MB = 1024 * 1024
 const FILE_SIZE_LIMIT_MB = 5
@@ -76,9 +77,13 @@ export function TableImportCsvDialog({
   open,
   onOpenChange,
 }: TableImportCsvDialogProps) {
-  const { tableId } = useParams<{ tableId: string }>()
+  const params = useParams<{ tableId: string }>()
+  const tableId = params?.tableId
   const { workspaceId } = useWorkspace()
-  const { table } = useGetTable({ tableId, workspaceId })
+  const { table } = useGetTable({
+    tableId: tableId ?? "",
+    workspaceId,
+  })
   const { importCsv, importCsvIsPending } = useImportCsv()
 
   const [isUploading, setIsUploading] = useState(false)
@@ -125,7 +130,7 @@ export function TableImportCsvDialog({
           file,
           column_mapping: JSON.stringify(columnMapping),
         },
-        tableId,
+        tableId: tableId ?? "",
         workspaceId,
       })
       toast({
@@ -284,38 +289,58 @@ interface CsvPreviewProps {
 }
 
 function CsvPreview({ csvData }: CsvPreviewProps) {
+
   return (
     <div className="space-y-4">
       <div className="text-sm font-medium">Preview (first 5 rows)</div>
-      <div className="max-h-60 overflow-auto rounded border">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b bg-muted/50">
-              {csvData.headers.map((header) => (
-                <th key={header} className="p-2 text-left">
+      <div className="rounded border max-h-60 overflow-auto">
+        <Table className="min-w-full table-fixed">
+          <TableHeader>
+            <TableRow>
+              {csvData.headers.map((header) => {
+                return (
+                <TableHead
+                  key={header}
+                  className="whitespace-nowrap sticky top-0 bg-muted/50 min-w-[160px]"
+                >
                   {header}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {csvData.preview.map((row, i) => (
-              <tr key={i} className="border-b">
-                {csvData.headers.map((header) => (
-                  <td
+                </TableHead>
+              )})}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {csvData.preview.map((row, i) => {
+              return (
+              <TableRow key={i}>
+                {csvData.headers.map((header) => {
+                  const cellValue = row[header];
+                  const isObject = typeof cellValue === 'object' && cellValue !== null;
+                  let displayValue;
+                  if (isObject) {
+                    const jsonString = JSON.stringify(cellValue);
+                    if (jsonString.length > 30) {
+                      displayValue = jsonString.substring(0, 27) + "...";
+                    } else {
+                      displayValue = jsonString;
+                    }
+                  } else {
+                    displayValue = String(cellValue || '');
+                  }
+
+
+                  return (
+                  <TableCell
                     key={header}
-                    className="max-w-xs truncate p-2"
-                    title={row[header]}
+                    className="truncate min-w-[160px]"
+                    title={isObject ? JSON.stringify(cellValue) : String(cellValue || '')}
                   >
-                    {typeof row[header] === "string" && row[header].length > 100
-                      ? row[header].substring(0, 100) + "..."
-                      : row[header]}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                    {displayValue}
+                  </TableCell>
+                )})}
+              </TableRow>
+            )})}
+          </TableBody>
+        </Table>
       </div>
     </div>
   )


### PR DESCRIPTION
## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [X] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [X] PR only implements a single feature or fixes a single bug.
- [X] Tests passing (`uv run pytest tests`)?
- [X] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Fixing CSV Importer Dialog window.

## Screenshots / Recordings



https://github.com/user-attachments/assets/3a78c001-bae0-4a69-9a5f-43f2909d00c0



## Steps to QA

1. Go to Tables
2. Create a Table
3. Try to import the CSV provided through Discord