### PR TITLE
fix(app): List all workflows when limit=0

### DIFF
--- a/frontend/src/components/builder/canvas/action-node.tsx
+++ b/frontend/src/components/builder/canvas/action-node.tsx
@@ -702,13 +702,11 @@ function ActionNodeToolbar({
               <CommandSeparator />
               {(childWorkflowAlias || childWorkflowId) && (
                 <CommandGroup heading="Subflow">
-                  <CommandItem
-                    disabled={!childWorkflowAlias && !childWorkflowId}
-                  >
+                  <CommandItem disabled={!childIdFromAlias && !childWorkflowId}>
                     <Link
                       href={`/workspaces/${workspaceId}/workflows/${childIdFromAlias ?? childWorkflowId}`}
                       className={
-                        !childWorkflowAlias && !childWorkflowId
+                        !childIdFromAlias && !childWorkflowId
                           ? "pointer-events-none"
                           : ""
                       }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -417,7 +417,7 @@ export function useWorkflowManager(filter?: WorkflowFilter) {
   const queryClient = useQueryClient()
   const { workspaceId } = useWorkspace()
 
-  // List workflows
+  // List all workflows
   const {
     data: workflows,
     isLoading: workflowsLoading,
@@ -428,6 +428,7 @@ export function useWorkflowManager(filter?: WorkflowFilter) {
       const response = await workflowsListWorkflows({
         workspaceId,
         tag: filter?.tag,
+        limit: 0,
       })
       return response.items
     },

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -45,6 +45,7 @@ from tracecat.workflow.management.models import (
     ExternalWorkflowDefinition,
     WorkflowCommitResponse,
     WorkflowCreate,
+    WorkflowDefinitionMinimal,
     WorkflowDefinitionReadMinimal,
     WorkflowMoveToFolder,
     WorkflowRead,
@@ -64,24 +65,49 @@ async def list_workflows(
         description="Filter workflows by tags",
         alias="tag",
     ),
-    limit: int = Query(default=20, ge=1, le=100),
+    # limit=0 returns all workflows
+    limit: int = Query(default=20, ge=0, le=100),
     cursor: str | None = Query(default=None),
     reverse: bool = Query(default=False),
 ) -> CursorPaginatedResponse[WorkflowReadMinimal]:
     """List workflows."""
     service = WorkflowsManagementService(session, role=role)
 
-    # Create cursor pagination parameters
-    params = CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
+    # Handle limit=0 to return all workflows
+    if limit == 0:
+        # Fetch all workflows without pagination
+        workflows_with_defns = await service.list_workflows(tags=filter_tags)
+
+        # Return unpaginated response
+        return CursorPaginatedResponse(
+            items=wfs_and_defns_to_response(workflows_with_defns),
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
 
     # Get paginated workflows
     paginated_response = await service.list_workflows_paginated(
-        params, tags=filter_tags
+        CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),
+        tags=filter_tags,
     )
 
-    # Transform workflows to WorkflowReadMinimal format
-    workflows_minimal = []
-    for workflow, defn in paginated_response.items:
+    # Return cursor paginated response with transformed items
+    return CursorPaginatedResponse(
+        items=wfs_and_defns_to_response(paginated_response.items),
+        next_cursor=paginated_response.next_cursor,
+        prev_cursor=paginated_response.prev_cursor,
+        has_more=paginated_response.has_more,
+        has_previous=paginated_response.has_previous,
+    )
+
+
+def wfs_and_defns_to_response(
+    wfs_and_defns: list[tuple[Workflow, WorkflowDefinitionMinimal | None]],
+) -> list[WorkflowReadMinimal]:
+    res = []
+    for workflow, defn in wfs_and_defns:
         tags = [
             TagRead.model_validate(tag, from_attributes=True) for tag in workflow.tags
         ]
@@ -90,7 +116,7 @@ async def list_workflows(
             if defn
             else None
         )
-        workflows_minimal.append(
+        res.append(
             WorkflowReadMinimal(
                 id=WorkflowUUID.new(workflow.id).short(),
                 title=workflow.title,
@@ -107,15 +133,7 @@ async def list_workflows(
                 folder_id=workflow.folder_id,
             )
         )
-
-    # Return cursor paginated response with transformed items
-    return CursorPaginatedResponse(
-        items=workflows_minimal,
-        next_cursor=paginated_response.next_cursor,
-        prev_cursor=paginated_response.prev_cursor,
-        has_more=paginated_response.has_more,
-        has_previous=paginated_response.has_previous,
-    )
+    return res
 
 
 @router.post("", status_code=status.HTTP_201_CREATED, tags=["workflows"])


### PR DESCRIPTION
# Summary
When we added pagination, the client-side useWorkflowManager hook started returning the first page of items. This resulted in the following:
- Tags view returning only 20 items max
- Workflow aliases not being found, because we were trying to look up aliases of workflows outside of the first page

The solution is to allow setting limit=0 to return all workflows, thus restoring the pre-pagination behavior and fixing the above issues.

# Changes
- **include asc/desc ordering for folder workflows**
- **correctly disable 'Open subflow' node menu item if unavailable**
- **refactor: Enhance workflow listing functionality**

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed workflow listing to return all workflows when limit=0, restoring pre-pagination behavior and resolving issues with missing tags and aliases.

- **Bug Fixes**
  - Tags view now shows all workflows.
  - Workflow aliases are correctly found outside the first page.
  - Folder workflows support asc/desc ordering.
  - "Open subflow" menu item is disabled if unavailable.

<!-- End of auto-generated description by cubic. -->

