### PR TITLE
feat(app): Implement events toolbar

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6224,6 +6224,9 @@ export const $WorkflowExecutionRead = {
       ],
       title: "Parent Wf Exec Id",
     },
+    trigger_type: {
+      $ref: "#/components/schemas/TriggerType",
+    },
     events: {
       items: {
         $ref: "#/components/schemas/WorkflowExecutionEvent",
@@ -6250,6 +6253,7 @@ export const $WorkflowExecutionRead = {
     "workflow_type",
     "task_queue",
     "history_length",
+    "trigger_type",
     "events",
   ],
   title: "WorkflowExecutionRead",
@@ -6337,6 +6341,9 @@ export const $WorkflowExecutionReadCompact = {
       ],
       title: "Parent Wf Exec Id",
     },
+    trigger_type: {
+      $ref: "#/components/schemas/TriggerType",
+    },
     events: {
       items: {
         $ref: "#/components/schemas/WorkflowExecutionEventCompact",
@@ -6363,6 +6370,7 @@ export const $WorkflowExecutionReadCompact = {
     "workflow_type",
     "task_queue",
     "history_length",
+    "trigger_type",
     "events",
   ],
   title: "WorkflowExecutionReadCompact",
@@ -6450,6 +6458,9 @@ export const $WorkflowExecutionReadMinimal = {
       ],
       title: "Parent Wf Exec Id",
     },
+    trigger_type: {
+      $ref: "#/components/schemas/TriggerType",
+    },
   },
   type: "object",
   required: [
@@ -6460,6 +6471,7 @@ export const $WorkflowExecutionReadMinimal = {
     "workflow_type",
     "task_queue",
     "history_length",
+    "trigger_type",
   ],
   title: "WorkflowExecutionReadMinimal",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1970,6 +1970,7 @@ export type WorkflowExecutionRead = {
    */
   history_length: number
   parent_wf_exec_id?: string | null
+  trigger_type: TriggerType
   /**
    * The events in the workflow execution
    */
@@ -2025,6 +2026,7 @@ export type WorkflowExecutionReadCompact = {
    */
   history_length: number
   parent_wf_exec_id?: string | null
+  trigger_type: TriggerType
   /**
    * Compact events in the workflow execution
    */
@@ -2071,6 +2073,7 @@ export type WorkflowExecutionReadMinimal = {
    */
   history_length: number
   parent_wf_exec_id?: string | null
+  trigger_type: TriggerType
 }
 
 export type WorkflowExecutionTerminate = {

--- a/frontend/src/components/builder/builder.tsx
+++ b/frontend/src/components/builder/builder.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/tooltip"
 import { WorkflowCanvas } from "@/components/builder/canvas/canvas"
 import { BuilderSidebarEvents } from "@/components/builder/events/events-sidebar"
+import { EventsSidebarToolbar } from "@/components/builder/events/events-sidebar-toolbar"
 import { BuilderPanel } from "@/components/builder/panel/builder-panel"
 
 interface BuilderProps {
@@ -88,9 +89,10 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
           collapsible={true}
           minSize={24}
           maxSize={48}
-          className="h-full"
+          className="relative h-full"
         >
           <BuilderSidebarEvents />
+          <EventsSidebarToolbar />
         </ResizablePanel>
         <TooltipProvider>
           <Tooltip>

--- a/frontend/src/components/builder/events/events-sidebar-toolbar.tsx
+++ b/frontend/src/components/builder/events/events-sidebar-toolbar.tsx
@@ -1,0 +1,93 @@
+import { $TriggerType, TriggerType } from "@/client"
+import { FilterIcon } from "lucide-react"
+
+import { useLocalStorage } from "@/lib/hooks"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { getTriggerTypeIcon } from "@/components/builder/events/events-workflow"
+
+const AVAILABLE_TRIGGER_TYPES: readonly TriggerType[] = $TriggerType.enum
+export function EventsSidebarToolbar() {
+  const [selectedTriggerTypes, setSelectedTriggerTypes] = useLocalStorage<
+    TriggerType[]
+  >("selected-trigger-types", [...AVAILABLE_TRIGGER_TYPES])
+
+  const handleTriggerTypeToggle = (triggerType: TriggerType) => {
+    if (selectedTriggerTypes.includes(triggerType)) {
+      // Don't allow removing the last trigger type
+      if (selectedTriggerTypes.length <= 1) {
+        return
+      }
+      const newTypes = selectedTriggerTypes.filter(
+        (type) => type !== triggerType
+      )
+      setSelectedTriggerTypes(newTypes)
+    } else {
+      // Add the trigger type
+      setSelectedTriggerTypes([...selectedTriggerTypes, triggerType])
+    }
+  }
+
+  return (
+    <div
+      id="events-sidebar-toolbar-wrapper"
+      className={`absolute bottom-4 right-4 z-20`}
+    >
+      <div
+        id="events-sidebar-toolbar"
+        className="flex items-center justify-center rounded-lg border border-input bg-background shadow-md [&>*]:h-8 [&>:first-child]:rounded-l-lg [&>:last-child]:rounded-r-lg"
+      >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              className="flex items-center gap-1 rounded-none px-3 py-2"
+            >
+              <FilterIcon className="size-4 text-foreground/70" />
+              <span className="whitespace-nowrap text-xs text-foreground/70">
+                Filter
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              Trigger Types
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {AVAILABLE_TRIGGER_TYPES.map((triggerType) => (
+              <DropdownMenuCheckboxItem
+                key={triggerType}
+                checked={selectedTriggerTypes.includes(triggerType)}
+                onCheckedChange={() => handleTriggerTypeToggle(triggerType)}
+              >
+                <div className="flex items-center gap-2">
+                  {getTriggerTypeIcon(triggerType)}
+                  <span>
+                    {triggerType.charAt(0).toUpperCase() + triggerType.slice(1)}
+                  </span>
+                </div>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {/* <Button
+          variant="ghost"
+          className="flex items-center gap-1 rounded-none px-3 py-2"
+          onClick={toggleToolbarPosition}
+        >
+          <SettingsIcon className="size-4 text-foreground/70" />
+          <span className="whitespace-nowrap text-xs text-foreground/70">
+            Settings
+          </span>
+        </Button> */}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/builder/events/events-sidebar.tsx
+++ b/frontend/src/components/builder/events/events-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import React, { useEffect, useState } from "react"
 import { $TriggerType, TriggerType } from "@/client"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
@@ -18,8 +18,6 @@ import {
   useLocalStorage,
   useOrgAppSettings,
 } from "@/lib/hooks"
-import { Checkbox } from "@/components/ui/checkbox"
-import { Label } from "@/components/ui/label"
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -232,14 +230,13 @@ function BuilderSidebarEventsList({
       >
         <div className="sticky top-0 z-10 mt-0.5 bg-background">
           <ScrollArea className="w-full whitespace-nowrap rounded-md">
-            <TabsList className="inline-flex h-8 w-full items-center justify-start bg-transparent p-0">
+            <TabsList className="inline-flex h-8 flex-1 items-center justify-start bg-transparent p-0">
               {tabItems.map((tab) => (
                 <TabsTrigger
                   key={tab.value}
                   value={tab.value}
                   className="flex h-full min-w-20 items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none sm:min-w-16 md:min-w-20"
                 >
-                  {/* TODO(chris): Please adjust this */}
                   <tab.icon className="mr-2 size-4 sm:mr-1" />
                   <span className="hidden sm:inline">{tab.label}</span>
                   <span className="sm:hidden">{tab.label.slice(0, 4)}</span>

--- a/frontend/src/components/builder/events/events-workflow.tsx
+++ b/frontend/src/components/builder/events/events-workflow.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react"
 import Link from "next/link"
 import {
+  TriggerType,
   WorkflowExecutionEventCompact,
   WorkflowExecutionEventStatus,
   WorkflowExecutionReadCompact,
@@ -8,7 +9,7 @@ import {
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspace } from "@/providers/workspace"
-import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { DotsHorizontalIcon, QuestionMarkIcon } from "@radix-ui/react-icons"
 import {
   AlarmClockCheckIcon,
   AlarmClockOffIcon,
@@ -27,7 +28,10 @@ import {
   LoaderIcon,
   ScanEyeIcon,
   SquareArrowOutUpRightIcon,
+  UserIcon,
+  WebhookIcon,
   WorkflowIcon,
+  ZapIcon,
 } from "lucide-react"
 
 import { executionId } from "@/lib/event-history"
@@ -60,6 +64,32 @@ export function WorkflowEventsHeader({
   const parentExecId = parentExec ? executionId(parentExec) : null
   return (
     <div className="space-y-2 p-4 text-xs text-muted-foreground">
+      {/* Trigger type */}
+      <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
+          <ZapIcon className="size-3" />
+          <span>Trigger type</span>
+        </div>
+        <div className="ml-auto">
+          <Tooltip delayDuration={500}>
+            <TooltipTrigger>
+              <Badge
+                variant="secondary"
+                className="flex items-center gap-1 text-foreground/70"
+              >
+                {getTriggerTypeIcon(execution.trigger_type)}
+                <span>
+                  {execution.trigger_type.charAt(0).toUpperCase() +
+                    execution.trigger_type.slice(1)}
+                </span>
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="font-mono tracking-tight">
+              {execution.id}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
       <div className="flex items-center gap-1">
         <div className="flex items-center gap-2">
           <CircleDot className="size-3" />
@@ -426,5 +456,45 @@ export function getWorkflowEventIcon(
       return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
     default:
       throw new Error("Invalid status")
+  }
+}
+
+export function getTriggerTypeIcon(
+  triggerType: TriggerType,
+  className?: string
+) {
+  switch (triggerType) {
+    case "manual":
+      return (
+        <div className="relative rounded-full bg-blue-400">
+          <UserIcon
+            className={cn("size-3 scale-[0.8] stroke-white", className)}
+            strokeWidth={2.5}
+          />
+        </div>
+      )
+    case "scheduled":
+      return (
+        <div className="relative rounded-full bg-amber-500">
+          <CalendarSearchIcon
+            className={cn("size-3 scale-[0.7] stroke-white", className)}
+            strokeWidth={2.5}
+          />
+        </div>
+      )
+    case "webhook":
+      return (
+        <div className="relative rounded-full bg-purple-400">
+          <WebhookIcon
+            className={cn("size-3 scale-[0.7] stroke-white", className)}
+            strokeWidth={2.5}
+          />
+        </div>
+      )
+    default:
+      console.error(`Unknown trigger type: ${triggerType}`)
+      return (
+        <QuestionMarkIcon className={cn("size-3 text-gray-600", className)} />
+      )
   }
 }

--- a/frontend/src/components/executions/event-history.tsx
+++ b/frontend/src/components/executions/event-history.tsx
@@ -147,7 +147,11 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
   switch (eventType) {
     /* === Workflow Execution Events === */
     case "WORKFLOW_EXECUTION_STARTED":
-      return <WorkflowIcon className={cn("fill-white stroke-sky-500/80", className)} />
+      return (
+        <WorkflowIcon
+          className={cn("fill-white stroke-sky-500/80", className)}
+        />
+      )
     case "WORKFLOW_EXECUTION_COMPLETED":
       return (
         <WorkflowIcon
@@ -155,7 +159,9 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
         />
       )
     case "WORKFLOW_EXECUTION_FAILED":
-      return <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
+      return (
+        <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
+      )
     case "WORKFLOW_EXECUTION_CANCELED":
       return (
         <CircleMinusIcon
@@ -201,7 +207,9 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
         />
       )
     case "CHILD_WORKFLOW_EXECUTION_FAILED":
-      return <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
+      return (
+        <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
+      )
     /* === Activity Task Events === */
     case "ACTIVITY_TASK_SCHEDULED":
       return (
@@ -220,7 +228,9 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
         />
       )
     case "ACTIVITY_TASK_FAILED":
-      return <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
+      return (
+        <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
+      )
     case "ACTIVITY_TASK_TIMED_OUT":
       return (
         <AlarmClockOffIcon
@@ -236,7 +246,9 @@ function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
       )
     case "WORKFLOW_EXECUTION_UPDATE_REJECTED":
       return (
-        <CircleXIcon className={cn("fill-indigo-500/50 stroke-white", className)} />
+        <CircleXIcon
+          className={cn("fill-indigo-500/50 stroke-white", className)}
+        />
       )
     case "WORKFLOW_EXECUTION_UPDATE_COMPLETED":
       return (

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -142,6 +142,7 @@ import {
   tagsUpdateTag,
   TagsUpdateTagData,
   triggersUpdateWebhook,
+  TriggerType,
   usersUsersPatchCurrentUser,
   UserUpdate,
   WebhookUpdate,
@@ -737,7 +738,13 @@ export function useCreateManualWorkflowExecution(workflowId: string) {
   }
 }
 
-export function useLastManualExecution(workflowId?: string) {
+export function useLastExecution({
+  workflowId,
+  triggerTypes,
+}: {
+  workflowId?: string | null
+  triggerTypes: TriggerType[]
+}) {
   const { workspaceId } = useWorkspace()
   const {
     data: lastExecution,
@@ -745,14 +752,14 @@ export function useLastManualExecution(workflowId?: string) {
     error: lastExecutionError,
   } = useQuery<WorkflowExecutionReadMinimal | null, TracecatApiError>({
     enabled: !!workflowId,
-    queryKey: ["last-manual-execution", workflowId],
+    queryKey: ["last-execution", workflowId, triggerTypes?.sort().join(",")],
     queryFn: async () => {
       const executions = await workflowExecutionsListWorkflowExecutions({
         workspaceId,
         workflowId,
-        trigger: ["manual"],
         limit: 1,
         userId: "current",
+        trigger: triggerTypes,
       })
 
       return executions.length > 0 ? executions[0] : null

--- a/tracecat/workflow/executions/models.py
+++ b/tracecat/workflow/executions/models.py
@@ -21,7 +21,11 @@ from google.protobuf.json_format import MessageToDict
 from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 
-from tracecat.dsl.common import ChildWorkflowMemo, DSLRunArgs
+from tracecat.dsl.common import (
+    ChildWorkflowMemo,
+    DSLRunArgs,
+    get_trigger_type_from_search_attr,
+)
 from tracecat.dsl.enums import JoinStrategy, PlatformAction, WaitStrategy
 from tracecat.dsl.models import (
     ActionErrorInfo,
@@ -88,6 +92,7 @@ class WorkflowExecutionBase(BaseModel):
     task_queue: str
     history_length: int = Field(..., description="Number of events in the history")
     parent_wf_exec_id: WorkflowExecutionID | None = None
+    trigger_type: TriggerType
 
 
 class WorkflowExecutionReadMinimal(WorkflowExecutionBase):
@@ -104,6 +109,9 @@ class WorkflowExecutionReadMinimal(WorkflowExecutionBase):
             task_queue=execution.task_queue,
             history_length=execution.history_length,
             parent_wf_exec_id=execution.parent_id,
+            trigger_type=get_trigger_type_from_search_attr(
+                execution.typed_search_attributes, execution.id
+            ),
         )
 
 

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -8,7 +8,7 @@ from tracecat.auth.dependencies import WorkspaceUserRole
 from tracecat.auth.enums import SpecialUserID
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.schemas import WorkflowDefinition
-from tracecat.dsl.common import DSLInput
+from tracecat.dsl.common import DSLInput, get_trigger_type_from_search_attr
 from tracecat.ee.interactions.models import InteractionRead
 from tracecat.ee.interactions.service import InteractionService
 from tracecat.identifiers import UserID
@@ -121,6 +121,9 @@ async def get_workflow_execution(
         history_length=execution.history_length,
         events=events,
         interactions=interactions,
+        trigger_type=get_trigger_type_from_search_attr(
+            execution.typed_search_attributes, execution.id
+        ),
     )
 
 
@@ -154,6 +157,9 @@ async def get_workflow_execution_compact(
         history_length=execution.history_length,
         events=compact_events,
         interactions=interactions,
+        trigger_type=get_trigger_type_from_search_attr(
+            execution.typed_search_attributes, execution.id
+        ),
     )
 
 


### PR DESCRIPTION
# Description
- Add events sidebar toolbar
- Toolbar currently contains "filter", which will let you multi-select one or more trigger types.
- This toolbar can be extended to have other functionality

# Changes
- **Allow querying for last execution with all trigger types**
- **Update openapi ts client**
- **WIP**
- **Add floating events toolbar**


# Screens

<img width="1728" alt="Screenshot 2025-05-20 at 14 47 24" src="https://github.com/user-attachments/assets/4c3a3500-db0a-45bf-be21-648fe4d22bd4" />

