### PR TITLE
fix(ui): Prevent YAML line wrapping in CodeMirror editor

### DIFF
--- a/frontend/src/components/editor/codemirror/yaml-editor.tsx
+++ b/frontend/src/components/editor/codemirror/yaml-editor.tsx
@@ -85,7 +85,15 @@ export const YamlStyledEditor = React.forwardRef<
   const editorRef = useRef<EditorView | null>(null)
 
   const textValue = React.useMemo(
-    () => stripNewline(field.value ? YAML.stringify(field.value) : ""),
+    () =>
+      stripNewline(
+        field.value
+          ? YAML.stringify(field.value, {
+              lineWidth: 0, // Disable line wrapping
+              minContentWidth: 0, // Allow content to extend beyond default width
+            })
+          : ""
+      ),
     [field.value]
   )
   // Internal editor value - always a string representation of the YAML
@@ -785,7 +793,12 @@ export function YamlViewOnlyEditor({
   const textValue = React.useMemo(() => {
     if (!value) return ""
     return stripNewline(
-      typeof value === "string" ? value : YAML.stringify(value)
+      typeof value === "string"
+        ? value
+        : YAML.stringify(value, {
+            lineWidth: 0, // Disable line wrapping
+            minContentWidth: 0, // Allow content to extend beyond default width
+          })
     )
   }, [value])
 


### PR DESCRIPTION
## Summary
- Configure YAML.stringify with `lineWidth: 0` and `minContentWidth: 0` to prevent automatic line wrapping
- Fixes issue where long lines would be broken into multiple lines after save/reload cycle in the YAML editor

## Test plan
- [ ] Open a workflow with long YAML lines in the editor
- [ ] Save the workflow and refresh the page
- [ ] Verify that long lines remain intact without being broken up

## Screens
Saving the form and refreshing
### Before

https://github.com/user-attachments/assets/b28f3d53-16aa-4d5e-98fc-ebcddcf22861

### After

https://github.com/user-attachments/assets/d697fbfd-e5a5-4276-ae39-0abc7256c2f8



🤖 Generated with [Claude Code](https://claude.ai/code)