### PR TITLE
feat(integrations): Reply to message

### DIFF
--- a/registry/tracecat_registry/integrations/microsoft_teams.py
+++ b/registry/tracecat_registry/integrations/microsoft_teams.py
@@ -81,7 +81,7 @@ async def send_teams_message(
     default_title="Reply to a Teams message",
     description="Send a reply to a Microsoft Teams message.",
     display_group="Microsoft Teams",
-    doc_url="https://learn.microsoft.com/en-us/graph/api/channel-post-messages",
+    doc_url="https://learn.microsoft.com/en-us/graph/api/channel-post-replies",
     namespace="tools.microsoft_teams",
     secrets=[microsoft_teams_ac_oauth_secret],
 )

--- a/registry/tracecat_registry/integrations/microsoft_teams.py
+++ b/registry/tracecat_registry/integrations/microsoft_teams.py
@@ -90,7 +90,7 @@ async def reply_teams_message(
     channel_id: ChannelId,
     message_id: MessageId,
     message: Annotated[str, Doc("The message to send.")],
-) -> dict[str, str]:
+) -> dict[str, Any]:
     token = secrets.get(microsoft_teams_ac_oauth_secret.token_name)
 
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}


### PR DESCRIPTION
Added replies to existing Teams messages.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new function to send replies to existing Microsoft Teams messages using the Graph API.

- **New Features**
  - Added reply_teams_message to post replies in Teams channels.

<!-- End of auto-generated description by cubic. -->

