### PR TITLE
feat(integrations): Splunk fields / list data models templates

### DIFF
--- a/registry/tracecat_registry/templates/tools/splunk/discover_fields.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/discover_fields.yml
@@ -1,0 +1,76 @@
+type: action
+definition:
+  title: Discover fields
+  description: Discover fields in Splunk data using the fieldsummary command with statistics and sample values.
+  display_group: Splunk
+  doc_url: https://docs.splunk.com/Documentation/Splunk/9.4.1/SearchReference/Fieldsummary
+  namespace: tools.splunk
+  name: discover_fields
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    index:
+      type: str
+      description: Index to search for fields. Use * for all indexes.
+      default: "*"
+    start_time:
+      type: datetime
+      description: Start time for the search.
+    end_time:
+      type: datetime
+      description: End time for the search.
+    max_values:
+      type: int
+      description: Maximum number of sample values to return per field.
+      default: 5
+    limit:
+      type: int
+      description: Maximum number of fields to return. Set to 0 for no limit.
+      default: 100
+  steps:
+    - ref: create_search
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/search/jobs
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+          Content-Type: application/x-www-form-urlencoded
+        payload: search=search index=${{ inputs.index }} | fieldsummary maxvals=${{ inputs.max_values }} | sort -count | head ${{ inputs.limit }}&output_mode=json&start_time=${{ inputs.start_time }}&end_time=${{ inputs.end_time }}
+        timeout: 30
+    - ref: get_results
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/search/jobs/${{ steps.create_search.result.data.sid }}/results
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        params:
+          output_mode: json
+          count: 0
+        timeout: 30
+    - ref: format_results
+      action: core.transform.reshape
+      args:
+        value:
+          fields: ${{ steps.get_results.result.data.results }}
+          summary:
+            total_fields: ${{ steps.get_results.result.data.results | length }}
+            index_searched: ${{ inputs.index }}
+            time_range:
+              start: ${{ inputs.start_time }}
+              end: ${{ inputs.end_time }}
+            max_values_per_field: ${{ inputs.max_values }}
+            limit_applied: ${{ inputs.limit }}
+  returns: ${{ steps.format_results.result }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_data_models.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_data_models.yml
@@ -1,0 +1,42 @@
+type: action
+definition:
+  title: List data models
+  description: List all data models on the Splunk server with metadata, object hierarchies, field schemas, and acceleration status.
+  display_group: Splunk
+  doc_url: https://docs.splunk.com/Documentation/Splunk/9.4.1/RESTREF/RESTdata#data.2Fmodels
+  namespace: tools.splunk
+  name: list_data_models
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    app_name:
+      type: str
+      description: Specific app context to search in (optional). If not provided, searches all apps.
+      default: "-"
+    limit:
+      type: int
+      description: Maximum number of data models to return.
+      default: 100
+  steps:
+    - ref: get_data_models
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/servicesNS/-/${{ inputs.app_name }}/data/models
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        params:
+          output_mode: json
+          count: ${{ inputs.limit }}
+        timeout: 30
+  returns: ${{ steps.get_data_models.result.data.entry }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_field_extractions.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_field_extractions.yml
@@ -1,0 +1,42 @@
+type: action
+definition:
+  title: List field extractions
+  description: List all configured field extraction rules with regex patterns, transforms, and sourcetype-specific filtering.
+  display_group: Splunk
+  doc_url: https://docs.splunk.com/Documentation/Splunk/9.4.1/RESTREF/RESTknowledge#data.2Fprops.2Fextractions
+  namespace: tools.splunk
+  name: list_field_extractions
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    app_name:
+      type: str
+      description: Specific app context to search in (optional). If not provided, searches all apps.
+      default: "-"
+    limit:
+      type: int
+      description: Maximum number of field extractions to return.
+      default: 100
+  steps:
+    - ref: get_field_extractions
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/servicesNS/-/${{ inputs.app_name }}/data/props/extractions
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        params:
+          output_mode: json
+          count: ${{ inputs.limit }}
+        timeout: 30
+  returns: ${{ steps.get_field_extractions.result.data.entry }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_indexes.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_indexes.yml
@@ -1,0 +1,48 @@
+type: action
+definition:
+  title: List indexes
+  description: List all recognized indexes on the Splunk server with full metadata including size, event counts, and storage paths.
+  display_group: Splunk
+  doc_url: https://docs.splunk.com/Documentation/Splunk/9.4.1/RESTREF/RESTdata#data.2Findexes
+  namespace: tools.splunk
+  name: list_indexes
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    datatype:
+      type: str
+      description: Filter by index data type.
+      default: "all"
+      enum: ["all", "event", "metric"]
+    include_internal:
+      type: bool
+      description: Whether to include internal indexes (_internal, _audit, etc.).
+      default: false
+  steps:
+    - ref: get_indexes
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/data/indexes
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        params:
+          datatype: ${{ inputs.datatype }}
+          output_mode: json
+        timeout: 30
+    - ref: filter_indexes
+      action: core.transform.filter
+      args:
+        items: ${{ steps.get_indexes.result.data.entry }}
+        python_lambda: "lambda x: True if ${{ inputs.include_internal }} else not x.get('content', {}).get('isInternal', False)"
+  returns: ${{ steps.filter_indexes.result }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_sourcetypes.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_sourcetypes.yml
@@ -1,0 +1,55 @@
+type: action
+definition:
+  title: List sourcetypes
+  description: List all defined sourcetypes on the Splunk server.
+  display_group: Splunk
+  doc_url: https://docs.splunk.com/Documentation/Splunk/9.4.1/RESTREF/RESTsearch
+  namespace: tools.splunk
+  name: list_sourcetypes
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    limit:
+      type: int
+      description: Maximum number of sourcetypes to return. Set to 0 for no limit.
+      default: 0
+  steps:
+    - ref: get_sourcetypes
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/saved/sourcetypes
+        method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        params:
+          output_mode: json
+          count: ${{ inputs.limit }}
+        timeout: 30
+    - ref: format_results
+      action: core.transform.reshape
+      args:
+        value:
+          sourcetypes: >-
+            {% set result = [] %}
+            {% for st in steps.get_sourcetypes.result.data.entry %}
+              {% set sourcetype = {
+                "name": st.name,
+                "description": st.content.get("description", ""),
+                "category": st.content.get("category", "")
+              } %}
+              {% set _ = result.append(sourcetype) %}
+            {% endfor %}
+            {{ result }}
+          total_count: ${{ steps.get_sourcetypes.result.data.entry | length }}
+          limit_applied: ${{ inputs.limit }}
+  returns: ${{ steps.format_results.result }}

--- a/registry/tracecat_registry/templates/tools/splunk/search_events.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/search_events.yml
@@ -23,6 +23,10 @@ definition:
     limit:
       type: int
       description: Maximum number of events to return.
+    adhoc_search_level:
+      type: str
+      description: Adhoc search level.
+      default: "smart"
     base_url:
       type: str
       description: Splunk base URL (e.g. https://localhost:8089).
@@ -44,6 +48,7 @@ definition:
           earliest_time: ${{ inputs.start_time }}
           latest_time: ${{ inputs.end_time }}
           max_count: ${{ inputs.limit }}
+          adhoc_search_level: ${{ inputs.adhoc_search_level }}
     - ref: search_id
       action: core.transform.apply
       args:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added new Splunk integration templates to list data models, field extractions, indexes, and sourcetypes, and to discover fields. Also added an adhoc search level option to event search.

- **New Features**
  - Templates for listing Splunk data models, field extractions, indexes, and sourcetypes.
  - Template for discovering fields using the fieldsummary command.
  - Added adhoc_search_level input to event search.

<!-- End of auto-generated description by cubic. -->

