### PR TITLE
feat: Enhance OAuth secret handling with discriminated unions and provider keys

### DIFF
--- a/alembic/versions/4c1a69e5b34b_migrate_provider_ids_remove_suffixes.py
+++ b/alembic/versions/4c1a69e5b34b_migrate_provider_ids_remove_suffixes.py
@@ -1,0 +1,126 @@
+"""migrate_provider_ids_remove_suffixes
+
+Revision ID: 4c1a69e5b34b
+Revises: 89a8d57c3608
+Create Date: 2025-07-04 21:11:28.940515
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4c1a69e5b34b"
+down_revision: str | None = "89a8d57c3608"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """
+    Migrate existing OAuth integrations to remove _ac/_cc suffixes from provider_ids.
+
+    This migration uses a static mapping approach to update specific provider IDs:
+    1. Updates provider_ids by removing _ac (Authorization Code) and _cc (Client Credentials) suffixes
+    2. Ensures grant_type is correctly set based on the original suffix
+    3. Uses explicit mappings for all known legacy provider IDs
+    """
+    # Get a reference to the oauth_integration table
+    connection = op.get_bind()
+
+    # Static mapping for provider IDs with _ac suffix (Authorization Code)
+    ac_mappings = [
+        ("microsoft_ac", "microsoft"),
+        ("microsoft_teams_ac", "microsoft_teams"),
+    ]
+
+    for old_provider_id, new_provider_id in ac_mappings:
+        connection.execute(
+            sa.text("""
+                UPDATE oauth_integration
+                SET provider_id = :new_provider_id,
+                    grant_type = 'AUTHORIZATION_CODE'
+                WHERE provider_id = :old_provider_id
+            """),
+            {"old_provider_id": old_provider_id, "new_provider_id": new_provider_id},
+        )
+
+    # Static mapping for provider IDs with _cc suffix (Client Credentials)
+    cc_mappings = [
+        ("microsoft_cc", "microsoft"),
+        ("microsoft_teams_cc", "microsoft_teams"),
+    ]
+
+    for old_provider_id, new_provider_id in cc_mappings:
+        connection.execute(
+            sa.text("""
+                UPDATE oauth_integration
+                SET provider_id = :new_provider_id,
+                    grant_type = 'CLIENT_CREDENTIALS'
+                WHERE provider_id = :old_provider_id
+            """),
+            {"old_provider_id": old_provider_id, "new_provider_id": new_provider_id},
+        )
+
+    # Log the changes for verification
+    result = connection.execute(
+        sa.text("""
+            SELECT provider_id, grant_type, COUNT(*) as count
+            FROM oauth_integration
+            GROUP BY provider_id, grant_type
+            ORDER BY provider_id, grant_type
+        """)
+    )
+
+    print("Updated OAuth integrations:")
+    for row in result:
+        print(f"  {row.provider_id} ({row.grant_type}): {row.count} records")
+
+
+def downgrade() -> None:
+    """
+    Downgrade migration - restore _ac/_cc suffixes to provider_ids.
+
+    This will restore the original format where grant types were encoded in provider_id suffixes.
+    Uses static mapping to reverse the changes from upgrade().
+    """
+    connection = op.get_bind()
+
+    # Static mapping to restore _ac suffix (Authorization Code)
+    ac_reverse_mappings = [
+        ("microsoft", "microsoft_ac"),
+        ("microsoft_teams", "microsoft_teams_ac"),
+    ]
+
+    for new_provider_id, old_provider_id in ac_reverse_mappings:
+        connection.execute(
+            sa.text("""
+                UPDATE oauth_integration
+                SET provider_id = :old_provider_id
+                WHERE provider_id = :new_provider_id
+                AND grant_type = 'AUTHORIZATION_CODE'
+            """),
+            {"old_provider_id": old_provider_id, "new_provider_id": new_provider_id},
+        )
+
+    # Static mapping to restore _cc suffix (Client Credentials)
+    cc_reverse_mappings = [
+        ("microsoft", "microsoft_cc"),
+        ("microsoft_teams", "microsoft_teams_cc"),
+    ]
+
+    for new_provider_id, old_provider_id in cc_reverse_mappings:
+        connection.execute(
+            sa.text("""
+                UPDATE oauth_integration
+                SET provider_id = :old_provider_id
+                WHERE provider_id = :new_provider_id
+                AND grant_type = 'CLIENT_CREDENTIALS'
+            """),
+            {"old_provider_id": old_provider_id, "new_provider_id": new_provider_id},
+        )
+
+    print("Restored provider_id suffixes for OAuth integrations")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5429,7 +5429,7 @@ export const $RegistrySecret = {
 } as const
 
 export const $RegistrySecretType_Input = {
-  anyOf: [
+  oneOf: [
     {
       $ref: "#/components/schemas/RegistrySecret",
     },
@@ -5437,10 +5437,17 @@ export const $RegistrySecretType_Input = {
       $ref: "#/components/schemas/RegistryOAuthSecret-Input",
     },
   ],
+  discriminator: {
+    propertyName: "type",
+    mapping: {
+      custom: "#/components/schemas/RegistrySecret",
+      oauth: "#/components/schemas/RegistryOAuthSecret-Input",
+    },
+  },
 } as const
 
 export const $RegistrySecretType_Output = {
-  anyOf: [
+  oneOf: [
     {
       $ref: "#/components/schemas/RegistrySecret",
     },
@@ -5448,6 +5455,13 @@ export const $RegistrySecretType_Output = {
       $ref: "#/components/schemas/RegistryOAuthSecret-Output",
     },
   ],
+  discriminator: {
+    propertyName: "type",
+    mapping: {
+      custom: "#/components/schemas/RegistrySecret",
+      oauth: "#/components/schemas/RegistryOAuthSecret-Output",
+    },
+  },
 } as const
 
 export const $ReopenedEventRead = {
@@ -7299,18 +7313,7 @@ export const $TemplateActionDefinition_Input = {
       anyOf: [
         {
           items: {
-            oneOf: [
-              {
-                $ref: "#/components/schemas/RegistrySecretType-Input",
-              },
-            ],
-            discriminator: {
-              propertyName: "type",
-              mapping: {
-                custom: "#/components/schemas/RegistrySecretType-Input",
-                oauth: "#/components/schemas/RegistrySecretType-Input",
-              },
-            },
+            $ref: "#/components/schemas/RegistrySecretType-Input",
           },
           type: "array",
         },
@@ -7437,18 +7440,7 @@ export const $TemplateActionDefinition_Output = {
       anyOf: [
         {
           items: {
-            oneOf: [
-              {
-                $ref: "#/components/schemas/RegistrySecretType-Output",
-              },
-            ],
-            discriminator: {
-              propertyName: "type",
-              mapping: {
-                custom: "#/components/schemas/RegistrySecretType-Output",
-                oauth: "#/components/schemas/RegistrySecretType-Output",
-              },
-            },
+            $ref: "#/components/schemas/RegistrySecretType-Output",
           },
           type: "array",
         },

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3596,6 +3596,10 @@ export const $IntegrationTestConnectionResponse = {
 
 export const $IntegrationUpdate = {
   properties: {
+    grant_type: {
+      $ref: "#/components/schemas/OAuthGrantType",
+      description: "OAuth grant type for this integration",
+    },
     client_id: {
       anyOf: [
         {
@@ -3651,19 +3655,9 @@ export const $IntegrationUpdate = {
       title: "Scopes",
       description: "OAuth scopes to request for this integration",
     },
-    grant_type: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/OAuthGrantType",
-        },
-        {
-          type: "null",
-        },
-      ],
-      description: "OAuth grant type for this integration",
-    },
   },
   type: "object",
+  required: ["grant_type"],
   title: "IntegrationUpdate",
   description: "Request model for updating an integration.",
 } as const
@@ -4457,7 +4451,7 @@ export const $RegistryActionCreate = {
       anyOf: [
         {
           items: {
-            $ref: "#/components/schemas/RegistrySecret",
+            $ref: "#/components/schemas/RegistrySecretType-Input",
           },
           type: "array",
         },
@@ -4649,7 +4643,7 @@ export const $RegistryActionRead = {
       anyOf: [
         {
           items: {
-            $ref: "#/components/schemas/RegistrySecret",
+            $ref: "#/components/schemas/RegistrySecretType-Output",
           },
           type: "array",
         },
@@ -4975,7 +4969,7 @@ export const $RegistryActionUpdate = {
       anyOf: [
         {
           items: {
-            $ref: "#/components/schemas/RegistrySecret",
+            $ref: "#/components/schemas/RegistrySecretType-Input",
           },
           type: "array",
         },
@@ -5145,6 +5139,59 @@ export const $RegistryActionValidationErrorInfo = {
   type: "object",
   required: ["type", "details", "is_template", "loc_primary"],
   title: "RegistryActionValidationErrorInfo",
+} as const
+
+export const $RegistryOAuthSecret_Input = {
+  properties: {
+    type: {
+      type: "string",
+      const: "oauth",
+      title: "Type",
+      default: "oauth",
+    },
+    provider_id: {
+      type: "string",
+      title: "Provider Id",
+    },
+    grant_type: {
+      type: "string",
+      enum: ["authorization_code", "client_credentials"],
+      title: "Grant Type",
+    },
+  },
+  type: "object",
+  required: ["provider_id", "grant_type"],
+  title: "RegistryOAuthSecret",
+  description: "OAuth secret for a provider.",
+} as const
+
+export const $RegistryOAuthSecret_Output = {
+  properties: {
+    type: {
+      type: "string",
+      const: "oauth",
+      title: "Type",
+      default: "oauth",
+    },
+    provider_id: {
+      type: "string",
+      title: "Provider Id",
+    },
+    grant_type: {
+      type: "string",
+      enum: ["authorization_code", "client_credentials"],
+      title: "Grant Type",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+      readOnly: true,
+    },
+  },
+  type: "object",
+  required: ["provider_id", "grant_type", "name"],
+  title: "RegistryOAuthSecret",
+  description: "OAuth secret for a provider.",
 } as const
 
 export const $RegistryRepositoryCreate = {
@@ -5329,6 +5376,12 @@ export const $RegistryRepositoryUpdate = {
 
 export const $RegistrySecret = {
   properties: {
+    type: {
+      type: "string",
+      const: "custom",
+      title: "Type",
+      default: "custom",
+    },
     name: {
       type: "string",
       pattern: "[a-z0-9_]+",
@@ -5373,6 +5426,28 @@ export const $RegistrySecret = {
   type: "object",
   required: ["name"],
   title: "RegistrySecret",
+} as const
+
+export const $RegistrySecretType_Input = {
+  anyOf: [
+    {
+      $ref: "#/components/schemas/RegistrySecret",
+    },
+    {
+      $ref: "#/components/schemas/RegistryOAuthSecret-Input",
+    },
+  ],
+} as const
+
+export const $RegistrySecretType_Output = {
+  anyOf: [
+    {
+      $ref: "#/components/schemas/RegistrySecret",
+    },
+    {
+      $ref: "#/components/schemas/RegistryOAuthSecret-Output",
+    },
+  ],
 } as const
 
 export const $ReopenedEventRead = {
@@ -7131,7 +7206,7 @@ export const $TemplateAction_Input = {
       default: "action",
     },
     definition: {
-      $ref: "#/components/schemas/TemplateActionDefinition",
+      $ref: "#/components/schemas/TemplateActionDefinition-Input",
     },
   },
   type: "object",
@@ -7148,7 +7223,7 @@ export const $TemplateAction_Output = {
       default: "action",
     },
     definition: {
-      $ref: "#/components/schemas/TemplateActionDefinition",
+      $ref: "#/components/schemas/TemplateActionDefinition-Output",
     },
   },
   type: "object",
@@ -7156,7 +7231,7 @@ export const $TemplateAction_Output = {
   title: "TemplateAction",
 } as const
 
-export const $TemplateActionDefinition = {
+export const $TemplateActionDefinition_Input = {
   properties: {
     name: {
       type: "string",
@@ -7224,7 +7299,156 @@ export const $TemplateActionDefinition = {
       anyOf: [
         {
           items: {
-            $ref: "#/components/schemas/RegistrySecret",
+            oneOf: [
+              {
+                $ref: "#/components/schemas/RegistrySecretType-Input",
+              },
+            ],
+            discriminator: {
+              propertyName: "type",
+              mapping: {
+                custom: "#/components/schemas/RegistrySecretType-Input",
+                oauth: "#/components/schemas/RegistrySecretType-Input",
+              },
+            },
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Secrets",
+      description: "The secrets to pass to the action",
+    },
+    expects: {
+      additionalProperties: {
+        $ref: "#/components/schemas/ExpectedField",
+      },
+      type: "object",
+      title: "Expects",
+      description: "The arguments to pass to the action",
+    },
+    steps: {
+      items: {
+        $ref: "#/components/schemas/ActionStep",
+      },
+      type: "array",
+      title: "Steps",
+      description: "The sequence of steps for the action",
+    },
+    returns: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "object",
+        },
+      ],
+      title: "Returns",
+      description: "The result of the action",
+    },
+  },
+  type: "object",
+  required: [
+    "name",
+    "namespace",
+    "title",
+    "display_group",
+    "expects",
+    "steps",
+    "returns",
+  ],
+  title: "TemplateActionDefinition",
+} as const
+
+export const $TemplateActionDefinition_Output = {
+  properties: {
+    name: {
+      type: "string",
+      title: "Name",
+      description: "The action name",
+    },
+    namespace: {
+      type: "string",
+      title: "Namespace",
+      description: "The namespace of the action",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+      description: "The title of the action",
+    },
+    description: {
+      type: "string",
+      title: "Description",
+      description: "The description of the action",
+      default: "",
+    },
+    display_group: {
+      type: "string",
+      title: "Display Group",
+      description: "The display group of the action",
+    },
+    doc_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Doc Url",
+      description: "Link to documentation",
+    },
+    author: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Author",
+      description: "Author of the action",
+    },
+    deprecated: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Deprecated",
+      description: "Marks action as deprecated along with message",
+    },
+    secrets: {
+      anyOf: [
+        {
+          items: {
+            oneOf: [
+              {
+                $ref: "#/components/schemas/RegistrySecretType-Output",
+              },
+            ],
+            discriminator: {
+              propertyName: "type",
+              mapping: {
+                custom: "#/components/schemas/RegistrySecretType-Output",
+                oauth: "#/components/schemas/RegistrySecretType-Output",
+              },
+            },
           },
           type: "array",
         },

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -328,7 +328,7 @@ export const publicIncomingWebhook = (
   data: PublicIncomingWebhookData
 ): CancelablePromise<PublicIncomingWebhookResponse> => {
   return __request(OpenAPI, {
-    method: "GET",
+    method: "POST",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,
@@ -368,7 +368,7 @@ export const publicIncomingWebhook1 = (
   data: PublicIncomingWebhook1Data
 ): CancelablePromise<PublicIncomingWebhook1Response> => {
   return __request(OpenAPI, {
-    method: "POST",
+    method: "GET",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,
@@ -3808,6 +3808,7 @@ export const integrationsListIntegrations = (
  * @param data The data for the request.
  * @param data.providerId
  * @param data.workspaceId
+ * @param data.grantType
  * @returns IntegrationRead Successful Response
  * @throws ApiError
  */
@@ -3822,6 +3823,7 @@ export const integrationsGetIntegration = (
     },
     query: {
       workspace_id: data.workspaceId,
+      grant_type: data.grantType,
     },
     errors: {
       422: "Validation Error",
@@ -3835,6 +3837,7 @@ export const integrationsGetIntegration = (
  * @param data The data for the request.
  * @param data.providerId
  * @param data.workspaceId
+ * @param data.grantType
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -3849,6 +3852,7 @@ export const integrationsDeleteIntegration = (
     },
     query: {
       workspace_id: data.workspaceId,
+      grant_type: data.grantType,
     },
     errors: {
       422: "Validation Error",
@@ -3863,6 +3867,7 @@ export const integrationsDeleteIntegration = (
  * @param data.providerId
  * @param data.workspaceId
  * @param data.requestBody
+ * @param data.grantType
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -3877,6 +3882,7 @@ export const integrationsUpdateIntegration = (
     },
     query: {
       workspace_id: data.workspaceId,
+      grant_type: data.grantType,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -3922,6 +3928,7 @@ export const integrationsConnectProvider = (
  * @param data The data for the request.
  * @param data.providerId
  * @param data.workspaceId
+ * @param data.grantType
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -3936,6 +3943,7 @@ export const integrationsDisconnectIntegration = (
     },
     query: {
       workspace_id: data.workspaceId,
+      grant_type: data.grantType,
     },
     errors: {
       422: "Validation Error",
@@ -3998,6 +4006,7 @@ export const providersListProviders = (
  * @param data The data for the request.
  * @param data.providerId
  * @param data.workspaceId
+ * @param data.grantType
  * @returns ProviderRead Successful Response
  * @throws ApiError
  */
@@ -4012,6 +4021,7 @@ export const providersGetProvider = (
     },
     query: {
       workspace_id: data.workspaceId,
+      grant_type: data.grantType,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -33,7 +33,7 @@ import {
   type ActionUpdate,
   ApiError,
   type RegistryActionRead,
-  type RegistryOAuthSecret,
+  type RegistryOAuthSecret_Output as RegistryOAuthSecret,
   type RegistrySecret,
   type ValidationResult,
 } from "@/client"

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -8,6 +8,7 @@ import {
   CircleCheckIcon,
   CodeIcon,
   Database,
+  ExternalLinkIcon,
   FileTextIcon,
   LayoutListIcon,
   LinkIcon,
@@ -31,6 +32,9 @@ import {
   $JoinStrategy,
   type ActionUpdate,
   ApiError,
+  type RegistryActionRead,
+  type RegistryOAuthSecret,
+  type RegistrySecret,
   type ValidationResult,
 } from "@/client"
 import {
@@ -928,54 +932,9 @@ function ActionPanelContent({
                           <div className="space-y-4 px-4">
                             {registryAction.secrets &&
                             registryAction.secrets.length > 0 ? (
-                              <div className="text-xs text-muted-foreground">
-                                <span>
-                                  This action requires the following secrets:
-                                </span>
-                                <Table>
-                                  <TableHeader>
-                                    <TableRow className="h-6  text-xs capitalize">
-                                      <TableHead
-                                        className="font-bold"
-                                        colSpan={1}
-                                      >
-                                        Secret Name
-                                      </TableHead>
-                                      <TableHead
-                                        className="font-bold"
-                                        colSpan={1}
-                                      >
-                                        Required Keys
-                                      </TableHead>
-                                      <TableHead
-                                        className="font-bold"
-                                        colSpan={1}
-                                      >
-                                        Optional Keys
-                                      </TableHead>
-                                    </TableRow>
-                                  </TableHeader>
-                                  <TableBody>
-                                    {registryAction.secrets.map(
-                                      (secret, idx) => (
-                                        <TableRow
-                                          key={idx}
-                                          className="font-mono text-xs tracking-tight text-muted-foreground"
-                                        >
-                                          <TableCell>{secret.name}</TableCell>
-                                          <TableCell>
-                                            {secret.keys?.join(", ") || "-"}
-                                          </TableCell>
-                                          <TableCell>
-                                            {secret.optional_keys?.join(", ") ||
-                                              "-"}
-                                          </TableCell>
-                                        </TableRow>
-                                      )
-                                    )}
-                                  </TableBody>
-                                </Table>
-                              </div>
+                              <RegistryActionSecrets
+                                secrets={registryAction.secrets}
+                              />
                             ) : (
                               <span className="text-xs text-muted-foreground">
                                 No secrets required.
@@ -1664,6 +1623,101 @@ export function ActionPanelNotFound({
           </Button>
         )}
       </div>
+    </div>
+  )
+}
+
+function RegistryActionSecrets({
+  secrets,
+}: {
+  secrets: NonNullable<RegistryActionRead["secrets"]>
+}) {
+  const { workspaceId } = useWorkspace()
+  const customSecrets = secrets.filter(
+    (secret): secret is RegistrySecret => secret.type === "custom"
+  )
+  const oauthSecrets = secrets.filter(
+    (secret): secret is RegistryOAuthSecret => secret.type === "oauth"
+  )
+  return (
+    <div className="text-xs text-muted-foreground space-y-4">
+      {/* Regular Secrets Table */}
+      {customSecrets.length > 0 && (
+        <div>
+          <span className="block mb-2">
+            This action requires the following secrets:
+          </span>
+          <Table>
+            <TableHeader>
+              <TableRow className="h-6  text-xs capitalize">
+                <TableHead className="font-bold" colSpan={1}>
+                  Secret Name
+                </TableHead>
+                <TableHead className="font-bold" colSpan={1}>
+                  Required Keys
+                </TableHead>
+                <TableHead className="font-bold" colSpan={1}>
+                  Optional Keys
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {customSecrets.map((secret) => (
+                <TableRow
+                  key={secret.name}
+                  className="font-mono text-xs tracking-tight text-muted-foreground"
+                >
+                  <TableCell>{secret.name}</TableCell>
+                  <TableCell>{secret.keys?.join(", ") || "-"}</TableCell>
+                  <TableCell>
+                    {secret.optional_keys?.join(", ") || "-"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {/* OAuth Secrets Table */}
+      {oauthSecrets.length > 0 && (
+        <div>
+          <span className="block mb-2">
+            This action requires the following OAuth integrations:
+          </span>
+          <Table>
+            <TableHeader>
+              <TableRow className="h-6  text-xs capitalize">
+                <TableHead className="font-bold" colSpan={1}>
+                  Provider ID
+                </TableHead>
+                <TableHead className="font-bold" colSpan={1}>
+                  Grant Type
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {oauthSecrets.map((secret) => (
+                <TableRow
+                  key={`${secret.provider_id}-${secret.grant_type}`}
+                  className="font-mono text-xs tracking-tight text-muted-foreground"
+                >
+                  <TableCell className="flex items-center gap-1">
+                    <span>{secret.provider_id}</span>
+                    <Link
+                      href={`/workspaces/${workspaceId}/integrations/${secret.provider_id}?tab=configuration`}
+                      target="_blank"
+                    >
+                      <ExternalLinkIcon className="size-3" strokeWidth={2.5} />
+                    </Link>
+                  </TableCell>
+                  <TableCell>{secret.grant_type}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -469,12 +469,7 @@ export const providerIcons: Record<
   string,
   (props: CustomIconProps) => JSX.Element
 > = {
-  microsoft_ac: ({ className, ...rest }) => (
-    <div className={className}>
-      <MicrosoftIcon {...rest} />
-    </div>
-  ),
-  microsoft_cc: ({ className, ...rest }) => (
+  microsoft: ({ className, ...rest }) => (
     <div className={className}>
       <MicrosoftIcon {...rest} />
     </div>
@@ -489,12 +484,7 @@ export const providerIcons: Record<
       <MicrosoftEntraIcon {...rest} />
     </div>
   ),
-  microsoft_teams_ac: ({ className, ...rest }) => (
-    <div className={className}>
-      <MicrosoftTeamsIcon {...rest} />
-    </div>
-  ),
-  microsoft_teams_cc: ({ className, ...rest }) => (
+  microsoft_teams: ({ className, ...rest }) => (
     <div className={className}>
       <MicrosoftTeamsIcon {...rest} />
     </div>

--- a/registry/tracecat_registry/__init__.py
+++ b/registry/tracecat_registry/__init__.py
@@ -17,12 +17,20 @@ from tracecat_registry._internal.exceptions import (
     SecretNotFoundError,
 )
 from tracecat_registry._internal.logger import logger
-from tracecat_registry._internal.models import RegistrySecret
+from tracecat_registry._internal.models import (
+    RegistryOAuthSecret,
+    RegistrySecret,
+    RegistrySecretType,
+    RegistrySecretTypeValidator,
+)
 
 __all__ = [
     "registry",
     "RegistrySecret",
     "logger",
+    "RegistryOAuthSecret",
+    "RegistrySecretType",
+    "RegistrySecretTypeValidator",
     "secrets",
     "exceptions",
     "RegistryActionError",

--- a/registry/tracecat_registry/_internal/models.py
+++ b/registry/tracecat_registry/_internal/models.py
@@ -9,7 +9,6 @@ from pydantic import (
     computed_field,
     model_validator,
 )
-from tracecat.logger import logger
 
 """
 IMPORTANT: Pydantic Annotated Metadata Ordering
