### PR TITLE
perf(engine): Add compression payload codec

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -65,6 +65,65 @@ jobs:
       - name: Install dependencies
         run: uv venv --python 3.12 && uv pip install ".[dev]"
 
+  test-workflow-codec:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.git-ref }}
+
+      - name: Install uv
+        uses: useblacksmith/setup-uv@v4
+        with:
+          version: "0.4.20"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Set up Python 3.12
+        uses: useblacksmith/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install system dependencies
+        run: |
+          # Install ripgrep for grep integration tests
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
+          # Install kubectl
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+          kubectl version --client
+
+      - name: Run environment setup script
+        run: |
+          echo "y
+          localhost
+          n
+          test@tracecat.com" | bash env.sh
+
+      - name: Start core Docker services
+        env:
+          TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
+        run: docker compose -f docker-compose.dev.yml up -d temporal api worker executor postgres_db caddy
+
+      - name: Install dependencies
+        run: |
+          uv pip install ".[dev]"
+          uv pip install ./registry
+
+      - name: Run workflow tests with compression
+        env:
+          TRACECAT__SYSTEM_PATH: "/usr/local/bin:/usr/bin:/bin"
+          # Enable compression
+          TRACECAT__CONTEXT_COMPRESSION_ENABLED: true
+        run: uv run pytest tests/workflows/test_workflows.py -ra
+
   test-all:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 60

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -122,7 +122,7 @@ jobs:
           TRACECAT__SYSTEM_PATH: "/usr/local/bin:/usr/bin:/bin"
           # Enable compression
           TRACECAT__CONTEXT_COMPRESSION_ENABLED: true
-        run: uv run pytest tests/workflows/test_workflows.py -ra
+        run: uv run pytest tests/unit/test_workflows.py -ra
 
   test-all:
     runs-on: blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -122,6 +122,8 @@ jobs:
           TRACECAT__SYSTEM_PATH: "/usr/local/bin:/usr/bin:/bin"
           # Enable compression
           TRACECAT__CONTEXT_COMPRESSION_ENABLED: true
+          # Apply unconditionally
+          TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB: 0
         run: uv run pytest tests/unit/test_workflows.py -ra
 
   test-all:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "asyncpg==0.29.0",
     "cloudpickle==3.0.0",
     "colorlog==6.8.2",
+    "cramjam>=2.10.0",
     "cryptography==44.0.1",
     "dateparser>=1.2.1,<1.3.0",
     "defusedxml==0.7.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,7 @@ def env_sandbox(monkeysession: pytest.MonkeyPatch):
     # Need this for local unit tests
     monkeysession.setattr(config, "TRACECAT__EXECUTOR_URL", "http://localhost:8001")
     if os.getenv("TRACECAT__CONTEXT_COMPRESSION_ENABLED"):
