### PR TITLE
feat(engine): Make run_if and gather expression resolution sync Temporal activities

### DIFF
--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -2,32 +2,23 @@ import os
 
 import pytest
 from temporalio.client import WorkflowFailureError
-from temporalio.worker import Worker
 
 from tests import shared
 from tracecat.contexts import ctx_role
-from tracecat.dsl.action import DSLActivities
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import RETRY_POLICIES, DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.models import ActionStatement
-from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.logger import logger
 
 
 @pytest.mark.anyio
-async def test_execution_fails_fatal(test_role):
+async def test_execution_fails_fatal(test_role, test_worker_factory):
     dsl = DSLInput.from_yaml("tests/data/workflows/unit_error_fatal.yml")
     test_name = f"test_fatal_execution-{dsl.title}"
     wf_exec_id = shared.generate_test_exec_id(test_name)
     client = await get_temporal_client()
-    async with Worker(
-        client,
-        task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-        activities=DSLActivities.load(),
-        workflows=[DSLWorkflow],
-        workflow_runner=new_sandbox_runner(),
-    ):
+    async with test_worker_factory(client):
         with pytest.raises(WorkflowFailureError) as e:
             await client.execute_workflow(
                 DSLWorkflow.run,
@@ -80,7 +71,7 @@ async def test_execution_fails_fatal(test_role):
 @pytest.mark.anyio
 @pytest.mark.skip
 async def test_execution_fails_invalid_expressions(
-    expression, expected_error, test_role
+    expression, expected_error, test_role, test_worker_factory
 ):
     dsl = DSLInput(
         title="Testing invalid expressions: " + expected_error,
@@ -106,13 +97,7 @@ async def test_execution_fails_invalid_expressions(
     test_name = f"test_execution_fails_invalid_expressions-{dsl.title}"
     wf_exec_id = shared.generate_test_exec_id(test_name)
     client = await get_temporal_client()
-    async with Worker(
-        client,
-        task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-        activities=DSLActivities.load(),
-        workflows=[DSLWorkflow],
-        workflow_runner=new_sandbox_runner(),
-    ):
+    async with test_worker_factory(client):
         with pytest.raises(WorkflowFailureError):
             result = await client.execute_workflow(
                 DSLWorkflow.run,
@@ -122,7 +107,3 @@ async def test_execution_fails_invalid_expressions(
                 retry_policy=RETRY_POLICIES["workflow:fail_fast"],
             )
             logger.info(result)
-
-        # assert (
-        #     expected_error in str(exc_info.value)
-        # ), f"Expected '{expected_error}' in error message, but got: {str(exc_info.value)}"

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -8,10 +8,10 @@ from tests import shared
 from tracecat.contexts import ctx_role
 from tracecat.dsl.action import DSLActivities
 from tracecat.dsl.client import get_temporal_client
-from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.common import RETRY_POLICIES, DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.models import ActionStatement
 from tracecat.dsl.worker import new_sandbox_runner
-from tracecat.dsl.workflow import DSLWorkflow, retry_policies
+from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.logger import logger
 
 
@@ -34,7 +34,7 @@ async def test_execution_fails_fatal(test_role):
                 DSLRunArgs(dsl=dsl, role=ctx_role.get(), wf_id=shared.TEST_WF_ID),
                 id=wf_exec_id,
                 task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-                retry_policy=retry_policies["workflow:fail_fast"],
+                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
             )
             assert "Couldn't resolve expression 'ACTIONS.a.result.invalid'" in str(e)
 
@@ -119,7 +119,7 @@ async def test_execution_fails_invalid_expressions(
                 DSLRunArgs(dsl=dsl, role=test_role, wf_id=shared.TEST_WF_ID),
                 id=wf_exec_id,
                 task_queue=os.environ["TEMPORAL__CLUSTER_QUEUE"],
-                retry_policy=retry_policies["workflow:fail_fast"],
+                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
             )
             logger.info(result)
 

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -10,10 +10,10 @@ from temporalio.worker import Worker
 
 from tests.shared import TEST_WF_ID, generate_test_exec_id
 from tracecat.contexts import ctx_interaction
-from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.common import RETRY_POLICIES, DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.models import ActionStatement
 from tracecat.dsl.worker import get_activities, new_sandbox_runner
-from tracecat.dsl.workflow import DSLWorkflow, retry_policies
+from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.enums import InteractionStatus, InteractionType
 from tracecat.ee.interactions.models import (
     InteractionContext,
@@ -114,7 +114,7 @@ async def test_workflow_interaction(svc_role: Role, temporal_client: Client):
                 run_args,
                 id=wf_exec_id,
                 task_queue=queue,
-                retry_policy=retry_policies["workflow:fail_fast"],
+                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
                 execution_timeout=timedelta(seconds=10),
             )
             async with InteractionService.with_session(role=role) as svc:

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -34,6 +34,7 @@ from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.schemas import Workflow
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import (
+    RETRY_POLICIES,
     DSLEntrypoint,
     DSLInput,
     DSLRunArgs,
@@ -53,7 +54,7 @@ from tracecat.dsl.models import (
     ScatterArgs,
 )
 from tracecat.dsl.worker import get_activities, new_sandbox_runner
-from tracecat.dsl.workflow import DSLWorkflow, retry_policies
+from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.expressions.common import ExprContext
 from tracecat.identifiers.workflow import (
     WF_EXEC_ID_PATTERN,
@@ -452,7 +453,7 @@ async def test_workflow_set_environment_correct(test_role, temporal_client):
             run_args,
             id=wf_exec_id,
             task_queue=queue,
-            retry_policy=retry_policies["workflow:fail_fast"],
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
         )
     assert result == "__TEST_ENVIRONMENT__"
 
@@ -511,7 +512,7 @@ async def test_workflow_override_environment_correct(test_role, temporal_client)
             run_args,
             id=wf_exec_id,
             task_queue=queue,
-            retry_policy=retry_policies["workflow:fail_fast"],
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
         )
     assert result == "__CORRECT_ENVIRONMENT__"
 
@@ -568,7 +569,7 @@ async def test_workflow_default_environment_correct(test_role, temporal_client):
             run_args,
             id=wf_exec_id,
             task_queue=queue,
-            retry_policy=retry_policies["workflow:fail_fast"],
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
         )
     assert result == "default"
 
@@ -615,7 +616,7 @@ async def _run_workflow(client: Client, wf_exec_id: str, run_args: DSLRunArgs):
             run_args,
             id=wf_exec_id,
             task_queue=queue,
-            retry_policy=retry_policies["workflow:fail_fast"],
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
         )
     return result
 
@@ -3157,7 +3158,7 @@ async def test_workflow_detached_child_workflow(
             run_args,
             id=wf_exec_id,
             task_queue=queue,
-            retry_policy=retry_policies["workflow:fail_fast"],
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
         )
         # Wait for parent completion
         await parent_handle.result()
@@ -4713,7 +4714,7 @@ async def test_workflow_scatter_gather(
             run_args,
             id=wf_exec_id,
             task_queue=queue,
-            retry_policy=retry_policies["workflow:fail_fast"],
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
         )
         assert result == expected
 
@@ -4798,6 +4799,6 @@ async def test_workflow_env_and_trigger_access_in_stream(
             run_args,
             id=wf_exec_id,
             task_queue=queue,
-            retry_policy=retry_policies["workflow:fail_fast"],
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
         )
         assert result == expected

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -19,6 +19,7 @@ from tracecat.db.engine import get_async_session_context_manager
 from tracecat.dsl.models import ActionErrorInfo, ActionStatement, RunActionInput
 from tracecat.executor.client import ExecutorClient
 from tracecat.expressions.common import ExprContext
+from tracecat.expressions.core import TemplateExpression
 from tracecat.logger import logger
 from tracecat.registry.actions.models import RegistryActionValidateResponse
 from tracecat.types.auth import Role
@@ -188,3 +189,13 @@ class DSLActivities:
             wait_until, settings={"TIMEZONE": "UTC", "RETURN_AS_TIMEZONE_AWARE": True}
         )
         return dt.isoformat() if dt else None
