### PR TITLE
fix(ui): Enable deletion of git repo url and package

### DIFF
--- a/frontend/src/components/organization/org-settings-git.tsx
+++ b/frontend/src/components/organization/org-settings-git.tsx
@@ -41,8 +41,14 @@ const gitFormSchema = z.object({
       // Requires at least 2 path segments (org/repo) to match backend validation
       const regex = /^git\+ssh:\/\/git@[^/]+\/[^/]+\/.+?(?:\.git)?(?:@[^/]+)?$/
       return regex.test(url)
-    }, "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"),
-  git_repo_package_name: z.string().nullish(),
+    }, "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)")
+    // Empty string signals removal
+    .transform((url) => url?.trim() || null),
+  git_repo_package_name: z
+    .string()
+    .nullish()
+    // Empty string signals removal
+    .transform((name) => name?.trim() || null),
 })
 
 type GitFormValues = z.infer<typeof gitFormSchema>
@@ -65,8 +71,8 @@ export function OrgSettingsGitForm() {
           text: domain,
         })
       ) ?? [{ id: "0", text: "github.com" }],
-      git_repo_url: gitSettings?.git_repo_url,
-      git_repo_package_name: gitSettings?.git_repo_package_name,
+      git_repo_url: gitSettings?.git_repo_url ?? "",
+      git_repo_package_name: gitSettings?.git_repo_package_name ?? "",
     },
   })
   const onSubmit = async (data: GitFormValues) => {

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -1874,7 +1874,7 @@ export function useOrgGitSettings() {
           console.error("Failed to update Git settings", error)
           toast({
             title: "Failed to update Git settings",
-            description: `An error occurred while updating the Git settings: ${error.body.detail}`,
+            description: `An error occurred while updating the Git settings: ${typeof error.body.detail === "object" ? JSON.stringify(error.body.detail) : error.body.detail}`,
           })
       }
     },


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (\`uv run pytest tests\`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (\`pre-commit run --all-files\`)?

## Description

This PR fixes a UX issue where users cannot delete/clear Git repository settings in the Organization Settings page. Previously, attempting to clear the Git repo URL or package name fields would result in validation errors, preventing users from removing these configurations.

**Changes made:**
- Added form field transformations to treat empty strings as \`null\` (deletion signal)
- Updated default form values to use empty strings instead of \`undefined\`
- Maintained existing SSH URL validation while allowing clearing of fields

**Behavior:**
- Users can now clear Git repo URL by emptying the field
- Users can now clear Git package name by emptying the field  
- Validation still enforces proper SSH URL format when a value is provided
- Empty fields are transformed to \`null\` before submission to signal deletion

## Related Issues

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

1. Navigate to Organization Settings → Git Repository tab
2. If Git settings exist, clear the Git repo URL field and save - should succeed
3. If Git settings exist, clear the Git package name field and save - should succeed  
4. Try entering an invalid Git URL - validation should still work
5. Try entering a valid Git SSH URL - should save successfully