### PR TITLE
feat: Add toggle for injecting case content into chat agent prompts

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -764,12 +764,17 @@ export const $AgentSettingsRead = {
       type: "string",
       title: "Agent Case Chat Prompt",
     },
+    agent_case_chat_inject_content: {
+      type: "boolean",
+      title: "Agent Case Chat Inject Content",
+    },
   },
   type: "object",
   required: [
     "agent_default_model",
     "agent_fixed_args",
     "agent_case_chat_prompt",
+    "agent_case_chat_inject_content",
   ],
   title: "AgentSettingsRead",
 } as const
@@ -809,6 +814,13 @@ export const $AgentSettingsUpdate = {
       description:
         "Additional instructions for case chat agent; prepended to UI-provided instructions.",
       default: "",
+    },
+    agent_case_chat_inject_content: {
+      type: "boolean",
+      title: "Agent Case Chat Inject Content",
+      description:
+        "Whether to automatically inject case content into agent prompts when a case_id is available.",
+      default: false,
     },
   },
   type: "object",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -388,7 +388,7 @@ export const publicIncomingWebhook = (
   data: PublicIncomingWebhookData
 ): CancelablePromise<PublicIncomingWebhookResponse> => {
   return __request(OpenAPI, {
-    method: "GET",
+    method: "POST",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,
@@ -428,7 +428,7 @@ export const publicIncomingWebhook1 = (
   data: PublicIncomingWebhook1Data
 ): CancelablePromise<PublicIncomingWebhook1Response> => {
   return __request(OpenAPI, {
-    method: "POST",
+    method: "GET",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -184,6 +184,7 @@ export type AgentSettingsRead = {
   agent_default_model: string | null
   agent_fixed_args: string | null
   agent_case_chat_prompt: string
+  agent_case_chat_inject_content: boolean
 }
 
 export type AgentSettingsUpdate = {
@@ -199,6 +200,10 @@ export type AgentSettingsUpdate = {
    * Additional instructions for case chat agent; prepended to UI-provided instructions.
    */
   agent_case_chat_prompt?: string
+  /**
+   * Whether to automatically inject case content into agent prompts when a case_id is available.
+   */
+  agent_case_chat_inject_content?: boolean
 }
 
 /**
@@ -5165,7 +5170,7 @@ export type PublicCheckHealthResponse = {
 
 export type $OpenApiTs = {
   "/webhooks/{workflow_id}/{secret}": {
-    get: {
+    post: {
       req: PublicIncomingWebhookData
       res: {
         /**
@@ -5178,7 +5183,7 @@ export type $OpenApiTs = {
         422: HTTPValidationError
       }
     }
-    post: {
+    get: {
       req: PublicIncomingWebhook1Data
       res: {
         /**

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -533,7 +533,7 @@ function CaseContentInjectionSection() {
     return (
       <AlertNotification
         level="error"
-        message={`Error loading agent settings: ${agentSettingsError instanceof Error ? agentSettingsError.message : "Unknown error"}`}
+        message="Failed to load agent settings."
       />
     )
   }

--- a/tracecat/chat/service.py
+++ b/tracecat/chat/service.py
@@ -2,7 +2,9 @@ import uuid
 from collections.abc import Sequence
 
 import orjson
+import yaml
 from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
 from tracecat_registry.integrations.agents.builder import ModelMessageTA
 from tracecat_registry.integrations.agents.tokens import (
     DATA_KEY,
@@ -10,6 +12,7 @@ from tracecat_registry.integrations.agents.tokens import (
     END_TOKEN_VALUE,
 )
 
+from tracecat.cases.service import CasesService
 from tracecat.chat.models import ChatMessage
 from tracecat.chat.tools import get_default_tools
 from tracecat.db.schemas import Chat
@@ -17,6 +20,8 @@ from tracecat.identifiers import UserID
 from tracecat.logger import logger
 from tracecat.redis.client import get_redis_client
 from tracecat.service import BaseWorkspaceService
+from tracecat.settings.service import get_setting_cached
+from tracecat.types.auth import Role
 
 
 class ChatService(BaseWorkspaceService):
@@ -161,3 +166,32 @@ class ChatService(BaseWorkspaceService):
                 error=str(e),
             )
             return []
+
+
+async def inject_case_content(
+    *, session: AsyncSession, role: Role, case_id: uuid.UUID
+) -> str | None:
+    if await get_setting_cached(
+        "agent_case_chat_inject_content",
+        session=session,
+        default=False,
+    ):
+        case_svc = CasesService(session, role)
+        if case := await case_svc.get_case(case_id):
+            # Add indication that this is the current case
+            # Prepare case data for YAML dump, including tags if they exist
+            case_data = case.model_dump(mode="json")
+            if case.tags:
+                case_data["tags"] = [tag.name for tag in case.tags]
+
+            case_content = (
+                f"This is the current case you are working on:\n\n"
+                "<case_context>\n"
+                f"```yaml\n"
+                f"{yaml.dump(case_data, indent=2)}\n"
+                "```\n"
+                "</case_context>\n"
+            )
+
+            return case_content
+    return None

--- a/tracecat/settings/models.py
+++ b/tracecat/settings/models.py
@@ -149,6 +149,7 @@ class AgentSettingsRead(BaseSettingsGroup):
     agent_default_model: str | None
     agent_fixed_args: str | None
     agent_case_chat_prompt: str
+    agent_case_chat_inject_content: bool
 
 
 class AgentSettingsUpdate(BaseSettingsGroup):
@@ -165,6 +166,10 @@ class AgentSettingsUpdate(BaseSettingsGroup):
     agent_case_chat_prompt: str = Field(
         default="",
         description="Additional instructions for case chat agent; prepended to UI-provided instructions.",
+    )
+    agent_case_chat_inject_content: bool = Field(
+        default=False,
+        description="Whether to automatically inject case content into agent prompts when a case_id is available.",
     )
 
 


### PR DESCRIPTION
## Summary
Adds organization-level setting to control whether case content is automatically injected into agent prompts when a case ID is available.

- Add `agent_case_chat_inject_content` boolean field to AgentSettings
- Update frontend settings component with toggle control  
- Implement case content injection logic in ChatService
- Generate corresponding API client types

## Screens
<img width="992" height="276" alt="image" src="https://github.com/user-attachments/assets/b7932f6c-4ade-4dd0-84e5-b2c1b6a79823" />

<img width="411" height="413" alt="image" src="https://github.com/user-attachments/assets/d293e938-f777-49eb-801f-b858a9152179" />



🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an org-level toggle to auto-inject case details into case chats so agents get context without calling get_case manually. The setting is off by default.

- **New Features**
  - Added agent_case_chat_inject_content to AgentSettings (default false).
  - Frontend toggle in Org → Agent Settings with immediate save.
  - ChatService injects YAML case context into instructions for case chats when enabled.
  - Updated generated API types/schemas for the new setting.

- **Bug Fixes**
  - Corrected HTTP methods for public incoming webhook endpoints in generated client (GET/POST swap).

<!-- End of auto-generated description by cubic. -->

