### PR TITLE
Rocket.Chat action node to send message

### DIFF
--- a/registry/tracecat_registry/templates/tools/rocketchat/send_message.yaml
+++ b/registry/tracecat_registry/templates/tools/rocketchat/send_message.yaml
@@ -1,0 +1,28 @@
+type: action
+definition:
+  title: Send Message to Rocket.Chat
+  description: send a message to a Rocket.Chat channel
+  display_group: RocketChat
+  doc_url: https://docs.rocket.chat/docs/integrations
+  namespace: tools.rocketchat
+  author: EfusRyuga
+  name: send_message
+  expects:
+    webhook_url:
+      type: str
+      description: url of the Rocket.Chat webhook
+    message:
+      type: str
+      description: message to send to the Rocket.Chat channel
+      default: 'Hello from Tracecat!'
+  steps:
+    - ref: send_message
+      action: core.http_request
+      args:
+        method: POST
+        url: ${{ inputs.webhook_url }}
+        headers:
+          Content-Type: application/json
+        payload:
+          text: ${{ inputs.message }}
+  returns: ${{ steps.send_message.result }}


### PR DESCRIPTION
## Checklist

- [x ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

add an action node to send messages on Rocket.Chat via the webhook feature of Rocket.Chat.


## Screenshots / Recordings

add your webhook and text in the action node:
<img width="965" height="676" alt="example" src="https://github.com/user-attachments/assets/268561c7-633f-400d-b204-ecc03a9c93a2" />
run the workflow
<img width="1535" height="77" alt="result" src="https://github.com/user-attachments/assets/fd308d66-8958-45e9-ace2-613c963f6210" />


## Steps to QA

Prerequisite : 
having a running rocket.chat with admin rights

optional : create a dedicated channel
create a user
create an incoming webhook that specifies using the user and the channel, click save.
copy the webhook to the action node field
optional : specify the text you want to send

click run -> the specified user should have sent a message to the specified channel

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new action node to send messages to Rocket.Chat channels using incoming webhooks.

- **New Features**
  - Allows users to specify a webhook URL and message text to send messages from workflows to Rocket.Chat.

<!-- End of auto-generated description by cubic. -->

