### PR TITLE
feat(ui): Streamline case UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,9 @@ just gen-functions
 - Use named exports over default exports
 - Use "Title case example" over "Title Case Example" for UI text
 
+### UI Component Best Practices
+- **Avoid background colors on child elements within bordered containers**: When using shadcn components like SidebarInset that have rounded borders, don't add background colors (e.g., `bg-card`, `bg-background`) to immediate child elements. These backgrounds can paint over the parent's rounded border corners, making them appear cut off or missing. Instead, let the parent container handle the background styling.
+
 ### Code Quality
 - **Ruff**: Line length 88, comprehensive linting rules
 - **MyPy**: Strict type checking mode

--- a/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
@@ -45,7 +45,7 @@ export default function CaseDetailLayout({
     <SidebarProvider>
       <AppSidebar />
       {/* Case content inset */}
-      <SidebarInset className="flex-1 min-w-0">
+      <SidebarInset className="flex-1 min-w-0 mr-px">
         <div className="flex h-full flex-col">
           <ControlsHeader />
           <div className="flex-1 overflow-y-auto">{children}</div>
@@ -54,7 +54,7 @@ export default function CaseDetailLayout({
 
       {/* Drag divider */}
       <DragDivider
-        className="w-3 shrink-0"
+        className="w-1.5 shrink-0"
         value={chatWidth}
         min={MIN_CHAT_WIDTH}
         max={maxChatWidth}
@@ -63,7 +63,7 @@ export default function CaseDetailLayout({
 
       {/* Chat inset */}
       <SidebarInset
-        className="flex-none min-w-[300px]"
+        className="flex-none min-w-[300px] ml-px"
         style={{ width: chatWidth, maxWidth: maxChatWidth }}
       >
         <CaseChat caseId={caseId} isChatOpen={isChatOpen} />

--- a/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { GripVertical } from "lucide-react"
 import { useParams } from "next/navigation"
 import type React from "react"
 import { useEffect, useState } from "react"
 import { CaseChat } from "@/components/cases/case-chat"
+import { DragDivider } from "@/components/drag-divider"
 import { ControlsHeader } from "@/components/nav/controls-header"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
@@ -37,32 +37,6 @@ export default function CaseDetailLayout({
     return () => window.removeEventListener("resize", computeMax)
   }, [])
 
-  // Handler to initiate drag resizing
-  const handleDividerMouseDown = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => {
-    e.preventDefault()
-
-    const startX = e.clientX
-    const startWidth = chatWidth
-
-    const onMouseMove = (moveEvent: MouseEvent) => {
-      const deltaX = startX - moveEvent.clientX
-      let newWidth = startWidth + deltaX
-      // Clamp within min/max bounds
-      newWidth = Math.min(Math.max(newWidth, MIN_CHAT_WIDTH), maxChatWidth)
-      setChatWidth(newWidth)
-    }
-
-    const onMouseUp = () => {
-      window.removeEventListener("mousemove", onMouseMove)
-      window.removeEventListener("mouseup", onMouseUp)
-    }
-
-    window.addEventListener("mousemove", onMouseMove)
-    window.addEventListener("mouseup", onMouseUp)
-  }
-
   if (!caseId) {
     return <>{children}</>
   }
@@ -79,15 +53,13 @@ export default function CaseDetailLayout({
       </SidebarInset>
 
       {/* Drag divider */}
-      <div
-        className="group relative w-3 shrink-0 cursor-col-resize flex items-center justify-center"
-        onMouseDown={handleDividerMouseDown}
-      >
-        {/* slim line that appears on hover */}
-        <div className="absolute inset-y-3 w-px bg-transparent transition-colors duration-150 group-hover:bg-border" />
-        {/* grip icon shows on hover */}
-        <GripVertical className="h-4 w-4 text-border opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
-      </div>
+      <DragDivider
+        className="w-3 shrink-0"
+        value={chatWidth}
+        min={MIN_CHAT_WIDTH}
+        max={maxChatWidth}
+        onChange={setChatWidth}
+      />
 
       {/* Chat inset */}
       <SidebarInset

--- a/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
@@ -2,9 +2,13 @@
 
 import { useParams } from "next/navigation"
 import type React from "react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { CaseChat } from "@/components/cases/case-chat"
-import { DragDivider } from "@/components/drag-divider"
+import {
+  DEFAULT_MAX,
+  DEFAULT_MIN,
+  DragDivider,
+} from "@/components/drag-divider"
 import { ControlsHeader } from "@/components/nav/controls-header"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
@@ -16,26 +20,9 @@ export default function CaseDetailLayout({
 }) {
   const params = useParams<{ caseId: string }>()
   const caseId = params?.caseId
-  const [isChatOpen, setIsChatOpen] = useState(true)
 
-  // Chat panel width in pixels. Default corresponds to Tailwind w-96 (384px).
-  const MIN_CHAT_WIDTH = 300
-  const [maxChatWidth, setMaxChatWidth] = useState<number>(1200)
-  const [chatWidth, setChatWidth] = useState<number>(
-    Math.min(1000, maxChatWidth)
-  )
-
-  // Update max width on mount and window resize
-  useEffect(() => {
-    const computeMax = () => {
-      if (typeof window !== "undefined") {
-        setMaxChatWidth(Math.floor(window.innerWidth * 0.6))
-      }
-    }
-    computeMax()
-    window.addEventListener("resize", computeMax)
-    return () => window.removeEventListener("resize", computeMax)
-  }, [])
+  // Default starting width roughly Tailwind's w-96 (384px)
+  const [chatWidth, setChatWidth] = useState<number>(DEFAULT_MIN)
 
   if (!caseId) {
     return <>{children}</>
@@ -56,17 +43,19 @@ export default function CaseDetailLayout({
       <DragDivider
         className="w-1.5 shrink-0"
         value={chatWidth}
-        min={MIN_CHAT_WIDTH}
-        max={maxChatWidth}
         onChange={setChatWidth}
       />
 
       {/* Chat inset */}
       <SidebarInset
-        className="flex-none min-w-[300px] ml-px"
-        style={{ width: chatWidth, maxWidth: maxChatWidth }}
+        className="flex-none ml-px"
+        style={{
+          width: chatWidth,
+          minWidth: DEFAULT_MIN,
+          maxWidth: DEFAULT_MAX,
+        }}
       >
-        <CaseChat caseId={caseId} isChatOpen={isChatOpen} />
+        <CaseChat caseId={caseId} isChatOpen={true} />
       </SidebarInset>
     </SidebarProvider>
   )

--- a/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
@@ -1,15 +1,41 @@
-import type { Metadata } from "next"
+"use client"
 
-export const metadata: Metadata = {
-  title: "Case details",
-}
+import { useParams } from "next/navigation"
+import type React from "react"
+import { useState } from "react"
+import { CaseChat } from "@/components/cases/case-chat"
+import { ControlsHeader } from "@/components/nav/controls-header"
+import { AppSidebar } from "@/components/sidebar/app-sidebar"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 
 export default function CaseDetailLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const params = useParams<{ caseId: string }>()
+  const caseId = params?.caseId
+  const [isChatOpen, setIsChatOpen] = useState(true)
+
+  if (!caseId) {
+    return <>{children}</>
+  }
+
   return (
-    <div className="h-full bg-background rounded-lg shadow-sm">{children}</div>
+    <SidebarProvider>
+      <AppSidebar />
+      {/* Case content inset */}
+      <SidebarInset>
+        <div className="flex h-full flex-col">
+          <ControlsHeader />
+          <div className="flex-1 overflow-y-auto">{children}</div>
+        </div>
+      </SidebarInset>
+
+      {/* Chat inset */}
+      <SidebarInset className="w-96">
+        <CaseChat caseId={caseId} isChatOpen={isChatOpen} />
+      </SidebarInset>
+    </SidebarProvider>
   )
 }

--- a/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
@@ -1,8 +1,9 @@
 "use client"
 
+import { GripVertical } from "lucide-react"
 import { useParams } from "next/navigation"
 import type React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { CaseChat } from "@/components/cases/case-chat"
 import { ControlsHeader } from "@/components/nav/controls-header"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
@@ -17,6 +18,51 @@ export default function CaseDetailLayout({
   const caseId = params?.caseId
   const [isChatOpen, setIsChatOpen] = useState(true)
 
+  // Chat panel width in pixels. Default corresponds to Tailwind w-96 (384px).
+  const MIN_CHAT_WIDTH = 300
+  const [maxChatWidth, setMaxChatWidth] = useState<number>(1200)
+  const [chatWidth, setChatWidth] = useState<number>(
+    Math.min(1000, maxChatWidth)
+  )
+
+  // Update max width on mount and window resize
+  useEffect(() => {
+    const computeMax = () => {
+      if (typeof window !== "undefined") {
+        setMaxChatWidth(Math.floor(window.innerWidth * 0.6))
+      }
+    }
+    computeMax()
+    window.addEventListener("resize", computeMax)
+    return () => window.removeEventListener("resize", computeMax)
+  }, [])
+
+  // Handler to initiate drag resizing
+  const handleDividerMouseDown = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    e.preventDefault()
+
+    const startX = e.clientX
+    const startWidth = chatWidth
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const deltaX = startX - moveEvent.clientX
+      let newWidth = startWidth + deltaX
+      // Clamp within min/max bounds
+      newWidth = Math.min(Math.max(newWidth, MIN_CHAT_WIDTH), maxChatWidth)
+      setChatWidth(newWidth)
+    }
+
+    const onMouseUp = () => {
+      window.removeEventListener("mousemove", onMouseMove)
+      window.removeEventListener("mouseup", onMouseUp)
+    }
+
+    window.addEventListener("mousemove", onMouseMove)
+    window.addEventListener("mouseup", onMouseUp)
+  }
+
   if (!caseId) {
     return <>{children}</>
   }
@@ -25,15 +71,29 @@ export default function CaseDetailLayout({
     <SidebarProvider>
       <AppSidebar />
       {/* Case content inset */}
-      <SidebarInset>
+      <SidebarInset className="flex-1 min-w-0">
         <div className="flex h-full flex-col">
           <ControlsHeader />
           <div className="flex-1 overflow-y-auto">{children}</div>
         </div>
       </SidebarInset>
 
+      {/* Drag divider */}
+      <div
+        className="group relative w-3 shrink-0 cursor-col-resize flex items-center justify-center"
+        onMouseDown={handleDividerMouseDown}
+      >
+        {/* slim line that appears on hover */}
+        <div className="absolute inset-y-3 w-px bg-transparent transition-colors duration-150 group-hover:bg-border" />
+        {/* grip icon shows on hover */}
+        <GripVertical className="h-4 w-4 text-border opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
+      </div>
+
       {/* Chat inset */}
-      <SidebarInset className="w-96">
+      <SidebarInset
+        className="flex-none min-w-[300px]"
+        style={{ width: chatWidth, maxWidth: maxChatWidth }}
+      >
         <CaseChat caseId={caseId} isChatOpen={isChatOpen} />
       </SidebarInset>
     </SidebarProvider>

--- a/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from "next/navigation"
 import type React from "react"
+import { useState } from "react"
 import { CaseChat } from "@/components/cases/case-chat"
 import { ControlsHeader } from "@/components/nav/controls-header"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
@@ -16,6 +17,9 @@ export default function CaseDetailLayout({
   const params = useParams<{ caseId: string }>()
   const caseId = params?.caseId
 
+  // Track whether the chat sidebar is open
+  const [chatOpen, setChatOpen] = useState(true)
+
   if (!caseId) {
     return <>{children}</>
   }
@@ -26,15 +30,20 @@ export default function CaseDetailLayout({
       {/* Case content inset */}
       <SidebarInset className="flex-1 min-w-0 mr-px">
         <div className="flex h-full flex-col">
-          <ControlsHeader />
+          <ControlsHeader
+            isChatOpen={chatOpen}
+            onToggleChat={() => setChatOpen((prev) => !prev)}
+          />
           <div className="flex-1 overflow-y-auto">{children}</div>
         </div>
       </SidebarInset>
 
       {/* Chat sidebar */}
-      <ResizableSidebar>
-        <CaseChat caseId={caseId} isChatOpen={true} />
-      </ResizableSidebar>
+      {chatOpen && (
+        <ResizableSidebar>
+          <CaseChat caseId={caseId} isChatOpen />
+        </ResizableSidebar>
+      )}
     </SidebarProvider>
   )
 }

--- a/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/[caseId]/layout.tsx
@@ -2,15 +2,10 @@
 
 import { useParams } from "next/navigation"
 import type React from "react"
-import { useState } from "react"
 import { CaseChat } from "@/components/cases/case-chat"
-import {
-  DEFAULT_MAX,
-  DEFAULT_MIN,
-  DragDivider,
-} from "@/components/drag-divider"
 import { ControlsHeader } from "@/components/nav/controls-header"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
+import { ResizableSidebar } from "@/components/ui/resizable-sidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 
 export default function CaseDetailLayout({
@@ -20,9 +15,6 @@ export default function CaseDetailLayout({
 }) {
   const params = useParams<{ caseId: string }>()
   const caseId = params?.caseId
-
-  // Default starting width roughly Tailwind's w-96 (384px)
-  const [chatWidth, setChatWidth] = useState<number>(DEFAULT_MIN)
 
   if (!caseId) {
     return <>{children}</>
@@ -39,24 +31,10 @@ export default function CaseDetailLayout({
         </div>
       </SidebarInset>
 
-      {/* Drag divider */}
-      <DragDivider
-        className="w-1.5 shrink-0"
-        value={chatWidth}
-        onChange={setChatWidth}
-      />
-
-      {/* Chat inset */}
-      <SidebarInset
-        className="flex-none ml-px"
-        style={{
-          width: chatWidth,
-          minWidth: DEFAULT_MIN,
-          maxWidth: DEFAULT_MAX,
-        }}
-      >
+      {/* Chat sidebar */}
+      <ResizableSidebar>
         <CaseChat caseId={caseId} isChatOpen={true} />
-      </SidebarInset>
+      </ResizableSidebar>
     </SidebarProvider>
   )
 }

--- a/frontend/src/app/workspaces/layout.tsx
+++ b/frontend/src/app/workspaces/layout.tsx
@@ -57,9 +57,10 @@ export default function WorkspaceLayout({
 }
 
 function WorkspaceChildren({ children }: { children: React.ReactNode }) {
-  const params = useParams<{ workflowId?: string }>()
+  const params = useParams<{ workflowId?: string; caseId?: string }>()
   const pathname = usePathname()
   const isWorkflowBuilder = !!params?.workflowId
+  const isCaseDetail = !!params?.caseId
   const isSettingsPage = pathname?.includes("/settings")
   const isOrganizationPage = pathname?.includes("/organization")
   const isRegistryPage = pathname?.includes("/registry")
@@ -76,6 +77,11 @@ function WorkspaceChildren({ children }: { children: React.ReactNode }) {
 
   // Settings, organization and registry pages have their own sidebars
   if (isSettingsPage || isOrganizationPage || isRegistryPage) {
+    return <>{children}</>
+  }
+
+  // Case detail pages have their own layout with dual SidebarInset
+  if (isCaseDetail) {
     return <>{children}</>
   }
 

--- a/frontend/src/components/cases/case-chat.tsx
+++ b/frontend/src/components/cases/case-chat.tsx
@@ -8,7 +8,7 @@ export function CaseChat({
   isChatOpen: boolean
 }) {
   return (
-    <div className="h-full border-l bg-background flex flex-col">
+    <div className="h-full flex flex-col">
       {isChatOpen && <ChatInterface entityType="case" entityId={caseId} />}
     </div>
   )

--- a/frontend/src/components/cases/case-comments-section.tsx
+++ b/frontend/src/components/cases/case-comments-section.tsx
@@ -91,53 +91,61 @@ export function CommentSection({
   }
   return (
     <div className="mx-auto w-full">
-      <div className="space-y-4 p-4">
-        {caseComments?.map((comment) => {
-          const user = new User(comment.user ?? SYSTEM_USER_READ)
-          const displayName = user.getDisplayName()
-          const isEditing = editingCommentId === comment.id
+      <div className="bg-card">
+        <div className="space-y-3">
+          {caseComments?.map((comment) => {
+            const user = new User(comment.user ?? SYSTEM_USER_READ)
+            const displayName = user.getDisplayName()
+            const isEditing = editingCommentId === comment.id
 
-          return (
-            <div key={comment.id} className="group flex gap-3">
-              <CaseUserAvatar user={user} />
-              <div className="flex-1 space-y-1">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    {/* This should be user name */}
-                    <span className="text-sm font-medium">{displayName}</span>
-                    <CaseEventTimestamp
-                      createdAt={comment.created_at}
-                      lastEditedAt={comment.last_edited_at}
-                    />
+            return (
+              <div key={comment.id} className="group">
+                <div className="rounded-lg border border-border/50 py-3 px-4 hover:bg-accent/30 transition-colors">
+                  {/* Two-row layout: Row 1 – avatar, name, timestamp & actions. Row 2 – comment content */}
+                  <div className="space-y-1">
+                    {/* Row 1 */}
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <CaseUserAvatar user={user} size="sm" />
+                        {/* User display name */}
+                        <span className="text-sm font-medium text-foreground">
+                          {displayName}
+                        </span>
+                        <CaseEventTimestamp
+                          createdAt={comment.created_at}
+                          lastEditedAt={comment.last_edited_at}
+                        />
+                      </div>
+                      {!isEditing && (
+                        <CommentActionsWithEditing
+                          caseId={caseId}
+                          workspaceId={workspaceId}
+                          comment={comment}
+                          onEdit={() => setEditingCommentId(comment.id)}
+                        />
+                      )}
+                    </div>
+
+                    {/* Row 2 */}
+                    {isEditing ? (
+                      <InlineCommentEdit
+                        comment={comment}
+                        caseId={caseId}
+                        workspaceId={workspaceId}
+                        onStopEditing={() => setEditingCommentId(null)}
+                      />
+                    ) : (
+                      <CaseCommentViewer content={comment.content} />
+                    )}
                   </div>
-                  {!isEditing && (
-                    <CommentActionsWithEditing
-                      caseId={caseId}
-                      workspaceId={workspaceId}
-                      comment={comment}
-                      onEdit={() => setEditingCommentId(comment.id)}
-                    />
-                  )}
                 </div>
-
-                {isEditing ? (
-                  <InlineCommentEdit
-                    comment={comment}
-                    caseId={caseId}
-                    workspaceId={workspaceId}
-                    onStopEditing={() => setEditingCommentId(null)}
-                  />
-                ) : (
-                  <CaseCommentViewer content={comment.content} />
-                )}
               </div>
-            </div>
-          )
-        })}
-      </div>
-
-      <div className="p-4 pt-0">
-        <CommentTextBox caseId={caseId} workspaceId={workspaceId} />
+            )
+          })}
+        </div>
+        <div className="mt-3">
+          <CommentTextBox caseId={caseId} workspaceId={workspaceId} />
+        </div>
       </div>
     </div>
   )
@@ -208,7 +216,8 @@ function CommentTextBox({
   }
   return (
     <div className="flex w-full items-end gap-2">
-      <div className="relative flex w-full">
+      {/* Match styling of ChatInput */}
+      <div className="relative flex w-full gap-2 rounded-md border border-border px-4 transition-colors hover:border-muted-foreground/40">
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(handleCommentSubmit)}
@@ -222,7 +231,7 @@ function CommentTextBox({
                   <FormControl>
                     <Textarea
                       placeholder="Leave a comment..."
-                      className="min-h-[80px] w-full resize-none rounded-md border-gray-200 bg-gray-50 pr-16 text-gray-800 placeholder:text-gray-400 focus-visible:ring-muted-foreground/30"
+                      className="shadow-none size-full resize-none border-none min-h-[60px] pl-0 pr-16 placeholder:text-muted-foreground focus-visible:ring-0"
                       value={field.value}
                       onChange={field.onChange}
                       onKeyDown={handleKeyDown}
@@ -231,11 +240,11 @@ function CommentTextBox({
                 </FormItem>
               )}
             />
-            <div className="absolute bottom-3 right-3 flex gap-2">
+            <div className="absolute bottom-2 right-2 flex gap-1.5">
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 rounded-md text-gray-400 hover:bg-gray-100 hover:text-muted-foreground"
+                className="size-7 rounded-md text-gray-400 hover:bg-gray-100 hover:text-muted-foreground"
                 disabled
               >
                 <PaperclipIcon className="size-4" />
@@ -245,7 +254,7 @@ function CommentTextBox({
                 variant="ghost"
                 size="icon"
                 type="submit"
-                className="size-8 rounded-md text-gray-400 hover:bg-gray-200/80 hover:text-muted-foreground"
+                className="size-7 rounded-md text-gray-400 hover:bg-gray-200/80 hover:text-muted-foreground"
                 disabled={!form.watch("content").trim()}
               >
                 <ArrowUpIcon className="size-4" />
@@ -309,39 +318,39 @@ function InlineCommentEdit({
 
   return (
     <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(handleSubmit)}
-        className="mt-2 space-y-3"
-      >
-        <FormField
-          control={form.control}
-          name="content"
-          render={({ field }) => (
-            <FormItem>
-              <FormControl>
-                <Textarea
-                  autoFocus
-                  className="min-h-[80px] w-full resize-none rounded-md border-gray-200 bg-background"
-                  onKeyDown={handleKeyDown}
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={onStopEditing}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" size="sm">
-            Save
-          </Button>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="mt-2">
+        <div className="relative rounded-md">
+          <FormField
+            control={form.control}
+            name="content"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <Textarea
+                    autoFocus
+                    className="min-h-[60px] w-full resize-none rounded-md border-none bg-transparent pl-0 pr-20 shadow-none placeholder:text-muted-foreground focus-visible:ring-0"
+                    onKeyDown={handleKeyDown}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage className="px-3" />
+              </FormItem>
+            )}
+          />
+          <div className="absolute bottom-2 right-2 flex gap-1.5">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={onStopEditing}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" className="h-6 px-2 text-xs">
+              Save
+            </Button>
+          </div>
         </div>
       </form>
     </Form>

--- a/frontend/src/components/cases/case-description-editor.tsx
+++ b/frontend/src/components/cases/case-description-editor.tsx
@@ -142,7 +142,7 @@ export function CaseCommentViewer({
 
   // Renders the editor instance using a React component.
   return (
-    <div className={cn("mx-0 py-2  text-sm", className)}>
+    <div className={cn("text-base p-0 m-0", className)}>
       <BlockNoteView
         editor={editor}
         theme="light"
@@ -158,6 +158,9 @@ export function CaseCommentViewer({
         }}
         style={{
           height: "100%",
+          padding: 0,
+          margin: 0,
+          fontSize: "14px",
         }}
       />
     </div>

--- a/frontend/src/components/cases/case-panel-common.tsx
+++ b/frontend/src/components/cases/case-panel-common.tsx
@@ -106,8 +106,8 @@ export function CaseEventTimestamp({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger className="cursor-default">
-          <span className="flex items-center gap-1 text-xs text-muted-foreground  hover:text-foreground">
-            {showIcon && <Clock className="size-3" />}
+          <span className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+            {showIcon && <Clock className="h-3 w-3 flex-shrink-0" />}
             {shortTimeAgo(createdAtDate)}
             {lastEditedAt && <span className="ml-1">(edited)</span>}
           </span>

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 import type {
   CasePriority,
   CaseSeverity,
@@ -19,7 +19,6 @@ import type {
 } from "@/client"
 import { CaseActivityFeed } from "@/components/cases/case-activity-feed"
 import { CaseAttachmentsSection } from "@/components/cases/case-attachments-section"
-import { CaseChat } from "@/components/cases/case-chat"
 import { CommentSection } from "@/components/cases/case-comments-section"
 import { CustomField } from "@/components/cases/case-panel-custom-fields"
 import { CasePanelDescription } from "@/components/cases/case-panel-description"
@@ -42,11 +41,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@/components/ui/resizable"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useGetCase, useUpdateCase } from "@/lib/hooks"
@@ -56,15 +50,9 @@ type CasePanelTab = "comments" | "activity" | "attachments" | "payload"
 
 interface CasePanelContentProps {
   caseId: string
-  onChatToggle?: (isOpen: boolean) => void
-  isChatOpen?: boolean
 }
 
-export function CasePanelView({
-  caseId,
-  onChatToggle,
-  isChatOpen: externalChatOpen,
-}: CasePanelContentProps) {
+export function CasePanelView({ caseId }: CasePanelContentProps) {
   const { workspaceId, workspace } = useWorkspace()
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -97,25 +85,6 @@ export function CasePanelView({
     },
     [router, workspaceId, caseId]
   )
-
-  // Chat state management
-  const [localChatOpen, setLocalChatOpen] = useState(true)
-  const isChatOpen =
-    externalChatOpen !== undefined ? externalChatOpen : localChatOpen
-
-  // Load chat panel state from localStorage
-  useEffect(() => {
-    const savedState = localStorage.getItem(`case-chat-panel-${caseId}`)
-    if (savedState === "true") {
-      setLocalChatOpen(true)
-      onChatToggle?.(true)
-    }
-  }, [caseId, onChatToggle])
-
-  // Save chat panel state to localStorage
-  useEffect(() => {
-    localStorage.setItem(`case-chat-panel-${caseId}`, isChatOpen.toString())
-  }, [caseId, isChatOpen])
 
   if (caseDataIsLoading) {
     return (
@@ -179,14 +148,11 @@ export function CasePanelView({
   const customFields = caseData.fields.filter((field) => !field.reserved)
 
   return (
-    <div className="h-full bg-background flex w-full">
-      <ResizablePanelGroup
-        direction="horizontal"
-        className="h-full w-full min-w-0"
-      >
+    <div className="h-full flex w-full">
+      <div className="h-full w-full min-w-0 flex">
         {/* Case properties section */}
-        <ResizablePanel defaultSize={16} minSize={10} maxSize={30}>
-          <div className="h-full overflow-y-auto p-4 border-r min-w-0">
+        <div className="w-64 min-w-[200px] max-w-[300px] border-r">
+          <div className="h-full overflow-y-auto p-4 min-w-0">
             <div className="space-y-10">
               {/* Properties Section */}
               <CasePanelSection
@@ -298,12 +264,11 @@ export function CasePanelView({
               </CasePanelSection>
             </div>
           </div>
-        </ResizablePanel>
-        <ResizableHandle className="bg-transparent" />
+        </div>
         {/* Main section */}
-        <ResizablePanel defaultSize={60} minSize={30}>
+        <div className="flex-1 min-w-0">
           <div className="h-full overflow-auto min-w-0">
-            <div className="py-4 px-6 max-w-4xl mx-auto">
+            <div className="py-8 pb-24 px-6 max-w-4xl mx-auto">
               {/* Header with Chat Toggle */}
               <div className="flex items-center justify-between mb-4">
                 <div className="flex-1">
@@ -381,15 +346,8 @@ export function CasePanelView({
               </Tabs>
             </div>
           </div>
-        </ResizablePanel>
-        {/* Chat section */}
-        <ResizableHandle className="bg-transparent" />
-        <ResizablePanel defaultSize={24} minSize={20} maxSize={40}>
-          <div className="h-full min-w-0 max-w-md">
-            <CaseChat caseId={caseId} isChatOpen={isChatOpen} />
-          </div>
-        </ResizablePanel>
-      </ResizablePanelGroup>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/cases/case-workflow-trigger.tsx
+++ b/frontend/src/components/cases/case-workflow-trigger.tsx
@@ -171,7 +171,7 @@ export function CaseWorkflowTrigger({ caseData }: CaseWorkflowTriggerProps) {
         <AlertDialogContent className="max-w-md">
           <AlertDialogHeader>
             <AlertDialogTitle className="text-sm">
-              Confirm Workflow Trigger
+              Confirm workflow trigger
             </AlertDialogTitle>
             <AlertDialogDescription className="text-xs">
               Are you sure you want to trigger &quot;{selectedWorkflow?.title}

--- a/frontend/src/components/chat/action-multiselect.tsx
+++ b/frontend/src/components/chat/action-multiselect.tsx
@@ -110,7 +110,7 @@ export function ActionMultiselect<T extends FieldValues>({
       <div className="lg:col-span-2 space-y-4">
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-lg font-semibold">Available Tools</h3>
+            <h3 className="text-lg font-semibold">Available tools</h3>
             <Badge variant="secondary">{selectedActions.length} selected</Badge>
           </div>
           <div className="relative">

--- a/frontend/src/components/chat/chat-input.tsx
+++ b/frontend/src/components/chat/chat-input.tsx
@@ -111,7 +111,7 @@ export function ChatInput({
   }, [messageValue, adjustTextareaHeight])
 
   return (
-    <div className="bg-background p-3 pt-0 rounded-b-lg">
+    <div className="bg-card p-3 pt-0 rounded-b-lg">
       <div className="relative flex flex-col w-full gap-2 rounded-md transition-colors border hover:border-muted-foreground/40">
         <Form {...form}>
           <form

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -161,7 +161,7 @@ export function ChatInterface({
     return (
       <div className="flex h-full flex-col">
         {/* Chat Header */}
-        <div className="bg-background px-4 py-3">
+        <div className="px-4 py-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <MessageSquare className="h-4 w-4 text-muted-foreground" />
@@ -203,7 +203,7 @@ export function ChatInterface({
   return (
     <div className="flex h-full flex-col">
       {/* Chat Header */}
-      <div className="bg-background px-4 py-2">
+      <div className="px-4 py-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <MessageSquare className="h-4 w-4 text-muted-foreground" />
@@ -343,14 +343,14 @@ export function ChatInterface({
                 <div className="flex items-center gap-3">
                   <div className="flex-1">
                     <h4 className="text-sm font-medium text-foreground mb-1">
-                      Configuration Required
+                      {chatReason === "no_model" && "No default model"}
+                      {chatReason === "no_credentials" && "Missing credentials"}
                     </h4>
                     <p className="text-xs text-muted-foreground">
                       {chatReason === "no_model" &&
-                        "Your organization hasn't selected a default AI model for chat operations."}
+                        "Select a default model in agent settings to enable chat."}
                       {chatReason === "no_credentials" &&
-                        `Credentials for the ${provider} provider need to be configured to enable chat.`}
-                      Click to go to the agent settings page.
+                        `Configure ${provider} credentials in agent settings to enable chat.`}
                     </p>
                   </div>
                   <ChevronDown className="size-4 text-muted-foreground rotate-[-90deg]" />

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { formatDistanceToNow } from "date-fns"
-import { BookOpen, ChevronDown, MessageSquare, Plus } from "lucide-react"
+import { ChevronDown, ListTodo, MessageSquare, Plus } from "lucide-react"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import type { ChatEntity, ChatRead } from "@/client"
@@ -299,7 +299,7 @@ export function ChatInterface({
                     onClick={handleCreateChat}
                     disabled={createChatPending}
                   >
-                    <Plus className="h-3 w-3" />
+                    <Plus className="h-4 w-4" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">New chat</TooltipContent>
@@ -317,7 +317,7 @@ export function ChatInterface({
                     onClick={handleSaveAsPrompt}
                     disabled={createPromptPending || !messages?.length}
                   >
-                    <BookOpen className="h-3 w-3" />
+                    <ListTodo className="h-4 w-4" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">Generate runbook</TooltipContent>

--- a/frontend/src/components/chat/chat-tools-dialog.tsx
+++ b/frontend/src/components/chat/chat-tools-dialog.tsx
@@ -6,14 +6,7 @@ import { Controller, useForm } from "react-hook-form"
 import { z } from "zod"
 import { ActionMultiselect } from "@/components/chat/action-multiselect"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog"
 import { Form, FormItem, FormMessage } from "@/components/ui/form"
 import { useGetChat, useUpdateChat } from "@/hooks/use-chat"
 import { useWorkspace } from "@/providers/workspace"
@@ -65,14 +58,6 @@ export function ChatToolsDialog({
         className="sm:max-w-[800px]"
         aria-label="Configure chat tools"
       >
-        <DialogHeader>
-          <DialogTitle>Configure Tools</DialogTitle>
-          <DialogDescription>
-            Select the tools available to the AI agent for this chat. The agent
-            will only be able to use the tools you enable here.
-          </DialogDescription>
-        </DialogHeader>
-
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleSave)} className="space-y-4">
             <div className="py-4">

--- a/frontend/src/components/dashboard/folder-view-toggle.tsx
+++ b/frontend/src/components/dashboard/folder-view-toggle.tsx
@@ -112,7 +112,7 @@ export function FolderViewToggle({
   return (
     <div
       className={cn(
-        "inline-flex items-center rounded-md border border-muted bg-transparent",
+        "inline-flex items-center rounded-md border bg-transparent",
         className
       )}
     >

--- a/frontend/src/components/drag-divider.tsx
+++ b/frontend/src/components/drag-divider.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { GripVertical } from "lucide-react"
+import type React from "react"
+import { cn } from "@/lib/utils"
+
+export interface DragDividerProps {
+  /** Current size (width for vertical divider, height for horizontal) in pixels */
+  value: number
+  /** Callback fired with the new size while dragging */
+  onChange: (newSize: number) => void
+  /** Minimum size allowed */
+  min?: number
+  /** Maximum size allowed */
+  max?: number
+  /** Orientation of the divider. Defaults to "vertical" (i.e. a vertical bar that resizes width) */
+  orientation?: "vertical" | "horizontal"
+  /** Additional Tailwind classes */
+  className?: string
+}
+
+/**
+ * DragDivider provides a simple draggable separator for resizing two adjacent panels.
+ * It is intentionally lightweight and framework-agnostic so it can be dropped into
+ * any layout that manages its own size state.
+ */
+export function DragDivider({
+  value,
+  onChange,
+  min = 100,
+  max = 1000,
+  orientation = "vertical",
+  className,
+}: DragDividerProps) {
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.preventDefault()
+
+    const startCoord = orientation === "vertical" ? e.clientX : e.clientY
+    const startSize = value
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const currentCoord =
+        orientation === "vertical" ? moveEvent.clientX : moveEvent.clientY
+      const delta = startCoord - currentCoord
+      let newSize = startSize + delta
+      newSize = Math.min(Math.max(newSize, min), max)
+      onChange(newSize)
+    }
+
+    const onMouseUp = () => {
+      window.removeEventListener("mousemove", onMouseMove)
+      window.removeEventListener("mouseup", onMouseUp)
+    }
+
+    window.addEventListener("mousemove", onMouseMove)
+    window.addEventListener("mouseup", onMouseUp)
+  }
+
+  return (
+    <div
+      data-orientation={orientation}
+      onMouseDown={handleMouseDown}
+      className={cn(
+        // Base styles
+        "group relative flex shrink-0 items-center justify-center",
+        // Cursor styles
+        orientation === "vertical" ? "cursor-col-resize" : "cursor-row-resize",
+        className
+      )}
+    >
+      {/* Slim line that appears on hover */}
+      <div
+        className={cn(
+          "absolute bg-transparent transition-colors duration-150 group-hover:bg-border",
+          orientation === "vertical" ? "inset-y-3 w-px" : "inset-x-3 h-px"
+        )}
+      />
+      {/* Grip icon shows on hover */}
+      <GripVertical
+        className={cn(
+          "text-border opacity-0 transition-opacity duration-150 group-hover:opacity-100",
+          orientation === "horizontal" && "rotate-90",
+          "h-4 w-4"
+        )}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/drag-divider.tsx
+++ b/frontend/src/components/drag-divider.tsx
@@ -4,15 +4,14 @@ import { GripVertical } from "lucide-react"
 import type React from "react"
 import { cn } from "@/lib/utils"
 
+export const DEFAULT_MIN = 400
+export const DEFAULT_MAX = 600
+
 export interface DragDividerProps {
   /** Current size (width for vertical divider, height for horizontal) in pixels */
   value: number
   /** Callback fired with the new size while dragging */
   onChange: (newSize: number) => void
-  /** Minimum size allowed */
-  min?: number
-  /** Maximum size allowed */
-  max?: number
   /** Orientation of the divider. Defaults to "vertical" (i.e. a vertical bar that resizes width) */
   orientation?: "vertical" | "horizontal"
   /** Additional Tailwind classes */
@@ -27,8 +26,6 @@ export interface DragDividerProps {
 export function DragDivider({
   value,
   onChange,
-  min = 100,
-  max = 1000,
   orientation = "vertical",
   className,
 }: DragDividerProps) {
@@ -43,7 +40,7 @@ export function DragDivider({
         orientation === "vertical" ? moveEvent.clientX : moveEvent.clientY
       const delta = startCoord - currentCoord
       let newSize = startSize + delta
-      newSize = Math.min(Math.max(newSize, min), max)
+      newSize = Math.min(Math.max(newSize, DEFAULT_MIN), DEFAULT_MAX)
       onChange(newSize)
     }
 

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -36,7 +36,6 @@ import {
   useIntegrationProvider,
   useLocalStorage,
 } from "@/lib/hooks"
-import { cn } from "@/lib/utils"
 import { useWorkspace } from "@/providers/workspace"
 
 interface PageConfig {
@@ -430,12 +429,7 @@ export function ControlsHeader({
             className="h-7 w-7"
             onClick={onToggleChat}
           >
-            <PanelRight
-              className={cn(
-                "h-4 w-4 text-muted-foreground transition-transform",
-                isChatOpen && "rotate-180"
-              )}
-            />
+            <PanelRight className="h-4 w-4 text-muted-foreground" />
             <span className="sr-only">Toggle Chat</span>
           </Button>
         )}

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -135,13 +135,13 @@ function CaseBreadcrumb({
 
   return (
     <Breadcrumb>
-      <BreadcrumbList className="flex items-center gap-2 text-sm">
+      <BreadcrumbList className="relative z-10 flex items-center gap-2 text-sm flex-nowrap overflow-hidden whitespace-nowrap min-w-0 bg-white pr-1">
         <BreadcrumbItem>
           <BreadcrumbLink asChild className="font-semibold hover:no-underline">
             <Link href={`/workspaces/${workspaceId}/cases`}>Cases</Link>
           </BreadcrumbLink>
         </BreadcrumbItem>
-        <BreadcrumbSeparator>
+        <BreadcrumbSeparator className="shrink-0">
           <span className="text-muted-foreground">/</span>
         </BreadcrumbSeparator>
         <BreadcrumbItem>
@@ -168,17 +168,22 @@ function CaseTimestamp({
   }
 
   return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <span className="flex items-center gap-1">
-        <Calendar className="h-3 w-3" />
-        Created {format(new Date(caseData.created_at), "MMM d, yyyy, h:mm a")}
+    <div className="flex items-center gap-2 text-xs text-muted-foreground min-w-0">
+      <span className="hidden sm:flex items-center gap-1 min-w-0">
+        <Calendar className="h-3 w-3 flex-shrink-0" />
+        <span className="hidden lg:inline flex-shrink-0">Created</span>
+        <span className="truncate min-w-0">
+          {format(new Date(caseData.created_at), "MMM d, yyyy, h:mm a")}
+        </span>
       </span>
-      <span>•</span>
-      <span>
-        Updated{" "}
-        {formatDistanceToNow(new Date(caseData.updated_at), {
-          addSuffix: true,
-        })}
+      <span className="hidden sm:inline flex-shrink-0">•</span>
+      <span className="flex items-center gap-1 min-w-0">
+        <span className="hidden sm:inline flex-shrink-0">Updated</span>
+        <span className="truncate min-w-0">
+          {formatDistanceToNow(new Date(caseData.updated_at), {
+            addSuffix: true,
+          })}
+        </span>
       </span>
     </div>
   )
@@ -195,13 +200,13 @@ function TableBreadcrumb({
 
   return (
     <Breadcrumb>
-      <BreadcrumbList className="flex items-center gap-2 text-sm">
+      <BreadcrumbList className="relative z-10 flex items-center gap-2 text-sm flex-nowrap overflow-hidden whitespace-nowrap min-w-0 bg-white pr-1">
         <BreadcrumbItem>
           <BreadcrumbLink asChild className="font-semibold hover:no-underline">
             <Link href={`/workspaces/${workspaceId}/tables`}>Tables</Link>
           </BreadcrumbLink>
         </BreadcrumbItem>
-        <BreadcrumbSeparator>
+        <BreadcrumbSeparator className="shrink-0">
           <span className="text-muted-foreground">/</span>
         </BreadcrumbSeparator>
         <BreadcrumbItem>
@@ -235,7 +240,7 @@ function IntegrationBreadcrumb({
 
   return (
     <Breadcrumb>
-      <BreadcrumbList className="flex items-center gap-2 text-sm">
+      <BreadcrumbList className="relative z-10 flex items-center gap-2 text-sm flex-nowrap overflow-hidden whitespace-nowrap min-w-0 bg-white pr-1">
         <BreadcrumbItem>
           <BreadcrumbLink asChild className="font-semibold hover:no-underline">
             <Link href={`/workspaces/${workspaceId}/integrations`}>
@@ -243,7 +248,7 @@ function IntegrationBreadcrumb({
             </Link>
           </BreadcrumbLink>
         </BreadcrumbItem>
-        <BreadcrumbSeparator>
+        <BreadcrumbSeparator className="shrink-0">
           <span className="text-muted-foreground">/</span>
         </BreadcrumbSeparator>
         <BreadcrumbItem>
@@ -382,9 +387,9 @@ export function ControlsHeader() {
   const isCaseDetail = pagePath.match(/^\/cases\/([^/]+)$/)
 
   return (
-    <header className="flex h-10 items-center justify-between border-b px-6">
-      <div className="flex items-center gap-3">
-        <SidebarTrigger className="h-7 w-7" />
+    <header className="flex h-10 items-center border-b px-3 overflow-hidden">
+      <div className="flex items-center gap-3 min-w-0">
+        <SidebarTrigger className="h-7 w-7 flex-shrink-0" />
         {typeof pageConfig.title === "string" ? (
           <h1 className="text-sm font-semibold">{pageConfig.title}</h1>
         ) : (
@@ -392,10 +397,17 @@ export function ControlsHeader() {
         )}
       </div>
 
+      {/* Spacer to ensure timestamp doesn't overlap */}
+      <div className="flex-1 min-w-[1rem]" />
+
       {pageConfig.actions ? (
-        <div className="flex items-center gap-2">{pageConfig.actions}</div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {pageConfig.actions}
+        </div>
       ) : isCaseDetail ? (
-        <CaseTimestamp caseId={isCaseDetail[1]} workspaceId={workspaceId} />
+        <div className="flex-shrink min-w-0">
+          <CaseTimestamp caseId={isCaseDetail[1]} workspaceId={workspaceId} />
+        </div>
       ) : null}
     </header>
   )

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { format, formatDistanceToNow } from "date-fns"
-import { Calendar, Plus } from "lucide-react"
+import { Calendar, PanelRight, Plus } from "lucide-react"
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
 import { type ReactNode, useState } from "react"
@@ -36,11 +36,19 @@ import {
   useIntegrationProvider,
   useLocalStorage,
 } from "@/lib/hooks"
+import { cn } from "@/lib/utils"
 import { useWorkspace } from "@/providers/workspace"
 
 interface PageConfig {
   title: string | ReactNode
   actions?: ReactNode
+}
+
+interface ControlsHeaderProps {
+  /** Whether the right-hand chat sidebar is currently open */
+  isChatOpen?: boolean
+  /** Callback to toggle the chat sidebar */
+  onToggleChat?: () => void
 }
 
 function WorkflowsActions() {
@@ -367,7 +375,10 @@ function getPageConfig(
   return null
 }
 
-export function ControlsHeader() {
+export function ControlsHeader({
+  isChatOpen,
+  onToggleChat,
+}: ControlsHeaderProps = {}) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const { workspaceId } = useWorkspace()
@@ -388,6 +399,7 @@ export function ControlsHeader() {
 
   return (
     <header className="flex h-10 items-center border-b px-3 overflow-hidden">
+      {/* Left section: sidebar toggle + title */}
       <div className="flex items-center gap-3 min-w-0">
         <SidebarTrigger className="h-7 w-7 flex-shrink-0" />
         {typeof pageConfig.title === "string" ? (
@@ -397,18 +409,37 @@ export function ControlsHeader() {
         )}
       </div>
 
-      {/* Spacer to ensure timestamp doesn't overlap */}
+      {/* Middle spacer keeps actions/right buttons from overlapping title */}
       <div className="flex-1 min-w-[1rem]" />
 
-      {pageConfig.actions ? (
-        <div className="flex items-center gap-2 flex-shrink-0">
-          {pageConfig.actions}
-        </div>
-      ) : isCaseDetail ? (
-        <div className="flex-shrink min-w-0">
-          <CaseTimestamp caseId={isCaseDetail[1]} workspaceId={workspaceId} />
-        </div>
-      ) : null}
+      {/* Right section: actions / timestamp / chat toggle */}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {pageConfig.actions
+          ? pageConfig.actions
+          : isCaseDetail && (
+              <CaseTimestamp
+                caseId={isCaseDetail[1]}
+                workspaceId={workspaceId}
+              />
+            )}
+
+        {onToggleChat && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={onToggleChat}
+          >
+            <PanelRight
+              className={cn(
+                "h-4 w-4 text-muted-foreground transition-transform",
+                isChatOpen && "rotate-180"
+              )}
+            />
+            <span className="sr-only">Toggle Chat</span>
+          </Button>
+        )}
+      </div>
     </header>
   )
 }

--- a/frontend/src/components/sidebar/app-menu.tsx
+++ b/frontend/src/components/sidebar/app-menu.tsx
@@ -87,7 +87,7 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="default"
-              className="data-[state=open]:bg-zinc-100 dark:data-[state=open]:bg-zinc-900 pl-0"
+              className="data-[state=open]:bg-sidebar-accent dark:data-[state=open]:bg-sidebar-accent pl-0"
             >
               <img src="/icon.png" alt="Tracecat" className="size-6 ml-0.5" />
               <span className="truncate font-semibold text-zinc-700 dark:text-zinc-300">
@@ -112,7 +112,7 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
                   className={cn(
                     "flex items-center gap-2 py-1 px-2",
                     workspace.id === workspaceId &&
-                      "bg-zinc-100 dark:bg-zinc-800"
+                      "bg-sidebar-accent dark:bg-sidebar-accent"
                   )}
                 >
                   <div className="flex size-6 items-center justify-center rounded-md bg-muted text-[10px]">

--- a/frontend/src/components/ui/resizable-sidebar.tsx
+++ b/frontend/src/components/ui/resizable-sidebar.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import type React from "react"
+import { useState } from "react"
+import {
+  DEFAULT_MAX,
+  DEFAULT_MIN,
+  DragDivider,
+} from "@/components/drag-divider"
+import { SidebarInset } from "@/components/ui/sidebar"
+import { cn } from "@/lib/utils"
+
+interface ResizableSidebarProps {
+  children: React.ReactNode
+  /** Which side of the flex row the sidebar should appear on. Default: right */
+  side?: "left" | "right"
+  /** Initial width in px */
+  initial?: number
+  /** Min width in px */
+  min?: number
+  /** Max width in px */
+  max?: number
+  /** Additional classes for the SidebarInset wrapper */
+  insetClassName?: string
+  /** Additional classes for the DragDivider */
+  dividerClassName?: string
+}
+
+/**
+ * ResizableSidebar composes a SidebarInset with a DragDivider to provide a
+ * draggable panel that can be placed on the left or right of a flex row.
+ * All sizing state and clamping logic is handled internally so layouts can
+ * simply drop this component in.
+ */
+export function ResizableSidebar({
+  children,
+  side = "right",
+  initial = DEFAULT_MIN,
+  min = DEFAULT_MIN,
+  max = DEFAULT_MAX,
+  insetClassName,
+  dividerClassName,
+}: ResizableSidebarProps) {
+  const [width, setWidth] = useState<number>(initial)
+
+  const insetClasses = cn("flex-none", insetClassName, {
+    "ml-px": side === "right",
+    "mr-px": side === "left",
+  })
+
+  const divider = (
+    <DragDivider
+      className={cn("w-1.5 shrink-0", dividerClassName)}
+      value={width}
+      onChange={setWidth}
+    />
+  )
+
+  return (
+    <>
+      {side === "right" ? divider : null}
+      <SidebarInset
+        className={insetClasses}
+        style={{ width, minWidth: min, maxWidth: max }}
+      >
+        {children}
+      </SidebarInset>
+      {side === "left" ? divider : null}
+    </>
+  )
+}

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -335,7 +335,7 @@ const SidebarInset = React.forwardRef<
       className={cn(
         "relative flex w-full flex-1 flex-col h-[calc(100vh-2*0.5rem)]",
         // Standard inset styling with selective margins: only top/bottom plus outer edges.
-        "md:peer-data-[variant=inset]:mt-2 md:peer-data-[variant=inset]:mb-2 md:peer-data-[variant=inset]:first:ml-2 md:peer-data-[variant=inset]:last:mr-2 md:peer-data-[variant=inset]:rounded-lg md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:border-zinc-200 md:peer-data-[variant=inset]:dark:border-zinc-800 md:peer-data-[variant=inset]:bg-background",
+        "md:peer-data-[variant=inset]:mt-2 md:peer-data-[variant=inset]:mb-2 md:peer-data-[variant=inset]:first:ml-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:last:mr-2 md:peer-data-[variant=inset]:rounded-lg md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:border-zinc-200 md:peer-data-[variant=inset]:dark:border-zinc-800 md:peer-data-[variant=inset]:bg-background",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -334,7 +334,8 @@ const SidebarInset = React.forwardRef<
       ref={ref}
       className={cn(
         "relative flex w-full flex-1 flex-col h-[calc(100vh-2*0.5rem)]",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-lg md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:border-zinc-200 md:peer-data-[variant=inset]:dark:border-zinc-800 md:peer-data-[variant=inset]:bg-background",
+        // Standard inset styling with selective margins: only top/bottom plus outer edges.
+        "md:peer-data-[variant=inset]:mt-2 md:peer-data-[variant=inset]:mb-2 md:peer-data-[variant=inset]:first:ml-2 md:peer-data-[variant=inset]:last:mr-2 md:peer-data-[variant=inset]:rounded-lg md:peer-data-[variant=inset]:border md:peer-data-[variant=inset]:border-zinc-200 md:peer-data-[variant=inset]:dark:border-zinc-800 md:peer-data-[variant=inset]:bg-background",
         className
       )}
       {...props}


### PR DESCRIPTION
Before:
<img width="1728" height="953" alt="Screenshot 2025-08-01 at 1 42 19 PM" src="https://github.com/user-attachments/assets/c8e0c58a-1288-499f-8cc6-c6ac84968e0b" />

After:
<img width="1728" height="953" alt="Screenshot 2025-08-01 at 1 00 32 PM" src="https://github.com/user-attachments/assets/1f5d5f13-d4b4-46f4-8d77-c222a3dedcfe" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Streamlined the case detail UI by moving chat to a resizable sidebar, updating comment cards, and improving layout spacing for better readability.

- **UI Improvements**
  - Chat is now in a toggleable, resizable sidebar on case pages.
  - Comment cards have clearer layout and consistent styling.
  - Controls header and sidebar spacing are more responsive and compact.

<!-- End of auto-generated description by cubic. -->