@@ -147,7 +146,6 @@ def _validate_registry_secret_type(value: Any) -> Any:
     3. Other legacy secrets without clear type indicators will fail validation
     4. Modern secrets with explicit 'type' field are passed through unchanged
     """
-    logger.warning("BEFORE VALIDATION")
     if isinstance(value, dict) and "type" not in value:
         if "keys" in value or "optional_keys" in value:
             # Legacy custom secret with keys - set type to "custom"

--- a/registry/tracecat_registry/_internal/models.py
+++ b/registry/tracecat_registry/_internal/models.py
@@ -1,6 +1,56 @@
-from typing import Annotated, Self
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, StringConstraints, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    Field,
+    StringConstraints,
+    TypeAdapter,
+    computed_field,
+    model_validator,
+)
+from tracecat.logger import logger
+
+"""
+IMPORTANT: Pydantic Annotated Metadata Ordering
+
+Pydantic v2 processes Annotated metadata in a specific order that is CRITICAL to understand:
+
+1. RIGHT-TO-LEFT pass: Pydantic walks metadata from right to left, executing BeforeValidators
+   immediately as it encounters them.
+
+2. LEFT-TO-RIGHT pass: After reaching the leftmost item, Pydantic walks back left to right,
+   executing AfterValidators, applying Field constraints, etc.
+
+This means:
+- BeforeValidators on the RIGHT execute BEFORE those on the LEFT
+- Field(discriminator="type") must see the final, transformed data
+- If your BeforeValidator adds/modifies fields that discriminator needs,
+  the BeforeValidator MUST be to the RIGHT of Field()
+
+Example of CORRECT ordering:
+```python
+type T = Annotated[
+    Union[A, B],
+    Field(discriminator="type"),                    # ← Needs "type" field to exist
+    BeforeValidator(add_type_field_if_missing),     # ← Adds "type" field (runs first)
+]
+```
+
+Example of INCORRECT ordering:
+```python
+type T = Annotated[
+    Union[A, B],
+    BeforeValidator(add_type_field_if_missing),     # ← Runs second (too late!)
+    Field(discriminator="type"),                    # ← Runs first, "type" doesn't exist yet
+]
+```
+
+This is why our RegistrySecretType uses Field() first, then BeforeValidator() - the validator
+adds the "type" field that the discriminator requires.
+
+See: https://docs.pydantic.dev/latest/concepts/validators/#ordering-of-validators-within-annotated
+"""
 
 SecretName = Annotated[str, StringConstraints(pattern=r"[a-z0-9_]+")]
 """Validator for a secret name. e.g. 'aws_access_key_id'"""
@@ -10,6 +60,8 @@ SecretKey = Annotated[str, StringConstraints(pattern=r"[a-zA-Z0-9_]+")]
 
 
 class RegistrySecret(BaseModel):
+    type: Literal["custom"] = Field(default="custom", frozen=True)
+
     name: SecretName
     """The name of the secret."""
 
@@ -25,19 +77,22 @@ class RegistrySecret(BaseModel):
     @model_validator(mode="after")
     def validate_keys(cls, v):
         if isinstance(v.name, str) and v.name.endswith("_oauth"):
-            if v.keys is not None or v.optional_keys is not None:
-                raise ValueError("OAuth secrets cannot have keys or optional_keys")
-        else:
-            if v.keys is None and v.optional_keys is None:
-                raise ValueError(
-                    "At least one of 'keys' or 'optional_keys' must be specified"
-                )
+            # Cannont have a RegistrySecret with _oauth suffix
+            raise ValueError(
+                "OAuth secrets are not allowed to have keys or optional_keys"
+            )
+
+        if v.keys is None and v.optional_keys is None:
+            raise ValueError(
+                "At least one of 'keys' or 'optional_keys' must be specified"
+            )
         return v
 
     def __hash__(self) -> int:
         """Custom hash implementation based on relevant fields."""
         return hash(
             (
+                self.type,
                 self.name,
                 tuple(self.keys) if self.keys else None,
                 tuple(self.optional_keys) if self.optional_keys else None,
@@ -45,22 +100,85 @@ class RegistrySecret(BaseModel):
             )
         )
 
+
+class RegistryOAuthSecret(BaseModel):
+    """OAuth secret for a provider."""
+
+    type: Literal["oauth"] = Field(default="oauth", frozen=True)
+    provider_id: str
+    """The provider id of the secret."""
+    grant_type: Literal["authorization_code", "client_credentials"]
+    """The grant type for the OAuth secret."""
+
+    @computed_field
     @property
-    def is_oauth(self) -> bool:
-        return self.name.endswith("_oauth")
+    def name(self) -> str:
+        return f"{self.provider_id}_oauth"
 
     @property
-    def provider_id(self) -> str:
-        return self.name.replace("_oauth", "")
+    def token_name(self) -> str:
+        """The keyname for the OAuth secret.
 
