### PR TITLE
refactor: Optional provider config

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
@@ -107,11 +107,7 @@ const statusStyles: Record<
   },
 }
 
-export function ProviderDetailContent({
-  provider,
-}: {
-  provider: ProviderRead
-}) {
+function ProviderDetailContent({ provider }: { provider: ProviderRead }) {
   const { workspaceId } = useWorkspace()
   const [isConfigDialogOpen, setIsConfigDialogOpen] = useState(false)
   const [errorMessage, setErrorMessage] = useState("")

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3158,6 +3158,7 @@ export function useIntegrationProvider({
     queryKey: ["integration", providerId, workspaceId],
     queryFn: async () =>
       await integrationsGetIntegration({ providerId, workspaceId }),
+    retry: retryHandler,
   })
 
   // Get provider schema

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -306,4 +306,6 @@ async def get_provider_schema(
     provider_impl: Annotated[type[BaseOAuthProvider], Depends(get_provider)],
 ) -> ProviderSchema:
     """Get JSON Schema for provider-specific configuration."""
-    return ProviderSchema(json_schema=provider_impl.schema())
+
+    schema = provider_impl.schema() or {}
+    return ProviderSchema(json_schema=schema)


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Made provider configuration optional for OAuth integrations, allowing providers without a config schema to work smoothly.

- **Refactors**
  - Updated backend and frontend to handle missing or empty provider config schemas.
  - Improved error handling and UI feedback for provider config forms.

<!-- End of auto-generated description by cubic. -->

