### PR TITLE
fix: Handle OAuth grant type properly in frontend integrations

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
@@ -16,7 +16,7 @@ import {
 import Link from "next/link"
 import { useParams, useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useState } from "react"
-import type { ProviderRead } from "@/client"
+import type { OAuthGrantType, ProviderRead } from "@/client"
 import { ProviderIcon } from "@/components/icons"
 import { SuccessIcon, statusStyles } from "@/components/integrations/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -59,14 +59,17 @@ import { cn } from "@/lib/utils"
 import { useWorkspace } from "@/providers/workspace"
 
 export default function ProviderDetailPage() {
+  const searchParams = useSearchParams()
   const params = useParams()
   const { workspaceId } = useWorkspace()
   const providerId = params.providerId as string
+  const grantType = searchParams.get("grant_type") as OAuthGrantType
 
   const { provider, providerIsLoading, providerError } = useIntegrationProvider(
     {
       providerId,
       workspaceId,
+      grantType,
     }
   )
 
@@ -137,7 +140,11 @@ function ProviderDetailContent({ provider }: { provider: ProviderRead }) {
     disconnectProviderIsPending,
     testConnection,
     testConnectionIsPending,
-  } = useIntegrationProvider({ providerId, workspaceId })
+  } = useIntegrationProvider({
+    providerId,
+    workspaceId,
+    grantType: provider.grant_type,
+  })
   const { metadata, integration_status: integrationStatus } = provider
 
   // Check if actually connected based on backend status

--- a/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
@@ -14,7 +14,12 @@ import {
   Zap,
 } from "lucide-react"
 import Link from "next/link"
-import { useParams, useRouter, useSearchParams } from "next/navigation"
+import {
+  notFound,
+  useParams,
+  useRouter,
+  useSearchParams,
+} from "next/navigation"
 import { useCallback, useState } from "react"
 import type { OAuthGrantType, ProviderRead } from "@/client"
 import { ProviderIcon } from "@/components/icons"
@@ -63,15 +68,19 @@ export default function ProviderDetailPage() {
   const params = useParams()
   const { workspaceId } = useWorkspace()
   const providerId = params.providerId as string
-  const grantType = searchParams.get("grant_type") as OAuthGrantType
+  const grantType = searchParams.get("grant_type") as OAuthGrantType | null
 
   const { provider, providerIsLoading, providerError } = useIntegrationProvider(
     {
       providerId,
       workspaceId,
-      grantType,
+      grantType: grantType || undefined,
     }
   )
+
+  if (!grantType) {
+    notFound()
+  }
 
   if (providerIsLoading) {
     return <CenteredSpinner />

--- a/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
@@ -120,10 +120,18 @@ export default function IntegrationsPage() {
     })
   }, [providers, searchQuery, selectedCategory, selectedStatus])
 
