### PR TITLE
feat(integrations): Implement git port

### DIFF
--- a/frontend/src/components/organization/org-settings-git.tsx
+++ b/frontend/src/components/organization/org-settings-git.tsx
@@ -38,7 +38,8 @@ const gitFormSchema = z.object({
       // - Nested groups: git+ssh://git@gitlab.com/org/team/subteam/repo.git
       // - With ref: git+ssh://git@github.com/org/repo.git@main
       // - Optional .git suffix
-      const regex = /^git\+ssh:\/\/git@[^/]+\/.+?(?:\.git)?(?:@[^/]+)?$/
+      // Requires at least 2 path segments (org/repo) to match backend validation
+      const regex = /^git\+ssh:\/\/git@[^/]+\/[^/]+\/.+?(?:\.git)?(?:@[^/]+)?$/
       return regex.test(url)
     }, "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"),
   git_repo_package_name: z.string().nullish(),

--- a/frontend/src/components/organization/org-settings-git.tsx
+++ b/frontend/src/components/organization/org-settings-git.tsx
@@ -29,10 +29,18 @@ const gitFormSchema = z.object({
   git_repo_url: z
     .string()
     .nullish()
-    .refine(
-      (url) => !url || /^git\+ssh:\/\/git@[^/]+\/[^/]+\/[^/@]+\.git$/.test(url),
-      "Must be a valid Git SSH URL in format: git+ssh://git@host/org/repo.git"
-    ),
+    .refine((url) => {
+      if (!url) return true
+      // Matches the backend regex in tracecat/git/utils.py
+      // Supports:
+      // - Standard format: git+ssh://git@github.com/org/repo.git
+      // - With port: git+ssh://git@gitlab.example.com:2222/org/repo.git
+      // - Nested groups: git+ssh://git@gitlab.com/org/team/subteam/repo.git
+      // - With ref: git+ssh://git@github.com/org/repo.git@main
+      // - Optional .git suffix
+      const regex = /^git\+ssh:\/\/git@[^/]+\/.+?(?:\.git)?(?:@[^/]+)?$/
+      return regex.test(url)
+    }, "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"),
   git_repo_package_name: z.string().nullish(),
 })
 
