### PR TITLE
refactor(app): Drop provider_id in oauth callback

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -3752,6 +3752,34 @@ export const foldersMoveFolder = (
 }
 
 /**
+ * Oauth Callback
+ * Handle OAuth callback for the specified provider.
+ *
+ * Validates the state parameter against the database to ensure it was issued
+ * by our server and hasn't expired. This prevents CSRF attacks.
+ * @param data The data for the request.
+ * @param data.code Authorization code from OAuth provider
+ * @param data.state State parameter from authorization request
+ * @returns IntegrationOAuthCallback Successful Response
+ * @throws ApiError
+ */
+export const integrationsOauthCallback = (
+  data: IntegrationsOauthCallbackData
+): CancelablePromise<IntegrationsOauthCallbackResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/integrations/callback",
+    query: {
+      code: data.code,
+      state: data.state,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * List Integrations
  * List all integrations for the current user.
  * @param data The data for the request.
@@ -3881,38 +3909,6 @@ export const integrationsConnectProvider = (
     },
     query: {
       workspace_id: data.workspaceId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Oauth Callback
- * Handle OAuth callback for the specified provider.
- *
- * Validates the state parameter against the database to ensure it was issued
- * by our server and hasn't expired. This prevents CSRF attacks.
- * @param data The data for the request.
- * @param data.providerId
- * @param data.code Authorization code from OAuth provider
- * @param data.state State parameter from authorization request
- * @returns IntegrationOAuthCallback Successful Response
- * @throws ApiError
- */
-export const integrationsOauthCallback = (
-  data: IntegrationsOauthCallbackData
-): CancelablePromise<IntegrationsOauthCallbackResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/integrations/{provider_id}/callback",
-    path: {
-      provider_id: data.providerId,
-    },
-    query: {
-      code: data.code,
-      state: data.state,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4109,6 +4109,19 @@ export type FoldersMoveFolderData = {
 
 export type FoldersMoveFolderResponse = WorkflowFolderRead
 
+export type IntegrationsOauthCallbackData = {
+  /**
+   * Authorization code from OAuth provider
+   */
+  code: string
+  /**
+   * State parameter from authorization request
+   */
+  state: string
+}
+
+export type IntegrationsOauthCallbackResponse = IntegrationOAuthCallback
+
 export type IntegrationsListIntegrationsData = {
   workspaceId: string
 }
@@ -4143,20 +4156,6 @@ export type IntegrationsConnectProviderData = {
 }
 
 export type IntegrationsConnectProviderResponse = IntegrationOAuthConnect
-
-export type IntegrationsOauthCallbackData = {
-  /**
-   * Authorization code from OAuth provider
-   */
-  code: string
-  providerId: string
-  /**
-   * State parameter from authorization request
-   */
-  state: string
-}
-
-export type IntegrationsOauthCallbackResponse = IntegrationOAuthCallback
 
 export type IntegrationsDisconnectIntegrationData = {
   providerId: string
@@ -6095,6 +6094,21 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/integrations/callback": {
+    get: {
+      req: IntegrationsOauthCallbackData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: IntegrationOAuthCallback
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
   "/integrations": {
     get: {
       req: IntegrationsListIntegrationsData
@@ -6159,21 +6173,6 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: IntegrationOAuthConnect
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/integrations/{provider_id}/callback": {
-    get: {
-      req: IntegrationsOauthCallbackData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: IntegrationOAuthCallback
         /**
          * Validation Error
          */

--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -1114,10 +1114,7 @@ class TestBaseOAuthProvider:
             "write",
         }  # Compare as sets
         assert mock_provider.grant_type == OAuthGrantType.AUTHORIZATION_CODE
-        assert (
-            mock_provider.redirect_uri()
-            == "http://localhost/integrations/mock_provider/callback"
-        )
+        assert mock_provider.redirect_uri() == "http://localhost/integrations/callback"
 
     async def test_get_authorization_url(
         self, mock_provider: MockOAuthProvider

--- a/tracecat/integrations/base.py
+++ b/tracecat/integrations/base.py
@@ -144,7 +144,7 @@ class AuthorizationCodeOAuthProvider(BaseOAuthProvider):
     @classmethod
     def redirect_uri(cls) -> str:
         """The redirect URI for the OAuth provider."""
-        return f"{config.TRACECAT__PUBLIC_APP_URL}/integrations/{cls.id}/callback"
+        return f"{config.TRACECAT__PUBLIC_APP_URL}/integrations/callback"
 
     def _use_pkce(self) -> bool:
         """Override to enable PKCE for providers that support/require it."""


### PR DESCRIPTION
# Summary
Remove oauth provider id from the callback path param to allow sharing of a single oauth app over multiple apps. This works because we store oauth state in the db with the provider id and cross-check with the state (pkey for the table).

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the provider_id from the OAuth callback path to allow a single OAuth app to be shared across multiple apps.

- **Refactors**
  - Changed the callback route to /integrations/callback and updated related backend and frontend code.

<!-- End of auto-generated description by cubic. -->