-  const handleProviderClick = (providerId: string, enabled: boolean) => {
+  const handleProviderClick = ({
+    id,
+    enabled,
+    grantType,
+  }: {
+    id: string
+    enabled: boolean
+    grantType: OAuthGrantType
+  }) => {
     if (enabled) {
       router.push(
-        `/workspaces/${workspaceId}/integrations/${providerId}?tab=overview`
+        `/workspaces/${workspaceId}/integrations/${id}?tab=overview&grant_type=${grantType}`
       )
     }
   }
@@ -243,19 +251,26 @@ export default function IntegrationsPage() {
                 name,
                 description,
                 categories: providerCategories,
+                grant_type: grantType,
               } = provider
               const statusInfo = getStatusInfo(provider.integration_status)
 
-              const { icon: Icon, label } = grantTypeStyles[provider.grant_type]
+              const { icon: Icon, label } = grantTypeStyles[grantType]
               return (
                 <Card
-                  key={id}
+                  key={`${id}-${grantType}`}
                   className={cn(
                     !!enabled
                       ? "cursor-pointer transition-colors duration-200 hover:bg-accent/50"
                       : "cursor-not-allowed opacity-50"
                   )}
-                  onClick={() => handleProviderClick(id, enabled)}
+                  onClick={() =>
+                    handleProviderClick({
+                      id,
+                      enabled,
+                      grantType,
+                    })
+                  }
                 >
                   <CardHeader className="flex flex-col gap-1">
                     <div className="flex items-start justify-between">

--- a/frontend/src/components/provider-config-form.tsx
+++ b/frontend/src/components/provider-config-form.tsx
@@ -87,6 +87,7 @@ export function ProviderConfigForm({
   const {
     metadata: { id },
     scopes: { default: defaultScopes, allowed_patterns: allowedPatterns },
+    grant_type: grantType,
   } = provider
   const { workspaceId } = useWorkspace()
   const {
@@ -97,6 +98,7 @@ export function ProviderConfigForm({
   } = useIntegrationProvider({
     providerId: id,
     workspaceId,
+    grantType,
   })
   const properties = Object.entries(schema.properties || {})
   const zodSchema = useMemo(() => jsonSchemaToZod(schema), [schema])
@@ -182,7 +184,7 @@ export function ProviderConfigForm({
           provider_config: config || undefined,
           // All scopes
           scopes: scopes || undefined,
-          grant_type: provider.grant_type,
+          grant_type: grantType,
         }
         await updateIntegration(params)
         onSuccess?.()
@@ -190,7 +192,7 @@ export function ProviderConfigForm({
         console.error(error)
       }
     },
-    [updateIntegration, onSuccess, defaultScopes]
+    [updateIntegration, onSuccess, defaultScopes, grantType]
   )
 
   if (integrationIsLoading) {

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3149,7 +3149,7 @@ export function useIntegrationProvider({
 }: {
   providerId: string
   workspaceId: string
-  grantType: OAuthGrantType
+  grantType?: OAuthGrantType
 }) {
   const queryClient = useQueryClient()
 

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -53,6 +53,7 @@ import {
   integrationsListIntegrations,
   integrationsTestConnection,
   integrationsUpdateIntegration,
+  type OAuthGrantType,
   type OAuthSettingsRead,
   type OrganizationDeleteOrgMemberData,
   type OrganizationDeleteSessionData,
@@ -3144,9 +3145,11 @@ export function useIntegrations(workspaceId: string) {
 export function useIntegrationProvider({
   providerId,
   workspaceId,
+  grantType,
 }: {
   providerId: string
   workspaceId: string
+  grantType: OAuthGrantType
 }) {
   const queryClient = useQueryClient()
 
@@ -3156,9 +3159,13 @@ export function useIntegrationProvider({
     isLoading: integrationIsLoading,
     error: integrationError,
   } = useQuery<IntegrationRead, TracecatApiError>({
-    queryKey: ["integration", providerId, workspaceId],
+    queryKey: ["integration", providerId, workspaceId, grantType],
     queryFn: async () =>
-      await integrationsGetIntegration({ providerId, workspaceId }),
+      await integrationsGetIntegration({
+        providerId,
+        workspaceId,
+        grantType,
+      }),
     retry: retryHandler,
   })
 
@@ -3168,9 +3175,9 @@ export function useIntegrationProvider({
     isLoading: providerIsLoading,
     error: providerError,
   } = useQuery<ProviderRead, TracecatApiError>({
-    queryKey: ["provider-schema", providerId, workspaceId],
+    queryKey: ["provider-schema", providerId, workspaceId, grantType],
     queryFn: async () =>
-      await providersGetProvider({ providerId, workspaceId }),
+      await providersGetProvider({ providerId, workspaceId, grantType }),
   })
 
   // Update
@@ -3187,13 +3194,13 @@ export function useIntegrationProvider({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["integration", providerId, workspaceId],
+        queryKey: ["integration", providerId, workspaceId, grantType],
       })
       queryClient.invalidateQueries({
         queryKey: ["providers", workspaceId],
       })
       queryClient.invalidateQueries({
-        queryKey: ["provider-schema", providerId, workspaceId],
+        queryKey: ["provider-schema", providerId, workspaceId, grantType],
       })
     },
     onError: (error: TracecatApiError) => {
@@ -3236,13 +3243,13 @@ export function useIntegrationProvider({
       await integrationsDisconnectIntegration({ providerId, workspaceId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["integration", providerId, workspaceId],
+        queryKey: ["integration", providerId, workspaceId, grantType],
       })
       queryClient.invalidateQueries({
         queryKey: ["providers", workspaceId],
       })
       queryClient.invalidateQueries({
-        queryKey: ["provider-schema", providerId, workspaceId],
+        queryKey: ["provider-schema", providerId, workspaceId, grantType],
       })
       toast({
         title: "Disconnected",
@@ -3270,13 +3277,13 @@ export function useIntegrationProvider({
     onSuccess: (result) => {
       if (result.success) {
         queryClient.invalidateQueries({
-          queryKey: ["integration", providerId, workspaceId],
+          queryKey: ["integration", providerId, workspaceId, grantType],
         })
         queryClient.invalidateQueries({
           queryKey: ["providers", workspaceId],
         })
         queryClient.invalidateQueries({
-          queryKey: ["provider-schema", providerId, workspaceId],
+          queryKey: ["provider-schema", providerId, workspaceId, grantType],
         })
         toast({
           title: "Connection successful",


### PR DESCRIPTION
## Summary
- Fixed OAuth grant type handling in frontend integrations to properly pass grant type parameters through the UI flow
- Added grant type to URL query parameters when navigating to integration detail pages
- Updated hooks and components to include grant type in API calls for proper OAuth flow handling

## Changes
- Modified integrations list page to include `grant_type` in provider click handler and URL navigation
- Updated provider detail page to extract grant type from search params and pass it to API calls
- Enhanced `useIntegrationProvider` hook to accept and use grant type parameter in all queries
- Updated provider config form to use the grant type from provider object

## Test plan
- [x] Navigate to integrations page and click on an OAuth integration
- [x] Verify grant type is included in URL parameters
- [x] Test connecting/disconnecting OAuth integrations with different grant types
- [x] Verify provider configuration form works correctly with grant type parameter
- [x] Test that existing integrations continue to work without regression

🤖 Generated with [Claude Code](https://claude.ai/code)

## Screens

https://github.com/user-attachments/assets/26a6238d-38a3-4c4b-a0d7-264a25bfd439



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed OAuth grant type handling in frontend integrations so the correct grant type is passed through the UI and API calls.

- **Bug Fixes**
  - Added grant type to integration URLs and API requests.
  - Updated hooks and components to support grant type in all relevant flows.

<!-- End of auto-generated description by cubic. -->

