### PR TITLE
refactor(engine): Reduce webhook logging verbosity

### DIFF
--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -73,7 +73,8 @@ async def incoming_webhook(
     This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
     The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
     """
-    logger.info("Webhook hit", path=workflow_id, payload=payload, role=ctx_role.get())
+    logger.info("Webhook hit", path=workflow_id, role=ctx_role.get())
+    logger.trace("Webhook payload", payload=payload)
 
     dsl_input = DSLInput(**defn.content)
 
@@ -147,7 +148,8 @@ async def incoming_webhook_wait(
     This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
     The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
     """
-    logger.info("Webhook hit", path=workflow_id, payload=payload, role=ctx_role.get())
+    logger.info("Webhook hit", path=workflow_id, role=ctx_role.get())
+    logger.trace("Webhook payload", payload=payload)
 
     dsl_input = DSLInput(**defn.content)
 
@@ -185,9 +187,9 @@ async def receive_interaction(
         "Received interaction",
         workflow_id=workflow_id,
         category=category,
-        input=input,
         role=ctx_role.get(),
     )
+    logger.trace("Interaction input", input=input)
 
     try:
         # Get temporal client and workflow handle


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduced the amount of information logged at the info level for webhooks by moving payload and input details to trace logs.

<!-- End of auto-generated description by cubic. -->

