### PR TITLE
feat: Allow port in git repository url

### DIFF
--- a/tracecat/registry/repositories/models.py
+++ b/tracecat/registry/repositories/models.py
@@ -64,6 +64,7 @@ class RegistryRepositoryCreate(BaseModel):
         if not re.match(
             r"^git\+ssh://git@"  # Protocol and user prefix
             r"[-a-zA-Z0-9.]+"  # Hostname
+            r"(:[0-9]{1,5})?"  # Port
             r"/[-a-zA-Z0-9._]+/"  # Organization/user
             r"[-a-zA-Z0-9._]+\.git$",  # Repository name
             v,

--- a/tracecat/registry/repositories/models.py
+++ b/tracecat/registry/repositories/models.py
@@ -64,7 +64,7 @@ class RegistryRepositoryCreate(BaseModel):
         if not re.match(
             r"^git\+ssh://git@"  # Protocol and user prefix
             r"[-a-zA-Z0-9.]+"  # Hostname
-            r"(:[0-9]{1,5})?"  # Port
+            r"(\:([1-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?"  # Port
             r"/[-a-zA-Z0-9._]+/"  # Organization/user
             r"[-a-zA-Z0-9._]+\.git$",  # Repository name
             v,


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [X] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [X] PR only implements a single feature or fixes a single bug.
- [X] Tests passing (`uv run pytest tests`)?
- [X] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR allows the user to have a git repository with SSH server on a non default port.

## Steps to QA

Add a new repository `git+ssh://git@host/org/repo.git`
Add a new repository `git+ssh://git@host:1234/org/repo.git`
Both repositories should sync well
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for specifying a port in git repository SSH URLs.

- **New Features**
  - Users can now add repositories using SSH URLs with custom ports, such as git+ssh://git@host:1234/org/repo.git.

<!-- End of auto-generated description by cubic. -->

