### PR TITLE
feat(integration): Adding Jira Get User ID + Assign User to Issue

### DIFF
--- a/registry/tracecat_registry/templates/tools/jira/assign_issue.yml
+++ b/registry/tracecat_registry/templates/tools/jira/assign_issue.yml
@@ -1,0 +1,35 @@
+type: action
+definition:
+  title: Assign issue
+  description: Assign an issue to a user.
+  display_group: Jira
+  doc_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-assignee-put
+  namespace: tools.jira
+  name: assign_issue
+  secrets:
+    - name: jira
+      keys: ["JIRA_USEREMAIL", "JIRA_API_TOKEN"]
+  expects:
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+    issue_key:
+      type: str
+      description: Jira issue key (e.g. TC-123)
+    user_id:
+      type: str
+      description: Jira user ID (e.g. 1234567890)
+  steps:
+    - ref: assign_issue
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/rest/api/3/issue/${{ inputs.issue_key }}/assignee
+        method: PUT
+        auth:
+          username: ${{ SECRETS.jira.JIRA_USEREMAIL }}
+          password: ${{ SECRETS.jira.JIRA_API_TOKEN }}
+        payload:
+          accountId: ${{ inputs.user_id }}
+  returns:
+    error: ${{ steps.assign_issue.result.data }}
+    status: ${{ steps.assign_issue.result.status_code }}

--- a/registry/tracecat_registry/templates/tools/jira/get_user_id.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_user_id.yml
@@ -1,0 +1,28 @@
+type: action
+definition:
+  title: Get user ID
+  description: Get a user ID from Jira.
+  display_group: Jira
+  doc_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-user-search/#api-rest-api-3-user-search-get
+  namespace: tools.jira
+  name: get_user_id
+  secrets:
+    - name: jira
+      keys: ["JIRA_USEREMAIL", "JIRA_API_TOKEN"]
+  expects:
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net)
+    username:
+      type: str
+      description: Jira username (e.g. john.doe@example.com)
+  steps:
+    - ref: get_user_id
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/rest/api/3/user/search?query=${{ inputs.username }}&maxResults=1
+        method: GET
+        auth:
+          username: ${{ SECRETS.jira.JIRA_USEREMAIL }}
+          password: ${{ SECRETS.jira.JIRA_API_TOKEN }}
+  returns: ${{ steps.get_user_id.result.data }}

--- a/registry/tracecat_registry/templates/tools/jira/get_user_id.yml
+++ b/registry/tracecat_registry/templates/tools/jira/get_user_id.yml
@@ -20,9 +20,12 @@ definition:
     - ref: get_user_id
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/rest/api/3/user/search?query=${{ inputs.username }}&maxResults=1
+        url: ${{ inputs.base_url }}/rest/api/3/user/search
         method: GET
         auth:
           username: ${{ SECRETS.jira.JIRA_USEREMAIL }}
           password: ${{ SECRETS.jira.JIRA_API_TOKEN }}
+        params:
+          query: ${{ inputs.username }}
+          maxResults: 1
   returns: ${{ steps.get_user_id.result.data }}


### PR DESCRIPTION
## Description

Adding Jira Integration Commands:
-  Get User ID based on query parameters (like email)
- Adding user to assignee in Jira Issue 

Its worth noting that if successful assign user to jira ticket returns no data and a 204 status code.  


## Screenshots / Recordings

![image](https://github.com/user-attachments/assets/df58849e-6165-49de-80a9-027f39e9994b)

![image](https://github.com/user-attachments/assets/eb6a4592-254c-4785-890c-8c5ee1316430)



## Steps to QA

- Set up Jira integration
- Use Get User ID step with params
- Use Assign Issue step 
- Check Jira issue for success
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added two new Jira integration actions: one to get a user's Jira ID by email, and one to assign a user to a Jira issue.

- **New Features**
  - Get Jira user ID using an email address.
  - Assign a user to a Jira issue by user ID.

<!-- End of auto-generated description by cubic. -->

