### PR TITLE
feat(ui): More accurate icons in workflow history viewer

### DIFF
--- a/frontend/src/components/executions/event-history.tsx
+++ b/frontend/src/components/executions/event-history.tsx
@@ -5,14 +5,13 @@ import { WorkflowEventType, WorkflowExecutionEvent } from "@/client"
 import {
   AlarmClockOffIcon,
   BookCheckIcon,
-  CalendarCheck,
+  CalendarCheckIcon,
   CircleArrowRightIcon,
   CircleCheck,
   CircleDotIcon,
   CircleMinusIcon,
-  CircleX,
-  GlobeIcon,
-  Play,
+  CircleXIcon,
+  PlayIcon,
   WorkflowIcon,
 } from "lucide-react"
 
@@ -148,15 +147,15 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
   switch (eventType) {
     /* === Workflow Execution Events === */
     case "WORKFLOW_EXECUTION_STARTED":
-      return <GlobeIcon className={cn("stroke-emerald-500", className)} />
+      return <WorkflowIcon className={cn("fill-white stroke-sky-500/80", className)} />
     case "WORKFLOW_EXECUTION_COMPLETED":
       return (
-        <CircleCheck
-          className={cn("fill-emerald-500 stroke-white", className)}
+        <WorkflowIcon
+          className={cn("fill-white stroke-emerald-500", className)}
         />
       )
     case "WORKFLOW_EXECUTION_FAILED":
-      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
+      return <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
     case "WORKFLOW_EXECUTION_CANCELED":
       return (
         <CircleMinusIcon
@@ -172,7 +171,7 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
     case "WORKFLOW_EXECUTION_CONTINUED_AS_NEW":
       return (
         <CircleArrowRightIcon
-          className={cn("fill-blue-500 stroke-white", className)}
+          className={cn("fill-sky-500/80 stroke-white", className)}
         />
       )
     case "WORKFLOW_EXECUTION_TIMED_OUT":
@@ -191,37 +190,37 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
       )
     case "CHILD_WORKFLOW_EXECUTION_STARTED":
       return (
-        <Play
-          className={cn("fill-violet-400/80 stroke-violet-400/80", className)}
+        <WorkflowIcon
+          className={cn("fill-orange-200/50 stroke-orange-500/70", className)}
         />
       )
     case "CHILD_WORKFLOW_EXECUTION_COMPLETED":
       return (
         <CircleCheck
-          className={cn("fill-violet-400/80 stroke-white", className)}
+          className={cn("fill-emerald-500 stroke-white", className)}
         />
       )
     case "CHILD_WORKFLOW_EXECUTION_FAILED":
-      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
+      return <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
     /* === Activity Task Events === */
     case "ACTIVITY_TASK_SCHEDULED":
       return (
-        <CalendarCheck
+        <CalendarCheckIcon
           className={cn("fill-orange-200/50 stroke-orange-500/70", className)}
         />
       )
     case "ACTIVITY_TASK_STARTED":
       return (
-        <Play className={cn("fill-sky-500/80 stroke-sky-500/80", className)} />
+        <PlayIcon className={cn("fill-white stroke-sky-500/80", className)} />
       )
     case "ACTIVITY_TASK_COMPLETED":
       return (
         <CircleCheck
-          className={cn("fill-sky-500/80 stroke-white", className)}
+          className={cn("fill-emerald-500 stroke-white", className)}
         />
       )
     case "ACTIVITY_TASK_FAILED":
-      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
+      return <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
     case "ACTIVITY_TASK_TIMED_OUT":
       return (
         <AlarmClockOffIcon
@@ -237,12 +236,12 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
       )
     case "WORKFLOW_EXECUTION_UPDATE_REJECTED":
       return (
-        <CircleX className={cn("fill-indigo-500/50 stroke-white", className)} />
+        <CircleXIcon className={cn("fill-indigo-500/50 stroke-white", className)} />
       )
     case "WORKFLOW_EXECUTION_UPDATE_COMPLETED":
       return (
         <CircleCheck
-          className={cn("fill-indigo-500/50 stroke-white", className)}
+          className={cn("fill-emerald-500/50 stroke-white", className)}
         />
       )
 


### PR DESCRIPTION
## Before
![Screenshot 2025-05-17 at 6 01 18 PM](https://github.com/user-attachments/assets/529db4e3-71b0-49c9-9015-ecc4f49e7d26)

## After
![Screenshot 2025-05-17 at 6 00 41 PM](https://github.com/user-attachments/assets/503ee020-dfda-421a-a48a-04085d2f13f2)

Intention: draw the eyes to click inputs (orange), result (green). Previously inputs and output were both blue.