### PR TITLE
feat(ui): Add error boundaries in builder UI

### DIFF
--- a/frontend/src/components/builder/builder.tsx
+++ b/frontend/src/components/builder/builder.tsx
@@ -6,6 +6,7 @@ import { SidebarIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { WorkflowBuilderErrorBoundary } from "@/components/error-boundaries"
 import {
   CustomResizableHandle,
   ResizablePanel,
@@ -72,16 +73,17 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
   }, [toggleActionPanel])
 
   return (
-    <TooltipProvider delayDuration={0}>
-      <ResizablePanelGroup
-        className="h-full"
-        direction="horizontal"
-        onLayout={(sizes: number[]) => {
-          document.cookie = `react-resizable-panels:layout=${JSON.stringify(
-            sizes
-          )}`
-        }}
-      >
+    <WorkflowBuilderErrorBoundary>
+      <TooltipProvider delayDuration={0}>
+        <ResizablePanelGroup
+          className="h-full"
+          direction="horizontal"
+          onLayout={(sizes: number[]) => {
+            document.cookie = `react-resizable-panels:layout=${JSON.stringify(
+              sizes
+            )}`
+          }}
+        >
         <ResizablePanel
           ref={sidebarRef}
           defaultSize={defaultLayout[0]}
@@ -154,5 +156,6 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
         </ResizablePanel>
       </ResizablePanelGroup>
     </TooltipProvider>
+    </WorkflowBuilderErrorBoundary>
   )
 }

--- a/frontend/src/components/error-boundaries.tsx
+++ b/frontend/src/components/error-boundaries.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import React from "react"
+import { Input } from "@/components/ui/input"
+import {
+  BaseErrorBoundary,
+  ErrorBoundaryProps,
+  ErrorInfo,
+  MinimalErrorFallback,
+  SectionErrorFallback,
+  FormFieldErrorFallback
+} from "@/components/error-boundary"
+
+// Component Error Boundary - for individual components
+export function ComponentErrorBoundary({
+  children,
+  onError,
+  ...props
+}: ErrorBoundaryProps) {
+  const handleError = (error: Error, errorInfo: ErrorInfo) => {
+    // Log component-specific error
+    console.warn("Component Error Boundary:", error.message)
+    onError?.(error, errorInfo)
+  }
+
+  return (
+    <BaseErrorBoundary
+      {...props}
+      fallback={MinimalErrorFallback}
+      onError={handleError}
+    >
+      {children}
+    </BaseErrorBoundary>
+  )
+}
+
+// Section Error Boundary - for logical sections like tabs, forms
+export function SectionErrorBoundary({
+  children,
+  onError,
+  ...props
+}: ErrorBoundaryProps) {
+  const handleError = (error: Error, errorInfo: ErrorInfo) => {
+    // Log section-specific error
+    console.warn("Section Error Boundary:", error.message)
+    onError?.(error, errorInfo)
+  }
+
+  return (
+    <BaseErrorBoundary
+      {...props}
+      fallback={SectionErrorFallback}
+      onError={handleError}
+    >
+      {children}
+    </BaseErrorBoundary>
+  )
+}
+
+// Form Field Error Boundary - for form inputs with graceful degradation
+export function FormFieldErrorBoundary({
+  children,
+  onError,
+  fallbackInput,
+  ...props
+}: ErrorBoundaryProps & { fallbackInput?: React.ReactNode }) {
+  const handleError = (error: Error, errorInfo: ErrorInfo) => {
+    // Log form field error
+    console.warn("Form Field Error Boundary:", error.message)
+    onError?.(error, errorInfo)
+  }
+
+  // Custom fallback that includes a simple input option
+  const FormFieldFallback = ({ error, resetError, errorId }: { error: Error | null, resetError: () => void, errorId: string }) => (
+    <FormFieldErrorFallback
+      error={error}
+      resetError={resetError}
+      errorId={errorId}
+      errorInfo={null}
+    >
+      {fallbackInput || <Input placeholder="Simplified text input (error mode)" />}
+    </FormFieldErrorFallback>
+  )
+
+  return (
+    <BaseErrorBoundary
+      {...props}
+      fallback={FormFieldFallback}
+      onError={handleError}
+    >
+      {children}
+    </BaseErrorBoundary>
+  )
+}
+
+// Expression Error Boundary - specifically for template expressions
+export function ExpressionErrorBoundary({
+  children,
+  onError,
+  fieldName,
+  value,
+  onChange,
+  fallbackInput,
+  ...props
+}: ErrorBoundaryProps & {
+  fieldName?: string
+  value?: string
+  onChange?: (value: string) => void
+  fallbackInput?: React.ReactNode
+}) {
+  const handleError = (error: Error, errorInfo: ErrorInfo) => {
+    // Log expression-specific error with context
+    console.warn(`Expression Error Boundary [${fieldName}]:`, error.message)
+    onError?.(error, errorInfo)
+  }
+
+  // Custom fallback that provides a simple text input
+  const ExpressionFallback = ({ error, resetError, errorId }: { error: Error | null, resetError: () => void, errorId: string }) => (
+    <FormFieldErrorFallback
+      error={error}
+      resetError={resetError}
+      errorId={errorId}
+      errorInfo={null}
+    >
+      {fallbackInput}
+    </FormFieldErrorFallback>
+  )
+
+  return (
+    <BaseErrorBoundary
+      {...props}
+      fallback={ExpressionFallback}
+      onError={handleError}
+    >
+      {children}
+    </BaseErrorBoundary>
+  )
+}
+
+// Workflow Builder Error Boundary - top-level protection
+export function WorkflowBuilderErrorBoundary({
+  children,
+  onError,
+  ...props
+}: ErrorBoundaryProps) {
+  const handleError = (error: Error, errorInfo: ErrorInfo) => {
+    // Log workflow builder error - this is serious
+    console.error("Workflow Builder Error Boundary:", error.message)
+
+    // Could send to error reporting service here
+    onError?.(error, errorInfo)
+  }
+
+  return (
+    <BaseErrorBoundary
+      {...props}
+      onError={handleError}
+    >
+      {children}
+    </BaseErrorBoundary>
+  )
+}
+
+// Template Pills Error Boundary - for CodeMirror template pill rendering
+export function TemplatePillErrorBoundary({
+  children,
+  onError,
+  ...props
+}: ErrorBoundaryProps) {
+  const handleError = (error: Error, errorInfo: ErrorInfo) => {
+    // Log template pill error
+    console.warn("Template Pill Error Boundary:", error.message)
+    onError?.(error, errorInfo)
+  }
+
+  // Minimal fallback for template pills to not disrupt editor flow
+  const TemplatePillFallback = ({ error }: { error: Error | null, resetError: () => void }) => (
+    <span className="cm-template-pill cm-template-error" title={`Error: ${error?.message}`}>
+      [Error]
+    </span>
+  )
+
+  return (
+    <BaseErrorBoundary
+      {...props}
+      fallback={TemplatePillFallback}
+      onError={handleError}
+    >
+      {children}
+    </BaseErrorBoundary>
+  )
+}

