### PR TITLE
feat(integrations): MCPHost and ShortTermMemory ABC

### DIFF
--- a/registry/tracecat_registry/integrations/mcp/agent.py
+++ b/registry/tracecat_registry/integrations/mcp/agent.py
@@ -422,6 +422,18 @@ class MCPHost(ABC, Generic[DepsT]):
                             await self.update_message(result, deps)
                     elif Agent.is_call_tools_node(node):
                         result = await self._process_call_tools_node(node, run, deps)
+
+                        if isinstance(result, ToolCallRequestResult):
+                            # Request tool approval
+                            await self.request_tool_approval(result, deps)
+                            return result
+
+                        elif isinstance(result, ToolResultNodeResult):
+                            # Post tool result
+                            await self.post_tool_result(result, deps)
+                            # Continue processing the next node
+                            continue
+
                     elif Agent.is_end_node(node):
                         output = node.data.output
                         result = EndNodeResult(output=output)

--- a/registry/tracecat_registry/integrations/mcp/agent.py
+++ b/registry/tracecat_registry/integrations/mcp/agent.py
@@ -460,9 +460,14 @@ class MCPHost(ABC, Generic[DepsT]):
             else:
                 raise ValueError("`message_id` is required for non-new conversations")
 
-        result = await self._run_agent(
-            user_prompt=user_prompt, deps=deps, message_history=message_history
-        )
+        try:
+            result = await self._run_agent(
+                user_prompt=user_prompt, deps=deps, message_history=message_history
+            )
+        except ExceptionGroup as e:
+            await self._handle_exception_with_error_posting(e.exceptions[0], deps)
+        except Exception as e:
+            await self._handle_exception_with_error_posting(e, deps)
 
         return MCPHostResult(
             conversation_id=deps.conversation_id,

--- a/registry/tracecat_registry/integrations/mcp/agent.py
+++ b/registry/tracecat_registry/integrations/mcp/agent.py
@@ -1,8 +1,12 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 import hashlib
+import httpx
+from dataclasses import dataclass
 from pydantic import BaseModel
 from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerHTTP
 from pydantic_ai.messages import ModelMessage
+from pydantic_core import to_jsonable_python
 from pydantic import computed_field
 from pydantic_ai.messages import (
     FunctionToolCallEvent,
@@ -14,81 +18,16 @@ from pydantic_ai.messages import (
     TextPart,
     ToolReturnPart,
 )
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 from pydantic_ai.agent import ModelRequestNode, AgentRun, CallToolsNode
 
+from tracecat_registry.integrations.pydantic_ai import build_agent
+from tracecat_registry.integrations.mcp.exceptions import AgentRunError
 from tracecat_registry.integrations.mcp.memory import ShortTermMemory
-from tracecat_registry import RegistrySecret
 
 
-mcp_secret = RegistrySecret(
-    name="mcp",
-    optional_keys=["MCP_HTTP_HEADERS"],
-    optional=True,
-)
-"""MCP headers.
-
-- name: `mcp`
-- optional_keys:
-    - `MCP_HTTP_HEADERS`: Optional HTTP headers to send to the MCP server.
-"""
-
-anthropic_secret = RegistrySecret(
-    name="anthropic",
-    optional_keys=["ANTHROPIC_API_KEY"],
-    optional=True,
-)
-"""Anthropic API key.
-
-- name: `anthropic`
-- optional_keys:
-    - `ANTHROPIC_API_KEY`: Optional Anthropic API key.
-"""
-
-openai_secret = RegistrySecret(
-    name="openai",
-    optional_keys=["OPENAI_API_KEY"],
-    optional=True,
-)
-"""OpenAI API key.
-
-- name: `openai`
-- optional_keys:
-    - `OPENAI_API_KEY`: Optional OpenAI API key.
-"""
-
-gemini_secret = RegistrySecret(
-    name="gemini",
-    optional_keys=["GEMINI_API_KEY"],
-    optional=True,
-)
-"""Gemini API key.
-
-- name: `gemini`
-- optional_keys:
-    - `GEMINI_API_KEY`: Optional Gemini API key.
-"""
-
-
-bedrock_secret = RegistrySecret(
-    name="amazon_bedrock",
-    optional_keys=[
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_SESSION_TOKEN",
-        "AWS_REGION",
-    ],
-    optional=True,
-)
-"""Bedrock API key.
-
-- name: `amazon_bedrock`
-- optional_keys:
-    - `AWS_ACCESS_KEY_ID`: Optional AWS access key ID.
-    - `AWS_SECRET_ACCESS_KEY`: Optional AWS secret access key.
-    - `AWS_SESSION_TOKEN`: Optional AWS session token.
-    - `AWS_REGION`: Optional AWS region.
-"""
+def hash_tool_call(tool_name: str, tool_args: str | dict[str, Any]) -> str:
+    return hashlib.md5(f"{tool_name}:{tool_args}".encode()).hexdigest()
 
 
 class EmptyNodeResult(BaseModel):
@@ -100,25 +39,100 @@ class ModelRequestNodeResult(BaseModel):
     tool_call_parts: list[str]
 
 
-class ToolCallNodeResult(BaseModel):
+class ToolCallRequestResult(BaseModel):
     name: str
     args: str | dict[str, Any]
 
     @computed_field(return_type=str)
     @property
     def hash(self) -> str:
-        return hashlib.md5(f"{self.name}:{self.args}".encode()).hexdigest()
+        return hash_tool_call(self.name, self.args)
 
 
 class ToolResultNodeResult(BaseModel):
     name: str
     content: str | dict[str, Any]
+    call_id: str | None = None  # Only specified if tool call is approved
+
+
+@dataclass
+class MCPHostDeps:
+    conversation_id: str  # e.g. `thread_ts` in Slack
+    message_id: str  # e.g. `ts` in Slack
+
+
+class MCPHostResult(BaseModel):
+    conversation_id: str
+    message_id: str
+    message_history: list[ModelMessage]
 
 
 class MCPHost(ABC):
-    def __init__(self, agent: Agent, memory: ShortTermMemory):
-        self.agent = agent
+    def __init__(
+        self,
+        model_name: str,
+        model_provider: str,
+        memory: ShortTermMemory,
+        mcp_servers: list[MCPServerHTTP],
+        approved_tool_calls: list[str] | None = None,
+        agent_settings: dict[str, Any] | None = None,
+    ):
+        self.agent = build_agent(
+            model_name=model_name,
+            model_provider=model_provider,
+            model_settings=agent_settings,
+            mcp_servers=mcp_servers,
+            dep_type=MCPHostDeps,
+        )
         self.memory = memory
+        self._approved_tool_calls = approved_tool_calls
+
+    @abstractmethod
+    def post_conversation_start(self, deps: MCPHostDeps) -> None:
+        pass
+
+    @abstractmethod
+    def post_message(self, result: ModelRequestNodeResult, deps: MCPHostDeps) -> None:
+        pass
+
+    @abstractmethod
+    def update_message(self, result: ModelRequestNodeResult, deps: MCPHostDeps) -> None:
+        pass
+
+    @abstractmethod
+    def request_tool_approval(
+        self, result: ToolCallRequestResult, deps: MCPHostDeps
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def post_tool_approval(
+        self, result: ToolCallRequestResult, approved: bool, deps: MCPHostDeps
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def post_tool_result(self, result: ToolResultNodeResult, deps: MCPHostDeps) -> None:
+        pass
+
+    @abstractmethod
+    def post_conversation_end(self, deps: MCPHostDeps) -> None:
+        pass
+
+    @abstractmethod
+    def post_error_message(self, exc: Exception, deps: MCPHostDeps) -> None:
+        pass
+
+    def is_approved_tool_call(
+        self, tool_name: str, tool_args: str | dict[str, Any]
+    ) -> bool:
+        return (
+            self._approved_tool_calls is not None
+            and hash_tool_call(tool_name, tool_args) in self._approved_tool_calls
+        )
+
+    def is_new_conversation(self, conversation_id: str) -> bool:
+        return len(self.memory.get_messages(conversation_id)) == 0
 
     async def _process_model_request_node(
         self,
@@ -127,6 +141,7 @@ class MCPHost(ABC):
     ) -> ModelRequestNodeResult | EmptyNodeResult:
         text_parts = []
         tool_call_parts = []
+        conversation_id = run.ctx.deps.conversation_id  # type: ignore
         async with node.stream(run.ctx) as handle_stream:
             async for event in handle_stream:
                 if isinstance(event, PartStartEvent) and isinstance(
@@ -142,49 +157,144 @@ class MCPHost(ABC):
                         tool_call_parts.append(event.delta.args_delta)
 
         if len(text_parts) > 0 or len(tool_call_parts) > 0:
+            self.memory.add_assistant_message(
+                conversation_id=conversation_id,
+                content="".join(text_parts),
+            )
+
             return ModelRequestNodeResult(
                 text_parts=text_parts,
                 tool_call_parts=tool_call_parts,
             )
+
         return EmptyNodeResult(node_type="model_request")
 
     async def _process_call_tools_node(
-        self, node: CallToolsNode[None, str], run: AgentRun
-    ) -> ToolCallNodeResult | ToolResultNodeResult | EmptyNodeResult:
+        self,
+        node: CallToolsNode[None, str],
+        run: AgentRun,
+    ) -> ToolCallRequestResult | ToolResultNodeResult | EmptyNodeResult:
+        conversation_id = run.ctx.deps.conversation_id  # type: ignore
+
         async with node.stream(run.ctx) as handle_stream:
             async for event in handle_stream:
                 if isinstance(event, FunctionToolCallEvent):
-                    return ToolCallNodeResult(
-                        name=event.part.tool_name,
-                        args=event.part.args,
+                    tool_name = event.part.tool_name
+                    tool_args = event.part.args
+                    tool_call_id = event.part.tool_call_id
+
+                    if not self.is_approved_tool_call(tool_name, tool_args):
+                        return ToolCallRequestResult(
+                            name=tool_name,
+                            args=tool_args,
+                        )
+
+                    self.memory.add_tool_call(
+                        conversation_id=conversation_id,
+                        tool_name=tool_name,
+                        tool_args=tool_args,
+                        tool_call_id=tool_call_id,
                     )
+
                 elif isinstance(event, FunctionToolResultEvent) and isinstance(
                     event.result, ToolReturnPart
                 ):
-                    return ToolResultNodeResult(
+                    result = ToolResultNodeResult(
                         name=event.result.tool_name,
                         content=event.result.content,
                     )
+                    self.memory.add_tool_result(
+                        conversation_id=conversation_id,
+                        tool_name=event.result.tool_name,
+                        tool_result=event.result.content,
+                        tool_call_id=event.tool_call_id,
+                    )
+                    return result
+
         return EmptyNodeResult(node_type="tool_call")
 
-    async def run(
-        self, user_prompt: str, message_history: list[ModelMessage] | None = None
-    ):
-        async with self.agent.run_mcp_servers():
-            async with self.agent.iter(
-                user_prompt=user_prompt, message_history=message_history
-            ) as run:
-                async for node in run:
-                    if Agent.is_model_request_node(node):
-                        result = await self._process_model_request_node(node, run)
-                    elif Agent.is_call_tools_node(node):
-                        result = await self._process_call_tools_node(node, run)
-                    elif Agent.is_end_node(node):
-                        result = EmptyNodeResult(node_type="end")
-                    else:
-                        raise ValueError(f"Unknown node type: {node}")
+    def _post_error_message_safe(
+        self, exc: Exception, deps: MCPHostDeps
+    ) -> Exception | None:
+        """Safely post error message and return any exception that occurred during posting."""
+        try:
+            self.post_error_message(exc, deps)
+            return None
+        except Exception as post_exc:
+            return post_exc
 
-                    if isinstance(result, ModelRequestNodeResult):
-                        pass
-                    elif isinstance(result, ToolCallNodeResult):
-                        pass
+    def _handle_exception_with_error_posting(
+        self, exc: Exception, deps: MCPHostDeps
+    ) -> NoReturn:
+        """Handle exception by posting error message safely and raising appropriate chained exception."""
+        post_error_exc = self._post_error_message_safe(exc, deps)
+
+        # Create the main exception
+        main_exc = (
+            ConnectionError(f"Failed to connect to MCP server: {exc!s}")
+            if isinstance(exc, httpx.ConnectError)
+            else AgentRunError(
+                exc_cls=type(exc),
+                exc_msg=str(exc),
+                message_history=to_jsonable_python(
+                    self.memory.get_messages(deps.conversation_id)
+                ),
+            )
+        )
+
+        # Chain with post error if it occurred
+        if post_error_exc is not None:
+            main_exc = AgentRunError(
+                exc_cls=type(main_exc),
+                exc_msg=f"Original error: {main_exc}. Additionally, failed to post error message: {post_error_exc}",
+                message_history=to_jsonable_python(
+                    self.memory.get_messages(deps.conversation_id)
+                ),
+            )
+
+        raise main_exc from exc
+
+    async def run(
+        self,
+        user_prompt: str,
+        deps: MCPHostDeps,
+        message_history: list[ModelMessage] | None = None,
+    ) -> MCPHostResult:
+        try:
+            conversation_id = deps.conversation_id
+            async with self.agent.run_mcp_servers():
+                async with self.agent.iter(
+                    user_prompt=user_prompt,
+                    message_history=message_history,
+                    deps=deps,  # type: ignore
+                ) as run:
+                    if self.is_new_conversation(conversation_id):
+                        self.post_conversation_start(deps)
+
+                    async for node in run:
+                        if Agent.is_model_request_node(node):
+                            result = await self._process_model_request_node(node, run)
+                            if isinstance(result, ModelRequestNodeResult):
+                                if self.is_new_conversation(conversation_id):
+                                    self.post_message(result, deps)
+                                else:
+                                    self.update_message(result, deps)
+                        elif Agent.is_call_tools_node(node):
+                            result = await self._process_call_tools_node(node, run)
+                        elif Agent.is_end_node(node):
+                            result = EmptyNodeResult(node_type="end")
+                            self.post_conversation_end(deps)
+                        else:
+                            raise ValueError(f"Unknown node type: {node}")
+        except ExceptionGroup as e:
+            self._handle_exception_with_error_posting(e.exceptions[0], deps)
+        except Exception as e:
+            self._handle_exception_with_error_posting(e, deps)
+        else:
+            return MCPHostResult(
+                conversation_id=deps.conversation_id,
+                message_id=deps.message_id,
+                message_history=to_jsonable_python(
+                    self.memory.get_messages(deps.conversation_id)
+                ),
+            )

--- a/registry/tracecat_registry/integrations/mcp/agent.py
+++ b/registry/tracecat_registry/integrations/mcp/agent.py
@@ -1,0 +1,190 @@
+from abc import ABC
+import hashlib
+from pydantic import BaseModel
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage
+from pydantic import computed_field
+from pydantic_ai.messages import (
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    PartStartEvent,
+    PartDeltaEvent,
+    TextPartDelta,
+    ToolCallPartDelta,
+    TextPart,
+    ToolReturnPart,
+)
+from typing import Any, Literal
+from pydantic_ai.agent import ModelRequestNode, AgentRun, CallToolsNode
+
+from tracecat_registry.integrations.mcp.memory import ShortTermMemory
+from tracecat_registry import RegistrySecret
+
+
+mcp_secret = RegistrySecret(
+    name="mcp",
+    optional_keys=["MCP_HTTP_HEADERS"],
+    optional=True,
+)
+"""MCP headers.
+
+- name: `mcp`
+- optional_keys:
+    - `MCP_HTTP_HEADERS`: Optional HTTP headers to send to the MCP server.
+"""
+
+anthropic_secret = RegistrySecret(
+    name="anthropic",
+    optional_keys=["ANTHROPIC_API_KEY"],
+    optional=True,
+)
+"""Anthropic API key.
+
+- name: `anthropic`
+- optional_keys:
+    - `ANTHROPIC_API_KEY`: Optional Anthropic API key.
+"""
+
+openai_secret = RegistrySecret(
+    name="openai",
+    optional_keys=["OPENAI_API_KEY"],
+    optional=True,
+)
+"""OpenAI API key.
+
+- name: `openai`
+- optional_keys:
+    - `OPENAI_API_KEY`: Optional OpenAI API key.
+"""
+
+gemini_secret = RegistrySecret(
+    name="gemini",
+    optional_keys=["GEMINI_API_KEY"],
+    optional=True,
+)
+"""Gemini API key.
+
+- name: `gemini`
+- optional_keys:
+    - `GEMINI_API_KEY`: Optional Gemini API key.
+"""
+
+
+bedrock_secret = RegistrySecret(
+    name="amazon_bedrock",
+    optional_keys=[
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION",
+    ],
+    optional=True,
+)
+"""Bedrock API key.
+
+- name: `amazon_bedrock`
+- optional_keys:
+    - `AWS_ACCESS_KEY_ID`: Optional AWS access key ID.
+    - `AWS_SECRET_ACCESS_KEY`: Optional AWS secret access key.
+    - `AWS_SESSION_TOKEN`: Optional AWS session token.
+    - `AWS_REGION`: Optional AWS region.
+"""
+
+
+class EmptyNodeResult(BaseModel):
+    node_type: Literal["model_request", "tool_call", "tool_result", "end"]
+
+
+class ModelRequestNodeResult(BaseModel):
+    text_parts: list[str]
+    tool_call_parts: list[str]
+
+
+class ToolCallNodeResult(BaseModel):
+    name: str
+    args: str | dict[str, Any]
+
+    @computed_field(return_type=str)
+    @property
+    def hash(self) -> str:
+        return hashlib.md5(f"{self.name}:{self.args}".encode()).hexdigest()
+
+
+class ToolResultNodeResult(BaseModel):
+    name: str
+    content: str | dict[str, Any]
+
+
+class MCPHost(ABC):
+    def __init__(self, agent: Agent, memory: ShortTermMemory):
+        self.agent = agent
+        self.memory = memory
+
+    async def _process_model_request_node(
+        self,
+        node: ModelRequestNode[None, str],
+        run: AgentRun,
+    ) -> ModelRequestNodeResult | EmptyNodeResult:
+        text_parts = []
+        tool_call_parts = []
+        async with node.stream(run.ctx) as handle_stream:
+            async for event in handle_stream:
+                if isinstance(event, PartStartEvent) and isinstance(
+                    event.part, TextPart
+                ):
+                    text_parts.append(event.part.content)
+                elif isinstance(event, PartDeltaEvent):
+                    if isinstance(event.delta, TextPartDelta):
+                        text_parts.append(event.delta.content_delta)
+                    elif isinstance(event.delta, ToolCallPartDelta):
+                        # If the LLM is starting a tool call stream,
+                        # we need to break the "context" block
+                        tool_call_parts.append(event.delta.args_delta)
+
+        if len(text_parts) > 0 or len(tool_call_parts) > 0:
+            return ModelRequestNodeResult(
+                text_parts=text_parts,
+                tool_call_parts=tool_call_parts,
+            )
+        return EmptyNodeResult(node_type="model_request")
+
+    async def _process_call_tools_node(
+        self, node: CallToolsNode[None, str], run: AgentRun
+    ) -> ToolCallNodeResult | ToolResultNodeResult | EmptyNodeResult:
+        async with node.stream(run.ctx) as handle_stream:
+            async for event in handle_stream:
+                if isinstance(event, FunctionToolCallEvent):
+                    return ToolCallNodeResult(
+                        name=event.part.tool_name,
+                        args=event.part.args,
+                    )
+                elif isinstance(event, FunctionToolResultEvent) and isinstance(
+                    event.result, ToolReturnPart
+                ):
+                    return ToolResultNodeResult(
+                        name=event.result.tool_name,
+                        content=event.result.content,
+                    )
+        return EmptyNodeResult(node_type="tool_call")
+
+    async def run(
+        self, user_prompt: str, message_history: list[ModelMessage] | None = None
+    ):
+        async with self.agent.run_mcp_servers():
+            async with self.agent.iter(
+                user_prompt=user_prompt, message_history=message_history
+            ) as run:
+                async for node in run:
+                    if Agent.is_model_request_node(node):
+                        result = await self._process_model_request_node(node, run)
+                    elif Agent.is_call_tools_node(node):
+                        result = await self._process_call_tools_node(node, run)
+                    elif Agent.is_end_node(node):
+                        result = EmptyNodeResult(node_type="end")
+                    else:
+                        raise ValueError(f"Unknown node type: {node}")
+
+                    if isinstance(result, ModelRequestNodeResult):
+                        pass
+                    elif isinstance(result, ToolCallNodeResult):
+                        pass

--- a/registry/tracecat_registry/integrations/mcp/agent.py
+++ b/registry/tracecat_registry/integrations/mcp/agent.py
@@ -161,12 +161,6 @@ class MCPHost(ABC, Generic[DepsT]):
         pass
 
     @abstractmethod
-    async def post_tool_approval(
-        self, result: ToolCallRequestResult, approved: bool, deps: DepsT
-    ) -> Self:
-        pass
-
-    @abstractmethod
     async def post_tool_result(self, result: ToolResultNodeResult, deps: DepsT) -> Self:
         pass
 

--- a/registry/tracecat_registry/integrations/mcp/agent.py
+++ b/registry/tracecat_registry/integrations/mcp/agent.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import hashlib
 import httpx
+import json
 from dataclasses import dataclass
 from pydantic import BaseModel
 from pydantic_ai import Agent
@@ -33,7 +34,23 @@ T = TypeVar("T", bound=str | dict[str, Any])
 
 
 def hash_tool_call(tool_name: str, tool_args: str | dict[str, Any]) -> str:
-    return hashlib.md5(f"{tool_name}:{tool_args}".encode()).hexdigest()
+    """Generate a consistent hash for a tool call.
+
+    Args:
+        tool_name: Name of the tool
+        tool_args: Arguments for the tool call (string or dict)
+
+    Returns:
+        MD5 hash of the tool call
+    """
+    if isinstance(tool_args, dict):
+        # Convert to JSON-serializable format and sort keys for consistency
+        serializable_args = to_jsonable_python(tool_args)
+        args_str = json.dumps(serializable_args, sort_keys=True, separators=(",", ":"))
+    else:
+        args_str = str(tool_args)
+
+    return hashlib.md5(f"{tool_name}:{args_str}".encode()).hexdigest()
 
 
 class EmptyNodeResult(BaseModel):

--- a/registry/tracecat_registry/integrations/mcp/exceptions.py
+++ b/registry/tracecat_registry/integrations/mcp/exceptions.py
@@ -1,4 +1,5 @@
 import json
+import dataclasses
 
 
 class AgentRunError(RuntimeError):
@@ -9,31 +10,50 @@ class AgentRunError(RuntimeError):
         exc_cls: type[Exception],
         exc_msg: str,
         message_history: list[dict] | None = None,
+        deps: object | None = None,
     ):
         self.exc_cls = exc_cls
         self.exc_msg = exc_msg
         self.message_history = message_history
+        self.deps = deps
 
         # Build comprehensive error message with debug info
         msg_parts = [f"Agent run failed with unhandled error: {exc_cls.__name__}"]
 
-        if exc_msg or message_history:
-            msg_parts.append("")  # Empty line before details
-
         if exc_msg:
             msg_parts.extend(
                 [
+                    "",
                     "Error details:",
                     f"  Type: {exc_cls.__name__}",
                     f"  Message: {exc_msg}",
                 ]
             )
 
+        if deps is not None:
+            deps_info = [
+                "",
+                "Dependencies info:",
+                f"  Type: {type(deps).__name__}",
+            ]
+
+            # Show dataclass fields if it's a dataclass
+            if dataclasses.is_dataclass(deps):
+                fields = dataclasses.fields(deps)
+                field_values = []
+                for field in fields:
+                    try:
+                        value = getattr(deps, field.name)
+                        field_values.append(f"{field.name}={repr(value)}")
+                    except AttributeError:
+                        field_values.append(f"{field.name}=<missing>")
+                deps_info.append(f"  Fields: {', '.join(field_values)}")
+
+            msg_parts.extend(deps_info)
+
         if message_history:
-            if exc_msg:
-                msg_parts.append("")  # Space between sections
             msg_parts.extend(
-                ["Agent message history:", json.dumps(message_history, indent=2)]
+                ["", "Agent message history:", json.dumps(message_history, indent=2)]
             )
 
         super().__init__("\n".join(msg_parts))

--- a/registry/tracecat_registry/integrations/mcp/exceptions.py
+++ b/registry/tracecat_registry/integrations/mcp/exceptions.py
@@ -1,0 +1,39 @@
+import json
+
+
+class AgentRunError(RuntimeError):
+    """Error raised when the agent run fails."""
+
+    def __init__(
+        self,
+        exc_cls: type[Exception],
+        exc_msg: str,
+        message_history: list[dict] | None = None,
+    ):
+        self.exc_cls = exc_cls
+        self.exc_msg = exc_msg
+        self.message_history = message_history
+
+        # Build comprehensive error message with debug info
+        msg_parts = [f"Agent run failed with unhandled error: {exc_cls.__name__}"]
+
+        if exc_msg or message_history:
+            msg_parts.append("")  # Empty line before details
+
+        if exc_msg:
+            msg_parts.extend(
+                [
+                    "Error details:",
+                    f"  Type: {exc_cls.__name__}",
+                    f"  Message: {exc_msg}",
+                ]
+            )
+
+        if message_history:
+            if exc_msg:
+                msg_parts.append("")  # Space between sections
+            msg_parts.extend(
+                ["Agent message history:", json.dumps(message_history, indent=2)]
+            )
+
+        super().__init__("\n".join(msg_parts))

--- a/registry/tracecat_registry/integrations/mcp/hosts/slack.py
+++ b/registry/tracecat_registry/integrations/mcp/hosts/slack.py
@@ -1,141 +1,37 @@
-import orjson
-from pydantic import BaseModel, model_validator, Field, computed_field
-from pydantic_core import to_jsonable_python
-
-import httpx
-from tracecat_registry.integrations.pydantic_ai import build_agent
-from tracecat_registry.integrations.slack_sdk import call_method
+import json
+import uuid
+from typing import Any
+from dataclasses import dataclass
 
 import diskcache as dc
-import json
-
-from typing import Annotated, Any, Self
-from typing_extensions import Doc
-
-import hashlib
-
-from pydantic_ai.mcp import MCPServerHTTP
-from pydantic_ai.agent import Agent
-from pydantic_ai.messages import (
-    FunctionToolCallEvent,
-    FunctionToolResultEvent,
-    PartStartEvent,
-    PartDeltaEvent,
-    TextPartDelta,
-    ModelMessagesTypeAdapter,
-    ToolCallPartDelta,
-    ModelMessage,
-    ModelRequest,
-    ModelResponse,
-    TextPart,
-    ToolCallPart,
-    ToolReturnPart,
-)
-from tracecat_registry.integrations.slack_sdk import format_buttons, slack_secret
-
-
-from tracecat_registry import registry, RegistrySecret, secrets
+from pydantic import BaseModel, Field, computed_field, model_validator
+from typing_extensions import Self
 
 from tracecat.logger import logger
-import uuid
-
-
-BLOCKS_CACHE = dc.FanoutCache(
-    directory=".cache/blocks", shards=8, timeout=0.05
-)  # key=ts
-MESSAGE_CACHE = dc.FanoutCache(
-    directory=".cache/messages", shards=8, timeout=0.05
-)  # key=thread_ts
-TOOL_CALLS_CACHE = dc.FanoutCache(
-    directory=".cache/tool_calls", shards=8, timeout=0.05
-)  # key=thread_ts
-APPROVED_TOOLS_CACHE = dc.FanoutCache(
-    directory=".cache/approved_tools", shards=8, timeout=0.05
-)  # key=tool_name
-TOOL_RESULTS_CACHE = dc.FanoutCache(
-    directory=".cache/tool_results", shards=8, timeout=0.05
-)  # key=tool_call_id
-
-
-def _hash_tool_call(name: str, args: str | dict[str, Any]) -> str:
-    """Hash a tool call.
-
-    Note: we cannot use the tool call ID because it is not stored in
-    the message history the first time it is requested (i.e. because of HiTL).
-    The second time it is requested, a new tool call ID is generated even
-    though the tool call name and arguments are the same.
-    """
-    return hashlib.md5(f"{name}:{args}".encode()).hexdigest()
-
-
-mcp_secret = RegistrySecret(
-    name="mcp",
-    optional_keys=["MCP_HTTP_HEADERS"],
-    optional=True,
+from tracecat_registry.integrations.mcp.agent import (
+    MCPHost,
+    MCPHostDeps,
+    ModelRequestNodeResult,
+    ToolCallRequestResult,
+    ToolResultNodeResult,
+    MessageStartResult,
 )
-"""MCP headers.
-
-- name: `mcp`
-- optional_keys:
-    - `MCP_HTTP_HEADERS`: Optional HTTP headers to send to the MCP server.
-"""
-
-anthropic_secret = RegistrySecret(
-    name="anthropic",
-    optional_keys=["ANTHROPIC_API_KEY"],
-    optional=True,
-)
-"""Anthropic API key.
-
-- name: `anthropic`
-- optional_keys:
-    - `ANTHROPIC_API_KEY`: Optional Anthropic API key.
-"""
-
-openai_secret = RegistrySecret(
-    name="openai",
-    optional_keys=["OPENAI_API_KEY"],
-    optional=True,
-)
-"""OpenAI API key.
-
-- name: `openai`
-- optional_keys:
-    - `OPENAI_API_KEY`: Optional OpenAI API key.
-"""
-
-gemini_secret = RegistrySecret(
-    name="gemini",
-    optional_keys=["GEMINI_API_KEY"],
-    optional=True,
-)
-"""Gemini API key.
-
-- name: `gemini`
-- optional_keys:
-    - `GEMINI_API_KEY`: Optional Gemini API key.
-"""
+from tracecat_registry.integrations.mcp.memory import FanoutCacheMemory
+from tracecat_registry.integrations.slack_sdk import call_method, format_buttons
 
 
-bedrock_secret = RegistrySecret(
-    name="amazon_bedrock",
-    optional_keys=[
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_SESSION_TOKEN",
-        "AWS_REGION",
-    ],
-    optional=True,
-)
-"""Bedrock API key.
+@dataclass
+class SlackMCPHostDeps:
+    """Slack-specific dependencies extending MCPHostDeps."""
 
-- name: `amazon_bedrock`
-- optional_keys:
-    - `AWS_ACCESS_KEY_ID`: Optional AWS access key ID.
-    - `AWS_SECRET_ACCESS_KEY`: Optional AWS secret access key.
-    - `AWS_SESSION_TOKEN`: Optional AWS session token.
-    - `AWS_REGION`: Optional AWS region.
-"""
+    conversation_id: str
+    """`thread_ts` thread timestamp in Slack."""
+    user_id: str
+    """Slack user ID who initiated the conversation."""
+    channel_id: str
+    """Slack channel ID where the conversation is happening."""
+    message_id: str | None = None
+    """`ts` message timestamp in Slack (None for conversation start)."""
 
 
 class SlackMessage(BaseModel):
@@ -282,974 +178,517 @@ class SlackInteractionPayload(BaseModel):
         return None
 
 
-def _get_message_history(thread_ts: str) -> list[ModelMessage]:
-    """Get the message history for a thread."""
-    return ModelMessagesTypeAdapter.validate_python(MESSAGE_CACHE.get(thread_ts, []))
-
-
-# TODO: Move into tracecat_registry.integrations.pydantic_ai
-# Consider updating _parse_message_history to handle tool calls
-
-
-def _add_user_message(thread_ts: str, message: str) -> list[dict[str, Any]]:
-    """Add a user message to the message history."""
-    messages: list[dict[str, Any]] = MESSAGE_CACHE.get(thread_ts, [])  # type: ignore
-    user_prompt = ModelRequest.user_text_prompt(user_prompt=message)
-    messages.append(to_jsonable_python(user_prompt))
-    MESSAGE_CACHE.set(thread_ts, messages)
-    logger.info(
-        "Added user message to message history",
-        thread_ts=thread_ts,
-        messages=messages,
-        num_messages=len(messages),
-    )
-    return messages
-
-
-def _add_assistant_message(thread_ts: str, message: str) -> list[dict[str, Any]]:
-    """Add an assistant message to the message history."""
-    messages: list[dict[str, Any]] = MESSAGE_CACHE.get(thread_ts, [])  # type: ignore
-    assistant_response = ModelResponse(parts=[TextPart(content=message)])
-    messages.append(to_jsonable_python(assistant_response))
-    MESSAGE_CACHE.set(thread_ts, messages)
-    logger.info(
-        "Added assistant message to message history",
-        thread_ts=thread_ts,
-        messages=messages,
-        num_messages=len(messages),
-    )
-    return messages
-
-
-def _add_tool_call_request(
-    thread_ts: str, tool_name: str, tool_args: str | dict[str, Any], tool_call_id: str
-) -> list[dict[str, Any]]:
-    """Add a tool call request to the message history."""
-    messages: list[dict[str, Any]] = MESSAGE_CACHE.get(thread_ts, [])  # type: ignore
-    parts = [
-        ToolCallPart(tool_name=tool_name, args=tool_args, tool_call_id=tool_call_id)
-    ]
-    tool_call = ModelResponse(parts=parts)  # type: ignore
-    messages.append(to_jsonable_python(tool_call))
-    MESSAGE_CACHE.set(thread_ts, messages)
-    logger.info(
-        "Added tool call request to message history",
-        thread_ts=thread_ts,
-        messages=messages,
-        num_messages=len(messages),
-    )
-    return messages
-
-
-def _add_tool_call_result(
-    thread_ts: str, tool_name: str, tool_result: str, tool_call_id: str
-) -> list[dict[str, Any]]:
-    """Add a tool call result to the message history."""
-    messages: list[dict[str, Any]] = MESSAGE_CACHE.get(thread_ts, [])  # type: ignore
-    parts = [
-        ToolReturnPart(
-            tool_name=tool_name, content=tool_result, tool_call_id=tool_call_id
-        )
-    ]
-    tool_result = ModelRequest(parts=parts)  # type: ignore
-    messages.append(to_jsonable_python(tool_result))
-    MESSAGE_CACHE.set(thread_ts, messages)
-    logger.info(
-        "Added tool call result to message history",
-        thread_ts=thread_ts,
-        messages=messages,
-        num_messages=len(messages),
-    )
-    return messages
-
-
-async def _process_model_request_node(
-    node,
-    run,
-    ts: str,
-    blocks: list[dict[str, Any]],
-    channel_id: str,
-    thread_ts: str,
-) -> tuple[PartStartEvent | PartDeltaEvent, str, list[dict[str, Any]]]:
-    """Process a model request node."""
-    log = logger.bind(
-        ts=ts,
-        thread_ts=thread_ts,
-        channel_id=channel_id,
-    )
-    log.info("Processing model request node", node=node)
-    message_parts = []
-    new_tool_call = False
-    async with node.stream(run.ctx) as handle_stream:
-        async for event in handle_stream:
-            if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
-                message_parts.append(event.part.content)
-            elif isinstance(event, PartDeltaEvent):
-                if isinstance(event.delta, TextPartDelta):
-                    message_parts.append(event.delta.content_delta)
-                elif isinstance(event.delta, ToolCallPartDelta):
-                    # If the LLM is starting a tool call stream,
-                    # we need to break the "context" block
-                    message_parts.append(event.delta.args_delta)
-                    new_tool_call = True
-
-    if ts is not None and len(blocks) > 0:
-        # Update message (identify by ts) directly
-        log.info("Updating existing message", message_parts=message_parts)
-        msg = await _update_message(
-            blocks=blocks,
-            ts=ts,
-            new_tool_call=new_tool_call,
-            message_parts=message_parts,
-            channel_id=channel_id,
-        )
-    else:
-        # Post new message to thread or start a new conversation in channel
-        log.info("Posting new message", message_parts=message_parts)
-        msg = await _post_message(
-            message_parts=message_parts,
-            channel_id=channel_id,
-            thread_ts=thread_ts,
-        )
-
-    # Checkpoint
-    ts, blocks = msg.ts, msg.blocks
-    log.info(
-        "Caching Slack blocks",
-        blocks=blocks,
-        num_blocks=len(blocks),
-    )
-    BLOCKS_CACHE.set(ts, blocks)
-    _add_assistant_message(thread_ts, "".join(message_parts))
-
-    if event is None:
-        log.warning("No event was returned from the model request node.")
-
-    return event, ts, blocks
-
-
-async def _process_call_tools_node(
-    node,
-    run,
-    ts: str,
-    blocks: list[dict[str, Any]],
-    channel_id: str,
-    thread_ts: str,
-) -> tuple[
-    FunctionToolCallEvent | FunctionToolResultEvent | None, str, list[dict[str, Any]]
-]:
-    log = logger.bind(
-        ts=ts,
-        thread_ts=thread_ts,
-        channel_id=channel_id,
-    )
-    log.info("Processing call tools node", node=node)
-    event = None
-    async with node.stream(run.ctx) as handle_stream:
-        async for event in handle_stream:
-            if isinstance(event, FunctionToolCallEvent):
-                log.info("Requesting tool call", event=event)
-                # Request approval for tool call
-                tool_name = event.part.tool_name
-                tool_args = event.part.args
-                tool_call_id = event.call_id
-                tool_call_hash = _hash_tool_call(tool_name, tool_args)
-                is_approved = APPROVED_TOOLS_CACHE.get(tool_call_hash)
-                if is_approved:
-                    log.info(
-                        "Approved tool call. Resetting cache for tool call request.",
-                        tool_call_hash=tool_call_hash,
-                    )
-                    APPROVED_TOOLS_CACHE.delete(tool_call_hash)
-                    _add_tool_call_request(
-                        thread_ts,
-                        tool_name,
-                        tool_args,
-                        tool_call_id,
-                    )
-                else:
-                    msg = await _request_tool_approval(
-                        blocks=blocks,
-                        ts=ts,
-                        tool_name=tool_name,
-                        tool_args=tool_args,
-                        tool_call_id=tool_call_id,
-                        channel_id=channel_id,
-                    )
-                    ts, blocks = msg.ts, msg.blocks
-
-                    # Checkpoint
-                    logger.info(
-                        "Caching Slack blocks",
-                        ts=ts,
-                        blocks=blocks,
-                        num_blocks=len(blocks),
-                    )
-                    BLOCKS_CACHE.set(ts, blocks)
-                    TOOL_CALLS_CACHE.set(
-                        thread_ts,
-                        {
-                            "tool_call_id": tool_call_id,
-                            "tool_name": tool_name,
-                            "tool_args": tool_args,
-                        },
-                    )
-                    return event, ts, blocks
-
-            elif isinstance(event, FunctionToolResultEvent) and isinstance(
-                event.result, ToolReturnPart
-            ):
-                log.info("Processing tool call result", event=event)
-                # Update message with the result of the tool call
-                tool_result = event.result.content
-                tool_name = event.result.tool_name
-                tool_call_id = event.tool_call_id
-                msg = await _update_tool_approval(
-                    blocks=blocks,
-                    ts=ts,
-                    tool_result=tool_result,
-                    tool_call_id=tool_call_id,
-                    channel_id=channel_id,
-                )
-                ts, blocks = msg.ts, msg.blocks
-                logger.info(
-                    "Caching Slack blocks",
-                    ts=ts,
-                    blocks=blocks,
-                    num_blocks=len(blocks),
-                )
-                BLOCKS_CACHE.set(ts, blocks)
-                _add_tool_call_result(
-                    thread_ts,
-                    tool_name,
-                    tool_result,
-                    tool_call_id,
-                )
-
-    if event is None:
-        log.warning("No event was returned from the call tools node.")
-
-    return event, ts, blocks
-
-
-async def _run_agent(
-    agent: Agent,
-    *,
-    ts: str,
-    user_prompt: str,
-    message_history: list[ModelMessage] | None,
-    channel_id: str,
-    thread_ts: str,
-) -> dict[str, Any]:
-    log = logger.bind(
-        ts=ts,
-        thread_ts=thread_ts,
-        channel_id=channel_id,
-    )
-    log.info(
-        "🤖 Starting agent run",
-        user_prompt=user_prompt,
-        message_history=message_history,
-    )
-    async with agent.run_mcp_servers():
-        async with agent.iter(
-            user_prompt=user_prompt, message_history=message_history
-        ) as run:
-            async for node in run:
-                blocks: list[dict[str, Any]] = BLOCKS_CACHE.get(ts, [])  # type: ignore
-                log.info(
-                    "Retrieved blocks from cache", blocks=blocks, num_blocks=len(blocks)
-                )
-                if Agent.is_model_request_node(node):
-                    log.info("Processing model request node", node=node)
-                    event, ts, blocks = await _process_model_request_node(
-                        node=node,
-                        run=run,
-                        ts=ts,
-                        blocks=blocks,
-                        channel_id=channel_id,
-                        thread_ts=thread_ts,
-                    )
-
-                elif Agent.is_call_tools_node(node):
-                    log.info("Processing call tools node", node=node)
-                    event, ts, blocks = await _process_call_tools_node(
-                        node=node,
-                        run=run,
-                        ts=ts,
-                        blocks=blocks,
-                        channel_id=channel_id,
-                        thread_ts=thread_ts,
-                    )
-                    if isinstance(event, FunctionToolCallEvent):
-                        log.info("Request human-in-the-loop for tool call", event=event)
-                        break
-
-                elif Agent.is_end_node(node):
-                    blocks = BLOCKS_CACHE.get(ts, [])  # type: ignore
-                    await _send_final_message(
-                        blocks=blocks,
-                        ts=ts,
-                        channel_id=channel_id,
-                    )
-
-    blocks = BLOCKS_CACHE.get(ts, [])  # type: ignore
-    all_messages = MESSAGE_CACHE.get(thread_ts, [])  # type: ignore
-    result = {
-        "blocks": blocks,
-        "all_messages": all_messages,
-        "thread_ts": thread_ts,
-        "ts": ts,
-    }
-    return result
-
-
-class AgentRunError(RuntimeError):
-    """Error raised when the agent run fails."""
+class SlackMCPHost(MCPHost):
+    """Slack implementation of MCPHost."""
 
     def __init__(
         self,
-        exc_cls: type[Exception],
-        exc_msg: str,
-        message_history: list[dict] | None = None,
+        model_name: str,
+        model_provider: str,
+        mcp_servers: list,
+        approved_tool_calls: list[str] | None = None,
+        agent_settings: dict[str, Any] | None = None,
     ):
-        self.exc_cls = exc_cls
-        self.exc_msg = exc_msg
-        self.message_history = message_history
+        # Initialize memory
+        memory = FanoutCacheMemory()
 
-        # Build comprehensive error message with debug info
-        msg_parts = [f"Agent run failed with unhandled error: {exc_cls.__name__}"]
-
-        if exc_msg or message_history:
-            msg_parts.append("")  # Empty line before details
-
-        if exc_msg:
-            msg_parts.extend(
-                [
-                    "Error details:",
-                    f"  Type: {exc_cls.__name__}",
-                    f"  Message: {exc_msg}",
-                ]
-            )
-
-        if message_history:
-            if exc_msg:
-                msg_parts.append("")  # Space between sections
-            msg_parts.extend(
-                ["Agent message history:", json.dumps(message_history, indent=2)]
-            )
-
-        super().__init__("\n".join(msg_parts))
-
-
-@registry.register(
-    default_title="(Experimental) MCP Slack chatbot",
-    description="Chat with a MCP server using Slack.",
-    display_group="MCP",
-    doc_url="https://ai.pydantic.dev/mcp/client/",
-    secrets=[
-        mcp_secret,
-        anthropic_secret,
-        openai_secret,
-        gemini_secret,
-        bedrock_secret,
-        slack_secret,
-    ],
-    namespace="mcp.host",
-)
-async def slackbot(
-    trigger: Annotated[dict[str, Any] | None, Doc("Webhook trigger payload")],
-    channel_id: Annotated[
-        str,
-        Doc(
-            "Slack channel ID of the channel where the user is interacting with the bot."
-        ),
-    ],
-    agent_settings: Annotated[dict[str, Any], Doc("Agent settings")],
-    base_url: Annotated[str, Doc("Base URL of the MCP server.")],
-    timeout: Annotated[int, Doc("Initial connection timeout in seconds.")] = 10,
-):
-    log = logger.bind(
-        channel_id=channel_id,
-        event_type="slack_chat",
-    )
-    log.info("Starting Slack chat handler")
-
-    headers = secrets.get("MCP_HTTP_HEADERS")
-    if headers is not None:
-        headers = orjson.loads(headers)
-    server = MCPServerHTTP(base_url, headers=headers, timeout=timeout)
-    agent = build_agent(**agent_settings, mcp_servers=[server])
-
-    slack_event = None
-    slack_payload = None
-    if isinstance(trigger, dict):
-        if "payload" in trigger:
-            slack_payload = orjson.loads(trigger["payload"])
-            log.info("Received Slack interaction payload")
-        else:
-            slack_event = trigger
-            log.info("Received Slack event")
-    else:
-        raise ValueError(f"Invalid trigger type. Expected JSON object. Got {trigger!r}")
-
-    if slack_event is not None:
-        # App mentions (can either be a new conversation or a continuation)
-        slack_event_payload = SlackEventPayload.model_validate(slack_event)
-        thread_ts = slack_event_payload.thread_ts
-        ts = slack_event_payload.ts
-        user_prompt = slack_event_payload.user_prompt
-        message_history = _get_message_history(thread_ts)
-
-        log = log.bind(
-            thread_ts=thread_ts,
-            ts=ts,
-            event_type="app_mention",
+        super().__init__(
+            model_name=model_name,
+            model_provider=model_provider,
+            memory=memory,
+            mcp_servers=mcp_servers,
+            approved_tool_calls=approved_tool_calls,
+            agent_settings=agent_settings,
         )
-        log.info("Processing app mention")
 
-        # Add user message to message history
-        _add_user_message(thread_ts, user_prompt)
+        # Slack-specific caches
+        self.blocks_cache = dc.FanoutCache(
+            directory=".cache/blocks", shards=8, timeout=0.05
+        )  # key=ts
+        # TODO: Implement this as an ABC class to interface with a global interactions table in the future
+        # Should be managed directly by the MCPHost class
+        self.tool_results_cache = dc.FanoutCache(
+            directory=".cache/tool_results", shards=8, timeout=0.05
+        )  # key=tool_call_id
 
-    elif slack_payload is not None:
-        # Approval buttons (assume the user has already started a conversation)
-        slack_interaction_payload = SlackInteractionPayload.model_validate(
-            slack_payload
-        )
-        thread_ts = slack_interaction_payload.thread_ts
-        ts = slack_interaction_payload.ts
+    async def post_message_start(self, deps: MCPHostDeps) -> MessageStartResult:
+        """Called when a new model request / assistant message starts."""
+        # Cast to SlackMCPHostDeps for Slack-specific fields
+        slack_deps = deps if isinstance(deps, SlackMCPHostDeps) else None
+        if slack_deps is None:
+            raise ValueError("SlackMCPHost requires SlackMCPHostDeps")
 
-        # Check if this is a view_result action
-        if slack_interaction_payload.action_value == "view_result":
-            log = log.bind(
-                thread_ts=thread_ts,
-                ts=ts,
-                event_type="view_result",
-            )
-            log.info("Processing view_result interaction")
-            await _handle_view_result_modal(slack_interaction_payload)
+        thread_ts = slack_deps.conversation_id
 
-            # Return early, as we don't need to run the agent for this interaction
-            return {
-                "thread_ts": thread_ts,
-                "ts": ts,
-                "action": "view_result",
+        # Get bot and user info to avoid triggering notifications
+        bot_info = await call_method("auth_test")
+        bot_id = bot_info["user_id"]
+
+        # Get user info for display name
+        user_info = await call_method("users_info", params={"user": slack_deps.user_id})
+        user_name = user_info["user"]["name"]
+
+        # Get bot info for display name
+        bot_user_info = await call_method("users_info", params={"user": bot_id})
+        bot_name = bot_user_info["user"]["name"]
+
+        # Create initial context message (no notifications)
+        msg = f"@{bot_name} is conversing with @{user_name}"
+
+        blocks = [
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": msg}],
             }
+        ]
 
-        else:
-            # Get message history
-            message_history = _get_message_history(thread_ts)
-
-            # Get cached blocks and tool call ID
-            blocks: list[dict[str, Any]] | None = BLOCKS_CACHE.get(ts)  # type: ignore
-            tool_call: dict[str, str] | None = TOOL_CALLS_CACHE.get(thread_ts)  # type: ignore
-            if blocks is None:
-                raise ValueError(f"No cached blocks found for timestamp {ts}")
-            if tool_call is None:
-                raise ValueError(
-                    f"No cached tool call ID found for thread timestamp {thread_ts}"
-                )
-            log.info("Retrieved cached blocks", blocks=blocks, num_blocks=len(blocks))
-            log.info("Retrieved cached tool call ID", tool_call=tool_call)
-
-            tool_call_id = tool_call["tool_call_id"]
-            tool_name = tool_call["tool_name"]
-            tool_args = tool_call["tool_args"]
-
-            log = log.bind(
-                thread_ts=thread_ts,
-                ts=ts,
-                tool_call_id=tool_call_id,
-                tool_name=tool_name,
-                tool_args=tool_args,
-                event_type="interaction",
-            )
-            log.info("Processing interaction")
-
-            msg = await _receive_approval(
-                blocks=blocks,
-                ts=slack_interaction_payload.ts,
-                action_value=slack_interaction_payload.action_value,
-                tool_name=tool_name,
-                tool_args=tool_args,
-                tool_call_id=tool_call_id,
-                channel_id=channel_id,
-            )
-            ts, blocks = msg.ts, msg.blocks
-            log.info("Updated blocks", blocks=blocks, num_blocks=len(blocks))
-            if slack_interaction_payload.action_value == "run":
-                user_prompt = (
-                    "Run the previously approved tool call now. "
-                    "Return the complete result in a structured format. "
-                    "Summarize key findings briefly."
-                )
-            else:
-                user_prompt = (
-                    "The user declined the tool call. "
-                    "Acknowledge this politely and continue helping with their original request. "
-                    "Only suggest alternative approaches if you cannot answer their question without tools."
-                )
-            BLOCKS_CACHE.set(ts, blocks)
-
-    else:
-        raise ValueError(
-            "Either `slack_event` or `slack_payload` must be provided. Got null values for both."
+        # Post the initial message
+        response = await call_method(
+            "chat_postMessage",
+            params={
+                "channel": slack_deps.channel_id,
+                "thread_ts": thread_ts,
+                "blocks": blocks,
+            },
         )
 
-    # Run the agent and handle its response
-    try:
-        result = await _run_agent(
-            agent=agent,
-            ts=ts,
-            user_prompt=user_prompt,
-            message_history=message_history,
-            channel_id=channel_id,
+        message_id = response["ts"]
+        self.blocks_cache.set(message_id, blocks)
+
+        logger.info(
+            "Posted message start",
             thread_ts=thread_ts,
+            ts=message_id,
+            bot_name=bot_name,
+            user_name=user_name,
         )
-    except ExceptionGroup as e:
-        # Extract the first error from the exception group
-        exc = e.exceptions[0]
-        if isinstance(exc, httpx.ConnectError):
-            raise ConnectionError(f"Failed to connect to MCP server: {exc!s}") from exc
-        else:
-            blocks = BLOCKS_CACHE.get(ts, [])  # type: ignore
-            await _post_error_message(
-                blocks=blocks,
-                channel_id=channel_id,
-                ts=ts,
-                thread_ts=thread_ts,
-            )
-            raise AgentRunError(
-                exc_cls=type(exc),
-                exc_msg=str(exc),
-                message_history=MESSAGE_CACHE.get(thread_ts, []),  # type: ignore
-            ) from exc
-    except Exception as e:
-        blocks = BLOCKS_CACHE.get(ts, [])  # type: ignore
-        await _post_error_message(
-            blocks=blocks,
-            channel_id=channel_id,
-            ts=ts,
-            thread_ts=thread_ts,
-        )
-        raise AgentRunError(
-            exc_cls=type(e),
-            exc_msg=str(e),
-            message_history=MESSAGE_CACHE.get(thread_ts, []),  # type: ignore
-        ) from e
 
-    return result
+        return MessageStartResult(message_id=message_id)
 
+    async def update_message(
+        self, result: ModelRequestNodeResult, deps: MCPHostDeps
+    ) -> None:
+        """Update an existing message in Slack."""
+        slack_deps = deps if isinstance(deps, SlackMCPHostDeps) else None
+        if slack_deps is None:
+            raise ValueError("SlackMCPHost requires SlackMCPHostDeps")
 
-async def _post_error_message(
-    blocks: list[dict[str, Any]] | None,
-    ts: str,
-    *,
-    channel_id: str,
-    thread_ts: str,
-) -> None:
-    """Post an error message to Slack."""
+        message = "".join(result.text_parts)
+        blocks = self.blocks_cache.get(slack_deps.message_id, [])
+        if not isinstance(blocks, list):
+            blocks = []
 
-    bot_id = (await call_method("auth_test"))["user_id"]
-    bot_name = (await call_method("users_info", params={"user": bot_id}))["user"][
-        "name"
-    ]
-    msg = (
-        "‼️ Unexpected error occurred. "
-        f"Please wait a moment and mention `@{bot_name}` in the thread to continue the conversation."
-    )
-
-    if blocks is not None and len(blocks) > 0:
-        # Check if the last block is a tool call
+        # Check if most recent block is a tool call
         updated_blocks = [*blocks]
-        last_block = blocks[-1]
-        if last_block.get("block_id", "").startswith("tool_call:"):
-            # Replace the last block with a section block
-            # Replace hourglass emoji with red cross emoji
-            last_block["elements"][0]["text"] = (
-                last_block["elements"][0]["text"]
-                .replace("⏳", "❌")
-                .replace(":hourglass_flowing_sand:", "x")
-            )
-            # Update the last block
+        if blocks and blocks[-1].get("block_id", "").startswith("tool_call:"):
+            # Replace hourglass emoji with ok emoji
+            last_block = blocks[-1].copy()
+            last_block.pop("block_id", None)
+            if last_block.get("type") == "context":
+                last_block["elements"][0]["text"] = (
+                    last_block["elements"][0]["text"]
+                    .replace("⏳", "🆗")
+                    .replace(":hourglass_flowing_sand:", ":ok:")
+                )
             updated_blocks[-1] = last_block
-            # Update the blocks
-            await call_method(
-                "chat_update",
-                params={
-                    "channel": channel_id,
-                    "ts": ts,
-                    "blocks": updated_blocks,
-                },
-            )
 
-    await call_method(
-        "chat_postMessage",
-        params={
-            "channel": channel_id,
-            "thread_ts": thread_ts,
-            "blocks": [
-                {
-                    "type": "context",
-                    "elements": [{"type": "mrkdwn", "text": msg}],
-                }
-            ],
-        },
-    )
-
-
-def _update_last_tool_block(last_block: dict[str, Any]) -> dict[str, Any]:
-    updated_block = last_block.copy()  # Create a copy to avoid side effects
-    # Drop block ID
-    updated_block.pop("block_id", None)
-    # Replace hourglass emoji with ok emoji
-    if updated_block.get("type") == "context":
-        updated_block["elements"][0]["text"] = (
-            updated_block["elements"][0]["text"]
-            .replace("⏳", "🆗")
-            .replace(":hourglass_flowing_sand:", ":ok:")
-        )
-    return updated_block
-
-
-async def _post_message(
-    message_parts: list[str],
-    channel_id: str,
-    thread_ts: str,
-) -> SlackMessage:
-    """Post a message to Slack."""
-    msg = "".join(message_parts)
-    blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": msg}}]
-    response = await call_method(
-        "chat_postMessage",
-        params={
-            "channel": channel_id,
-            "thread_ts": thread_ts,
-            "text": msg,
-            "blocks": blocks,
-        },
-    )
-    return SlackMessage(ts=response["ts"], blocks=blocks)
-
-
-async def _update_message(
-    blocks: list[dict[str, Any]],
-    ts: str,
-    *,
-    new_tool_call: bool,
-    message_parts: list[str],
-    channel_id: str,
-) -> SlackMessage:
-    """Send message parts to Slack."""
-    message = "".join(message_parts)
-
-    # Check if most recent block is a tool call
-    updated_blocks = [*blocks]
-    last_block = blocks[-1]
-    if last_block.get("block_id", "").startswith("tool_call:"):
-        # Replace hourglass emoji with ok emoji
-        updated_block = _update_last_tool_block(last_block)
-        updated_blocks[-1] = updated_block
-        if not new_tool_call:
-            # Add new context block
+            # Check if this is a new tool call
+            new_tool_call = len(result.tool_call_parts) > 0
+            if not new_tool_call:
+                # Add new context block
+                updated_blocks.append(
+                    {
+                        "type": "context",
+                        "block_id": f"tool_call:{uuid.uuid1()}",
+                        "elements": [{"type": "mrkdwn", "text": f"⏳ {message}"}],
+                    }
+                )
+        else:
             updated_blocks.append(
                 {
-                    "type": "context",
-                    "block_id": f"tool_call:{uuid.uuid1()}",
-                    "elements": [{"type": "mrkdwn", "text": f"⏳ {message}"}],
+                    "type": "section",
+                    "block_id": f"message:{uuid.uuid1()}",
+                    "text": {"type": "mrkdwn", "text": message},
                 }
             )
-    else:
-        updated_blocks.append(
-            {
-                "type": "section",
-                "block_id": f"message:{uuid.uuid1()}",
-                "text": {"type": "mrkdwn", "text": message},
-            }
+
+        # Update the Slack message
+        await call_method(
+            "chat_update",
+            params={
+                "channel": slack_deps.channel_id,
+                "ts": slack_deps.message_id,
+                "blocks": updated_blocks,
+            },
         )
 
-    response = await call_method(
-        "chat_update",
-        params={
-            "channel": channel_id,
-            "ts": ts,
-            "text": message,
-            "blocks": updated_blocks,
-        },
-    )
-    return SlackMessage(ts=response["ts"], blocks=updated_blocks)
+        self.blocks_cache.set(slack_deps.message_id, updated_blocks)
 
+        logger.info(
+            "Updated message",
+            thread_ts=slack_deps.conversation_id,
+            ts=slack_deps.message_id,
+            message=message,
+        )
 
-async def _request_tool_approval(
-    blocks: list[dict[str, Any]],
-    ts: str,
-    *,
-    tool_name: str,
-    tool_args: str | dict[str, Any],
-    tool_call_id: str,
-    channel_id: str,
-) -> SlackMessage:
-    """Request approval from the user on Slack.
+    async def request_tool_approval(
+        self, result: ToolCallRequestResult, deps: MCPHostDeps
+    ) -> None:
+        """Request approval for a tool call via Slack buttons."""
+        slack_deps = deps if isinstance(deps, SlackMCPHostDeps) else None
+        if slack_deps is None:
+            raise ValueError("SlackMCPHost requires SlackMCPHostDeps")
 
-    Returns the thread timestamp of the interactive message that was posted.
-    """
-    buttons = format_buttons(
-        [
-            {
-                "text": "➡️ Run tool",
-                "action_id": f"run:{tool_call_id}",
-                "value": "run",
-                "style": "primary",
+        blocks = self.blocks_cache.get(slack_deps.message_id, [])
+        if not isinstance(blocks, list):
+            blocks = []
+
+        # Generate a tool call ID for this request
+        tool_call_id = str(uuid.uuid4())
+
+        buttons = format_buttons(
+            [
+                {
+                    "text": "➡️ Run tool",
+                    "action_id": f"run:{tool_call_id}",
+                    "value": "run",
+                    "style": "primary",
+                },
+                {
+                    "text": "Skip",
+                    "action_id": f"skip:{tool_call_id}",
+                    "value": "skip",
+                },
+            ],
+            block_id=f"tool_call:{tool_call_id}",
+        )
+
+        updated_blocks = [*blocks]
+        updated_blocks.extend(
+            [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"> *⚙️ {result.name}*\n> ```\n{json.dumps(result.args, indent=2)}\n```",
+                    },
+                },
+                buttons,
+            ]
+        )
+
+        # Update the Slack message
+        await call_method(
+            "chat_update",
+            params={
+                "channel": slack_deps.channel_id,
+                "ts": slack_deps.message_id,
+                "blocks": updated_blocks,
             },
-            {
-                "text": "Skip",
-                "action_id": f"skip:{tool_call_id}",
-                "value": "skip",
-            },
-        ],
-        block_id=f"tool_call:{tool_call_id}",
-    )
+        )
 
-    updated_blocks = [*blocks]
-    updated_blocks.extend(
-        [
+        self.blocks_cache.set(slack_deps.message_id, updated_blocks)
+
+        logger.info(
+            "Requested tool approval",
+            thread_ts=slack_deps.conversation_id,
+            ts=slack_deps.message_id,
+            tool_name=result.name,
+            tool_call_id=tool_call_id,
+        )
+
+    async def post_tool_approval(
+        self, result: ToolCallRequestResult, approved: bool, deps: MCPHostDeps
+    ) -> None:
+        """Update the message after tool approval/rejection."""
+        slack_deps = deps if isinstance(deps, SlackMCPHostDeps) else None
+        if slack_deps is None:
+            raise ValueError("SlackMCPHost requires SlackMCPHostDeps")
+
+        blocks = self.blocks_cache.get(slack_deps.message_id, [])
+        if not isinstance(blocks, list):
+            blocks = []
+        updated_blocks = []
+
+        # Find and update the tool call block
+        for block in blocks:
+            if block.get("block_id", "").startswith("tool_call:"):
+                if approved:
+                    msg = "⏳ Running tool..."
+                    block = {
+                        "type": "context",
+                        "block_id": block["block_id"],
+                        "elements": [{"type": "mrkdwn", "text": msg}],
+                    }
+                else:
+                    msg = "⏭️ Skipped tool."
+                    block = {
+                        "type": "context",
+                        "block_id": block["block_id"],
+                        "elements": [{"type": "mrkdwn", "text": msg}],
+                    }
+            updated_blocks.append(block)
+
+        # Update the Slack message
+        await call_method(
+            "chat_update",
+            params={
+                "channel": slack_deps.channel_id,
+                "ts": slack_deps.message_id,
+                "blocks": updated_blocks,
+            },
+        )
+
+        self.blocks_cache.set(slack_deps.message_id, updated_blocks)
+
+        logger.info(
+            "Posted tool approval",
+            thread_ts=slack_deps.conversation_id,
+            ts=slack_deps.message_id,
+            tool_name=result.name,
+            approved=approved,
+        )
+
+    async def post_tool_result(
+        self, result: ToolResultNodeResult, deps: MCPHostDeps
+    ) -> None:
+        """Post the result of a tool call."""
+        slack_deps = deps if isinstance(deps, SlackMCPHostDeps) else None
+        if slack_deps is None:
+            raise ValueError("SlackMCPHost requires SlackMCPHostDeps")
+
+        blocks = self.blocks_cache.get(slack_deps.message_id, [])
+        if not isinstance(blocks, list):
+            blocks = []
+        updated_blocks = [*blocks]
+
+        # Store the result in cache for modal display
+        result_id = (
+            f"{result.call_id}_{uuid.uuid4().hex[:8]}"
+            if result.call_id
+            else str(uuid.uuid4())
+        )
+        self.tool_results_cache.set(result_id, result.content)
+
+        # Replace hourglass emoji with ok emoji in the last block
+        if updated_blocks:
+            last_block = updated_blocks[-1].copy()
+            last_block.pop("block_id", None)
+            if last_block.get("type") == "context":
+                last_block["elements"][0]["text"] = (
+                    last_block["elements"][0]["text"]
+                    .replace("⏳", "🆗")
+                    .replace(":hourglass_flowing_sand:", ":ok:")
+                )
+            updated_blocks[-1] = last_block
+
+        # Add view result button
+        if result.call_id:
+            updated_blocks.append(
+                {
+                    "type": "actions",
+                    "block_id": f"tool_result:{result.call_id}",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "✅ View tool result",
+                                "emoji": True,
+                            },
+                            "value": result_id,
+                            "action_id": f"view_result:{result.call_id}",
+                        }
+                    ],
+                }
+            )
+
+        # Update the Slack message
+        await call_method(
+            "chat_update",
+            params={
+                "channel": slack_deps.channel_id,
+                "ts": slack_deps.message_id,
+                "blocks": updated_blocks,
+            },
+        )
+
+        self.blocks_cache.set(slack_deps.message_id, updated_blocks)
+
+        logger.info(
+            "Posted tool result",
+            thread_ts=slack_deps.conversation_id,
+            ts=slack_deps.message_id,
+            tool_name=result.name,
+            result_id=result_id,
+        )
+
+    async def post_message_end(self, deps: MCPHostDeps) -> None:
+        """Post a final message when the conversation ends."""
+        slack_deps = deps if isinstance(deps, SlackMCPHostDeps) else None
+        if slack_deps is None:
+            raise ValueError("SlackMCPHost requires SlackMCPHostDeps")
+
+        blocks = self.blocks_cache.get(slack_deps.message_id, [])
+        if not isinstance(blocks, list):
+            blocks = []
+        updated_blocks = [*blocks]
+
+        # Add tip message
+        updated_blocks.append(
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"> *⚙️ {tool_name}*\n> ```\n{json.dumps(tool_args, indent=2)}\n```",
+                    "text": "💡 Tip: Mention the bot in the thread to continue the conversation.",
                 },
-            },
-            buttons,
-        ]
-    )
-    logger.info("Posting tool call approval", blocks=updated_blocks)
-    response = await call_method(
-        "chat_update",
-        params={
-            "channel": channel_id,
-            "ts": ts,
-            "text": "Requesting tool call approval",
-            "blocks": updated_blocks,
-        },
-    )
-    interaction_ts = response["ts"]
-    return SlackMessage(ts=interaction_ts, blocks=updated_blocks)
-
-
-async def _receive_approval(
-    blocks: list[dict[str, Any]],
-    ts: str,
-    *,
-    action_value: str,
-    tool_name: str,
-    tool_args: str | dict[str, Any],
-    tool_call_id: str,
-    channel_id: str,
-) -> SlackMessage:
-    """Disable the buttons for a tool call."""
-    msg = None
-    updated_blocks = []
-    tool_call_hash = _hash_tool_call(tool_name, tool_args)
-    for block in blocks:
-        if block.get("block_id") == f"tool_call:{tool_call_id}":
-            if action_value == "run":
-                msg = "⏳ Running tool..."
-                block = {
-                    "type": "context",
-                    "block_id": f"tool_call:{tool_call_id}",
-                    "elements": [{"type": "mrkdwn", "text": msg}],
-                }
-                APPROVED_TOOLS_CACHE.set(tool_call_hash, True)
-            elif action_value == "skip":
-                msg = "⏭️ Skipped tool."
-                block = {
-                    "type": "context",
-                    "block_id": f"tool_call:{tool_call_id}",
-                    "elements": [{"type": "mrkdwn", "text": msg}],
-                }
-                APPROVED_TOOLS_CACHE.set(tool_call_hash, False)
-            else:
-                raise ValueError(
-                    f"Invalid Slack action value. Got {action_value!r}. Expected 'run' or 'skip'."
-                )
-        updated_blocks.append(block)
-
-    if msg is None:
-        raise ValueError(
-            f"Expected Slack block with block_id {f'tool_call:{tool_call_id}'}. Got {blocks!r}."
+            }
         )
 
-    response = await call_method(
-        "chat_update",
-        params={
-            "channel": channel_id,
-            "ts": ts,
-            "text": msg,
-            "blocks": updated_blocks,
-        },
-    )
-    return SlackMessage(ts=response["ts"], blocks=updated_blocks)
-
-
-async def _update_tool_approval(
-    blocks: list[dict[str, Any]],
-    ts: str,
-    *,
-    tool_result: str,
-    tool_call_id: str,
-    channel_id: str,
-):
-    """Update the message with the result of the tool call."""
-    updated_blocks = [*blocks]
-
-    # Store the result in cache instead of the button
-    result_id = f"{tool_call_id}_{uuid.uuid4().hex[:8]}"
-    TOOL_RESULTS_CACHE.set(result_id, tool_result)
-
-    # Replace hourglass emoji with ok emoji
-    last_block = updated_blocks[-1]
-    updated_block = _update_last_tool_block(last_block)
-    updated_blocks[-1] = updated_block
-
-    # Add view result button
-    updated_blocks.append(
-        {
-            "type": "actions",
-            "block_id": f"tool_result:{tool_call_id}",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "✅ View tool result",
-                        "emoji": True,
-                    },
-                    "value": result_id,
-                    "action_id": f"view_result:{tool_call_id}",
-                }
-            ],
-        }
-    )
-
-    response = await call_method(
-        "chat_update",
-        params={
-            "channel": channel_id,
-            "ts": ts,
-            "text": "Tool call completed",
-            "blocks": updated_blocks,
-        },
-    )
-    return SlackMessage(ts=response["ts"], blocks=updated_blocks)
-
-
-async def _open_tool_result_modal(
-    trigger_id: str,
-    tool_result: str,
-    tool_call_id: str,
-):
-    """Open a modal with the tool result."""
-    # Create modal view with a limit on text length to prevent Slack errors
-    # Slack has various limits including 3000 chars for text blocks
-    max_length = 2900  # Safe limit for modal text blocks
-    is_truncated = len(tool_result) > max_length
-    if is_truncated:
-        tool_result = tool_result[:max_length] + "..."
-
-    modal_blocks = [
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": f"*Tool Call ID:* `{tool_call_id}`"},
-        },
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": f"```\n{tool_result}\n```"},
-        },
-    ]
-
-    modal_view = {
-        "type": "modal",
-        "title": {"type": "plain_text", "text": "Tool Result"},
-        "blocks": modal_blocks,
-    }
-    await call_method(
-        "views_open",
-        params={
-            "trigger_id": trigger_id,
-            "view": modal_view,
-        },
-    )
-
-
-async def _send_final_message(
-    blocks: list[dict[str, Any]],
-    ts: str,
-    *,
-    channel_id: str,
-) -> SlackMessage:
-    """Send the final message to Slack."""
-    # Get name of bot
-    bot_id = (await call_method("auth_test"))["user_id"]
-    bot_name = (await call_method("users_info", params={"user": bot_id}))["user"][
-        "name"
-    ]
-    updated_blocks = [*blocks]
-    updated_blocks.append(
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"💡 Tip: Mention `@{bot_name}` in the thread to continue the conversation.",
+        # Update the Slack message
+        await call_method(
+            "chat_update",
+            params={
+                "channel": slack_deps.channel_id,
+                "ts": slack_deps.message_id,
+                "blocks": updated_blocks,
             },
+        )
+
+        self.blocks_cache.set(slack_deps.message_id, updated_blocks)
+
+        logger.info(
+            "Posted message end",
+            thread_ts=slack_deps.conversation_id,
+            ts=slack_deps.message_id,
+        )
+
+    async def post_error_message(self, exc: Exception, deps: MCPHostDeps) -> None:
+        """Post an error message to Slack."""
+        slack_deps = deps if isinstance(deps, SlackMCPHostDeps) else None
+        if slack_deps is None:
+            raise ValueError("SlackMCPHost requires SlackMCPHostDeps")
+
+        blocks = self.blocks_cache.get(slack_deps.message_id, [])
+        if not isinstance(blocks, list):
+            blocks = []
+
+        msg = (
+            "‼️ Unexpected error occurred. "
+            "Please wait a moment and mention the bot in the thread to continue the conversation."
+        )
+
+        if blocks:
+            # Check if the last block is a tool call and update it
+            updated_blocks = [*blocks]
+            last_block = blocks[-1]
+            if last_block.get("block_id", "").startswith("tool_call:"):
+                # Replace hourglass emoji with red cross emoji
+                last_block["elements"][0]["text"] = (
+                    last_block["elements"][0]["text"]
+                    .replace("⏳", "❌")
+                    .replace(":hourglass_flowing_sand:", "x")
+                )
+                updated_blocks[-1] = last_block
+
+                # Update the Slack message
+                await call_method(
+                    "chat_update",
+                    params={
+                        "channel": slack_deps.channel_id,
+                        "ts": slack_deps.message_id,
+                        "blocks": updated_blocks,
+                    },
+                )
+
+                self.blocks_cache.set(slack_deps.message_id, updated_blocks)
+
+        # Post error context block as a separate message in the thread
+        error_blocks = [
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": msg}],
+            }
+        ]
+
+        await call_method(
+            "chat_postMessage",
+            params={
+                "channel": slack_deps.channel_id,
+                "thread_ts": slack_deps.conversation_id,
+                "blocks": error_blocks,
+            },
+        )
+
+        logger.error(
+            "Posted error message",
+            thread_ts=slack_deps.conversation_id,
+            ts=slack_deps.message_id,
+            error=str(exc),
+        )
+
+    async def handle_view_result_modal(self, payload: SlackInteractionPayload) -> None:
+        """Handle opening a modal to display tool results."""
+        result_id = payload.result_id
+        tool_call_id = payload.tool_call_id
+
+        if result_id is None or tool_call_id is None:
+            raise ValueError(
+                "Missing result_id or tool_call_id from interaction payload"
+            )
+
+        trigger_id = payload.trigger_id
+        if trigger_id is None:
+            raise ValueError("Cannot open modal: missing trigger_id")
+
+        # Load result from cache
+        tool_result = self.tool_results_cache.get(result_id)
+        if tool_result is None:
+            tool_result = "Unable to retrieve tool result from cache."
+        else:
+            tool_result = str(tool_result)
+
+        # Open modal with the tool result
+        await self._open_tool_result_modal(
+            trigger_id=trigger_id,
+            tool_result=tool_result,
+            tool_call_id=tool_call_id,
+        )
+
+    async def _open_tool_result_modal(
+        self,
+        trigger_id: str,
+        tool_result: str,
+        tool_call_id: str,
+    ) -> None:
+        """Open a modal with the tool result."""
+        # Create modal view with a limit on text length to prevent Slack errors
+        max_length = 2900  # Safe limit for modal text blocks
+        is_truncated = len(tool_result) > max_length
+        if is_truncated:
+            tool_result = tool_result[:max_length] + "..."
+
+        modal_blocks = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*Tool Call ID:* `{tool_call_id}`"},
+            },
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"```\n{tool_result}\n```"},
+            },
+        ]
+
+        modal_view = {
+            "type": "modal",
+            "title": {"type": "plain_text", "text": "Tool Result"},
+            "blocks": modal_blocks,
         }
