### PR TITLE
feat: Add org-level case chat agent prompt setting

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -760,9 +760,17 @@ export const $AgentSettingsRead = {
       ],
       title: "Agent Fixed Args",
     },
+    agent_case_chat_prompt: {
+      type: "string",
+      title: "Agent Case Chat Prompt",
+    },
   },
   type: "object",
-  required: ["agent_default_model", "agent_fixed_args"],
+  required: [
+    "agent_default_model",
+    "agent_fixed_args",
+    "agent_case_chat_prompt",
+  ],
   title: "AgentSettingsRead",
 } as const
 
@@ -794,6 +802,13 @@ export const $AgentSettingsUpdate = {
       title: "Agent Fixed Args",
       description:
         "Fixed arguments for agent tools as a JSON string. Format: {'tool_name': {'arg': 'value'}}",
+    },
+    agent_case_chat_prompt: {
+      type: "string",
+      title: "Agent Case Chat Prompt",
+      description:
+        "Additional instructions for case chat agent; prepended to UI-provided instructions.",
+      default: "",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -183,6 +183,7 @@ export type AgentOutput = {
 export type AgentSettingsRead = {
   agent_default_model: string | null
   agent_fixed_args: string | null
+  agent_case_chat_prompt: string
 }
 
 export type AgentSettingsUpdate = {
@@ -194,6 +195,10 @@ export type AgentSettingsUpdate = {
    * Fixed arguments for agent tools as a JSON string. Format: {'tool_name': {'arg': 'value'}}
    */
   agent_fixed_args?: string | null
+  /**
+   * Additional instructions for case chat agent; prepended to UI-provided instructions.
+   */
+  agent_case_chat_prompt?: string
 }
 
 /**

--- a/packages/tracecat-registry/tracecat_registry/integrations/agents/builder.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/agents/builder.py
@@ -944,25 +944,19 @@ async def run_agent(
         """
 
         # Build the final enhanced user prompt including date context
+        extra_instrs: list[str] = []
         if tools_prompt:
-            enhanced_instrs = "\n".join(
-                [
-                    instructions,
-                    current_date_prompt,
-                    tool_calling_prompt,
-                    tools_prompt,
-                    error_handling_prompt,
-                ]
-            )
-        else:
-            enhanced_instrs = "\n".join(
-                [
-                    instructions,
-                    current_date_prompt,
-                    tool_calling_prompt,
-                    error_handling_prompt,
-                ]
-            )
+            extra_instrs.append(tools_prompt)
+
+        enhanced_instrs = "\n".join(
+            [
+                instructions,
+                current_date_prompt,
+                tool_calling_prompt,
+                *extra_instrs,
+                error_handling_prompt,
+            ]
+        )
 
     builder = TracecatAgentBuilder(
         model_name=model_name,

--- a/tracecat/agent/executor/aio.py
+++ b/tracecat/agent/executor/aio.py
@@ -43,7 +43,11 @@ class AioAgentExecutor(BaseAgentExecutor):
             str, await get_setting_cached("agent_fixed_args", session=self.session)
         )
         try:
-            fixed_args = cast(dict[str, Any], orjson.loads(fixed_args_str))
+            fixed_args = (
+                cast(dict[str, Any], orjson.loads(fixed_args_str))
+                if fixed_args_str
+                else {}
+            )
         except Exception:
             logger.warning("Failed to parse fixed args", fixed_args_str=fixed_args_str)
             fixed_args = {}

--- a/tracecat/chat/router.py
+++ b/tracecat/chat/router.py
@@ -169,6 +169,12 @@ async def start_chat_turn(
         if request.instructions:
             instructions.append(request.instructions)
         merged_instructions = "\n".join(instructions) if instructions else None
+        logger.debug(
+            "Merged instructions",
+            merged_instructions=merged_instructions,
+            org_prompt=org_prompt,
+            request_instructions=request.instructions,
+        )
 
         model_info = ModelInfo(
             name=request.model_name,

--- a/tracecat/chat/router.py
+++ b/tracecat/chat/router.py
@@ -30,6 +30,7 @@ from tracecat.chat.service import ChatService
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.logger import logger
 from tracecat.redis.client import get_redis_client
+from tracecat.settings.service import get_setting_cached
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
@@ -155,6 +156,20 @@ async def start_chat_turn(
         )
 
     try:
+        # Fetch org-level case chat prompt and merge with UI instructions
+        org_prompt = await get_setting_cached(
+            "agent_case_chat_prompt", session=session, default=""
+        )
+        if not isinstance(org_prompt, str):
+            # This should never happen, but just in case
+            raise ValueError("Agent case chat prompt is not a string")
+        instructions: list[str] = []
+        if org_prompt.strip():
+            instructions.append(org_prompt)
+        if request.instructions:
+            instructions.append(request.instructions)
+        merged_instructions = "\n".join(instructions) if instructions else None
+
         model_info = ModelInfo(
             name=request.model_name,
             provider=request.model_provider,
@@ -166,7 +181,7 @@ async def start_chat_turn(
             user_prompt=request.message,
             tool_filters=ToolFilters(actions=chat.tools),
             session_id=str(chat_id),
-            instructions=request.instructions,
+            instructions=merged_instructions,
             model_info=model_info,
         )
         await executor.start(args)

--- a/tracecat/settings/models.py
+++ b/tracecat/settings/models.py
@@ -148,6 +148,7 @@ class AppSettingsUpdate(BaseSettingsGroup):
 class AgentSettingsRead(BaseSettingsGroup):
     agent_default_model: str | None
     agent_fixed_args: str | None
+    agent_case_chat_prompt: str
 
 
 class AgentSettingsUpdate(BaseSettingsGroup):
@@ -160,6 +161,10 @@ class AgentSettingsUpdate(BaseSettingsGroup):
         min_length=1,
         max_length=10000,
         description="Fixed arguments for agent tools as a JSON string. Format: {'tool_name': {'arg': 'value'}}",
+    )
+    agent_case_chat_prompt: str = Field(
+        default="",
+        description="Additional instructions for case chat agent; prepended to UI-provided instructions.",
     )
 
 


### PR DESCRIPTION
## Summary

Adds a new organization-level setting that allows administrators to configure a default prompt that gets automatically prepended to all case chat conversations.

## Screens
<img width="1059" height="401" alt="image" src="https://github.com/user-attachments/assets/31501ca1-6f9f-4b54-b67c-573fa903c326" />


### Backend Changes
- Added `agent_case_chat_prompt` field to `AgentSettingsRead` and `AgentSettingsUpdate` models with default empty string
- Updated chat router to fetch org prompt setting and merge with UI-provided instructions server-side
- Org prompt is prepended to UI instructions when both are present
- Handles empty values gracefully and preserves existing behavior

### Frontend Changes  
- Regenerated API client types to include the new setting field
- Added `CaseChatPromptSection` component to organization agent settings page
- Integrated with existing `useOrgAgentSettings` hook for seamless CRUD operations
- Uses shadcn Textarea component with proper form validation and error handling
- Displays existing value by default and shows loading/updating states
- Includes clear description of functionality for administrators

### Key Features
✅ Server-side instruction merging with org prompt prepended to UI instructions  
✅ Graceful handling of empty values with sensible defaults  
✅ Full TypeScript integration with generated API types  
✅ Consistent UI following existing settings page patterns  
✅ Proper form validation and error handling  
✅ Real-time updates with toast notifications  

## Test plan

- [x] Backend linting and type checking passes
- [x] Frontend compilation and type checking passes  
- [x] API client types properly generated with new field
- [x] UI component renders and integrates with existing form patterns
- [ ] Manual testing: Set org prompt via UI and verify it appears in chat conversations
- [ ] Manual testing: Verify empty/null values are handled properly
- [ ] Manual testing: Confirm toast notifications appear on successful update

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an org-level case chat agent prompt that admins can set. The prompt is prepended server-side to all case chat instructions with safe defaults.

- New Features
  - Added agent_case_chat_prompt to AgentSettingsRead/Update (default "").
  - Chat router prepends the org prompt to UI instructions and handles empty values.
  - New CaseChatPromptSection on org agent settings: textarea input, validation, loading/error states, and save via existing hook.
  - Regenerated API client types to include the new field.

- Refactors / Fixes
  - Gracefully handle null agent_fixed_args in the executor.
  - Simplified prompt construction in the agent builder.
  - Added debug logging for merged instructions in chat router.

<!-- End of auto-generated description by cubic. -->