--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,0 +1,312 @@
+"use client"
+
+import React, { Component, ReactNode } from "react"
+import { AlertTriangleIcon, RefreshCwIcon } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+// Base error boundary types
+export interface ErrorInfo {
+  componentStack: string
+  errorBoundary?: string
+  errorBoundaryStack?: string
+}
+
+export interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+  errorInfo: ErrorInfo | null
+  errorId: string
+}
+
+export interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback?: React.ComponentType<ErrorFallbackProps>
+  onError?: (error: Error, errorInfo: ErrorInfo) => void
+  isolateError?: boolean
+}
+
+export interface ErrorFallbackProps {
+  error: Error | null
+  errorInfo: ErrorInfo | null
+  resetError: () => void
+  errorId: string
+}
+
+// Base Error Boundary Component
+export class BaseErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  private resetTimeoutId: number | null = null
+
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      errorId: ""
+    }
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return {
+      hasError: true,
+      error,
+      errorId: Math.random().toString(36).substring(7)
+    }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({
+      errorInfo
+    })
+
+    // Call custom error handler if provided
+    this.props.onError?.(error, errorInfo)
+
+    // Log error for debugging
+    console.group(`🚨 Error Boundary Caught Error [${this.state.errorId}]`)
+    console.error("Error:", error)
+    console.error("Error Info:", errorInfo)
+    console.groupEnd()
+  }
+
+  componentWillUnmount() {
+    if (this.resetTimeoutId) {
+      window.clearTimeout(this.resetTimeoutId)
+    }
+  }
+
+  resetError = () => {
+    if (this.resetTimeoutId) {
+      window.clearTimeout(this.resetTimeoutId)
+    }
+
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      errorId: ""
+    })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const Fallback = this.props.fallback || DefaultErrorFallback
+      return (
+        <Fallback
+          error={this.state.error}
+          errorInfo={this.state.errorInfo}
+          resetError={this.resetError}
+          errorId={this.state.errorId}
+        />
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+// Default Error Fallback Component
+export function DefaultErrorFallback({
+  error,
+  errorInfo,
+  resetError,
+  errorId
+}: ErrorFallbackProps) {
+  const [showDetails, setShowDetails] = React.useState(false)
+
+  return (
+    <Alert variant="destructive" className="m-4">
+      <AlertTriangleIcon className="size-4" />
+      <AlertTitle>Something went wrong</AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p className="text-sm">
+          An unexpected error occurred. You can try to reload this section or continue with your work.
+        </p>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={resetError}
+            className="h-8"
+          >
+            <RefreshCwIcon className="mr-2 size-3" />
+            Retry
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowDetails(!showDetails)}
+            className="h-8"
+          >
+            {showDetails ? "Hide" : "Show"} Details
+          </Button>
+        </div>
+        {showDetails && (
+          <Card className="mt-4">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">Error Details</CardTitle>
+            </CardHeader>
+            <CardContent className="text-xs">
+              <div className="space-y-2">
+                <div>
+                  <span className="font-medium">Error ID:</span> {errorId}
+                </div>
+                <div>
+                  <span className="font-medium">Message:</span> {error?.message}
+                </div>
+                {error?.stack && (
+                  <div>
+                    <span className="font-medium">Stack:</span>
+                    <pre className="mt-1 whitespace-pre-wrap rounded bg-muted p-2 text-xs">
+                      {error.stack}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+// Minimal Error Fallback for tight spaces
+export function MinimalErrorFallback({
+  error,
+  resetError,
+  errorId
+}: ErrorFallbackProps) {
+  return (
+    <div className="flex items-center gap-2 rounded border border-destructive/20 bg-destructive/10 p-2 text-xs text-destructive">
+      <AlertTriangleIcon className="size-3 shrink-0" />
+      <span className="flex-1 truncate">Error occurred</span>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={resetError}
+        className="size-6 p-0"
+        title="Retry"
+      >
+        <RefreshCwIcon className="size-3" />
+      </Button>
+    </div>
+  )
+}
+
+// Inline Error Fallback for form fields
+export function InlineErrorFallback({
+  error,
+  resetError,
+  errorId
+}: ErrorFallbackProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 rounded border border-destructive/20 bg-destructive/5 p-2 text-xs text-destructive">
+        <AlertTriangleIcon className="size-3" />
+        <span className="flex-1">Component error: {error?.message}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={resetError}
+          className="h-6 px-2 text-xs"
+        >
+          Retry
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// Section Error Fallback for larger sections
+export function SectionErrorFallback({
+  error,
+  resetError,
+  errorId
+}: ErrorFallbackProps) {
+  return (
+    <div className="rounded-md border border-destructive/20 bg-destructive/5 p-4">
+      <div className="flex items-start gap-3">
+        <AlertTriangleIcon className="mt-0.5 size-5 text-destructive" />
+        <div className="flex-1 space-y-3">
+          <div>
+            <h4 className="text-sm font-medium text-destructive">
+              Section temporarily unavailable
+            </h4>
+            <p className="mt-1 text-xs text-muted-foreground">
+              This section encountered an error but the rest of your workflow is still functional.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={resetError}
+              className="h-8"
+            >
+              <RefreshCwIcon className="mr-2 size-3" />
+              Reload Section
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Form Field Error Fallback with graceful degradation
+export function FormFieldErrorFallback({
+  error,
+  resetError,
+  errorId,
+  children
+}: ErrorFallbackProps & { children?: ReactNode }) {
+  const [fallbackMode, setFallbackMode] = React.useState<"error" | "text">("error")
+
+  if (fallbackMode === "text") {
+    return (
+      <div className="space-y-2">
+        <div className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-600">
+          Field is in simplified mode due to an error.
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setFallbackMode("error")}
+            className="ml-2 h-6 px-2 text-xs"
+          >
+            Show Error
+          </Button>
+        </div>
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 rounded border border-destructive/20 bg-destructive/5 p-2 text-xs text-destructive">
+        <AlertTriangleIcon className="size-3" />
+        <span className="flex-1">Field error: {error?.message}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={resetError}
+          className="h-6 px-2 text-xs"
+        >
+          Retry
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setFallbackMode("text")}
+          className="h-6 px-2 text-xs"
+        >
+          Use Simple Mode
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION





# Changes
- **add error boundary components**
- **add boundaries around expression pills, form inputs, panel tabs, and workflow builder**

# Testing
if we make expression pills throw an error when rendering to dom:
![Screenshot 2025-06-19 at 22 13 46](https://github.com/user-attachments/assets/b3748569-fc86-4b0b-85a0-23ce75a1d911)

we usually get
![Screenshot 2025-06-19 at 22 14 05](https://github.com/user-attachments/assets/dbe389a6-7e00-4ee0-83d9-741757630b28)

but with this pr we add various layers of error handling.
Error handling at the pill level

https://github.com/user-attachments/assets/41fb709a-90df-4ee5-a344-a5ac5d20433d


error handling at the field level:

https://github.com/user-attachments/assets/355b4183-7079-4e1c-9e33-3e131509ab69




<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added error boundaries to the builder UI to catch and display errors in key areas without breaking the whole app.

- **New Features**
  - Added error boundary components.
  - Wrapped expression pills, form inputs, panel tabs, and the workflow builder with error boundaries.

<!-- End of auto-generated description by cubic. -->

