### PR TITLE
fix(integrations): Fix pagerduty resolve event validation error

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/pagerduty/resolve_event.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/pagerduty/resolve_event.yml
@@ -25,5 +25,5 @@ definition:
         payload:
           event_action: resolve
           dedup_key: ${{ inputs.incident_key }}
-          routing_key: ${{ inputs.routing_key }}
+          routing_key: ${{ inputs.service_key }}
   returns: ${{ steps.resolve_event.result.data }}


### PR DESCRIPTION
Fixes issue introduced by #1326, CI appears to not run when only template yamls are changed.

- Changed the routing_key input to service_key to align with the updated PagerDuty integration requirements.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the PagerDuty resolve event template to use the service_key input for routing_key, resolving the Events API validation error. This aligns the template with the updated PagerDuty integration and unblocks resolve actions.

<!-- End of auto-generated description by cubic. -->

