### PR TITLE
feat(app): Differentiate disconnect and delete operations for integrations

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -87,6 +87,8 @@ import type {
   FoldersUpdateFolderResponse,
   IntegrationsConnectProviderData,
   IntegrationsConnectProviderResponse,
+  IntegrationsDeleteIntegrationData,
+  IntegrationsDeleteIntegrationResponse,
   IntegrationsDisconnectIntegrationData,
   IntegrationsDisconnectIntegrationResponse,
   IntegrationsGetIntegrationData,
@@ -326,7 +328,7 @@ export const publicIncomingWebhook = (
   data: PublicIncomingWebhookData
 ): CancelablePromise<PublicIncomingWebhookResponse> => {
   return __request(OpenAPI, {
-    method: "GET",
+    method: "POST",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,
@@ -366,7 +368,7 @@ export const publicIncomingWebhook1 = (
   data: PublicIncomingWebhook1Data
 ): CancelablePromise<PublicIncomingWebhook1Response> => {
   return __request(OpenAPI, {
-    method: "POST",
+    method: "GET",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,
@@ -3800,17 +3802,17 @@ export const integrationsGetIntegration = (
 }
 
 /**
- * Disconnect Integration
- * Disconnect integration for the specified provider.
+ * Delete Integration
+ * Delete integration for the specified provider (removes the integration record completely).
  * @param data The data for the request.
  * @param data.providerId
  * @param data.workspaceId
  * @returns void Successful Response
  * @throws ApiError
  */
-export const integrationsDisconnectIntegration = (
-  data: IntegrationsDisconnectIntegrationData
-): CancelablePromise<IntegrationsDisconnectIntegrationResponse> => {
+export const integrationsDeleteIntegration = (
+  data: IntegrationsDeleteIntegrationData
+): CancelablePromise<IntegrationsDeleteIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
     url: "/integrations/{provider_id}",
@@ -3906,6 +3908,33 @@ export const integrationsOauthCallback = (
     query: {
       code: data.code,
       state: data.state,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Disconnect Integration
+ * Disconnect integration for the specified provider (revokes tokens but keeps configuration).
+ * @param data The data for the request.
+ * @param data.providerId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const integrationsDisconnectIntegration = (
+  data: IntegrationsDisconnectIntegrationData
+): CancelablePromise<IntegrationsDisconnectIntegrationResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/integrations/{provider_id}/disconnect",
+    path: {
+      provider_id: data.providerId,
+    },
+    query: {
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4122,12 +4122,12 @@ export type IntegrationsGetIntegrationData = {
 
 export type IntegrationsGetIntegrationResponse = IntegrationRead
 
-export type IntegrationsDisconnectIntegrationData = {
+export type IntegrationsDeleteIntegrationData = {
   providerId: string
   workspaceId: string
 }
 
-export type IntegrationsDisconnectIntegrationResponse = void
+export type IntegrationsDeleteIntegrationResponse = void
 
 export type IntegrationsUpdateIntegrationData = {
   providerId: string
@@ -4158,6 +4158,13 @@ export type IntegrationsOauthCallbackData = {
 }
 
 export type IntegrationsOauthCallbackResponse = IntegrationOAuthCallback
+
+export type IntegrationsDisconnectIntegrationData = {
+  providerId: string
+  workspaceId: string
+}
+
+export type IntegrationsDisconnectIntegrationResponse = void
 
 export type IntegrationsTestConnectionData = {
   providerId: string
@@ -4274,7 +4281,7 @@ export type PublicCheckHealthResponse = {
 
 export type $OpenApiTs = {
   "/webhooks/{workflow_id}/{secret}": {
-    get: {
+    post: {
       req: PublicIncomingWebhookData
       res: {
         /**
@@ -4287,7 +4294,7 @@ export type $OpenApiTs = {
         422: HTTPValidationError
       }
     }
-    post: {
+    get: {
       req: PublicIncomingWebhook1Data
       res: {
         /**
@@ -6119,7 +6126,7 @@ export type $OpenApiTs = {
       }
     }
     delete: {
-      req: IntegrationsDisconnectIntegrationData
+      req: IntegrationsDeleteIntegrationData
       res: {
         /**
          * Successful Response
@@ -6168,6 +6175,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: IntegrationOAuthCallback
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/integrations/{provider_id}/disconnect": {
+    post: {
+      req: IntegrationsDisconnectIntegrationData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
         /**
          * Validation Error
          */


### PR DESCRIPTION
## Summary
- Add separate disconnect and delete endpoints for integrations
- Disconnect (POST `/integrations/{provider_id}/disconnect`) revokes tokens but keeps configuration
- Delete (DELETE `/integrations/{provider_id}`) removes the integration record completely
- Update frontend client types and service methods accordingly

## Test plan
- [ ] Test disconnect functionality preserves integration configuration
- [ ] Test delete functionality completely removes integration
- [ ] Verify frontend client generates correct API calls
- [ ] Test error handling for both endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added separate endpoints for disconnecting and deleting integrations. Disconnect now revokes tokens but keeps the configuration, while delete fully removes the integration.

- **New Features**
  - POST `/integrations/{provider_id}/disconnect` revokes tokens but keeps integration settings.
  - DELETE `/integrations/{provider_id}` removes the integration record.
  - Updated frontend types and service methods to support both actions.

<!-- End of auto-generated description by cubic. -->

