### PR TITLE
feat(app): Implement after-commit callbacks for Temporal schedule management

### DIFF
--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from tracecat import config
+from tracecat.db import session_events  # noqa: F401 - ensure listeners are registered
 
 # Global so we don't create more than one engine per process.
 # Outside of being best practice, this is needed so we can properly pool

--- a/tracecat/db/session_events.py
+++ b/tracecat/db/session_events.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any, Final, cast
+
+import sqlalchemy.orm
+from sqlalchemy import event
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tracecat.logger import logger
+
+_AFTER_COMMIT_KEY: Final[str] = "after_commit_callbacks"
+_EVENT_LOOP_KEY: Final[str] = "event_loop"
+AsyncCallback = Callable[[], Awaitable[Any]]
+
+
+def add_after_commit_callback(session: AsyncSession, callback: AsyncCallback) -> None:
+    """Register a callable to run after this session commits.
+
+    The callable may be sync or async. If async, it will be scheduled onto
+    the event loop captured during registration.
+
+    Args:
+        async_session: The async SQLModel session to register the callback with.
+        fn: The callable function to execute after commit. Should return an awaitable.
+
+    Returns:
+        None
+
+    Note:
+        The callback will be executed on the event loop that was active when
+        this function was called. If no event loop is running, the callback
+        will still be registered but may not execute properly.
+    """
+    logger.debug("Adding after_commit callback", callback=callback)
+    sync = session.sync_session
+    sync.info.setdefault(_AFTER_COMMIT_KEY, []).append(callback)
+    # Capture the current loop if available; used to schedule async callbacks.
+    try:
+        loop = asyncio.get_running_loop()
+        sync.info.setdefault(_EVENT_LOOP_KEY, loop)
+    except RuntimeError:
+        loop = None
+
+
+@event.listens_for(sqlalchemy.orm.Session, "after_commit")
+def _run_after_commit(session: sqlalchemy.orm.Session) -> None:
+    """Execute all registered after-commit callbacks for the given session.
+
+    This function is automatically called by SQLAlchemy after a session commits.
+    It retrieves all registered callbacks and executes them, handling both
+    synchronous and asynchronous callbacks appropriately.
+
+    Args:
+        session: The SQLAlchemy session that just committed.
+
+    Returns:
+        None
+
+    Note:
+        Async callbacks are scheduled as tasks on the event loop that was
+        captured during callback registration. If no loop was captured,
+        a new event loop is created.
+    """
+    callbacks = cast(list[AsyncCallback], session.info.pop(_AFTER_COMMIT_KEY, []))
+    logger.debug("Running after_commit callbacks", session=session, callbacks=callbacks)
+    if not callbacks:
+        return
+    if _EVENT_LOOP_KEY in session.info:
+        loop = session.info[_EVENT_LOOP_KEY]
+    else:
+        loop = asyncio.new_event_loop()
+    for cb in callbacks:
+        try:
+            coro = cb()
+            # Ensure we have a coroutine before creating task
+            if asyncio.iscoroutine(coro):
+                loop.create_task(coro)
+            else:
+                logger.debug("Callback did not return a coroutine", callback=cb)
+        except Exception as e:
+            logger.exception("after_commit callback failed", error=e)

--- a/tracecat/db/session_events.py
+++ b/tracecat/db/session_events.py
@@ -22,8 +22,8 @@ def add_after_commit_callback(session: AsyncSession, callback: AsyncCallback) ->
     the event loop captured during registration.
 
     Args:
-        async_session: The async SQLModel session to register the callback with.
-        fn: The callable function to execute after commit. Should return an awaitable.
+        session: The async SQLModel session to register the callback with.
+        callback: The callable function to execute after commit. Should return an awaitable.
 
     Returns:
         None

--- a/tracecat/db/session_events.py
+++ b/tracecat/db/session_events.py
@@ -67,10 +67,10 @@ def _run_after_commit(session: sqlalchemy.orm.Session) -> None:
     logger.debug("Running after_commit callbacks", session=session, callbacks=callbacks)
     if not callbacks:
         return
-    if _EVENT_LOOP_KEY in session.info:
-        loop = session.info[_EVENT_LOOP_KEY]
-    else:
-        loop = asyncio.new_event_loop()
+    if _EVENT_LOOP_KEY not in session.info:
+        logger.error("Expected event loop not found in session info", session=session)
+        return
+    loop = session.info[_EVENT_LOOP_KEY]
     for cb in callbacks:
         try:
             if (coro := cb()) and asyncio.iscoroutine(coro):


### PR DESCRIPTION
## Summary
- Introduces after-commit callback system for database sessions
- Refactors schedule service to use callbacks for Temporal operations
- Ensures database consistency by deferring external API calls until after commit

## Changes
- Added `session_events.py` with callback registration system
- Modified schedule service create/update/delete operations to use after-commit callbacks
- Temporal operations now happen after successful database commits

## Benefits
- Eliminates transaction rollback issues when Temporal operations fail
- Improves data consistency and reliability
- Better error handling and logging for external service failures

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Implemented after-commit callbacks for DB sessions and refactored schedule management to run Temporal operations only after a successful commit. This improves data consistency and avoids rollbacks caused by external failures.

- **New Features**
  - Added session_events with add_after_commit_callback and an SQLAlchemy after_commit listener.
  - Captures the current event loop and schedules async callbacks safely.

- **Refactors**
  - Schedules service runs Temporal create/update/delete via after-commit callbacks.
  - DB commits first; Temporal calls happen after commit with improved logging and error handling.
  - engine.py imports session_events to ensure listeners are registered.

<!-- End of auto-generated description by cubic. -->

