### PR TITLE
fix(ui): Add core keymap back to ExpressionInput

### DIFF
--- a/frontend/src/components/editor/expression-input.tsx
+++ b/frontend/src/components/editor/expression-input.tsx
@@ -230,6 +230,7 @@ function ExpressionInputCore({
     }
 
     return baseExtensions.concat([
+      createCoreKeymap(),
       // Input-specific styling to match shadcn Input
       EditorView.theme({
         "&": {


### PR DESCRIPTION
# Motivation
Previously unable to add newlines. Add core keymap back to the expression input component.

# Screens

https://github.com/user-attachments/assets/9782cb07-2086-4ad3-a6d7-50da6125cf76



    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restored the core keymap to the ExpressionInput component so standard keyboard shortcuts work as expected.

<!-- End of auto-generated description by cubic. -->

