### PR TITLE
feat(integrations): Extend S3 actions with endpoint url

### DIFF
--- a/registry/tracecat_registry/integrations/aws_boto3.py
+++ b/registry/tracecat_registry/integrations/aws_boto3.py
@@ -210,6 +210,10 @@ async def call_api(
             description="Method name e.g. 'list_buckets', 'list_instances'",
         ),
     ],
+    endpoint_url: Annotated[
+        str | None,
+        Field(..., description="Endpoint URL for the AWS service."),
+    ] = None,
     params: Annotated[
         dict[str, Any] | None,
         Field(..., description="Parameters for the API method."),
@@ -217,7 +221,7 @@ async def call_api(
 ) -> dict[str, Any]:
     params = params or {}
     session = await get_session()
-    async with session.client(service_name) as client:  # type: ignore
+    async with session.client(service_name, endpoint_url=endpoint_url) as client:  # type: ignore
         response = await getattr(client, method_name)(**params)
         return response
 
@@ -245,6 +249,10 @@ async def call_paginated_api(
             description="Paginator name e.g. 'list_objects_v2', 'describe_instances'.",
         ),
     ],
+    endpoint_url: Annotated[
+        str | None,
+        Field(..., description="Endpoint URL for the AWS service."),
+    ] = None,
     params: Annotated[
         dict[str, Any] | None,
         Field(..., description="Parameters for the API paginator."),
@@ -252,7 +260,7 @@ async def call_paginated_api(
 ) -> list[dict[str, Any]]:
     params = params or {}
     session = await get_session()
-    async with session.client(service_name) as client:  # type: ignore
+    async with session.client(service_name, endpoint_url=endpoint_url) as client:  # type: ignore
         paginator = client.get_paginator(paginator_name)
         pages = paginator.paginate(**params)
 

--- a/registry/tracecat_registry/integrations/aws_boto3.py
+++ b/registry/tracecat_registry/integrations/aws_boto3.py
@@ -5,6 +5,7 @@ Supports role-based authentication and session management.
 """
 
 from typing import Annotated, Any
+from typing_extensions import Doc
 
 import boto3
 import aioboto3
@@ -12,7 +13,6 @@ from types_aiobotocore_sts.type_defs import (
     CredentialsTypeDef as AsyncCredentialsTypeDef,
 )
 from types_boto3_sts.type_defs import CredentialsTypeDef
-from pydantic import Field
 
 from tracecat_registry import RegistrySecret, logger, registry, secrets
 
@@ -198,25 +198,19 @@ def get_sync_session() -> boto3.Session:
 async def call_api(
     service_name: Annotated[
         str,
-        Field(
-            ...,
-            description="AWS service name e.g. 's3', 'ec2', 'guardduty'.",
-        ),
+        Doc("AWS service name e.g. 's3', 'ec2', 'guardduty'."),
     ],
     method_name: Annotated[
         str,
-        Field(
-            ...,
-            description="Method name e.g. 'list_buckets', 'list_instances'",
-        ),
+        Doc("Method name e.g. 'list_buckets', 'list_instances'"),
     ],
     endpoint_url: Annotated[
         str | None,
-        Field(..., description="Endpoint URL for the AWS service."),
+        Doc("Endpoint URL for the AWS service."),
     ] = None,
     params: Annotated[
         dict[str, Any] | None,
-        Field(..., description="Parameters for the API method."),
+        Doc("Parameters for the API method."),
     ] = None,
 ) -> dict[str, Any]:
     params = params or {}
@@ -237,25 +231,19 @@ async def call_api(
 async def call_paginated_api(
     service_name: Annotated[
         str,
-        Field(
-            ...,
-            description="AWS service name e.g. 's3', 'ec2', 'guardduty'.",
-        ),
+        Doc("AWS service name e.g. 's3', 'ec2', 'guardduty'."),
     ],
     paginator_name: Annotated[
         str,
-        Field(
-            ...,
-            description="Paginator name e.g. 'list_objects_v2', 'describe_instances'.",
-        ),
+        Doc("Paginator name e.g. 'list_objects_v2', 'describe_instances'."),
     ],
     endpoint_url: Annotated[
         str | None,
-        Field(..., description="Endpoint URL for the AWS service."),
+        Doc("Endpoint URL for the AWS service."),
     ] = None,
     params: Annotated[
         dict[str, Any] | None,
-        Field(..., description="Parameters for the API paginator."),
+        Doc("Parameters for the API paginator."),
     ] = None,
 ) -> list[dict[str, Any]]:
     params = params or {}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for custom endpoint URLs in S3 API and paginator actions, allowing connections to non-default AWS endpoints.

<!-- End of auto-generated description by cubic. -->

