### PR TITLE
fix(ui): Fix events sidebar blocknote styles

### DIFF
--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -1,5 +1,9 @@
 "use client"
 
+import "@blocknote/core/fonts/inter.css"
+import "@blocknote/shadcn/style.css"
+import "@/components/cases/editor.css"
+
 import React, { useEffect } from "react"
 import {
   AgentOutput,
@@ -24,6 +28,7 @@ import {
   ChevronRightIcon,
   CircleDot,
   LoaderIcon,
+  MessageCircle,
   RefreshCw,
   Undo2Icon,
 } from "lucide-react"
@@ -228,17 +233,16 @@ export function AgentOutputEvent({
     </div>
   )
 }
-
 export function SystemPromptPartComponent({
   part,
 }: {
   part: SystemPromptPart
 }) {
   return (
-    <Card className="rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs shadow-sm">
+    <Card className="rounded-lg border-[0.5px] bg-muted/40 p-3 text-xs leading-[1.5] shadow-sm">
       <div className="flex items-start gap-2">
         <CaseUserAvatar user={SYSTEM_USER} size="sm" />
-        <div className="whitespace-pre-wrap">
+        <div className="overflow-x-auto whitespace-pre-wrap break-words">
           {typeof part.content === "string"
             ? part.content
             : JSON.stringify(part.content, null, 2)}
@@ -251,10 +255,10 @@ export function SystemPromptPartComponent({
 export function UserPromptPartComponent({ part }: { part: UserPromptPart }) {
   const { user } = useAuth()
   return (
-    <Card className="rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs shadow-sm">
+    <Card className="rounded-lg border-[0.5px] bg-muted/40 p-3 text-xs leading-[1.5] shadow-sm">
       <div className="flex items-start gap-2">
         {user && <CaseUserAvatar user={user} size="sm" />}
-        <div className="whitespace-pre-wrap">
+        <div className="overflow-x-auto whitespace-pre-wrap break-words">
           {typeof part.content === "string"
             ? part.content
             : JSON.stringify(part.content, null, 2)}
@@ -395,11 +399,19 @@ export function TextPartComponent({ text }: { text: TextPart }) {
     animations: false,
     codeBlock,
   })
+
   useEffect(() => {
-    loadInitialContent(editor, text.content)
+    if (text.content) {
+      loadInitialContent(editor, text.content)
+    }
   }, [text.content, editor])
   return (
-    <Card className="overflow-scroll whitespace-pre-wrap rounded-md border-[0.5px] bg-muted/20 p-2 text-xs shadow-sm">
+    <div className="flex flex-col gap-2 overflow-scroll whitespace-pre-wrap rounded-md border-[0.5px] bg-muted/20 p-3 text-xs shadow-sm">
+      <div className="flex items-center gap-1">
+        <MessageCircle className="size-4" />
+        <span className="text-xs font-semibold text-foreground/80">Agent</span>
+      </div>
+
       <BlockNoteView
         editor={editor}
         theme="light"
@@ -409,9 +421,10 @@ export function TextPartComponent({ text }: { text: TextPart }) {
           height: "100%",
           width: "100%",
           whiteSpace: "pre-wrap",
+          lineHeight: "1.5",
         }}
       />
-    </Card>
+    </div>
   )
 }
 

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -236,7 +236,7 @@ export function SystemPromptPartComponent({
 }) {
   return (
     <Card className="rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs shadow-sm">
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         <CaseUserAvatar user={SYSTEM_USER} size="sm" />
         <div className="whitespace-pre-wrap">
           {typeof part.content === "string"
@@ -252,7 +252,7 @@ export function UserPromptPartComponent({ part }: { part: UserPromptPart }) {
   const { user } = useAuth()
   return (
     <Card className="rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs shadow-sm">
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         {user && <CaseUserAvatar user={user} size="sm" />}
         <div className="whitespace-pre-wrap">
           {typeof part.content === "string"

--- a/frontend/src/components/cases/editor.css
+++ b/frontend/src/components/cases/editor.css
@@ -41,6 +41,13 @@
   font-size: var(--bn-font-size-h3);
 }
 
+.bn-block-content[data-content-type="codeBlock"] {
+  background-color: hsl(var(--foreground) / 0.85);
+  border-radius: 8px;
+  border: 1px solid hsl(var(--border));
+  font-size: var(--bn-font-size-sm);
+}
+
 /* Ensure all other elements use the base font size */
 .bn-editor,
 .bn-block-content,
@@ -48,7 +55,7 @@
 .bn-container [data-content-type="paragraph"],
 .bn-container [data-content-type="bulletListItem"],
 .bn-container [data-content-type="numberedListItem"] {
-  font-size: var(--bn-font-size-base);
+  font-size: var(--bn-font-size-sm);
 }
 
 /* Suggestion menu font size customization */


### PR DESCRIPTION
- **align user avatar to top**
- **Fix overflow issue, code block, table and added css styles**

# Screens
<img width="1728" alt="Screenshot 2025-06-10 at 12 59 11 (2)" src="https://github.com/user-attachments/assets/8cc1587e-1cf7-48ef-a8f2-5811171cca9a" />

<img width="438" alt="Screenshot 2025-06-10 at 13 17 40" src="https://github.com/user-attachments/assets/d28ddd58-7a36-4a44-87eb-c16804a7a4b5" />

<img width="422" alt="image" src="https://github.com/user-attachments/assets/8118ba03-d5f9-40a0-af02-348f0f6c50f8" />

