### PR TITLE
feat(integrations): HTTP pagination action

### DIFF
--- a/docs/quickstart/core-actions.mdx
+++ b/docs/quickstart/core-actions.mdx
@@ -121,7 +121,7 @@ Perform an HTTP request to a given URL.
     - The value can be:
         1.  A simple **base64 encoded string** representing the file content. In this case, the `form_field_name` will also be used as the filename in the `Content-Disposition` header.
         2.  A **dictionary (`FileUploadData`)** with the following keys:
-+            - `filename` (str): The actual filename to be sent in the `Content-Disposition` header (e.g., `"mydocument.pdf"`). If not provided or empty, the `form_field_name` will be used.
+            - `filename` (str): The actual filename to be sent in the `Content-Disposition` header (e.g., `"mydocument.pdf"`). If not provided or empty, the `form_field_name` will be used.
             - `content_base64` (str, required): The base64 encoded string of the file content.
             - `content_type` (str, optional): The MIME type of the file (e.g., `"application/pdf"`, `"image/png"`). If not provided, `httpx` will attempt to guess it.
 - `auth` (dict[str, str], optional): Basic auth credentials with `username` and `password` keys.
@@ -202,7 +202,7 @@ Perform an HTTP request to a given URL with polling.
 - `poll_retry_codes` (int | list[int], optional): Status codes on which the action will retry. If not specified, `poll_condition` must be provided.
 - `poll_interval` (float, optional): Interval in seconds between polling attempts. If not specified, defaults to polling with exponential wait.
 - `poll_max_attempts` (int, optional, default: 10): Maximum number of polling attempts. If set to 0, the action will poll indefinitely (until timeout).
-- `poll_condition` (str, optional): User defined Python lambda function. If returns a truthy value, stops polling. If not specified, `poll_retry_codes` must be provided.
+- `poll_condition` (str, optional): User defined Python lambda function. When it returns a truthy value, stops polling. If not specified, `poll_retry_codes` must be provided.
 
 **Returns**
 
