### PR TITLE
perf: Tune db engine connection settings

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -64,13 +64,13 @@ TRACECAT__DB_SSLMODE = os.environ.get("TRACECAT__DB_SSLMODE", "require")
 TRACECAT__DB_PASS__ARN = os.environ.get("TRACECAT__DB_PASS__ARN")
 """(AWS only) ARN of the secret to connect to the database with."""
 
-TRACECAT__DB_MAX_OVERFLOW = int(os.environ.get("TRACECAT__DB_MAX_OVERFLOW", 30))
+TRACECAT__DB_MAX_OVERFLOW = int(os.environ.get("TRACECAT__DB_MAX_OVERFLOW", 60))
 """The maximum number of connections to allow in the pool."""
-TRACECAT__DB_POOL_SIZE = int(os.environ.get("TRACECAT__DB_POOL_SIZE", 30))
+TRACECAT__DB_POOL_SIZE = int(os.environ.get("TRACECAT__DB_POOL_SIZE", 10))
 """The size of the connection pool."""
 TRACECAT__DB_POOL_TIMEOUT = int(os.environ.get("TRACECAT__DB_POOL_TIMEOUT", 30))
 """The timeout for the connection pool."""
-TRACECAT__DB_POOL_RECYCLE = int(os.environ.get("TRACECAT__DB_POOL_RECYCLE", 1800))
+TRACECAT__DB_POOL_RECYCLE = int(os.environ.get("TRACECAT__DB_POOL_RECYCLE", 600))
 """The time to recycle the connection pool."""
 
 # === Auth config === #

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -91,7 +91,7 @@ def _create_async_db_engine() -> AsyncEngine:
         "max_overflow": config.TRACECAT__DB_MAX_OVERFLOW,
         "pool_recycle": config.TRACECAT__DB_POOL_RECYCLE,
         "pool_size": config.TRACECAT__DB_POOL_SIZE,
-        "pool_pre_ping" : True,
+        "pool_pre_ping": True,
         "pool_use_lifo": True,  # Better for burst workloads
     }
     uri = _get_db_uri(driver="asyncpg")

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -91,6 +91,7 @@ def _create_async_db_engine() -> AsyncEngine:
         "max_overflow": config.TRACECAT__DB_MAX_OVERFLOW,
         "pool_recycle": config.TRACECAT__DB_POOL_RECYCLE,
         "pool_size": config.TRACECAT__DB_POOL_SIZE,
+        "pool_pre_ping" : True,
         "pool_use_lifo": True,  # Better for burst workloads
     }
     uri = _get_db_uri(driver="asyncpg")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable pool_pre_ping on the async DB engine to validate connections before use and prevent stale/stuck connections. Reduces connection errors after idle periods or DB restarts, improving reliability.

<!-- End of auto-generated description by cubic. -->

