### PR TITLE
build: Enable host port overrides and flexible container names

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,6 @@
 services:
   caddy:
     image: caddy:2.8.4-alpine
-    container_name: caddy
     restart: unless-stopped
     ports:
       - ${PUBLIC_APP_PORT}:${PUBLIC_APP_PORT}
@@ -15,10 +14,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: api
     restart: unless-stopped
     ports:
-      - 8000:8000
+      - ${API_PORT:-8000}:8000
     environment:
       # App
       LOG_LEVEL: ${LOG_LEVEL}
@@ -124,10 +122,10 @@ services:
       dockerfile: Dockerfile.dev
     restart: unless-stopped
     ports:
-      - 8265:8265
+      - ${EXECUTOR_DASHBOARD_PORT:-8265}:8265
       # NOTE: Unit tests in `test_workflows.py` need
       # to connect to the executor directly
-      - 8001:8000
+      - ${EXECUTOR_API_PORT:-8001}:8000
     environment:
       # Common
       LOG_LEVEL: ${LOG_LEVEL}
@@ -184,7 +182,7 @@ services:
       - ./frontend/node_modules:/app/node_modules
     restart: unless-stopped
     ports:
-      - 3000:3000
+      - ${UI_PORT:-3000}:3000
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
       NEXT_PUBLIC_APP_ENV: ${NEXT_PUBLIC_APP_ENV}
@@ -199,10 +197,9 @@ services:
 
   postgres_db:
     image: postgres:16
-    container_name: postgres_db
     restart: unless-stopped
     ports:
-      - 5432:5432
+      - ${PG_PORT:-5432}:5432
     shm_size: 128mb
     environment:
       POSTGRES_USER: ${TRACECAT__POSTGRES_USER}
@@ -212,7 +209,6 @@ services:
 
   temporal_postgres_db:
     image: postgres:13
-    container_name: temporal_postgres_db
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${TEMPORAL__POSTGRES_USER}
@@ -222,10 +218,9 @@ services:
 
   temporal:
     image: temporalio/auto-setup:${TEMPORAL__VERSION:-1.27.1}
-    container_name: temporal
     restart: unless-stopped
     ports:
-      - 7233:7233
+      - ${TEMPORAL_PORT:-7233}:7233
     environment:
       - DB=postgres12
       - DB_PORT=5432
@@ -240,9 +235,8 @@ services:
 
   temporal_ui:
     image: temporalio/ui:${TEMPORAL__UI_VERSION:-latest}
-    container_name: temporal_ui
     ports:
-      - 8081:8080
+      - ${TEMPORAL_UI_PORT:-8081}:8080
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:8080
@@ -252,11 +246,10 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2025-05-24T17-08-30Z
-    container_name: minio
     restart: unless-stopped
     ports:
-      - 9000:9000
-      - 9001:9001
+      - ${MINIO_PORT:-9000}:9000
+      - ${MINIO_CONSOLE_PORT:-9001}:9001
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
@@ -272,10 +265,9 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: redis
     restart: unless-stopped
     ports:
-      - 6379:6379
+      - ${REDIS_PORT_HOST:-6379}:6379
     volumes:
       - redis-data:/data
     command: redis-server --appendonly yes


### PR DESCRIPTION
# Motivation
This lets you deploy multiple instances of Tracecat locally with correct networking. Needed this to test git sync but thought it would be useful in general. This is also only a dev config.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allow multiple local Tracecat instances by removing fixed container names and adding env-based host port overrides in docker-compose.dev.yml. Defaults keep current ports, so existing dev setups continue to work.

- New Features
  - Removed container_name from dev services to avoid name collisions.
  - Added env-driven host ports with defaults across services: API_PORT, EXECUTOR_DASHBOARD_PORT, EXECUTOR_API_PORT, UI_PORT, PG_PORT, TEMPORAL_PORT, TEMPORAL_UI_PORT, MINIO_PORT, MINIO_CONSOLE_PORT, REDIS_PORT_HOST.

- Migration
  - No action needed for current usage.
  - To run another instance, set unique ports (e.g., API_PORT=8100, UI_PORT=3100, PG_PORT=5542) and start the stack.

<!-- End of auto-generated description by cubic. -->

