### PR TITLE
feat(ui): Yaml input only for reshape action

### DIFF
--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -271,6 +271,9 @@ function ActionPanelContent({
     useGetRegistryAction(action?.type)
   const actionControlFlow = action?.control_flow ?? {}
 
+  // Special-case: disable form mode for reshape actions
+  const isReshapeAction = action?.type === "core.transform.reshape"
+
   const actionInputsObj = useMemo(
     () => parseYaml(action?.inputs) ?? {},
     [action?.inputs]
@@ -303,7 +306,9 @@ function ActionPanelContent({
   const [activeTab, setActiveTab] = useState<ActionPanelTabs>("inputs")
   const [open, setOpen] = useState(false)
   // Check if form mode is enabled via organization settings
-  const formModeEnabled = appSettings?.app_action_form_mode_enabled ?? true
+  // Keep org-wide toggle AND force YAML mode for reshape
+  const formModeEnabled =
+    !isReshapeAction && (appSettings?.app_action_form_mode_enabled ?? true)
   const [inputMode, setInputMode] = useState<InputMode>(
     formModeEnabled ? "form" : "yaml"
   )


### PR DESCRIPTION
# Motivation
Multi-line strings get their formatting stripped due to serialization between form/yaml view. This is poor UX. This PR implements a band-aid solution to prevent serialization from interfering with UX.

# Solution
Always render yaml input view for `core.reshape.transform` actions, as this is the most frequently used data transformation action in the platform.

# Screens
Reshape only has yaml mode, and yaml formatting remains intact between saves.

https://github.com/user-attachments/assets/9711aaa6-a1bb-4e85-b299-6627f8391e01




## Summary by cubic
The reshape action now only allows YAML input, disabling the form input mode for this action type. This ensures users always edit reshape actions in YAML mode.

