### PR TITLE
fix: SAML_ACCEPTED_TIME_DIFF not in env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ USER_AUTH_SECRET=your-auth-secret
 
 # SAML SSO settings
 SAML_IDP_METADATA_URL=
+SAML_ACCEPTED_TIME_DIFF=3
 
 # --- Temporal ---
 TEMPORAL__CLUSTER_URL=temporal:7233


### PR DESCRIPTION
Fixes #1208.

A `ValueError` occurred during Tracecat startup due to `SAML_ACCEPTED_TIME_DIFF` being an empty string.

This happened because:
*   The `docker-compose.yml` file referenced `${SAML_ACCEPTED_TIME_DIFF}`.
*   The variable was missing from the `.env.example` template.
*   Docker Compose defaults undefined variables to an empty string (`""`), rather than leaving them unset.
*   The Python code in `tracecat/config.py` attempted `int(os.environ.get("SAML_ACCEPTED_TIME_DIFF", "3"))`, receiving `""` instead of `None`, thus bypassing the default and causing `int("")` to fail.

The fix involved adding `SAML_ACCEPTED_TIME_DIFF=3` to the `.env.example` file. This ensures that when `.env` is generated, `SAML_ACCEPTED_TIME_DIFF` is properly defined, preventing the `ValueError` and allowing Tracecat to start successfully.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added SAML_ACCEPTED_TIME_DIFF to .env.example to prevent startup errors when running Tracecat with Docker Compose.

<!-- End of auto-generated description by cubic. -->

