### PR TITLE
feat(ui): Add sorting functionality to integrations page

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { ArrowUpDown, Filter, Key, type LucideIcon, Search, User2Icon } from "lucide-react"
+import {
+  ArrowUpDown,
+  Filter,
+  Key,
+  type LucideIcon,
+  Search,
+  User2Icon,
+} from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useMemo, useState } from "react"
 import {
@@ -84,7 +91,9 @@ export default function IntegrationsPage() {
     useState<ProviderCategory | null>(null)
   const [selectedStatus, setSelectedStatus] =
     useState<IntegrationStatus | null>(null)
-  const [sortBy, setSortBy] = useState<"default" | "name" | "availability">("default")
+  const [sortBy, setSortBy] = useState<"default" | "name" | "availability">(
+    "default"
+  )
 
   const { providers, providersIsLoading, providersError } =
     useIntegrations(workspaceId)

--- a/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
@@ -1,13 +1,6 @@
 "use client"
 
-import {
-  ArrowUpDown,
-  Filter,
-  Key,
-  type LucideIcon,
-  Search,
-  User2Icon,
-} from "lucide-react"
+import { Filter, Key, type LucideIcon, Search, User2Icon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useMemo, useState } from "react"
 import {
@@ -91,9 +84,6 @@ export default function IntegrationsPage() {
     useState<ProviderCategory | null>(null)
   const [selectedStatus, setSelectedStatus] =
     useState<IntegrationStatus | null>(null)
-  const [sortBy, setSortBy] = useState<"default" | "name" | "availability">(
-    "default"
-  )
 
   const { providers, providersIsLoading, providersError } =
     useIntegrations(workspaceId)
@@ -116,26 +106,14 @@ export default function IntegrationsPage() {
 
     if (!filtered) return filtered
 
-    // Sort the filtered results
+    // Sort by availability first (enabled first), then alphabetical by name
     return [...filtered].sort((a, b) => {
-      if (sortBy === "availability") {
-        // First sort by enabled status (enabled first)
-        if (a.enabled !== b.enabled) {
-          return a.enabled ? -1 : 1
-        }
-        // Then by name alphabetically
-        return a.name.localeCompare(b.name)
-      } else if (sortBy === "name") {
-        return a.name.localeCompare(b.name)
-      } else {
-        // Default: availability first, then alphabetical
-        if (a.enabled !== b.enabled) {
-          return a.enabled ? -1 : 1
-        }
-        return a.name.localeCompare(b.name)
+      if (a.enabled !== b.enabled) {
+        return a.enabled ? -1 : 1
       }
+      return a.name.localeCompare(b.name)
     })
-  }, [providers, searchQuery, selectedCategory, selectedStatus, sortBy])
+  }, [providers, searchQuery, selectedCategory, selectedStatus])
 
   const handleProviderClick = (providerId: string, enabled: boolean) => {
     if (enabled) {
@@ -210,22 +188,6 @@ export default function IntegrationsPage() {
                 <SelectItem value="all">All Status</SelectItem>
                 <SelectItem value="available">Available</SelectItem>
                 <SelectItem value="connected">Connected</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select
-              value={sortBy}
-              onValueChange={(value) =>
-                setSortBy(value as "default" | "name" | "availability")
-              }
-            >
-              <SelectTrigger className="w-full sm:w-48">
-                <ArrowUpDown className="mr-2 size-4" />
-                <SelectValue placeholder="Sort by" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="default">Default</SelectItem>
-                <SelectItem value="availability">Availability</SelectItem>
-                <SelectItem value="name">Name (A-Z)</SelectItem>
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
## Summary
- Add sorting dropdown to integrations page with three options: Default, Availability, and Name (A-Z)
- ~Default and Availability sorting prioritize enabled integrations first, then sort alphabetically~ removed sort dropdown
- Name sorting provides pure alphabetical ordering
- Maintains existing filtering functionality while adding sort capability

## Test plan
- [x] Verify sorting dropdown appears in integrations page filters
- [x] Test Default sorting (enabled first, then alphabetical)
- [x] Test Availability sorting (same as default)
- [x] Test Name sorting (pure alphabetical)
- [x] Confirm sorting works with existing search and category filters
- [x] Verify UI layout remains responsive

🤖 Generated with [Claude Code](https://claude.ai/code)
    

# Screens

![image](https://github.com/user-attachments/assets/2391817f-71e4-405e-a322-0f34c71cf993)

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a sorting dropdown to the integrations page, letting users sort by Default, Availability, or Name (A-Z) while keeping existing filters.

<!-- End of auto-generated description by cubic. -->

