### PR TITLE
fix(ui): Show correct message for non-running workflows with no events

### DIFF
--- a/frontend/src/components/builder/events/events-sidebar.tsx
+++ b/frontend/src/components/builder/events/events-sidebar.tsx
@@ -191,7 +191,7 @@ function BuilderSidebarEventsList({
           {appSettings?.app_interactions_enabled && (
             <WorkflowInteractions execution={execution} />
           )}
-          <WorkflowEvents events={execution.events} />
+          <WorkflowEvents events={execution.events} status={execution.status} />
         </>
       ),
     },

--- a/frontend/src/components/builder/events/events-workflow.tsx
+++ b/frontend/src/components/builder/events/events-workflow.tsx
@@ -210,8 +210,10 @@ export function WorkflowEventsHeader({
 }
 export function WorkflowEvents({
   events,
+  status,
 }: {
   events: WorkflowExecutionEventCompact[]
+  status: WorkflowExecutionReadCompact["status"]
 }) {
   const {
     selectedActionEventRef,
@@ -435,8 +437,17 @@ export function WorkflowEvents({
             ) : (
               <div className="flex h-16 items-center justify-center bg-muted-foreground/5 p-3 text-center text-xs text-muted-foreground">
                 <div className="flex items-center justify-center gap-2">
-                  <LoaderIcon className="size-3 animate-spin text-muted-foreground" />
-                  <span>Waiting for events...</span>
+                  {status === "RUNNING" ? (
+                    <>
+                      <LoaderIcon className="size-3 animate-spin text-muted-foreground" />
+                      <span>Waiting for events...</span>
+                    </>
+                  ) : (
+                    <>
+                      <CircleDot className="size-3 text-muted-foreground" />
+                      <span>No events</span>
+                    </>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- Fixed the workflow events display to show appropriate messages based on workflow status
- When a workflow is not running and has no events, it now shows "No events" instead of "Waiting for events..."
- Added status prop to WorkflowEvents component to enable status-aware messaging

## Screens

<img width="584" height="322" alt="image" src="https://github.com/user-attachments/assets/9c220115-e6ec-4474-b02e-fa11e7f8cfdb" />


## Test plan
- [ ] View a workflow execution that has completed with no events - should show "No events"
- [ ] View a workflow execution that is currently running with no events - should show "Waiting for events..."
- [ ] Verify existing functionality remains intact for workflows with events

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the workflow events display to show "No events" when a workflow is not running and has no events, instead of "Waiting for events...".

- **Bug Fixes**
  - Updated the WorkflowEvents component to use workflow status for accurate messaging.

<!-- End of auto-generated description by cubic. -->

