### PR TITLE
fix: Properly handle datetime args in jsonschema validation

### DIFF
--- a/tracecat/validation/common.py
+++ b/tracecat/validation/common.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
@@ -65,6 +66,9 @@ def json_schema_to_pydantic(
             # Pass the field_name_for_enum for context in case array items are enums/objects
             return list[create_field(items_schema, f"{enum_field_name}Item")]
         elif type_ == "string":
+            format_type = prop_schema.get("format")
+            if format_type == "date-time":
+                return datetime
             return str
         elif type_ == "integer":
             return int


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed handling of "date-time" string fields in JSON Schema validation so they are now correctly converted to Python datetime objects.

- **Bug Fixes**
  - Updated field creation to return datetime for "date-time" formats.
  - Added tests to check both string and datetime inputs for these fields.

<!-- End of auto-generated description by cubic. -->

