### PR TITLE
fix: cache git url

### DIFF
--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -386,8 +386,8 @@ async def test_git_context_cache_expiry(mock_session):
         assert ssh_cmd1 == "ssh -i /tmp/expired_key"
         assert mock_git_url.call_count == 1
 
-        # Advance time by 20 seconds (still within 30 second TTL)
-        mock_time.return_value = initial_time + 20
+        # Advance time by 40 seconds (still within 60 second TTL)
+        mock_time.return_value = initial_time + 40
 
         # Second call - should use cache
         git_url2, ssh_cmd2 = await get_git_context_cached(role=test_role)
@@ -395,8 +395,8 @@ async def test_git_context_cache_expiry(mock_session):
         assert ssh_cmd2 == "ssh -i /tmp/expired_key"
         assert mock_git_url.call_count == 1  # Still 1
 
-        # Advance time by 31 seconds (beyond 30 second TTL)
-        mock_time.return_value = initial_time + 31
+        # Advance time by 61 seconds (beyond 60 second TTL)
+        mock_time.return_value = initial_time + 61
 
         # Update mock returns for new fetch
         new_git_url = GitUrl(host="github.com", org="test", repo="repo", ref="ghi789")

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -134,6 +134,12 @@ async def test_dispatch_action_with_foreach(
 @pytest.mark.anyio
 async def test_dispatch_action_with_git_url(mock_session, basic_task_input):
     """Test dispatch_action_on_cluster with a git url, patching get_async_session_context_manager."""
+    # Import ctx_role to set the role context
+    from tracecat.contexts import ctx_role
+
+    # Set up the role context for the test
+    test_role = Role(type="service", service_id="tracecat-executor")
+    ctx_role.set(test_role)
 
     # Patch the async session context manager to yield a mock session
     @asynccontextmanager

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -411,15 +411,15 @@ async def test_git_context_cache_expiry(mock_session):
 
 
 @pytest.mark.anyio
-async def test_git_context_cache_different_roles(mock_session):
-    """Test that different roles have separate cache entries."""
+async def test_git_context_cache_different_workspaces(mock_session):
+    """Test that different workspaces have separate cache entries."""
     from tracecat.contexts import ctx_role
     from tracecat.executor.service import _git_context_cache, get_git_context_cached
 
     # Clear the cache first
     _git_context_cache.clear()
 
-    # Set up two different roles
+    # Set up two different roles with different workspaces
     ws1_id = uuid.uuid4()
     ws2_id = uuid.uuid4()
     role1 = Role(
@@ -491,7 +491,7 @@ async def test_git_context_cache_different_roles(mock_session):
         assert result1_cached[1] == "ssh -i /tmp/key1"
         assert mock_git_url.call_count == 2  # Still 2, used cache
 
-        # Verify cache has entries for both roles
+        # Verify cache has entries for both workspaces
         assert len(_git_context_cache) == 2
 
 

--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -272,3 +272,278 @@ async def test_run_action_from_input_secrets_handling(mocker, test_role):
 
     # Verify environment parameter
     assert call_kwargs["environment"] == "test_env"
+
+
+@pytest.mark.anyio
+async def test_git_context_cache_hit(mock_session):
+    """Test that git context is cached and reused on subsequent calls."""
+    from tracecat.contexts import ctx_role
+    from tracecat.executor.service import _git_context_cache, get_git_context_cached
+
+    # Clear the cache first
+    _git_context_cache.clear()
+
+    # Set up the role context
+    test_role = Role(
+        type="service",
+        service_id="tracecat-executor",
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    ctx_role.set(test_role)
+
+    # Mock the session context manager
+    @asynccontextmanager
+    async def mock_session_cm():
+        yield mock_session
+
+    def get_session_cm():
+        return mock_session_cm()
+
+    with (
+        patch(
+            "tracecat.executor.service.get_async_session_context_manager",
+            new=get_session_cm,
+        ),
+        patch("tracecat.executor.service.safe_prepare_git_url") as mock_git_url,
+        patch("tracecat.executor.service.get_ssh_command") as mock_ssh_cmd,
+    ):
+        # Set up mock returns
+        test_git_url = GitUrl(host="github.com", org="test", repo="repo", ref="abc123")
+        mock_git_url.return_value = test_git_url
+        mock_ssh_cmd.return_value = "ssh -i /tmp/test_key"
+
+        # First call - should fetch from DB
+        git_url1, ssh_cmd1 = await get_git_context_cached(role=test_role)
+        assert git_url1 == test_git_url
+        assert ssh_cmd1 == "ssh -i /tmp/test_key"
+        assert mock_git_url.call_count == 1
+        assert mock_ssh_cmd.call_count == 1
+
+        # Second call - should use cache
+        git_url2, ssh_cmd2 = await get_git_context_cached(role=test_role)
+        assert git_url2 == test_git_url
+        assert ssh_cmd2 == "ssh -i /tmp/test_key"
+        # Should still be 1 since it used cache
+        assert mock_git_url.call_count == 1
+        assert mock_ssh_cmd.call_count == 1
+
+        # Third call - verify cache still works
+        git_url3, ssh_cmd3 = await get_git_context_cached(role=test_role)
+        assert git_url3 == test_git_url
+        assert ssh_cmd3 == "ssh -i /tmp/test_key"
+        assert mock_git_url.call_count == 1
+        assert mock_ssh_cmd.call_count == 1
+
+
+@pytest.mark.anyio
+async def test_git_context_cache_expiry(mock_session):
+    """Test that git context cache expires after TTL and refetches."""
+    from tracecat.contexts import ctx_role
+    from tracecat.executor.service import _git_context_cache, get_git_context_cached
+
+    # Clear the cache first
+    _git_context_cache.clear()
+
+    # Set up the role context
+    test_role = Role(
+        type="service",
+        service_id="tracecat-executor",
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    ctx_role.set(test_role)
+
+    # Mock the session context manager
+    @asynccontextmanager
+    async def mock_session_cm():
+        yield mock_session
+
+    def get_session_cm():
+        return mock_session_cm()
+
+    with (
+        patch(
+            "tracecat.executor.service.get_async_session_context_manager",
+            new=get_session_cm,
+        ),
+        patch("tracecat.executor.service.safe_prepare_git_url") as mock_git_url,
+        patch("tracecat.executor.service.get_ssh_command") as mock_ssh_cmd,
+        patch("tracecat.executor.service.time.time") as mock_time,
+    ):
+        # Set up mock returns
+        test_git_url = GitUrl(host="github.com", org="test", repo="repo", ref="def456")
+        mock_git_url.return_value = test_git_url
+        mock_ssh_cmd.return_value = "ssh -i /tmp/expired_key"
+
+        # Set initial time
+        initial_time = 1000.0
+        mock_time.return_value = initial_time
+
+        # First call - should fetch from DB
+        git_url1, ssh_cmd1 = await get_git_context_cached(role=test_role)
+        assert git_url1 == test_git_url
+        assert ssh_cmd1 == "ssh -i /tmp/expired_key"
+        assert mock_git_url.call_count == 1
+
+        # Advance time by 20 seconds (still within 30 second TTL)
+        mock_time.return_value = initial_time + 20
+
+        # Second call - should use cache
+        git_url2, ssh_cmd2 = await get_git_context_cached(role=test_role)
+        assert git_url2 == test_git_url
+        assert ssh_cmd2 == "ssh -i /tmp/expired_key"
+        assert mock_git_url.call_count == 1  # Still 1
+
+        # Advance time by 31 seconds (beyond 30 second TTL)
+        mock_time.return_value = initial_time + 31
+
+        # Update mock returns for new fetch
+        new_git_url = GitUrl(host="github.com", org="test", repo="repo", ref="ghi789")
+        mock_git_url.return_value = new_git_url
+        mock_ssh_cmd.return_value = "ssh -i /tmp/new_key"
+
+        # Third call - should refetch due to expired cache
+        git_url3, ssh_cmd3 = await get_git_context_cached(role=test_role)
+        assert git_url3 == new_git_url
+        assert ssh_cmd3 == "ssh -i /tmp/new_key"
+        assert mock_git_url.call_count == 2  # Should have fetched again
+
+
+@pytest.mark.anyio
+async def test_git_context_cache_different_roles(mock_session):
+    """Test that different roles have separate cache entries."""
+    from tracecat.contexts import ctx_role
+    from tracecat.executor.service import _git_context_cache, get_git_context_cached
+
+    # Clear the cache first
+    _git_context_cache.clear()
+
+    # Set up two different roles
+    ws1_id = uuid.uuid4()
+    ws2_id = uuid.uuid4()
+    role1 = Role(
+        type="service",
+        service_id="tracecat-executor",
+        workspace_id=ws1_id,
+        user_id=uuid.uuid4(),
+    )
+    role2 = Role(
+        type="service",
+        service_id="tracecat-executor",
+        workspace_id=ws2_id,
+        user_id=uuid.uuid4(),
+    )
+
+    # Mock the session context manager
+    @asynccontextmanager
+    async def mock_session_cm():
+        yield mock_session
+
+    def get_session_cm():
+        return mock_session_cm()
+
+    with (
+        patch(
+            "tracecat.executor.service.get_async_session_context_manager",
+            new=get_session_cm,
+        ),
+        patch("tracecat.executor.service.safe_prepare_git_url") as mock_git_url,
+        patch("tracecat.executor.service.get_ssh_command") as mock_ssh_cmd,
+    ):
+        # Set up mock to return different values based on role
+        git_url1 = GitUrl(host="github.com", org="org1", repo="repo1", ref="ref1")
+        git_url2 = GitUrl(host="github.com", org="org2", repo="repo2", ref="ref2")
+
+        def git_url_side_effect(*args, **kwargs):
+            role = kwargs.get("role")
+            if role and role.workspace_id == ws1_id:
+                return git_url1
+            return git_url2
+
+        def ssh_cmd_side_effect(*args, **kwargs):
+            role = kwargs.get("role")
+            if role and role.workspace_id == ws1_id:
+                return "ssh -i /tmp/key1"
+            return "ssh -i /tmp/key2"
+
+        mock_git_url.side_effect = git_url_side_effect
+        mock_ssh_cmd.side_effect = ssh_cmd_side_effect
+
+        # Fetch for role1
+        ctx_role.set(role1)
+        result1 = await get_git_context_cached(role=role1)
+        assert result1[0] == git_url1
+        assert result1[1] == "ssh -i /tmp/key1"
+        assert mock_git_url.call_count == 1
+
+        # Fetch for role2 - should not use role1's cache
+        ctx_role.set(role2)
+        result2 = await get_git_context_cached(role=role2)
+        assert result2[0] == git_url2
+        assert result2[1] == "ssh -i /tmp/key2"
+        assert mock_git_url.call_count == 2  # Should have fetched for role2
+
+        # Fetch again for role1 - should use cache
+        ctx_role.set(role1)
+        result1_cached = await get_git_context_cached(role=role1)
+        assert result1_cached[0] == git_url1
+        assert result1_cached[1] == "ssh -i /tmp/key1"
+        assert mock_git_url.call_count == 2  # Still 2, used cache
+
+        # Verify cache has entries for both roles
+        assert len(_git_context_cache) == 2
+
+
+@pytest.mark.anyio
+async def test_git_context_cache_no_git_url(mock_session):
+    """Test caching when no git URL is configured."""
+    from tracecat.contexts import ctx_role
+    from tracecat.executor.service import _git_context_cache, get_git_context_cached
+
+    # Clear the cache first
+    _git_context_cache.clear()
+
+    # Set up the role context
+    test_role = Role(
+        type="service",
+        service_id="tracecat-executor",
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    ctx_role.set(test_role)
+
+    # Mock the session context manager
+    @asynccontextmanager
+    async def mock_session_cm():
+        yield mock_session
+
+    def get_session_cm():
+        return mock_session_cm()
+
+    with (
+        patch(
+            "tracecat.executor.service.get_async_session_context_manager",
+            new=get_session_cm,
+        ),
+        patch("tracecat.executor.service.safe_prepare_git_url") as mock_git_url,
+        patch("tracecat.executor.service.get_ssh_command") as mock_ssh_cmd,
+    ):
+        # Set up mock to return None (no git configured)
+        mock_git_url.return_value = None
+
+        # First call - should fetch and get None
+        git_url1, ssh_cmd1 = await get_git_context_cached(role=test_role)
+        assert git_url1 is None
+        assert ssh_cmd1 is None
+        assert mock_git_url.call_count == 1
+        assert (
+            mock_ssh_cmd.call_count == 0
+        )  # Should not call get_ssh_command when no git_url
+
+        # Second call - should use cache
+        git_url2, ssh_cmd2 = await get_git_context_cached(role=test_role)
+        assert git_url2 is None
+        assert ssh_cmd2 is None
+        assert mock_git_url.call_count == 1  # Still 1, used cache
+        assert mock_ssh_cmd.call_count == 0

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import time
 import traceback
 from collections.abc import Iterator, Mapping
 from pathlib import Path
@@ -64,6 +65,57 @@ from tracecat.types.exceptions import (
 
 type ArgsT = Mapping[str, Any]
 type ExecutionResult = Any | ExecutorActionErrorInfo
+
+_git_context_lock = asyncio.Lock()
+_git_context_cache: dict[tuple[str, str], tuple[float, Any, str | None]] = {}
+
+
+async def get_git_context_cached(role: Role) -> tuple[Any | None, str | None]:
+    """Cache git URL and SSH command for 30 seconds to avoid repeated DB sessions.
+
+    Returns:
+        Tuple of (git_url, ssh_command) or (None, None) if not configured
+    """
+    cache_key = (str(role.workspace_id), str(role.user_id))
+
+    # Check cache first
+    if cached := _git_context_cache.get(cache_key):
+        expire_time, git_url, ssh_cmd = cached
+        if time.time() < expire_time:
+            logger.debug("Using cached git context", workspace_id=role.workspace_id)
+            return git_url, ssh_cmd
+
+    # Load once under lock
+    async with _git_context_lock:
+        # Double-check after acquiring lock
+        if cached := _git_context_cache.get(cache_key):
+            expire_time, git_url, ssh_cmd = cached
+            if time.time() < expire_time:
+                return git_url, ssh_cmd
+
+        # Actually fetch from database
+        logger.debug(
+            "Fetching git context from database", workspace_id=role.workspace_id
+        )
+        async with (
+            get_async_session_context_manager() as session,
+            with_session(session=session),
+        ):
+            git_url = await safe_prepare_git_url(session=session, role=role)
+            ssh_cmd = None
+            if git_url:
+                ssh_cmd = await get_ssh_command(
+                    git_url=git_url, session=session, role=role
+                )
+
+        # Cache for 30 seconds
+        _git_context_cache[cache_key] = (time.time() + 30, git_url, ssh_cmd)
+        logger.debug(
+            "Cached git context",
+            workspace_id=role.workspace_id,
+            has_git_url=bool(git_url),
+        )
+        return git_url, ssh_cmd
 
 
 def sync_executor_entrypoint(input: RunActionInput, role: Role) -> ExecutionResult:
@@ -497,18 +549,12 @@ async def dispatch_action_on_cluster(input: RunActionInput) -> Any:
     role = ctx_role.get()
     ctx = DispatchActionContext(role=role)
 
-    # XXX(perf): Handle the session ourselves.
-    # Not sure if it's the root cause but according to https://github.com/fastapi/fastapi/discussions/10450
-    # FastAPI DI session might cause unreleased connections.
-    async with (
-        get_async_session_context_manager() as session,
-        with_session(session=session),  # Set the session in the context
-    ):
-        if git_url := await safe_prepare_git_url(session=session):
-            sh_cmd = await get_ssh_command(git_url=git_url, session=session, role=role)
-            ctx.ssh_command = sh_cmd
-            ctx.git_url = git_url
-    # XXX(perf): We do *not* hold the session open for the duration of the action.
+    # Use cached git context to avoid opening DB sessions unnecessarily
+    git_url, ssh_cmd = await get_git_context_cached(role=role)
+    if git_url:
+        ctx.git_url = git_url
+        ctx.ssh_command = ssh_cmd
+
     return await _dispatch_action(input=input, ctx=ctx)
 
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -71,7 +71,7 @@ _git_context_cache: dict[str, tuple[float, Any, str | None]] = {}
 
 
 async def get_git_context_cached(role: Role) -> tuple[Any | None, str | None]:
-    """Cache git URL and SSH command for 30 seconds to avoid repeated DB sessions.
+    """Cache git URL and SSH command for 60 seconds to avoid repeated DB sessions.
 
     Returns:
         Tuple of (git_url, ssh_command) or (None, None) if not configured
@@ -108,8 +108,8 @@ async def get_git_context_cached(role: Role) -> tuple[Any | None, str | None]:
                     git_url=git_url, session=session, role=role
                 )
 
-        # Cache for 30 seconds
-        _git_context_cache[cache_key] = (time.time() + 30, git_url, ssh_cmd)
+        # Cache for 60 seconds
+        _git_context_cache[cache_key] = (time.time() + 60, git_url, ssh_cmd)
         logger.debug(
             "Cached git context",
             workspace_id=role.workspace_id,

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -67,7 +67,7 @@ type ArgsT = Mapping[str, Any]
 type ExecutionResult = Any | ExecutorActionErrorInfo
 
 _git_context_lock = asyncio.Lock()
-_git_context_cache: dict[tuple[str, str], tuple[float, Any, str | None]] = {}
+_git_context_cache: dict[str, tuple[float, Any, str | None]] = {}
 
 
 async def get_git_context_cached(role: Role) -> tuple[Any | None, str | None]:
@@ -76,7 +76,7 @@ async def get_git_context_cached(role: Role) -> tuple[Any | None, str | None]:
     Returns:
         Tuple of (git_url, ssh_command) or (None, None) if not configured
     """
-    cache_key = (str(role.workspace_id), str(role.user_id))
+    cache_key = str(role.workspace_id)
 
     # Check cache first
     if cached := _git_context_cache.get(cache_key):


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Caches the git URL and SSH command for 30 seconds to avoid opening a database session on every action dispatch. This reduces DB load and improves dispatch performance.

- **Bug Fixes**
  - Added an in-memory cache (TTL 30s) with an asyncio lock to fetch git context once per workspace/user.
  - Updated dispatch_action_on_cluster to use the cached context instead of creating a session each time.
  - Added debug logs for cache hits/misses; behavior unchanged when git is not configured.

<!-- End of auto-generated description by cubic. -->

