### PR TITLE
perf(engine): Disable worker eager execution to try distribute load

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -183,6 +183,12 @@ TEMPORAL__TASK_TIMEOUT = os.environ.get("TEMPORAL__TASK_TIMEOUT")
 TEMPORAL__METRICS_PORT = os.environ.get("TEMPORAL__METRICS_PORT")
 """Port for the Temporal metrics server."""
 
+
+TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION = os.environ.get(
+    "TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION", "true"
+).lower() in ("true", "1")
+"""Disable eager activity execution for Temporal workflows."""
+
 # Secrets manager config
 TRACECAT__UNSAFE_DISABLE_SM_MASKING = os.environ.get(
     "TRACECAT__UNSAFE_DISABLE_SM_MASKING",

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -13,6 +13,7 @@ from temporalio.worker.workflow_sandbox import (
 with workflow.unsafe.imports_passed_through():
     import sentry_sdk
 
+    from tracecat import config
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.interceptor import SentryInterceptor
@@ -88,8 +89,12 @@ async def main() -> None:
         workflows=[DSLWorkflow],
         workflow_runner=new_sandbox_runner(),
         interceptors=interceptors,
+        disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
     ):
-        logger.info("Worker started, ctrl+c to exit")
+        logger.info(
+            "Worker started, ctrl+c to exit",
+            disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
+        )
         # Wait until interrupted
         await interrupt_event.wait()
         logger.info("Shutting down")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disabled eager activity execution for Temporal workers to help distribute load more evenly.

- **Config**
  - Added TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION environment variable to control this behavior.

<!-- End of auto-generated description by cubic. -->

