### PR TITLE
fix(ui): Logout doesn't redirect to sign-in

### DIFF
--- a/frontend/src/providers/auth.tsx
+++ b/frontend/src/providers/auth.tsx
@@ -68,6 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await queryClient.invalidateQueries({
       queryKey: ["auth"],
     })
+    router.push("/sign-in")
     return logoutResponse
   }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the logout flow so users are redirected to the sign-in page after logging out. After invalidating the "auth" query, we navigate to /sign-in to prevent staying on protected pages.

<!-- End of auto-generated description by cubic. -->

