### PR TITLE
feat(engine): Webhook event batching

### DIFF
--- a/tracecat/webhooks/models.py
+++ b/tracecat/webhooks/models.py
@@ -9,6 +9,11 @@ from tracecat.identifiers.workflow import WorkflowID
 
 type WebhookStatus = Literal["online", "offline"]
 type WebhookMethod = Literal["GET", "POST"]
+NDJSON_CONTENT_TYPES = (
+    "application/x-ndjson",
+    "application/jsonlines",
+    "application/jsonl",
+)
 
 
 class WebhookRead(Resource):

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -1,22 +1,35 @@
+from itertools import batched
 from typing import Annotated, Any, TypedDict
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from temporalio.service import RPCError
 
+from tracecat.concurrency import cooperative
 from tracecat.contexts import ctx_role
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.enums import InteractionCategory
 from tracecat.ee.interactions.models import InteractionInput
-from tracecat.identifiers.workflow import AnyWorkflowIDPath
+from tracecat.identifiers.workflow import AnyWorkflowIDPath, generate_exec_id
 from tracecat.logger import logger
 from tracecat.webhooks.dependencies import (
     PayloadDep,
     ValidWorkflowDefinitionDep,
+    parse_content_type,
     parse_interaction_payload,
     validate_incoming_webhook,
 )
+from tracecat.webhooks.models import NDJSON_CONTENT_TYPES
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.models import (
     ReceiveInteractionResponse,
@@ -53,6 +66,7 @@ async def incoming_webhook(
         description="Vendor specific webhook verification. Supported vendors: `okta`.",
     ),
     request: Request,
+    content_type: Annotated[str | None, Header(alias="content-type")] = None,
 ) -> WorkflowExecutionCreateResponse | OktaVerificationResponse | Response:
     """Webhook endpoint to trigger a workflow.
 
@@ -64,12 +78,35 @@ async def incoming_webhook(
     dsl_input = DSLInput(**defn.content)
 
     service = await WorkflowExecutionsService.connect()
-    response = service.create_workflow_execution_nowait(
-        dsl=dsl_input,
-        wf_id=workflow_id,
-        payload=payload,
-        trigger_type=TriggerType.WEBHOOK,
-    )
+    # If this was a ndjson, automatically batch the requests
+    # This is a workaround for the fact that Temporal doesn't support batching
+    # of webhook requests
+    mime_type = parse_content_type(content_type)[0] if content_type else ""
+    if mime_type in NDJSON_CONTENT_TYPES and isinstance(payload, list):
+        one_response = None
+        async for p in cooperative(batched(payload, 4)):
+            one_response = service.create_workflow_execution_nowait(
+                dsl=dsl_input,
+                wf_id=workflow_id,
+                payload=p,
+                trigger_type=TriggerType.WEBHOOK,
+            )
+        # Currently just return the last response's wf_exec_id
+        response = WorkflowExecutionCreateResponse(
+            message="Workflow execution created",
+            wf_id=workflow_id,
+            wf_exec_id=one_response["wf_exec_id"]
+            if one_response
+            else generate_exec_id(workflow_id),  # This should never happen
+        )
+
+    else:
+        response = service.create_workflow_execution_nowait(
+            dsl=dsl_input,
+            wf_id=workflow_id,
+            payload=payload,
+            trigger_type=TriggerType.WEBHOOK,
+        )
 
     # Response handling
     if echo:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added batching support for incoming NDJSON webhook events, allowing multiple events to be processed in a single request.

- **New Features**
  - NDJSON webhook payloads are now split into batches of 4 and processed together.
  - Only the last batch's workflow execution ID is returned in the response.

<!-- End of auto-generated description by cubic. -->

