### PR TITLE
feat(integrations): Additional EDR schemas

### DIFF
--- a/registry/tracecat_registry/schemas/edr/abort_scan_device.yml
+++ b/registry/tracecat_registry/schemas/edr/abort_scan_device.yml
@@ -1,0 +1,3 @@
+device_id:
+  type: str
+  description: ID of a managed device.

--- a/registry/tracecat_registry/schemas/edr/allow_ip_address.yml
+++ b/registry/tracecat_registry/schemas/edr/allow_ip_address.yml
@@ -2,3 +2,6 @@
 ip_address:
   type: str
   description: The IP address to allow.
+device_id:
+  type: str
+  description: The device ID to apply this rule to.

--- a/registry/tracecat_registry/schemas/edr/block_file_hash.yml
+++ b/registry/tracecat_registry/schemas/edr/block_file_hash.yml
@@ -1,0 +1,10 @@
+# https://d3fend.mitre.org/technique/d3f:FileHashFiltering/
+file_hash:
+  type: str
+  description: The file hash to block.
+
+scope:
+  type: str
+  description: Scope of the block rule.
+  enum: ["global", "site", "group", "agent"]
+  default: "global"

--- a/registry/tracecat_registry/schemas/edr/block_ioc.yml
+++ b/registry/tracecat_registry/schemas/edr/block_ioc.yml
@@ -1,0 +1,9 @@
+ioc_value:
+  type: str
+  description: The IOC value to block.
+
+scope:
+  type: str
+  description: Scope of the IOC block.
+  enum: ["global", "site", "group", "agent"]
+  default: "global"

--- a/registry/tracecat_registry/schemas/edr/block_ip_address.yml
+++ b/registry/tracecat_registry/schemas/edr/block_ip_address.yml
@@ -2,3 +2,6 @@
 ip_address:
   type: str
   description: The IP address to block.
+device_id:
+  type: str
+  description: The device ID to apply this rule to.

--- a/registry/tracecat_registry/schemas/edr/disable_agent.yml
+++ b/registry/tracecat_registry/schemas/edr/disable_agent.yml
@@ -1,0 +1,3 @@
+agent_id:
+  type: str
+  description: ID of the agent to enable.

--- a/registry/tracecat_registry/schemas/edr/enable_agent.yml
+++ b/registry/tracecat_registry/schemas/edr/enable_agent.yml
@@ -1,0 +1,3 @@
+agent_id:
+  type: str
+  description: ID of the agent to enable.

--- a/registry/tracecat_registry/schemas/edr/isolate_endpoint.yml
+++ b/registry/tracecat_registry/schemas/edr/isolate_endpoint.yml
@@ -1,0 +1,4 @@
+# https://d3fend.mitre.org/technique/d3f:NetworkIsolation/
+endpoint_id:
+  type: str
+  description: ID of the endpoint.

--- a/registry/tracecat_registry/schemas/edr/list_alerts.yml
+++ b/registry/tracecat_registry/schemas/edr/list_alerts.yml
@@ -1,0 +1,18 @@
+start_time:
+  type: datetime
+  description: Start time for the query (inclusive).
+end_time:
+  type: datetime
+  description: End time for the query (exclusive).
+severity:
+  type: str | None
+  description: Severity to filter alerts by.
+  default: null
+query:
+  type: str | None
+  description: Query or filter to apply to alerts.
+  default: null
+limit:
+  type: int
+  description: Maximum number of alerts to return.
+  default: 100

--- a/registry/tracecat_registry/schemas/edr/scan_device.yml
+++ b/registry/tracecat_registry/schemas/edr/scan_device.yml
@@ -1,0 +1,9 @@
+device_id:
+  type: str
+  description: ID of a managed device.
+
+scan_type:
+  type: str
+  description: Type of scan to perform.
+  enum: ["quick", "full", "custom", "memory", "registry"]
+  default: "full"

--- a/registry/tracecat_registry/schemas/edr/supress_detection.yml
+++ b/registry/tracecat_registry/schemas/edr/supress_detection.yml
@@ -1,0 +1,3 @@
+detection_id:
+  type: str
+  description: Unique identifier of the detection to suppress.

--- a/registry/tracecat_registry/schemas/edr/unblock_file_hash.yml
+++ b/registry/tracecat_registry/schemas/edr/unblock_file_hash.yml
@@ -1,0 +1,3 @@
+file_hash:
+  type: str
+  description: The file hash to block.

--- a/registry/tracecat_registry/schemas/edr/unblock_ioc.yml
+++ b/registry/tracecat_registry/schemas/edr/unblock_ioc.yml
@@ -1,0 +1,3 @@
+ioc_value:
+  type: str
+  description: The IOC value to block.

--- a/registry/tracecat_registry/schemas/edr/unisolate_endpoint.yml
+++ b/registry/tracecat_registry/schemas/edr/unisolate_endpoint.yml
@@ -1,0 +1,3 @@
+endpoint_id:
+  type: str
+  description: ID of the endpoint.

--- a/registry/tracecat_registry/schemas/edr/unsurpress_detection.yml
+++ b/registry/tracecat_registry/schemas/edr/unsurpress_detection.yml
@@ -1,0 +1,3 @@
+detection_id:
+  type: str
+  description: Unique identifier of the detection to suppress.


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Additional EDR schemas.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added new EDR action schemas and updated existing ones to support more device and alert management operations. This expands integration options for EDR workflows.

<!-- End of auto-generated description by cubic. -->

