### PR TITLE
fix(ui): Fix status filter showing no results when "All Status" selected

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
@@ -51,6 +51,11 @@ const getStatusInfo = (status: IntegrationStatus) => {
         label: "Configured",
         className: "bg-yellow-100 text-yellow-800 hover:bg-yellow-200",
       }
+    case "not_configured":
+      return {
+        label: "Available",
+        className: "bg-gray-100 text-gray-800 hover:bg-gray-200",
+      }
     default:
       return {
         label: "Available",
@@ -159,7 +164,9 @@ export default function IntegrationsPage() {
             <Select
               value={selectedCategory ?? "all"}
               onValueChange={(value) =>
-                setSelectedCategory(value as ProviderCategory)
+                setSelectedCategory(
+                  value === "all" ? null : (value as ProviderCategory)
+                )
               }
             >
               <SelectTrigger className="w-full sm:w-48">
@@ -178,7 +185,9 @@ export default function IntegrationsPage() {
             <Select
               value={selectedStatus ?? "all"}
               onValueChange={(value) =>
-                setSelectedStatus(value as IntegrationStatus)
+                setSelectedStatus(
+                  value === "all" ? null : (value as IntegrationStatus)
+                )
               }
             >
               <SelectTrigger className="w-full sm:w-48">
@@ -186,7 +195,8 @@ export default function IntegrationsPage() {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Status</SelectItem>
-                <SelectItem value="available">Available</SelectItem>
+                <SelectItem value="not_configured">Available</SelectItem>
+                <SelectItem value="configured">Configured</SelectItem>
                 <SelectItem value="connected">Connected</SelectItem>
               </SelectContent>
             </Select>


### PR DESCRIPTION
## Summary
- Fixed status filter to properly handle "all" value by converting to null instead of passing "all" as a status
- Updated available integrations filter to use correct "not_configured" status value
- Added explicit case handling for "not_configured" status in getStatusInfo

## Test plan
- [ ] Navigate to the integrations page
- [ ] Verify that selecting "All Status" from the status dropdown shows all integrations
- [ ] Verify that selecting "Available" shows only integrations with status "not_configured"
- [ ] Verify that selecting "Configured" shows only integrations with status "configured"  
- [ ] Verify that selecting "Connected" shows only integrations with status "connected"
- [ ] Test combinations of category and status filters to ensure they work together correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the status filter on the integrations page so selecting "All Status" now shows all integrations as expected.

- **Bug Fixes**
  - Changed the filter to treat "all" as no filter instead of a status value.
  - Updated the "Available" filter to use the correct "not_configured" status.
  - Added handling for "not_configured" in the status display logic.

<!-- End of auto-generated description by cubic. -->

