### PR TITLE
perf(ui): Cache workflows page using nextjs Link

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
@@ -145,8 +145,10 @@ export default function ProviderDetailPage() {
       <Breadcrumb className="mb-6">
         <BreadcrumbList>
           <BreadcrumbItem>
-            <BreadcrumbLink href={`/workspaces/${workspaceId}/integrations`}>
-              Integrations
+            <BreadcrumbLink asChild>
+              <Link href={`/workspaces/${workspaceId}/integrations`}>
+                Integrations
+              </Link>
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />

--- a/frontend/src/app/workspaces/[workspaceId]/tables/[tableId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/tables/[tableId]/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ArrowLeftIcon } from "lucide-react"
+import Link from "next/link"
 import { useParams } from "next/navigation"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
@@ -41,12 +42,14 @@ export default function TablePage() {
           <Breadcrumb>
             <BreadcrumbList>
               <BreadcrumbItem>
-                <BreadcrumbLink
-                  href={`/workspaces/${workspaceId}/tables`}
-                  className="flex items-center"
-                >
-                  <ArrowLeftIcon className="mr-2 size-4" />
-                  Tables
+                <BreadcrumbLink asChild>
+                  <Link
+                    href={`/workspaces/${workspaceId}/tables`}
+                    className="flex items-center"
+                  >
+                    <ArrowLeftIcon className="mr-2 size-4" />
+                    Tables
+                  </Link>
                 </BreadcrumbLink>
               </BreadcrumbItem>
               <BreadcrumbSeparator>{"/"}</BreadcrumbSeparator>

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -96,7 +96,6 @@ export function BuilderNav() {
   }
 
   const manualTriggerDisabled = workflow.version === null
-  const workflowsPath = `/workspaces/${workspaceId}/workflows`
 
   return (
     <div className="flex w-full items-center">
@@ -104,8 +103,10 @@ export function BuilderNav() {
         <Breadcrumb>
           <BreadcrumbList className="flex-nowrap overflow-hidden whitespace-nowrap">
             <BreadcrumbItem>
-              <BreadcrumbLink href={workflowsPath}>
-                {workspace.name}
+              <BreadcrumbLink asChild>
+                <Link href={`/workspaces/${workspaceId}/workflows`}>
+                  {workspace.name}
+                </Link>
               </BreadcrumbLink>
             </BreadcrumbItem>
             <BreadcrumbSeparator className="shrink-0 font-semibold">


### PR DESCRIPTION
# Summary
<BreadcrumbLink> component isn't caching properly. Replacing with nextjs <Link> seems to help. 

# Screens
## Original behavior

https://github.com/user-attachments/assets/bcf8ec99-c1f3-4a41-82fa-24905ab1212c

## With Nextjs Link

https://github.com/user-attachments/assets/d2bc2234-45ca-444b-9098-6b2ba3a9c65a







<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