+
+    @staticmethod
+    @activity.defn
+    def evaluate_single_expression_activity(
+        expression: str,
+        operand: dict[str, Any],
+    ) -> Any:
+        """Synchronously evaluate an expression. Strip whitespace from the expression."""
+        expr = TemplateExpression(expression.strip(), operand=operand)
+        return expr.result()

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -15,12 +15,14 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    ValidationError,
     field_validator,
     model_validator,
 )
 from pydantic_core import PydanticCustomError
 from temporalio import workflow
-from temporalio.common import SearchAttributeKey, TypedSearchAttributes
+from temporalio.common import RetryPolicy, SearchAttributeKey, TypedSearchAttributes
+from temporalio.exceptions import ApplicationError, ChildWorkflowError, FailureError
 
 from tracecat.db.schemas import Action
 from tracecat.dsl.enums import (
@@ -53,7 +55,13 @@ from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.parse import traverse_leaves
 from tracecat.types.auth import Role
-from tracecat.types.exceptions import TracecatDSLError
+from tracecat.types.exceptions import (
+    TracecatCredentialsError,
+    TracecatDSLError,
+    TracecatException,
+    TracecatExpressionError,
+    TracecatValidationError,
+)
 from tracecat.workflow.actions.models import ActionControlFlow
 from tracecat.workflow.executions.enums import TemporalSearchAttr, TriggerType
 
@@ -663,3 +671,38 @@ def get_trigger_type_from_search_attr(
         )
         return TriggerType.MANUAL
     return TriggerType(trigger_type)
+
+
+NON_RETRYABLE_ERROR_TYPES = [
+    # General
+    Exception.__name__,
+    TypeError.__name__,
+    ValueError.__name__,
+    RuntimeError.__name__,
+    # Pydantic
+    ValidationError.__name__,
+    # Tracecat
+    TracecatException.__name__,
+    TracecatExpressionError.__name__,
+    TracecatValidationError.__name__,
+    TracecatDSLError.__name__,
+    TracecatCredentialsError.__name__,
+    # Temporal
+    ApplicationError.__name__,
+    ChildWorkflowError.__name__,
+    FailureError.__name__,
+]
+
+RETRY_POLICIES = {
+    "activity:fail_fast": RetryPolicy(
+        # XXX: Do not set max attempts to 0, it will default to unlimited
+        maximum_attempts=1,
+        non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
+    ),
+    "activity:fail_slow": RetryPolicy(maximum_attempts=6),
+    "workflow:fail_fast": RetryPolicy(
+        # XXX: Do not set max attempts to 0, it will default to unlimited
+        maximum_attempts=1,
+        non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
+    ),
+}

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -6,41 +6,44 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
-from pydantic_core import to_json
 from temporalio import workflow
-from temporalio.exceptions import ApplicationError
 
-from tracecat.common import is_iterable
-from tracecat.concurrency import cooperative
-from tracecat.contexts import ctx_stream_id
-from tracecat.dsl.common import AdjDst, DSLInput, edge_components_from_dep
-from tracecat.dsl.enums import (
-    EdgeMarker,
-    EdgeType,
-    JoinStrategy,
-    PlatformAction,
-    Sentinel,
-    SkipStrategy,
-    StreamErrorHandlingStrategy,
-)
-from tracecat.dsl.models import (
-    ROOT_STREAM,
-    ActionErrorInfo,
-    ActionErrorInfoAdapter,
-    ActionStatement,
-    ExecutionContext,
-    GatherArgs,
-    ScatterArgs,
-    StreamID,
-    Task,
-    TaskExceptionInfo,
-    TaskResult,
-)
-from tracecat.expressions.common import ExprContext
-from tracecat.expressions.core import TemplateExpression
-from tracecat.expressions.eval import eval_templated_object
-from tracecat.logger import logger
-from tracecat.types.exceptions import TaskUnreachable
+with workflow.unsafe.imports_passed_through():
+    from pydantic_core import to_json
+    from temporalio import workflow
+    from temporalio.exceptions import ApplicationError
+
+    from tracecat.common import is_iterable
+    from tracecat.concurrency import cooperative
+    from tracecat.contexts import ctx_stream_id
+    from tracecat.dsl.common import AdjDst, DSLInput, edge_components_from_dep
+    from tracecat.dsl.enums import (
+        EdgeMarker,
+        EdgeType,
+        JoinStrategy,
+        PlatformAction,
+        Sentinel,
+        SkipStrategy,
+        StreamErrorHandlingStrategy,
+    )
+    from tracecat.dsl.models import (
+        ROOT_STREAM,
+        ActionErrorInfo,
+        ActionErrorInfoAdapter,
+        ActionStatement,
+        ExecutionContext,
+        GatherArgs,
+        ScatterArgs,
+        StreamID,
+        Task,
+        TaskExceptionInfo,
+        TaskResult,
+    )
+    from tracecat.expressions.common import ExprContext
+    from tracecat.expressions.core import TemplateExpression
+    from tracecat.expressions.eval import eval_templated_object
+    from tracecat.logger import logger
+    from tracecat.types.exceptions import TaskUnreachable
 
 
 @dataclass(frozen=True, slots=True)

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -4,19 +4,25 @@ import asyncio
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, cast
 
 from temporalio import workflow
 
 with workflow.unsafe.imports_passed_through():
     from pydantic_core import to_json
-    from temporalio import workflow
     from temporalio.exceptions import ApplicationError
 
     from tracecat.common import is_iterable
     from tracecat.concurrency import cooperative
     from tracecat.contexts import ctx_stream_id
-    from tracecat.dsl.common import AdjDst, DSLInput, edge_components_from_dep
+    from tracecat.dsl.action import DSLActivities
+    from tracecat.dsl.common import (
+        RETRY_POLICIES,
+        AdjDst,
+        DSLInput,
+        edge_components_from_dep,
+    )
     from tracecat.dsl.enums import (
         EdgeMarker,
         EdgeType,
@@ -40,7 +46,6 @@ with workflow.unsafe.imports_passed_through():
         TaskResult,
     )
     from tracecat.expressions.common import ExprContext
-    from tracecat.expressions.core import TemplateExpression
     from tracecat.expressions.eval import eval_templated_object
     from tracecat.logger import logger
     from tracecat.types.exceptions import TaskUnreachable
@@ -392,7 +397,7 @@ class DSLScheduler:
                 raise TaskUnreachable(f"Task {task} is unreachable")
 
             # 3) Check if the task should self-skip based on its `run_if` condition
-            if self._task_should_skip(task, stmt):
+            if await self._task_should_skip(task, stmt):
                 self.logger.info("Task should self-skip", task=task)
                 return await self._handle_skip_path(task, stmt)
 
@@ -582,14 +587,14 @@ class DSLScheduler:
             for dep_ref in deps
         )
 
