### PR TITLE
fix(app): Sort workflows by `created_at` in regular list endpoint

### DIFF
--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -63,7 +63,7 @@ class WorkflowsManagementService(BaseService):
     service_name = "workflows"
 
     async def list_workflows(
-        self, *, tags: list[str] | None = None
+        self, *, tags: list[str] | None = None, reverse: bool = False
     ) -> list[tuple[Workflow, WorkflowDefinitionMinimal | None]]:
         """List workflows with their latest definitions.
 
@@ -105,6 +105,17 @@ class WorkflowsManagementService(BaseService):
                 ),
             )
         )
+
+        if reverse:
+            stmt = stmt.order_by(
+                col(Workflow.created_at).asc(),
+                col(Workflow.id).asc(),
+            )
+        else:
+            stmt = stmt.order_by(
+                col(Workflow.created_at).desc(),
+                col(Workflow.id).desc(),
+            )
 
         if tags:
             tag_set = set(tags)

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -76,7 +76,9 @@ async def list_workflows(
     # Handle limit=0 to return all workflows
     if limit == 0:
         # Fetch all workflows without pagination
-        workflows_with_defns = await service.list_workflows(tags=filter_tags)
+        workflows_with_defns = await service.list_workflows(
+            tags=filter_tags, reverse=reverse
+        )
 
         # Return unpaginated response
         return CursorPaginatedResponse(


### PR DESCRIPTION
When we added special handling for limit=0 we ended up not sorting the workflows returned

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Workflows are now sorted by their creation date in the list endpoint, showing the newest first by default. An option to reverse the order is also available.

<!-- End of auto-generated description by cubic. -->

