### PR TITLE
Splunk metadata integrations using query language

### DIFF
--- a/registry/tracecat_registry/templates/tools/splunk/discover_fields.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/discover_fields.yml
@@ -1,0 +1,59 @@
+type: action
+definition:
+  title: Discover fields
+  description: Discover fields in Splunk data using the fieldsummary command with statistics and sample values.
+  display_group: Splunk
+  doc_url: https://docs.splunk.com/Documentation/Splunk/9.4.1/SearchReference/Fieldsummary
+  namespace: tools.splunk
+  name: discover_fields
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    index:
+      type: str
+      description: Index to search for fields. Use * for all indexes.
+      default: "*"
+    start_time:
+      type: datetime
+      description: Start time for the search.
+    end_time:
+      type: datetime
+      description: End time for the search.
+    max_values:
+      type: int
+      description: Maximum number of sample values to return per field.
+      default: 5
+    limit:
+      type: int
+      description: Maximum number of fields to return.
+      default: 100
+    adhoc_search_level:
+      type: str
+      description: Adhoc search level.
+      default: fast
+  steps:
+    - ref: search_job
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/search/jobs
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        form_data:
+          search: "search index=${{ inputs.index }} | fieldsummary maxvals=${{ inputs.max_values }} | sort -count | head ${{ inputs.limit }}"
+          earliest_time: ${{ inputs.start_time }}
+          latest_time: ${{ inputs.end_time }}
+          adhoc_search_level: ${{ inputs.adhoc_search_level }}
+          exec_mode: oneshot
+          output_mode: json
+  returns: ${{ steps.search_job.result }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_data_models.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_data_models.yml
@@ -1,0 +1,39 @@
+type: action
+definition:
+  title: List data models
+  description: List all data models on the Splunk server using native Splunk search.
+  display_group: Splunk
+  namespace: tools.splunk
+  name: list_data_models
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    adhoc_search_level:
+      type: str
+      description: Adhoc search level.
+      default: fast
+  steps:
+    - ref: search_job
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/search/jobs
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        form_data:
+          search: "| rest /servicesNS/-/-/data/models | table title description app"
+          adhoc_search_level: ${{ inputs.adhoc_search_level }}
+          exec_mode: oneshot
+          output_mode: json
+          max_count: 100
+  returns: ${{ steps.search_job.result }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_field_extractions.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_field_extractions.yml
@@ -1,0 +1,39 @@
+type: action
+definition:
+  title: List field extractions
+  description: List all configured field extraction rules using a simple Splunk query.
+  display_group: Splunk
+  namespace: tools.splunk
+  name: list_field_extractions
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    adhoc_search_level:
+      type: str
+      description: Adhoc search level.
+      default: fast
+  steps:
+    - ref: search_job
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/search/jobs
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        form_data:
+          search: "| rest /services/data/props/extractions | table title, eai:acl.app, content.regex, content.stanza"
+          adhoc_search_level: ${{ inputs.adhoc_search_level }}
+          exec_mode: oneshot
+          output_mode: json
+          max_count: 100
+  returns: ${{ steps.search_job.result }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_indexes.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_indexes.yml
@@ -1,0 +1,39 @@
+type: action
+definition:
+  title: List indexes
+  description: List all indexes on the Splunk server using native Splunk search.
+  display_group: Splunk
+  namespace: tools.splunk
+  name: list_indexes
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    adhoc_search_level:
+      type: str
+      description: Adhoc search level.
+      default: fast
+  steps:
+    - ref: search_job
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/search/jobs
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        form_data:
+          search: "| rest /services/data/indexes | table title homePath maxTotalDataSizeMB frozenTimePeriodInSecs"
+          adhoc_search_level: ${{ inputs.adhoc_search_level }}
+          exec_mode: oneshot
+          output_mode: json
+          max_count: 100
+  returns: ${{ steps.search_job.result }}

--- a/registry/tracecat_registry/templates/tools/splunk/list_sourcetypes.yml
+++ b/registry/tracecat_registry/templates/tools/splunk/list_sourcetypes.yml
@@ -1,0 +1,40 @@
+type: action
+definition:
+  title: List sourcetypes
+  description: List all defined sourcetypes on the Splunk server.
+  display_group: Splunk
+  doc_url: https://docs.splunk.com/Documentation/Splunk/9.4.1/RESTREF/RESTsearch
+  namespace: tools.splunk
+  name: list_sourcetypes
+  secrets:
+    - name: splunk
+      keys:
+        - SPLUNK_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Splunk base URL (e.g. https://localhost:8089).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
+    adhoc_search_level:
+      type: str
+      description: Adhoc search level.
+      default: fast
+  steps:
+    - ref: search_job
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/services/search/jobs
+        method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
+        headers:
+          Authorization: Bearer ${{ SECRETS.splunk.SPLUNK_API_KEY }}
+        form_data:
+          search: "| rest /services/saved/sourcetypes | table name description category"
+          adhoc_search_level: ${{ inputs.adhoc_search_level }}
+          exec_mode: oneshot
+          output_mode: json
+          max_count: 100
+  returns: ${{ steps.search_job.result }}


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Splunk Metadata Integrations
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added new Splunk metadata integrations that use query language actions to list fields, indexes, data models, field extractions, and sourcetypes. This makes it easier to discover and manage Splunk metadata from within the platform.

<!-- End of auto-generated description by cubic. -->

