### PR TITLE
feat(ui): Expose action ref in ActionRead

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -226,6 +226,11 @@ export const $ActionRead = {
       ],
       title: "Interaction",
     },
+    ref: {
+      type: "string",
+      title: "Ref",
+      readOnly: true,
+    },
   },
   type: "object",
   required: [
@@ -236,6 +241,7 @@ export const $ActionRead = {
     "status",
     "inputs",
     "is_interactive",
+    "ref",
   ],
   title: "ActionRead",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -41,6 +41,7 @@ export type ActionRead = {
   control_flow?: ActionControlFlow
   is_interactive: boolean
   interaction?: ResponseInteraction | ApprovalInteraction | null
+  readonly ref: string
 }
 
 export type ActionReadMinimal = {

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import httpx
 import yaml
-from slugify import slugify
 
+from tracecat.identifiers.action import ref
 from tracecat.identifiers.workflow import EXEC_ID_PREFIX, WorkflowUUID
 from tracecat.registry.actions.models import TemplateAction
 
@@ -25,7 +25,7 @@ TEST_WF_ID = WorkflowUUID(int=0)
 
 
 def generate_test_exec_id(name: str) -> str:
-    return TEST_WF_ID.short() + f"/{EXEC_ID_PREFIX}" + slugify(name, separator="_")
+    return TEST_WF_ID.short() + f"/{EXEC_ID_PREFIX}" + ref(name)
 
 
 def glob_file_paths(dir_path: Path, file_ext: str) -> list[Path]:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -25,7 +25,6 @@ with workflow.unsafe.imports_passed_through():
     import jsonpath_ng.parser  # noqa
     import tracecat_registry  # noqa
     from pydantic import ValidationError
-    from slugify import slugify
 
     from tracecat import config, identifiers
     from tracecat.concurrency import GatheringTaskGroup
@@ -1126,7 +1125,7 @@ class DSLWorkflow:
         if args.dsl is None:
             raise ValueError("DSL is required to run error handler workflow")
         # Use Temporal memo to store the action ref in the child workflow run
-        memo = ChildWorkflowMemo(action_ref=slugify(args.dsl.title, separator="_"))
+        memo = ChildWorkflowMemo(action_ref=identifiers.action.ref(args.dsl.title))
         await workflow.execute_child_workflow(
             DSLWorkflow.run,
             args,

--- a/tracecat/workflow/actions/models.py
+++ b/tracecat/workflow/actions/models.py
@@ -1,11 +1,12 @@
 import dateparser
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from tracecat.dsl.enums import JoinStrategy
 from tracecat.dsl.models import ActionRetryPolicy
 from tracecat.ee.interactions.models import ActionInteraction
 from tracecat.identifiers.action import ActionID
+from tracecat.identifiers.action import ref as _ref
 from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowIDShort
 
 
@@ -53,6 +54,10 @@ class ActionRead(BaseModel):
     control_flow: ActionControlFlow = Field(default_factory=ActionControlFlow)
     is_interactive: bool
     interaction: ActionInteraction | None = None
+
+    @computed_field
+    def ref(self) -> str:
+        return _ref(self.title)
 
 
 class ActionReadMinimal(BaseModel):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a read-only ref field to the ActionRead model to expose a stable string reference for each action.

- **New Features**
  - ActionRead now includes a computed ref field based on the action title.
  - Updated related code and tests to use the new ref function.

<!-- End of auto-generated description by cubic. -->

