### PR TITLE
fix(integrations): Splunk Max Results Over 100

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/splunk/search_events.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/splunk/search_events.yml
@@ -51,4 +51,5 @@ definition:
           exec_mode: oneshot
           output_mode: json
           max_count: ${{ inputs.limit }}
+          count: 0
   returns: ${{ steps.search_job.result.data }}


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Fixed a small issue with Splunk integration where max limit doesn't let you get more than 100 results. This PR changes adding a `count: 0` which will tell Splunk to return all results up to the max_count. Without `count: 0` this the count by default is 100 and will override your limit if the number of results is over 100



## Screenshots / Recordings

<img width="738" height="962" alt="image" src="https://github.com/user-attachments/assets/dbfcb0d4-11f8-441b-95d6-0dcfbf344edb" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Splunk searches being capped at 100 results. Sets count: 0 so Splunk returns up to max_count (from inputs.limit) instead of the default 100.

<!-- End of auto-generated description by cubic. -->

