### PR TITLE
feat(enine): Use uv in ray runtime env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,10 @@ RUN chmod +x /app/entrypoint.sh
 RUN uv pip install .
 RUN uv pip install ./registry
 
+# Ensure uv binary is available where Ray expects it
+RUN mkdir -p /root/.local/bin && \
+    ln -s $(which uv) /root/.local/bin/uv
+
 # Fix ownership of all apiuser directories after root operations
 # This ensures apiuser can access all necessary files and directories
 RUN chown -R apiuser:apiuser /home/apiuser /app/.scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,9 @@ RUN uv pip install .
 RUN uv pip install ./registry
 
 # Ensure uv binary is available where Ray expects it
-RUN mkdir -p /root/.local/bin && \
-    ln -s $(which uv) /root/.local/bin/uv
+RUN mkdir -p /home/apiuser/.local/bin && \
+    ln -s $(which uv) /home/apiuser/.local/bin/uv && \
+    chown -R apiuser:apiuser /home/apiuser/.local/bin
 
 # Fix ownership of all apiuser directories after root operations
 # This ensures apiuser can access all necessary files and directories

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -39,6 +39,10 @@ RUN chmod +x /app/entrypoint.sh
 RUN uv pip install -e .
 RUN uv pip install -e ./registry
 
+# Ensure uv binary is available where Ray expects it
+RUN mkdir -p /root/.local/bin && \
+    ln -s $(which uv) /root/.local/bin/uv
+
 # Create necessary directories for development
 RUN mkdir -p /root/.deno /app/node_modules /app/.scripts && \
     # Copy pre-cached deno modules if they exist

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -399,9 +399,9 @@ async def run_action_on_ray_cluster(
         )
         pip_deps.extend([local_repo_path, *required_deps])
 
-    # Add pip dependencies to runtime env
+    # Add pip dependencies to runtime env using uv
     if pip_deps:
-        additional_vars["pip"] = pip_deps
+        additional_vars["uv"] = pip_deps
 
     runtime_env = RuntimeEnv(env_vars=env_vars, **additional_vars)
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -367,6 +367,10 @@ async def run_action_on_ray_cluster(
     """
     # Initialize runtime environment variables
     env_vars = {"GIT_SSH_COMMAND": ctx.ssh_command} if ctx.ssh_command else {}
+    # Override UV_SYSTEM_PYTHON to allow uv to respect Ray's virtual environment
+    # The global UV_SYSTEM_PYTHON=1 in Dockerfile forces system Python usage,
+    # but Ray creates its own virtual environment and expects uv to use it
+    env_vars["UV_SYSTEM_PYTHON"] = "false"
     additional_vars: dict[str, Any] = {}
 
     # Add git URL to pip dependencies if SHA is present


### PR DESCRIPTION
# Summary
- Unblocked first pass from #789.
- This is also a first step to addressing conflicting between the platform and user's dependencies

- **[claudesquad] update from 'uv-runtime-env' on 29 Jun 25 16:52 PDT (paused)**
- **fix(Dockerfile): Update uv binary path and ownership for apiuser; set UV_SYSTEM_PYTHON to false in service.py for Ray compatibility**

# Testing
- Tested with local docker compose production build. 

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
