### PR TITLE
fix(interceptor): Ensure workflow IDs and trigger types are set as strings in Sentry tags

### DIFF
--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -40,7 +40,7 @@ def _set_fingerprint(
 
         # Set additional tags for the workflow from its DSLRunArgs
         if parent_run_context := arg.parent_run_context:
-            sentry.set_tag("tracecat.parent.workflow_id", parent_run_context.wf_id)
+            sentry.set_tag("tracecat.parent.workflow_id", str(parent_run_context.wf_id))
             sentry.set_tag(
                 "tracecat.parent.workflow_exec_id", parent_run_context.wf_exec_id
             )
@@ -80,6 +80,7 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
             trigger_type = get_trigger_type(info)
             if (role := ctx_role.get()) and role.workspace_id:
                 sentry.set_tag("tracecat.workspace_id", str(role.workspace_id))
+            sentry.set_tag("tracecat.trigger_type", trigger_type.value)
             # Fingerprint to each workflow ID
             _set_fingerprint(scope, input, info, trigger_type)
             try:


### PR DESCRIPTION
## Summary
- Fixes workflow ID type casting to string for Sentry tags in parent run context
- Adds missing trigger type tag to Sentry scope

## Changes
- Cast `parent_run_context.wf_id` to string when setting Sentry tag
- Add `tracecat.trigger_type` tag with trigger type value

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix Sentry tagging in the interceptor: cast tracecat.parent.workflow_id to a string and add tracecat.trigger_type. This ensures consistent tag types for filtering/grouping and includes trigger context in error traces.

<!-- End of auto-generated description by cubic. -->