@@ -231,6 +231,102 @@ Examples:
 ```
 </CodeGroup>
 
+## HTTP Paginate
+
+Paginate through a HTTP response.
+
+**Parameters**
+
+- Accepts all parameters from `core.http_request` **except for the `files` parameter.** `core.http_paginate` does not support file uploads.
+- `stop_condition` (str, required): User defined Python lambda function. When it returns a truthy value, stops pagination.
+- `next_request` (str, required): User defined Python lambda function. Returns the next request as a JSON of `url`, `method`, `headers`, `params`, `payload`, `form_data` to paginate to.
+- `items_jsonpath` (str, optional): JSONPath expression that evaluates to the items to paginate through.
+- `limit` (int, optional, default: 1000): Maximum number of items to paginate through.
+
+Examples:
+
+<CodeGroup>
+  ```json Cursor in body (response example)
+  {
+    "items": [{"id": 1}, {"id": 2}],
+    "cursor": "https://api.example.com/resources?cursor=abc123"
+  }
+  ```
+
+  ```yaml Cursor in body (pagination config)
+  stop_condition: "lambda x: x['data'].get('cursor') is None"
+  next_request: "lambda x: {'url': x['data'].get('cursor')}"
+  items_jsonpath: $.items
+  limit: 1000
+  ```
+
+  ```json Offset + total (response example)
+  {
+    "items": [{"id": 101}, {"id": 102}],
+    "offset": 0,
+    "limit": 100,
+    "total": 250
+  }
+  ```
+
+  ```yaml Offset + total (pagination config)
+  stop_condition: "lambda x: (x['data'].get('offset', 0) + x['data'].get('limit', 0)) >= x['data'].get('total', 0)"
+  next_request: "lambda x: {'params': {'offset': x['data'].get('offset', 0) + x['data'].get('limit', 0)}}"
+  items_jsonpath: $.items
+  limit: 1000
+  ```
+
+  ```json nextPageToken in body (response example)
+  {
+    "items": [{"id": "a"}, {"id": "b"}],
+    "nextPageToken": "token-123"
+  }
+  ```
+
+  ```yaml nextPageToken in body (pagination config)
+  stop_condition: "lambda x: not x['data'].get('nextPageToken')"
+  next_request: "lambda x: {'params': {'pageToken': x['data'].get('nextPageToken')}}"
+  items_jsonpath: $.items
+  limit: 1000
+  ```
+
+  ```http Link header (response headers example)
+  Link: <https://api.example.com/resources?page=3>; rel="next", <https://api.example.com/resources?page=50>; rel="last"
+  ```
+
+  ```yaml Link header (pagination config)
+  # Stops when no rel="next" link is present
+  stop_condition: "lambda x: 'link' not in {k.lower(): v for k, v in x['headers'].items()} or 'rel=\"next\"' not in {k.lower(): v for k, v in x['headers'].items()}['link']"
+  # Picks the rel="next" URL from the Link header
+  next_request: "lambda x: {'url': [p.split(';')[0].strip('<> ') for p in {k.lower(): v for k, v in x['headers'].items()}['link'].split(',') if 'rel=\"next\"' in p][0]}"
+  items_jsonpath: $.items
+  limit: 1000
+  ```
+
+  ```http Header token (response headers + body example)
+  x-next-cursor: abc123
+  ---
+  { "items": [{"id": 1}], "count": 1 }
+  ```
+
+  ```yaml Header token (pagination config)
+  stop_condition: "lambda x: not x['headers'].get('x-next-cursor')"
+  next_request: "lambda x: {'params': {'cursor': x['headers'].get('x-next-cursor')}}"
+  items_jsonpath: $.items
+  limit: 1000
+  ```
+
+  ```json Stop on empty items (response example)
+  { "items": [] }
+  ```
+
+  ```yaml Stop on empty items (pagination config)
+  stop_condition: "lambda x: not x['data'].get('items')"
+  next_request: "lambda x: {'params': {'page': (x['data'].get('page', 1) + 1)}}"
+  items_jsonpath: $.items
+  limit: 1000
+  ```
+</CodeGroup>
 
 ## Tutorial: URLScan
 

--- a/docs/quickstart/core-actions.mdx
+++ b/docs/quickstart/core-actions.mdx
@@ -243,6 +243,11 @@ Paginate through a HTTP response.
 - `items_jsonpath` (str, optional): JSONPath expression that evaluates to the items to paginate through.
 - `limit` (int, optional, default: 1000): Maximum number of items to paginate through.
 
+**Returns**
+
+- With `items_jsonpath`: A flat list of items collected across pages, truncated to `limit` items.
+- Without `items_jsonpath`: A list of per-page `HTTPResponse` objects, where `limit` applies per page.
+
 Examples:
 
 <CodeGroup>
@@ -327,6 +332,12 @@ Examples:
   limit: 1000
   ```
 </CodeGroup>
+
+<Note>
+  To capture the entire response body from each page as items, set `items_jsonpath` to `$`.
+  This returns a flat list of page bodies (e.g., `[page1_body, page2_body, ...]`).
+  If you omit `items_jsonpath`, the action returns a list of full `HTTPResponse` objects (headers, status_code, data) — one per page.
+</Note>
 
 ## Tutorial: URLScan
 

--- a/packages/tracecat-registry/tracecat_registry/core/http.py
+++ b/packages/tracecat-registry/tracecat_registry/core/http.py
@@ -653,7 +653,7 @@ async def http_poll(
     poll_condition: Annotated[
         str | None,
         Doc(
-            "Python lambda function that determines when polling should STOP. The function receives a dict with `headers`, `data`, and `status_code` fields."
+            "Python lambda function when evaluated to True, stops polling. The function receives a dict with `headers`, `data`, and `status_code` fields."
         ),
     ] = None,
 ) -> HTTPResponse:

--- a/packages/tracecat-registry/tracecat_registry/core/http.py
+++ b/packages/tracecat-registry/tracecat_registry/core/http.py
@@ -784,13 +784,17 @@ async def http_paginate(
         str | None,
         Doc("JSONPath expression that evaluates to the items to paginate through."),
     ] = None,
+    limit: Annotated[
+        int,
+        Doc("Maximum number of items to paginate through. Defaults to 1000."),
+    ] = 1000,
 ) -> list[HTTPResponse]:
     """Paginate through a HTTP response."""
 
     stop_condition_fn = build_safe_lambda(stop_condition)
     next_request_fn = build_safe_lambda(next_request)
     responses = []
