### PR TITLE
fix(ui): Fix usage of useWorkspaceId in org workspace settings

### DIFF
--- a/frontend/src/app/organization/settings/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/organization/settings/workspaces/[workspaceId]/page.tsx
@@ -14,6 +14,7 @@ export default function OrganizationWorkspaceSettingsPage() {
   const router = useRouter()
   const { user } = useAuth()
   const workspaceId = params.workspaceId
+  const { role } = useCurrentUserRole(workspaceId)
 
   const {
     data: workspace,
@@ -40,7 +41,6 @@ export default function OrganizationWorkspaceSettingsPage() {
 
   // Check if user is org admin or workspace admin
   const isOrgAdmin = user?.isPrivileged()
-  const { role } = useCurrentUserRole()
   const isWorkspaceAdmin = role === "admin"
 
   if (!isOrgAdmin && !isWorkspaceAdmin) {

--- a/frontend/src/components/workspaces/add-workspace-member.tsx
+++ b/frontend/src/components/workspaces/add-workspace-member.tsx
@@ -53,7 +53,7 @@ export function AddWorkspaceMember({
   className,
 }: { workspace: WorkspaceRead } & React.HTMLAttributes<HTMLButtonElement>) {
   const { user } = useAuth()
-  const { role } = useCurrentUserRole()
+  const { role } = useCurrentUserRole(workspace.id)
   const { addMember: addWorkspaceMember } = useWorkspaceMutations()
   const [showDialog, setShowDialog] = useState(false)
   const form = useForm<AddUser>({

--- a/frontend/src/components/workspaces/workspace-members-table.tsx
+++ b/frontend/src/components/workspaces/workspace-members-table.tsx
@@ -64,7 +64,7 @@ export function WorkspaceMembersTable({
   const { user } = useAuth()
   const [selectedUser, setSelectedUser] = useState<WorkspaceMember | null>(null)
   const [isChangeRoleOpen, setIsChangeRoleOpen] = useState(false)
-  const { role } = useCurrentUserRole()
+  const { role } = useCurrentUserRole(workspace.id)
   const { removeMember, updateMember } = useWorkspaceMutations()
   const { members, membersLoading, membersError } = useWorkspaceMembers(
     workspace.id

--- a/frontend/src/hooks/use-workspace.ts
+++ b/frontend/src/hooks/use-workspace.ts
@@ -48,11 +48,7 @@ export function useWorkspaceDetails() {
  *   - roleLoading: Whether the role is currently loading.
  *   - roleError: Any error encountered while fetching the role.
  */
-export function useCurrentUserRole(workspaceId: string): {
-  role?: string
-  roleLoading: boolean
-  roleError?: unknown
-} {
+export function useCurrentUserRole(workspaceId: string) {
   const { user } = useAuth()
   const {
     data: role,

--- a/frontend/src/hooks/use-workspace.ts
+++ b/frontend/src/hooks/use-workspace.ts
@@ -39,8 +39,20 @@ export function useWorkspaceDetails() {
   return { workspace, workspaceLoading, workspaceError }
 }
 
-export function useCurrentUserRole() {
-  const workspaceId = useWorkspaceId()
+/**
+ * Returns the membership role of the current user in the specified workspace.
+ *
+ * @param workspaceId - The ID of the workspace to check membership for.
+ * @returns An object containing:
+ *   - role: The user's role in the workspace, or undefined if not found.
+ *   - roleLoading: Whether the role is currently loading.
+ *   - roleError: Any error encountered while fetching the role.
+ */
+export function useCurrentUserRole(workspaceId: string): {
+  role?: string
+  roleLoading: boolean
+  roleError?: unknown
+} {
   const { user } = useAuth()
   const {
     data: role,


### PR DESCRIPTION
Org workspace settings wasn't loading.

## Screens
<img width="1728" height="947" alt="Screenshot 2025-08-25 at 12 41 01" src="https://github.com/user-attachments/assets/29d28f92-ff03-42eb-880b-87fef85db103" />


<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes incorrect workspace role lookups by requiring a workspaceId for useCurrentUserRole. Restores accurate admin checks in org workspace settings and member management.

- **Bug Fixes**
  - Refactored useCurrentUserRole(workspaceId) to scope role to a specific workspace.
  - Passed workspaceId in settings page, AddWorkspaceMember, and WorkspaceMembersTable.
  - Ensures only workspace/org admins see and use admin actions.

<!-- End of auto-generated description by cubic. -->

