### PR TITLE
feat: Enable unlimited workflow timeouts by default

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -12110,14 +12110,7 @@ export const $WorkspaceSettingsRead = {
       title: "Git Repo Url",
     },
     workflow_unlimited_timeout_enabled: {
-      anyOf: [
-        {
-          type: "boolean",
-        },
-        {
-          type: "null",
-        },
-      ],
+      type: "boolean",
       title: "Workflow Unlimited Timeout Enabled",
     },
     workflow_default_timeout_seconds: {
@@ -12133,6 +12126,7 @@ export const $WorkspaceSettingsRead = {
     },
   },
   type: "object",
+  required: ["workflow_unlimited_timeout_enabled"],
   title: "WorkspaceSettingsRead",
 } as const
 
@@ -12150,26 +12144,25 @@ export const $WorkspaceSettingsUpdate = {
       title: "Git Repo Url",
     },
     workflow_unlimited_timeout_enabled: {
-      anyOf: [
-        {
-          type: "boolean",
-        },
-        {
-          type: "null",
-        },
-      ],
+      type: "boolean",
       title: "Workflow Unlimited Timeout Enabled",
+      description:
+        "Allow workflows to run indefinitely without timeout constraints. When enabled, individual workflow timeout settings are ignored.",
+      default: true,
     },
     workflow_default_timeout_seconds: {
       anyOf: [
         {
           type: "integer",
+          minimum: 0,
         },
         {
           type: "null",
         },
       ],
       title: "Workflow Default Timeout Seconds",
+      description:
+        "Default timeout in seconds for workflows in this workspace. Must be greater than or equal to 0.",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3907,13 +3907,19 @@ export type WorkspaceRole = "editor" | "admin"
 
 export type WorkspaceSettingsRead = {
   git_repo_url?: string | null
-  workflow_unlimited_timeout_enabled?: boolean | null
+  workflow_unlimited_timeout_enabled: boolean
   workflow_default_timeout_seconds?: number | null
 }
 
 export type WorkspaceSettingsUpdate = {
   git_repo_url?: string | null
-  workflow_unlimited_timeout_enabled?: boolean | null
+  /**
+   * Allow workflows to run indefinitely without timeout constraints. When enabled, individual workflow timeout settings are ignored.
+   */
+  workflow_unlimited_timeout_enabled?: boolean
+  /**
+   * Default timeout in seconds for workflows in this workspace. Must be greater than or equal to 0.
+   */
   workflow_default_timeout_seconds?: number | null
 }
 

--- a/frontend/src/components/organization/org-workspace-settings.tsx
+++ b/frontend/src/components/organization/org-workspace-settings.tsx
@@ -76,7 +76,7 @@ export function OrgWorkspaceSettings({
       name: workspace.name,
       git_repo_url: workspace.settings?.git_repo_url || "",
       workflow_unlimited_timeout_enabled:
-        workspace.settings?.workflow_unlimited_timeout_enabled || false,
+        workspace.settings?.workflow_unlimited_timeout_enabled ?? true,
       workflow_default_timeout_seconds:
         workspace.settings?.workflow_default_timeout_seconds || undefined,
     },

--- a/tracecat/workspaces/models.py
+++ b/tracecat/workspaces/models.py
@@ -22,14 +22,14 @@ class WorkspaceSettings(TypedDict):
 # Schema
 class WorkspaceSettingsRead(BaseModel):
     git_repo_url: str | None = None
-    workflow_unlimited_timeout_enabled: bool | None = None
+    workflow_unlimited_timeout_enabled: bool
     workflow_default_timeout_seconds: int | None = None
 
 
 class WorkspaceSettingsUpdate(BaseModel):
     git_repo_url: str | None = None
-    workflow_unlimited_timeout_enabled: bool | None = Field(
-        default=None,
+    workflow_unlimited_timeout_enabled: bool = Field(
+        default=True,
         description="Allow workflows to run indefinitely without timeout constraints. When enabled, individual workflow timeout settings are ignored.",
     )
     workflow_default_timeout_seconds: int | None = Field(


### PR DESCRIPTION
## Summary
- Set `workflow_unlimited_timeout_enabled` to `True` by default for new workspaces
- Updated both backend models and frontend form defaults

## Changes
- Backend: Default `workflow_unlimited_timeout_enabled` to `True` in workspace settings models
- Frontend: Use nullish coalescing (`??`) to default to `true` when setting is null

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable unlimited workflow timeouts by default for new workspaces. Makes the setting required (non-null) and true by default across backend and frontend.

- **Refactors**
  - Made workflow_unlimited_timeout_enabled a required boolean; default true in update model.
  - Removed nullable type from schemas and types; added clearer field descriptions.
  - Frontend form now defaults via ?? true when the setting is missing.
  - Enforced minimum 0 for workflow_default_timeout_seconds.

- **Migration**
  - Regenerate client types.
  - Update any consumers that expected workflow_unlimited_timeout_enabled to be nullable.

<!-- End of auto-generated description by cubic. -->

