### PR TITLE
test: Improve workspace management logic in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,18 +368,16 @@ async def test_admin_role(test_workspace, mock_org_id):
 @pytest.fixture(scope="function")
 async def test_workspace():
     """Create a test workspace for the test session."""
-    workspace_name = "__test_workspace"
+    ws_id = uuid.uuid4()
+    workspace_name = f"__test_workspace_{ws_id.hex[:8]}"
 
     async with WorkspaceService.with_session(role=system_role()) as svc:
-        # Check if test workspace already exists
-        existing_workspaces = await svc.admin_list_workspaces()
-        for ws in existing_workspaces:
-            if ws.name == workspace_name:
-                logger.info("Found existing test workspace, deleting it first")
-                await svc.delete_workspace(ws.id)
+        if await svc.get_workspace(ws_id):
+            logger.info("Found existing test workspace, deleting it first")
+            await svc.delete_workspace(ws_id)
 
         # Create new test workspace
-        workspace = await svc.create_workspace(name=workspace_name)
+        workspace = await svc.create_workspace(name=workspace_name, override_id=ws_id)
 
         logger.info("Created test workspace", workspace=workspace)
 
@@ -389,9 +387,9 @@ async def test_workspace():
             # Clean up the workspace
             logger.info("Teardown test workspace")
             try:
-                await svc.delete_workspace(workspace.id)
+                await svc.delete_workspace(ws_id)
             except Exception as e:
-                logger.error(f"Error during workspace cleanup: {e}")
+                logger.warning(f"Error during workspace cleanup: {e}")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
- Updated test workspace creation to use a unique ID for better isolation.
- Simplified existing workspace check and deletion process.
- Enhanced logging for workspace cleanup errors.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
