### PR TITLE
feat(agents): Add ABC that runs if memory cache miss

### DIFF
--- a/registry/tracecat_registry/integrations/mcp/exceptions.py
+++ b/registry/tracecat_registry/integrations/mcp/exceptions.py
@@ -2,6 +2,14 @@ import json
 import dataclasses
 
 
+class ConversationNotFoundError(RuntimeError):
+    """Error raised when the agent run fails because of a conversation not found in memory."""
+
+    def __init__(self, deps: object):
+        self.deps = deps
+        super().__init__(f"Conversation not found in memory: {deps}")
+
+
 class AgentRunError(RuntimeError):
     """Error raised when the agent run fails."""
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added logic to detect memory cache misses and notify users in Slack when past conversation data is missing.

- **New Features**
  - Introduced a method to handle memory misses and post a warning message in Slack.
  - Raised a specific error when a conversation is not found in memory.

<!-- End of auto-generated description by cubic. -->

