### PR TITLE
feat(integrations): ElasticSearch integrations: Search, Indices, Aliases, Mapping, and Index Templates

### DIFF
--- a/registry/tracecat_registry/templates/tools/elasticsearch/get_index_template.yml
+++ b/registry/tracecat_registry/templates/tools/elasticsearch/get_index_template.yml
@@ -1,0 +1,27 @@
+type: action
+definition:
+  title: Get index template
+  description: Get the definition of a specific index template using the _index_template API.
+  display_group: Elasticsearch
+  namespace: tools.elasticsearch
+  name: get_index_template
+  secrets:
+    - name: elasticsearch
+      keys:
+        - ELASTICSEARCH_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Elasticsearch base URL (e.g. https://your-cluster.es.io:443).
+    template_name:
+      type: str
+      description: Name of the index template to retrieve.
+  steps:
+    - ref: get_index_template_request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/_index_template/${{ inputs.template_name }}
+        method: GET
+        headers:
+          Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
+  returns: ${{ steps.get_index_template_request.result }}

--- a/registry/tracecat_registry/templates/tools/elasticsearch/get_mapping.yml
+++ b/registry/tracecat_registry/templates/tools/elasticsearch/get_mapping.yml
@@ -1,0 +1,27 @@
+type: action
+definition:
+  title: Get mapping
+  description: Get the mapping definition for a specific index using the _mapping API.
+  display_group: Elasticsearch
+  namespace: tools.elasticsearch
+  name: get_mapping
+  secrets:
+    - name: elasticsearch
+      keys:
+        - ELASTICSEARCH_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Elasticsearch base URL (e.g. https://your-cluster.es.io:443).
+    index:
+      type: str
+      description: Name of the index to get the mapping for.
+  steps:
+    - ref: get_mapping_request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/${{ inputs.index }}/_mapping
+        method: GET
+        headers:
+          Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
+  returns: ${{ steps.get_mapping_request.result }}

--- a/registry/tracecat_registry/templates/tools/elasticsearch/list_aliases.yml
+++ b/registry/tracecat_registry/templates/tools/elasticsearch/list_aliases.yml
@@ -1,0 +1,24 @@
+type: action
+definition:
+  title: List aliases
+  description: List all aliases on the Elasticsearch cluster using the _alias API.
+  display_group: Elasticsearch
+  namespace: tools.elasticsearch
+  name: list_aliases
+  secrets:
+    - name: elasticsearch
+      keys:
+        - ELASTICSEARCH_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Elasticsearch base URL (e.g. https://your-cluster.es.io:443).
+  steps:
+    - ref: list_aliases_request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/_alias
+        method: GET
+        headers:
+          Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
+  returns: ${{ steps.list_aliases_request.result }}

--- a/registry/tracecat_registry/templates/tools/elasticsearch/list_indices.yml
+++ b/registry/tracecat_registry/templates/tools/elasticsearch/list_indices.yml
@@ -1,0 +1,31 @@
+type: action
+definition:
+  title: List indices
+  description: List all indices on the Elasticsearch cluster using the _cat/indices API.
+  display_group: Elasticsearch
+  namespace: tools.elasticsearch
+  name: list_indices
+  secrets:
+    - name: elasticsearch
+      keys:
+        - ELASTICSEARCH_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Elasticsearch base URL (e.g. https://your-cluster.es.io:443).
+    verbose:
+      type: bool
+      description: Whether to include column headers in the response.
+      default: true
+  steps:
+    - ref: list_indices_request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/_cat/indices
+        method: GET
+        headers:
+          Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
+        params:
+          v: ${{ inputs.verbose }}
+          format: json
+  returns: ${{ steps.list_indices_request.result }}

--- a/registry/tracecat_registry/templates/tools/elasticsearch/search_all_indices.yml
+++ b/registry/tracecat_registry/templates/tools/elasticsearch/search_all_indices.yml
@@ -1,0 +1,80 @@
+type: action
+definition:
+  title: Search across indices
+  description: Search across all indices using the _search API.
+  display_group: Elasticsearch
+  namespace: tools.elasticsearch
+  name: search_all_indices
+  secrets:
+    - name: elasticsearch
+      keys:
+        - ELASTICSEARCH_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Elasticsearch base URL (e.g. https://your-cluster.es.io:443).
+    query:
+      type: dict[str, any]
+      description: Elasticsearch query object (just the query part, not the complete request body).
+    from:
+      type: int
+      description: Starting document offset (default is 0).
+      default: 0
+    size:
+      type: int
+      description: Number of hits to return (default is 10).
+      default: 10
+    timeout:
+      type: str
+      description: Maximum time to wait for search results (e.g. "30s", "1m").
+      default: "30s"
+    allow_partial_search_results:
+      type: bool
+      description: Return partial results if some shards fail or timeout.
+      default: true
+    track_total_hits:
+      type: bool
+      description: Return exact total hit count for alerting thresholds.
+      default: true
+    terminate_after:
+      type: int
+      description: Maximum documents to collect per shard (0 = no limit).
+      default: 0
+    ignore_unavailable:
+      type: bool
+      description: Continue search if some indices are missing or closed.
+      default: false
+    allow_no_indices:
+      type: bool
+      description: Allow requests that don't match any indices.
+      default: true
+    expand_wildcards:
+      type: str
+      description: Types of indices wildcard patterns can match (open,closed,hidden).
+      default: "open"
+    source_fields:
+      type: list[str]
+      description: Source fields to return (improves performance, reduces data exposure).
+      default: []
+  steps:
+    - ref: search_request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/_search
+        method: GET
+        headers:
+          Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
+          Content-Type: application/json
+        params:
+          from: ${{ inputs.from }}
+          size: ${{ inputs.size }}
+          timeout: ${{ inputs.timeout }}
+          allow_partial_search_results: ${{ inputs.allow_partial_search_results }}
+          track_total_hits: ${{ inputs.track_total_hits }}
+          terminate_after: ${{ inputs.terminate_after }}
+          ignore_unavailable: ${{ inputs.ignore_unavailable }}
+          allow_no_indices: ${{ inputs.allow_no_indices }}
+          expand_wildcards: ${{ inputs.expand_wildcards }}
+          _source: ${{ inputs.source_fields }}
+        payload: ${{ inputs.query }}
+  returns: ${{ steps.search_request.result }}

--- a/registry/tracecat_registry/templates/tools/elasticsearch/search_index_specific.yml
+++ b/registry/tracecat_registry/templates/tools/elasticsearch/search_index_specific.yml
@@ -1,0 +1,73 @@
+type: action
+definition:
+  title: Search in a specific index
+  description: Search in a specific Elasticsearch index using the _search API.
+  display_group: Elasticsearch
+  namespace: tools.elasticsearch
+  name: search
+  secrets:
+    - name: elasticsearch
+      keys:
+        - ELASTICSEARCH_API_KEY
+  expects:
+    base_url:
+      type: str
+      description: Elasticsearch base URL (e.g. https://your-cluster.es.io:443).
+    index:
+      type: str
+      description: Name of the index to search in.
+    query:
+      type: dict[str, any]
+      description: Elasticsearch query object
+    from:
+      type: int
+      description: Starting document offset (default is 0).
+      default: 0
+    size:
+      type: int
+      description: Number of hits to return (default is 10).
+      default: 10
+    timeout:
+      type: str
+      description: Maximum time to wait for search results (e.g. "30s", "1m").
+      default: "30s"
+    allow_partial_search_results:
+      type: bool
+      description: Return partial results if some shards fail or timeout.
+      default: true
+    track_total_hits:
+      type: bool
+      description: Return exact total hit count for alerting thresholds.
+      default: true
+    terminate_after:
+      type: int
+      description: Maximum documents to collect per shard (0 = no limit).
+      default: 0
+    ignore_unavailable:
+      type: bool
+      description: Continue search if some indices are missing or closed.
+      default: false
+    source_fields:
+      type: list[str]
+      description: Source fields to return (improves performance, reduces data exposure).
+      default: []
+  steps:
+    - ref: search_request
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/${{ inputs.index }}/_search
+        method: GET
+        headers:
+          Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
+          Content-Type: application/json
+        params:
+          from: ${{ inputs.from }}
+          size: ${{ inputs.size }}
+          timeout: ${{ inputs.timeout }}
+          allow_partial_search_results: ${{ inputs.allow_partial_search_results }}
+          track_total_hits: ${{ inputs.track_total_hits }}
+          terminate_after: ${{ inputs.terminate_after }}
+          ignore_unavailable: ${{ inputs.ignore_unavailable }}
+          _source: ${{ inputs.source_fields }}
+        payload: ${{ inputs.query }}
+  returns: ${{ steps.search_request.result }}


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Integrations done for ElasticSearch:
- Search through all indices
- Search through a specific index
- Get all indices
- Get all aliases
- Get mapping
- Get template

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added new ElasticSearch integrations to support searching, listing indices and aliases, and retrieving mappings and index templates.

- **New Features**
  - Search across all indices or a specific index.
  - List all indices and aliases.
  - Get index mappings and index templates.

<!-- End of auto-generated description by cubic. -->