-    @classmethod
-    def oauth(cls, provider_id: str) -> Self:
-        """Create an OAuth secret for the specified provider.
+        `SECRETS.<provider_id>.<prefix>_[SERVICE|USER]_TOKEN`
 
-        Args:
-            provider_id: The identifier for the OAuth provider (e.g., 'microsoft_graph').
-
-        Returns:
-            A new RegistrySecret instance configured for OAuth authentication.
+        <prefix> is the provider_id in uppercase.
         """
-        return cls(name=f"{provider_id}_oauth")
+        prefix = self.provider_id.upper()
+        match self.grant_type:
+            case "client_credentials":
+                return f"{prefix}_SERVICE_TOKEN"
+            case "authorization_code":
+                return f"{prefix}_USER_TOKEN"
+            case _:
+                raise ValueError(f"Invalid grant type: {self.grant_type}")
+
+    def __hash__(self) -> int:
+        """Custom hash implementation based on relevant fields."""
+        return hash((self.type, self.provider_id, self.grant_type))
+
+
+# Custom validator to handle backward compatibility
+def _validate_registry_secret_type(value: Any) -> Any:
+    """Add backward compatibility for legacy RegistrySecret objects without 'type' field.
+
+    This validator ensures that:
+    1. Legacy custom secrets (with keys/optional_keys) get type="custom"
+    2. Legacy OAuth secrets (names ending in '_oauth') get type="oauth"
+    3. Other legacy secrets without clear type indicators will fail validation
+    4. Modern secrets with explicit 'type' field are passed through unchanged
+    """
+    logger.warning("BEFORE VALIDATION")
+    if isinstance(value, dict) and "type" not in value:
+        if "keys" in value or "optional_keys" in value:
+            # Legacy custom secret with keys - set type to "custom"
+            value = {**value, "type": "custom"}
+        elif value.get("name", "").endswith("_oauth"):
+            # Legacy OAuth secret - extract provider_id and set defaults
+            provider_id = value["name"].replace("_oauth", "")
+            value = {
+                **value,
+                "type": "oauth",
+                "provider_id": provider_id,
+                "grant_type": "authorization_code",  # Default grant type for legacy
+            }
+        # Note: We deliberately don't add a fallback 'else' clause here.
+        # Legacy secrets that don't fit either pattern should fail validation
+        # to maintain data integrity. This forces proper migration.
+    return value
+
+
+# Tagged union with backward compatibility
+#
+# CRITICAL ORDERING: Field() must come BEFORE BeforeValidator() because:
+# 1. Pydantic processes Annotated metadata RIGHT-TO-LEFT for BeforeValidators
+# 2. BeforeValidator (rightmost) runs FIRST, adding the "type" field to legacy data
+# 3. Field(discriminator="type") runs SECOND, using the now-present "type" field
+# 4. If reversed, Field() would run first and fail because "type" doesn't exist yet
+type RegistrySecretType = Annotated[
+    RegistrySecret | RegistryOAuthSecret,
+    Field(discriminator="type"),  # ← Runs second: needs "type" field
+    BeforeValidator(_validate_registry_secret_type),  # ← Runs first: adds "type" field
+]
+RegistrySecretTypeValidator: TypeAdapter[RegistrySecretType] = TypeAdapter(
+    RegistrySecretType
+)