-    )
-    response = await call_method(
-        "chat_update",
-        params={"channel": channel_id, "ts": ts, "blocks": updated_blocks},
-    )
-    return SlackMessage(ts=response["ts"], blocks=updated_blocks)
 
-
-async def _handle_view_result_modal(payload: SlackInteractionPayload) -> None:
-    """Handle opening a modal to display tool results.
-
-    Args:
-        slack_interaction_payload: The validated Slack interaction payload
-
-    Raises:
-        ValueError: If required data is missing
-        RuntimeError: If there's an error opening the modal
-    """
-    # Use computed properties instead of direct data manipulation
-    result_id = payload.result_id
-    tool_call_id = payload.tool_call_id
-
-    if result_id is None or tool_call_id is None:
-        error_msg = "Missing result_id or tool_call_id from interaction payload"
-        raise ValueError(error_msg)
-
-    # Process trigger_id immediately to avoid expiration
-    # Trigger IDs expire within 3 seconds of the user action
-    trigger_id = payload.trigger_id
-    if trigger_id is None:
-        error_msg = "Cannot open modal: missing trigger_id"
-        raise ValueError(error_msg)
-
-    # Load result from cache first, before any other async operations
-    tool_result = None
-    if result_id.startswith(tool_call_id + "_"):
-        cached_result = TOOL_RESULTS_CACHE.get(result_id)
-        if cached_result is not None:
-            tool_result = str(cached_result)
-
-    # If we couldn't get a result from cache, use a placeholder
-    if tool_result is None:
-        tool_result = "Unable to retrieve tool result from cache."
-
-    # Open modal with minimal delay
-    await _open_tool_result_modal(
-        trigger_id=trigger_id,
-        tool_result=tool_result,
-        tool_call_id=tool_call_id,
-    )
+        await call_method(
+            "views_open",
+            params={
+                "trigger_id": trigger_id,
+                "view": modal_view,
+            },
+        )