+        logger.info("Enabling compression for workflow context")
         monkeysession.setattr(config, "TRACECAT__CONTEXT_COMPRESSION_ENABLED", True)
         # Force compression for local unit tests
         monkeysession.setattr(config, "TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB", 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,11 @@ def env_sandbox(monkeysession: pytest.MonkeyPatch):
     monkeysession.setattr(config, "TRACECAT__AUTH_ALLOWED_DOMAINS", ["tracecat.com"])
     # Need this for local unit tests
     monkeysession.setattr(config, "TRACECAT__EXECUTOR_URL", "http://localhost:8001")
+    if os.getenv("TRACECAT__CONTEXT_COMPRESSION_ENABLED"):
+        monkeysession.setattr(config, "TRACECAT__CONTEXT_COMPRESSION_ENABLED", True)
+        # Force compression for local unit tests
+        monkeysession.setattr(config, "TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB", 0)
+
     # Add Homebrew path for macOS development environments
     monkeysession.setattr(
         config,

--- a/tests/unit/test_workflow_timers.py
+++ b/tests/unit/test_workflow_timers.py
@@ -16,7 +16,7 @@ from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 
 from tests.shared import TEST_WF_ID, generate_test_exec_id
-from tracecat.dsl._converter import pydantic_data_converter
+from tracecat.dsl._converter import get_data_converter
 from tracecat.dsl.action import DSLActivities
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.models import ActionRetryPolicy, ActionStatement, RunActionInput
@@ -27,9 +27,11 @@ from tracecat.types.auth import Role
 
 
 @pytest.fixture
-async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
+async def env(
+    monkeysession: pytest.MonkeyPatch,
+) -> AsyncGenerator[WorkflowEnvironment, None]:
     async with await WorkflowEnvironment.start_time_skipping(
-        data_converter=pydantic_data_converter
+        data_converter=get_data_converter(compression_enabled=False)
     ) as env:
         yield env
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -297,14 +297,14 @@ TRACECAT__MAX_ROWS_CLIENT_POSTGRES = int(
 
 # === Context Compression === #
 TRACECAT__CONTEXT_COMPRESSION_ENABLED = os.environ.get(
-    "TRACECAT__CONTEXT_COMPRESSION_ENABLED", "true"
+    "TRACECAT__CONTEXT_COMPRESSION_ENABLED", "false"
 ).lower() in ("true", "1")
 """Enable compression of large action results in workflow contexts. Defaults to False."""
 
 TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB = int(
-    os.environ.get("TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB", 0)
+    os.environ.get("TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB", 16)
 )
-"""Threshold in KB above which action results are compressed. Defaults to 64KB."""
+"""Threshold in KB above which action results are compressed. Defaults to 16KB."""
 
 TRACECAT__CONTEXT_COMPRESSION_ALGORITHM = os.environ.get(
     "TRACECAT__CONTEXT_COMPRESSION_ALGORITHM", "zstd"

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -294,3 +294,19 @@ TRACECAT__MAX_ROWS_CLIENT_POSTGRES = int(
     os.environ.get("TRACECAT__MAX_ROWS_CLIENT_POSTGRES", 1000)
 )
 """Maximum number of rows that can be returned from PostgreSQL client queries. Defaults to 1,000."""
+
+# === Context Compression === #
+TRACECAT__CONTEXT_COMPRESSION_ENABLED = os.environ.get(
+    "TRACECAT__CONTEXT_COMPRESSION_ENABLED", "true"
+).lower() in ("true", "1")
+"""Enable compression of large action results in workflow contexts. Defaults to False."""
+
+TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB = int(
+    os.environ.get("TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB", 0)
+)
+"""Threshold in KB above which action results are compressed. Defaults to 64KB."""
+
+TRACECAT__CONTEXT_COMPRESSION_ALGORITHM = os.environ.get(
+    "TRACECAT__CONTEXT_COMPRESSION_ALGORITHM", "zstd"
+)
+"""Compression algorithm to use. Supported: zstd, gzip, brotli. Defaults to zstd."""

--- a/tracecat/dsl/_converter.py
+++ b/tracecat/dsl/_converter.py
@@ -11,6 +11,11 @@ from temporalio.converter import (
     JSONPlainPayloadConverter,
 )
 
+from tracecat import config
+from tracecat.dsl.compression import (
+    get_compression_payload_codec,
+)
+
 
 def _serializer(obj: Any) -> Any:
     """Serializer for arbitrary objects.
@@ -66,6 +71,9 @@ class PydanticPayloadConverter(CompositePayloadConverter):
 
 
 pydantic_data_converter = DataConverter(
-    payload_converter_class=PydanticPayloadConverter
+    payload_converter_class=PydanticPayloadConverter,
+    payload_codec=get_compression_payload_codec()
+    if config.TRACECAT__CONTEXT_COMPRESSION_ENABLED
+    else None,
 )
-"""Data converter using Pydantic JSON conversion."""
+"""Data converter using Pydantic JSON conversion with optional compression."""

--- a/tracecat/dsl/_converter.py
+++ b/tracecat/dsl/_converter.py
@@ -11,10 +11,7 @@ from temporalio.converter import (
     JSONPlainPayloadConverter,
 )
 
-from tracecat import config
-from tracecat.dsl.compression import (
-    get_compression_payload_codec,
-)
+from tracecat.dsl.compression import get_compression_payload_codec
 
 
 def _serializer(obj: Any) -> Any:
@@ -70,10 +67,9 @@ class PydanticPayloadConverter(CompositePayloadConverter):
         )
 
 
-pydantic_data_converter = DataConverter(
-    payload_converter_class=PydanticPayloadConverter,
-    payload_codec=get_compression_payload_codec()
-    if config.TRACECAT__CONTEXT_COMPRESSION_ENABLED
-    else None,
-)
-"""Data converter using Pydantic JSON conversion with optional compression."""
+def get_data_converter(*, compression_enabled: bool = False) -> DataConverter:
+    """Data converter using Pydantic JSON conversion with optional compression."""
+    return DataConverter(
+        payload_converter_class=PydanticPayloadConverter,
+        payload_codec=get_compression_payload_codec() if compression_enabled else None,
+    )

--- a/tracecat/dsl/client.py
+++ b/tracecat/dsl/client.py
@@ -12,6 +12,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from tracecat import config
 from tracecat.config import (
     TEMPORAL__API_KEY__ARN,
     TEMPORAL__CLUSTER_NAMESPACE,
@@ -19,7 +20,7 @@ from tracecat.config import (
     TEMPORAL__CONNECT_RETRIES,
     TEMPORAL__METRICS_PORT,
 )
-from tracecat.dsl._converter import pydantic_data_converter
+from tracecat.dsl._converter import get_data_converter
 from tracecat.logger import logger
 
 _client: Client | None = None
@@ -67,7 +68,9 @@ async def connect_to_temporal() -> Client:
         rpc_metadata=rpc_metadata,
         api_key=api_key,
         tls=tls_config,
-        data_converter=pydantic_data_converter,
+        data_converter=get_data_converter(
+            compression_enabled=config.TRACECAT__CONTEXT_COMPRESSION_ENABLED
+        ),
         runtime=runtime,
     )
     return client

--- a/tracecat/dsl/compression.py
+++ b/tracecat/dsl/compression.py
@@ -1,0 +1,206 @@
+"""Temporal PayloadCodec for compressing large workflow payloads."""
+
+from collections.abc import Iterable
+
+import cramjam
+from loguru import logger
+from temporalio.api.common.v1 import Payload
+from temporalio.converter import PayloadCodec
+
+from tracecat.concurrency import cooperative
+from tracecat.config import (
+    TRACECAT__CONTEXT_COMPRESSION_ALGORITHM,
+    TRACECAT__CONTEXT_COMPRESSION_ENABLED,
+    TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB,
+)
+
+
+class CompressionPayloadCodec(PayloadCodec):
+    """Temporal PayloadCodec that compresses large payloads using zstd/gzip/brotli.
+
+    This codec automatically compresses payloads that exceed a configurable size
+    threshold, helping workflows handle large data without hitting Temporal's
+    payload size limits.
+    """
+
+    def __init__(
+        self,
+        threshold_bytes: int | None = None,
+        algorithm: str | None = None,
+        enabled: bool | None = None,
+    ):
+        self.enabled = (
+            enabled if enabled is not None else TRACECAT__CONTEXT_COMPRESSION_ENABLED
+        )
+        self.threshold = (
+            threshold_bytes
+            if threshold_bytes is not None
+            else TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB * 1024
+        )
+        self.algorithm = algorithm or TRACECAT__CONTEXT_COMPRESSION_ALGORITHM
+
+        if self.enabled and self.algorithm not in ("zstd", "gzip", "brotli"):
+            raise ValueError(f"Unsupported compression algorithm: {self.algorithm}")
+
+        logger.info(
+            "Compression codec initialized",
+            enabled=self.enabled,
+            threshold=self.threshold,
+            algorithm=self.algorithm,
+        )
+
+    async def encode(self, payloads: Iterable[Payload]) -> list[Payload]:
+        """Encode payloads, compressing those that exceed the threshold."""
+        if not self.enabled:
+            return list(payloads)
+
+        result = []
+        async for payload in cooperative(payloads):
+            # Check if payload size exceeds threshold
+            if len(payload.data) <= self.threshold:
+                result.append(payload)
+                continue
+
+            try:
+                # Compress the payload data
+                if self.algorithm == "zstd":
+                    compressed_data = bytes(cramjam.zstd.compress(payload.data, 11))  # type: ignore
+                    encoding = b"binary/zstd"
+                elif self.algorithm == "gzip":
+                    compressed_data = bytes(cramjam.gzip.compress(payload.data))  # type: ignore
+                    encoding = b"binary/gzip"
+                elif self.algorithm == "brotli":
+                    compressed_data = bytes(cramjam.brotli.compress(payload.data))  # type: ignore
+                    encoding = b"binary/brotli"
+                else:
+                    logger.warning(f"Unknown compression algorithm: {self.algorithm}")
+                    result.append(payload)
+                    continue
+
+                # Calculate compression ratio
+                original_size = len(payload.data)
+                compressed_size = len(compressed_data)
+                compression_ratio = (
+                    original_size / compressed_size if compressed_size > 0 else 1.0
+                )
+
+                logger.debug(
+                    "Compressed payload",
+                    original_size=original_size,
+                    compressed_size=compressed_size,
+                    compression_ratio=f"{compression_ratio:.2f}x",
+                    algorithm=self.algorithm,
+                )
+
+                # Create new payload with compression metadata
+                # Store the original encoding so we can restore it later
+                original_encoding = payload.metadata.get("encoding", b"")
+                new_metadata = dict(payload.metadata)
+                new_metadata.update(
+                    {
+                        "encoding": encoding,
+                        "original_encoding": original_encoding,
+                        "original_size": str(original_size).encode(),
+                        "compressed_size": str(compressed_size).encode(),
+                    }
+                )
+
+                result.append(
+                    Payload(
+                        metadata=new_metadata,
+                        data=compressed_data,
+                    )
+                )
+
+            except Exception as e:
+                logger.error(
+                    "Failed to compress payload, storing uncompressed",
+                    original_size=len(payload.data),
+                    algorithm=self.algorithm,
+                    error=str(e),
+                )
+                result.append(payload)
+
+        return result
+
+    async def decode(self, payloads: Iterable[Payload]) -> list[Payload]:
+        """Decode payloads, decompressing those that were compressed."""
+        result = []
+        async for payload in cooperative(payloads):
+            encoding = payload.metadata.get("encoding", b"").decode()
+
+            # If not compressed, return as-is
+            if not encoding.startswith("binary/"):
+                result.append(payload)
+                continue
+
+            try:
+                # Decompress based on encoding
+                if encoding == "binary/zstd":
+                    decompressed_data = bytes(cramjam.zstd.decompress(payload.data))  # type: ignore
+                elif encoding == "binary/gzip":
+                    decompressed_data = bytes(cramjam.gzip.decompress(payload.data))  # type: ignore
+                elif encoding == "binary/brotli":
+                    decompressed_data = bytes(cramjam.brotli.decompress(payload.data))  # type: ignore
+                else:
+                    logger.warning(f"Unknown compression encoding: {encoding}")
+                    result.append(payload)
+                    continue
+
+                # Create new payload with original metadata restored
+                # Restore the original encoding that was preserved during compression
+                original_encoding = payload.metadata.get("original_encoding", b"")
+                new_metadata = {
+                    k: v
+                    for k, v in payload.metadata.items()
+                    if k
+                    not in (
+                        "encoding",
+                        "original_encoding",
+                        "original_size",
+                        "compressed_size",
+                    )
+                }
+                # Restore the original encoding
+                if original_encoding:
+                    new_metadata["encoding"] = original_encoding
+
+                logger.debug(
+                    "Decompressed payload",
+                    original_size=payload.metadata.get("original_size", b"").decode(),
+                    compressed_size=payload.metadata.get(
+                        "compressed_size", b""
+                    ).decode(),
+                    encoding=encoding,
+                )
+
+                result.append(
+                    Payload(
+                        metadata=new_metadata,
+                        data=decompressed_data,
+                    )
+                )
+
+            except Exception as e:
+                logger.error(
+                    "Failed to decompress payload",
+                    encoding=encoding,
+                    compressed_size=len(payload.data),
+                    error=str(e),
+                )
+                # Return the compressed payload as-is if decompression fails
+                result.append(payload)
+
+        return result
+
+
+# Global codec instance
+_compression_codec_instance: CompressionPayloadCodec | None = None
+
+
+def get_compression_payload_codec() -> CompressionPayloadCodec:
+    """Get the global compression payload codec instance."""
+    global _compression_codec_instance
+    if _compression_codec_instance is None:
+        _compression_codec_instance = CompressionPayloadCodec()
+    return _compression_codec_instance


### PR DESCRIPTION
# Rationale
- Large payloads aren't being loaded properly
- Use zstd through `cramjam` to compress json data. e.g. 1.9MB -> 50KB.
- Use payload codec so workflows transparently pass data around
- We are just buying time for the proper impl -- which involves s3/minio, redis, and passing data refs around

# Changes
- **feat: Add context compression support for workflow payloads**
- **add conftest flag**
- **add gh action workflow**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added context compression for workflow payloads to reduce payload size and support larger workflows. Compression can be enabled, configured, and uses zstd, gzip, or brotli.

- **New Features**
  - Compresses large workflow payloads automatically based on size and configuration.
  - Added settings for enabling compression, setting a size threshold, and choosing the compression algorithm.
  - Updated payload extraction and workflow event methods to handle compressed data.
  - Added tests and a GitHub Actions workflow to verify compression behavior.

<!-- End of auto-generated description by cubic. -->

