### PR TITLE
bug: Updates to Jira Update Issue Fields Documentation

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/jira/update_issue_fields.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/jira/update_issue_fields.yml
@@ -18,14 +18,14 @@ definition:
       description: >-
         List of fields to update in the issue.
         Each field is an object with the following keys:
-        - `key`: The Jira custom field ID.
+        - `customfield_10000`: The Jira custom field ID.
         - `value`: The field value.
 
         For example:
         ```
         [
-          {"key": "customfield_10000", "value": "New value"},
-          {"key": "customfield_10001", "value": "Another value"}
+          {"customfield_10000": "New value"},
+          {"customfield_10001": ["Another value"]}
         ]
         ```
     base_url:


### PR DESCRIPTION



## Description

The documentation or description of the jira issue update field command isn't accurate to how it works so this is a little PR to update it ever so slightly.


## Screenshots / Recordings

Error using the old key value example in the description:
<img width="583" height="775" alt="image" src="https://github.com/user-attachments/assets/0797846b-fc2e-4d83-b824-c4e619421961" />

Using the new outlined format:
<img width="340" height="311" alt="image" src="https://github.com/user-attachments/assets/1d7735be-5926-43eb-a875-efe0a484ff1b" />


