### PR TITLE
refactor(registry+app): Move field components to registry

### DIFF
--- a/registry/tracecat_registry/__init__.py
+++ b/registry/tracecat_registry/__init__.py
@@ -17,6 +17,21 @@ from tracecat_registry._internal.exceptions import (
 )
 from tracecat_registry._internal.logger import logger
 from tracecat_registry._internal.models import RegistrySecret
+from tracecat_registry._internal.fields import (
+    Component,
+    ComponentID,
+    Integer,
+    Float,
+    Text,
+    Code,
+    Select,
+    TagInput,
+    TextArea,
+    Toggle,
+    Yaml,
+    ActionType,
+    WorkflowAlias,
+)
 
 __all__ = [
     "registry",
@@ -26,4 +41,18 @@ __all__ = [
     "exceptions",
     "RegistryActionError",
     "ActionIsInterfaceError",
+    # Fields
+    "Component",
+    "ComponentID",
+    "Integer",
+    "Float",
+    "Text",
+    "Code",
+    "Select",
+    "TagInput",
+    "TextArea",
+    "Toggle",
+    "Yaml",
+    "ActionType",
+    "WorkflowAlias",
 ]

--- a/registry/tracecat_registry/_internal/fields.py
+++ b/registry/tracecat_registry/_internal/fields.py
@@ -1,0 +1,114 @@
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Literal
+
+
+class ComponentID(StrEnum):
+    """The ID of a component in the UI"""
+
+    CODE = "code"
+    SELECT = "select"
+    TEXT_AREA = "text-area"
+    TOGGLE = "toggle"
+    TEXT = "text"
+    INTEGER = "integer"
+    FLOAT = "float"
+    TAG_INPUT = "tag-input"
+    YAML = "yaml"
+    ACTION_TYPE = "action-type"
+    WORKFLOW_ALIAS = "workflow-alias"
+
+
+@dataclass(slots=True)
+class Component: ...
+
+
+@dataclass(slots=True)
+class Text(Component):
+    """Base class for fields"""
+
+    component_id: Literal[ComponentID.TEXT] = ComponentID.TEXT
+
+
+@dataclass(slots=True)
+class Code(Component):
+    """Render field as code block in UI"""
+
+    component_id: Literal[ComponentID.CODE] = ComponentID.CODE
+    lang: Literal["yaml", "python"] = "python"
+
+
+@dataclass(slots=True)
+class Select(Component):
+    """Render field as dropdown in UI"""
+
+    component_id: Literal[ComponentID.SELECT] = ComponentID.SELECT
+    options: list[str] | None = None
+    multiple: bool = False
+
+
+@dataclass(slots=True)
+class TagInput(Component):
+    """Render field as tag input in UI"""
+
+    component_id: Literal[ComponentID.TAG_INPUT] = ComponentID.TAG_INPUT
+
+
+@dataclass(slots=True)
+class TextArea(Component):
+    """Render field as textarea in UI"""
+
+    component_id: Literal[ComponentID.TEXT_AREA] = ComponentID.TEXT_AREA
+    rows: int = 4
+    placeholder: str = ""
+
+
+@dataclass(slots=True)
+class Integer(Component):
+    """Render field as integer input"""
+
+    component_id: Literal[ComponentID.INTEGER] = ComponentID.INTEGER
+    min_val: int | None = None
+    max_val: int | None = None
+    step: int = 1
+
+
+@dataclass(slots=True)
+class Float(Component):
+    """Render field as float input"""
+
+    component_id: Literal[ComponentID.FLOAT] = ComponentID.FLOAT
+    min_val: float | None = None
+    max_val: float | None = None
+    step: float = 0.1
+
+
+@dataclass(slots=True)
+class Toggle(Component):
+    """Render field as toggle switch"""
+
+    label_on: str = "On"
+    label_off: str = "Off"
+    component_id: Literal[ComponentID.TOGGLE] = ComponentID.TOGGLE
+
+
+@dataclass(slots=True)
+class Yaml(Component):
+    """Render field as YAML editor in UI"""
+
+    component_id: Literal[ComponentID.YAML] = ComponentID.YAML
+
+
+@dataclass(slots=True)
+class ActionType(Component):
+    """Render field as action type dropdown in UI"""
+
+    component_id: Literal[ComponentID.ACTION_TYPE] = ComponentID.ACTION_TYPE
+    multiple: bool = False
+
+
+@dataclass(slots=True)
+class WorkflowAlias(Component):
+    """Render field as workflow alias dropdown in UI"""
+
+    component_id: Literal[ComponentID.WORKFLOW_ALIAS] = ComponentID.WORKFLOW_ALIAS

--- a/registry/tracecat_registry/core/python.py
+++ b/registry/tracecat_registry/core/python.py
@@ -10,8 +10,7 @@ from typing import Annotated, Any, TypedDict
 
 from tracecat.config import TRACECAT__PYODIDE_VERSION, TRACECAT__NODE_MODULES_DIR
 from tracecat.logger import logger
-from tracecat.registry.fields import Code
-from tracecat_registry import registry
+from tracecat_registry import registry, Code
 from typing_extensions import Doc
 
 

--- a/registry/tracecat_registry/integrations/agents/builder.py
+++ b/registry/tracecat_registry/integrations/agents/builder.py
@@ -31,7 +31,6 @@ from tracecat.expressions.eval import extract_templated_secrets
 from tracecat.expressions.expectations import create_expectation_model
 from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
-from tracecat.registry.fields import ActionType, TextArea
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.secrets.secrets_manager import env_sandbox
 from tracecat_registry.integrations.pydantic_ai import (
@@ -39,7 +38,7 @@ from tracecat_registry.integrations.pydantic_ai import (
     build_agent,
 )
 
-from tracecat_registry import registry, RegistrySecret
+from tracecat_registry import registry, RegistrySecret, ActionType, TextArea
 from tracecat.types.exceptions import RegistryError
 from tracecat_registry.integrations.agents.exceptions import AgentRunError
 

--- a/tracecat/registry/fields.py
+++ b/tracecat/registry/fields.py
@@ -1,123 +1,25 @@
 import inspect
 import types
-from dataclasses import dataclass
-from enum import Enum, StrEnum
+from enum import Enum
 from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import Field, RootModel
+from tracecat_registry import (
+    ActionType,
+    Code,
+    Component,
+    Float,
+    Integer,
+    Select,
+    TagInput,
+    Text,
+    TextArea,
+    Toggle,
+    WorkflowAlias,
+    Yaml,
+)
 
 from tracecat.logger import logger
-
-
-class ComponentID(StrEnum):
-    """The ID of a component in the UI"""
-
-    CODE = "code"
-    SELECT = "select"
-    TEXT_AREA = "text-area"
-    TOGGLE = "toggle"
-    TEXT = "text"
-    INTEGER = "integer"
-    FLOAT = "float"
-    TAG_INPUT = "tag-input"
-    YAML = "yaml"
-    ACTION_TYPE = "action-type"
-    WORKFLOW_ALIAS = "workflow-alias"
-
-
-@dataclass(slots=True)
-class Component: ...
-
-
-@dataclass(slots=True)
-class Text(Component):
-    """Base class for fields"""
-
-    component_id: Literal[ComponentID.TEXT] = ComponentID.TEXT
-
-
-@dataclass(slots=True)
-class Code(Component):
-    """Render field as code block in UI"""
-
-    component_id: Literal[ComponentID.CODE] = ComponentID.CODE
-    lang: Literal["yaml", "python"] = "python"
-
-
-@dataclass(slots=True)
-class Select(Component):
-    """Render field as dropdown in UI"""
-
-    component_id: Literal[ComponentID.SELECT] = ComponentID.SELECT
-    options: list[str] | None = None
-    multiple: bool = False
-
-
-@dataclass(slots=True)
-class TagInput(Component):
-    """Render field as tag input in UI"""
-
-    component_id: Literal[ComponentID.TAG_INPUT] = ComponentID.TAG_INPUT
-
-
-@dataclass(slots=True)
-class TextArea(Component):
-    """Render field as textarea in UI"""
-
-    component_id: Literal[ComponentID.TEXT_AREA] = ComponentID.TEXT_AREA
-    rows: int = 4
-    placeholder: str = ""
-
-
-@dataclass(slots=True)
-class Integer(Component):
-    """Render field as integer input"""
-
-    component_id: Literal[ComponentID.INTEGER] = ComponentID.INTEGER
-    min_val: int | None = None
-    max_val: int | None = None
-    step: int = 1
-
-
-@dataclass(slots=True)
-class Float(Component):
-    """Render field as float input"""
-
-    component_id: Literal[ComponentID.FLOAT] = ComponentID.FLOAT
-    min_val: float | None = None
-    max_val: float | None = None
-    step: float = 0.1
-
-
-@dataclass(slots=True)
-class Toggle(Component):
-    """Render field as toggle switch"""
-
-    label_on: str = "On"
-    label_off: str = "Off"
-    component_id: Literal[ComponentID.TOGGLE] = ComponentID.TOGGLE
-
-
-@dataclass(slots=True)
-class Yaml(Component):
-    """Render field as YAML editor in UI"""
-
-    component_id: Literal[ComponentID.YAML] = ComponentID.YAML
-
-
-@dataclass(slots=True)
-class ActionType(Component):
-    """Render field as action type dropdown in UI"""
-
-    component_id: Literal[ComponentID.ACTION_TYPE] = ComponentID.ACTION_TYPE
-    multiple: bool = False
-
-
-@dataclass(slots=True)
-class WorkflowAlias(Component):
-    """Render field as workflow alias dropdown in UI"""
-
-    component_id: Literal[ComponentID.WORKFLOW_ALIAS] = ComponentID.WORKFLOW_ALIAS
 
 
 def _safe_issubclass(cls: type, base: type) -> bool:


### PR DESCRIPTION
# Motivation
This is the logically correct place to add these annotations as they are tightly coupled to UDFs. 

# TODO
Make the fields frozen

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved field component classes from the app to the registry package to centralize and simplify field definitions.

- **Refactors**
  - Relocated all field component classes to `tracecat_registry._internal.fields`.
  - Updated imports across the codebase to use the new location.

<!-- End of auto-generated description by cubic. -->

