### PR TITLE
perf(app): Don't selectin load User relationships

### DIFF
--- a/tracecat/db/schemas.py
+++ b/tracecat/db/schemas.py
@@ -164,26 +164,34 @@ class User(SQLModelBaseUserDB, table=True):
         back_populates="user",
         sa_relationship_kwargs={
             "cascade": "all, delete",
-            **DEFAULT_SA_RELATIONSHIP_KWARGS,
+            "lazy": "select",
         },
     )
     workspaces: list["Workspace"] = Relationship(
         back_populates="members",
         link_model=Membership,
-        sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS,
+        sa_relationship_kwargs={
+            "lazy": "select",
+        },
     )
     assigned_cases: list["Case"] = Relationship(
         back_populates="assignee",
-        sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS,
+        sa_relationship_kwargs={
+            "lazy": "select",
+        },
     )
     access_tokens: list["AccessToken"] = Relationship(
         back_populates="user",
-        sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS,
+        sa_relationship_kwargs={
+            "lazy": "select",
+        },
     )
     # Relationships
     chats: list["Chat"] = Relationship(
         back_populates="user",
-        sa_relationship_kwargs=DEFAULT_SA_RELATIONSHIP_KWARGS,
+        sa_relationship_kwargs={
+            "lazy": "select",
+        },
     )
 
 


### PR DESCRIPTION
# Motivation
We notice that /users/me is an endpoint provided by fastapi-users, but is impacted by the worksapce membership regression (~10x slower). It is then either the lib code or something that's implicitly triggered on every `User` load. Looking into the db queries shows selectin being triggered on all endpoints. This is unnecessary.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched User model relationships to lazy loading (lazy="select") instead of selectin eager loading. This prevents auto-loading related collections when fetching users, reducing initial DB work and memory in common paths.

<!-- End of auto-generated description by cubic. -->

