### PR TITLE
fix: Prevent empty run_if and for_each statements in action forms

### DIFF
--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -140,6 +140,14 @@ const actionFormSchema = z.object({
         z.string().max(1000, "For each must be less than 1000 characters")
       ),
     ])
+    .transform((val) => {
+      if (Array.isArray(val)) {
+        return val.filter((item) => item.trim() !== "")
+      } else if (typeof val === "string") {
+        return val.trim() !== "" ? val : undefined
+      }
+      return val
+    })
     .optional(),
   run_if: z
     .string()

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -144,6 +144,7 @@ const actionFormSchema = z.object({
   run_if: z
     .string()
     .max(1000, "Run if must be less than 1000 characters")
+    .transform((val) => (!!val ? val : undefined))
     .optional(),
   // Retry policy fields
   max_attempts: z.number().int().min(0).optional(),

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -152,7 +152,7 @@ const actionFormSchema = z.object({
   run_if: z
     .string()
     .max(1000, "Run if must be less than 1000 characters")
-    .transform((val) => (!!val ? val : undefined))
+    .transform((val) => (val?.trim() ? val.trim() : undefined))
     .optional(),
   // Retry policy fields
   max_attempts: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary
- Fix issue where empty strings in `run_if` fields were being saved instead of being removed
- Add transform logic to coerce empty `run_if` strings to `undefined`
- Filter out empty strings from `for_each` array values
- Ensure empty conditional statements are properly handled in the action form schema

## Changes
- Added `.transform()` to `for_each` field to filter empty strings from arrays and convert empty strings to undefined
- Added `.transform()` to `run_if` field to convert falsy values to undefined
- This prevents saving empty conditional logic that could cause issues during workflow execution

## Test plan
- [ ] Create a new action in the workflow builder
- [ ] Add a run_if condition, then delete it (leaving empty string)
- [ ] Save the action and verify run_if is not saved as empty string
- [ ] Add multiple for_each items, delete some to leave empty strings
- [ ] Verify empty strings are filtered out from the for_each array

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevented empty strings from being saved in the run_if and for_each fields in action forms to improve data validation.

- **Bug Fixes**
  - Empty run_if values are now set to undefined instead of being saved as empty strings.
  - Empty strings are filtered out from for_each arrays.

<!-- End of auto-generated description by cubic. -->

