### PR TITLE
feat(ui): Case records

### DIFF
--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -2,6 +2,7 @@
 
 import {
   Activity,
+  BoxIcon,
   Braces,
   MessageSquare,
   MoreHorizontal,
@@ -32,6 +33,7 @@ import {
 import { CasePanelSummary } from "@/components/cases/case-panel-summary"
 import { CasePayloadSection } from "@/components/cases/case-payload-section"
 import { CasePropertyRow } from "@/components/cases/case-property-row"
+import { CaseRecordsSection } from "@/components/cases/case-records-section"
 import { CaseWorkflowTrigger } from "@/components/cases/case-workflow-trigger"
 import { AlertNotification } from "@/components/notifications"
 import { TagBadge } from "@/components/tag-badge"
@@ -56,7 +58,12 @@ import {
 } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-type CasePanelTab = "comments" | "activity" | "attachments" | "payload"
+type CasePanelTab =
+  | "comments"
+  | "activity"
+  | "attachments"
+  | "records"
+  | "payload"
 
 interface CasePanelContentProps {
   caseId: string
@@ -86,7 +93,7 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
   // Get active tab from URL query params, default to "comments"
   const activeTab = (
     searchParams &&
-    ["comments", "activity", "attachments", "payload"].includes(
+    ["comments", "activity", "attachments", "records", "payload"].includes(
       searchParams.get("tab") || ""
     )
       ? (searchParams.get("tab") ?? "comments")
@@ -409,6 +416,13 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                   </TabsTrigger>
                   <TabsTrigger
                     className="flex h-full items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs font-medium ml-6 data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="records"
+                  >
+                    <BoxIcon className="mr-1.5 h-3.5 w-3.5" />
+                    Records
+                  </TabsTrigger>
+                  <TabsTrigger
+                    className="flex h-full items-center justify-center rounded-none border-b-2 border-transparent py-0 text-xs font-medium ml-6 data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="payload"
                   >
                     <Braces className="mr-1.5 h-3.5 w-3.5" />
@@ -426,6 +440,13 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
 
                 <TabsContent value="attachments" className="mt-4">
                   <CaseAttachmentsSection
+                    caseId={caseId}
+                    workspaceId={workspaceId}
+                  />
+                </TabsContent>
+
+                <TabsContent value="records" className="mt-4">
+                  <CaseRecordsSection
                     caseId={caseId}
                     workspaceId={workspaceId}
                   />

--- a/frontend/src/components/cases/case-records-section.tsx
+++ b/frontend/src/components/cases/case-records-section.tsx
@@ -1,0 +1,557 @@
+"use client"
+
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import type { ColumnDef } from "@tanstack/react-table"
+import { formatDistanceToNow } from "date-fns"
+import { BoxIcon, Loader2, Pencil, Trash2, Unlink } from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { Control, FieldValues } from "react-hook-form"
+import { useForm } from "react-hook-form"
+import type { CaseRecordRead, EntityFieldRead, EntityRead } from "@/client"
+import { DataTable, DataTableColumnHeader } from "@/components/data-table"
+import {
+  YamlStyledEditor,
+  type YamlStyledEditorRef,
+} from "@/components/editor/codemirror/yaml-editor"
+import { EntitySelectorPopover } from "@/components/entities/entity-selector-popover"
+import { CompactJsonViewer } from "@/components/json-viewer-compact"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useEntities, useEntity, useEntityFields } from "@/hooks/use-entities"
+import { useCaseRecords, useCreateCaseRecord } from "@/lib/hooks"
+import { getIconByName } from "@/lib/icons"
+import { capitalizeFirst } from "@/lib/utils"
+import { WorkflowProvider } from "@/providers/workflow"
+
+interface CaseRecordsSectionProps {
+  caseId: string
+  workspaceId: string
+}
+
+export function CaseRecordsSection({
+  caseId,
+  workspaceId,
+}: CaseRecordsSectionProps) {
+  const { records, recordsIsLoading, recordsError } = useCaseRecords({
+    caseId,
+    workspaceId,
+  })
+  const { entities } = useEntities(workspaceId)
+  const [_selectedRecord, setSelectedRecord] = useState<CaseRecordRead | null>(
+    null
+  )
+  const [_editDialogOpen, setEditDialogOpen] = useState(false)
+  const [_deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [selectedEntityId, setSelectedEntityId] = useState<string>("")
+  const [selectedEntityKey, setSelectedEntityKey] = useState<string>("")
+
+  const entityById = useMemo(() => {
+    const map = new Map<string, EntityRead>()
+    entities?.forEach((entity) => map.set(entity.id, entity))
+    return map
+  }, [entities])
+
+  const handleEditRecord = (record: CaseRecordRead) => {
+    setSelectedRecord(record)
+    setEditDialogOpen(true)
+  }
+
+  const handleUnlinkRecord = (record: CaseRecordRead) => {
+    // TODO: Implement unlink functionality
+    console.log("Unlink record:", record)
+  }
+
+  const handleDeleteRecord = (record: CaseRecordRead) => {
+    setSelectedRecord(record)
+    setDeleteDialogOpen(true)
+  }
+
+  const handleEntitySelect = (entity: EntityRead) => {
+    setSelectedEntityId(entity.id)
+    setSelectedEntityKey(entity.key)
+    setCreateDialogOpen(true)
+  }
+
+  const columns: ColumnDef<CaseRecordRead>[] = [
+    {
+      accessorKey: "entity_id",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Entity"
+        />
+      ),
+      cell: ({ row }) => {
+        const entity = entityById.get(row.original.entity_id)
+        const IconComponent = entity?.icon
+          ? getIconByName(entity.icon)
+          : undefined
+        const initials = entity?.display_name?.[0]?.toUpperCase() || "?"
+
+        return (
+          <div className="flex items-center gap-2.5">
+            <Avatar className="size-7 shrink-0">
+              <AvatarFallback className="text-xs">
+                {IconComponent ? (
+                  <IconComponent className="size-4" />
+                ) : (
+                  initials
+                )}
+              </AvatarFallback>
+            </Avatar>
+            <div>
+              <div className="text-sm font-medium">
+                {row.original.entity_display_name ||
+                  entity?.display_name ||
+                  row.original.entity_id}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {row.original.entity_key ||
+                  entity?.key ||
+                  row.original.entity_id}
+              </div>
+            </div>
+          </div>
+        )
+      },
+      enableSorting: false,
+      enableHiding: false,
+    },
+    {
+      accessorKey: "created_at",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Created"
+        />
+      ),
+      cell: ({ row }) => (
+        <div className="text-xs text-muted-foreground">
+          {capitalizeFirst(
+            formatDistanceToNow(new Date(row.original.created_at), {
+              addSuffix: true,
+            })
+          )}
+        </div>
+      ),
+      enableSorting: true,
+      enableHiding: false,
+    },
+    {
+      accessorKey: "updated_at",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Updated"
+        />
+      ),
+      cell: ({ row }) => (
+        <div className="text-xs text-muted-foreground">
+          {capitalizeFirst(
+            formatDistanceToNow(new Date(row.original.updated_at), {
+              addSuffix: true,
+            })
+          )}
+        </div>
+      ),
+      enableSorting: true,
+      enableHiding: false,
+    },
+    {
+      accessorKey: "data",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Record"
+        />
+      ),
+      cell: ({ row }) => {
+        const data = row.original.data || {}
+        return (
+          <div className="max-w-xs">
+            <CompactJsonViewer src={data} />
+          </div>
+        )
+      },
+      enableSorting: false,
+      enableHiding: false,
+    },
+    {
+      id: "actions",
+      enableHiding: false,
+      cell: ({ row }) => {
+        return (
+          <div className="flex justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="size-8 p-0"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <span className="sr-only">Open menu</span>
+                  <DotsHorizontalIcon className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => handleEditRecord(row.original)}
+                >
+                  <Pencil className="mr-2 h-3 w-3" />
+                  <span>Edit</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => handleUnlinkRecord(row.original)}
+                >
+                  <Unlink className="mr-2 h-3 w-3" />
+                  <span>Unlink from case</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => handleDeleteRecord(row.original)}
+                >
+                  <Trash2 className="mr-2 h-3 w-3 text-rose-600" />
+                  <span className="text-rose-600">Delete</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )
+      },
+    },
+  ]
+
+  if (recordsIsLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-8 w-24" />
+        </div>
+        <Skeleton className="h-[200px] w-full" />
+      </div>
+    )
+  }
+
+  if (recordsError) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8">
+        <p className="text-sm text-muted-foreground">
+          Failed to load case records
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          {recordsError.message}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground ml-3">
+          {records?.length || 0} record{records?.length !== 1 ? "s" : ""} linked
+          to this case
+        </div>
+        <EntitySelectorPopover
+          entities={entities}
+          onSelect={handleEntitySelect}
+          buttonText="Add record"
+        />
+      </div>
+
+      {records && records.length > 0 ? (
+        <DataTable<CaseRecordRead, unknown>
+          data={records}
+          columns={columns}
+          isLoading={recordsIsLoading}
+          error={recordsError as Error | null}
+          emptyMessage="No records linked to this case"
+          tableId={`${workspaceId}-case-${caseId}-records`}
+        />
+      ) : (
+        <NoRecords />
+      )}
+
+      {selectedEntityId && (
+        <CreateCaseRecordDialog
+          open={createDialogOpen}
+          onOpenChange={(open) => {
+            setCreateDialogOpen(open)
+            if (!open) {
+              setSelectedEntityId("")
+              setSelectedEntityKey("")
+            }
+          }}
+          caseId={caseId}
+          workspaceId={workspaceId}
+          entityId={selectedEntityId}
+          entityKey={selectedEntityKey}
+          onSuccess={() => {
+            setSelectedEntityId("")
+            setSelectedEntityKey("")
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function NoRecords() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <div className="p-3 rounded-full bg-muted/50 mb-3">
+        <BoxIcon className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <h3 className="text-sm font-medium text-muted-foreground mb-1">
+        No records linked
+      </h3>
+      <p className="text-xs text-muted-foreground/75 text-center max-w-[250px]">
+        Add records to track entities related to this case
+      </p>
+    </div>
+  )
+}
+
+// Dialog component for creating a record directly linked to the case
+function CreateCaseRecordDialog({
+  open,
+  onOpenChange,
+  caseId,
+  workspaceId,
+  entityId,
+  entityKey,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  caseId: string
+  workspaceId: string
+  entityId: string
+  entityKey: string
+  onSuccess?: () => void
+}) {
+  const { createCaseRecord, createCaseRecordIsPending } = useCreateCaseRecord({
+    caseId,
+    workspaceId,
+  })
+  const { entity } = useEntity(workspaceId, entityId)
+  const { fields } = useEntityFields(workspaceId, entityId, false)
+  const yamlEditorRef = useRef<YamlStyledEditorRef | null>(null)
+  const [submissionError, setSubmissionError] = useState<string | null>(null)
+
+  const form = useForm<{ data: Record<string, unknown> }>({
+    defaultValues: {
+      data: {},
+    },
+  })
+
+  const placeholderForField = useCallback((f: EntityFieldRead): unknown => {
+    const t = String(f.type).toUpperCase()
+    if (t === "SELECT") {
+      const options = (f.options || []).map((o) => o.key)
+      return options[0] ?? "option"
+    }
+    if (t === "MULTI_SELECT") {
+      const options = (f.options || []).map((o) => o.key)
+      return options.length > 0
+        ? options.slice(0, Math.max(1, Math.min(2, options.length)))
+        : ["item"]
+    }
+    switch (t) {
+      case "TEXT":
+        return "text"
+      case "INTEGER":
+        return 123
+      case "NUMBER":
+        return 123.45
+      case "BOOL":
+        return true
+      case "DATE":
+        return "2025-01-01"
+      case "DATETIME":
+        return "2025-01-01T12:00:00Z"
+      case "JSON":
+        return { key: "value" }
+      default:
+        return "value"
+    }
+  }, [])
+
+  // Build example payload from field schema
+  const examplePayload = useMemo(() => {
+    if (!fields) return {}
+    const ex: Record<string, unknown> = {}
+    for (const f of fields as EntityFieldRead[]) {
+      ex[f.key] = placeholderForField(f)
+    }
+    return ex
+  }, [fields, placeholderForField])
+
+  // Set initial value when dialog opens
+  useEffect(() => {
+    if (open && examplePayload) {
+      form.setValue("data", examplePayload)
+    }
+  }, [open, examplePayload, form])
+
+  const onSubmit = async (values: { data: Record<string, unknown> }) => {
+    try {
+      setSubmissionError(null)
+      yamlEditorRef.current?.commitToForm()
+
+      const recordData = values.data
+      if (
+        recordData === null ||
+        typeof recordData !== "object" ||
+        Array.isArray(recordData)
+      ) {
+        setSubmissionError(
+          "Invalid data format. Please provide a valid YAML object."
+        )
+        return
+      }
+
+      await createCaseRecord({
+        entity_key: entityKey,
+        data: recordData,
+      })
+
+      form.reset()
+      setSubmissionError(null)
+      onOpenChange(false)
+      onSuccess?.()
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error && error.message
+          ? error.message
+          : "Failed to create record. Please check your data and try again."
+      setSubmissionError(errorMessage)
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Create record for case</DialogTitle>
+            <DialogDescription>
+              Create a new {entity?.display_name || "entity"} record that will
+              be linked to this case.
+            </DialogDescription>
+          </DialogHeader>
+
+          {submissionError && (
+            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {submissionError}
+            </div>
+          )}
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              {/* Display selected entity */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Entity</label>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  {entity?.icon &&
+                    (() => {
+                      const IconComponent = getIconByName(entity.icon)
+                      return IconComponent ? (
+                        <IconComponent className="h-4 w-4" />
+                      ) : null
+                    })()}
+                  <span className="font-medium text-foreground">
+                    {entity?.display_name || "Loading..."}
+                  </span>
+                  {entity?.key && (
+                    <Badge variant="secondary" className="text-xs">
+                      {entity.key}
+                    </Badge>
+                  )}
+                </div>
+              </div>
+
+              <FormField
+                control={form.control}
+                name="data"
+                rules={{ required: "Please enter record data" }}
+                render={() => (
+                  <FormItem>
+                    <FormLabel>Record data</FormLabel>
+                    <FormControl>
+                      <div className="min-h-[200px]">
+                        <WorkflowProvider
+                          workflowId=""
+                          workspaceId={workspaceId}
+                        >
+                          <YamlStyledEditor
+                            ref={yamlEditorRef}
+                            name={"data"}
+                            control={
+                              form.control as unknown as Control<FieldValues>
+                            }
+                          />
+                        </WorkflowProvider>
+                      </div>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </form>
+          </Form>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setSubmissionError(null)
+                onOpenChange(false)
+              }}
+              disabled={createCaseRecordIsPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={form.handleSubmit(onSubmit)}
+              disabled={createCaseRecordIsPending}
+            >
+              {createCaseRecordIsPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Create record
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/components/cases/case-records-table.tsx
+++ b/frontend/src/components/cases/case-records-table.tsx
@@ -1,0 +1,256 @@
+"use client"
+
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import type { ColumnDef } from "@tanstack/react-table"
+import { formatDistanceToNow } from "date-fns"
+import { Pencil, Trash2, Unlink } from "lucide-react"
+import { useMemo, useState } from "react"
+import type { CaseRecordRead, EntityRead } from "@/client"
+import { DataTable, DataTableColumnHeader } from "@/components/data-table"
+import { CompactJsonViewer } from "@/components/json-viewer-compact"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useEntities } from "@/hooks/use-entities"
+import { getIconByName } from "@/lib/icons"
+import { capitalizeFirst } from "@/lib/utils"
+import { DeleteCaseRecordAlertDialog } from "./delete-case-record-dialog"
+import { EditCaseRecordDialog } from "./edit-case-record-dialog"
+
+interface CaseRecordsTableProps {
+  records: CaseRecordRead[]
+  isLoading: boolean
+  error: Error | null
+  caseId: string
+  workspaceId: string
+}
+
+export function CaseRecordsTable({
+  records,
+  isLoading,
+  error,
+  caseId,
+  workspaceId,
+}: CaseRecordsTableProps) {
+  const { entities } = useEntities(workspaceId)
+  const [selectedRecord, setSelectedRecord] = useState<CaseRecordRead | null>(
+    null
+  )
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [unlinkDialogOpen, setUnlinkDialogOpen] = useState(false)
+
+  const entityById = useMemo(() => {
+    const map = new Map<string, EntityRead>()
+    entities?.forEach((entity) => map.set(entity.id, entity))
+    return map
+  }, [entities])
+
+  const handleEditRecord = (record: CaseRecordRead) => {
+    setSelectedRecord(record)
+    setEditDialogOpen(true)
+  }
+
+  const handleUnlinkRecord = (record: CaseRecordRead) => {
+    setSelectedRecord(record)
+    setUnlinkDialogOpen(true)
+  }
+
+  const handleDeleteRecord = (record: CaseRecordRead) => {
+    setSelectedRecord(record)
+    setDeleteDialogOpen(true)
+  }
+
+  const columns: ColumnDef<CaseRecordRead>[] = [
+    {
+      accessorKey: "entity_id",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Entity"
+        />
+      ),
+      cell: ({ row }) => {
+        const entity = entityById.get(row.original.entity_id)
+        const IconComponent = entity?.icon
+          ? getIconByName(entity.icon)
+          : undefined
+        const initials = entity?.display_name?.[0]?.toUpperCase() || "?"
+
+        return (
+          <div className="flex items-center gap-2.5">
+            <Avatar className="size-7 shrink-0">
+              <AvatarFallback className="text-xs">
+                {IconComponent ? (
+                  <IconComponent className="size-4" />
+                ) : (
+                  initials
+                )}
+              </AvatarFallback>
+            </Avatar>
+            <div>
+              <div className="text-sm font-medium">
+                {row.original.entity_display_name ||
+                  entity?.display_name ||
+                  row.original.entity_id}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {row.original.entity_key ||
+                  entity?.key ||
+                  row.original.entity_id}
+              </div>
+            </div>
+          </div>
+        )
+      },
+      enableSorting: false,
+      enableHiding: false,
+    },
+    {
+      accessorKey: "created_at",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Created"
+        />
+      ),
+      cell: ({ row }) => (
+        <div className="text-xs text-muted-foreground">
+          {capitalizeFirst(
+            formatDistanceToNow(new Date(row.original.created_at), {
+              addSuffix: true,
+            })
+          )}
+        </div>
+      ),
+      enableSorting: true,
+      enableHiding: false,
+    },
+    {
+      accessorKey: "updated_at",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Updated"
+        />
+      ),
+      cell: ({ row }) => (
+        <div className="text-xs text-muted-foreground">
+          {capitalizeFirst(
+            formatDistanceToNow(new Date(row.original.updated_at), {
+              addSuffix: true,
+            })
+          )}
+        </div>
+      ),
+      enableSorting: true,
+      enableHiding: false,
+    },
+    {
+      accessorKey: "data",
+      header: ({ column }) => (
+        <DataTableColumnHeader
+          className="text-xs"
+          column={column}
+          title="Record"
+        />
+      ),
+      cell: ({ row }) => {
+        const data = row.original.data || {}
+        return (
+          <div className="max-w-xs">
+            <CompactJsonViewer src={data} />
+          </div>
+        )
+      },
+      enableSorting: false,
+      enableHiding: false,
+    },
+    {
+      id: "actions",
+      enableHiding: false,
+      cell: ({ row }) => {
+        return (
+          <div className="flex justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="size-8 p-0"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <span className="sr-only">Open menu</span>
+                  <DotsHorizontalIcon className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => handleEditRecord(row.original)}
+                >
+                  <Pencil className="mr-2 h-3 w-3" />
+                  <span>Edit</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => handleUnlinkRecord(row.original)}
+                >
+                  <Unlink className="mr-2 h-3 w-3" />
+                  <span>Unlink from case</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => handleDeleteRecord(row.original)}
+                >
+                  <Trash2 className="mr-2 h-3 w-3 text-rose-600" />
+                  <span className="text-rose-600">Delete</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )
+      },
+    },
+  ]
+
+  return (
+    <>
+      <DataTable<CaseRecordRead, unknown>
+        data={records}
+        columns={columns}
+        isLoading={isLoading}
+        error={error}
+        emptyMessage="No records linked to this case"
+        tableId={`${workspaceId}-case-${caseId}-records`}
+      />
+      <EditCaseRecordDialog
+        open={editDialogOpen}
+        onOpenChange={setEditDialogOpen}
+        record={selectedRecord}
+        caseId={caseId}
+        workspaceId={workspaceId}
+      />
+      <DeleteCaseRecordAlertDialog
+        open={unlinkDialogOpen}
+        onOpenChange={setUnlinkDialogOpen}
+        record={selectedRecord}
+        caseId={caseId}
+        workspaceId={workspaceId}
+        mode="unlink"
+      />
+      <DeleteCaseRecordAlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        record={selectedRecord}
+        caseId={caseId}
+        workspaceId={workspaceId}
+        mode="delete"
+      />
+    </>
+  )
+}

--- a/frontend/src/components/cases/delete-case-record-dialog.tsx
+++ b/frontend/src/components/cases/delete-case-record-dialog.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import type { CaseRecordRead } from "@/client"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { useDeleteCaseRecord, useUnlinkCaseRecord } from "@/lib/hooks"
+
+interface DeleteCaseRecordAlertDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  record: CaseRecordRead | null
+  caseId: string
+  workspaceId: string
+  mode?: "delete" | "unlink"
+}
+
+export function DeleteCaseRecordAlertDialog({
+  open,
+  onOpenChange,
+  record,
+  caseId,
+  workspaceId,
+  mode = "delete",
+}: DeleteCaseRecordAlertDialogProps) {
+  const { deleteCaseRecord, deleteCaseRecordIsPending } = useDeleteCaseRecord({
+    caseId,
+    workspaceId,
+  })
+
+  const { unlinkCaseRecord, unlinkCaseRecordIsPending } = useUnlinkCaseRecord({
+    caseId,
+    workspaceId,
+  })
+
+  const handleAction = async () => {
+    if (record) {
+      if (mode === "unlink") {
+        await unlinkCaseRecord(record.id)
+      } else {
+        await deleteCaseRecord(record.id)
+      }
+      onOpenChange(false)
+    }
+  }
+
+  const isPending =
+    mode === "unlink" ? unlinkCaseRecordIsPending : deleteCaseRecordIsPending
+
+  const title = mode === "unlink" ? "Unlink record from case" : "Delete record"
+  const description =
+    mode === "unlink"
+      ? "Are you sure you want to unlink this record from the case? The record data will not be deleted."
+      : "Are you sure you want to delete this record? This action cannot be undone."
+  const actionText = mode === "unlink" ? "Unlink" : "Delete"
+  const pendingText = mode === "unlink" ? "Unlinking..." : "Deleting..."
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={handleAction}
+            disabled={isPending}
+          >
+            {isPending ? pendingText : actionText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/cases/edit-case-record-dialog.tsx
+++ b/frontend/src/components/cases/edit-case-record-dialog.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { useEffect, useState } from "react"
+import type { CaseRecordRead } from "@/client"
+import { ApiError } from "@/client"
+import { CodeEditor } from "@/components/editor/codemirror/code-editor"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useUpdateCaseRecord } from "@/lib/hooks"
+
+interface EditCaseRecordDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  record: CaseRecordRead | null
+  caseId: string
+  workspaceId: string
+}
+
+export function EditCaseRecordDialog({
+  open,
+  onOpenChange,
+  record,
+  caseId,
+  workspaceId,
+}: EditCaseRecordDialogProps) {
+  const [submissionError, setSubmissionError] = useState<string | null>(null)
+  const [jsonValue, setJsonValue] = useState<string>("")
+  const [isValidJson, setIsValidJson] = useState(true)
+  const { updateCaseRecord, updateCaseRecordIsPending } = useUpdateCaseRecord({
+    caseId,
+    workspaceId,
+  })
+
+  useEffect(() => {
+    if (record?.data) {
+      setJsonValue(JSON.stringify(record.data, null, 2))
+      setIsValidJson(true)
+      setSubmissionError(null)
+    }
+  }, [record])
+
+  const handleJsonChange = (value: string) => {
+    setJsonValue(value)
+    try {
+      JSON.parse(value)
+      setIsValidJson(true)
+      setSubmissionError(null)
+    } catch {
+      setIsValidJson(false)
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!record || !isValidJson) return
+
+    try {
+      const parsedData = JSON.parse(jsonValue)
+      await updateCaseRecord({
+        caseRecordId: record.id,
+        data: parsedData,
+      })
+      onOpenChange(false)
+    } catch (error) {
+      let detail: string | undefined
+      if (error instanceof ApiError) {
+        const body: unknown = error.body
+        if (body && typeof body === "object" && "detail" in body) {
+          const d = (body as { detail?: unknown }).detail
+          if (typeof d === "string") {
+            detail = d
+          }
+        }
+      }
+      const errorMessage =
+        detail ||
+        (error instanceof Error && error.message
+          ? error.message
+          : "Failed to update record. Please try again.")
+      setSubmissionError(errorMessage)
+    }
+  }
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setSubmissionError(null)
+      setJsonValue("")
+      setIsValidJson(true)
+    }
+    onOpenChange(newOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[80vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Edit record</DialogTitle>
+          <DialogDescription>
+            Modify the record data in JSON format.
+          </DialogDescription>
+        </DialogHeader>
+        {submissionError && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Error updating record</AlertTitle>
+            <AlertDescription>{submissionError}</AlertDescription>
+          </Alert>
+        )}
+        <div className="flex-1 overflow-auto min-h-[300px]">
+          <CodeEditor
+            value={jsonValue}
+            onChange={handleJsonChange}
+            language="json"
+            className="h-full"
+          />
+        </div>
+        {!isValidJson && (
+          <div className="text-sm text-destructive">
+            Invalid JSON format. Please check your syntax.
+          </div>
+        )}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={updateCaseRecordIsPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!isValidJson || updateCaseRecordIsPending}
+          >
+            {updateCaseRecordIsPending ? "Saving..." : "Save changes"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/entities/entity-selector-popover.tsx
+++ b/frontend/src/components/entities/entity-selector-popover.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { Plus } from "lucide-react"
+import { useState } from "react"
+import type { EntityRead } from "@/client"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { getIconByName } from "@/lib/icons"
+
+interface EntitySelectorPopoverProps {
+  entities: EntityRead[] | undefined
+  onSelect: (entity: EntityRead) => void
+  buttonText?: string
+  buttonSize?: "default" | "sm" | "lg" | "icon"
+  buttonVariant?:
+    | "default"
+    | "outline"
+    | "ghost"
+    | "secondary"
+    | "destructive"
+    | "link"
+  buttonClassName?: string
+  align?: "start" | "center" | "end"
+  placeholder?: string
+  emptyMessage?: string
+}
+
+export function EntitySelectorPopover({
+  entities,
+  onSelect,
+  buttonText = "Add record",
+  buttonSize = "sm",
+  buttonVariant = "outline",
+  buttonClassName = "h-7 bg-white",
+  align = "end",
+  placeholder = "Search entities...",
+  emptyMessage = "No entity found.",
+}: EntitySelectorPopoverProps) {
+  const [open, setOpen] = useState(false)
+
+  const handleSelect = (entity: EntityRead) => {
+    setOpen(false)
+    onSelect(entity)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          size={buttonSize}
+          variant={buttonVariant}
+          className={buttonClassName}
+        >
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          {buttonText}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[300px] p-0" align={align}>
+        <Command>
+          <CommandInput placeholder={placeholder} className="h-9" />
+          <CommandEmpty>{emptyMessage}</CommandEmpty>
+          <CommandList>
+            <CommandGroup>
+              {entities?.map((entity: EntityRead) => {
+                const IconComponent = entity.icon
+                  ? getIconByName(entity.icon)
+                  : null
+                return (
+                  <CommandItem
+                    key={entity.id}
+                    value={entity.display_name}
+                    onSelect={() => handleSelect(entity)}
+                    className="flex items-center gap-2"
+                  >
+                    {IconComponent && (
+                      <IconComponent className="h-3.5 w-3.5 text-muted-foreground" />
+                    )}
+                    <span>{entity.display_name}</span>
+                    {entity.key && (
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {entity.key}
+                      </span>
+                    )}
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -20,6 +20,7 @@ import {
   ViewMode,
 } from "@/components/dashboard/folder-view-toggle"
 import { CreateEntityDialog } from "@/components/entities/create-entity-dialog"
+import { EntitySelectorPopover } from "@/components/entities/entity-selector-popover"
 import { CreateRecordDialog } from "@/components/records/create-record-dialog"
 import { CreateTableDialog } from "@/components/tables/table-create-dialog"
 import { TableInsertButton } from "@/components/tables/table-insert-button"
@@ -33,20 +34,7 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
 import { Button } from "@/components/ui/button"
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
 import { Label } from "@/components/ui/label"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
 import { SidebarTrigger } from "@/components/ui/sidebar"
 import { Switch } from "@/components/ui/switch"
 import { toast } from "@/components/ui/use-toast"
@@ -257,58 +245,20 @@ function RecordsActions() {
   const workspaceId = useWorkspaceId()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [selectedEntityId, setSelectedEntityId] = useState<string>("")
-  const [comboboxOpen, setComboboxOpen] = useState(false)
   const { entities } = useEntities(workspaceId)
 
-  const handleEntitySelect = (entityId: string) => {
-    setSelectedEntityId(entityId)
-    setComboboxOpen(false)
+  const handleEntitySelect = (entity: EntityRead) => {
+    setSelectedEntityId(entity.id)
     setDialogOpen(true)
   }
 
   return (
     <>
-      <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
-        <PopoverTrigger asChild>
-          <Button variant="outline" size="sm" className="h-7 bg-white">
-            <Plus className="mr-1 h-3.5 w-3.5" />
-            Add record
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[300px] p-0" align="end">
-          <Command>
-            <CommandInput placeholder="Search entities..." className="h-9" />
-            <CommandEmpty>No entity found.</CommandEmpty>
-            <CommandList>
-              <CommandGroup>
-                {entities?.map((entity: EntityRead) => {
-                  const IconComponent = entity.icon
-                    ? getIconByName(entity.icon)
-                    : null
-                  return (
-                    <CommandItem
-                      key={entity.id}
-                      value={entity.display_name}
-                      onSelect={() => handleEntitySelect(entity.id)}
-                      className="flex items-center gap-2"
-                    >
-                      {IconComponent && (
-                        <IconComponent className="h-3.5 w-3.5 text-muted-foreground" />
-                      )}
-                      <span>{entity.display_name}</span>
-                      {entity.key && (
-                        <span className="ml-auto text-xs text-muted-foreground">
-                          {entity.key}
-                        </span>
-                      )}
-                    </CommandItem>
-                  )
-                })}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
+      <EntitySelectorPopover
+        entities={entities}
+        onSelect={handleEntitySelect}
+        buttonText="Add record"
+      />
       {selectedEntityId && (
         <CreateRecordDialog
           open={dialogOpen}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -47,7 +47,10 @@ import {
   type CaseTagRead,
   type CaseUpdate,
   caseRecordsCreateCaseRecord,
+  caseRecordsDeleteCaseRecord,
   caseRecordsListCaseRecords,
+  caseRecordsUnlinkCaseRecord,
+  caseRecordsUpdateCaseRecord,
   casesAddTag,
   casesCreateCase,
   casesCreateComment,
@@ -2810,6 +2813,157 @@ export function useCreateCaseRecord({
     createCaseRecord,
     createCaseRecordIsPending,
     createCaseRecordError,
+  }
+}
+
+export function useUpdateCaseRecord({
+  caseId,
+  workspaceId,
+}: {
+  caseId: string
+  workspaceId: string
+}) {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: updateCaseRecord,
+    isPending: updateCaseRecordIsPending,
+    error: updateCaseRecordError,
+  } = useMutation({
+    mutationFn: async ({
+      caseRecordId,
+      data,
+    }: {
+      caseRecordId: string
+      data: Record<string, unknown>
+    }) => {
+      return await caseRecordsUpdateCaseRecord({
+        caseId,
+        caseRecordId,
+        workspaceId,
+        requestBody: { data },
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["case-records", caseId, workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["case-events", caseId, workspaceId],
+      })
+      toast({
+        title: "Record updated",
+        description: "The record has been successfully updated.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      toast({
+        title: "Failed to update record",
+        description:
+          error.message || "An error occurred while updating the record.",
+        variant: "destructive",
+      })
+    },
+  })
+  return {
+    updateCaseRecord,
+    updateCaseRecordIsPending,
+    updateCaseRecordError,
+  }
+}
+
+export function useDeleteCaseRecord({
+  caseId,
+  workspaceId,
+}: {
+  caseId: string
+  workspaceId: string
+}) {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: deleteCaseRecord,
+    isPending: deleteCaseRecordIsPending,
+    error: deleteCaseRecordError,
+  } = useMutation({
+    mutationFn: async (caseRecordId: string) => {
+      return await caseRecordsDeleteCaseRecord({
+        caseId,
+        caseRecordId,
+        workspaceId,
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["case-records", caseId, workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["case-events", caseId, workspaceId],
+      })
+      toast({
+        title: "Record removed",
+        description: "The record has been removed from this case.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      toast({
+        title: "Failed to remove record",
+        description:
+          error.message || "An error occurred while removing the record.",
+        variant: "destructive",
+      })
+    },
+  })
+  return {
+    deleteCaseRecord,
+    deleteCaseRecordIsPending,
+    deleteCaseRecordError,
+  }
+}
+
+export function useUnlinkCaseRecord({
+  caseId,
+  workspaceId,
+}: {
+  caseId: string
+  workspaceId: string
+}) {
+  const queryClient = useQueryClient()
+  const {
+    mutateAsync: unlinkCaseRecord,
+    isPending: unlinkCaseRecordIsPending,
+    error: unlinkCaseRecordError,
+  } = useMutation({
+    mutationFn: async (caseRecordId: string) => {
+      return await caseRecordsUnlinkCaseRecord({
+        caseId,
+        caseRecordId,
+        workspaceId,
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["case-records", caseId, workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["case-events", caseId, workspaceId],
+      })
+      toast({
+        title: "Record unlinked",
+        description: "The record has been unlinked from this case.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      toast({
+        title: "Failed to unlink record",
+        description:
+          error.message || "An error occurred while unlinking the record.",
+        variant: "destructive",
+      })
+    },
+  })
+  return {
+    unlinkCaseRecord,
+    unlinkCaseRecordIsPending,
+    unlinkCaseRecordError,
   }
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new Records tab to the Case panel to view and manage linked entity records. Users can add, edit, unlink, and delete records with clear dialogs and validation.

- **New Features**
  - Records tab lists linked records with entity info, timestamps, and a compact data preview.
  - Add, edit, unlink, and delete actions via dialogs (YAML editor for create, JSON editor with validation for edit) with success/error toasts.
  - New hooks: useCaseRecords, useCreateCaseRecord, useUpdateCaseRecord, useDeleteCaseRecord, useUnlinkCaseRecord with query invalidation.

- **Refactors**
  - Introduced reusable EntitySelectorPopover and replaced the inline combobox in the records header.
  - Wired the new tab and section into CasePanelView.

<!-- End of auto-generated description by cubic. -->

