### PR TITLE
feat(engine): Improve chat streaming with Redis TTL and enhanced agent execution

### DIFF
--- a/registry/tracecat_registry/integrations/agents/builder.py
+++ b/registry/tracecat_registry/integrations/agents/builder.py
@@ -835,7 +835,7 @@ async def run_agent(
             stream_key = f"agent-stream:{stream_id}"
             try:
                 redis_client = await get_redis_client()
-                logger.info("Redis streaming enabled", stream_key=stream_key)
+                logger.debug("Redis streaming enabled", stream_key=stream_key)
 
                 messages = await redis_client.xrange(stream_key, min_id="-", max_id="+")
 
@@ -960,7 +960,7 @@ async def run_agent(
                         maxlen=10000,
                         approximate=True,
                     )
-                    logger.info("Added end-of-stream marker", stream_key=stream_key)
+                    logger.debug("Added end-of-stream marker", stream_key=stream_key)
                 except Exception as e:
                     logger.warning("Failed to add end-of-stream marker", error=str(e))
 

--- a/tracecat/chat/router.py
+++ b/tracecat/chat/router.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import orjson
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
-from tracecat_registry.integrations.agents.builder import ModelMessageTA, agent
+from tracecat_registry.integrations.agents.builder import ModelMessageTA, run_agent
 
 from tracecat.agent.service import AgentManagementService
 from tracecat.auth.credentials import RoleACL
@@ -161,14 +161,14 @@ async def start_chat_turn(
         # Fire-and-forget execution using the agent function directly
         agent_svc = AgentManagementService(session, role)
         async with agent_svc.with_model_config() as model_config:
-            coro = agent(
+            coro = run_agent(
                 instructions=request.instructions,
                 user_prompt=request.message,
                 fixed_arguments=request.context,
                 model_name=model_config.name,
                 model_provider=model_config.provider,
                 actions=chat.tools,
-                workflow_run_id=str(chat_id),
+                stream_id=str(chat_id),
             )
             _ = asyncio.create_task(coro)
 

--- a/tracecat/chat/service.py
+++ b/tracecat/chat/service.py
@@ -119,7 +119,7 @@ class ChatService(BaseWorkspaceService):
 
             # Handle case where stream doesn't exist or has expired
             if not messages:
-                logger.info(
+                logger.debug(
                     "No messages found in Redis stream (may have expired)",
                     stream_key=stream_key,
                     chat_id=chat.id,

--- a/tracecat/chat/service.py
+++ b/tracecat/chat/service.py
@@ -119,7 +119,7 @@ class ChatService(BaseWorkspaceService):
 
             # Handle case where stream doesn't exist or has expired
             if not messages:
-                logger.debug(
+                logger.info(
                     "No messages found in Redis stream (may have expired)",
                     stream_key=stream_key,
                     chat_id=chat.id,

--- a/tracecat/chat/service.py
+++ b/tracecat/chat/service.py
@@ -117,6 +117,15 @@ class ChatService(BaseWorkspaceService):
             # Read all messages from the Redis stream
             messages = await redis_client.xrange(stream_key, min_id="-", max_id="+")
 
+            # Handle case where stream doesn't exist or has expired
+            if not messages:
+                logger.info(
+                    "No messages found in Redis stream (may have expired)",
+                    stream_key=stream_key,
+                    chat_id=chat.id,
+                )
+                return []
+
             parsed_messages: list[ChatMessage] = []
             for id, fields in messages:
                 try:

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -349,6 +349,12 @@ TRACECAT__WORKFLOW_RETURN_STRATEGY = os.environ.get(
 ).lower()
 """Strategy to use when returning a value from a workflow. Supported: context, minimal. Defaults to minimal."""
 
+# === Redis config === #
+REDIS_CHAT_TTL_SECONDS = int(
+    os.environ.get("REDIS_CHAT_TTL_SECONDS", 30 * 24 * 60 * 60)  # 30 days
+)
+"""TTL for Redis chat history streams in seconds. Defaults to 30 days."""
+
 # === File limits === #
 TRACECAT__MAX_ATTACHMENT_SIZE_BYTES = int(
     os.environ.get("TRACECAT__MAX_ATTACHMENT_SIZE_BYTES", 20 * 1024 * 1024)

--- a/tracecat/prompt/flows.py
+++ b/tracecat/prompt/flows.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime
 
 from sqlmodel.ext.asyncio.session import AsyncSession
-from tracecat_registry.integrations.agents.builder import agent
+from tracecat_registry.integrations.agents.builder import run_agent
 
 from tracecat.agent.service import AgentManagementService
 from tracecat.cases.service import CasesService
@@ -44,12 +44,12 @@ async def execute_runbook_for_case(
     # NOTE: In production, this should use workspace-specific credentials
     agent_svc = AgentManagementService(session, role)
     async with agent_svc.with_model_config() as model_config:
-        coro = agent(
+        coro = run_agent(
             instructions=prompt.content,
             model_name=model_config.name,
             model_provider=model_config.provider,
             actions=prompt.tools,
-            workflow_run_id=str(chat.id),
+            stream_id=str(chat.id),
             user_prompt=textwrap.dedent(f"""
             You are working with the following case:
             <CaseId>


### PR DESCRIPTION
## Summary
- Refactored agent execution into `run_agent` function with improved stream handling. The `ai_agent` udf doesn't need to expose `stream_id` in its interface so we refactored this to call `run_agent`
- Added Redis chat TTL configuration (30 days default) with automatic stream expiration
- Enhanced error handling for Redis stream operations and connection failures
- Changed Redis streaming logs from info to debug level to reduce noise
- Fixed unused variable warning in Redis message processing

## Key Changes
- **Agent Refactoring**: Split `agent` function into public API wrapper and `run_agent` implementation
- **Redis TTL**: Added `REDIS_CHAT_TTL_SECONDS` config with automatic stream expiration
- **Error Handling**: Better handling of expired/missing Redis streams
- **Logging**: Reduced Redis streaming verbosity by changing info → debug logs
- **Code Quality**: Fixed unused `message_id` variable in stream processing

## Test plan
- [x] Agent execution works with and without stream_id
- [x] Redis streams automatically expire after configured TTL
- [x] Chat service handles missing/expired streams gracefully
- [x] All existing streaming functionality preserved
- [x] No regression in agent response quality

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved chat streaming by adding Redis TTL for automatic stream expiration, refactored agent execution for better stream handling, and reduced Redis log noise.

- **Enhancements**
  - Added configurable Redis chat TTL (default 30 days) for stream auto-expiry.
  - Refactored agent logic into a new `run_agent` function with improved error handling.
  - Changed Redis streaming logs from info to debug level.
  - Fixed unused variable warning in Redis message processing.

<!-- End of auto-generated description by cubic. -->

