### PR TITLE
Add basic set operations and checks as inline functions

### DIFF
--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -15,6 +15,8 @@ from tracecat.expressions.functions import (
     capitalize,
     cast,
     check_ip_version,
+    contains_any_of,
+    contains_none_of,
     create_days,
     create_hours,
     create_minutes,
@@ -43,7 +45,6 @@ from tracecat.expressions.functions import (
     get_year,
     greater_than,
     greater_than_or_equal,
-    has_any_in,
     hours_between,
     index_by_key,
     intersection,
@@ -69,7 +70,6 @@ from tracecat.expressions.functions import (
     not_,
     not_empty,
     not_equal,
-    not_has_any_in,
     not_in,
     not_null,
     or_,
@@ -407,12 +407,12 @@ def test_is_in(func, a: Any, b: Any, expected: bool) -> None:
 @pytest.mark.parametrize(
     "func,a,b,expected",
     [
-        (has_any_in, [1, 3], [2, 3, 4], True),
-        (has_any_in, ["ex", "ma"], "hello", False),
-        (has_any_in, ["1", 2, 3.0], ["2", 2, 3.1], True),
-        (not_has_any_in, "enc", ["mic", "kitten"], True),
-        (not_has_any_in, "x", "hello", True),
-        (not_has_any_in, ["1", 4.0], ["1", 2.0, 3], False),
+        (contains_any_of, [1, 3], [2, 3, 4], True),
+        (contains_any_of, ["ex", "ma"], "hello", False),
+        (contains_any_of, ["1", 2, 3.0], ["2", 2, 3.1], True),
+        (contains_none_of, "enc", ["mic", "kitten"], True),
+        (contains_none_of, "x", "hello", True),
+        (contains_none_of, ["1", 4.0], ["1", 2.0, 3], False),
     ],
 )
 def test_has_any_in(func, a: Any, b: Any, expected: bool) -> None:

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -26,6 +26,7 @@ from tracecat.expressions.functions import (
     dict_keys,
     dict_lookup,
     dict_values,
+    difference,
     div,
     endswith,
     flatten,
@@ -42,8 +43,10 @@ from tracecat.expressions.functions import (
     get_year,
     greater_than,
     greater_than_or_equal,
+    has_any_in,
     hours_between,
     index_by_key,
+    intersection,
     ipv4_in_subnet,
     ipv4_is_public,
     ipv6_in_subnet,
@@ -66,6 +69,7 @@ from tracecat.expressions.functions import (
     not_,
     not_empty,
     not_equal,
+    not_has_any_in,
     not_in,
     not_null,
     or_,
@@ -87,10 +91,12 @@ from tracecat.expressions.functions import (
     strip,
     sub,
     sum_,
+    symmetric_difference,
     titleize,
     to_datetime,
     to_time,
     to_timestamp,
+    union,
     unset_timezone,
     uppercase,
     url_decode,
@@ -395,6 +401,44 @@ def test_equality(func, a: Any, b: Any, expected: bool) -> None:
     ],
 )
 def test_is_in(func, a: Any, b: Any, expected: bool) -> None:
+    assert func(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "func,a,b,expected",
+    [
+        (has_any_in, [1, 3], [2, 3, 4], True),
+        (has_any_in, ["ex", "ma"], "hello", False),
+        (has_any_in, ["1", 2, 3.0], ["2", 2, 3.1], True),
+        (not_has_any_in, "enc", ["mic", "kitten"], True),
+        (not_has_any_in, "x", "hello", True),
+        (not_has_any_in, ["1", 4.0], ["1", 2.0, 3], False),
+    ],
+)
+def test_has_any_in(func, a: Any, b: Any, expected: bool) -> None:
+    assert func(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "func,a,b,expected",
+    [
+        (union, [1, 2, 3], [3, 4, 5], [1, 2, 3, 4, 5]),
+        (union, [1, 2, 3], ["hello", "world"], [1, 2, 3, "hello", "world"]),
+        (intersection, [1, 2, 3], [3, 4, 5], [3]),
+        (intersection, [1, 2, 3], ["hello", "world"], []),
+        (difference, [1, 2, 3], [3, 4, 5], [1, 2]),
+        (difference, [1, 2, 3], ["hello", "world"], [1, 2, 3]),
+        (symmetric_difference, [1, 2, 3], [3, 4, 5], [1, 2, 4, 5]),
+        (
+            symmetric_difference,
+            [1, 2, 3],
+            ["hello", "world"],
+            [1, 2, 3, "hello", "world"],
+        ),
+    ],
+)
+def test_set_operations(func, a: Any, b: Any, expected: list[Any]) -> None:
+    """Test set operations functions."""
     assert func(a, b) == expected
 
 

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -330,12 +330,12 @@ def not_empty(x: Sequence[Any]) -> bool:
     return len(x) > 0
 
 
-def has_any_in(a: Sequence[Any], b: Sequence[Any]) -> bool:
+def contains_any_of(a: Sequence[Any], b: Sequence[Any]) -> bool:
     """Check if any of the elements of the first sequence exist in the second sequence."""
     return bool(set(a) & set(b))
 
 
-def not_has_any_in(a: Sequence[Any], b: Sequence[Any]) -> bool:
+def contains_none_of(a: Sequence[Any], b: Sequence[Any]) -> bool:
     """Check if all of of the elements of the first sequence don't exist in the second sequence."""
     return not (bool(set(a) & set(b)))
 
@@ -973,12 +973,10 @@ _FUNCTION_MAPPING = {
     "compact": compact,
     "contains": is_in,  # alias for is_in
     "does_not_contain": not_in,  # alias for not_in
-    "contains_any": has_any_in,  # alias for has_any_in
-    "does_not_contain_any": not_has_any_in,  # alias for not_has_any_in
+    "contains_any_of": contains_any_of,
+    "contains_none_of": contains_none_of,
     "difference": difference,
     "flatten": flatten,
-    "has_any_in": has_any_in,
-    "not_has_any_in": not_has_any_in,
     "intersection": intersection,
     "is_empty": is_empty,
     "is_in": is_in,

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -330,6 +330,16 @@ def not_empty(x: Sequence[Any]) -> bool:
     return len(x) > 0
 
 
+def has_any_in(a: Sequence[Any], b: Sequence[Any]) -> bool:
+    """Check if any of of the elements of the first sequence exist in the second sequence."""
+    return bool(set(a) & set(b))
+
+
+def not_has_any_in(a: Sequence[Any], b: Sequence[Any]) -> bool:
+    """Check if all of of the elements of the first sequence don't exist in the second sequence."""
+    return not (bool(set(a) & set(b)))
+
+
 def _custom_chain(*args) -> Any:
     """Recursively flattens nested iterables into a single generator."""
     for arg in args:
@@ -347,6 +357,26 @@ def flatten(iterables: Sequence[Sequence[Any]]) -> list[Any]:
 def unique(items: Sequence[Any]) -> list[Any]:
     """List of hashable items (e.g. strings, numbers) to remove duplicates from."""
     return list(set(items))
+
+
+def union(a: Sequence[Any], b: Sequence[Any]) -> list[Any]:
+    """Return a list containing the union of elements from two sequences."""
+    return list(set(a).union(b))
+
+
+def intersection(a: Sequence[Any], b: Sequence[Any]) -> list[Any]:
+    """Return a list containing the intersection of elements from two sequences."""
+    return list(set(a).intersection(b))
+
+
+def difference(a: Sequence[Any], b: Sequence[Any]) -> list[Any]:
+    """Return a list of elements that are in the first sequence but not in the second."""
+    return list(set(a).difference(b))
+
+
+def symmetric_difference(a: Sequence[Any], b: Sequence[Any]) -> list[Any]:
+    """Return a list of elements that are in either sequence but not in both."""
+    return list(set(a).symmetric_difference(b))
 
 
 def join_strings(items: Sequence[str], sep: str) -> str:
@@ -943,7 +973,13 @@ _FUNCTION_MAPPING = {
     "compact": compact,
     "contains": is_in,  # alias for is_in
     "does_not_contain": not_in,  # alias for not_in
+    "contains_any": has_any_in,  # alias for has_any_in
+    "does_not_contain_any": not_has_any_in,  # alias for not_has_any_in
+    "difference": difference,
     "flatten": flatten,
+    "has_any_in": has_any_in,
+    "not_has_any_in": not_has_any_in,
+    "intersection": intersection,
     "is_empty": is_empty,
     "is_in": is_in,
     "length": len,
@@ -951,6 +987,8 @@ _FUNCTION_MAPPING = {
     "is_not_empty": not_empty,  # alias for not_empty
     "not_in": not_in,
     "is_not_in": not_in,  # alias for not_in
+    "symmetric_difference": symmetric_difference,
+    "union": union,
     "unique": unique,
     "zip_map": zip_map,  # Inspired by Terraform: https://developer.hashicorp.com/terraform/language/functions/zipmap
     # Math

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -331,7 +331,7 @@ def not_empty(x: Sequence[Any]) -> bool:
 
 
 def has_any_in(a: Sequence[Any], b: Sequence[Any]) -> bool:
-    """Check if any of of the elements of the first sequence exist in the second sequence."""
+    """Check if any of the elements of the first sequence exist in the second sequence."""
     return bool(set(a) & set(b))
 
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds a test for two list intersecting. It also contains some basic set operation functions like intersection, union, difference and symmetric difference.

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Resolves #1328

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

<img width="1864" height="809" alt="image" src="https://github.com/user-attachments/assets/25c652a5-3b64-4386-9c66-3d000cfa5a49" />

<img width="1864" height="809" alt="image" src="https://github.com/user-attachments/assets/98722ff5-6f11-4577-87f7-2c300cf46a62" />


## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added inline functions for set operations (union, intersection, difference, symmetric difference) and checks (has_any_in, not_has_any_in), with tests to cover these cases.

- **New Features**
  - Added set operation functions: union, intersection, difference, symmetric_difference.
  - Added has_any_in and not_has_any_in functions for sequence checks.
  - Added tests for all new functions.

<!-- End of auto-generated description by cubic. -->

