### PR TITLE
fix: Stabilize webhook operation IDs in generated TypeScript client

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -232,10 +232,10 @@ import type {
   ProvidersListProvidersData,
   ProvidersListProvidersResponse,
   PublicCheckHealthResponse,
-  PublicIncomingWebhook1Data,
-  PublicIncomingWebhook1Response,
-  PublicIncomingWebhookData,
-  PublicIncomingWebhookResponse,
+  PublicIncomingWebhookGetData,
+  PublicIncomingWebhookGetResponse,
+  PublicIncomingWebhookPostData,
+  PublicIncomingWebhookPostResponse,
   PublicIncomingWebhookWaitData,
   PublicIncomingWebhookWaitResponse,
   PublicReceiveInteractionData,
@@ -444,7 +444,7 @@ import type {
 } from "./types.gen"
 
 /**
- * Incoming Webhook
+ * Incoming Webhook Post
  * Webhook endpoint to trigger a workflow.
  *
  * This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
@@ -459,9 +459,9 @@ import type {
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const publicIncomingWebhook = (
-  data: PublicIncomingWebhookData
-): CancelablePromise<PublicIncomingWebhookResponse> => {
+export const publicIncomingWebhookPost = (
+  data: PublicIncomingWebhookPostData
+): CancelablePromise<PublicIncomingWebhookPostResponse> => {
   return __request(OpenAPI, {
     method: "POST",
     url: "/webhooks/{workflow_id}/{secret}",
@@ -484,7 +484,7 @@ export const publicIncomingWebhook = (
 }
 
 /**
- * Incoming Webhook
+ * Incoming Webhook Get
  * Webhook endpoint to trigger a workflow.
  *
  * This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
@@ -499,9 +499,9 @@ export const publicIncomingWebhook = (
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const publicIncomingWebhook1 = (
-  data: PublicIncomingWebhook1Data
-): CancelablePromise<PublicIncomingWebhook1Response> => {
+export const publicIncomingWebhookGet = (
+  data: PublicIncomingWebhookGetData
+): CancelablePromise<PublicIncomingWebhookGetResponse> => {
   return __request(OpenAPI, {
     method: "GET",
     url: "/webhooks/{workflow_id}/{secret}",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4398,7 +4398,7 @@ export type login = {
   client_secret?: string | null
 }
 
-export type PublicIncomingWebhookData = {
+export type PublicIncomingWebhookPostData = {
   contentType?: string | null
   /**
    * Echo back to the caller
@@ -4416,9 +4416,9 @@ export type PublicIncomingWebhookData = {
   workflowId: string
 }
 
-export type PublicIncomingWebhookResponse = unknown
+export type PublicIncomingWebhookPostResponse = unknown
 
-export type PublicIncomingWebhook1Data = {
+export type PublicIncomingWebhookGetData = {
   contentType?: string | null
   /**
    * Echo back to the caller
@@ -4436,7 +4436,7 @@ export type PublicIncomingWebhook1Data = {
   workflowId: string
 }
 
-export type PublicIncomingWebhook1Response = unknown
+export type PublicIncomingWebhookGetResponse = unknown
 
 export type PublicIncomingWebhookWaitData = {
   contentType?: string | null
@@ -6162,7 +6162,7 @@ export type PublicCheckHealthResponse = {
 export type $OpenApiTs = {
   "/webhooks/{workflow_id}/{secret}": {
     post: {
-      req: PublicIncomingWebhookData
+      req: PublicIncomingWebhookPostData
       res: {
         /**
          * Successful Response
@@ -6175,7 +6175,7 @@ export type $OpenApiTs = {
       }
     }
     get: {
-      req: PublicIncomingWebhook1Data
+      req: PublicIncomingWebhookGetData
       res: {
         /**
          * Successful Response


### PR DESCRIPTION
## Summary
- Split webhook endpoint into separate POST and GET handlers with stable operation IDs
- POST handler generates `publicIncomingWebhookPost`
- GET handler generates `publicIncomingWebhookGet`
- Both handlers share common `_incoming_webhook` implementation to maintain identical functionality  
- Added `WebhookResponse` type alias for cleaner type annotations
- This prevents unstable diffs in the generated TypeScript client

## Test plan
- [x] Run `just gen-client` to regenerate the TypeScript client
- [x] Verify `publicIncomingWebhookPost` uses POST method (primary webhook triggering)
- [x] Verify `publicIncomingWebhookGet` uses GET method (webhook verification challenges)
- [x] No more method flipping between GET/POST on client regeneration

🤖 Generated with [Claude Code](https://claude.ai/code)