### PR TITLE
fix(app): Delete Temporal schedules when deleting workflow

### DIFF
--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -53,6 +53,7 @@ from tracecat.workflow.management.models import (
     WorkflowDSLCreateResponse,
     WorkflowUpdate,
 )
+from tracecat.workflow.schedules import bridge
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
 
 
@@ -320,7 +321,7 @@ class WorkflowsManagementService(BaseService):
 
     async def delete_workflow(self, workflow_id: WorkflowID) -> None:
         """Delete a workflow and clean up associated resources.
-        
+
         This method ensures that Temporal schedules are properly deleted
         before the database cascade deletion occurs.
         """
@@ -330,16 +331,14 @@ class WorkflowsManagementService(BaseService):
         )
         result = await self.session.exec(statement)
         workflow = result.one()
-        
+
         # Clean up Temporal schedules before cascade deletion
         # This prevents orphaned schedules in Temporal
         schedule_service = WorkflowSchedulesService(self.session, role=self.role)
-        schedules = await schedule_service.list_schedules(workflow_id=workflow_id)
-        
+        schedules = await schedule_service.list_schedules(workflow_id)
+
         for schedule in schedules:
             try:
-                # Delete from Temporal first, then let cascade deletion handle DB cleanup
-                from tracecat.workflow.schedules import bridge
                 await bridge.delete_schedule(schedule.id)
                 self.logger.info(
                     "Deleted Temporal schedule during workflow cleanup",
@@ -354,7 +353,7 @@ class WorkflowsManagementService(BaseService):
                     workflow_id=workflow_id,
                     error=str(e),
                 )
-        
+
         # Now delete the workflow (cascade will handle database schedule cleanup)
         await self.session.delete(workflow)
         await self.session.commit()


### PR DESCRIPTION
- **Refactor: Clean up Temporal schedules on workflow deletion**
- **cleanup**

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Workflows now delete their associated Temporal schedules when removed, preventing orphaned schedules and keeping data in sync.

<!-- End of auto-generated description by cubic. -->

