### PR TITLE
perf(engine): Improve fallback parser function

### DIFF
--- a/tracecat/dsl/_converter.py
+++ b/tracecat/dsl/_converter.py
@@ -1,8 +1,8 @@
-from functools import partial
 from typing import Any
 
 import orjson
-from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel
+from pydantic_core import to_jsonable_python
 from temporalio.api.common.v1 import Payload
 from temporalio.converter import (
     CompositePayloadConverter,
@@ -10,6 +10,18 @@ from temporalio.converter import (
     DefaultPayloadConverter,
     JSONPlainPayloadConverter,
 )
+
+
+def _serializer(obj: Any) -> Any:
+    """Serializer for arbitrary objects.
+
+    This is used to serialize arbitrary objects to JSON.
+    """
+    if isinstance(obj, BaseModel):
+        # We exclude unset values to avoid sending them to Temporal
+        # as after serialization they will are treated as set values.
+        return obj.model_dump(exclude_unset=True)
+    return to_jsonable_python(obj, fallback=str)
 
 
 class PydanticORJSONPayloadConverter(JSONPlainPayloadConverter):
@@ -31,9 +43,7 @@ class PydanticORJSONPayloadConverter(JSONPlainPayloadConverter):
             metadata={"encoding": self.encoding.encode()},
             data=orjson.dumps(
                 value,
-                # We exclude unset values to avoid sending them to Temporal
-                # as after serialization they will are treated as set values.
-                default=partial(jsonable_encoder, exclude_unset=True),
+                default=_serializer,
                 option=orjson.OPT_SORT_KEYS | orjson.OPT_NON_STR_KEYS,
             ),
         )
@@ -59,33 +69,3 @@ pydantic_data_converter = DataConverter(
     payload_converter_class=PydanticPayloadConverter
 )
 """Data converter using Pydantic JSON conversion."""
-
-
-# test = {
-#     "role": {
-#         "type": "service",
-#         "workspace_id": UUID("c0963ef7-8577-4da6-9860-6ea7b4db900b"),
-#         "user_id": UUID("00000000-0000-4444-aaaa-000000000000"),
-#         "service_id": "tracecat-runner",
-#     },
-#     "dsl": {
-#         "title": "test_workflow_override_environment_correct",
-#         "description": "Test that we can set the runtime environment for a workflow. The workflow should use the environment set in the DSL config.",
-#         "entrypoint": {"ref": "a", "expects": {}},
-#         "actions": [
-#             {
-#                 "ref": "a",
-#                 "description": "",
-#                 "action": "core.transform.reshape",
-#                 "args": {"value": "${{ ENV.environment }}"},
-#                 "depends_on": [],
-#             }
-#         ],
-#         "config": {"environment": "__TEST_ENVIRONMENT__"},
-#         "triggers": [],
-#         "inputs": {},
-#         "tests": [],
-#         "returns": "${{ ACTIONS.a.result }}",
-#     },
-#     "wf_id": "wf-00000000000000000000000000000000",
-# }

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -823,6 +823,10 @@ class DSLWorkflow:
         Not sure why we can't just run the function directly here.
         Pydantic throws an invalid JsonSchema error when we do so.
         """
+        if not self.dsl.entrypoint.expects:
+            return DSLValidationResult(
+                status="success", msg="No trigger inputs expected"
+            )
 
         validation_result = await workflow.execute_activity(
             validate_trigger_inputs_activity,
@@ -997,7 +1001,6 @@ class DSLWorkflow:
         ).model_dump()
         self.logger.info(
             "Running child workflow",
-            run_args=run_args,
             wait_strategy=args.wait_strategy,
             memo=memo,
         )


### PR DESCRIPTION
- **perf(engine): Don't run ValidateTriggerInputsActivityInputs if there are no expected fields**
- **use to_jsonable_python as default serializer instead of fastapi**

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