-    def _task_should_skip(self, task: Task, stmt: ActionStatement) -> bool:
+    async def _task_should_skip(self, task: Task, stmt: ActionStatement) -> bool:
         """Check if a task should be skipped based on its `run_if` condition."""
         run_if = stmt.run_if
         if run_if is not None:
             context = self.get_context(task.stream_id)
-            expr = TemplateExpression(run_if, operand=context)
             self.logger.debug("`run_if` condition", run_if=run_if)
-            if not bool(expr.result()):
+            expr_result = await self.resolve_expression(run_if, context)
+            if not bool(expr_result):
                 self.logger.info("Task `run_if` condition was not met, skipped")
                 return True
         return False
@@ -910,7 +915,7 @@ class DSLScheduler:
         # This means we must compute a return value for the gather.
         # We should only compute the items to store if we aren't skipping
         current_context = self.get_context(stream_id)
-        items = TemplateExpression(args.items, operand=current_context).result()
+        items = await self.resolve_expression(args.items, current_context)
 
         # Once we have the item, we go down 1 level in the stream hierarchy
         # and set the item as the result of the action in that stream
@@ -1098,6 +1103,20 @@ class DSLScheduler:
             "Action not found in any stream", action_ref=action_ref, stream_id=stream_id
         )
         return None