--- a/registry/tracecat_registry/integrations/mcp/hosts/slack.py
+++ b/registry/tracecat_registry/integrations/mcp/hosts/slack.py
@@ -932,12 +932,14 @@ async def slackbot(
         deps = handler_result.deps
         user_prompt = handler_result.user_prompt
         message_history = handler_result.message_history
+        new_message = True
 
     elif slack_payload is not None:
         log.info("Received Slack interaction payload")
         interaction_result = await _handle_slack_interaction(
             slack_payload, slack_host, channel_id, log
         )
+        new_message = False
 
         # If it's a view_result interaction, return early
         if isinstance(interaction_result, SlackViewResultResponse):
@@ -958,6 +960,7 @@ async def slackbot(
     # Run the agent
     result = await slack_host.run(
         user_prompt=user_prompt,
+        new_message=new_message,
         deps=deps,
         message_history=message_history,
     )

--- a/registry/tracecat_registry/integrations/mcp/hosts/slack.py
+++ b/registry/tracecat_registry/integrations/mcp/hosts/slack.py
@@ -952,6 +952,7 @@ async def slackbot(
         deps = interaction_result.deps
         user_prompt = interaction_result.user_prompt
         message_history = interaction_result.message_history
+
     else:
         raise ValueError(
             "Either `slack_event` or `slack_payload` must be provided. Got null values for both."

--- a/registry/tracecat_registry/integrations/mcp/memory.py
+++ b/registry/tracecat_registry/integrations/mcp/memory.py
@@ -1,0 +1,123 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+import diskcache as dc
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_core import to_jsonable_python
+
+
+class ShortTermMemory(ABC):
+    """Lightweight abstract base class for short-term conversation memory management.
+
+    - Short-term memory is defined as the memory of the current conversation only.
+    - This interface is designed to be minimal and platform-agnostic.
+    - We want to allow easy swapping between different persistent stores.
+    """
+
+    @abstractmethod
+    async def get_messages(self, conversation_id: str) -> list[ModelMessage]:
+        """Get the message history for a conversation."""
+        pass
+
+    @abstractmethod
+    async def add_user_message(self, conversation_id: str, content: str) -> None:
+        """Add a user message to the conversation."""
+        pass
+
+    @abstractmethod
+    async def add_assistant_message(self, conversation_id: str, content: str) -> None:
+        """Add an assistant message to the conversation."""
+        pass
+
+    @abstractmethod
+    async def add_tool_call(
+        self,
+        conversation_id: str,
+        tool_name: str,
+        tool_args: str | dict[str, Any],
+        tool_call_id: str,
+    ) -> None:
+        """Add a tool call to the conversation."""
+        pass
+
+    @abstractmethod
+    async def add_tool_result(
+        self, conversation_id: str, tool_name: str, result: str, tool_call_id: str
+    ) -> None:
+        """Add a tool result to the conversation."""
+        pass
+
+    @abstractmethod
+    async def clear_conversation(self, conversation_id: str) -> None:
+        """Clear all messages for a conversation."""
+        pass
+
+
+class FanoutCacheMemory(ShortTermMemory):
+    """FanoutCache-based memory implementation."""
+
+    def __init__(
+        self, directory: str = ".cache/messages", shards: int = 8, timeout: float = 0.05
+    ):
+        self.cache = dc.FanoutCache(directory=directory, shards=shards, timeout=timeout)
+
+    async def get_messages(self, conversation_id: str) -> list[ModelMessage]:
+        """Get the message history for a conversation."""
+        messages = self.cache.get(conversation_id, [])
+        return ModelMessagesTypeAdapter.validate_python(messages)
+
+    async def add_user_message(self, conversation_id: str, content: str) -> None:
+        """Add a user message to the conversation."""
+        messages: list[dict[str, Any]] = self.cache.get(conversation_id, [])  # type: ignore
+        user_prompt = ModelRequest.user_text_prompt(user_prompt=content)
+        messages.append(to_jsonable_python(user_prompt))
+        self.cache.set(conversation_id, messages)
+
+    async def add_assistant_message(self, conversation_id: str, content: str) -> None:
+        """Add an assistant message to the conversation."""
+        messages: list[dict[str, Any]] = self.cache.get(conversation_id, [])  # type: ignore
+        assistant_response = ModelResponse(parts=[TextPart(content=content)])
+        messages.append(to_jsonable_python(assistant_response))
+        self.cache.set(conversation_id, messages)
+
+    async def add_tool_call(
+        self,
+        conversation_id: str,
+        tool_name: str,
+        tool_args: str | dict[str, Any],
+        tool_call_id: str,
+    ) -> None:
+        """Add a tool call to the conversation."""
+        messages: list[dict[str, Any]] = self.cache.get(conversation_id, [])  # type: ignore
+        parts = [
+            ToolCallPart(tool_name=tool_name, args=tool_args, tool_call_id=tool_call_id)
+        ]
+        tool_call = ModelResponse(parts=parts)  # type: ignore
+        messages.append(to_jsonable_python(tool_call))
+        self.cache.set(conversation_id, messages)
+
+    async def add_tool_result(
+        self, conversation_id: str, tool_name: str, result: str, tool_call_id: str
+    ) -> None:
+        """Add a tool result to the conversation."""
+        messages: list[dict[str, Any]] = self.cache.get(conversation_id, [])  # type: ignore
+        parts = [
+            ToolReturnPart(
+                tool_name=tool_name, content=result, tool_call_id=tool_call_id
+            )
+        ]
+        tool_result_msg = ModelRequest(parts=parts)  # type: ignore
+        messages.append(to_jsonable_python(tool_result_msg))
+        self.cache.set(conversation_id, messages)
+
+    async def clear_conversation(self, conversation_id: str) -> None:
+        """Clear all messages for a conversation."""
+        self.cache.delete(conversation_id)

--- a/registry/tracecat_registry/integrations/mcp/memory.py
+++ b/registry/tracecat_registry/integrations/mcp/memory.py
@@ -50,7 +50,11 @@ class ShortTermMemory(ABC):
 
     @abstractmethod
     def add_tool_result(
-        self, conversation_id: str, tool_name: str, tool_result: str, tool_call_id: str
+        self,
+        conversation_id: str,
+        tool_name: str,
+        tool_result: str | dict[str, Any],
+        tool_call_id: str,
     ) -> None:
         """Add a tool result to the conversation."""
         pass

--- a/registry/tracecat_registry/integrations/pydantic_ai.py
+++ b/registry/tracecat_registry/integrations/pydantic_ai.py
@@ -160,6 +160,7 @@ def build_agent(
     model_settings: dict[str, Any] | None = None,
     mcp_servers: list[MCPServerHTTP] | None = None,
     retries: Annotated[int, Doc("Number of retries")] = 3,
+    deps_type: type[Any] | None = None,
     **kwargs: Any,
 ) -> Agent:
     match model_provider:
@@ -227,16 +228,21 @@ def build_agent(
             )
 
     mcp_servers = mcp_servers or []
-    agent = Agent(
-        model=model,
-        instructions=instructions,
-        output_type=response_format,
-        model_settings=ModelSettings(**model_settings) if model_settings else None,
-        mcp_servers=mcp_servers,
-        retries=retries,
+    agent_kwargs = {
+        "model": model,
+        "instructions": instructions,
+        "output_type": response_format,
+        "model_settings": ModelSettings(**model_settings) if model_settings else None,
+        "mcp_servers": mcp_servers,
+        "retries": retries,
         **kwargs,
-    )
+    }
 
+    # Only add deps_type if it's provided
+    if deps_type is not None:
+        agent_kwargs["deps_type"] = deps_type
+
+    agent = Agent(**agent_kwargs)
     return agent
 
 

--- a/registry/tracecat_registry/integrations/pydantic_ai.py
+++ b/registry/tracecat_registry/integrations/pydantic_ai.py
@@ -24,6 +24,7 @@ from pydantic_ai.mcp import MCPServerHTTP
 from pydantic_ai.settings import ModelSettings
 
 from tracecat.validation.common import json_schema_to_pydantic
+from tracecat_registry import RegistrySecret
 
 
 from tracecat_registry.integrations.aws_boto3 import get_sync_session
@@ -46,6 +47,85 @@ SUPPORTED_OUTPUT_TYPES = {
     "list[int]": list[int],
     "list[str]": list[str],
 }
+
+
+mcp_secret = RegistrySecret(
+    name="mcp",
+    optional_keys=["MCP_HTTP_HEADERS"],
+    optional=True,
+)
+"""MCP headers.
+
+- name: `mcp`
+- optional_keys:
+    - `MCP_HTTP_HEADERS`: Optional HTTP headers to send to the MCP server.
+"""
+
+anthropic_secret = RegistrySecret(
+    name="anthropic",
+    optional_keys=["ANTHROPIC_API_KEY"],
+    optional=True,
+)
+"""Anthropic API key.
+
+- name: `anthropic`
+- optional_keys:
+    - `ANTHROPIC_API_KEY`: Optional Anthropic API key.
+"""
+
+openai_secret = RegistrySecret(
+    name="openai",
+    optional_keys=["OPENAI_API_KEY"],
+    optional=True,
+)
+"""OpenAI API key.
+
+- name: `openai`
+- optional_keys:
+    - `OPENAI_API_KEY`: Optional OpenAI API key.
+"""
+
+gemini_secret = RegistrySecret(
+    name="gemini",
+    optional_keys=["GEMINI_API_KEY"],
+    optional=True,
+)
+"""Gemini API key.
+
+- name: `gemini`
+- optional_keys:
+    - `GEMINI_API_KEY`: Optional Gemini API key.
+"""
+
+
+bedrock_secret = RegistrySecret(
+    name="amazon_bedrock",
+    optional_keys=[
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION",
+    ],
+    optional=True,
+)
+"""Bedrock API key.
+
+- name: `amazon_bedrock`
+- optional_keys:
+    - `AWS_ACCESS_KEY_ID`: Optional AWS access key ID.
+    - `AWS_SECRET_ACCESS_KEY`: Optional AWS secret access key.
+    - `AWS_SESSION_TOKEN`: Optional AWS session token.
+    - `AWS_REGION`: Optional AWS region.
+"""
+
+
+PYDANTIC_AI_REGISTRY_SECRETS = [
+    mcp_secret,
+    anthropic_secret,
+    openai_secret,
+    gemini_secret,
+    bedrock_secret,
+]
 
 
 def _parse_message_history(message_history: list[dict[str, Any]]) -> list[ModelMessage]:
@@ -74,12 +154,13 @@ def _parse_message_history(message_history: list[dict[str, Any]]) -> list[ModelM
 def build_agent(
     model_name: str,
     model_provider: str,
-    model_settings: dict[str, Any] | None = None,
     base_url: str | None = None,
     instructions: str | None = None,
     output_type: str | dict[str, Any] | None = None,
+    model_settings: dict[str, Any] | None = None,
     mcp_servers: list[MCPServerHTTP] | None = None,
     retries: Annotated[int, Doc("Number of retries")] = 3,
+    **kwargs: Any,
 ) -> Agent:
     match model_provider:
         case "openai":
@@ -153,6 +234,7 @@ def build_agent(
         model_settings=ModelSettings(**model_settings) if model_settings else None,
         mcp_servers=mcp_servers,
         retries=retries,
+        **kwargs,
     )
 
     return agent


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added an abstract MCPHost class and ShortTermMemory interface to standardize agent and memory logic, and refactored the Slack integration to use these new abstractions for cleaner, more modular code.

- **New Features**
  - Introduced MCPHost and ShortTermMemory ABCs for platform-agnostic agent and memory management.
  - Added FanoutCacheMemory as a diskcache-based implementation of ShortTermMemory.
  - Updated Slack integration to use MCPHost, improving separation of concerns and maintainability.
  - Centralized LLM secret definitions in the pydantic_ai module.
  - Better error messages for agent run (chains multiple exceptions together into a nice format and returns all cached messages so far)

<!-- End of auto-generated description by cubic. -->

## Highlights
`SlackMCPHost` can successful deal with multi-chain tool calling.

## Screens
<img width="850" alt="Screenshot 2025-05-26 at 5 22 20 PM" src="https://github.com/user-attachments/assets/c9cac9cd-e522-4b79-a9fb-5ee0f5256d13" />
<img width="850" alt="Screenshot 2025-05-26 at 5 22 28 PM" src="https://github.com/user-attachments/assets/9be74dd1-062f-4904-b6fa-40cb77e68429" />
<img width="1080" alt="Screenshot 2025-05-26 at 5 20 55 PM" src="https://github.com/user-attachments/assets/f2858111-e2e3-405d-933d-cc3c4e411c04" />
<img width="717" alt="Screenshot 2025-05-26 at 5 20 41 PM" src="https://github.com/user-attachments/assets/0a27a98c-28ec-4bd1-a935-de87687bbb56" />
<img width="993" alt="Screenshot 2025-05-26 at 5 20 29 PM" src="https://github.com/user-attachments/assets/a437f663-85e8-4977-a9df-6d30f7acce87" />
