### PR TITLE
feat(agent): Add retries and model_settings to agent builder

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -9,5 +9,6 @@ globs: *.py
 - Always use python 3.11+ type hints. This means prefer using builtin types (e.g. `list`, `dict`, `set`) for type hints over the equivalent types from the `typing` module.
 - Always follow the Google Python style guide
 - Always put imports at the top of the file. Do not use scoped imports unless strictly necessary.
-- Use `uv run` and `uv pip install`
 - All tests under `tests/unit` are actually integration tests. Do not use mocks. Test logic as closely as production as possible.
+- Always use `uv run` to execute python and `pytest` in the CLI.
+- Always use `uv pip install` to install pip packages.

--- a/registry/tracecat_registry/integrations/agents/builder.py
+++ b/registry/tracecat_registry/integrations/agents/builder.py
@@ -435,6 +435,13 @@ async def agent(
         Doc("Actions (e.g. 'tools.slack.post_message') to include in the agent."),
     ] = None,
     instructions: Annotated[str | None, Doc("Instructions for the agent.")] = None,
+    output_type: Annotated[
+        str | dict[str, Any] | None, Doc("Output type for the agent.")
+    ] = None,
+    model_settings: Annotated[
+        dict[str, Any] | None, Doc("Model settings for the agent.")
+    ] = None,
+    retries: Annotated[int, Doc("Number of retries for the agent.")] = 3,
     include_usage: Annotated[
         bool, Doc("Whether to include usage information in the output.")
     ] = False,
@@ -445,6 +452,9 @@ async def agent(
         model_provider=model_provider,
         base_url=base_url,
         instructions=instructions,
+        output_type=output_type,
+        model_settings=model_settings,
+        retries=retries,
     )
 
     if not namespaces and not actions:

--- a/tests/registry/test_pydantic_ai.py
+++ b/tests/registry/test_pydantic_ai.py
@@ -278,3 +278,85 @@ def test_pydantic_ai_call_with_enum_output():
     # assert result["status"] == "shipped"
     # However, LLM responses can vary, so checking inclusion in the enum is safer for a live test.
     print(f"Live LLM call for enum test returned: {result}")
+
+
+def test_pydantic_ai_call_with_model_settings():
+    """Tests that model_settings are correctly passed to the model."""
+    # First call with high temperature (more random)
+    result_creative = call(
+        instructions="You are a helpful assistant.",
+        user_prompt="Write a single sentence about Paris that's creative and unusual.",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        model_settings={"temperature": 1.0, "top_p": 1.0},
+    )
+
+    # Second call with low temperature (more deterministic)
+    result_factual = call(
+        instructions="You are a helpful assistant.",
+        user_prompt="Write a single sentence about Paris that's factual and straightforward.",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        model_settings={"temperature": 0.0, "top_p": 1.0},
+    )
+
+    # Both should return a string
+    assert isinstance(result_creative, str)
+    assert isinstance(result_factual, str)
+
+    # Both should mention Paris
+    assert (
+        "Paris" in result_creative
+        or "paris" in result_creative.lower()
+        or "Eiffel Tower" in result_creative
+        or "eiffel tower" in result_creative.lower()
+        or "Seine" in result_creative
+        or "seine" in result_creative.lower()
+    )
+    assert "Paris" in result_factual or "paris" in result_factual.lower()
+
+    # Different outputs suggest the model_settings were applied
+    print(f"Creative result (temp=1.0): {result_creative}")
+    print(f"Factual result (temp=0.0): {result_factual}")
+
+
+def test_pydantic_ai_call_with_tool_choice():
+    """Tests that model_settings can include tool_choice for OpenAI."""
+
+    # Define a simple mock calculator tool
+    calculator_schema = {
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Perform a calculation",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "The mathematical expression to evaluate",
+                    }
+                },
+                "required": ["expression"],
+            },
+        },
+    }
+
+    # Call with tool_choice to force tool use
+    result = call(
+        instructions="You are a helpful calculator assistant.",
+        user_prompt="What is 123 + 456?",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        model_settings={
+            "temperature": 0.0,
+            "tools": [calculator_schema],
+            "tool_choice": {"type": "function", "function": {"name": "calculator"}},
+        },
+    )
+
+    # Result should contain the calculation result in some form
+    assert isinstance(result, str)
+    assert "579" in result or "123 + 456" in result
+
+    print(f"Tool choice result: {result}")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added retry logic to agent tool calls so they are retried until successful, improving reliability for complex prompts. Also added support for passing custom model settings to agents.

- **Bug Fixes**
  - Retries tool calls up to a set number of times if they fail.

- **New Features**
  - Allows custom model settings (like temperature and tool choice) to be passed to agents.

<!-- End of auto-generated description by cubic. -->

