### PR TITLE
build(fix): More conservative retries and depends on

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -58,8 +58,6 @@ services:
       - ./registry:/app/registry
       - ./alembic:/app/alembic
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
-    depends_on:
-      - executor
 
   worker:
     build:
@@ -155,8 +153,6 @@ services:
       NEXT_PUBLIC_AUTH_TYPES: ${TRACECAT__AUTH_TYPES}
       NEXT_SERVER_API_URL: ${NEXT_SERVER_API_URL}
       NODE_ENV: ${NODE_ENV}
-    depends_on:
-      - api
     volumes:
       - ./frontend/src:/app/src
       - ./frontend/.next:/app/.next

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -58,6 +58,8 @@ services:
       - ./registry:/app/registry
       - ./alembic:/app/alembic
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
+    depends_on:
+      - temporal
 
   worker:
     build:
@@ -91,6 +93,9 @@ services:
       - ./registry:/app/registry
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     command: ["python", "tracecat/dsl/worker.py"]
+    depends_on:
+      - api
+      - temporal
 
   executor:
     build:
@@ -132,6 +137,8 @@ services:
         "8000",
         "--reload",
       ]
+    depends_on:
+      - temporal
 
   ui:
     build:
@@ -158,6 +165,8 @@ services:
       - ./frontend/.next:/app/.next
       - ./frontend/node_modules:/app/node_modules
     attach: false
+    depends_on:
+      - api
 
   postgres_db:
     image: postgres:16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     volumes:
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     depends_on:
-      - executor
+      - temporal
 
   worker:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.35.1}
@@ -90,6 +90,9 @@ services:
     volumes:
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     command: ["python", "tracecat/dsl/worker.py"]
+    depends_on:
+      - api
+      - temporal
 
   executor:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.35.1}
@@ -123,6 +126,9 @@ services:
         "--port",
         "8000",
       ]
+    depends_on:
+      - temporal
+
   ui:
     image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-0.35.1}
     container_name: ui

--- a/tracecat/dsl/client.py
+++ b/tracecat/dsl/client.py
@@ -35,7 +35,7 @@ async def _retrieve_temporal_api_key(arn: str) -> str:
 
 @retry(
     stop=stop_after_attempt(TEMPORAL__CONNECT_RETRIES),
-    wait=wait_exponential(multiplier=1, min=5, max=180),  # Up to 3 minutes
+    wait=wait_exponential(multiplier=1, min=1, max=120),  # Up to 2 minutes
     retry=retry_if_exception_type((TemporalError, RuntimeError)),
     reraise=True,
 )

--- a/tracecat/dsl/client.py
+++ b/tracecat/dsl/client.py
@@ -35,7 +35,7 @@ async def _retrieve_temporal_api_key(arn: str) -> str:
 
 @retry(
     stop=stop_after_attempt(TEMPORAL__CONNECT_RETRIES),
-    wait=wait_exponential(multiplier=1, min=1, max=10),
+    wait=wait_exponential(multiplier=1, min=5, max=180),  # Up to 3 minutes
     retry=retry_if_exception_type((TemporalError, RuntimeError)),
     reraise=True,
 )


### PR DESCRIPTION
Should fix  #1127 

## What's the issue
- Worker is the smallest image seems to spin up too early (before `temporal` and `api` is ready)
- We have retry connection for worker but it only retries up to 10 seconds

## Fix
- Increase worker connection retry to 2 minutes
- Add `depends_on` in docker compose to worker (now waits for `temporal` and `api`)