### PR TITLE
chore: Make tracecat-ee part of default installation

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -136,7 +136,7 @@ jobs:
           # Expect a base64 encoded key
           CUSTOM_REPO_SSH_PRIVATE_KEY: ${{ secrets.CUSTOM_REPO_SSH_PRIVATE_KEY }}
         run: |
-           uv run --extra ee pytest tests/integration -ra
+           uv run pytest tests/integration -ra
 
       - name: Show Docker logs on failure
         if: failure()

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -65,7 +65,7 @@ jobs:
           cd custom-integrations-starter-kit
 
       - name: Install dependencies
-        run: uv sync --frozen --extra ee
+        run: uv sync --frozen
 
   test-workflow-codec:
     runs-on: blacksmith-4vcpu-ubuntu-2204
@@ -134,7 +134,7 @@ jobs:
           docker compose -f docker-compose.dev.yml ps
 
       - name: Install dependencies
-        run: uv sync --frozen --extra ee
+        run: uv sync --frozen
 
       - name: Run workflow tests with compression
         env:
@@ -250,7 +250,7 @@ jobs:
         run: docker compose -f docker-compose.dev.yml up -d temporal api worker executor postgres_db caddy minio
 
       - name: Install dependencies
-        run: uv sync --frozen --extra ee
+        run: uv sync --frozen
 
       - name: Run tests
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ just gen-functions
 
 ### Enterprise Edition
 - **Package**: `packages/tracecat-ee/` contains paid enterprise features
-- **Installation**: Install with `uv sync --extra ee` or `pip install tracecat[ee]`
+- **Installation**: Install with `uv sync` or `pip install tracecat[ee]`
 - **Shims**: `tracecat/ee/` contains shims for backward compatibility
 - **Features**: RBAC, multi-tenancy, SSO integration, advanced auth, interactions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=packages,target=packages \
-    uv sync --locked --no-install-project --no-dev --no-editable --extra ee
+    uv sync --locked --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
@@ -77,7 +77,7 @@ RUN chmod +x /app/entrypoint.sh
 
 # Install the project with EE features
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev --no-editable --extra ee
+    uv sync --locked --no-dev --no-editable
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -39,7 +39,7 @@ COPY scripts/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Install packages from lock file with dev dependencies and EE features for hot reloading
-RUN uv sync --frozen --no-dev --extra ee
+RUN uv sync --frozen --no-dev
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "temporalio==1.9.0",
     "tenacity==8.3.0",
     "tomli==2.2.1",
+    "tracecat-ee",
     "tracecat-registry",
     "uv==0.8.4",
     "uvicorn>=0.33.0,<0.34",
@@ -75,8 +76,6 @@ Homepage = "https://tracecat.com"
 Documentation = "https://docs.tracecat.com/"
 Repository = "https://github.com/TracecatHQ/tracecat"
 
-[project.optional-dependencies]
-ee = ["tracecat-ee"]
 
 [tool.uv.sources]
 tracecat-registry = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -3632,15 +3632,11 @@ dependencies = [
     { name = "temporalio" },
     { name = "tenacity" },
     { name = "tomli" },
+    { name = "tracecat-ee" },
     { name = "tracecat-registry" },
     { name = "uv" },
     { name = "uvicorn" },
     { name = "virtualenv" },
-]
-
-[package.optional-dependencies]
-ee = [
-    { name = "tracecat-ee" },
 ]
 
 [package.dev-dependencies]
@@ -3699,13 +3695,12 @@ requires-dist = [
     { name = "temporalio", specifier = "==1.9.0" },
     { name = "tenacity", specifier = "==8.3.0" },
     { name = "tomli", specifier = "==2.2.1" },
-    { name = "tracecat-ee", marker = "extra == 'ee'", editable = "packages/tracecat-ee" },
+    { name = "tracecat-ee", editable = "packages/tracecat-ee" },
     { name = "tracecat-registry", editable = "packages/tracecat-registry" },
     { name = "uv", specifier = "==0.8.4" },
     { name = "uvicorn", specifier = ">=0.33.0,<0.34" },
     { name = "virtualenv", specifier = "==20.27.0" },
 ]
-provides-extras = ["ee"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Updated installation instructions in CLAUDE.md to remove the 'ee' extra.
- Modified Dockerfile and Dockerfile.dev to eliminate '--extra ee' from the 'uv sync' commands.
- Adjusted integration and Python test workflows to reflect the removal of 'ee' extra during dependency installation.
- Added 'tracecat-ee' as a direct dependency in pyproject.toml and updated uv.lock accordingly.
