### PR TITLE
feat(integrations): Core HTTP request action now only raises for HTTP ≥ 400

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/http.py
+++ b/packages/tracecat-registry/tracecat_registry/core/http.py
@@ -589,7 +589,8 @@ async def http_request(
                     data=form_data,
                     files=httpx_files_param,
                 )
-            response.raise_for_status()
+            if response.status_code >= 400:
+                response.raise_for_status()
         except httpx.HTTPStatusError as e:
             error_message = _http_status_error_to_message(e)
             logger.error(


### PR DESCRIPTION
## Description

This PR changes the HTTP request action’s error semantics to only raise for HTTP status codes ≥ 400.
Previously, non-2xx (including 3xx redirects) were treated as errors in some cases, which prevented workflows from inspecting redirect responses when follow_redirects: false.

What’s changed
Error policy: 1xx/2xx/3xx no longer raise; only 4xx/5xx raise.

## Related Issues
HTTP request action treats 302 redirects as errors when follow_redirects=false  #1380

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update the HTTP request action to only raise on HTTP 4xx/5xx. Redirects (3xx) no longer raise, letting workflows inspect 302 responses when follow_redirects=false and addressing #1380.

<!-- End of auto-generated description by cubic. -->

