### PR TITLE
fix: Correct type casting for typename in BaseExprValidator

### DIFF
--- a/tracecat/expressions/validator/base.py
+++ b/tracecat/expressions/validator/base.py
@@ -317,7 +317,7 @@ class BaseExprValidator(Visitor):
             raise ValueError("Expected a tree")
         if child.data == "literal":
             try:
-                functions.cast(child.children[0], typename)
+                functions.cast(child.children[0], str(typename))
             except ValueError as e:
                 self.add(
                     status="error",


### PR DESCRIPTION
## Summary
- Fix type casting issue in BaseExprValidator where typename parameter wasn't properly converted to string before passing to cast function

## Test plan
- Verify existing validation tests pass
- Ensure type casting works correctly with various typename values

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a type casting bug in BaseExprValidator: typename is now converted to str before calling functions.cast. This prevents validation errors when typename isn’t already a string.

<!-- End of auto-generated description by cubic. -->

