### PR TITLE
feat(engine): Given schedules admin role

### DIFF
--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -4,10 +4,10 @@ import temporalio.client
 from temporalio.common import TypedSearchAttributes
 
 from tracecat import config
-from tracecat.contexts import ctx_role
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import DSLRunArgs
 from tracecat.identifiers import ScheduleID, WorkflowID
+from tracecat.types.auth import Role
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.schedules.models import ScheduleUpdate
 
@@ -24,6 +24,7 @@ async def _get_handle(schedule_id: ScheduleID) -> temporalio.client.ScheduleHand
 async def create_schedule(
     workflow_id: WorkflowID,
     schedule_id: ScheduleID,
+    role: Role,
     *,
     every: timedelta,
     offset: timedelta | None = None,
@@ -52,9 +53,7 @@ async def create_schedule(
                 # Scheduled workflow only needs to know the workflow ID
                 # and the role of the user who scheduled it. Everything else
                 # is pulled inside the workflow itself.
-                DSLRunArgs(
-                    role=ctx_role.get(), wf_id=workflow_id, schedule_id=schedule_id
-                ),
+                DSLRunArgs(role=role, wf_id=workflow_id, schedule_id=schedule_id),
                 id=workflow_schedule_id,
                 task_queue=config.TEMPORAL__CLUSTER_QUEUE,
                 typed_search_attributes=SEARCH_ATTRS,


### PR DESCRIPTION
# Motivation
Scheduled workflows run with `AccessLevel.BASIC`:

<img width="552" height="93" alt="image" src="https://github.com/user-attachments/assets/6b76121f-7892-47ae-bd96-c5104286f0bc" />

# Solution
Use `AccessLevel.ADMIN` role for schedules

# Screens
## Before
Currently, creating and deleting the row fails with the error shown in the screenshot

https://github.com/user-attachments/assets/55a9e6dd-96b9-4b8b-b13c-18fac09f5e1f

## After
After adding these changes, recreating the schedule (important, as the role isn't dynamic) for the same workflow runs successfully.

https://github.com/user-attachments/assets/72745211-646e-4b3f-ac16-82a39e705c44

