### PR TITLE
fix(app): Add ordering for workflow items in folders view

### DIFF
--- a/tracecat/workflow/management/folders/router.py
+++ b/tracecat/workflow/management/folders/router.py
@@ -28,7 +28,7 @@ async def get_directory(
     """Get directory items (workflows and folders) in the given path."""
     service = WorkflowFolderService(session, role=role)
     try:
-        result = await service.get_directory_items(path)
+        result = await service.get_directory_items(path, order_by="desc")
     except TracecatNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     return list(result)

--- a/tracecat/workflow/management/folders/service.py
+++ b/tracecat/workflow/management/folders/service.py
@@ -452,7 +452,7 @@ class WorkflowFolderService(BaseService):
         return result.all()
 
     async def get_directory_items(
-        self, path: str = "/", *, order_by: Literal["asc", "desc"]
+        self, path: str = "/", *, order_by: Literal["asc", "desc"] = "desc"
     ) -> Sequence[DirectoryItem]:
         """Get all directory items (workflows and folders) in the given path.
 

--- a/tracecat/workflow/management/folders/service.py
+++ b/tracecat/workflow/management/folders/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
+from typing import Literal
 
 import sqlalchemy as sa
 from sqlmodel import and_, cast, col, func, or_, select
@@ -450,7 +451,9 @@ class WorkflowFolderService(BaseService):
         result = await self.session.exec(statement)
         return result.all()
 
-    async def get_directory_items(self, path: str = "/") -> Sequence[DirectoryItem]:
+    async def get_directory_items(
+        self, path: str = "/", *, order_by: Literal["asc", "desc"]
+    ) -> Sequence[DirectoryItem]:
         """Get all directory items (workflows and folders) in the given path.
 
         Args:
@@ -501,6 +504,11 @@ class WorkflowFolderService(BaseService):
                     WorkflowDefinition.workflow_id == Workflow.id,
                     WorkflowDefinition.version == latest_defn_subq.c.latest_version,
                 ),
+            )
+            .order_by(
+                col(Workflow.created_at).desc()
+                if order_by == "desc"
+                else col(Workflow.created_at).asc()
             )
         )
 


### PR DESCRIPTION
Table in folder view was receiving workflows out of order.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings
### Before
<img width="1280" height="964" alt="image" src="https://github.com/user-attachments/assets/d083df54-a882-4692-9bd5-aff5e23fd515" />


### After
<img width="1433" height="589" alt="image" src="https://github.com/user-attachments/assets/910e5ec0-fe63-4411-b133-1d9914974726" />

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added ordering to workflow items in the folders view so items are now sorted by creation date, newest first.

<!-- End of auto-generated description by cubic. -->