+
+    async def resolve_expression(
+        self, expression: str, context: ExecutionContext
+    ) -> Any:
+        """Evaluate an expression."""
+        self.logger.trace(
+            "Resolving expression", expression=expression, context=context
+        )
+        return await workflow.execute_activity(
+            DSLActivities.evaluate_single_expression_activity,
+            args=(expression, context),
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        )
 
 
 def _is_error_info(detail: Any) -> bool:

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -27,10 +27,10 @@ from tracecat import config
 from tracecat.contexts import ctx_role
 from tracecat.db.schemas import Interaction
 from tracecat.dsl.client import get_temporal_client
-from tracecat.dsl.common import DSLInput, DSLRunArgs
+from tracecat.dsl.common import RETRY_POLICIES, DSLInput, DSLRunArgs
 from tracecat.dsl.models import Task, TriggerInputs
 from tracecat.dsl.validation import validate_trigger_inputs
-from tracecat.dsl.workflow import DSLWorkflow, retry_policies
+from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.models import InteractionInput
 from tracecat.ee.interactions.service import InteractionService
 from tracecat.identifiers import UserID
@@ -673,7 +673,7 @@ class WorkflowExecutionsService:
                 ),
                 id=wf_exec_id,
                 task_queue=config.TEMPORAL__CLUSTER_QUEUE,
-                retry_policy=retry_policies["workflow:fail_fast"],
+                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
                 # We don't currently differentiate between exec and run timeout as we fail fast for workflows
                 execution_timeout=datetime.timedelta(seconds=dsl.config.timeout),
                 search_attributes=search_attrs,


### PR DESCRIPTION
- **temporal passthrough scheduler imports**
- **move retry policies and non retryable error types into dsl.common**
- **move run_if and gather expression resolution into sync temporal activities**
- **adapt workflow tests to work for + fix concurrency issue with open_streams**

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved workflow performance by moving expression evaluation into synchronous Temporal activities and centralizing retry policies and error types.

- **Refactors**
  - Moved retry policies and non-retryable error types to `dsl.common`.
  - Shifted `run_if` and gather expression resolution to synchronous activities.
  - Updated scheduler imports for Temporal passthrough.
  - Fixed concurrency issue with `open_streams` and updated workflow tests.

<!-- End of auto-generated description by cubic. -->