@@ -99,7 +107,7 @@ export function OrgSettingsGitForm() {
               <FormLabel>Remote repository URL</FormLabel>
               <FormControl>
                 <Input
-                  placeholder="git+ssh://git@my-host/my-org/my-repo.git"
+                  placeholder="git+ssh://git@gitlab.example.com:2222/org/team/repo.git"
                   {...field}
                   value={field.value ?? ""}
                 />
@@ -107,7 +115,7 @@ export function OrgSettingsGitForm() {
               <FormDescription>
                 Git URL of the remote repository. Must use{" "}
                 <span className="font-mono tracking-tighter">git+ssh</span>{" "}
-                scheme.
+                scheme. Supports nested groups and custom ports.
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -151,7 +159,7 @@ export function OrgSettingsGitForm() {
               </FormControl>
               <FormDescription>
                 Add domains that are allowed for Git operations (e.g.,
-                github.com)
+                github.com, gitlab.com, or gitlab.example.com:2222 with port)
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -72,12 +72,84 @@ class TestParseGitUrl:
         assert git_url.repo == "myrepo"
         assert git_url.ref == "main"
 
+    def test_parse_gitlab_self_hosted_with_port(self):
+        """Test parsing GitLab self-hosted URL with port."""
+        url = "git+ssh://git@gitlab.example.com:2222/myorg/myrepo.git"
+        git_url = parse_git_url(url)
+        assert git_url.host == "gitlab.example.com:2222"
+        assert git_url.org == "myorg"
+        assert git_url.repo == "myrepo"
+        assert git_url.ref is None
+
+    def test_parse_gitlab_self_hosted_with_port_and_ref(self):
+        """Test parsing GitLab self-hosted URL with port and ref."""
+        url = "git+ssh://git@gitlab.example.com:2222/myorg/myrepo.git@develop"
+        git_url = parse_git_url(url)
+        assert git_url.host == "gitlab.example.com:2222"
+        assert git_url.org == "myorg"
+        assert git_url.repo == "myrepo"
+        assert git_url.ref == "develop"
+
+    def test_parse_gitlab_nested_groups(self):
+        """Test parsing GitLab URL with nested groups/subgroups."""
+        url = "git+ssh://git@gitlab.com/myorg/team/subteam/myrepo.git"
+        git_url = parse_git_url(url)
+        assert git_url.host == "gitlab.com"
+        assert git_url.org == "myorg/team/subteam"
+        assert git_url.repo == "myrepo"
+        assert git_url.ref is None
+
+    def test_parse_gitlab_deep_nested_groups(self):
+        """Test parsing GitLab URL with deeply nested groups."""
+        url = (
+            "git+ssh://git@gitlab.com/org/dept/team/project/subproject/repo.git@feature"
+        )
+        git_url = parse_git_url(url)
+        assert git_url.host == "gitlab.com"
+        assert git_url.org == "org/dept/team/project/subproject"
+        assert git_url.repo == "repo"
+        assert git_url.ref == "feature"
+
+    def test_parse_gitlab_nested_groups_with_port(self):
+        """Test parsing GitLab self-hosted URL with port and nested groups."""
+        url = "git+ssh://git@gitlab.company.com:8022/platform/backend/services/auth-service.git"
+        git_url = parse_git_url(url)
+        assert git_url.host == "gitlab.company.com:8022"
+        assert git_url.org == "platform/backend/services"
+        assert git_url.repo == "auth-service"
+        assert git_url.ref is None
+
+    def test_parse_bitbucket_url(self):
+        """Test parsing Bitbucket URL."""
+        url = "git+ssh://git@bitbucket.org/workspace/myrepo.git"
+        git_url = parse_git_url(url)
+        assert git_url.host == "bitbucket.org"
+        assert git_url.org == "workspace"
+        assert git_url.repo == "myrepo"
+        assert git_url.ref is None
+
+    def test_parse_bitbucket_url_with_ref(self):
+        """Test parsing Bitbucket URL with ref."""
+        url = "git+ssh://git@bitbucket.org/workspace/myrepo.git@develop"
+        git_url = parse_git_url(url)
+        assert git_url.host == "bitbucket.org"
+        assert git_url.org == "workspace"
+        assert git_url.repo == "myrepo"
+        assert git_url.ref == "develop"
+
     def test_parse_url_allowed_domains(self):
         """Test parsing with allowed domains."""
         url = "git+ssh://git@github.com/myorg/myrepo.git"
         allowed_domains = {"github.com", "gitlab.com"}
         git_url = parse_git_url(url, allowed_domains=allowed_domains)
         assert git_url.host == "github.com"
+
+    def test_parse_url_allowed_domains_with_port(self):
+        """Test parsing with allowed domains including port."""
+        url = "git+ssh://git@gitlab.example.com:2222/myorg/myrepo.git"
+        allowed_domains = {"gitlab.example.com:2222", "github.com"}
+        git_url = parse_git_url(url, allowed_domains=allowed_domains)
+        assert git_url.host == "gitlab.example.com:2222"
 
     def test_parse_url_disallowed_domain(self):
         """Test parsing with disallowed domain."""

--- a/tracecat/git/utils.py
+++ b/tracecat/git/utils.py
@@ -13,7 +13,7 @@ from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatSettingsError
 
 GIT_SSH_URL_REGEX = re.compile(
-    r"^git\+ssh://git@(?P<host>[^/]+)/(?P<path>.+?)(?:\.git)?(?:@(?P<ref>[^/]+))?$"
+    r"^git\+ssh://git@(?P<host>[^/]+)/(?P<path>[^@]+?)(?:\.git)?(?:@(?P<ref>[^/@]+))?$"
 )
 """Git SSH URL with git user and optional ref. Supports nested groups and ports."""
 

--- a/tracecat/git/utils.py
+++ b/tracecat/git/utils.py
@@ -13,15 +13,16 @@ from tracecat.types.auth import Role
 from tracecat.types.exceptions import TracecatSettingsError
 
 GIT_SSH_URL_REGEX = re.compile(
-    r"^git\+ssh://git@(?P<host>[^/]+)/(?P<org>[^/]+)/(?P<repo>[^/@]+?)(?:\.git)?(?:@(?P<ref>[^/]+))?$"
+    r"^git\+ssh://git@(?P<host>[^/]+)/(?P<path>.+?)(?:\.git)?(?:@(?P<ref>[^/]+))?$"
 )
-"""Git SSH URL with git user and optional ref."""
+"""Git SSH URL with git user and optional ref. Supports nested groups and ports."""
 
 
 def parse_git_url(url: str, *, allowed_domains: set[str] | None = None) -> GitUrl:
     """Parse a Git repository URL to extract components.
 
     Handles Git SSH URLs with 'git+ssh' prefix and optional '@' for branch specification.
+    Supports nested groups (GitLab), ports, and various URL structures.
 
     Args:
         url: The repository URL to parse.
@@ -35,16 +36,20 @@ def parse_git_url(url: str, *, allowed_domains: set[str] | None = None) -> GitUr
     """
     if match := GIT_SSH_URL_REGEX.match(url):
         host = match.group("host")
-        org = match.group("org")
-        repo = match.group("repo")
+        path = match.group("path")
         ref = match.group("ref")
 
-        if (
-            not isinstance(host, str)
-            or not isinstance(org, str)
-            or not isinstance(repo, str)
-        ):
+        if not isinstance(host, str) or not isinstance(path, str):
             raise ValueError(f"Invalid Git URL: {url}")
+
+        # Split the path to separate org/groups from repo name
+        # The last segment is the repo, everything else is the org/group path
+        path_parts = path.split("/")
+        if len(path_parts) < 2:
+            raise ValueError(f"Invalid Git URL path format: {url}")
+
+        repo = path_parts[-1]
+        org = "/".join(path_parts[:-1])
 
         if allowed_domains and host not in allowed_domains:
             raise ValueError(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add support for git+ssh URLs with custom ports, nested group paths, optional .git suffix, and @ref. Updates backend parsing, aligns frontend validation, and adds tests to cover these cases.

- **New Features**
  - Backend parsing now accepts host with port and splits path into org/groups and repo.
  - Supports nested groups (e.g., org/team/subteam), optional .git, and @branch refs.
  - Allowed domains check now matches host including port.
  - Frontend validation regex updated to match backend; UI copy clarifies ports and nested groups.
  - Added unit tests for GitLab self-hosted with ports, nested groups, Bitbucket, and allowed domains with ports.

- **Migration**
  - If using non-standard SSH ports, add host:port to git_allowed_domains (e.g., gitlab.example.com:2222).

<!-- End of auto-generated description by cubic. -->

