### PR TITLE
fix(alertmedia): Lat & Long can be zero

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/update_trip.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/update_trip.yml
@@ -99,9 +99,9 @@ definition:
                   destination_address["city"] = city
               if country_code:
                   destination_address["country"] = country_code
-              if latitude:
+              if latitude or latitude == 0:
                   destination_address["latitude"] = latitude
-              if longitude:
+              if longitude or longitude == 0:
                   destination_address["longitude"] = longitude
               if destination_address:
                   payload["destination_address"] = destination_address

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/update_trip.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/update_trip.yml
@@ -99,7 +99,7 @@ definition:
                   destination_address["city"] = city
               if country_code:
                   destination_address["country"] = country_code
-              if latitude or latitude == 0:
+              if latitude is None:
                   destination_address["latitude"] = latitude
               if longitude or longitude == 0:
                   destination_address["longitude"] = longitude

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/update_trip.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/alertmedia/update_trip.yml
@@ -101,7 +101,7 @@ definition:
                   destination_address["country"] = country_code
               if latitude is None:
                   destination_address["latitude"] = latitude
-              if longitude or longitude == 0:
+              if longitude is None:
                   destination_address["longitude"] = longitude
               if destination_address:
                   payload["destination_address"] = destination_address


### PR DESCRIPTION
Fix for lat and long allowed to be zero.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix update_trip to include latitude and longitude when the value is 0. This prevents zero coordinates from being omitted, so trips at the equator or prime meridian are updated correctly.

<!-- End of auto-generated description by cubic. -->

