### PR TITLE
feat: Add upload attachment to Jira Integration

### DIFF
--- a/registry/tracecat_registry/templates/tools/jira/upload_attachment.yml
+++ b/registry/tracecat_registry/templates/tools/jira/upload_attachment.yml
@@ -1,0 +1,44 @@
+type: action
+definition:
+  title: Upload attachment
+  description: Upload an attachment to a Jira issue.
+  display_group: Jira
+  doc_url: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post
+  namespace: tools.jira
+  name: upload_attachment
+  secrets:
+    - name: jira
+      keys: ["JIRA_USEREMAIL", "JIRA_API_TOKEN"]
+  expects:
+    base64_content:
+      type: str
+      description: Base64 encoded content of the file to upload.
+    filename:
+      type: str
+      description: Name of the file to upload.
+    content_type:
+      type: str
+      description: MIME type of the file (e.g., "application/pdf", "image/png", "text/plain").
+    ticket:
+      type: str
+      description: Jira issue key or ID to upload the attachment to (e.g., "PROJ-123").
+    base_url:
+      type: str
+      description: Jira tenant URL (e.g. https://tracecat.atlassian.net).
+  steps:
+    - ref: upload_attachment
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/rest/api/3/issue/${{ inputs.ticket }}/attachments
+        method: POST
+        auth:
+          username: ${{ SECRETS.jira.JIRA_USEREMAIL }}
+          password: ${{ SECRETS.jira.JIRA_API_TOKEN }}
+        headers:
+          X-Atlassian-Token: nocheck
+        files:
+          file:
+            filename: ${{ inputs.filename }}
+            content_base64: ${{ inputs.base64_content }}
+            content_type: ${{ inputs.content_type }}
+  returns: ${{ steps.upload_attachment.result }}


### PR DESCRIPTION


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Simple integration template to upload files to Jira

## Related Issues

https://github.com/TracecatHQ/tracecat/issues/1220

## Screenshots / Recordings
<img width="1426" height="597" alt="image" src="https://github.com/user-attachments/assets/7090e55b-b1c1-49ab-8873-8bd32619520f" />



## Steps to QA

- Set up creds
- Create a upload command action 
- Run Upload 🎉 

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new Jira command to upload file attachments to issues using base64-encoded content.

- **New Features**
  - Supports uploading files to a specified Jira issue by providing the file name, content type, and Jira credentials.

<!-- End of auto-generated description by cubic. -->