--- a/registry/tracecat_registry/_internal/models.py
+++ b/registry/tracecat_registry/_internal/models.py
@@ -76,7 +76,7 @@ class RegistrySecret(BaseModel):
     @model_validator(mode="after")
     def validate_keys(cls, v):
         if isinstance(v.name, str) and v.name.endswith("_oauth"):
-            # Cannont have a RegistrySecret with _oauth suffix
+            # Cannot have a RegistrySecret with _oauth suffix
             raise ValueError(
                 "OAuth secrets are not allowed to have keys or optional_keys"
             )

--- a/registry/tracecat_registry/_internal/registry.py
+++ b/registry/tracecat_registry/_internal/registry.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 
 from tracecat_registry._internal.constants import DEFAULT_NAMESPACE
-from tracecat_registry._internal.models import RegistrySecret
+from tracecat_registry._internal.models import RegistrySecretType
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -17,7 +17,7 @@ def register(
     deprecated: str | None = None,
     namespace: str = DEFAULT_NAMESPACE,
     description: str,
-    secrets: list[RegistrySecret] | None = None,
+    secrets: list[RegistrySecretType] | None = None,
     include_in_schema: bool = True,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator factory to register a new UDF (User-Defined Function) with additional parameters.

--- a/registry/tracecat_registry/integrations/agents/builder.py
+++ b/registry/tracecat_registry/integrations/agents/builder.py
@@ -8,6 +8,7 @@ import base64
 from typing import Any, Union, Annotated, Self
 from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
+from tracecat_registry import RegistrySecretType
 from tracecat_registry.integrations.agents.parsers import try_parse_json
 from pydantic_ai.agent import AgentRunResult
 from typing_extensions import Doc
@@ -19,27 +20,24 @@ from pydantic_ai.usage import Usage
 from pydantic_ai.tools import Tool
 from pydantic_core import PydanticUndefined
 
-from tracecat.auth.sandbox import AuthSandbox
-from tracecat.contexts import ctx_run
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.executor.service import (
     _run_action_direct,
+    get_action_secrets,
     run_template_action,
     flatten_secrets,
 )
-from tracecat.expressions.eval import extract_templated_secrets
 from tracecat.expressions.expectations import create_expectation_model
 from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.registry.fields import ActionType, TextArea
-from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.secrets.secrets_manager import env_sandbox
 from tracecat_registry.integrations.pydantic_ai import (
     PYDANTIC_AI_REGISTRY_SECRETS,
     build_agent,
 )
 
-from tracecat_registry import registry, RegistrySecret
+from tracecat_registry import registry
 from tracecat.types.exceptions import RegistryError
 from tracecat_registry.integrations.agents.exceptions import AgentRunError
 from tracecat_registry.integrations.agents.tools import (
@@ -143,31 +141,7 @@ async def call_tracecat_action(action_name: str, args: dict[str, Any]) -> Any:
         action_secrets = await service.fetch_all_action_secrets(reg_action)
         bound_action = service.get_bound(reg_action, mode="execution")
 
-    # Get runtime environment from context or use default
-    runtime_env = getattr(ctx_run.get(), "environment", DEFAULT_SECRETS_ENVIRONMENT)
-
-    # Extract secrets from args and action
-    args_secrets = set(extract_templated_secrets(args))
-    optional_secrets = {s.name for s in action_secrets if s.optional}
-    required_secrets = {s.name for s in action_secrets if not s.optional}
-    secrets_to_fetch = required_secrets | args_secrets | optional_secrets
-
-    logger.info(
-        "Handling secrets for agent tool call",
-        action=action_name,
-        required_secrets=required_secrets,
-        optional_secrets=optional_secrets,
-        args_secrets=args_secrets,
-        secrets_to_fetch=secrets_to_fetch,
-    )
-
-    # Fetch all required secrets
-    async with AuthSandbox(
-        secrets=secrets_to_fetch,
-        environment=runtime_env,
-        optional_secrets=optional_secrets,
-    ) as sandbox:
-        secrets = sandbox.secrets.copy()
+    secrets = await get_action_secrets(args=args, action_secrets=action_secrets)
 
     # Call action with secrets in environment
     context = create_default_execution_context()
@@ -388,7 +362,7 @@ class TracecatAgentBuilder:
         self.tools: list[Tool] = []
         self.namespace_filters: list[str] = []
         self.action_filters: list[str] = []
-        self.collected_secrets: set[RegistrySecret] = set()
+        self.collected_secrets: set[RegistrySecretType] = set()
 
     def with_namespace_filters(self, *namespaces: str) -> Self:
         """Add namespace filters for tools (e.g., 'tools.slack', 'tools.email')."""
@@ -502,12 +476,13 @@ class TracecatAgentBuilder:
         return agent
 
 
+# TODO: unused
 async def collect_secrets_for_filters(
     namespace_filters: list[str] | None = None,
     action_filters: list[str] | None = None,
-) -> set[RegistrySecret]:
+) -> set[RegistrySecretType]:
     """Collect all secrets required by actions matching the given filters."""
-    collected_secrets: set[RegistrySecret] = set()
+    collected_secrets: set[RegistrySecretType] = set()
 
     async with RegistryActionsService.with_session() as service:
         if action_filters:

--- a/registry/tracecat_registry/integrations/microsoft_entra.py
+++ b/registry/tracecat_registry/integrations/microsoft_entra.py
@@ -3,15 +3,18 @@ from typing_extensions import Doc
 
 import httpx
 
-from tracecat_registry import RegistrySecret, registry, secrets
+from tracecat_registry import registry, secrets
+from tracecat_registry._internal.models import RegistryOAuthSecret
 
-microsoft_entra_oauth_secret = RegistrySecret.oauth("microsoft_entra")
+microsoft_entra_oauth_secret = RegistryOAuthSecret(
+    provider_id="microsoft_entra",
+    grant_type="authorization_code",
+)
 """Microsoft Entra OAuth2.0 credentials (Authorization Code grant).
 
 - name: `microsoft_entra`
 - provider_id: `microsoft_entra`
-usage:
-MICROSOFT_ENTRA_ACCESS_TOKEN
+- token_name: `MICROSOFT_ENTRA_AC_TOKEN`
 """
 
 
@@ -30,7 +33,7 @@ async def get_user_id_by_email(
 
     Note: This API requires User.ReadBasic.All, User.Read.All, or Directory.Read.All permissions.
     """
-    token = secrets.get("MICROSOFT_ENTRA_ACCESS_TOKEN")
+    token = secrets.get(microsoft_entra_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}"}
 

--- a/registry/tracecat_registry/integrations/microsoft_teams.py
+++ b/registry/tracecat_registry/integrations/microsoft_teams.py
@@ -5,16 +5,18 @@ from typing_extensions import Doc
 
 import httpx
 
-from tracecat_registry import RegistrySecret, registry, secrets
+from tracecat_registry import RegistryOAuthSecret, registry, secrets
 
 
-microsoft_teams_ac_oauth_secret = RegistrySecret.oauth("microsoft_teams_ac")
+microsoft_teams_ac_oauth_secret = RegistryOAuthSecret(
+    provider_id="microsoft_teams",
+    grant_type="authorization_code",
+)
 """Microsoft Teams OAuth2.0 credentials (Authorization Code grant).
 
-- name: `microsoft_teams_ac`
-- provider_id: `microsoft_teams_ac`
-usage:
-MICROSOFT_TEAMS_AC_ACCESS_TOKEN
+- name: `microsoft_teams`
+- provider_id: `microsoft_teams`
+- token_name: `MICROSOFT_TEAMS_[SERVICE|USER]_TOKEN`
 """
 
 TeamId = Annotated[str, Doc("The ID of the team.")]
@@ -58,7 +60,7 @@ async def send_teams_message(
     channel_id: ChannelId,
     message: Annotated[str, Doc("The message to send.")],
 ) -> dict[str, str]:
-    token = secrets.get("MICROSOFT_TEAMS_AC_ACCESS_TOKEN")
+    token = secrets.get(microsoft_teams_ac_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
@@ -105,7 +107,7 @@ async def create_teams_channel(
 
     For private channels, at least one owner must be specified in owner_user_ids.
     """
-    token = secrets.get("MICROSOFT_TEAMS_AC_ACCESS_TOKEN")
+    token = secrets.get(microsoft_teams_ac_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
@@ -171,7 +173,7 @@ async def list_channel_messages(
 
     Note: This API requires ChannelMessage.Read.All or ChannelMessage.Read.Group permissions.
     """
-    token = secrets.get("MICROSOFT_TEAMS_AC_ACCESS_TOKEN")
+    token = secrets.get(microsoft_teams_ac_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -208,7 +210,7 @@ async def delete_teams_channel(
 
     Note: This API requires Channel.Delete.All or Channel.Delete.Group permissions.
     """
-    token = secrets.get("MICROSOFT_TEAMS_AC_ACCESS_TOKEN")
+    token = secrets.get(microsoft_teams_ac_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -460,7 +462,7 @@ async def send_teams_buttons(
     ] = None,
 ) -> dict[str, Any]:
     """Send ActionSet buttons as a Teams thumbnail card."""
-    token = secrets.get("MICROSOFT_TEAMS_AC_ACCESS_TOKEN")
+    token = secrets.get(microsoft_teams_ac_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
@@ -539,7 +541,7 @@ async def send_adaptive_card(
     title: OptionalTitle = None,
 ) -> dict[str, Any]:
     """Send an Adaptive Card message to Teams (without ActionSet elements)."""
-    token = secrets.get("MICROSOFT_TEAMS_AC_ACCESS_TOKEN")
+    token = secrets.get(microsoft_teams_ac_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 

--- a/tests/unit/test_oauth_state.py
+++ b/tests/unit/test_oauth_state.py
@@ -15,8 +15,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from tracecat import config
 from tracecat.db.schemas import OAuthStateDB, User, Workspace
 from tracecat.integrations.base import AuthorizationCodeOAuthProvider
+from tracecat.integrations.enums import OAuthGrantType
 from tracecat.integrations.models import (
     ProviderCategory,
+    ProviderKey,
     ProviderMetadata,
     ProviderScopes,
 )
@@ -318,11 +320,14 @@ class TestOAuthState:
         test_role_with_user: Role,
     ) -> None:
         """Test the full OAuth flow with state management."""
-        provider_id = MockOAuthProvider.id
+        provider_key = ProviderKey(
+            id=MockOAuthProvider.id,
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        )
 
         # Store provider configuration
         await integration_service.store_provider_config(
-            provider_id=provider_id,
+            provider_key=provider_key,
             client_id="test_client_id",
             client_secret=SecretStr("test_client_secret"),
             provider_config={"redirect_uri": "http://localhost:8000/callback"},
@@ -339,7 +344,7 @@ class TestOAuthState:
             state=state_id,
             workspace_id=test_role_with_user.workspace_id,
             user_id=test_role_with_user.user_id,
-            provider_id=provider_id,
+            provider_id=provider_key.id,
             expires_at=expires_at,
         )
         session.add(oauth_state)

--- a/tests/unit/test_template_actions.py
+++ b/tests/unit/test_template_actions.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 from pydantic import BaseModel, SecretStr, TypeAdapter
+from tracecat_registry import RegistrySecret
 
 from tests.shared import TEST_WF_ID, generate_test_exec_id
 from tracecat import config
@@ -23,7 +24,6 @@ from tracecat.registry.actions.models import (
     ActionStep,
     BoundRegistryAction,
     RegistryActionCreate,
-    RegistrySecret,
     TemplateAction,
     TemplateActionDefinition,
 )

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -12,6 +12,8 @@ import uvloop
 from ray.exceptions import RayTaskError
 from ray.runtime_env import RuntimeEnv
 from sqlmodel.ext.asyncio.session import AsyncSession
+from tracecat_registry import RegistrySecretType
+from tracecat_registry._internal.models import RegistryOAuthSecret
 
 from tracecat import config
 from tracecat.auth.sandbox import AuthSandbox
@@ -34,6 +36,8 @@ from tracecat.expressions.eval import (
     get_iterables_from_expression,
 )
 from tracecat.git import prepare_git_url
+from tracecat.integrations.enums import OAuthGrantType
+from tracecat.integrations.models import ProviderKey
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.parse import get_pyproject_toml_required_deps, traverse_leaves
@@ -195,6 +199,81 @@ async def run_template_action(
     )
 
 
+async def get_action_secrets(
+    args: ArgsT,
+    action_secrets: set[RegistrySecretType],
+) -> dict[str, Any]:
+    # Handle secrets from the task args
+    args_secrets = extract_templated_secrets(args)
+    # Get oauth integrations from the action secrets
+    args_oauth_secrets: set[str] = set()
+    args_basic_secrets: set[str] = set()
+    for secret in args_secrets:
+        if secret.endswith("_oauth"):
+            args_oauth_secrets.add(secret)
+        else:
+            args_basic_secrets.add(secret)
+
+    # Handle secrets from the action
+    required_basic_secrets: set[str] = set()
+    optional_basic_secrets: set[str] = set()
+    oauth_secrets: dict[ProviderKey, RegistryOAuthSecret] = {}
+    for secret in action_secrets:
+        if secret.type == "oauth":
+            oauth_secrets[
+                ProviderKey(
+                    id=secret.provider_id, grant_type=OAuthGrantType(secret.grant_type)
+                )
+            ] = secret
+        elif secret.optional:
+            optional_basic_secrets.add(secret.name)
+        else:
+            required_basic_secrets.add(secret.name)
+
+    # Get secrets to fetch
+    all_basic_secrets = (
+        required_basic_secrets | args_basic_secrets | optional_basic_secrets
+    )
+    logger.info(
+        "Handling secrets",
+        required_basic_secrets=required_basic_secrets,
+        optional_basic_secrets=optional_basic_secrets,
+        oauth_provider_ids=oauth_secrets,
+        args_secrets=args_secrets,
+        secrets_to_fetch=all_basic_secrets,
+    )
+
+    # Get all basic secrets in one call
+    secrets: dict[str, Any] = {}
+    async with AuthSandbox(
+        secrets=all_basic_secrets,
+        environment=get_runtime_env(),
+        optional_secrets=optional_basic_secrets,
+    ) as sandbox:
+        secrets |= sandbox.secrets.copy()
+
+    # Get oauth integrations
+    async with IntegrationService.with_session() as service:
+        oauth_integrations = await service.list_integrations(
+            provider_keys=set(oauth_secrets.keys())
+        )
+        for integration in oauth_integrations:
+            await service.refresh_token_if_needed(integration)
+            access_token = await service.get_access_token(integration)
+            secret = oauth_secrets[
+                ProviderKey(
+                    id=integration.provider_id, grant_type=integration.grant_type
+                )
+            ]
+            # SECRETS.<provider_id>.[<prefix>_[SERVICE|USER]_TOKEN]
+            # NOTE: We are overriding the provider_id key here assuming its unique
+            # <prefix> is the provider_id in uppercase.
+            secrets[integration.provider_id] = {
+                secret.token_name: access_token.get_secret_value()
+            }
+    return secrets
+
+
 async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
     """Main entrypoint for running an action."""
     ctx_role.set(role)
@@ -212,63 +291,7 @@ async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
         action_secrets = await service.fetch_all_action_secrets(reg_action)
         action = service.get_bound(reg_action, mode="execution")
 
-    # Handle secrets from the task args
-    args_secrets = extract_templated_secrets(task.args)
-    # Get oauth integrations from the action secrets
-    args_oauth_secrets: set[str] = set()
-    args_basic_secrets: set[str] = set()
-    for secret in args_secrets:
-        if secret.endswith("_oauth"):
-            args_oauth_secrets.add(secret)
-        else:
-            args_basic_secrets.add(secret)
-
-    # Handle secrets from the action
-    required_basic_secrets: set[str] = set()
-    optional_basic_secrets: set[str] = set()
-    oauth_provider_ids: set[str] = set()
-    for secret in action_secrets:
-        if secret.is_oauth:
-            oauth_provider_ids.add(secret.provider_id)
-        elif secret.optional:
-            optional_basic_secrets.add(secret.name)
-        else:
-            required_basic_secrets.add(secret.name)
-
-    # Get secrets to fetch
-    all_basic_secrets = (
-        required_basic_secrets | args_basic_secrets | optional_basic_secrets
-    )
-    logger.info(
-        "Handling secrets",
-        required_basic_secrets=required_basic_secrets,
-        optional_basic_secrets=optional_basic_secrets,
-        oauth_provider_ids=oauth_provider_ids,
-        args_secrets=args_secrets,
-        secrets_to_fetch=all_basic_secrets,
-    )
-
-    # Get all basic secrets in one call
-    secrets: dict[str, Any] = {}
-    async with AuthSandbox(
-        secrets=all_basic_secrets,
-        environment=get_runtime_env(),
-        optional_secrets=optional_basic_secrets,
-    ) as sandbox:
-        secrets |= sandbox.secrets.copy()
-
-    # Get oauth integrations
-    async with IntegrationService.with_session() as service:
-        oauth_integrations = await service.list_integrations(
-            providers=oauth_provider_ids,
-        )
-        for integration in oauth_integrations:
-            await service.refresh_token_if_needed(integration)
-            access_token = await service.get_access_token(integration)
-            secrets[integration.provider_id] = {
-                f"{integration.provider_id.upper()}_ACCESS_TOKEN": access_token.get_secret_value()
-            }
-
+    secrets = await get_action_secrets(args=task.args, action_secrets=action_secrets)
     if config.TRACECAT__UNSAFE_DISABLE_SM_MASKING:
         log.warning(
             "Secrets masking is disabled. This is unsafe in production workflows."

--- a/tracecat/integrations/models.py
+++ b/tracecat/integrations/models.py
@@ -71,6 +71,13 @@ class IntegrationRead(BaseModel):
 class IntegrationUpdate(BaseModel):
     """Request model for updating an integration."""
 
+    # Additional identifier
+    grant_type: OAuthGrantType = Field(
+        ...,
+        description="OAuth grant type for this integration",
+    )
+
+    # Updateable fields
     client_id: str | None = Field(
         default=None,
         description="OAuth client ID for the provider",
@@ -88,10 +95,6 @@ class IntegrationUpdate(BaseModel):
     scopes: list[str] | None = Field(
         default=None,
         description="OAuth scopes to request for this integration",
-    )
-    grant_type: OAuthGrantType | None = Field(
-        default=None,
-        description="OAuth grant type for this integration",
     )
 
 
@@ -235,6 +238,19 @@ class OAuthProviderKwargs(TypedDict):
     client_id: Required[str]
     client_secret: Required[str]
     scopes: NotRequired[list[str] | None]
+
+
+class ProviderKey(BaseModel):
+    """Key for a provider that uniquely identifies it."""
+
+    id: str
+    grant_type: OAuthGrantType
+
+    def __str__(self) -> str:
+        return f"{self.id} ({self.grant_type.value})"
+
+    def __hash__(self) -> int:
+        return hash((self.id, self.grant_type))
 
 
 class ProviderSchema(BaseModel):

--- a/tracecat/integrations/providers/microsoft.py
+++ b/tracecat/integrations/providers/microsoft.py
@@ -50,7 +50,7 @@ AC_SCOPES = ProviderScopes(
 
 # Shared metadata for authorization code flow
 AC_METADATA = ProviderMetadata(
-    id="microsoft_ac",
+    id="microsoft",
     name="Microsoft",
     description="Generic Microsoft OAuth provider (Delegated user)",
     categories=[ProviderCategory.AUTH],
@@ -71,7 +71,7 @@ AC_METADATA = ProviderMetadata(
 class MicrosoftACProvider(AuthorizationCodeOAuthProvider):
     """Microsoft OAuth provider using authorization code flow."""
 
-    id: ClassVar[str] = "microsoft_ac"
+    id: ClassVar[str] = "microsoft"
 
     # Use shared constants
     _authorization_endpoint: ClassVar[str] = AUTHORIZATION_ENDPOINT
@@ -126,7 +126,7 @@ CC_SCOPES = ProviderScopes(
 
 # Shared metadata for client credentials flow
 CC_METADATA = ProviderMetadata(
-    id="microsoft_cc",
+    id="microsoft",
     name="Microsoft",
     description="Generic Microsoft OAuth provider (Service account)",
     categories=[ProviderCategory.AUTH],
@@ -148,7 +148,7 @@ CC_METADATA = ProviderMetadata(
 class MicrosoftCCProvider(ClientCredentialsOAuthProvider):
     """Microsoft OAuth provider using client credentials flow for server-to-server authentication."""
 
-    id: ClassVar[str] = "microsoft_cc"
+    id: ClassVar[str] = "microsoft"
 
     # Use shared constants
     _authorization_endpoint: ClassVar[str] = AUTHORIZATION_ENDPOINT

--- a/tracecat/integrations/providers/microsoft_teams.py
+++ b/tracecat/integrations/providers/microsoft_teams.py
@@ -41,7 +41,7 @@ AC_SCOPES = ProviderScopes(
 
 # Microsoft Teams specific metadata for authorization code flow
 AC_METADATA = ProviderMetadata(
-    id="microsoft_teams_ac",
+    id="microsoft_teams",
     name="Microsoft Teams",
     description="Microsoft Teams OAuth provider (Delegated user)",
     categories=[ProviderCategory.COMMUNICATION],
@@ -63,7 +63,7 @@ AC_METADATA = ProviderMetadata(
 class MicrosoftTeamsACProvider(MicrosoftACProvider):
     """Microsoft Teams OAuth provider for collaboration and communication."""
 
-    id: ClassVar[str] = "microsoft_teams_ac"
+    id: ClassVar[str] = "microsoft_teams"
 
     # Use Teams-specific constants
     scopes: ClassVar[ProviderScopes] = AC_SCOPES
@@ -80,7 +80,7 @@ CC_SCOPES = ProviderScopes(
 
 # Microsoft Teams specific metadata for client credentials flow
 CC_METADATA = ProviderMetadata(
-    id="microsoft_teams_cc",
+    id="microsoft_teams",
     name="Microsoft Teams",
     description="Microsoft Teams OAuth provider (Service account)",
     categories=[ProviderCategory.COMMUNICATION],
@@ -103,7 +103,7 @@ CC_METADATA = ProviderMetadata(
 class MicrosoftTeamsCCProvider(MicrosoftCCProvider):
     """Microsoft Teams OAuth provider using client credentials flow for server-to-server automation."""
 
-    id: ClassVar[str] = "microsoft_teams_cc"
+    id: ClassVar[str] = "microsoft_teams"
 
     # Use Teams-specific client credentials constants
     scopes: ClassVar[ProviderScopes] = CC_SCOPES

--- a/tracecat/registry/loaders.py
+++ b/tracecat/registry/loaders.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any, Literal, NoReturn
 
 from pydantic import BaseModel, TypeAdapter
-from tracecat_registry import RegistrySecret
+from tracecat_registry import RegistrySecretTypeValidator
 
 from tracecat import config
 from tracecat.db.schemas import RegistryAction
@@ -34,7 +34,10 @@ def get_bound_action_impl(
     action: RegistryAction, *, mode: LoaderMode = "validation"
 ) -> BoundRegistryAction:
     impl = RegistryActionImplValidator.validate_python(action.implementation)
-    secrets = [RegistrySecret(**secret) for secret in action.secrets or []]
+    secrets = [
+        RegistrySecretTypeValidator.validate_python(secret)
+        for secret in action.secrets or []
+    ]
     if impl.type == "udf":
         fn = load_udf_impl(impl)
         key = getattr(fn, "__tracecat_udf_key")

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -24,7 +24,7 @@ from pydantic import (
 )
 from pydantic_core import to_jsonable_python
 from sqlmodel.ext.asyncio.session import AsyncSession
-from tracecat_registry import RegistrySecret
+from tracecat_registry import RegistrySecretType
 from typing_extensions import Doc
 
 from tracecat import config
@@ -65,7 +65,7 @@ class RegisterKwargs(BaseModel):
     doc_url: str | None = None
     author: str | None = None
     deprecated: str | None = None
-    secrets: list[RegistrySecret] | None = None
+    secrets: list[RegistrySecretType] | None = None
     include_in_schema: bool = True
 
 
@@ -146,7 +146,7 @@ class Repository:
         type: Literal["udf", "template"],
         namespace: str,
         description: str,
-        secrets: list[RegistrySecret] | None,
+        secrets: list[RegistrySecretType] | None,
         args_cls: ArgsClsT,
         args_docs: dict[str, str],
         rtype: type,


### PR DESCRIPTION
## Summary

Refactored OAuth secret handling to use discriminated unions and provider keys for better type safety and unique identification.

### Key Changes

- **RegistryOAuthSecret**: New discriminated union model for OAuth secrets, dropped RegistrySecret.oauth
- **ProviderKey**: Composite key (provider ID + grant type) for unique OAuth provider identification  
- **Secret Handling**: Extracted `get_action_secrets` function from executor service
- **Migration**: Added static mapping migration to remove `_ac`/`_cc` suffixes from provider IDs
- **Frontend**: Updated API client and UI components for new OAuth secret types
- **Tests**: Updated all tests for refactored secret handling

### Breaking Changes

- `IntegrationUpdate` requires `grant_type` field
- OAuth providers now use `ProviderKey` instead of string IDs
- Registry secrets require explicit `type` field

Legacy OAuth secrets are automatically migrated with backward compatibility validators.

🤖 Generated with [Claude Code](https://claude.ai/code)
    

## Summary by cubic
Improved OAuth secret handling by introducing discriminated unions for registry secrets and a ProviderKey system for unique provider identification. Updated backend, frontend, and tests to use these new models, and made grant_type required for integrations.

- **Migration**
  - IntegrationUpdate now requires grant_type.
  - OAuth provider identification uses ProviderKey instead of string IDs.
  - Registry secret types are now discriminated unions with an explicit type field.
  - Legacy secrets are migrated automatically with compatibility validators.