-    while True:
+    while len(responses) < limit:
         response = await http_request(
             url=url,
             method=method,

--- a/tests/registry/test_core_http.py
+++ b/tests/registry/test_core_http.py
@@ -8,6 +8,7 @@ import respx
 from tenacity import RetryError
 from tracecat_registry.core.http import (
     FileUploadData,
+    http_paginate,
     http_poll,
     http_request,
     httpx_to_response,
@@ -861,3 +862,614 @@ async def test_http_request_file_upload_aggregate_size_exceeded() -> None:
     pytest.skip(
         "Cannot test aggregate size limit with current config: individual limit (20MB) * max files (5) = 100MB which equals aggregate limit (100MB). Need individual limit > 20MB or aggregate limit < 100MB to test this scenario."
     )
+
+
+# Test HTTP paginate function
+@pytest.fixture
+def pagination_scenarios():
+    """Fixture providing different pagination scenarios for testing."""
+    return {
+        "cursor_in_body": {
+            "responses": [
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": [{"id": 1}, {"id": 2}],
+                        "cursor": "https://api.example.com/resources?cursor=page2",
+                    },
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": [{"id": 3}, {"id": 4}],
+                        "cursor": "https://api.example.com/resources?cursor=page3",
+                    },
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [{"id": 5}], "cursor": None},
+                ),
+            ],
+            "stop_condition": "lambda x: x['data'].get('cursor') is None",
+            "next_request": "lambda x: {'url': x['data'].get('cursor')}",
+            "items_jsonpath": "$.items",
+            "expected_items": [
+                [{"id": 1}, {"id": 2}],
+                [{"id": 3}, {"id": 4}],
+                [{"id": 5}],
+            ],
+        },
+        "offset_total": {
+            "responses": [
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": [{"id": 101}, {"id": 102}],
+                        "offset": 0,
+                        "limit": 2,
+                        "total": 5,
+                    },
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": [{"id": 103}, {"id": 104}],
+                        "offset": 2,
+                        "limit": 2,
+                        "total": 5,
+                    },
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [{"id": 105}], "offset": 4, "limit": 2, "total": 5},
+                ),
+            ],
+            "stop_condition": "lambda x: (x['data'].get('offset', 0) + x['data'].get('limit', 0)) >= x['data'].get('total', 0)",
+            "next_request": "lambda x: {'params': {'offset': x['data'].get('offset', 0) + x['data'].get('limit', 0)}}",
+            "items_jsonpath": "$.items",
+            "expected_items": [
+                [{"id": 101}, {"id": 102}],
+                [{"id": 103}, {"id": 104}],
+                [{"id": 105}],
+            ],
+        },
+        "next_page_token": {
+            "responses": [
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": [{"id": "a"}, {"id": "b"}],
+                        "nextPageToken": "token-page2",
+                    },
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": [{"id": "c"}, {"id": "d"}],
+                        "nextPageToken": "token-page3",
+                    },
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [{"id": "e"}], "nextPageToken": None},
+                ),
+            ],
+            "stop_condition": "lambda x: not x['data'].get('nextPageToken')",
+            "next_request": "lambda x: {'params': {'pageToken': x['data'].get('nextPageToken')}}",
+            "items_jsonpath": "$.items",
+            "expected_items": [
+                [{"id": "a"}, {"id": "b"}],
+                [{"id": "c"}, {"id": "d"}],
+                [{"id": "e"}],
+            ],
+        },
+        "link_header": {
+            "responses": [
+                httpx.Response(
+                    status_code=200,
+                    headers={
+                        "Link": '<https://api.example.com/resources?page=2>; rel="next", <https://api.example.com/resources?page=10>; rel="last"'
+                    },
+                    json={"items": [{"id": 1}, {"id": 2}]},
+                ),
+                httpx.Response(
+                    status_code=200,
+                    headers={
+                        "Link": '<https://api.example.com/resources?page=3>; rel="next", <https://api.example.com/resources?page=10>; rel="last"'
+                    },
+                    json={"items": [{"id": 3}, {"id": 4}]},
+                ),
+                httpx.Response(
+                    status_code=200,
+                    headers={
+                        "Link": '<https://api.example.com/resources?page=10>; rel="last"'
+                    },
+                    json={"items": [{"id": 5}]},
+                ),
+            ],
+            "stop_condition": "lambda x: 'link' not in {k.lower(): v for k, v in x['headers'].items()} or 'rel=\"next\"' not in {k.lower(): v for k, v in x['headers'].items()}['link']",
+            "next_request": "lambda x: {'url': [p.split(';')[0].strip('<> ') for p in {k.lower(): v for k, v in x['headers'].items()}['link'].split(',') if 'rel=\"next\"' in p][0]}",
+            "items_jsonpath": "$.items",
+            "expected_items": [
+                [{"id": 1}, {"id": 2}],
+                [{"id": 3}, {"id": 4}],
+                [{"id": 5}],
+            ],
+        },
+        "header_cursor": {
+            "responses": [
+                httpx.Response(
+                    status_code=200,
+                    headers={"x-next-cursor": "cursor-page2"},
+                    json={"items": [{"id": 1}], "count": 1},
+                ),
+                httpx.Response(
+                    status_code=200,
+                    headers={"x-next-cursor": "cursor-page3"},
+                    json={"items": [{"id": 2}], "count": 1},
+                ),
+                httpx.Response(
+                    status_code=200,
+                    headers={},  # No x-next-cursor header
+                    json={"items": [{"id": 3}], "count": 1},
+                ),
+            ],
+            "stop_condition": "lambda x: not x['headers'].get('x-next-cursor')",
+            "next_request": "lambda x: {'params': {'cursor': x['headers'].get('x-next-cursor')}}",
+            "items_jsonpath": "$.items",
+            "expected_items": [[{"id": 1}], [{"id": 2}], [{"id": 3}]],
+        },
+        "empty_items_stop": {
+            "responses": [
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [{"id": 1}, {"id": 2}], "page": 1},
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [{"id": 3}], "page": 2},
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [], "page": 3},  # Empty items stops pagination
+                ),
+            ],
+            "stop_condition": "lambda x: not x['data'].get('items')",
+            "next_request": "lambda x: {'params': {'page': (x['data'].get('page', 1) + 1)}}",
+            "items_jsonpath": "$.items",
+            "expected_items": [[{"id": 1}, {"id": 2}], [{"id": 3}], []],
+        },
+    }
+
+
+@pytest.mark.anyio
+@respx.mock
+@pytest.mark.parametrize(
+    "scenario_name",
+    [
+        "cursor_in_body",
+        "offset_total",
+        "next_page_token",
+        "link_header",
+        "header_cursor",
+        "empty_items_stop",
+    ],
+)
+async def test_http_paginate_patterns(pagination_scenarios, scenario_name) -> None:
+    """Test various pagination patterns using parameterized scenarios."""
+    scenario = pagination_scenarios[scenario_name]
+
+    # Mock the API responses
+    route = respx.get("https://api.example.com/resources").mock(
+        side_effect=scenario["responses"]
+    )
+
+    # Call http_paginate with scenario-specific parameters
+    result = await http_paginate(
+        url="https://api.example.com/resources",
+        method="GET",
+        stop_condition=scenario["stop_condition"],
+        next_request=scenario["next_request"],
+        items_jsonpath=scenario["items_jsonpath"],
+        limit=1000,
+    )
+
+    # Verify correct number of requests
+    assert route.call_count == len(scenario["responses"])
+
+    # Verify results match expected items
+    assert isinstance(result, list)
+    assert len(result) == len(scenario["expected_items"])
+
+    for i, expected_items in enumerate(scenario["expected_items"]):
+        assert result[i] == expected_items, (
+            f"Mismatch at page {i} for scenario {scenario_name}"
+        )
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_without_jsonpath() -> None:
+    """Test pagination without items_jsonpath extraction.
+
+    Note: Current implementation only appends to results when items_jsonpath is provided.
+    Without items_jsonpath, the function still paginates but returns an empty list.
+    """
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={"data": "page1", "hasMore": True},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"data": "page2", "hasMore": True},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"data": "page3", "hasMore": False},
+        ),
+    ]
+
+    route = respx.get("https://api.example.com/data").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/data",
+        method="GET",
+        stop_condition="lambda x: not x['data'].get('hasMore')",
+        next_request="lambda x: {'url': 'https://api.example.com/data'}",
+        items_jsonpath=None,  # No JSONPath extraction
+        limit=1000,
+    )
+
+    # Current behavior: When items_jsonpath is None, nothing is appended to results
+    assert route.call_count == 3
+    assert len(result) == 0  # No items extracted without JSONPath
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_with_dollar_jsonpath() -> None:
+    """Test pagination using $ as JSONPath to get entire response data."""
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={"data": "page1", "hasMore": True},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"data": "page2", "hasMore": True},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"data": "page3", "hasMore": False},
+        ),
+    ]
+
+    route = respx.get("https://api.example.com/data").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/data",
+        method="GET",
+        stop_condition="lambda x: not x['data'].get('hasMore')",
+        next_request="lambda x: {'url': 'https://api.example.com/data'}",
+        items_jsonpath="$",  # Get entire response data
+        limit=1000,
+    )
+
+    assert route.call_count == 3
+    assert len(result) == 3
+
+    # With $ JSONPath, should return full data objects
+    for i in range(3):
+        assert result[i] == {"data": f"page{i + 1}", "hasMore": i < 2}
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_limit_enforcement() -> None:
+    """Test that pagination respects the limit parameter."""
+    # Create more responses than the limit
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={"items": [{"id": i}], "page": i},
+        )
+        for i in range(1, 10)  # 9 responses
+    ]
+
+    route = respx.get("https://api.example.com/limited").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/limited",
+        method="GET",
+        stop_condition="lambda x: False",  # Never stop based on condition
+        next_request="lambda x: {'params': {'page': x['data'].get('page', 0) + 1}}",
+        items_jsonpath="$.items",
+        limit=3,  # Limit to 3 pages
+    )
+
+    # Should stop after 3 requests due to limit
+    assert route.call_count == 3
+    assert len(result) == 3
+
+    # Verify we got the first 3 pages
+    for i in range(3):
+        assert result[i] == [{"id": i + 1}]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_with_post_method() -> None:
+    """Test pagination using POST method with payload."""
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={"results": [1, 2], "continuation": "token1"},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"results": [3, 4], "continuation": None},
+        ),
+    ]
+
+    route = respx.post("https://api.example.com/search").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/search",
+        method="POST",
+        payload={"query": "test"},
+        stop_condition="lambda x: x['data'].get('continuation') is None",
+        next_request="lambda x: {'payload': {'query': 'test', 'continuation': x['data'].get('continuation')}}",
+        items_jsonpath="$.results",
+        limit=1000,
+    )
+
+    assert route.call_count == 2
+    assert len(result) == 2
+    assert result[0] == [1, 2]
+    assert result[1] == [3, 4]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_with_headers_and_auth() -> None:
+    """Test pagination with headers and authentication."""
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={"items": ["a"], "next": 2},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"items": ["b"], "next": None},
+        ),
+    ]
+
+    route = respx.get("https://api.example.com/secure").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/secure",
+        method="GET",
+        headers={"X-API-Key": "secret"},
+        auth={"username": "user", "password": "pass"},
+        stop_condition="lambda x: x['data'].get('next') is None",
+        next_request="lambda x: {'params': {'page': x['data'].get('next')}}",
+        items_jsonpath="$.items",
+        limit=1000,
+    )
+
+    assert route.call_count == 2
+
+    # Check that auth headers were sent
+    for call in route.calls:
+        assert "Authorization" in call.request.headers
+        assert call.request.headers["X-API-Key"] == "secret"
+
+    assert result == [["a"], ["b"]]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_immediate_stop() -> None:
+    """Test pagination that stops immediately on first response."""
+    route = respx.get("https://api.example.com/single").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={"items": [1, 2, 3], "complete": True},
+        )
+    )
+
+    result = await http_paginate(
+        url="https://api.example.com/single",
+        method="GET",
+        stop_condition="lambda x: x['data'].get('complete') == True",
+        next_request="lambda x: {'url': 'https://api.example.com/single'}",
+        items_jsonpath="$.items",
+        limit=1000,
+    )
+
+    # Should only make one request
+    assert route.call_count == 1
+    assert len(result) == 1
+    assert result[0] == [1, 2, 3]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_complex_jsonpath() -> None:
+    """Test pagination with complex JSONPath expressions."""
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={
+                "response": {"data": {"users": [{"name": "Alice"}, {"name": "Bob"}]}},
+                "hasMore": True,
+            },
+        ),
+        httpx.Response(
+            status_code=200,
+            json={
+                "response": {"data": {"users": [{"name": "Charlie"}]}},
+                "hasMore": False,
+            },
+        ),
+    ]
+
+    route = respx.get("https://api.example.com/nested").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/nested",
+        method="GET",
+        stop_condition="lambda x: not x['data'].get('hasMore')",
+        next_request="lambda x: {'url': 'https://api.example.com/nested'}",
+        items_jsonpath="$.response.data.users",
+        limit=1000,
+    )
+
+    assert route.call_count == 2
+    assert len(result) == 2
+    assert result[0] == [{"name": "Alice"}, {"name": "Bob"}]
+    assert result[1] == [{"name": "Charlie"}]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_update_multiple_params() -> None:
+    """Test pagination that updates multiple request parameters."""
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={"items": [1], "next_offset": 10, "next_limit": 5},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"items": [2], "next_offset": None},
+        ),
+    ]
+
+    route = respx.get("https://api.example.com/multi").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/multi",
+        method="GET",
+        params={"offset": 0, "limit": 10},
+        stop_condition="lambda x: x['data'].get('next_offset') is None",
+        next_request="lambda x: {'params': {'offset': x['data'].get('next_offset'), 'limit': x['data'].get('next_limit', 10)}}",
+        items_jsonpath="$.items",
+        limit=1000,
+    )
+
+    assert route.call_count == 2
+    assert result == [[1], [2]]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_error_handling() -> None:
+    """Test error handling in pagination."""
+    route = respx.get("https://api.example.com/error").mock(
+        side_effect=[
+            httpx.Response(
+                status_code=200,
+                json={"items": [1], "next": True},
+            ),
+            httpx.Response(
+                status_code=500,
+                json={"error": "Internal Server Error"},
+            ),
+        ]
+    )
+
+    with pytest.raises(TracecatException) as excinfo:
+        await http_paginate(
+            url="https://api.example.com/error",
+            method="GET",
+            stop_condition="lambda x: not x['data'].get('next')",
+            next_request="lambda x: {'url': 'https://api.example.com/error'}",
+            items_jsonpath="$.items",
+            limit=1000,
+        )
+
+    assert route.call_count == 2
+    assert "500" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_timeout() -> None:
+    """Test timeout handling in pagination."""
+    route = respx.get("https://api.example.com/timeout").mock(
+        side_effect=[
+            httpx.Response(status_code=200, json={"items": [1], "next": True}),
+            httpx.ReadTimeout("Timeout"),
+        ]
+    )
+
+    with pytest.raises(httpx.ReadTimeout):
+        await http_paginate(
+            url="https://api.example.com/timeout",
+            method="GET",
+            stop_condition="lambda x: not x['data'].get('next')",
+            next_request="lambda x: {'url': 'https://api.example.com/timeout'}",
+            items_jsonpath="$.items",
+            timeout=1.0,
+            limit=1000,
+        )
+
+    assert route.call_count == 2
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_form_data() -> None:
+    """Test pagination with form data."""
+    responses = [
+        httpx.Response(
+            status_code=200,
+            json={"items": ["form1"], "page": 1},
+        ),
+        httpx.Response(
+            status_code=200,
+            json={"items": ["form2"], "page": 2},
+        ),
+    ]
+
+    route = respx.post("https://api.example.com/form").mock(side_effect=responses)
+
+    result = await http_paginate(
+        url="https://api.example.com/form",
+        method="POST",
+        form_data={"field": "value"},
+        stop_condition="lambda x: x['data'].get('page') >= 2",
+        next_request="lambda x: {'form_data': {'field': 'value', 'page': x['data'].get('page', 0) + 1}}",
+        items_jsonpath="$.items",
+        limit=1000,
+    )
+
+    assert route.call_count == 2
+    assert result == [["form1"], ["form2"]]
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_http_paginate_zero_limit() -> None:
+    """Test pagination with limit=0 (no items collected)."""
+    route = respx.get("https://api.example.com/zero").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={"items": [1, 2, 3]},
+        )
+    )
+
+    result = await http_paginate(
+        url="https://api.example.com/zero",
+        method="GET",
+        stop_condition="lambda x: True",  # Stop immediately
+        next_request="lambda x: {'url': 'https://api.example.com/zero'}",
+        items_jsonpath="$.items",
+        limit=0,  # Zero limit
+    )
+
+    # Should not make any requests when limit is 0
+    assert route.call_count == 0
+    assert result == []


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new core.http_paginate action to iterate through paginated HTTP APIs using simple lambdas to stop and fetch the next page. Includes docs with real-world patterns and comprehensive tests.

- New Features
  - Added core.http_paginate with stop_condition and next_request lambdas.
  - Supports JSONPath extraction (items_jsonpath) and a page limit (default 1000).
  - Reuses http_request options (except files); works with GET/POST, headers, params, payload, form-data, and auth.
  - Docs: new “HTTP Paginate” guide with examples (cursor in body, offset/total, nextPageToken, Link header, header token, stop on empty items).
  - Tests cover common patterns, limits, POST flows, headers/auth, form-data, errors, and timeouts.

<!-- End of auto-generated description by cubic. -->

