### PR TITLE
fix(app): Workspace admins can delete cases

### DIFF
--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import DBAPIError, NoResultFound
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.models import UserRead
 from tracecat.auth.users import search_users
+from tracecat.authz.models import WorkspaceRole
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.models import (
     AssigneeChangedEventRead,
@@ -47,7 +48,7 @@ from tracecat.storage import (
 )
 from tracecat.tags.models import TagRead
 from tracecat.tags.service import TagsService
-from tracecat.types.auth import AccessLevel, Role
+from tracecat.types.auth import Role
 from tracecat.types.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
@@ -70,7 +71,7 @@ WorkspaceAdminUser = Annotated[
         allow_user=True,
         allow_service=False,
         require_workspace="yes",
-        min_access_level=AccessLevel.ADMIN,
+        require_workspace_roles=WorkspaceRole.ADMIN,
     ),
 ]
 


### PR DESCRIPTION
- **refactor: Update workspace settings types and defaults**
- **refactor: Update workspace role requirements in router**

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes case deletion permissions so workspace admins can delete cases. Also tightens workspace settings types by making the timeout flag required with a safe default.

- **Bug Fixes**
  - Updated case routes to require_workspace_roles=WorkspaceRole.ADMIN, enabling workspace admins to delete cases.

- **Refactors**
  - Made workflow_unlimited_timeout_enabled a required boolean; default set to true (backend and frontend).
  - Added clear descriptions and enforced minimum 0 for workflow_default_timeout_seconds.
  - Cleaned up types and removed unused AccessLevel import.

<!-- End of auto-generated description by cubic. -->

