### PR TITLE
fix: await action updates before committing workflow

### DIFF
--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -76,9 +76,16 @@ export function BuilderNav() {
 
   const { workspaceId, workspace, workspaceLoading } = useWorkspace()
 
+  const { actionPanelRef } = useWorkflowBuilder()
+
   const handleCommit = async () => {
     console.log("Saving changes...")
     try {
+      // Flush any unsaved action-panel edits first
+      if (actionPanelRef?.current?.saveChanges) {
+        await actionPanelRef.current.saveChanges()
+      }
+
       const response = await commitWorkflow()
       const { status, errors } = response
       if (status === "failure") {


### PR DESCRIPTION
## Summary
Ensure that clicking the green "Save" button in the Builder navbar always persists any in-flight edits made in the Action panel before the workflow is committed.

## Changes
- **Extend ActionPanelRef interface** with `saveChanges: () => Promise<void>` method
- **Implement saveChanges method** in action panel to flush editors and submit form
- **Update builder navbar** to await action panel saves before workflow commit
- **Maintain backward compatibility** with existing keyboard shortcuts (Cmd+S)

## Technical Details
- Uses existing `commitAllEditors()` and `handleSave()` functions
- Wraps form submission in Promise for async coordination
- Graceful fallback when no action panel is open
- Proper error handling prevents workflow commit on action save failure

## Test Plan
- [x] Edit action field without saving manually
- [x] Click navbar "Save" button  
- [x] Verify action save completes before workflow commit
- [x] Test with no open action panels
- [x] Confirm existing Cmd+S shortcuts still work

## Before/After
**Before:** Action edits could be lost if user clicked navbar Save without manually saving action first

**After:** Navbar Save automatically persists any pending action edits before committing workflow

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clicking the "Save" button in the Builder navbar now saves any unsaved edits in the Action panel before committing the workflow, preventing data loss.

- **Bug Fixes**
  - Ensures all in-progress action edits are saved when saving the workflow.
  - Keeps keyboard shortcuts like Cmd+S working as before.

<!-- End of auto-generated description by cubic. -->

