### PR TITLE
feat(ee): UI for entities

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Entity fields",
+}
+
+export default function EntityFieldLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
@@ -166,7 +166,9 @@ export default function EntityDetailPage() {
       <CreateFieldDialog
         open={createFieldOpen}
         onOpenChange={setCreateFieldOpen}
-        onSubmit={createField}
+        onSubmit={async (data) => {
+          await createField(data)
+        }}
       />
       <EditFieldDialog
         field={fieldToEdit}

--- a/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
@@ -45,7 +45,7 @@ export default function EntityDetailPage() {
     includeInactive
   )
 
-  const { mutateAsync: createField } = useMutation({
+  const { mutateAsync: createField, isPending: isCreatingField } = useMutation({
     mutationFn: async (data: EntityFieldCreate) =>
       await entitiesCreateField({
         workspaceId,
@@ -175,6 +175,7 @@ export default function EntityDetailPage() {
         onSubmit={async (data) => {
           await createField(data)
         }}
+        isSubmitting={isCreatingField}
       />
       <EditFieldDialog
         field={fieldToEdit}

--- a/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useParams } from "next/navigation"
 import { useEffect, useState } from "react"
 import {
+  type EntityFieldCreate,
   type EntityFieldRead,
   entitiesActivateField,
   entitiesCreateField,
@@ -36,19 +37,19 @@ export default function EntityDetailPage() {
 
   const { entity, entityIsLoading, entityError } = useEntity(
     workspaceId,
-    String(entityId)
+    entityId
   )
   const { fields, fieldsIsLoading, fieldsError } = useEntityFields(
     workspaceId,
-    String(entityId),
+    entityId,
     includeInactive
   )
 
   const { mutateAsync: createField } = useMutation({
-    mutationFn: async (data: import("@/client").EntityFieldCreate) =>
+    mutationFn: async (data: EntityFieldCreate) =>
       await entitiesCreateField({
         workspaceId,
-        entityId: String(entityId),
+        entityId: entityId,
         requestBody: data,
       }),
     onSuccess: () => {
@@ -61,8 +62,7 @@ export default function EntityDetailPage() {
       console.error("Failed to create field", error)
       toast({
         title: "Error creating field",
-        description: "Failed to create field.",
-        variant: "destructive",
+        description: "Failed to create field. Please try again.",
       })
     },
   })
@@ -72,7 +72,7 @@ export default function EntityDetailPage() {
       mutationFn: async (fieldId: string) =>
         await entitiesDeactivateField({
           workspaceId,
-          entityId: String(entityId),
+          entityId: entityId,
           fieldId,
         }),
       onSuccess: () => {
@@ -85,8 +85,7 @@ export default function EntityDetailPage() {
         console.error("Failed to archive field", error)
         toast({
           title: "Error archiving field",
-          description: "Failed to archive the field.",
-          variant: "destructive",
+          description: "Failed to archive the field. Please try again.",
         })
       },
     })
@@ -96,7 +95,7 @@ export default function EntityDetailPage() {
       mutationFn: async (fieldId: string) =>
         await entitiesActivateField({
           workspaceId,
-          entityId: String(entityId),
+          entityId: entityId,
           fieldId,
         }),
       onSuccess: () => {
@@ -109,8 +108,7 @@ export default function EntityDetailPage() {
         console.error("Failed to restore field", error)
         toast({
           title: "Error restoring field",
-          description: "Failed to restore the field.",
-          variant: "destructive",
+          description: "Failed to restore the field. Please try again.",
         })
       },
     })
@@ -120,7 +118,7 @@ export default function EntityDetailPage() {
       mutationFn: async (fieldId: string) =>
         await entitiesDeleteField({
           workspaceId,
-          entityId: String(entityId),
+          entityId: entityId,
           fieldId,
         }),
       onSuccess: () => {
@@ -133,8 +131,7 @@ export default function EntityDetailPage() {
         console.error("Failed to delete field", error)
         toast({
           title: "Error deleting field",
-          description: "Failed to delete the field.",
-          variant: "destructive",
+          description: "Failed to delete the field. Please try again.",
         })
       },
     })
@@ -181,7 +178,7 @@ export default function EntityDetailPage() {
           try {
             await entitiesUpdateField({
               workspaceId,
-              entityId: String(entityId),
+              entityId: entityId,
               fieldId,
               requestBody: data,
             })
@@ -197,7 +194,6 @@ export default function EntityDetailPage() {
             toast({
               title: "Error updating field",
               description: "Failed to update the field. Please try again.",
-              variant: "destructive",
             })
           }
         }}

--- a/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/[entityId]/page.tsx
@@ -79,7 +79,10 @@ export default function EntityDetailPage() {
         queryClient.invalidateQueries({
           queryKey: ["entity-fields", workspaceId, entityId],
         })
-        toast({ title: "Field archived", description: "Field archived." })
+        toast({
+          title: "Field archived",
+          description: "Successfully archived field.",
+        })
       },
       onError: (error) => {
         console.error("Failed to archive field", error)
@@ -102,7 +105,10 @@ export default function EntityDetailPage() {
         queryClient.invalidateQueries({
           queryKey: ["entity-fields", workspaceId, entityId],
         })
-        toast({ title: "Field restored", description: "Field restored." })
+        toast({
+          title: "Field restored",
+          description: "Successfully restored field.",
+        })
       },
       onError: (error) => {
         console.error("Failed to restore field", error)
@@ -125,7 +131,10 @@ export default function EntityDetailPage() {
         queryClient.invalidateQueries({
           queryKey: ["entity-fields", workspaceId, entityId],
         })
-        toast({ title: "Field deleted", description: "Field deleted." })
+        toast({
+          title: "Field deleted",
+          description: "Successfully deleted field.",
+        })
       },
       onError: (error) => {
         console.error("Failed to delete field", error)

--- a/frontend/src/app/workspaces/[workspaceId]/entities/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Entities",
+}
+
+export default function EntitiesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/entities/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/page.tsx
@@ -61,7 +61,10 @@ export default function EntitiesPage() {
         queryClient.invalidateQueries({
           queryKey: ["entity-field-counts", workspaceId],
         })
-        toast({ title: "Entity archived", description: "Entity archived." })
+        toast({
+          title: "Entity archived",
+          description: "Successfully archived entity.",
+        })
       },
       onError: (error) => {
         console.error("Failed to archive entity", error)
@@ -81,7 +84,10 @@ export default function EntitiesPage() {
         queryClient.invalidateQueries({
           queryKey: ["entity-field-counts", workspaceId],
         })
-        toast({ title: "Entity restored", description: "Entity restored." })
+        toast({
+          title: "Entity restored",
+          description: "Successfully restored entity.",
+        })
       },
       onError: (error) => {
         console.error("Failed to restore entity", error)
@@ -100,7 +106,10 @@ export default function EntitiesPage() {
       queryClient.invalidateQueries({
         queryKey: ["entity-field-counts", workspaceId],
       })
-      toast({ title: "Entity deleted", description: "Entity deleted." })
+      toast({
+        title: "Entity deleted",
+        description: "Successfully deleted entity.",
+      })
     },
     onError: (error) => {
       console.error("Failed to delete entity", error)

--- a/frontend/src/app/workspaces/[workspaceId]/entities/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/page.tsx
@@ -6,6 +6,7 @@ import {
   entitiesActivateEntity,
   entitiesDeactivateEntity,
   entitiesDeleteEntity,
+  entitiesListFields,
   entitiesUpdateEntity,
 } from "@/client"
 import { EntitiesTable } from "@/components/entities/entities-table"
@@ -31,12 +32,11 @@ export default function EntitiesPage() {
     queryKey: ["entity-field-counts", workspaceId, entities?.length],
     queryFn: async () => {
       if (!entities || entities.length === 0) return {}
-      const services = await import("@/client")
       const counts: Record<string, number> = {}
       await Promise.all(
         entities.map(async (e) => {
           try {
-            const fields = await services.entitiesListFields({
+            const fields = await entitiesListFields({
               workspaceId,
               entityId: e.id,
               includeInactive: false,
@@ -67,8 +67,7 @@ export default function EntitiesPage() {
         console.error("Failed to archive entity", error)
         toast({
           title: "Error archiving entity",
-          description: "Failed to archive the entity.",
-          variant: "destructive",
+          description: "Failed to archive the entity. Please try again.",
         })
       },
     })
@@ -88,8 +87,7 @@ export default function EntitiesPage() {
         console.error("Failed to restore entity", error)
         toast({
           title: "Error restoring entity",
-          description: "Failed to restore the entity.",
-          variant: "destructive",
+          description: "Failed to restore the entity. Please try again.",
         })
       },
     })
@@ -108,8 +106,7 @@ export default function EntitiesPage() {
       console.error("Failed to delete entity", error)
       toast({
         title: "Error deleting entity",
-        description: "Failed to delete the entity.",
-        variant: "destructive",
+        description: "Failed to delete the entity. Please try again.",
       })
     },
   })
@@ -145,7 +142,6 @@ export default function EntitiesPage() {
         toast({
           title: "Error updating entity",
           description: "Failed to update the entity. Please try again.",
-          variant: "destructive",
         })
       },
     })

--- a/frontend/src/app/workspaces/[workspaceId]/entities/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/entities/page.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  type EntityRead,
+  entitiesActivateEntity,
+  entitiesDeactivateEntity,
+  entitiesDeleteEntity,
+  entitiesUpdateEntity,
+} from "@/client"
+import { EntitiesTable } from "@/components/entities/entities-table"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import { toast } from "@/components/ui/use-toast"
+import { useEntities } from "@/hooks/use-entities"
+import { useLocalStorage } from "@/lib/hooks"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+export default function EntitiesPage() {
+  const workspaceId = useWorkspaceId()
+  const queryClient = useQueryClient()
+  const [includeInactive] = useLocalStorage("entities-include-inactive", false)
+
+  const { entities, entitiesIsLoading, entitiesError } = useEntities(
+    workspaceId,
+    includeInactive
+  )
+
+  // Compute field counts by fetching fields per entity (best-effort)
+  const { data: fieldCounts = {} } = useQuery({
+    queryKey: ["entity-field-counts", workspaceId, entities?.length],
+    queryFn: async () => {
+      if (!entities || entities.length === 0) return {}
+      const services = await import("@/client")
+      const counts: Record<string, number> = {}
+      await Promise.all(
+        entities.map(async (e) => {
+          try {
+            const fields = await services.entitiesListFields({
+              workspaceId,
+              entityId: e.id,
+              includeInactive: false,
+            })
+            counts[e.id] = fields.length
+          } catch (_err) {
+            counts[e.id] = 0
+          }
+        })
+      )
+      return counts
+    },
+    enabled: !!entities && entities.length > 0,
+  })
+
+  const { mutateAsync: deactivateEntity, isPending: deactivatePending } =
+    useMutation({
+      mutationFn: async (entityId: string) =>
+        await entitiesDeactivateEntity({ workspaceId, entityId }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["entities", workspaceId] })
+        queryClient.invalidateQueries({
+          queryKey: ["entity-field-counts", workspaceId],
+        })
+        toast({ title: "Entity archived", description: "Entity archived." })
+      },
+      onError: (error) => {
+        console.error("Failed to archive entity", error)
+        toast({
+          title: "Error archiving entity",
+          description: "Failed to archive the entity.",
+          variant: "destructive",
+        })
+      },
+    })
+
+  const { mutateAsync: activateEntity, isPending: activatePending } =
+    useMutation({
+      mutationFn: async (entityId: string) =>
+        await entitiesActivateEntity({ workspaceId, entityId }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["entities", workspaceId] })
+        queryClient.invalidateQueries({
+          queryKey: ["entity-field-counts", workspaceId],
+        })
+        toast({ title: "Entity restored", description: "Entity restored." })
+      },
+      onError: (error) => {
+        console.error("Failed to restore entity", error)
+        toast({
+          title: "Error restoring entity",
+          description: "Failed to restore the entity.",
+          variant: "destructive",
+        })
+      },
+    })
+
+  const { mutateAsync: deleteEntity, isPending: deletePending } = useMutation({
+    mutationFn: async (entityId: string) =>
+      await entitiesDeleteEntity({ workspaceId, entityId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["entities", workspaceId] })
+      queryClient.invalidateQueries({
+        queryKey: ["entity-field-counts", workspaceId],
+      })
+      toast({ title: "Entity deleted", description: "Entity deleted." })
+    },
+    onError: (error) => {
+      console.error("Failed to delete entity", error)
+      toast({
+        title: "Error deleting entity",
+        description: "Failed to delete the entity.",
+        variant: "destructive",
+      })
+    },
+  })
+
+  const { mutateAsync: updateEntity, isPending: updateEntityIsPending } =
+    useMutation({
+      mutationFn: async ({
+        entity,
+        data,
+      }: {
+        entity: EntityRead
+        data: { display_name: string; description?: string; icon?: string }
+      }) => {
+        return await entitiesUpdateEntity({
+          workspaceId,
+          entityId: entity.id,
+          requestBody: {
+            display_name: data.display_name,
+            description: data.description ?? null,
+            icon: data.icon ?? null,
+          },
+        })
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["entities", workspaceId] })
+        toast({
+          title: "Entity updated",
+          description: "The entity settings were updated successfully.",
+        })
+      },
+      onError: (error) => {
+        console.error("Failed to update entity", error)
+        toast({
+          title: "Error updating entity",
+          description: "Failed to update the entity. Please try again.",
+          variant: "destructive",
+        })
+      },
+    })
+
+  if (entitiesIsLoading) return <CenteredSpinner />
+  if (entitiesError)
+    return <AlertNotification level="error" message={entitiesError.message} />
+
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container my-8 max-w-[1200px]">
+        <div className="space-y-4">
+          <EntitiesTable
+            entities={entities ?? []}
+            fieldCounts={fieldCounts}
+            onEditEntity={(entity, data) => updateEntity({ entity, data })}
+            onDeleteEntity={deleteEntity}
+            onDeactivateEntity={deactivateEntity}
+            onReactivateEntity={activateEntity}
+            isDeleting={deactivatePending || activatePending || deletePending}
+            isUpdating={updateEntityIsPending}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3465,6 +3465,425 @@ export const $EditorParamRead = {
   title: "EditorParamRead",
 } as const
 
+export const $EntityCreate = {
+  properties: {
+    key: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Key",
+      description: "Immutable entity key (snake_case)",
+    },
+    display_name: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 1000,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    icon: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Icon",
+    },
+  },
+  type: "object",
+  required: ["key", "display_name"],
+  title: "EntityCreate",
+} as const
+
+export const $EntityFieldCreate = {
+  properties: {
+    key: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Key",
+      description: "Immutable field key (snake_case)",
+    },
+    type: {
+      $ref: "#/components/schemas/FieldType",
+    },
+    display_name: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 1000,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    default_value: {
+      anyOf: [
+        {},
+        {
+          type: "null",
+        },
+      ],
+      title: "Default Value",
+      description: "Default value for the field",
+    },
+    options: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/EntityFieldOptionCreate",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Options",
+    },
+  },
+  type: "object",
+  required: ["key", "type", "display_name"],
+  title: "EntityFieldCreate",
+} as const
+
+export const $EntityFieldOptionCreate = {
+  properties: {
+    key: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Key",
+    },
+    label: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Label",
+    },
+  },
+  type: "object",
+  required: ["label"],
+  title: "EntityFieldOptionCreate",
+} as const
+
+export const $EntityFieldOptionRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    field_id: {
+      type: "string",
+      format: "uuid",
+      title: "Field Id",
+    },
+    key: {
+      type: "string",
+      title: "Key",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: ["id", "field_id", "key", "label", "created_at", "updated_at"],
+  title: "EntityFieldOptionRead",
+} as const
+
+export const $EntityFieldRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    entity_id: {
+      type: "string",
+      format: "uuid",
+      title: "Entity Id",
+    },
+    key: {
+      type: "string",
+      title: "Key",
+    },
+    type: {
+      $ref: "#/components/schemas/FieldType",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    default_value: {
+      anyOf: [
+        {},
+        {
+          type: "null",
+        },
+      ],
+      title: "Default Value",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+    options: {
+      items: {
+        $ref: "#/components/schemas/EntityFieldOptionRead",
+      },
+      type: "array",
+      title: "Options",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "entity_id",
+    "key",
+    "type",
+    "display_name",
+    "is_active",
+    "created_at",
+    "updated_at",
+  ],
+  title: "EntityFieldRead",
+} as const
+
+export const $EntityFieldUpdate = {
+  properties: {
+    display_name: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 1000,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    default_value: {
+      anyOf: [
+        {},
+        {
+          type: "null",
+        },
+      ],
+      title: "Default Value",
+      description: "Default value for the field",
+    },
+    options: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/EntityFieldOptionCreate",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Options",
+    },
+  },
+  type: "object",
+  title: "EntityFieldUpdate",
+} as const
+
+export const $EntityRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    key: {
+      type: "string",
+      title: "Key",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    icon: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Icon",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "key",
+    "display_name",
+    "is_active",
+    "created_at",
+    "updated_at",
+  ],
+  title: "EntityRead",
+} as const
+
+export const $EntityUpdate = {
+  properties: {
+    display_name: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 1000,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    icon: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Icon",
+    },
+  },
+  type: "object",
+  title: "EntityUpdate",
+} as const
+
 export const $ErrorDetails = {
   properties: {
     type: {
@@ -3952,6 +4371,23 @@ export const $FieldDiff = {
   type: "object",
   required: ["field", "old", "new"],
   title: "FieldDiff",
+} as const
+
+export const $FieldType = {
+  type: "string",
+  enum: [
+    "INTEGER",
+    "NUMBER",
+    "TEXT",
+    "BOOL",
+    "JSON",
+    "DATETIME",
+    "DATE",
+    "SELECT",
+    "MULTI_SELECT",
+  ],
+  title: "FieldType",
+  description: "Supported field types for entities.",
 } as const
 
 export const $Float = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -114,6 +114,34 @@ import type {
   EditorListFunctionsResponse,
   EditorValidateExpressionData,
   EditorValidateExpressionResponse,
+  EntitiesActivateEntityData,
+  EntitiesActivateEntityResponse,
+  EntitiesActivateFieldData,
+  EntitiesActivateFieldResponse,
+  EntitiesCreateEntityData,
+  EntitiesCreateEntityResponse,
+  EntitiesCreateFieldData,
+  EntitiesCreateFieldResponse,
+  EntitiesDeactivateEntityData,
+  EntitiesDeactivateEntityResponse,
+  EntitiesDeactivateFieldData,
+  EntitiesDeactivateFieldResponse,
+  EntitiesDeleteEntityData,
+  EntitiesDeleteEntityResponse,
+  EntitiesDeleteFieldData,
+  EntitiesDeleteFieldResponse,
+  EntitiesGetEntityData,
+  EntitiesGetEntityResponse,
+  EntitiesGetFieldData,
+  EntitiesGetFieldResponse,
+  EntitiesListEntitiesData,
+  EntitiesListEntitiesResponse,
+  EntitiesListFieldsData,
+  EntitiesListFieldsResponse,
+  EntitiesUpdateEntityData,
+  EntitiesUpdateEntityResponse,
+  EntitiesUpdateFieldData,
+  EntitiesUpdateFieldResponse,
   FeatureFlagsGetFeatureFlagsResponse,
   FoldersCreateFolderData,
   FoldersCreateFolderResponse,
@@ -401,7 +429,7 @@ export const publicIncomingWebhook = (
   data: PublicIncomingWebhookData
 ): CancelablePromise<PublicIncomingWebhookResponse> => {
   return __request(OpenAPI, {
-    method: "GET",
+    method: "POST",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,
@@ -441,7 +469,7 @@ export const publicIncomingWebhook1 = (
   data: PublicIncomingWebhook1Data
 ): CancelablePromise<PublicIncomingWebhook1Response> => {
   return __request(OpenAPI, {
-    method: "POST",
+    method: "GET",
     url: "/webhooks/{workflow_id}/{secret}",
     path: {
       secret: data.secret,
@@ -1945,6 +1973,388 @@ export const schedulesSearchSchedules = (
     },
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Entities
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.includeInactive
+ * @returns EntityRead Successful Response
+ * @throws ApiError
+ */
+export const entitiesListEntities = (
+  data: EntitiesListEntitiesData
+): CancelablePromise<EntitiesListEntitiesResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/entities",
+    query: {
+      include_inactive: data.includeInactive,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Entity
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const entitiesCreateEntity = (
+  data: EntitiesCreateEntityData
+): CancelablePromise<EntitiesCreateEntityResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/entities",
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Entity
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.workspaceId
+ * @returns EntityRead Successful Response
+ * @throws ApiError
+ */
+export const entitiesGetEntity = (
+  data: EntitiesGetEntityData
+): CancelablePromise<EntitiesGetEntityResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/entities/{entity_id}",
+    path: {
+      entity_id: data.entityId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Entity
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesUpdateEntity = (
+  data: EntitiesUpdateEntityData
+): CancelablePromise<EntitiesUpdateEntityResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/entities/{entity_id}",
+    path: {
+      entity_id: data.entityId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Entity
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesDeleteEntity = (
+  data: EntitiesDeleteEntityData
+): CancelablePromise<EntitiesDeleteEntityResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/entities/{entity_id}",
+    path: {
+      entity_id: data.entityId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Deactivate Entity
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesDeactivateEntity = (
+  data: EntitiesDeactivateEntityData
+): CancelablePromise<EntitiesDeactivateEntityResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/entities/{entity_id}/deactivate",
+    path: {
+      entity_id: data.entityId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Activate Entity
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesActivateEntity = (
+  data: EntitiesActivateEntityData
+): CancelablePromise<EntitiesActivateEntityResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/entities/{entity_id}/activate",
+    path: {
+      entity_id: data.entityId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Field
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const entitiesCreateField = (
+  data: EntitiesCreateFieldData
+): CancelablePromise<EntitiesCreateFieldResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/entities/{entity_id}/fields",
+    path: {
+      entity_id: data.entityId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Fields
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.workspaceId
+ * @param data.includeInactive
+ * @returns EntityFieldRead Successful Response
+ * @throws ApiError
+ */
+export const entitiesListFields = (
+  data: EntitiesListFieldsData
+): CancelablePromise<EntitiesListFieldsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/entities/{entity_id}/fields",
+    path: {
+      entity_id: data.entityId,
+    },
+    query: {
+      include_inactive: data.includeInactive,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Field
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.fieldId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesUpdateField = (
+  data: EntitiesUpdateFieldData
+): CancelablePromise<EntitiesUpdateFieldResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/entities/{entity_id}/fields/{field_id}",
+    path: {
+      entity_id: data.entityId,
+      field_id: data.fieldId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Field
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.fieldId
+ * @param data.workspaceId
+ * @returns EntityFieldRead Successful Response
+ * @throws ApiError
+ */
+export const entitiesGetField = (
+  data: EntitiesGetFieldData
+): CancelablePromise<EntitiesGetFieldResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/entities/{entity_id}/fields/{field_id}",
+    path: {
+      entity_id: data.entityId,
+      field_id: data.fieldId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Field
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.fieldId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesDeleteField = (
+  data: EntitiesDeleteFieldData
+): CancelablePromise<EntitiesDeleteFieldResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/entities/{entity_id}/fields/{field_id}",
+    path: {
+      entity_id: data.entityId,
+      field_id: data.fieldId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Deactivate Field
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.fieldId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesDeactivateField = (
+  data: EntitiesDeactivateFieldData
+): CancelablePromise<EntitiesDeactivateFieldResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/entities/{entity_id}/fields/{field_id}/deactivate",
+    path: {
+      entity_id: data.entityId,
+      field_id: data.fieldId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Activate Field
+ * @param data The data for the request.
+ * @param data.entityId
+ * @param data.fieldId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const entitiesActivateField = (
+  data: EntitiesActivateFieldData
+): CancelablePromise<EntitiesActivateFieldResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/entities/{entity_id}/fields/{field_id}/activate",
+    path: {
+      entity_id: data.entityId,
+      field_id: data.fieldId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1177,6 +1177,87 @@ export type EditorParamRead = {
   optional: boolean
 }
 
+export type EntityCreate = {
+  /**
+   * Immutable entity key (snake_case)
+   */
+  key: string
+  display_name: string
+  description?: string | null
+  icon?: string | null
+}
+
+export type EntityFieldCreate = {
+  /**
+   * Immutable field key (snake_case)
+   */
+  key: string
+  type: FieldType
+  display_name: string
+  description?: string | null
+  /**
+   * Default value for the field
+   */
+  default_value?: unknown | null
+  options?: Array<EntityFieldOptionCreate> | null
+}
+
+export type EntityFieldOptionCreate = {
+  key?: string | null
+  label: string
+}
+
+export type EntityFieldOptionRead = {
+  id: string
+  field_id: string
+  key: string
+  label: string
+  description?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type EntityFieldRead = {
+  id: string
+  entity_id: string
+  key: string
+  type: FieldType
+  display_name: string
+  description?: string | null
+  is_active: boolean
+  default_value?: unknown | null
+  created_at: string
+  updated_at: string
+  options?: Array<EntityFieldOptionRead>
+}
+
+export type EntityFieldUpdate = {
+  display_name?: string | null
+  description?: string | null
+  /**
+   * Default value for the field
+   */
+  default_value?: unknown | null
+  options?: Array<EntityFieldOptionCreate> | null
+}
+
+export type EntityRead = {
+  id: string
+  key: string
+  display_name: string
+  description?: string | null
+  icon?: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type EntityUpdate = {
+  display_name?: string | null
+  description?: string | null
+  icon?: string | null
+}
+
 export type ErrorDetails = {
   type: string
   loc: Array<number | string>
@@ -1321,6 +1402,20 @@ export type FieldDiff = {
   old: unknown
   new: unknown
 }
+
+/**
+ * Supported field types for entities.
+ */
+export type FieldType =
+  | "INTEGER"
+  | "NUMBER"
+  | "TEXT"
+  | "BOOL"
+  | "JSON"
+  | "DATETIME"
+  | "DATE"
+  | "SELECT"
+  | "MULTI_SELECT"
 
 export type Float = {
   component_id?: "float"
@@ -4298,6 +4393,113 @@ export type SchedulesSearchSchedulesData = {
 
 export type SchedulesSearchSchedulesResponse = Array<Schedule>
 
+export type EntitiesListEntitiesData = {
+  includeInactive?: boolean
+  workspaceId: string
+}
+
+export type EntitiesListEntitiesResponse = Array<EntityRead>
+
+export type EntitiesCreateEntityData = {
+  requestBody: EntityCreate
+  workspaceId: string
+}
+
+export type EntitiesCreateEntityResponse = unknown
+
+export type EntitiesGetEntityData = {
+  entityId: string
+  workspaceId: string
+}
+
+export type EntitiesGetEntityResponse = EntityRead
+
+export type EntitiesUpdateEntityData = {
+  entityId: string
+  requestBody: EntityUpdate
+  workspaceId: string
+}
+
+export type EntitiesUpdateEntityResponse = void
+
+export type EntitiesDeleteEntityData = {
+  entityId: string
+  workspaceId: string
+}
+
+export type EntitiesDeleteEntityResponse = void
+
+export type EntitiesDeactivateEntityData = {
+  entityId: string
+  workspaceId: string
+}
+
+export type EntitiesDeactivateEntityResponse = void
+
+export type EntitiesActivateEntityData = {
+  entityId: string
+  workspaceId: string
+}
+
+export type EntitiesActivateEntityResponse = void
+
+export type EntitiesCreateFieldData = {
+  entityId: string
+  requestBody: EntityFieldCreate
+  workspaceId: string
+}
+
+export type EntitiesCreateFieldResponse = unknown
+
+export type EntitiesListFieldsData = {
+  entityId: string
+  includeInactive?: boolean
+  workspaceId: string
+}
+
+export type EntitiesListFieldsResponse = Array<EntityFieldRead>
+
+export type EntitiesUpdateFieldData = {
+  entityId: string
+  fieldId: string
+  requestBody: EntityFieldUpdate
+  workspaceId: string
+}
+
+export type EntitiesUpdateFieldResponse = void
+
+export type EntitiesGetFieldData = {
+  entityId: string
+  fieldId: string
+  workspaceId: string
+}
+
+export type EntitiesGetFieldResponse = EntityFieldRead
+
+export type EntitiesDeleteFieldData = {
+  entityId: string
+  fieldId: string
+  workspaceId: string
+}
+
+export type EntitiesDeleteFieldResponse = void
+
+export type EntitiesDeactivateFieldData = {
+  entityId: string
+  fieldId: string
+  workspaceId: string
+}
+
+export type EntitiesDeactivateFieldResponse = void
+
+export type EntitiesActivateFieldData = {
+  entityId: string
+  fieldId: string
+  workspaceId: string
+}
+
+export type EntitiesActivateFieldResponse = void
+
 export type TagsListTagsData = {
   workspaceId: string
 }
@@ -5307,7 +5509,7 @@ export type PublicCheckHealthResponse = {
 
 export type $OpenApiTs = {
   "/webhooks/{workflow_id}/{secret}": {
-    get: {
+    post: {
       req: PublicIncomingWebhookData
       res: {
         /**
@@ -5320,7 +5522,7 @@ export type $OpenApiTs = {
         422: HTTPValidationError
       }
     }
-    post: {
+    get: {
       req: PublicIncomingWebhook1Data
       res: {
         /**
@@ -6088,6 +6290,204 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: Array<Schedule>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities": {
+    get: {
+      req: EntitiesListEntitiesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<EntityRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: EntitiesCreateEntityData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: unknown
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities/{entity_id}": {
+    get: {
+      req: EntitiesGetEntityData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: EntityRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: EntitiesUpdateEntityData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: EntitiesDeleteEntityData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities/{entity_id}/deactivate": {
+    patch: {
+      req: EntitiesDeactivateEntityData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities/{entity_id}/activate": {
+    patch: {
+      req: EntitiesActivateEntityData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities/{entity_id}/fields": {
+    post: {
+      req: EntitiesCreateFieldData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: unknown
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    get: {
+      req: EntitiesListFieldsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<EntityFieldRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities/{entity_id}/fields/{field_id}": {
+    patch: {
+      req: EntitiesUpdateFieldData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    get: {
+      req: EntitiesGetFieldData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: EntityFieldRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: EntitiesDeleteFieldData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities/{entity_id}/fields/{field_id}/deactivate": {
+    patch: {
+      req: EntitiesDeactivateFieldData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/entities/{entity_id}/fields/{field_id}/activate": {
+    patch: {
+      req: EntitiesActivateFieldData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
         /**
          * Validation Error
          */

--- a/frontend/src/components/entities/create-entity-dialog.tsx
+++ b/frontend/src/components/entities/create-entity-dialog.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { IconPicker } from "@/components/form/icon-picker"
@@ -45,15 +44,15 @@ interface CreateEntityDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onSubmit: (data: CreateEntityFormData) => Promise<void>
+  isSubmitting?: boolean
 }
 
 export function CreateEntityDialog({
   open,
   onOpenChange,
   onSubmit,
+  isSubmitting = false,
 }: CreateEntityDialogProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
   const form = useForm<CreateEntityFormData>({
     resolver: zodResolver(createEntitySchema),
     defaultValues: {
@@ -65,16 +64,9 @@ export function CreateEntityDialog({
   })
 
   const handleSubmit = async (data: CreateEntityFormData) => {
-    setIsSubmitting(true)
-    try {
-      await onSubmit(data)
-      form.reset()
-      onOpenChange(false)
-    } catch (error) {
-      console.error("Failed to create entity:", error)
-    } finally {
-      setIsSubmitting(false)
-    }
+    await onSubmit(data)
+    form.reset()
+    onOpenChange(false)
   }
 
   return (

--- a/frontend/src/components/entities/create-entity-dialog.tsx
+++ b/frontend/src/components/entities/create-entity-dialog.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { IconPicker } from "@/components/form/icon-picker"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+const createEntitySchema = z.object({
+  key: z
+    .string()
+    .min(1, "Key is required")
+    .regex(
+      /^[a-z][a-z0-9_]*$/,
+      "Key must start with a letter, be lowercase, and contain only letters, numbers, and underscores"
+    ),
+  display_name: z.string().min(1, "Display name is required"),
+  description: z.string().optional(),
+  icon: z.string().optional(),
+})
+
+type CreateEntityFormData = z.infer<typeof createEntitySchema>
+
+interface CreateEntityDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: CreateEntityFormData) => Promise<void>
+}
+
+export function CreateEntityDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+}: CreateEntityDialogProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const form = useForm<CreateEntityFormData>({
+    resolver: zodResolver(createEntitySchema),
+    defaultValues: {
+      key: "",
+      display_name: "",
+      description: "",
+      icon: "",
+    },
+  })
+
+  const handleSubmit = async (data: CreateEntityFormData) => {
+    setIsSubmitting(true)
+    try {
+      await onSubmit(data)
+      form.reset()
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Failed to create entity:", error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Create custom entity</DialogTitle>
+          <DialogDescription>
+            Create an entity to model your data.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="key"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Key</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="Alphanumeric lowercase with underscores"
+                      onChange={(e) =>
+                        field.onChange(e.target.value.toLowerCase())
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    This cannot be changed after creation
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="display_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Write a short human-readable name"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      className="resize-none text-xs"
+                      placeholder="Write a description"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="icon"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Icon</FormLabel>
+                  <FormControl>
+                    <IconPicker
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      className="text-xs"
+                      placeholder="Select an icon to represent this entity (optional)"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Creating..." : "Create entity"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/entities/create-field-dialog.tsx
+++ b/frontend/src/components/entities/create-field-dialog.tsx
@@ -5,7 +5,7 @@ import {
   Braces,
   Calendar,
   CalendarClock,
-  DecimalsArrowRight,
+  CircleDot,
   Hash,
   Info,
   ListTodo,
@@ -60,7 +60,7 @@ const fieldTypes: {
 }[] = [
   { value: "TEXT", label: "Text", icon: Type },
   { value: "INTEGER", label: "Integer", icon: Hash },
-  { value: "NUMBER", label: "Number", icon: DecimalsArrowRight },
+  { value: "NUMBER", label: "Number", icon: CircleDot },
   { value: "BOOL", label: "Boolean", icon: ToggleLeft },
   { value: "JSON", label: "JSON", icon: Braces },
   { value: "DATE", label: "Date", icon: Calendar },

--- a/frontend/src/components/entities/create-field-dialog.tsx
+++ b/frontend/src/components/entities/create-field-dialog.tsx
@@ -1,0 +1,441 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import {
+  Braces,
+  Calendar,
+  CalendarClock,
+  DecimalsArrowRight,
+  Hash,
+  Info,
+  ListTodo,
+  SquareCheck,
+  ToggleLeft,
+  Type,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import type { EntityFieldCreate, FieldType } from "@/client"
+import { MultiTagCommandInput } from "@/components/tags-input"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+const fieldTypes: {
+  value: FieldType
+  label: string
+  icon: React.ElementType
+}[] = [
+  { value: "TEXT", label: "Text", icon: Type },
+  { value: "INTEGER", label: "Integer", icon: Hash },
+  { value: "NUMBER", label: "Number", icon: DecimalsArrowRight },
+  { value: "BOOL", label: "Boolean", icon: ToggleLeft },
+  { value: "JSON", label: "JSON", icon: Braces },
+  { value: "DATE", label: "Date", icon: Calendar },
+  { value: "DATETIME", label: "Date and time", icon: CalendarClock },
+  { value: "SELECT", label: "Select", icon: SquareCheck },
+  { value: "MULTI_SELECT", label: "Multi-select", icon: ListTodo },
+]
+
+const createFieldSchema = z.object({
+  key: z
+    .string()
+    .min(1, "Field key is required")
+    .regex(
+      /^[a-z][a-z0-9_]*$/,
+      "Field key must start with a letter, be lowercase, and contain only letters, numbers, and underscores"
+    ),
+  type: z.enum([
+    "TEXT",
+    "INTEGER",
+    "NUMBER",
+    "BOOL",
+    "JSON",
+    "DATE",
+    "DATETIME",
+    "SELECT",
+    "MULTI_SELECT",
+  ] as const),
+  display_name: z.string().min(1, "Display name is required"),
+  description: z.string().optional(),
+  default_value: z.any().optional(),
+  options: z.array(z.string()).optional(),
+})
+
+type CreateFieldFormData = z.infer<typeof createFieldSchema>
+
+// Primitive field types that support default values
+const PRIMITIVE_FIELD_TYPES: FieldType[] = [
+  "TEXT",
+  "INTEGER",
+  "NUMBER",
+  "BOOL",
+  "JSON",
+  "SELECT",
+  "MULTI_SELECT",
+]
+
+interface CreateFieldDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: EntityFieldCreate) => Promise<void>
+  errorMessage?: string
+}
+
+export function CreateFieldDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  errorMessage,
+}: CreateFieldDialogProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const form = useForm<CreateFieldFormData>({
+    resolver: zodResolver(createFieldSchema),
+    defaultValues: {
+      key: "",
+      type: "TEXT" as const,
+      display_name: "",
+      description: "",
+      default_value: "",
+      options: [],
+    },
+  })
+
+  const fieldType = form.watch("type")
+  const supportsPrimitive = useMemo(
+    () => PRIMITIVE_FIELD_TYPES.includes(fieldType),
+    [fieldType]
+  )
+  const isSelectField = useMemo(
+    () => fieldType === "SELECT" || fieldType === "MULTI_SELECT",
+    [fieldType]
+  )
+
+  const handleSubmit = async (data: CreateFieldFormData) => {
+    setIsSubmitting(true)
+    try {
+      setSubmitError(null)
+      const processed = {
+        key: data.key,
+        type: data.type,
+        display_name: data.display_name,
+      } as EntityFieldCreate
+
+      if (data.description && data.description !== "") {
+        processed.description = data.description
+      }
+
+      if (
+        data.default_value !== undefined &&
+        data.default_value !== "" &&
+        data.default_value !== "_none"
+      ) {
+        if (data.type === "INTEGER") {
+          processed.default_value = parseInt(data.default_value as string, 10)
+        } else if (data.type === "NUMBER") {
+          processed.default_value = parseFloat(data.default_value as string)
+        } else if (data.type === "BOOL") {
+          processed.default_value = data.default_value === "true"
+        } else if (data.type === "MULTI_SELECT") {
+          const value = data.default_value as string
+          processed.default_value = value
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+        } else if (data.type === "JSON") {
+          try {
+            processed.default_value = JSON.parse(data.default_value as string)
+          } catch {
+            processed.default_value = data.default_value
+          }
+        }
+      } else {
+        delete processed.default_value
+      }
+
+      if (isSelectField) {
+        if (data.options && data.options.length > 0) {
+          processed.options = data.options.map((label) => ({ label }))
+        } else {
+          throw new Error("Please add at least one option for this field type")
+        }
+      } else {
+        delete processed.options
+      }
+
+      await onSubmit(processed)
+      form.reset()
+      onOpenChange(false)
+    } catch (error: unknown) {
+      console.error("Failed to create field:", error)
+      let message = "Failed to create the field. Please try again."
+      const err = error as {
+        body?: { detail?: string | string[]; message?: string; error?: string }
+        message?: string
+        status?: number
+        statusText?: string
+      }
+      const detail = err?.body?.detail
+      if (Array.isArray(detail)) message = detail.join("\n")
+      else
+        message =
+          (typeof detail === "string" && detail) ||
+          err?.body?.message ||
+          err?.body?.error ||
+          (err?.status && err?.statusText
+            ? `${err.status} ${err.statusText}`
+            : err?.message) ||
+          message
+      setSubmitError(message)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!open) setSubmitError(null)
+  }, [open])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Add field</DialogTitle>
+          <DialogDescription>Add a new field to this entity.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+          >
+            {(submitError || errorMessage) && (
+              <Alert variant="destructive">
+                <AlertTitle>Failed to create field</AlertTitle>
+                <AlertDescription>
+                  {submitError || errorMessage}
+                </AlertDescription>
+              </Alert>
+            )}
+            <FormField
+              control={form.control}
+              name="key"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Key</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Alphanumeric lowercase with underscores"
+                      {...field}
+                      onChange={(e) =>
+                        field.onChange(e.target.value.toLowerCase())
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    This cannot be changed after creation
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="display_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Write a short human-readable name"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="flex items-center gap-2">
+                    <FormLabel>Data type</FormLabel>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info className="h-4 w-4 text-muted-foreground" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>* Supports default value on entity creation</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a field type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {fieldTypes.map((type) => {
+                        const Icon = type.icon
+                        const supportsDefault = PRIMITIVE_FIELD_TYPES.includes(
+                          type.value
+                        )
+                        return (
+                          <SelectItem key={type.value} value={type.value}>
+                            <div className="flex items-center gap-2">
+                              <Icon className="h-4 w-4" />
+                              <span>
+                                {type.label}
+                                {supportsDefault && " *"}
+                              </span>
+                            </div>
+                          </SelectItem>
+                        )
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Write a description"
+                      className="resize-none text-xs"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {isSelectField && (
+              <FormField
+                control={form.control}
+                name="options"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Options</FormLabel>
+                    <FormControl>
+                      <MultiTagCommandInput
+                        value={field.value || []}
+                        onChange={field.onChange}
+                        placeholder="Add options..."
+                        allowCustomTags
+                        disableSuggestions
+                        className="w-full"
+                        searchKeys={["label"]}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+            {supportsPrimitive && (
+              <FormField
+                control={form.control}
+                name="default_value"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Default value</FormLabel>
+                    <FormControl>
+                      {fieldType === "BOOL" ? (
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value?.toString() || "_none"}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select default value" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="_none">No default</SelectItem>
+                            <SelectItem value="true">True</SelectItem>
+                            <SelectItem value="false">False</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <Input
+                          placeholder={
+                            fieldType === "INTEGER"
+                              ? "Enter integer default"
+                              : fieldType === "NUMBER"
+                                ? "Enter number default"
+                                : fieldType === "MULTI_SELECT"
+                                  ? "Comma-separated values"
+                                  : fieldType === "JSON"
+                                    ? '{"key": "value"} or []'
+                                    : "Enter default value"
+                          }
+                          {...field}
+                        />
+                      )}
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Creating..." : "Create field"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/entities/edit-entity-dialog.tsx
+++ b/frontend/src/components/entities/edit-entity-dialog.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import type { EntityRead } from "@/client"
+import { IconPicker } from "@/components/form/icon-picker"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+const schema = z.object({
+  display_name: z.string().min(1, "Display name is required"),
+  description: z.string().optional(),
+  icon: z.string().optional(),
+})
+
+export type EditEntityForm = z.infer<typeof schema>
+
+interface EditEntityDialogProps {
+  entity: EntityRead | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (data: EditEntityForm) => Promise<void>
+  isPending?: boolean
+}
+
+export function EditEntityDialog({
+  entity,
+  open,
+  onOpenChange,
+  onSubmit,
+  isPending,
+}: EditEntityDialogProps) {
+  const form = useForm<EditEntityForm>({
+    resolver: zodResolver(schema),
+    values: {
+      display_name: entity?.display_name || "",
+      description: entity?.description || "",
+      icon: entity?.icon || "",
+    },
+  })
+
+  useEffect(() => {
+    form.reset({
+      display_name: entity?.display_name || "",
+      description: entity?.description || "",
+      icon: entity?.icon || "",
+    })
+  }, [entity])
+
+  const handleSubmit = async (data: EditEntityForm) => {
+    await onSubmit({
+      display_name: data.display_name,
+      description: data.description || "",
+      icon: data.icon || "",
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Edit entity</DialogTitle>
+          <DialogDescription>Update entity details.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+          >
+            <FormItem>
+              <FormLabel>Identifier / Slug</FormLabel>
+              <FormControl>
+                <Input
+                  value={entity?.key || ""}
+                  disabled
+                  className="bg-muted text-xs"
+                />
+              </FormControl>
+              <FormDescription className="text-xs">
+                The entity key cannot be changed after creation
+              </FormDescription>
+            </FormItem>
+
+            <FormField
+              control={form.control}
+              name="display_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Write a short human-readable name"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      className="text-xs resize-none"
+                      placeholder="Write a description"
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="icon"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Icon</FormLabel>
+                  <FormControl>
+                    <IconPicker
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      className="text-xs"
+                      placeholder="Select an icon (optional)"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Saving..." : "Save changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/entities/edit-field-dialog.tsx
+++ b/frontend/src/components/entities/edit-field-dialog.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import type { EntityFieldRead, EntityFieldUpdate, FieldType } from "@/client"
+import { MultiTagCommandInput } from "@/components/tags-input"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+const editFieldSchema = z.object({
+  display_name: z.string().min(1, "Display name is required"),
+  description: z.string().optional(),
+  options: z.array(z.string()).optional(),
+})
+
+type EditFieldForm = z.infer<typeof editFieldSchema>
+
+interface EditFieldDialogProps {
+  field: EntityFieldRead | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (fieldId: string, data: EntityFieldUpdate) => Promise<void>
+  isPending?: boolean
+}
+
+export function EditFieldDialog({
+  field,
+  open,
+  onOpenChange,
+  onSubmit,
+  isPending,
+}: EditFieldDialogProps) {
+  const isSelectField = useMemo(() => {
+    const t: FieldType | undefined = field?.type
+    return t === "SELECT" || t === "MULTI_SELECT"
+  }, [field?.type])
+
+  const form = useForm<EditFieldForm>({
+    resolver: zodResolver(editFieldSchema),
+    values: {
+      display_name: field?.display_name || "",
+      description: field?.description || "",
+      options: field?.options?.map((o) => o.label) || [],
+    },
+  })
+
+  const handleSubmit = async (data: EditFieldForm) => {
+    if (!field) return
+    try {
+      const updateData: EntityFieldUpdate = {
+        display_name: data.display_name,
+        description: data.description || null,
+      }
+      if (isSelectField) {
+        if (data.options && data.options.length > 0) {
+          updateData.options = data.options.map((label) => ({ label }))
+        } else {
+          throw new Error("Please add at least one option for this field type")
+        }
+      }
+      await onSubmit(field.id, updateData)
+      onOpenChange(false)
+      form.reset()
+    } catch (error) {
+      console.error("Failed to update field:", error)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit field</DialogTitle>
+          <DialogDescription>
+            Update the name and description for this field.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+          >
+            <FormItem>
+              <FormLabel>Identifier / Slug</FormLabel>
+              <FormControl>
+                <Input
+                  value={field?.key || ""}
+                  disabled
+                  className="bg-muted text-xs"
+                />
+              </FormControl>
+              <FormDescription className="text-xs">
+                The field key cannot be changed after creation
+              </FormDescription>
+            </FormItem>
+
+            <FormItem>
+              <FormLabel>Data type</FormLabel>
+              <FormControl>
+                <Input
+                  value={field?.type || ""}
+                  disabled
+                  className="bg-muted text-xs"
+                />
+              </FormControl>
+              <FormDescription className="text-xs">
+                The field type cannot be changed after creation
+              </FormDescription>
+            </FormItem>
+
+            <FormField
+              control={form.control}
+              name="display_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      className="text-xs"
+                      placeholder="Write a short human-readable name"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder="Write a description"
+                      className="resize-none text-xs"
+                      rows={3}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {isSelectField && (
+              <FormField
+                control={form.control}
+                name="options"
+                render={({ field: formField }) => (
+                  <FormItem>
+                    <FormLabel>Options</FormLabel>
+                    <FormControl>
+                      <MultiTagCommandInput
+                        value={formField.value || []}
+                        onChange={formField.onChange}
+                        placeholder="Add options..."
+                        allowCustomTags
+                        disableSuggestions
+                        className="w-full"
+                        searchKeys={["label"]}
+                      />
+                    </FormControl>
+                    <FormDescription className="text-xs">
+                      Add or remove available options for this field
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Saving..." : "Save changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/entities/entities-table.tsx
+++ b/frontend/src/components/entities/entities-table.tsx
@@ -1,0 +1,427 @@
+"use client"
+
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { CheckCircle, Copy, Eye, Pencil, Trash2, XCircle } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import type { EntityRead } from "@/client"
+import {
+  DataTable,
+  DataTableColumnHeader,
+  type DataTableToolbarProps,
+} from "@/components/data-table"
+import { EditEntityDialog } from "@/components/entities/edit-entity-dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { getIconByName } from "@/lib/icons"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+interface EntitiesTableProps {
+  entities: EntityRead[]
+  fieldCounts: Record<string, number>
+  onEditEntity?: (
+    entity: EntityRead,
+    data: { display_name: string; description?: string; icon?: string }
+  ) => Promise<void>
+  onDeleteEntity?: (entityId: string) => Promise<void>
+  onDeactivateEntity: (entityId: string) => Promise<void>
+  onReactivateEntity: (entityId: string) => Promise<void>
+  isDeleting?: boolean
+  isUpdating?: boolean
+}
+
+export function EntitiesTable({
+  entities,
+  fieldCounts,
+  onEditEntity,
+  onDeleteEntity,
+  onDeactivateEntity,
+  onReactivateEntity,
+  isDeleting,
+  isUpdating,
+}: EntitiesTableProps) {
+  const router = useRouter()
+  const workspaceId = useWorkspaceId()
+  const [selectedEntity, setSelectedEntity] = useState<EntityRead | null>(null)
+  const [actionType, setActionType] = useState<"deactivate" | "delete" | null>(
+    null
+  )
+  const [settingsDialogOpen, setSettingsDialogOpen] = useState(false)
+  const [entityToEdit, setEntityToEdit] = useState<EntityRead | null>(null)
+
+  return (
+    <>
+      <AlertDialog
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setSelectedEntity(null)
+            setActionType(null)
+          }
+        }}
+      >
+        <DataTable
+          data={entities}
+          emptyMessage="No entities found."
+          getRowHref={(row) =>
+            row.original.is_active
+              ? `/workspaces/${workspaceId}/entities/${row.original.id}`
+              : undefined
+          }
+          columns={[
+            {
+              accessorKey: "display_name",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Entity"
+                />
+              ),
+              cell: ({ row }) => {
+                const IconComponent = row.original.icon
+                  ? getIconByName(row.original.icon)
+                  : undefined
+                const initials =
+                  row.original.display_name?.[0]?.toUpperCase() || "?"
+
+                return (
+                  <div className="flex items-center gap-2.5">
+                    <Avatar className="size-7 shrink-0">
+                      <AvatarFallback className="text-xs">
+                        {IconComponent ? (
+                          <IconComponent className="size-4" />
+                        ) : (
+                          initials
+                        )}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <div className="text-sm font-medium">
+                        {row.original.display_name}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {row.original.key}
+                      </div>
+                    </div>
+                  </div>
+                )
+              },
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "description",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Description"
+                />
+              ),
+              cell: ({ row }) => {
+                const desc = row.original.description as
+                  | string
+                  | null
+                  | undefined
+                if (!desc) return <div className="text-xs">-</div>
+                const truncated =
+                  desc.length > 140 ? `${desc.slice(0, 140)}...` : desc
+                const needsTooltip = desc.length > 140
+                return needsTooltip ? (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="text-xs truncate max-w-[360px]">
+                          {truncated}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <div className="max-w-xs text-xs whitespace-pre-wrap">
+                          {desc}
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ) : (
+                  <div className="text-xs">{truncated}</div>
+                )
+              },
+              enableSorting: false,
+              enableHiding: false,
+            },
+            {
+              id: "status",
+              accessorFn: (row) => (row.is_active ? "active" : "inactive"),
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Status"
+                />
+              ),
+              cell: ({ row }) => (
+                <Badge
+                  variant={row.original.is_active ? "default" : "secondary"}
+                  className="text-xs"
+                >
+                  {row.original.is_active ? "Active" : "Inactive"}
+                </Badge>
+              ),
+              filterFn: (row, _id, value: string[]) => {
+                const status = row.original.is_active ? "active" : "inactive"
+                return value.includes(status)
+              },
+              enableSorting: true,
+              enableHiding: false,
+              enableColumnFilter: true,
+            },
+            {
+              id: "fields",
+              accessorFn: (row) => fieldCounts[row.id] || 0,
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Fields"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {fieldCounts[row.original.id] || 0}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              id: "actions",
+              enableHiding: false,
+              cell: ({ row }) => {
+                return (
+                  <div className="flex justify-end">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          className="size-8 p-0"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <span className="sr-only">Open menu</span>
+                          <DotsHorizontalIcon className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            navigator.clipboard.writeText(row.original.id)
+                          }}
+                        >
+                          <Copy className="mr-2 h-3 w-3" />
+                          Copy entity ID
+                        </DropdownMenuItem>
+                        {row.original.is_active && (
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              router.push(
+                                `/workspaces/${workspaceId}/entities/${row.original.id}`
+                              )
+                            }}
+                          >
+                            <Eye className="mr-2 h-3 w-3" />
+                            View fields
+                          </DropdownMenuItem>
+                        )}
+                        {row.original.is_active && onEditEntity && (
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              setEntityToEdit(row.original)
+                              setSettingsDialogOpen(true)
+                            }}
+                          >
+                            <Pencil className="mr-2 h-3 w-3" />
+                            Edit entity
+                          </DropdownMenuItem>
+                        )}
+                        {row.original.is_active ? (
+                          <>
+                            <DropdownMenuSeparator />
+                            <AlertDialogTrigger asChild>
+                              <DropdownMenuItem
+                                className="text-rose-500 focus:text-rose-600"
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  setSelectedEntity(row.original)
+                                  setActionType("deactivate")
+                                }}
+                              >
+                                <XCircle className="mr-2 h-3 w-3" />
+                                Archive entity
+                              </DropdownMenuItem>
+                            </AlertDialogTrigger>
+                          </>
+                        ) : (
+                          <>
+                            <DropdownMenuItem
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                // Reactivate without blocking UI
+                                onReactivateEntity(row.original.id).catch(
+                                  (error) => {
+                                    console.error(
+                                      "Failed to reactivate entity:",
+                                      error
+                                    )
+                                  }
+                                )
+                              }}
+                            >
+                              <CheckCircle className="mr-2 h-3 w-3" />
+                              Restore entity
+                            </DropdownMenuItem>
+                            {onDeleteEntity && (
+                              <>
+                                <DropdownMenuSeparator />
+                                <AlertDialogTrigger asChild>
+                                  <DropdownMenuItem
+                                    className="text-rose-500 focus:text-rose-600"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      setSelectedEntity(row.original)
+                                      setActionType("delete")
+                                    }}
+                                  >
+                                    <Trash2 className="mr-2 h-3 w-3" />
+                                    Delete entity
+                                  </DropdownMenuItem>
+                                </AlertDialogTrigger>
+                              </>
+                            )}
+                          </>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                )
+              },
+            },
+          ]}
+          toolbarProps={defaultToolbarProps}
+        />
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {actionType === "delete"
+                ? "Delete entity permanently"
+                : "Archive entity"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {actionType === "delete" ? (
+                <>
+                  Are you sure you want to permanently delete the entity{" "}
+                  <strong>{selectedEntity?.display_name}</strong>? This action
+                  cannot be undone. All fields, records, and associated data
+                  will be permanently deleted.
+                </>
+              ) : (
+                <>
+                  Are you sure you want to archive the entity{" "}
+                  <strong>{selectedEntity?.display_name}</strong>? This will
+                  hide the entity from normal use, but all data will be
+                  preserved. You can restore the entity later.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant={actionType === "delete" ? "destructive" : "default"}
+              onClick={async () => {
+                if (selectedEntity) {
+                  try {
+                    if (actionType === "delete" && onDeleteEntity) {
+                      await onDeleteEntity(selectedEntity.id)
+                    } else if (actionType === "deactivate") {
+                      await onDeactivateEntity(selectedEntity.id)
+                    }
+                    setSelectedEntity(null)
+                    setActionType(null)
+                  } catch (error) {
+                    console.error(`Failed to ${actionType} entity:`, error)
+                  }
+                }
+              }}
+              disabled={isDeleting}
+            >
+              {actionType === "delete" ? "Delete Permanently" : "Archive"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {onEditEntity && (
+        <EditEntityDialog
+          entity={entityToEdit}
+          open={settingsDialogOpen}
+          onOpenChange={(open) => {
+            setSettingsDialogOpen(open)
+            if (!open) setEntityToEdit(null)
+          }}
+          onSubmit={async (data) => {
+            if (entityToEdit) {
+              await onEditEntity(entityToEdit, data)
+              setSettingsDialogOpen(false)
+              setEntityToEdit(null)
+            }
+          }}
+          isPending={isUpdating}
+        />
+      )}
+    </>
+  )
+}
+
+const defaultToolbarProps: DataTableToolbarProps<EntityRead> = {
+  filterProps: {
+    placeholder: "Filter entities...",
+    column: "display_name",
+  },
+  fields: [
+    {
+      column: "status",
+      title: "Status",
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+    },
+  ],
+}

--- a/frontend/src/components/entities/entities-table.tsx
+++ b/frontend/src/components/entities/entities-table.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import { DotsHorizontalIcon } from "@radix-ui/react-icons"
-import { CheckCircle, Copy, Eye, Pencil, Trash2, XCircle } from "lucide-react"
-import { useRouter } from "next/navigation"
+// no router needed for actions; only building href strings
 import { useState } from "react"
 import type { EntityRead } from "@/client"
 import {
@@ -12,26 +10,13 @@ import {
 } from "@/components/data-table"
 import { EditEntityDialog } from "@/components/entities/edit-entity-dialog"
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
+  EntityArchiveAlertDialog,
+  EntityDeleteAlertDialog,
+} from "@/components/entities/entity-confirm-dialog"
+import { EntityActions } from "@/components/entities/table-actions"
+import { ActiveDialog } from "@/components/entities/table-common"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import {
   Tooltip,
   TooltipContent,
@@ -65,327 +50,190 @@ export function EntitiesTable({
   isDeleting,
   isUpdating,
 }: EntitiesTableProps) {
-  const router = useRouter()
   const workspaceId = useWorkspaceId()
   const [selectedEntity, setSelectedEntity] = useState<EntityRead | null>(null)
-  const [actionType, setActionType] = useState<"deactivate" | "delete" | null>(
-    null
-  )
+  const [activeDialog, setActiveDialog] = useState<ActiveDialog | null>(null)
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false)
   const [entityToEdit, setEntityToEdit] = useState<EntityRead | null>(null)
 
   return (
     <>
-      <AlertDialog
-        onOpenChange={(isOpen) => {
-          if (!isOpen) {
-            setSelectedEntity(null)
-            setActionType(null)
-          }
-        }}
-      >
-        <DataTable
-          data={entities}
-          emptyMessage="No entities found."
-          getRowHref={(row) =>
-            row.original.is_active
-              ? `/workspaces/${workspaceId}/entities/${row.original.id}`
-              : undefined
-          }
-          columns={[
-            {
-              accessorKey: "display_name",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Entity"
-                />
-              ),
-              cell: ({ row }) => {
-                const IconComponent = row.original.icon
-                  ? getIconByName(row.original.icon)
-                  : undefined
-                const initials =
-                  row.original.display_name?.[0]?.toUpperCase() || "?"
+      <DataTable
+        data={entities}
+        emptyMessage="No entities found."
+        getRowHref={(row) =>
+          row.original.is_active
+            ? `/workspaces/${workspaceId}/entities/${row.original.id}`
+            : undefined
+        }
+        columns={[
+          {
+            accessorKey: "display_name",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Entity"
+              />
+            ),
+            cell: ({ row }) => {
+              const IconComponent = row.original.icon
+                ? getIconByName(row.original.icon)
+                : undefined
+              const initials =
+                row.original.display_name?.[0]?.toUpperCase() || "?"
 
-                return (
-                  <div className="flex items-center gap-2.5">
-                    <Avatar className="size-7 shrink-0">
-                      <AvatarFallback className="text-xs">
-                        {IconComponent ? (
-                          <IconComponent className="size-4" />
-                        ) : (
-                          initials
-                        )}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div>
-                      <div className="text-sm font-medium">
-                        {row.original.display_name}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {row.original.key}
-                      </div>
+              return (
+                <div className="flex items-center gap-2.5">
+                  <Avatar className="size-7 shrink-0">
+                    <AvatarFallback className="text-xs">
+                      {IconComponent ? (
+                        <IconComponent className="size-4" />
+                      ) : (
+                        initials
+                      )}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <div className="text-sm font-medium">
+                      {row.original.display_name}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {row.original.key}
                     </div>
                   </div>
-                )
-              },
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "description",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Description"
-                />
-              ),
-              cell: ({ row }) => {
-                const desc = row.original.description as
-                  | string
-                  | null
-                  | undefined
-                if (!desc) return <div className="text-xs">-</div>
-                const truncated =
-                  desc.length > 140 ? `${desc.slice(0, 140)}...` : desc
-                const needsTooltip = desc.length > 140
-                return needsTooltip ? (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="text-xs truncate max-w-[360px]">
-                          {truncated}
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <div className="max-w-xs text-xs whitespace-pre-wrap">
-                          {desc}
-                        </div>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ) : (
-                  <div className="text-xs">{truncated}</div>
-                )
-              },
-              enableSorting: false,
-              enableHiding: false,
-            },
-            {
-              id: "status",
-              accessorFn: (row) => (row.is_active ? "active" : "inactive"),
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Status"
-                />
-              ),
-              cell: ({ row }) => (
-                <Badge
-                  variant={row.original.is_active ? "default" : "secondary"}
-                  className="text-xs"
-                >
-                  {row.original.is_active ? "Active" : "Inactive"}
-                </Badge>
-              ),
-              filterFn: (row, _id, value: string[]) => {
-                const status = row.original.is_active ? "active" : "inactive"
-                return value.includes(status)
-              },
-              enableSorting: true,
-              enableHiding: false,
-              enableColumnFilter: true,
-            },
-            {
-              id: "fields",
-              accessorFn: (row) => fieldCounts[row.id] || 0,
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Fields"
-                />
-              ),
-              cell: ({ row }) => (
-                <div className="text-xs">
-                  {fieldCounts[row.original.id] || 0}
                 </div>
-              ),
-              enableSorting: true,
-              enableHiding: false,
+              )
             },
-            {
-              id: "actions",
-              enableHiding: false,
-              cell: ({ row }) => {
-                return (
-                  <div className="flex justify-end">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          className="size-8 p-0"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <span className="sr-only">Open menu</span>
-                          <DotsHorizontalIcon className="size-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            navigator.clipboard.writeText(row.original.id)
-                          }}
-                        >
-                          <Copy className="mr-2 h-3 w-3" />
-                          Copy entity ID
-                        </DropdownMenuItem>
-                        {row.original.is_active && (
-                          <DropdownMenuItem
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              router.push(
-                                `/workspaces/${workspaceId}/entities/${row.original.id}`
-                              )
-                            }}
-                          >
-                            <Eye className="mr-2 h-3 w-3" />
-                            View fields
-                          </DropdownMenuItem>
-                        )}
-                        {row.original.is_active && onEditEntity && (
-                          <DropdownMenuItem
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setEntityToEdit(row.original)
-                              setSettingsDialogOpen(true)
-                            }}
-                          >
-                            <Pencil className="mr-2 h-3 w-3" />
-                            Edit entity
-                          </DropdownMenuItem>
-                        )}
-                        {row.original.is_active ? (
-                          <>
-                            <DropdownMenuSeparator />
-                            <AlertDialogTrigger asChild>
-                              <DropdownMenuItem
-                                className="text-rose-500 focus:text-rose-600"
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  setSelectedEntity(row.original)
-                                  setActionType("deactivate")
-                                }}
-                              >
-                                <XCircle className="mr-2 h-3 w-3" />
-                                Archive entity
-                              </DropdownMenuItem>
-                            </AlertDialogTrigger>
-                          </>
-                        ) : (
-                          <>
-                            <DropdownMenuItem
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                // Reactivate without blocking UI
-                                onReactivateEntity(row.original.id).catch(
-                                  (error) => {
-                                    console.error(
-                                      "Failed to reactivate entity:",
-                                      error
-                                    )
-                                  }
-                                )
-                              }}
-                            >
-                              <CheckCircle className="mr-2 h-3 w-3" />
-                              Restore entity
-                            </DropdownMenuItem>
-                            {onDeleteEntity && (
-                              <>
-                                <DropdownMenuSeparator />
-                                <AlertDialogTrigger asChild>
-                                  <DropdownMenuItem
-                                    className="text-rose-500 focus:text-rose-600"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      setSelectedEntity(row.original)
-                                      setActionType("delete")
-                                    }}
-                                  >
-                                    <Trash2 className="mr-2 h-3 w-3" />
-                                    Delete entity
-                                  </DropdownMenuItem>
-                                </AlertDialogTrigger>
-                              </>
-                            )}
-                          </>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                )
-              },
-            },
-          ]}
-          toolbarProps={defaultToolbarProps}
-        />
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {actionType === "delete"
-                ? "Delete entity permanently"
-                : "Archive entity"}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {actionType === "delete" ? (
-                <>
-                  Are you sure you want to permanently delete the entity{" "}
-                  <strong>{selectedEntity?.display_name}</strong>? This action
-                  cannot be undone. All fields, records, and associated data
-                  will be permanently deleted.
-                </>
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "description",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Description"
+              />
+            ),
+            cell: ({ row }) => {
+              const desc = row.original.description as string | null | undefined
+              if (!desc) return <div className="text-xs">-</div>
+              const truncated =
+                desc.length > 140 ? `${desc.slice(0, 140)}...` : desc
+              const needsTooltip = desc.length > 140
+              return needsTooltip ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-xs truncate max-w-[360px]">
+                        {truncated}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="max-w-xs text-xs whitespace-pre-wrap">
+                        {desc}
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               ) : (
-                <>
-                  Are you sure you want to archive the entity{" "}
-                  <strong>{selectedEntity?.display_name}</strong>? This will
-                  hide the entity from normal use, but all data will be
-                  preserved. You can restore the entity later.
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              variant={actionType === "delete" ? "destructive" : "default"}
-              onClick={async () => {
-                if (selectedEntity) {
-                  try {
-                    if (actionType === "delete" && onDeleteEntity) {
-                      await onDeleteEntity(selectedEntity.id)
-                    } else if (actionType === "deactivate") {
-                      await onDeactivateEntity(selectedEntity.id)
+                <div className="text-xs">{truncated}</div>
+              )
+            },
+            enableSorting: false,
+            enableHiding: false,
+          },
+          {
+            id: "status",
+            accessorFn: (row) => (row.is_active ? "active" : "inactive"),
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Status"
+              />
+            ),
+            cell: ({ row }) => (
+              <Badge
+                variant={row.original.is_active ? "default" : "secondary"}
+                className="text-xs"
+              >
+                {row.original.is_active ? "Active" : "Inactive"}
+              </Badge>
+            ),
+            filterFn: (row, _id, value: string[]) => {
+              const status = row.original.is_active ? "active" : "inactive"
+              return value.includes(status)
+            },
+            enableSorting: true,
+            enableHiding: false,
+            enableColumnFilter: true,
+          },
+          {
+            id: "fields",
+            accessorFn: (row) => fieldCounts[row.id] || 0,
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Fields"
+              />
+            ),
+            cell: ({ row }) => (
+              <div className="text-xs">{fieldCounts[row.original.id] || 0}</div>
+            ),
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            id: "actions",
+            enableHiding: false,
+            cell: ({ row }) => {
+              return (
+                <div className="flex justify-end">
+                  <EntityActions
+                    entity={row.original}
+                    setSelectedEntity={(e) => setSelectedEntity(e)}
+                    setActiveDialog={setActiveDialog}
+                    onReactivateEntity={onReactivateEntity}
+                    onEdit={
+                      onEditEntity
+                        ? (e) => {
+                            setEntityToEdit(e)
+                            setSettingsDialogOpen(true)
+                          }
+                        : undefined
                     }
-                    setSelectedEntity(null)
-                    setActionType(null)
-                  } catch (error) {
-                    console.error(`Failed to ${actionType} entity:`, error)
-                  }
-                }
-              }}
-              disabled={isDeleting}
-            >
-              {actionType === "delete" ? "Delete Permanently" : "Archive"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+                  />
+                </div>
+              )
+            },
+          },
+        ]}
+        toolbarProps={defaultToolbarProps}
+      />
+
+      {/* Confirmation dialogs */}
+      <EntityArchiveAlertDialog
+        open={activeDialog === ActiveDialog.EntityArchive}
+        onOpenChange={() => setActiveDialog(null)}
+        selectedEntity={selectedEntity}
+        setSelectedEntity={setSelectedEntity}
+        onConfirm={onDeactivateEntity}
+        isPending={isDeleting}
+      />
+      {onDeleteEntity && (
+        <EntityDeleteAlertDialog
+          open={activeDialog === ActiveDialog.EntityDelete}
+          onOpenChange={() => setActiveDialog(null)}
+          selectedEntity={selectedEntity}
+          setSelectedEntity={setSelectedEntity}
+          onConfirm={onDeleteEntity}
+          isPending={isDeleting}
+        />
+      )}
 
       {onEditEntity && (
         <EditEntityDialog

--- a/frontend/src/components/entities/entity-confirm-dialog.tsx
+++ b/frontend/src/components/entities/entity-confirm-dialog.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import type { EntityRead } from "@/client"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+interface BaseProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isPending?: boolean
+}
+
+interface EntityActionDialogProps extends BaseProps {
+  selectedEntity: EntityRead | null
+  setSelectedEntity: (entity: EntityRead | null) => void
+  onConfirm: (entityId: string) => Promise<void>
+}
+
+export function EntityArchiveAlertDialog({
+  open,
+  onOpenChange,
+  selectedEntity,
+  setSelectedEntity,
+  onConfirm,
+  isPending,
+}: EntityActionDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) setSelectedEntity(null)
+        onOpenChange(isOpen)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Archive entity</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to archive the entity{" "}
+            <strong>{selectedEntity?.display_name}</strong>? This will hide the
+            entity from normal use, but all data will be preserved. You can
+            restore the entity later.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={async () => {
+              if (!selectedEntity) return
+              await onConfirm(selectedEntity.id)
+              setSelectedEntity(null)
+            }}
+            disabled={isPending}
+          >
+            Archive
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export function EntityDeleteAlertDialog({
+  open,
+  onOpenChange,
+  selectedEntity,
+  setSelectedEntity,
+  onConfirm,
+  isPending,
+}: EntityActionDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) setSelectedEntity(null)
+        onOpenChange(isOpen)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete entity permanently</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to permanently delete the entity{" "}
+            <strong>{selectedEntity?.display_name}</strong>? This action cannot
+            be undone. All fields, records, and associated data will be
+            permanently deleted.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={async () => {
+              if (!selectedEntity) return
+              await onConfirm(selectedEntity.id)
+              setSelectedEntity(null)
+            }}
+            disabled={isPending}
+          >
+            Delete Permanently
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/entities/entity-fields-table.tsx
+++ b/frontend/src/components/entities/entity-fields-table.tsx
@@ -1,0 +1,365 @@
+"use client"
+
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import {
+  Braces,
+  Calendar,
+  CalendarClock,
+  CheckCircle,
+  Copy,
+  DecimalsArrowRight,
+  Hash,
+  ListTodo,
+  Pencil,
+  SquareCheck,
+  ToggleLeft,
+  Trash2,
+  Type,
+  XCircle,
+} from "lucide-react"
+import { useState } from "react"
+import type { EntityFieldRead, FieldType } from "@/client"
+import {
+  DataTable,
+  DataTableColumnHeader,
+  type DataTableToolbarProps,
+} from "@/components/data-table"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+const fieldTypeConfig: Record<
+  FieldType,
+  { label: string; icon: React.ElementType }
+> = {
+  TEXT: { label: "Text", icon: Type },
+  INTEGER: { label: "Integer", icon: Hash },
+  NUMBER: { label: "Number", icon: DecimalsArrowRight },
+  BOOL: { label: "Boolean", icon: ToggleLeft },
+  JSON: { label: "JSON", icon: Braces },
+  DATE: { label: "Date", icon: Calendar },
+  DATETIME: { label: "Date and time", icon: CalendarClock },
+  SELECT: { label: "Select", icon: SquareCheck },
+  MULTI_SELECT: { label: "Multi-select", icon: ListTodo },
+}
+
+interface EntityFieldsTableProps {
+  fields: EntityFieldRead[]
+  onEditField?: (field: EntityFieldRead) => void
+  onDeleteField?: (fieldId: string) => Promise<void>
+  onDeactivateField?: (fieldId: string) => Promise<void>
+  onReactivateField?: (fieldId: string) => Promise<void>
+  isDeleting?: boolean
+}
+
+export function EntityFieldsTable({
+  fields,
+  onEditField,
+  onDeleteField,
+  onDeactivateField,
+  onReactivateField,
+  isDeleting,
+}: EntityFieldsTableProps) {
+  const [selectedField, setSelectedField] = useState<EntityFieldRead | null>(
+    null
+  )
+  const [actionType, setActionType] = useState<"delete" | "deactivate" | null>(
+    null
+  )
+
+  return (
+    <AlertDialog
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          setSelectedField(null)
+          setActionType(null)
+        }
+      }}
+    >
+      <DataTable
+        data={fields}
+        emptyMessage="No fields found."
+        columns={[
+          {
+            accessorKey: "display_name",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Field"
+              />
+            ),
+            cell: ({ row }) => (
+              <div>
+                <div className="text-sm font-medium">
+                  {row.original.display_name}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {row.original.key}
+                </div>
+              </div>
+            ),
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "type",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Data type"
+              />
+            ),
+            cell: ({ row }) => {
+              const t = row.getValue<FieldType>("type")
+              const cfg = fieldTypeConfig[t]
+              const Icon = cfg?.icon
+              return (
+                <Badge variant="secondary" className="text-xs">
+                  {Icon && <Icon className="mr-1.5 h-3 w-3" />}
+                  {cfg?.label || t}
+                </Badge>
+              )
+            },
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "description",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Description"
+              />
+            ),
+            cell: ({ row }) => {
+              const desc = row.getValue<string>("description")
+              if (!desc) return <div className="text-xs">-</div>
+              const truncated =
+                desc.length > 140 ? `${desc.slice(0, 140)}...` : desc
+              const needsTooltip = desc.length > 140
+              return needsTooltip ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-xs truncate max-w-[360px]">
+                        {truncated}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="max-w-xs text-xs whitespace-pre-wrap">
+                        {desc}
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                <div className="text-xs">{truncated}</div>
+              )
+            },
+            enableSorting: false,
+            enableHiding: false,
+          },
+          {
+            id: "status",
+            accessorFn: (row) => (row.is_active ? "active" : "inactive"),
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Status"
+              />
+            ),
+            cell: ({ row }) => (
+              <Badge
+                variant={row.original.is_active ? "default" : "secondary"}
+                className="text-xs"
+              >
+                {row.original.is_active ? "Active" : "Inactive"}
+              </Badge>
+            ),
+            filterFn: (row, _id, value: string[]) => {
+              const status = row.original.is_active ? "active" : "inactive"
+              return value.includes(status)
+            },
+            enableSorting: true,
+            enableHiding: false,
+            enableColumnFilter: true,
+          },
+          {
+            id: "actions",
+            enableHiding: false,
+            cell: ({ row }) => {
+              return (
+                <div className="flex justify-end">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" className="size-8 p-0">
+                        <span className="sr-only">Open menu</span>
+                        <DotsHorizontalIcon className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() =>
+                          navigator.clipboard.writeText(row.original.id)
+                        }
+                      >
+                        <Copy className="mr-2 h-3 w-3" />
+                        Copy field ID
+                      </DropdownMenuItem>
+                      {onEditField && (
+                        <DropdownMenuItem
+                          onClick={() => onEditField(row.original)}
+                        >
+                          <Pencil className="mr-2 h-3 w-3" />
+                          Edit field
+                        </DropdownMenuItem>
+                      )}
+                      {row.original.is_active && onDeactivateField && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              className="text-rose-500 focus:text-rose-600"
+                              onClick={() => {
+                                setSelectedField(row.original)
+                                setActionType("deactivate")
+                              }}
+                            >
+                              <XCircle className="mr-2 h-3 w-3" />
+                              Archive field
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                        </>
+                      )}
+                      {!row.original.is_active && onReactivateField && (
+                        <DropdownMenuItem
+                          onClick={() =>
+                            void onReactivateField(row.original.id)
+                          }
+                        >
+                          <CheckCircle className="mr-2 h-3 w-3" />
+                          Restore field
+                        </DropdownMenuItem>
+                      )}
+                      {!row.original.is_active && onDeleteField && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              className="text-rose-500 focus:text-rose-600"
+                              onClick={() => {
+                                setSelectedField(row.original)
+                                setActionType("delete")
+                              }}
+                            >
+                              <Trash2 className="mr-2 h-3 w-3" />
+                              Delete field
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              )
+            },
+          },
+        ]}
+        toolbarProps={defaultToolbarProps}
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {actionType === "delete"
+              ? "Delete field permanently"
+              : "Archive field"}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {actionType === "delete" ? (
+              <>
+                Are you sure you want to permanently delete the field{" "}
+                <strong>{selectedField?.display_name}</strong>? This action
+                cannot be undone and will delete all existing values for this
+                field across all records.
+              </>
+            ) : (
+              <>
+                Are you sure you want to archive the field{" "}
+                <strong>{selectedField?.display_name}</strong>? The field will
+                be hidden but data will be preserved.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant={actionType === "delete" ? "destructive" : "default"}
+            onClick={async () => {
+              if (selectedField) {
+                try {
+                  if (actionType === "delete" && onDeleteField) {
+                    await onDeleteField(selectedField.id)
+                  } else if (actionType === "deactivate" && onDeactivateField) {
+                    await onDeactivateField(selectedField.id)
+                  }
+                  setSelectedField(null)
+                  setActionType(null)
+                } catch (error) {
+                  console.error(`Failed to ${actionType} field:`, error)
+                }
+              }
+            }}
+            disabled={isDeleting}
+          >
+            {actionType === "delete" ? "Delete Permanently" : "Archive"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+const defaultToolbarProps: DataTableToolbarProps<EntityFieldRead> = {
+  filterProps: {
+    placeholder: "Filter fields...",
+    column: "display_name",
+  },
+  fields: [
+    {
+      column: "status",
+      title: "Status",
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+    },
+  ],
+}

--- a/frontend/src/components/entities/entity-fields-table.tsx
+++ b/frontend/src/components/entities/entity-fields-table.tsx
@@ -6,8 +6,8 @@ import {
   Calendar,
   CalendarClock,
   CheckCircle,
+  CircleDot,
   Copy,
-  DecimalsArrowRight,
   Hash,
   ListTodo,
   Pencil,
@@ -57,7 +57,7 @@ const fieldTypeConfig: Record<
 > = {
   TEXT: { label: "Text", icon: Type },
   INTEGER: { label: "Integer", icon: Hash },
-  NUMBER: { label: "Number", icon: DecimalsArrowRight },
+  NUMBER: { label: "Number", icon: CircleDot },
   BOOL: { label: "Boolean", icon: ToggleLeft },
   JSON: { label: "JSON", icon: Braces },
   DATE: { label: "Date", icon: Calendar },

--- a/frontend/src/components/entities/field-confirm-dialog.tsx
+++ b/frontend/src/components/entities/field-confirm-dialog.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import type { EntityFieldRead } from "@/client"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+interface BaseProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isPending?: boolean
+}
+
+interface FieldActionDialogProps extends BaseProps {
+  selectedField: EntityFieldRead | null
+  setSelectedField: (field: EntityFieldRead | null) => void
+  onConfirm: (fieldId: string) => Promise<void>
+}
+
+export function FieldArchiveAlertDialog({
+  open,
+  onOpenChange,
+  selectedField,
+  setSelectedField,
+  onConfirm,
+  isPending,
+}: FieldActionDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) setSelectedField(null)
+        onOpenChange(isOpen)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Archive field</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to archive the field{" "}
+            <strong>{selectedField?.display_name}</strong>? The field will be
+            hidden but data will be preserved.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={async () => {
+              if (!selectedField) return
+              await onConfirm(selectedField.id)
+              setSelectedField(null)
+            }}
+            disabled={isPending}
+          >
+            Archive
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export function FieldDeleteAlertDialog({
+  open,
+  onOpenChange,
+  selectedField,
+  setSelectedField,
+  onConfirm,
+  isPending,
+}: FieldActionDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) setSelectedField(null)
+        onOpenChange(isOpen)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete field permanently</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to permanently delete the field{" "}
+            <strong>{selectedField?.display_name}</strong>? This action cannot
+            be undone and will delete all existing values for this field across
+            all records.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={async () => {
+              if (!selectedField) return
+              await onConfirm(selectedField.id)
+              setSelectedField(null)
+            }}
+            disabled={isPending}
+          >
+            Delete Permanently
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/entities/table-actions.tsx
+++ b/frontend/src/components/entities/table-actions.tsx
@@ -1,0 +1,204 @@
+"use client"
+
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { CheckCircle, Copy, Eye, Pencil, Trash2, XCircle } from "lucide-react"
+import Link from "next/link"
+import type { EntityFieldRead, EntityRead } from "@/client"
+import { ActiveDialog } from "@/components/entities/table-common"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { toast } from "@/components/ui/use-toast"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+export function EntityActions({
+  entity,
+  setSelectedEntity,
+  setActiveDialog,
+  onReactivateEntity,
+  onEdit,
+}: {
+  entity: EntityRead
+  setSelectedEntity: (e: EntityRead) => void
+  setActiveDialog: (dialog: ActiveDialog | null) => void
+  onReactivateEntity?: (entityId: string) => Promise<void>
+  onEdit?: (e: EntityRead) => void
+}) {
+  const workspaceId = useWorkspaceId()
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className="size-8 p-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span className="sr-only">Open menu</span>
+          <DotsHorizontalIcon className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.stopPropagation()
+            navigator.clipboard.writeText(entity.id)
+            toast({ title: "Copied", description: "Entity ID copied." })
+          }}
+        >
+          <Copy className="mr-2 h-3 w-3" />
+          Copy entity ID
+        </DropdownMenuItem>
+
+        {entity.is_active && (
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+            asChild
+          >
+            <Link href={`/workspaces/${workspaceId}/entities/${entity.id}`}>
+              <Eye className="mr-2 h-3 w-3" />
+              View fields
+            </Link>
+          </DropdownMenuItem>
+        )}
+
+        {entity.is_active && onEdit && (
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation()
+              onEdit(entity)
+            }}
+          >
+            <Pencil className="mr-2 h-3 w-3" />
+            Edit entity
+          </DropdownMenuItem>
+        )}
+
+        {entity.is_active ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-rose-500 focus:text-rose-600"
+              onClick={(e) => {
+                e.stopPropagation()
+                setSelectedEntity(entity)
+                setActiveDialog(ActiveDialog.EntityArchive)
+              }}
+            >
+              <XCircle className="mr-2 h-3 w-3" />
+              Archive entity
+            </DropdownMenuItem>
+          </>
+        ) : (
+          <>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation()
+                onReactivateEntity?.(entity.id).catch((error) => {
+                  console.error("Failed to reactivate entity:", error)
+                })
+              }}
+            >
+              <CheckCircle className="mr-2 h-3 w-3" />
+              Restore entity
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-rose-500 focus:text-rose-600"
+              onClick={(e) => {
+                e.stopPropagation()
+                setSelectedEntity(entity)
+                setActiveDialog(ActiveDialog.EntityDelete)
+              }}
+            >
+              <Trash2 className="mr-2 h-3 w-3" />
+              Delete entity
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export function EntityFieldActions({
+  field,
+  setSelectedField,
+  setActiveDialog,
+  onReactivateField,
+  onEdit,
+}: {
+  field: EntityFieldRead
+  setSelectedField: (f: EntityFieldRead) => void
+  setActiveDialog: (dialog: ActiveDialog | null) => void
+  onReactivateField?: (fieldId: string) => Promise<void>
+  onEdit?: (f: EntityFieldRead) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="size-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <DotsHorizontalIcon className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={() => navigator.clipboard.writeText(field.id)}
+        >
+          <Copy className="mr-2 h-3 w-3" />
+          Copy field ID
+        </DropdownMenuItem>
+
+        {onEdit && (
+          <DropdownMenuItem onClick={() => onEdit(field)}>
+            <Pencil className="mr-2 h-3 w-3" />
+            Edit field
+          </DropdownMenuItem>
+        )}
+
+        {field.is_active ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-rose-500 focus:text-rose-600"
+              onClick={() => {
+                setSelectedField(field)
+                setActiveDialog(ActiveDialog.FieldArchive)
+              }}
+            >
+              <XCircle className="mr-2 h-3 w-3" />
+              Archive field
+            </DropdownMenuItem>
+          </>
+        ) : (
+          <>
+            <DropdownMenuItem
+              onClick={() => void onReactivateField?.(field.id)}
+            >
+              <CheckCircle className="mr-2 h-3 w-3" />
+              Restore field
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-rose-500 focus:text-rose-600"
+              onClick={() => {
+                setSelectedField(field)
+                setActiveDialog(ActiveDialog.FieldDelete)
+              }}
+            >
+              <Trash2 className="mr-2 h-3 w-3" />
+              Delete field
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/entities/table-common.tsx
+++ b/frontend/src/components/entities/table-common.tsx
@@ -1,0 +1,6 @@
+export enum ActiveDialog {
+  EntityArchive,
+  EntityDelete,
+  FieldArchive,
+  FieldDelete,
+}

--- a/frontend/src/components/form/icon-picker.tsx
+++ b/frontend/src/components/form/icon-picker.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import { Check, Search } from "lucide-react"
+import { useCallback, useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { type IconData, iconList } from "@/lib/icons"
+import { cn } from "@/lib/utils"
+
+interface IconPickerProps {
+  value?: string
+  onValueChange?: (value: string) => void
+  placeholder?: string
+  className?: string
+}
+
+export function IconPicker({
+  value,
+  onValueChange,
+  placeholder = "Select icon",
+  className,
+}: IconPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [searchTerm, setSearchTerm] = useState("")
+
+  const selectedIcon = useMemo(() => {
+    if (!value) return null
+    return iconList.find((icon) => icon.name === value)
+  }, [value])
+
+  const SelectedIconComponent = selectedIcon ? selectedIcon.icon : null
+
+  const filteredIcons = useMemo(() => {
+    const term = searchTerm.toLowerCase()
+    if (!term) return iconList
+
+    return iconList.filter(
+      (icon) =>
+        icon.name.toLowerCase().includes(term) ||
+        icon.displayName.toLowerCase().includes(term) ||
+        icon.category.toLowerCase().includes(term)
+    )
+  }, [searchTerm])
+
+  const groupedIcons = useMemo(() => {
+    const groups: Record<string, IconData[]> = {}
+    filteredIcons.forEach((icon) => {
+      if (!groups[icon.category]) {
+        groups[icon.category] = []
+      }
+      groups[icon.category].push(icon)
+    })
+    return groups
+  }, [filteredIcons])
+
+  const handleSelect = useCallback(
+    (iconName: string) => {
+      onValueChange?.(iconName)
+      setOpen(false)
+      setSearchTerm("")
+    },
+    [onValueChange]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "w-full justify-start text-left font-normal",
+            !value && "text-muted-foreground",
+            className
+          )}
+        >
+          {SelectedIconComponent && selectedIcon ? (
+            <div className="flex items-center gap-2">
+              <SelectedIconComponent className="h-4 w-4" />
+              <span>{selectedIcon.displayName}</span>
+            </div>
+          ) : (
+            <span>{placeholder}</span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[400px] p-0" align="start">
+        <div className="flex items-center border-b px-3">
+          <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          <Input
+            placeholder="Search icons..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="h-10 border-0 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+          />
+        </div>
+        <ScrollArea className="h-[300px]">
+          {Object.keys(groupedIcons).length === 0 ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              No icons found
+            </div>
+          ) : (
+            <div className="p-2">
+              {Object.entries(groupedIcons).map(([category, icons]) => (
+                <div key={category} className="mb-4">
+                  <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
+                    {category}
+                  </div>
+                  <div className="grid grid-cols-8 gap-1">
+                    {icons.map((icon) => {
+                      const IconComponent = icon.icon
+                      const isSelected = value === icon.name
+                      return (
+                        <button
+                          key={icon.name}
+                          type="button"
+                          onClick={() => handleSelect(icon.name)}
+                          className={cn(
+                            "relative flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-sm transition-colors hover:bg-accent hover:text-accent-foreground",
+                            isSelected && "border-primary bg-accent"
+                          )}
+                          title={icon.displayName}
+                        >
+                          <IconComponent className="h-4 w-4" />
+                          {isSelected && (
+                            <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-primary">
+                              <Check className="h-3 w-3 text-primary-foreground" />
+                            </div>
+                          )}
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+        {value && (
+          <div className="border-t p-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-xs"
+              onClick={() => handleSelect("")}
+            >
+              Clear selection
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -1,11 +1,13 @@
 "use client"
 
+import { useQueryClient } from "@tanstack/react-query"
 import { format, formatDistanceToNow } from "date-fns"
 import { Calendar, PanelRight, Plus } from "lucide-react"
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
 import { type ReactNode, useState } from "react"
 import type { OAuthGrantType } from "@/client"
+import { entitiesCreateEntity } from "@/client"
 import { AddCustomField } from "@/components/cases/add-custom-field"
 import { CreateCaseDialog } from "@/components/cases/case-create-dialog"
 import {
@@ -17,8 +19,10 @@ import {
   FolderViewToggle,
   ViewMode,
 } from "@/components/dashboard/folder-view-toggle"
+import { CreateEntityDialog } from "@/components/entities/create-entity-dialog"
 import { CreateTableDialog } from "@/components/tables/table-create-dialog"
 import { TableInsertButton } from "@/components/tables/table-insert-button"
+import { Badge } from "@/components/ui/badge"
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -28,13 +32,18 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
 import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
 import { SidebarTrigger } from "@/components/ui/sidebar"
+import { Switch } from "@/components/ui/switch"
+import { toast } from "@/components/ui/use-toast"
 import { AddWorkspaceMember } from "@/components/workspaces/add-workspace-member"
 import {
   NewCredentialsDialog,
   NewCredentialsDialogTrigger,
 } from "@/components/workspaces/add-workspace-secret"
+import { useEntity } from "@/hooks/use-entities"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
+import { entityEvents } from "@/lib/entity-events"
 import {
   useGetCase,
   useGetPrompt,
@@ -42,6 +51,7 @@ import {
   useIntegrationProvider,
   useLocalStorage,
 } from "@/lib/hooks"
+import { getIconByName } from "@/lib/icons"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 interface PageConfig {
@@ -54,6 +64,39 @@ interface ControlsHeaderProps {
   isChatOpen?: boolean
   /** Callback to toggle the chat sidebar */
   onToggleChat?: () => void
+}
+
+function EntitiesDetailHeaderActions() {
+  const [includeInactive, setIncludeInactive] = useLocalStorage(
+    "entities-include-inactive",
+    false
+  )
+  return (
+    <div className="flex items-center gap-4">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Label
+          htmlFor="entities-include-inactive"
+          className="text-xs text-muted-foreground"
+        >
+          Include inactive
+        </Label>
+        <Switch
+          id="entities-include-inactive"
+          checked={includeInactive}
+          onCheckedChange={setIncludeInactive}
+        />
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 bg-white"
+        onClick={() => entityEvents.emitAddField()}
+      >
+        <Plus className="mr-1 h-3.5 w-3.5" />
+        Add field
+      </Button>
+    </div>
+  )
 }
 
 function WorkflowsActions() {
@@ -138,6 +181,61 @@ function CredentialsActions() {
         </Button>
       </NewCredentialsDialogTrigger>
     </NewCredentialsDialog>
+  )
+}
+
+function EntitiesActions() {
+  const [createEntityDialogOpen, setCreateEntityDialogOpen] = useState(false)
+  const workspaceId = useWorkspaceId()
+  const queryClient = useQueryClient()
+
+  const handleCreateEntity = async (data: {
+    key: string
+    display_name: string
+    description?: string
+    icon?: string
+  }) => {
+    try {
+      await entitiesCreateEntity({
+        workspaceId,
+        requestBody: {
+          key: data.key,
+          display_name: data.display_name,
+          description: data.description,
+          icon: data.icon,
+        },
+      })
+      queryClient.invalidateQueries({ queryKey: ["entities", workspaceId] })
+      toast({
+        title: "Entity created",
+        description: `${data.display_name} has been created successfully.`,
+      })
+    } catch (_err) {
+      toast({
+        title: "Error creating entity",
+        description: "Failed to create entity. Please try again.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 bg-white"
+        onClick={() => setCreateEntityDialogOpen(true)}
+      >
+        <Plus className="mr-1 h-3.5 w-3.5" />
+        Add entity
+      </Button>
+      <CreateEntityDialog
+        open={createEntityDialogOpen}
+        onOpenChange={setCreateEntityDialogOpen}
+        onSubmit={handleCreateEntity}
+      />
+    </div>
   )
 }
 
@@ -308,6 +406,51 @@ function RunbookBreadcrumb({
   )
 }
 
+function EntityBreadcrumb({
+  entityId,
+  workspaceId,
+}: {
+  entityId: string
+  workspaceId: string
+}) {
+  const { entity } = useEntity(workspaceId, entityId)
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList className="relative z-10 flex items-center gap-2 text-sm flex-nowrap overflow-hidden whitespace-nowrap min-w-0 bg-white pr-1">
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild className="font-semibold hover:no-underline">
+            <Link href={`/workspaces/${workspaceId}/entities`}>Entities</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator className="shrink-0">
+          <span className="text-muted-foreground">/</span>
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage className="font-semibold flex items-center gap-2">
+            <span>{entity?.display_name || entityId}</span>
+            {entity?.key && (
+              <Badge
+                variant="secondary"
+                className="text-xs font-normal flex items-center gap-1"
+              >
+                {entity.icon &&
+                  (() => {
+                    const IconComponent = getIconByName(entity.icon)
+                    return IconComponent ? (
+                      <IconComponent className="h-3 w-3" />
+                    ) : null
+                  })()}
+                {entity.key}
+              </Badge>
+            )}
+          </BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
 function getPageConfig(
   pathname: string,
   workspaceId: string,
@@ -388,6 +531,25 @@ function getPageConfig(
     return {
       title: "Credentials",
       actions: <CredentialsActions />,
+    }
+  }
+
+  if (pagePath.startsWith("/entities")) {
+    // Entity detail page
+    const entityMatch = pagePath.match(/^\/entities\/([^/]+)$/)
+    if (entityMatch) {
+      const entityId = entityMatch[1]
+      return {
+        title: (
+          <EntityBreadcrumb entityId={entityId} workspaceId={workspaceId} />
+        ),
+        actions: <EntitiesDetailHeaderActions />,
+      }
+    }
+    // Index
+    return {
+      title: "Entities",
+      actions: <EntitiesActions />,
     }
   }
 

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -3,6 +3,7 @@
 import {
   KeyRoundIcon,
   ListTodoIcon,
+  ShapesIcon,
   SquareStackIcon,
   Table2Icon,
   UsersIcon,
@@ -65,6 +66,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       url: `${basePath}/tables`,
       icon: Table2Icon,
       isActive: pathname?.startsWith(`${basePath}/tables`),
+    },
+    {
+      title: "Entities",
+      url: `${basePath}/entities`,
+      icon: ShapesIcon,
+      isActive: pathname?.startsWith(`${basePath}/entities`),
     },
     {
       title: "Credentials",

--- a/frontend/src/hooks/use-entities.ts
+++ b/frontend/src/hooks/use-entities.ts
@@ -88,7 +88,6 @@ export function useUpdateEntityField(workspaceId: string, entityId: string) {
         toast({
           title: "Error updating field",
           description: "Failed to update the field. Please try again.",
-          variant: "destructive",
         })
       },
     })

--- a/frontend/src/hooks/use-entities.ts
+++ b/frontend/src/hooks/use-entities.ts
@@ -1,0 +1,97 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  type EntityFieldUpdate,
+  entitiesGetEntity,
+  entitiesListEntities,
+  entitiesListFields,
+  entitiesUpdateField,
+} from "@/client"
+import { toast } from "@/components/ui/use-toast"
+
+export function useEntities(workspaceId: string, includeInactive = true) {
+  const {
+    data: entities,
+    isLoading: entitiesIsLoading,
+    error: entitiesError,
+  } = useQuery({
+    queryKey: ["entities", workspaceId, includeInactive],
+    queryFn: async () =>
+      await entitiesListEntities({ workspaceId, includeInactive }),
+    enabled: !!workspaceId,
+  })
+
+  return { entities, entitiesIsLoading, entitiesError }
+}
+
+export function useEntity(workspaceId: string, entityId: string) {
+  const {
+    data: entity,
+    isLoading: entityIsLoading,
+    error: entityError,
+  } = useQuery({
+    queryKey: ["entity", workspaceId, entityId],
+    queryFn: async () => await entitiesGetEntity({ workspaceId, entityId }),
+    enabled: !!workspaceId && !!entityId,
+  })
+
+  return { entity, entityIsLoading, entityError }
+}
+
+export function useEntityFields(
+  workspaceId: string,
+  entityId: string,
+  includeInactive = false
+) {
+  const {
+    data: fields,
+    isLoading: fieldsIsLoading,
+    error: fieldsError,
+  } = useQuery({
+    queryKey: ["entity-fields", workspaceId, entityId, includeInactive],
+    queryFn: async () =>
+      await entitiesListFields({ workspaceId, entityId, includeInactive }),
+    enabled: !!workspaceId && !!entityId,
+  })
+
+  return { fields, fieldsIsLoading, fieldsError }
+}
+
+export function useUpdateEntityField(workspaceId: string, entityId: string) {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync: updateField, isPending: updateFieldIsPending } =
+    useMutation({
+      mutationFn: async ({
+        fieldId,
+        data,
+      }: {
+        fieldId: string
+        data: EntityFieldUpdate
+      }) =>
+        await entitiesUpdateField({
+          workspaceId,
+          entityId,
+          fieldId,
+          requestBody: data,
+        }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ["entity-fields", workspaceId, entityId],
+        })
+        toast({
+          title: "Field updated",
+          description: "The field was updated successfully.",
+        })
+      },
+      onError: (error) => {
+        console.error("Failed to update field", error)
+        toast({
+          title: "Error updating field",
+          description: "Failed to update the field. Please try again.",
+          variant: "destructive",
+        })
+      },
+    })
+
+  return { updateField, updateFieldIsPending }
+}

--- a/frontend/src/lib/entity-events.ts
+++ b/frontend/src/lib/entity-events.ts
@@ -1,0 +1,16 @@
+type Listener = () => void
+
+class EntityEvents {
+  private addFieldListeners: Set<Listener> = new Set()
+
+  onAddField(listener: Listener) {
+    this.addFieldListeners.add(listener)
+    return () => this.addFieldListeners.delete(listener)
+  }
+
+  emitAddField() {
+    this.addFieldListeners.forEach((cb) => cb())
+  }
+}
+
+export const entityEvents = new EntityEvents()

--- a/frontend/src/lib/entity-events.ts
+++ b/frontend/src/lib/entity-events.ts
@@ -5,7 +5,9 @@ class EntityEvents {
 
   onAddField(listener: Listener) {
     this.addFieldListeners.add(listener)
-    return () => this.addFieldListeners.delete(listener)
+    return () => {
+      this.addFieldListeners.delete(listener)
+    }
   }
 
   emitAddField() {

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -1,0 +1,516 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  Activity,
+  AlertCircle,
+  AlertTriangle,
+  Archive,
+  AtSign,
+  Award,
+  BarChart,
+  Battery,
+  Bell,
+  BellOff,
+  Bookmark,
+  Box,
+  Briefcase,
+  Building,
+  Building2,
+  Calendar,
+  Camera,
+  CheckCircle,
+  Clipboard,
+  Clock,
+  Cloud,
+  Code,
+  Command,
+  Copy,
+  Cpu,
+  CreditCard,
+  Database,
+  DollarSign,
+  Download,
+  Edit,
+  Eye,
+  EyeOff,
+  Feather,
+  File,
+  FileText,
+  Film,
+  Filter,
+  Fingerprint,
+  Flag,
+  Folder,
+  FolderOpen,
+  GitBranch,
+  GitCommit,
+  Globe,
+  Grid,
+  HardDrive,
+  Hash,
+  Headphones,
+  Heart,
+  Home,
+  Image,
+  Info,
+  Key,
+  Laptop,
+  Layers,
+  Layout,
+  Link,
+  List,
+  Lock,
+  Mail,
+  Map,
+  MapPin,
+  MessageSquare,
+  Mic,
+  Monitor,
+  Music,
+  Package,
+  Palette,
+  Phone,
+  PieChart,
+  Search,
+  Send,
+  Server,
+  Settings,
+  Share2,
+  Shield,
+  ShoppingCart,
+  Smartphone,
+  Star,
+  Tablet,
+  Tag,
+  Target,
+  Terminal,
+  ThumbsUp,
+  Timer,
+  Trash2,
+  TrendingUp,
+  Trophy,
+  Upload,
+  User,
+  UserCheck,
+  UserPlus,
+  Users,
+  Volume2,
+  Wallet,
+  Wifi,
+  Wrench,
+  XCircle,
+  Zap,
+} from "lucide-react"
+
+export interface IconData {
+  name: string
+  displayName: string
+  icon: LucideIcon
+  category: string
+}
+
+export const iconList: IconData[] = [
+  // People & Users
+  { name: "User", displayName: "User", icon: User, category: "People" },
+  { name: "Users", displayName: "Users", icon: Users, category: "People" },
+  {
+    name: "UserCheck",
+    displayName: "User check",
+    icon: UserCheck,
+    category: "People",
+  },
+  {
+    name: "UserPlus",
+    displayName: "User plus",
+    icon: UserPlus,
+    category: "People",
+  },
+
+  // Organizations
+  {
+    name: "Building",
+    displayName: "Building",
+    icon: Building,
+    category: "Organization",
+  },
+  {
+    name: "Building2",
+    displayName: "Building 2",
+    icon: Building2,
+    category: "Organization",
+  },
+  {
+    name: "Briefcase",
+    displayName: "Briefcase",
+    icon: Briefcase,
+    category: "Organization",
+  },
+  { name: "Home", displayName: "Home", icon: Home, category: "Organization" },
+
+  // Technology & Infrastructure
+  {
+    name: "Server",
+    displayName: "Server",
+    icon: Server,
+    category: "Technology",
+  },
+  {
+    name: "Database",
+    displayName: "Database",
+    icon: Database,
+    category: "Technology",
+  },
+  {
+    name: "HardDrive",
+    displayName: "Hard drive",
+    icon: HardDrive,
+    category: "Technology",
+  },
+  { name: "Cloud", displayName: "Cloud", icon: Cloud, category: "Technology" },
+  { name: "Cpu", displayName: "CPU", icon: Cpu, category: "Technology" },
+  {
+    name: "Monitor",
+    displayName: "Monitor",
+    icon: Monitor,
+    category: "Technology",
+  },
+  {
+    name: "Smartphone",
+    displayName: "Smartphone",
+    icon: Smartphone,
+    category: "Technology",
+  },
+  {
+    name: "Tablet",
+    displayName: "Tablet",
+    icon: Tablet,
+    category: "Technology",
+  },
+  {
+    name: "Laptop",
+    displayName: "Laptop",
+    icon: Laptop,
+    category: "Technology",
+  },
+  { name: "Wifi", displayName: "WiFi", icon: Wifi, category: "Technology" },
+
+  // Location
+  { name: "Globe", displayName: "Globe", icon: Globe, category: "Location" },
+  { name: "Map", displayName: "Map", icon: Map, category: "Location" },
+  {
+    name: "MapPin",
+    displayName: "Map pin",
+    icon: MapPin,
+    category: "Location",
+  },
+
+  // Files & Documents
+  { name: "File", displayName: "File", icon: File, category: "Files" },
+  {
+    name: "FileText",
+    displayName: "File text",
+    icon: FileText,
+    category: "Files",
+  },
+  { name: "Folder", displayName: "Folder", icon: Folder, category: "Files" },
+  {
+    name: "FolderOpen",
+    displayName: "Folder open",
+    icon: FolderOpen,
+    category: "Files",
+  },
+
+  // Communication
+  { name: "Mail", displayName: "Mail", icon: Mail, category: "Communication" },
+  {
+    name: "MessageSquare",
+    displayName: "Message",
+    icon: MessageSquare,
+    category: "Communication",
+  },
+  {
+    name: "Phone",
+    displayName: "Phone",
+    icon: Phone,
+    category: "Communication",
+  },
+  { name: "Bell", displayName: "Bell", icon: Bell, category: "Communication" },
+  {
+    name: "BellOff",
+    displayName: "Bell off",
+    icon: BellOff,
+    category: "Communication",
+  },
+
+  // Security
+  { name: "Shield", displayName: "Shield", icon: Shield, category: "Security" },
+  { name: "Lock", displayName: "Lock", icon: Lock, category: "Security" },
+  { name: "Key", displayName: "Key", icon: Key, category: "Security" },
+  {
+    name: "Fingerprint",
+    displayName: "Fingerprint",
+    icon: Fingerprint,
+    category: "Security",
+  },
+  { name: "Eye", displayName: "Eye", icon: Eye, category: "Security" },
+  {
+    name: "EyeOff",
+    displayName: "Eye off",
+    icon: EyeOff,
+    category: "Security",
+  },
+
+  // Finance & Commerce
+  {
+    name: "CreditCard",
+    displayName: "Credit card",
+    icon: CreditCard,
+    category: "Finance",
+  },
+  {
+    name: "DollarSign",
+    displayName: "Dollar sign",
+    icon: DollarSign,
+    category: "Finance",
+  },
+  { name: "Wallet", displayName: "Wallet", icon: Wallet, category: "Finance" },
+  {
+    name: "ShoppingCart",
+    displayName: "Shopping cart",
+    icon: ShoppingCart,
+    category: "Commerce",
+  },
+  {
+    name: "Package",
+    displayName: "Package",
+    icon: Package,
+    category: "Commerce",
+  },
+  { name: "Box", displayName: "Box", icon: Box, category: "Commerce" },
+
+  // Organization & Tags
+  { name: "Tag", displayName: "Tag", icon: Tag, category: "Organization" },
+  {
+    name: "Bookmark",
+    displayName: "Bookmark",
+    icon: Bookmark,
+    category: "Organization",
+  },
+  {
+    name: "Archive",
+    displayName: "Archive",
+    icon: Archive,
+    category: "Organization",
+  },
+
+  // Time
+  {
+    name: "Calendar",
+    displayName: "Calendar",
+    icon: Calendar,
+    category: "Time",
+  },
+  { name: "Clock", displayName: "Clock", icon: Clock, category: "Time" },
+  { name: "Timer", displayName: "Timer", icon: Timer, category: "Time" },
+
+  // Status & Alerts
+  {
+    name: "Activity",
+    displayName: "Activity",
+    icon: Activity,
+    category: "Status",
+  },
+  {
+    name: "AlertCircle",
+    displayName: "Alert circle",
+    icon: AlertCircle,
+    category: "Status",
+  },
+  {
+    name: "AlertTriangle",
+    displayName: "Alert triangle",
+    icon: AlertTriangle,
+    category: "Status",
+  },
+  { name: "Info", displayName: "Info", icon: Info, category: "Status" },
+  {
+    name: "CheckCircle",
+    displayName: "Check circle",
+    icon: CheckCircle,
+    category: "Status",
+  },
+  {
+    name: "XCircle",
+    displayName: "X circle",
+    icon: XCircle,
+    category: "Status",
+  },
+
+  // Tools & Settings
+  {
+    name: "Settings",
+    displayName: "Settings",
+    icon: Settings,
+    category: "Tools",
+  },
+  { name: "Wrench", displayName: "Wrench", icon: Wrench, category: "Tools" },
+
+  // Energy
+  { name: "Link", displayName: "Link", icon: Link, category: "Network" },
+  { name: "Zap", displayName: "Zap", icon: Zap, category: "Energy" },
+  {
+    name: "Battery",
+    displayName: "Battery",
+    icon: Battery,
+    category: "Energy",
+  },
+
+  // Media
+  { name: "Camera", displayName: "Camera", icon: Camera, category: "Media" },
+  { name: "Image", displayName: "Image", icon: Image, category: "Media" },
+  { name: "Film", displayName: "Film", icon: Film, category: "Media" },
+  { name: "Music", displayName: "Music", icon: Music, category: "Media" },
+  { name: "Volume2", displayName: "Volume", icon: Volume2, category: "Media" },
+  { name: "Mic", displayName: "Microphone", icon: Mic, category: "Media" },
+  {
+    name: "Headphones",
+    displayName: "Headphones",
+    icon: Headphones,
+    category: "Media",
+  },
+
+  // Recognition
+  { name: "Star", displayName: "Star", icon: Star, category: "Recognition" },
+  { name: "Heart", displayName: "Heart", icon: Heart, category: "Recognition" },
+  {
+    name: "ThumbsUp",
+    displayName: "Thumbs up",
+    icon: ThumbsUp,
+    category: "Recognition",
+  },
+  { name: "Award", displayName: "Award", icon: Award, category: "Recognition" },
+  {
+    name: "Trophy",
+    displayName: "Trophy",
+    icon: Trophy,
+    category: "Recognition",
+  },
+  { name: "Flag", displayName: "Flag", icon: Flag, category: "Recognition" },
+  {
+    name: "Target",
+    displayName: "Target",
+    icon: Target,
+    category: "Recognition",
+  },
+
+  // Analytics
+  {
+    name: "TrendingUp",
+    displayName: "Trending up",
+    icon: TrendingUp,
+    category: "Analytics",
+  },
+  {
+    name: "BarChart",
+    displayName: "Bar chart",
+    icon: BarChart,
+    category: "Analytics",
+  },
+  {
+    name: "PieChart",
+    displayName: "Pie chart",
+    icon: PieChart,
+    category: "Analytics",
+  },
+
+  // Development
+  {
+    name: "GitBranch",
+    displayName: "Git branch",
+    icon: GitBranch,
+    category: "Development",
+  },
+  {
+    name: "GitCommit",
+    displayName: "Git commit",
+    icon: GitCommit,
+    category: "Development",
+  },
+  { name: "Code", displayName: "Code", icon: Code, category: "Development" },
+  {
+    name: "Terminal",
+    displayName: "Terminal",
+    icon: Terminal,
+    category: "Development",
+  },
+  {
+    name: "Command",
+    displayName: "Command",
+    icon: Command,
+    category: "Development",
+  },
+  { name: "Hash", displayName: "Hash", icon: Hash, category: "Development" },
+  {
+    name: "AtSign",
+    displayName: "At sign",
+    icon: AtSign,
+    category: "Development",
+  },
+
+  // Interface Actions
+  { name: "Search", displayName: "Search", icon: Search, category: "Actions" },
+  { name: "Filter", displayName: "Filter", icon: Filter, category: "Actions" },
+  { name: "Edit", displayName: "Edit", icon: Edit, category: "Actions" },
+  { name: "Copy", displayName: "Copy", icon: Copy, category: "Actions" },
+  {
+    name: "Clipboard",
+    displayName: "Clipboard",
+    icon: Clipboard,
+    category: "Actions",
+  },
+  { name: "Trash2", displayName: "Trash", icon: Trash2, category: "Actions" },
+  {
+    name: "Download",
+    displayName: "Download",
+    icon: Download,
+    category: "Actions",
+  },
+  { name: "Upload", displayName: "Upload", icon: Upload, category: "Actions" },
+  { name: "Share2", displayName: "Share", icon: Share2, category: "Actions" },
+  { name: "Send", displayName: "Send", icon: Send, category: "Actions" },
+
+  // Layout
+  { name: "Layers", displayName: "Layers", icon: Layers, category: "Layout" },
+  { name: "Grid", displayName: "Grid", icon: Grid, category: "Layout" },
+  { name: "List", displayName: "List", icon: List, category: "Layout" },
+  { name: "Layout", displayName: "Layout", icon: Layout, category: "Layout" },
+
+  // Creative
+  {
+    name: "Palette",
+    displayName: "Palette",
+    icon: Palette,
+    category: "Creative",
+  },
+  {
+    name: "Feather",
+    displayName: "Feather",
+    icon: Feather,
+    category: "Creative",
+  },
+]
+
+export const iconMap = iconList.reduce(
+  (acc, item) => {
+    acc[item.name] = item.icon
+    return acc
+  },
+  {} as Record<string, LucideIcon>
+)
+
+export function getIconByName(name: string): LucideIcon | undefined {
+  return iconMap[name]
+}
+
+export const iconCategories = Array.from(
+  new Set(iconList.map((item) => item.category))
+)


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new Entities UI to manage entities and their fields in each workspace. Users can create, edit, delete, and activate/deactivate entities and fields, with responsive tables and toasts.

- **New Features**
  - Entities list at /workspaces/[workspaceId]/entities with include-inactive filter.
  - Entity detail page for managing fields at /workspaces/[workspaceId]/entities/[entityId].
  - Create/Edit dialogs for entities and fields, with validation and toasts.
  - Activate/Deactivate and delete actions from table row menus.
  - React Query hooks (useEntities, useEntity, useEntityFields) with cache updates.
  - Icon picker and icon library for entity icons.
  - Sidebar navigation item for Entities and header control to create an entity.
  - Generated API client schemas/types/services for all Entities endpoints.

<!-- End of auto-generated description by cubic. -->


<img width="1133" height="861" alt="Screenshot 2025-08-26 at 10 09 00 PM" src="https://github.com/user-attachments/assets/1e3c1096-a011-4a0e-aa7c-b97c6b878661" />
<img width="1133" height="861" alt="Screenshot 2025-08-26 at 10 08 56 PM" src="https://github.com/user-attachments/assets/7277fbb4-2dc7-47f3-8656-4e66bd33e5fc" />
<img width="1511" height="857" alt="Screenshot 2025-08-26 at 10 08 43 PM" src="https://github.com/user-attachments/assets/d0fdaab7-0d30-4405-a725-87e7dfdc1581" />
<img width="1511" height="857" alt="Screenshot 2025-08-26 at 10 08 37 PM" src="https://github.com/user-attachments/assets/d430a5ab-286f-49ef-945c-8084b0421e81" />
<img width="1511" height="857" alt="Screenshot 2025-08-26 at 10 08 34 PM" src="https://github.com/user-attachments/assets/f9eeba9a-7907-4c2a-805e-126b7e606ae3" />

