### PR TITLE
fix(engine): Check empty before decrypt and improve access token handling

### DIFF
--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -657,6 +657,7 @@ class TestIntegrationService:
 
         # Get access token only
         access_token_only = await integration_service.get_access_token(integration)
+        assert access_token_only is not None
         assert (
             access_token_only.get_secret_value()
             == mock_token_response.access_token.get_secret_value()

--- a/tracecat/secrets/encryption.py
+++ b/tracecat/secrets/encryption.py
@@ -71,3 +71,8 @@ def decrypt_value(encrypted_value: bytes, *, key: str) -> bytes:
         raise InvalidToken("Decryption failed: corrupted or invalid token") from e
     except Exception as e:
         raise ValueError(f"Decryption failed: {str(e)}") from e
+
+
+def is_set(value: bytes) -> bool:
+    """True when ciphertext is not empty."""
+    return value != b""

--- a/tracecat/secrets/encryption.py
+++ b/tracecat/secrets/encryption.py
@@ -75,4 +75,4 @@ def decrypt_value(encrypted_value: bytes, *, key: str) -> bytes:
 
 def is_set(value: bytes) -> bool:
     """True when ciphertext is not empty."""
-    return value != b""
+    return bool(value)


### PR DESCRIPTION
## Summary
- Add null checks for encrypted access tokens before decryption
- Add proper error handling in OAuth secret retrieval
- Update return types to handle None values appropriately
- Add test assertions for access token validation

## Changes
- **IntegrationService**: Modified `get_access_token()` and `_decrypt_token()` to return None for empty tokens
- **ExecutorService**: Added try-catch block around OAuth access token retrieval with proper logging
- **Encryption**: Added `is_set()` helper function to check if ciphertext is not empty
- **Tests**: Added assertion to ensure access token is not None

## Test plan
- [x] Unit tests pass for integration service
- [x] OAuth token handling works correctly with empty/invalid tokens
- [x] Error logging captures failed OAuth secret retrieval without crashing

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved access token handling by adding checks for empty tokens before decryption and better error logging during OAuth secret retrieval.

- **Bug Fixes**
  - Added null checks to prevent decrypting empty tokens.
  - Updated error handling to log and skip failed OAuth secret retrievals.
  - Adjusted return types to handle None values for missing tokens.
  - Added tests to ensure access tokens are validated correctly.

<!-- End of auto-generated description by cubic. -->

