### PR TITLE
feat(ui): Conversations and action profile nits

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -291,7 +291,7 @@ export function SystemPromptPartComponent({
         </div>
         {shouldTruncate && (
           <ChevronRightIcon
-            className={`ml-2 size-4 flex-shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+            className={`ml-2 size-4 shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`}
           />
         )}
       </div>
@@ -340,7 +340,7 @@ export function UserPromptPartComponent({
           </div>
           {shouldTruncate && (
             <ChevronRightIcon
-              className={`size-4 flex-shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+              className={`size-4 shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`}
             />
           )}
         </div>
@@ -381,7 +381,7 @@ export function RetryPromptPartComponent({
 
   return (
     <Card
-      className="cursor-pointer flex flex-col gap-2 rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs leading-normal shadow-sm hover:bg-muted/50"
+      className="flex cursor-pointer flex-col gap-2 rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs leading-normal shadow-sm hover:bg-muted/50"
       onClick={() => setIsExpanded(!isExpanded)}
     >
       <div className="flex items-center justify-between gap-1">
@@ -397,7 +397,7 @@ export function RetryPromptPartComponent({
           />
         )}
       </div>
-      <div className={`${isExpanded ? 'whitespace-pre-wrap' : 'whitespace-nowrap overflow-hidden text-ellipsis'}`}>
+      <div className={`${isExpanded ? 'whitespace-pre-wrap' : 'truncate'}`}>
         {displayContent}
       </div>
     </Card>

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -288,7 +288,7 @@ export function SystemPromptPartComponent({
       <div className="flex items-start gap-2">
         <CaseUserAvatar user={SYSTEM_USER} size="sm" />
         <div
-          className={`flex-1 overflow-x-auto break-words ${isExpanded ? "whitespace-pre-wrap" : "whitespace-nowrap"}`}
+          className={cn("flex-1 overflow-x-auto break-words", isExpanded ? "whitespace-pre-wrap" : "whitespace-nowrap")}
         >
           {displayContent}
         </div>

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -502,20 +502,24 @@ export function TextPartComponent({
     codeBlock,
   })
 
-  useEffect(() => {
-    if (text.content) {
-      loadInitialContent(editor, text.content)
-    }
-  }, [text.content, editor])
-
   const TRUNCATE_LIMIT = 200
   const shouldTruncate = text.content.length > TRUNCATE_LIMIT
+  useEffect(() => {
+    if (text.content) {
+      let contentToLoad
+      if (isExpanded) {
+        contentToLoad = text.content
+      } else {
+        // For collapsed view: normalize whitespace and truncate
+        const normalizedContent = text.content.replace(/\s+/g, ' ').trim()
+        contentToLoad = shouldTruncate
+          ? normalizedContent.substring(0, TRUNCATE_LIMIT) + "..."
+          : normalizedContent
+      }
 
-  // For collapsed view: normalize whitespace and truncate
-  const normalizedContent = text.content.replace(/\s+/g, ' ').trim()
-  const displayContent = shouldTruncate
-    ? normalizedContent.substring(0, TRUNCATE_LIMIT) + "..."
-    : normalizedContent
+      loadInitialContent(editor, contentToLoad)
+    }
+  }, [text.content, editor, isExpanded, shouldTruncate])
 
   return (
     <div
@@ -534,24 +538,20 @@ export function TextPartComponent({
         )}
       </div>
 
-      {isExpanded ? (
-        <BlockNoteView
-          editor={editor}
-          theme="light"
-          editable={false}
-          slashMenu={false}
-          style={{
-            height: "100%",
-            width: "100%",
-            whiteSpace: "pre-wrap",
-            lineHeight: "1.5",
-          }}
-        />
-      ) : (
-        <div className="whitespace-nowrap overflow-hidden text-ellipsis">
-          {displayContent}
-        </div>
-      )}
+      <BlockNoteView
+        editor={editor}
+        theme="light"
+        editable={false}
+        slashMenu={false}
+        style={{
+          height: "100%",
+          width: "100%",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          lineHeight: "1.5",
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -27,16 +27,16 @@ import { BlockNoteView } from "@blocknote/shadcn"
 import {
   ChevronRightIcon,
   CircleDot,
+  FileIcon,
+  FilePlusIcon,
+  FilterIcon,
+  FunctionSquareIcon,
+  ListIcon,
   LoaderIcon,
   MessageCircle,
   RefreshCw,
-  Undo2Icon,
-  FileIcon,
-  FilePlusIcon,
   SearchIcon,
-  ListIcon,
-  FilterIcon,
-  FunctionSquareIcon,
+  Undo2Icon,
 } from "lucide-react"
 
 import { SYSTEM_USER } from "@/lib/auth"
@@ -264,15 +264,16 @@ export function SystemPromptPartComponent({
   defaultExpanded?: boolean
 }) {
   const [isExpanded, setIsExpanded] = React.useState(defaultExpanded)
-  const content = typeof part.content === "string"
-    ? part.content
-    : JSON.stringify(part.content, null, 2)
+  const content =
+    typeof part.content === "string"
+      ? part.content
+      : JSON.stringify(part.content, null, 2)
 
   const TRUNCATE_LIMIT = 200
   const shouldTruncate = content.length > TRUNCATE_LIMIT
 
   // For collapsed view: normalize whitespace and truncate
-  const normalizedContent = content.replace(/\s+/g, ' ').trim()
+  const normalizedContent = content.replace(/\s+/g, " ").trim()
   const displayContent = isExpanded
     ? content
     : shouldTruncate
@@ -286,7 +287,9 @@ export function SystemPromptPartComponent({
     >
       <div className="flex items-start gap-2">
         <CaseUserAvatar user={SYSTEM_USER} size="sm" />
-        <div className={`flex-1 overflow-x-auto break-words ${isExpanded ? 'whitespace-pre-wrap' : 'whitespace-nowrap'}`}>
+        <div
+          className={`flex-1 overflow-x-auto break-words ${isExpanded ? "whitespace-pre-wrap" : "whitespace-nowrap"}`}
+        >
           {displayContent}
         </div>
         {shouldTruncate && (
@@ -308,15 +311,16 @@ export function UserPromptPartComponent({
 }) {
   const { user } = useAuth()
   const [isExpanded, setIsExpanded] = React.useState(defaultExpanded)
-  const content = typeof part.content === "string"
-    ? part.content
-    : JSON.stringify(part.content, null, 2)
+  const content =
+    typeof part.content === "string"
+      ? part.content
+      : JSON.stringify(part.content, null, 2)
 
   const TRUNCATE_LIMIT = 200
   const shouldTruncate = content.length > TRUNCATE_LIMIT
 
   // For collapsed view: normalize whitespace and truncate
-  const normalizedContent = content.replace(/\s+/g, ' ').trim()
+  const normalizedContent = content.replace(/\s+/g, " ").trim()
   const displayContent = isExpanded
     ? content
     : shouldTruncate
@@ -344,7 +348,9 @@ export function UserPromptPartComponent({
             />
           )}
         </div>
-        <div className={`overflow-x-auto break-words ${isExpanded ? 'whitespace-pre-wrap' : 'whitespace-nowrap'}`}>
+        <div
+          className={`overflow-x-auto break-words ${isExpanded ? "whitespace-pre-wrap" : "whitespace-nowrap"}`}
+        >
           {displayContent}
         </div>
       </div>
@@ -360,21 +366,22 @@ export function RetryPromptPartComponent({
   defaultExpanded?: boolean
 }) {
   const [isExpanded, setIsExpanded] = React.useState(defaultExpanded)
-  const content = typeof part.content === "string"
-    ? part.content
-    : part.content.map((c) => c.msg).join(' ')
+  const content =
+    typeof part.content === "string"
+      ? part.content
+      : part.content.map((c) => c.msg).join(" ")
 
   const TRUNCATE_LIMIT = 200
   const shouldTruncate = content.length > TRUNCATE_LIMIT
 
   // For collapsed view: normalize whitespace and truncate
-  const normalizedContent = content.replace(/\s+/g, ' ').trim()
+  const normalizedContent = content.replace(/\s+/g, " ").trim()
   const displayContent = isExpanded
-    ? (typeof part.content === "string"
-        ? part.content
-        : part.content.map((c) => {
-            return <span key={c.msg}>{c.msg}</span>
-          }))
+    ? typeof part.content === "string"
+      ? part.content
+      : part.content.map((c) => {
+          return <span key={c.msg}>{c.msg}</span>
+        })
     : shouldTruncate
       ? normalizedContent.substring(0, TRUNCATE_LIMIT) + "..."
       : normalizedContent
@@ -397,7 +404,7 @@ export function RetryPromptPartComponent({
           />
         )}
       </div>
-      <div className={`${isExpanded ? 'whitespace-pre-wrap' : 'truncate'}`}>
+      <div className={`${isExpanded ? "whitespace-pre-wrap" : "truncate"}`}>
         {displayContent}
       </div>
     </Card>
@@ -409,6 +416,12 @@ export function ToolReturnPartComponent({ part }: { part: ToolReturnPart }) {
 
   const toolName = part.tool_name
   const isDefaultTool = DEFAULT_TOOL_NAMES.has(toolName)
+
+  // Always resolve action type so hooks are called consistently
+  const actionType = reconstructActionType(toolName)
+  // Call hook unconditionally; it will be disabled internally when actionType is undefined
+  const { registryAction, registryActionIsLoading, registryActionError } =
+    useGetRegistryAction(isDefaultTool ? undefined : actionType)
 
   // Case 1 – default agent tool
   if (isDefaultTool) {
@@ -425,7 +438,9 @@ export function ToolReturnPartComponent({ part }: { part: ToolReturnPart }) {
               isExpanded && "border-b-[0.5px]"
             )}
           >
-            <div className="rounded-sm border-[0.5px] p-[3px]">{iconElement}</div>
+            <div className="rounded-sm border-[0.5px] p-[3px]">
+              {iconElement}
+            </div>
             <span className="text-xs font-semibold text-foreground/80">
               {toolName}
             </span>
@@ -448,12 +463,9 @@ export function ToolReturnPartComponent({ part }: { part: ToolReturnPart }) {
   }
 
   // Case 2 – registry action
-  const actionType = reconstructActionType(toolName)
-  const { registryAction, registryActionIsLoading, registryActionError } =
-    useGetRegistryAction(actionType)
-
-  if (registryActionIsLoading) return <Skeleton className="h-16 w-full" />
-
+  if (registryActionIsLoading) {
+    return <Skeleton className="h-16 w-full" />
+  }
   if (registryAction && !registryActionError) {
     return (
       <div className="flex flex-col gap-2">
@@ -573,7 +585,7 @@ export function TextPartComponent({
         contentToLoad = text.content
       } else {
         // For collapsed view: normalize whitespace and truncate
-        const normalizedContent = text.content.replace(/\s+/g, ' ').trim()
+        const normalizedContent = text.content.replace(/\s+/g, " ").trim()
         contentToLoad = shouldTruncate
           ? normalizedContent.substring(0, TRUNCATE_LIMIT) + "..."
           : normalizedContent
@@ -591,7 +603,9 @@ export function TextPartComponent({
       <div className="flex items-center justify-between gap-1">
         <div className="flex items-center gap-1">
           <MessageCircle className="size-4" />
-          <span className="text-xs font-semibold text-foreground/80">Agent</span>
+          <span className="text-xs font-semibold text-foreground/80">
+            Agent
+          </span>
         </div>
         {shouldTruncate && (
           <ChevronRightIcon
@@ -630,10 +644,17 @@ export function ToolCallPartComponent({
   const toolName = toolCall.tool_name
   const isDefaultTool = DEFAULT_TOOL_NAMES.has(toolName)
 
+  // Always resolve action type so hooks are called consistently
+  const actionType = reconstructActionType(toolName)
+  const { registryAction, registryActionIsLoading, registryActionError } =
+    useGetRegistryAction(isDefaultTool ? undefined : actionType)
+
   let args
   try {
     args =
-      typeof toolCall.args === "string" ? JSON.parse(toolCall.args) : toolCall.args
+      typeof toolCall.args === "string"
+        ? JSON.parse(toolCall.args)
+        : toolCall.args
   } catch {
     args = toolCall.args
   }
@@ -664,7 +685,9 @@ export function ToolCallPartComponent({
                     {key}
                   </td>
                   <td className="px-2 py-1 text-left align-top text-foreground/90">
-                    {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
+                    {typeof value === "string"
+                      ? value
+                      : JSON.stringify(value, null, 2)}
                   </td>
                 </tr>
               ))}
@@ -676,10 +699,6 @@ export function ToolCallPartComponent({
   }
 
   // Case 2 – registry action
-  const actionType = reconstructActionType(toolName)
-  const { registryAction, registryActionIsLoading, registryActionError } =
-    useGetRegistryAction(actionType)
-
   if (registryActionIsLoading) {
     return (
       <Card className="rounded-md border-[0.5px] bg-muted/20 p-2 text-xs shadow-sm">
@@ -696,7 +715,6 @@ export function ToolCallPartComponent({
       </Card>
     )
   }
-
   if (registryAction && !registryActionError) {
     return (
       <Card
@@ -732,7 +750,9 @@ export function ToolCallPartComponent({
                     {key}
                   </td>
                   <td className="px-2 py-1 text-left align-top text-foreground/90">
-                    {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
+                    {typeof value === "string"
+                      ? value
+                      : JSON.stringify(value, null, 2)}
                   </td>
                 </tr>
               ))}

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -622,7 +622,7 @@ export function TextPartComponent({
         style={{
           height: "100%",
           width: "100%",
-          whiteSpace: "nowrap",
+          whiteSpace: isExpanded ? "pre-wrap" : "nowrap",
           overflow: "hidden",
           textOverflow: "ellipsis",
           lineHeight: "1.5",

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -331,21 +331,53 @@ export function UserPromptPartComponent({
   )
 }
 
-export function RetryPromptPartComponent({ part }: { part: RetryPromptPart }) {
+export function RetryPromptPartComponent({
+  part,
+  defaultExpanded = false,
+}: {
+  part: RetryPromptPart
+  defaultExpanded?: boolean
+}) {
+  const [isExpanded, setIsExpanded] = React.useState(defaultExpanded)
+  const content = typeof part.content === "string"
+    ? part.content
+    : part.content.map((c) => c.msg).join(' ')
+
+  const TRUNCATE_LIMIT = 200
+  const shouldTruncate = content.length > TRUNCATE_LIMIT
+
+  // For collapsed view: normalize whitespace and truncate
+  const normalizedContent = content.replace(/\s+/g, ' ').trim()
+  const displayContent = isExpanded
+    ? (typeof part.content === "string"
+        ? part.content
+        : part.content.map((c) => {
+            return <span key={c.msg}>{c.msg}</span>
+          }))
+    : shouldTruncate
+      ? normalizedContent.substring(0, TRUNCATE_LIMIT) + "..."
+      : normalizedContent
+
   return (
-    <Card className="flex flex-col gap-2 rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs shadow-sm">
-      <div className="flex items-center gap-1">
-        <RefreshCw className="size-3 text-muted-foreground" />
-        <span className="text-xs font-semibold text-foreground/80">
-          Retry prompt
-        </span>
+    <Card
+      className="cursor-pointer flex flex-col gap-2 rounded-lg border-[0.5px] bg-muted/40 p-2 text-xs leading-normal shadow-sm hover:bg-muted/50"
+      onClick={() => setIsExpanded(!isExpanded)}
+    >
+      <div className="flex items-center justify-between gap-1">
+        <div className="flex items-center gap-1">
+          <RefreshCw className="size-3 text-muted-foreground" />
+          <span className="text-xs font-semibold text-foreground/80">
+            Retry prompt
+          </span>
+        </div>
+        {shouldTruncate && (
+          <ChevronRightIcon
+            className={`size-4 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+          />
+        )}
       </div>
-      <div className="whitespace-pre-wrap">
-        {typeof part.content === "string"
-          ? part.content
-          : part.content.map((c) => {
-              return <span key={c.msg}>{c.msg}</span>
-            })}
+      <div className={`${isExpanded ? 'whitespace-pre-wrap' : 'whitespace-nowrap overflow-hidden text-ellipsis'}`}>
+        {displayContent}
       </div>
     </Card>
   )

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -635,8 +635,8 @@ function ActionPanelContent({
                       flairsize: "md",
                     })}
                   </div>
-                  <div className="flex w-full flex-1 justify-between space-x-12">
-                    <div className="flex flex-col">
+                  <div className="flex w-full flex-1 space-x-4">
+                    <div className="flex flex-col flex-1">
                       {/* Editable action name */}
                       <FormField
                         control={methods.control}
@@ -655,20 +655,27 @@ function ActionPanelContent({
                         )}
                       />
 
-                      {/* Editable action description */}
+                      {/* Editable action description with tooltip */}
                       <FormField
                         control={methods.control}
                         name="description"
                         render={({ field }) => (
                           <FormItem className="mt-2 w-full">
-                            <FormControl>
-                              <Input
-                                variant="flat"
-                                className="w-full h-auto px-0 py-0 border-none text-xs leading-normal focus-visible:ring-0 placeholder:italic placeholder:text-muted-foreground"
-                                placeholder="No description"
-                                {...field}
-                              />
-                            </FormControl>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <FormControl>
+                                  <Input
+                                    variant="flat"
+                                    className="w-full max-w-[36rem] h-auto px-0 py-0 border-none bg-transparent text-xs leading-normal placeholder:italic placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:border-input focus-visible:bg-background whitespace-nowrap overflow-x-auto"
+                                    placeholder="No description"
+                                    {...field}
+                                  />
+                                </FormControl>
+                              </TooltipTrigger>
+                              <TooltipContent side="left" sideOffset={10} className="max-w-xs break-words text-xs">
+                                {field.value || "No description"}
+                              </TooltipContent>
+                            </Tooltip>
                           </FormItem>
                         )}
                       />

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -64,7 +64,6 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import {
   Select,
   SelectContent,
@@ -83,7 +82,6 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Textarea } from "@/components/ui/textarea"
 import { ToggleTabOption, ToggleTabs } from "@/components/ui/toggle-tabs"
 import {
   Tooltip,
@@ -105,7 +103,6 @@ import {
   WaitUntilTooltip,
 } from "@/components/builder/panel/action-panel-tooltips"
 import { ControlFlowField } from "@/components/builder/panel/control-flow-fields"
-import { CopyButton } from "@/components/copy-button"
 import { YamlViewOnlyEditor } from "@/components/editor/codemirror/yaml-editor"
 import { ExpressionInput } from "@/components/editor/expression-input"
 import {
@@ -636,7 +633,7 @@ function ActionPanelContent({
                     })}
                   </div>
                   <div className="flex w-full flex-1 space-x-4">
-                    <div className="flex flex-col flex-1">
+                    <div className="flex flex-1 flex-col">
                       {/* Editable action name */}
                       <FormField
                         control={methods.control}
@@ -646,7 +643,7 @@ function ActionPanelContent({
                             <FormControl>
                               <Input
                                 variant="flat"
-                                className="w-full h-auto px-0 py-0 border-none text-xs font-medium leading-none focus-visible:ring-0 focus-visible:border-input focus-visible:bg-background"
+                                className="h-auto w-full border-none p-0 text-xs font-medium leading-none focus-visible:border-input focus-visible:bg-background focus-visible:ring-0"
                                 placeholder="Name your action..."
                                 {...field}
                               />
@@ -666,7 +663,7 @@ function ActionPanelContent({
                                 <FormControl>
                                   <Input
                                     variant="flat"
-                                    className="w-full max-w-[36rem] h-auto px-0 py-0 border-none bg-transparent text-xs leading-normal placeholder:italic placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:border-input focus-visible:bg-background whitespace-nowrap overflow-x-auto"
+                                    className="h-auto w-full max-w-xl overflow-x-auto whitespace-nowrap border-none bg-transparent p-0 text-xs leading-normal placeholder:italic placeholder:text-muted-foreground focus-visible:border-input focus-visible:bg-background focus-visible:ring-0"
                                     placeholder="No description"
                                     {...field}
                                   />

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -28,7 +28,6 @@ import {
   MessagesSquare,
   Plus,
   SaveIcon,
-  SettingsIcon,
   ShapesIcon,
   SplitIcon,
 } from "lucide-react"
@@ -582,6 +581,12 @@ function ActionPanelContent({
     [inputMode, methods, action?.inputs, rawInputsYaml]
   )
 
+  const ActionIcon = registryAction
+    ? actionTypeToLabel[registryAction.type].icon
+    : Database
+  const isInteractive = methods.watch("is_interactive")
+  const interactionType = methods.watch("interaction.type")
+
   if (actionIsLoading || registryActionIsLoading) {
     return <CenteredSpinner />
   }
@@ -611,10 +616,6 @@ function ActionPanelContent({
     ...(validationErrors || []),
   ].filter((e) => e.ref === slugify(action.title))
 
-  const ActionIcon = actionTypeToLabel[registryAction.type].icon
-  const isInteractive = methods.watch("is_interactive")
-  const interactionType = methods.watch("interaction.type")
-
   return (
     <div onBlur={onPanelBlur}>
       <Tabs
@@ -626,7 +627,7 @@ function ActionPanelContent({
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
             <div className="relative">
-              <h3 className="p-4 py-6">
+              <h3 className="p-4 pt-6">
                 <div className="flex w-full items-start space-x-4">
                   <div className="flex-col">
                     {getIcon(registryAction.action, {
@@ -636,28 +637,42 @@ function ActionPanelContent({
                   </div>
                   <div className="flex w-full flex-1 justify-between space-x-12">
                     <div className="flex flex-col">
-                      <div className="flex w-full items-center justify-between text-xs font-medium leading-none">
-                        <div className="flex w-full">{action.title}</div>
-                      </div>
-                      <p className="mt-2 text-xs text-muted-foreground">
-                        {action.description || (
-                          <span className="italic">No description</span>
+                      {/* Editable action name */}
+                      <FormField
+                        control={methods.control}
+                        name="title"
+                        render={({ field }) => (
+                          <FormItem className="w-full">
+                            <FormControl>
+                              <Input
+                                variant="flat"
+                                className="w-full h-auto px-0 py-0 border-none text-xs font-medium leading-none focus-visible:ring-0 focus-visible:border-input focus-visible:bg-background"
+                                placeholder="Name your action..."
+                                {...field}
+                              />
+                            </FormControl>
+                          </FormItem>
                         )}
-                      </p>
+                      />
+
+                      {/* Editable action description */}
+                      <FormField
+                        control={methods.control}
+                        name="description"
+                        render={({ field }) => (
+                          <FormItem className="mt-2 w-full">
+                            <FormControl>
+                              <Input
+                                variant="flat"
+                                className="w-full h-auto px-0 py-0 border-none text-xs leading-normal focus-visible:ring-0 placeholder:italic placeholder:text-muted-foreground"
+                                placeholder="No description"
+                                {...field}
+                              />
+                            </FormControl>
+                          </FormItem>
+                        )}
+                      />
                       <div className="mt-2 hover:cursor-default">
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <div className="mt-2 flex items-center text-xs text-muted-foreground">
-                              <ActionIcon className="mr-1 size-3 stroke-2" />
-                              <span>
-                                {actionTypeToLabel[registryAction.type].label}
-                              </span>
-                            </div>
-                          </TooltipTrigger>
-                          <TooltipContent side="left" sideOffset={10}>
-                            Action type
-                          </TooltipContent>
-                        </Tooltip>
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <div className="mt-2 flex items-center text-xs text-muted-foreground">
@@ -743,73 +758,6 @@ function ActionPanelContent({
                     defaultValue={["action-inputs"]}
                     className="pb-10"
                   >
-                    <AccordionItem value="action-settings">
-                      <AccordionTrigger className="px-4 text-xs font-bold">
-                        <div className="flex items-center">
-                          <SettingsIcon className="mr-3 size-4" />
-                          <span>General</span>
-                        </div>
-                      </AccordionTrigger>
-                      {/* General settings for the action */}
-                      <AccordionContent>
-                        <div className="my-4 space-y-2 px-4">
-                          <FormField
-                            control={methods.control}
-                            name="title"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel className="text-xs">Name</FormLabel>
-                                <FormControl>
-                                  <Input
-                                    className="text-xs"
-                                    placeholder="Name your action..."
-                                    {...field}
-                                  />
-                                </FormControl>
-                                <FormMessage className="whitespace-pre-line" />
-                              </FormItem>
-                            )}
-                          />
-                          <FormField
-                            control={methods.control}
-                            name="description"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel className="text-xs">
-                                  Description
-                                </FormLabel>
-                                <FormControl>
-                                  <Textarea
-                                    className="text-xs"
-                                    placeholder="Describe your action..."
-                                    {...field}
-                                  />
-                                </FormControl>
-                                <FormMessage className="whitespace-pre-line" />
-                              </FormItem>
-                            )}
-                          />
-                          <div className="space-y-2">
-                            <Label className="flex items-center gap-2 text-xs font-medium">
-                              <span>Action ID</span>
-                              <CopyButton
-                                value={action.id}
-                                toastMessage="Copied action ID to clipboard"
-                              />
-                            </Label>
-                            <div className="rounded-md border shadow-sm">
-                              <Input
-                                value={action.id}
-                                className="rounded-md border-none text-xs shadow-none"
-                                readOnly
-                                disabled
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </AccordionContent>
-                    </AccordionItem>
-
                     {/* Interaction */}
                     {appSettings?.app_interactions_enabled &&
                       PERMITTED_INTERACTION_ACTIONS.includes(

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -669,7 +669,11 @@ function ActionPanelContent({
                                   />
                                 </FormControl>
                               </TooltipTrigger>
-                              <TooltipContent side="left" sideOffset={10} className="max-w-xs break-words text-xs">
+                              <TooltipContent
+                                side="left"
+                                sideOffset={10}
+                                className="max-w-xs break-words text-xs"
+                              >
                                 {field.value || "No description"}
                               </TooltipContent>
                             </Tooltip>

--- a/frontend/src/components/registry/icons.tsx
+++ b/frontend/src/components/registry/icons.tsx
@@ -6,11 +6,11 @@ export const actionTypeToLabel: Record<
   { label: string; icon: LucideIcon }
 > = {
   udf: {
-    label: "User Defined Function",
+    label: "User defined function",
     icon: SquareFunctionIcon,
   },
   template: {
-    label: "Template Action",
+    label: "Template action",
     icon: ToyBrickIcon,
   },
 }


### PR DESCRIPTION
<img width="676" alt="Screenshot 2025-06-18 at 8 54 05 PM" src="https://github.com/user-attachments/assets/350560a0-e3b5-4a1a-b765-59b9b0875e5f" />
<img width="1140" alt="Screenshot 2025-06-18 at 8 53 52 PM" src="https://github.com/user-attachments/assets/4e5d2ef3-3685-43c1-a4fb-9979f338e760" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the conversations UI by making user, model, and retry responses collapsible, and updated the action panel to allow inline editing of action names and descriptions.

- **UI Improvements**
  - Added expand/collapse for long responses in conversation views.
  - Made action name and description fields directly editable in the action panel.
  - Updated action type labels to use lowercase for consistency.

<!-- End of auto-generated description by cubic. -->

