### PR TITLE
fix(integrations): Support AWS RoleArn in pydantic AI bedrock

### DIFF
--- a/registry/tracecat_registry/integrations/amazon_s3.py
+++ b/registry/tracecat_registry/integrations/amazon_s3.py
@@ -38,7 +38,7 @@ s3_secret = RegistrySecret(
         - `AWS_PROFILE`
     Or:
         - `AWS_ROLE_ARN`
-        - `AWS_ROLE_SESSION_NAME`
+        - `AWS_ROLE_SESSION_NAME` (optional)
 """
 
 

--- a/registry/tracecat_registry/integrations/aws_boto3.py
+++ b/registry/tracecat_registry/integrations/aws_boto3.py
@@ -104,7 +104,7 @@ def get_sync_temporary_credentials(
 
 
 async def get_session() -> aioboto3.Session:
-    if secrets.get("AWS_ROLE_ARN") and secrets.get("AWS_ROLE_SESSION_NAME"):
+    if secrets.get("AWS_ROLE_ARN"):
         role_arn = secrets.get("AWS_ROLE_ARN")
         role_session_name = secrets.get("AWS_ROLE_SESSION_NAME")
         creds = await get_temporary_credentials(role_arn, role_session_name)
@@ -146,7 +146,7 @@ async def get_session() -> aioboto3.Session:
 
 
 def get_sync_session() -> boto3.Session:
-    if secrets.get("AWS_ROLE_ARN") and secrets.get("AWS_ROLE_SESSION_NAME"):
+    if secrets.get("AWS_ROLE_ARN"):
         role_arn = secrets.get("AWS_ROLE_ARN")
         role_session_name = secrets.get("AWS_ROLE_SESSION_NAME")
         creds = get_sync_temporary_credentials(role_arn, role_session_name)

--- a/registry/tracecat_registry/integrations/pydantic_ai.py
+++ b/registry/tracecat_registry/integrations/pydantic_ai.py
@@ -107,19 +107,26 @@ bedrock_secret = RegistrySecret(
     optional_keys=[
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
-        "AWS_SESSION_TOKEN",
         "AWS_REGION",
+        "AWS_PROFILE",
+        "AWS_ROLE_ARN",
+        "AWS_ROLE_SESSION_NAME",
     ],
     optional=True,
 )
-"""Bedrock API key.
+"""AWS credentials.
 
 - name: `amazon_bedrock`
 - optional_keys:
-    - `AWS_ACCESS_KEY_ID`: Optional AWS access key ID.
-    - `AWS_SECRET_ACCESS_KEY`: Optional AWS secret access key.
-    - `AWS_SESSION_TOKEN`: Optional AWS session token.
-    - `AWS_REGION`: Optional AWS region.
+    Either:
+        - `AWS_ACCESS_KEY_ID`
+        - `AWS_SECRET_ACCESS_KEY`
+        - `AWS_REGION`
+    Or:
+        - `AWS_PROFILE`
+    Or:
+        - `AWS_ROLE_ARN`
+        - `AWS_ROLE_SESSION_NAME` (optional)
 """
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for using AWS RoleArn credentials in pydantic AI Bedrock integrations. This allows authentication with just AWS_ROLE_ARN, making AWS_ROLE_SESSION_NAME optional.

- **Bug Fixes**
  - Updated credential checks to allow AWS_ROLE_ARN without requiring AWS_ROLE_SESSION_NAME.
  - Improved documentation for supported AWS credential options.

<!-- End of auto-generated description by cubic. -->

