### PR TITLE
feat: Add user ID (temporal namespace) and release (app version) to Sentry event

### DIFF
--- a/tracecat/dsl/interceptor.py
+++ b/tracecat/dsl/interceptor.py
@@ -74,6 +74,7 @@ class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
             )
             info = workflow.info()
             _set_common_workflow_tags(info)
+            sentry.set_user({"id": info.namespace})
             sentry.set_tag("temporal.workflow.task_queue", info.task_queue)
             sentry.set_tag("temporal.workflow.namespace", info.namespace)
             sentry.set_tag("temporal.workflow.run_id", info.run_id)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Sentry user ID (Temporal namespace) and sets release to the app version. Also scopes the Sentry environment by app env and namespace to improve alert routing and triage.

- **New Features**
  - Set Sentry user ID to the Temporal namespace.
  - Initialize Sentry with environment "{app_env}-{temporal_namespace}".
  - Set release to "tracecat@{APP_VERSION}".

<!-- End of auto-generated description by cubic. -->

