### PR TITLE
feat(core): Add UDFs for managing entity and case records

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/records.py
+++ b/packages/tracecat-registry/tracecat_registry/core/records.py
@@ -1,0 +1,506 @@
+"""UDFs for entity records and case records.
+
+This module exposes high-level UDFs over:
+- `tracecat.records.service.RecordService` (entity records)
+- `tracecat.cases.records.service.CaseRecordService` (case-linked records)
+
+See `core.cases` and `core.table` for decorator patterns.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+from uuid import UUID
+
+from typing_extensions import Doc
+
+from tracecat.cases.records.models import (
+    CaseRecordCreate,
+    CaseRecordDeleteResponse,
+    CaseRecordLink,
+    CaseRecordRead,
+    CaseRecordUpdate,
+)
+from tracecat.cases.records.service import CaseRecordService
+from tracecat.cases.service import CasesService
+from tracecat.entities.service import EntityService
+from tracecat.records.model import RecordCreate, RecordRead, RecordUpdate
+from tracecat.records.service import RecordService
+from tracecat_registry import registry
+
+
+@registry.register(
+    default_title="List records",
+    display_group="Records",
+    description="List entity records with optional entity filter using cursor pagination.",
+    namespace="core.records",
+)
+async def list_records(
+    limit: Annotated[
+        int,
+        Doc("Maximum number of items to return (page size)."),
+    ] = 20,
+    cursor: Annotated[
+        str | None,
+        Doc("Opaque cursor for pagination; use value from previous response."),
+    ] = None,
+    reverse: Annotated[
+        bool,
+        Doc("Reverse pagination direction (use with cursor for previous page)."),
+    ] = False,
+    entity_id: Annotated[
+        str | None,
+        Doc("Optional entity ID to filter records for a specific entity."),
+    ] = None,
+) -> dict[str, Any]:
+    entity_uuid: UUID | None = UUID(entity_id) if entity_id else None
+    async with RecordService.with_session() as service:
+        from tracecat.types.pagination import CursorPaginationParams
+
+        cpp = CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
+        resp = await service.list_records(cpp, entity_id=entity_uuid)
+    return {
+        "items": [item.model_dump(mode="json") for item in resp.items],
+        "next_cursor": resp.next_cursor,
+        "prev_cursor": resp.prev_cursor,
+        "has_more": resp.has_more,
+        "has_previous": resp.has_previous,
+        "total_estimate": resp.total_estimate,
+    }
+
+
+@registry.register(
+    default_title="List entity records",
+    display_group="Records",
+    description="List records for a specific entity using cursor pagination.",
+    namespace="core.records",
+)
+async def list_entity_records(
+    entity_id: Annotated[
+        str,
+        Doc("The entity ID to list records for."),
+    ],
+    limit: Annotated[
+        int,
+        Doc("Maximum number of items to return (page size)."),
+    ] = 20,
+    cursor: Annotated[
+        str | None,
+        Doc("Opaque cursor for pagination; use value from previous response."),
+    ] = None,
+    reverse: Annotated[
+        bool,
+        Doc("Reverse pagination direction (use with cursor for previous page)."),
+    ] = False,
+) -> dict[str, Any]:
+    from tracecat.types.pagination import CursorPaginationParams
+
+    entity_uuid = UUID(entity_id)
+    async with EntityService.with_session() as entities:
+        entity = await entities.get_entity(entity_uuid)
+        async with RecordService.with_session() as records:
+            resp = await records.list_entity_records(
+                entity,
+                CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),
+            )
+
+    return {
+        "items": [item.model_dump(mode="json") for item in resp.items],
+        "next_cursor": resp.next_cursor,
+        "prev_cursor": resp.prev_cursor,
+        "has_more": resp.has_more,
+        "has_previous": resp.has_previous,
+        "total_estimate": resp.total_estimate,
+    }
+
+
+@registry.register(
+    default_title="Get record",
+    display_group="Records",
+    description="Get a single entity record by record ID.",
+    namespace="core.records",
+)
+async def get_record(
+    record_id: Annotated[
+        str,
+        Doc("The entity record ID to retrieve."),
+    ],
+) -> dict[str, Any]:
+    record_uuid = UUID(record_id)
+    async with RecordService.with_session() as service:
+        record = await service.get_record_by_id(record_uuid)
+    return RecordRead.model_validate(record, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    default_title="Create record (by entity id)",
+    display_group="Records",
+    description="Create a new entity record for a given entity ID.",
+    namespace="core.records",
+)
+async def create_record(
+    entity_id: Annotated[
+        str,
+        Doc("The entity ID to create the record for."),
+    ],
+    data: Annotated[
+        dict[str, Any],
+        Doc("The JSON payload for the record (keys must match entity field keys)."),
+    ],
+) -> dict[str, Any]:
+    entity_uuid = UUID(entity_id)
+    async with EntityService.with_session() as entities:
+        entity = await entities.get_entity(entity_uuid)
+        async with RecordService.with_session() as records:
+            created = await records.create_record(entity, RecordCreate(data=data))
+    return RecordRead.model_validate(created, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    default_title="Create record (by entity key)",
+    display_group="Records",
+    description="Create a new entity record for a given entity key.",
+    namespace="core.records",
+)
+async def create_record_by_key(
+    entity_key: Annotated[
+        str,
+        Doc("The unique entity key to create the record for."),
+    ],
+    data: Annotated[
+        dict[str, Any],
+        Doc("The JSON payload for the record (keys must match entity field keys)."),
+    ],
+) -> dict[str, Any]:
+    async with EntityService.with_session() as entities:
+        entity = await entities.get_entity_by_key(entity_key)
+        async with RecordService.with_session() as records:
+            created = await records.create_record(entity, RecordCreate(data=data))
+    return RecordRead.model_validate(created, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    default_title="Update record",
+    display_group="Records",
+    description="Update an existing entity record by merging provided fields.",
+    namespace="core.records",
+)
+async def update_record(
+    record_id: Annotated[
+        str,
+        Doc("The entity record ID to update."),
+    ],
+    data: Annotated[
+        dict[str, Any],
+        Doc("Partial data to merge into the existing record."),
+    ],
+) -> dict[str, Any]:
+    record_uuid = UUID(record_id)
+    async with RecordService.with_session() as service:
+        record = await service.get_record_by_id(record_uuid)
+        updated = await service.update_record(record, RecordUpdate(data=data))
+    return RecordRead.model_validate(updated, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    default_title="Delete record",
+    display_group="Records",
+    description="Delete an entity record by ID.",
+    namespace="core.records",
+)
+async def delete_record(
+    record_id: Annotated[
+        str,
+        Doc("The entity record ID to delete."),
+    ],
+) -> None:
+    record_uuid = UUID(record_id)
+    async with RecordService.with_session() as service:
+        record = await service.get_record_by_id(record_uuid)
+        await service.delete_record(record)
+
+
+@registry.register(
+    default_title="List case records",
+    display_group="Cases",
+    description="List all records linked to a case.",
+    namespace="core.cases",
+)
+async def list_case_records(
+    case_id: Annotated[
+        str,
+        Doc("The case ID to list records for."),
+    ],
+) -> dict[str, Any]:
+    case_uuid = UUID(case_id)
+    async with CaseRecordService.with_session() as cr_service:
+        # Reuse the same session to fetch the case
+        cases = CasesService(cr_service.session, cr_service.role)
+        case = await cases.get_case(case_uuid)
+        if case is None:
+            raise ValueError(f"Case with ID {case_id} not found")
+        records = await cr_service.list_case_records(case)
+
+    items = [
+        CaseRecordRead(
+            id=rec.id,
+            case_id=rec.case_id,
+            entity_id=rec.entity_id,
+            record_id=rec.record_id,
+            entity_key=rec.entity.key,
+            entity_display_name=rec.entity.display_name,
+            data=rec.record.data,
+            created_at=rec.created_at,
+            updated_at=rec.updated_at,
+        ).model_dump(mode="json")
+        for rec in records
+    ]
+    return {"items": items, "total": len(items)}
+
+
+@registry.register(
+    default_title="Get case record",
+    display_group="Cases",
+    description="Get a specific case-linked record by link ID.",
+    namespace="core.cases",
+)
+async def get_case_record(
+    case_id: Annotated[
+        str,
+        Doc("The case ID containing the record."),
+    ],
+    case_record_id: Annotated[
+        str,
+        Doc("The case record link ID to retrieve."),
+    ],
+) -> dict[str, Any]:
+    case_uuid = UUID(case_id)
+    link_uuid = UUID(case_record_id)
+    async with CaseRecordService.with_session() as cr_service:
+        cases = CasesService(cr_service.session, cr_service.role)
+        case = await cases.get_case(case_uuid)
+        if case is None:
+            raise ValueError(f"Case with ID {case_id} not found")
+        record_link = await cr_service.get_case_record(case, link_uuid)
+        if record_link is None:
+            raise ValueError(f"Case record with ID {case_record_id} not found")
+    return CaseRecordRead(
+        id=record_link.id,
+        case_id=record_link.case_id,
+        entity_id=record_link.entity_id,
+        record_id=record_link.record_id,
+        entity_key=record_link.entity.key,
+        entity_display_name=record_link.entity.display_name,
+        data=record_link.record.data,
+        created_at=record_link.created_at,
+        updated_at=record_link.updated_at,
+    ).model_dump(mode="json")
+
+
+@registry.register(
+    default_title="Create case record",
+    display_group="Cases",
+    description="Create a new entity record and link it to a case.",
+    namespace="core.cases",
+)
+async def create_case_record(
+    case_id: Annotated[
+        str,
+        Doc("The case ID to add the record to."),
+    ],
+    entity_key: Annotated[
+        str,
+        Doc("The entity key for the record to create."),
+    ],
+    data: Annotated[
+        dict[str, Any],
+        Doc("The JSON payload for the new entity record."),
+    ],
+) -> dict[str, Any]:
+    case_uuid = UUID(case_id)
+    async with CaseRecordService.with_session() as cr_service:
+        cases = CasesService(cr_service.session, cr_service.role)
+        case = await cases.get_case(case_uuid)
+        if case is None:
+            raise ValueError(f"Case with ID {case_id} not found")
+        created = await cr_service.create_case_record(
+            case,
+            CaseRecordCreate(entity_key=entity_key, data=data),
+        )
+    return CaseRecordRead(
+        id=created.id,
+        case_id=created.case_id,
+        entity_id=created.entity_id,
+        record_id=created.record_id,
+        entity_key=created.entity.key,
+        entity_display_name=created.entity.display_name,
+        data=created.record.data,
+        created_at=created.created_at,
+        updated_at=created.updated_at,
+    ).model_dump(mode="json")
+
+
+@registry.register(
+    default_title="Link entity record to case",
+    display_group="Cases",
+    description="Link an existing entity record to a case.",
+    namespace="core.cases",
+)
+async def link_entity_record(
+    case_id: Annotated[
+        str,
+        Doc("The case ID to link the record to."),
+    ],
+    entity_record_id: Annotated[
+        str,
+        Doc("The entity record ID to link."),
+    ],
+) -> dict[str, Any]:
+    case_uuid = UUID(case_id)
+    er_uuid = UUID(entity_record_id)
+    async with CaseRecordService.with_session() as cr_service:
+        cases = CasesService(cr_service.session, cr_service.role)
+        case = await cases.get_case(case_uuid)
+        if case is None:
+            raise ValueError(f"Case with ID {case_id} not found")
+        linked = await cr_service.link_entity_record(
+            case,
+            CaseRecordLink(entity_record_id=er_uuid),
+        )
+    return CaseRecordRead(
+        id=linked.id,
+        case_id=linked.case_id,
+        entity_id=linked.entity_id,
+        record_id=linked.record_id,
+        entity_key=linked.entity.key,
+        entity_display_name=linked.entity.display_name,
+        data=linked.record.data,
+        created_at=linked.created_at,
+        updated_at=linked.updated_at,
+    ).model_dump(mode="json")
+
+
+@registry.register(
+    default_title="Update case record",
+    display_group="Cases",
+    description="Update the entity record data for a case-linked record.",
+    namespace="core.cases",
+)
+async def update_case_record(
+    case_id: Annotated[
+        str,
+        Doc("The case ID containing the record."),
+    ],
+    case_record_id: Annotated[
+        str,
+        Doc("The case record link ID to update."),
+    ],
+    data: Annotated[
+        dict[str, Any],
+        Doc("Partial data to merge into the underlying entity record."),
+    ],
+) -> dict[str, Any]:
+    case_uuid = UUID(case_id)
+    link_uuid = UUID(case_record_id)
+    async with CaseRecordService.with_session() as cr_service:
+        cases = CasesService(cr_service.session, cr_service.role)
+        case = await cases.get_case(case_uuid)
+        if case is None:
+            raise ValueError(f"Case with ID {case_id} not found")
+        record = await cr_service.get_case_record(case, link_uuid)
+        if record is None:
+            raise ValueError(f"Case record with ID {case_record_id} not found")
+        updated = await cr_service.update_case_record(
+            record, CaseRecordUpdate(data=data)
+        )
+    return CaseRecordRead(
+        id=updated.id,
+        case_id=updated.case_id,
+        entity_id=updated.entity_id,
+        record_id=updated.record_id,
+        entity_key=updated.entity.key,
+        entity_display_name=updated.entity.display_name,
+        data=updated.record.data,
+        created_at=updated.created_at,
+        updated_at=updated.updated_at,
+    ).model_dump(mode="json")
+
+
+@registry.register(
+    default_title="Unlink case record",
+    display_group="Cases",
+    description="Unlink a record from a case (soft delete of the link only).",
+    namespace="core.cases",
+)
+async def unlink_case_record(
+    case_id: Annotated[
+        str,
+        Doc("The case ID containing the record to unlink."),
+    ],
+    case_record_id: Annotated[
+        str,
+        Doc("The case record link ID to unlink."),
+    ],
+) -> dict[str, Any]:
+    case_uuid = UUID(case_id)
+    link_uuid = UUID(case_record_id)
+    async with CaseRecordService.with_session() as cr_service:
+        cases = CasesService(cr_service.session, cr_service.role)
+        case = await cases.get_case(case_uuid)
+        if case is None:
+            raise ValueError(f"Case with ID {case_id} not found")
+        record_link = await cr_service.get_case_record(case, link_uuid)
+        if record_link is None:
+            raise ValueError(f"Case record with ID {case_record_id} not found")
+        rec_id = record_link.record_id
+        await cr_service.unlink_case_record(record_link)
+    return CaseRecordDeleteResponse(
+        action="unlink",
+        case_id=UUID(case_id),
+        record_id=rec_id,
+        case_record_id=UUID(case_record_id),
+    ).model_dump(mode="json")
+
+
+@registry.register(
+    default_title="Delete case record",
+    display_group="Cases",
+    description="Delete a case-linked record and its underlying entity record.",
+    namespace="core.cases",
+)
+async def delete_case_record(
+    case_id: Annotated[
+        str,
+        Doc("The case ID containing the record to delete."),
+    ],
+    case_record_id: Annotated[
+        str,
+        Doc("The case record link ID to delete."),
+    ],
+) -> dict[str, Any]:
+    case_uuid = UUID(case_id)
+    link_uuid = UUID(case_record_id)
+    async with CaseRecordService.with_session() as cr_service:
+        cases = CasesService(cr_service.session, cr_service.role)
+        case = await cases.get_case(case_uuid)
+        if case is None:
+            raise ValueError(f"Case with ID {case_id} not found")
+        record_link = await cr_service.get_case_record(case, link_uuid)
+        if record_link is None:
+            raise ValueError(f"Case record with ID {case_record_id} not found")
+        rec_id = record_link.record_id
+        await cr_service.delete_case_record(record_link)
+    return CaseRecordDeleteResponse(
+        action="delete",
+        case_id=UUID(case_id),
+        record_id=rec_id,
+        case_record_id=UUID(case_record_id),
+    ).model_dump(mode="json")

--- a/tests/registry/test_core_records.py
+++ b/tests/registry/test_core_records.py
@@ -1,0 +1,797 @@
+"""Tests for core.records and case-record UDFs in the registry."""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from tracecat_registry.core.records import (
+    create_case_record,
+    create_record,
+    create_record_by_key,
+    delete_case_record,
+    delete_record,
+    get_case_record,
+    get_record,
+    link_entity_record,
+    list_case_records,
+    list_entity_records,
+    list_records,
+    unlink_case_record,
+    update_case_record,
+)
+from tracecat_registry.core.records import (
+    update_record as update_entity_record,
+)
+
+from tracecat.records.model import RecordRead
+from tracecat.types.exceptions import TracecatNotFoundError
+
+
+@pytest.fixture(scope="session")
+def redis_server():
+    """Override Redis server fixture to no-op for this module."""
+    yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+def clean_redis_db(redis_server):
+    """Override Redis cleanup to no-op for this module."""
+    yield
+
+
+@pytest.fixture
+def mock_record():
+    rec = MagicMock()
+    rec.id = uuid.uuid4()
+    rec.entity_id = uuid.uuid4()
+    rec.data = {"field": "value"}
+    rec.created_at = datetime.now()
+    rec.updated_at = datetime.now()
+    return rec
+
+
+@pytest.fixture
+def mock_record_read():
+    return RecordRead(
+        id=uuid.uuid4(),
+        entity_id=uuid.uuid4(),
+        data={"field": "value"},
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+@pytest.fixture
+def mock_case():
+    case = MagicMock()
+    case.id = uuid.uuid4()
+    return case
+
+
+def _make_cursor_response(items):
+    resp = MagicMock()
+    resp.items = items
+    resp.next_cursor = "next"
+    resp.prev_cursor = "prev"
+    resp.has_more = True
+    resp.has_previous = False
+    resp.total_estimate = 123
+    return resp
+
+
+@pytest.mark.anyio
+class TestEntityRecordUDFs:
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_list_records(self, mock_with_session, mock_record_read):
+        mock_service = AsyncMock()
+        mock_service.list_records.return_value = _make_cursor_response(
+            [mock_record_read]
+        )
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        result = await list_records()
+
+        mock_service.list_records.assert_called_once()
+        assert "items" in result and len(result["items"]) == 1
+        assert result["next_cursor"] == "next"
+        assert result["prev_cursor"] == "prev"
+        assert result["has_more"] is True
+        assert result["has_previous"] is False
+        assert result["total_estimate"] == 123
+
+    async def test_list_records_invalid_entity_id(self):
+        with pytest.raises(ValueError):
+            await list_records(entity_id="not-a-uuid")
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    @patch("tracecat_registry.core.records.EntityService.with_session")
+    async def test_list_entity_records(
+        self, mock_entities_with_session, mock_records_with_session, mock_record_read
+    ):
+        # Entities
+        mock_entities = AsyncMock()
+        entity_obj = MagicMock()
+        entity_obj.id = uuid.uuid4()
+        mock_entities.get_entity.return_value = entity_obj
+        mock_ent_ctx = AsyncMock()
+        mock_ent_ctx.__aenter__.return_value = mock_entities
+        mock_entities_with_session.return_value = mock_ent_ctx
+
+        # Records
+        mock_records = AsyncMock()
+        mock_records.list_entity_records.return_value = _make_cursor_response(
+            [mock_record_read]
+        )
+        mock_rec_ctx = AsyncMock()
+        mock_rec_ctx.__aenter__.return_value = mock_records
+        mock_records_with_session.return_value = mock_rec_ctx
+
+        result = await list_entity_records(entity_id=str(entity_obj.id))
+
+        mock_entities.get_entity.assert_called_once()
+        mock_records.list_entity_records.assert_called_once()
+        assert len(result["items"]) == 1
+
+    async def test_list_entity_records_invalid_entity_id(self):
+        with pytest.raises(ValueError):
+            await list_entity_records(entity_id="bad-uuid")
+
+    @patch("tracecat_registry.core.records.EntityService.with_session")
+    async def test_list_entity_records_entity_not_found(
+        self, mock_entities_with_session
+    ):
+        mock_entities = AsyncMock()
+        mock_entities.get_entity.side_effect = TracecatNotFoundError("Entity not found")
+        mock_ent_ctx = AsyncMock()
+        mock_ent_ctx.__aenter__.return_value = mock_entities
+        mock_entities_with_session.return_value = mock_ent_ctx
+
+        with pytest.raises(TracecatNotFoundError):
+            await list_entity_records(entity_id=str(uuid.uuid4()))
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_get_record(self, mock_with_session, mock_record):
+        mock_service = AsyncMock()
+        mock_service.get_record_by_id.return_value = mock_record
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        result = await get_record(record_id=str(mock_record.id))
+        assert result["id"] == str(mock_record.id)
+        assert result["entity_id"] == str(mock_record.entity_id)
+        assert result["data"] == mock_record.data
+
+    async def test_get_record_invalid_id(self):
+        with pytest.raises(ValueError):
+            await get_record(record_id="nope")
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_get_record_not_found(self, mock_with_session):
+        mock_service = AsyncMock()
+        mock_service.get_record_by_id.side_effect = TracecatNotFoundError(
+            "Record not found"
+        )
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        with pytest.raises(TracecatNotFoundError):
+            await get_record(record_id=str(uuid.uuid4()))
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    @patch("tracecat_registry.core.records.EntityService.with_session")
+    async def test_create_record(
+        self, mock_entities_with_session, mock_records_with_session
+    ):
+        # Entities
+        mock_entities = AsyncMock()
+        entity_obj = MagicMock()
+        entity_obj.id = uuid.uuid4()
+        mock_entities.get_entity.return_value = entity_obj
+        mock_ent_ctx = AsyncMock()
+        mock_ent_ctx.__aenter__.return_value = mock_entities
+        mock_entities_with_session.return_value = mock_ent_ctx
+
+        # Records
+        mock_records = AsyncMock()
+        created = MagicMock()
+        created.id = uuid.uuid4()
+        created.entity_id = entity_obj.id
+        created.data = {"a": 1}
+        created.created_at = datetime.now()
+        created.updated_at = datetime.now()
+        mock_records.create_record.return_value = created
+        mock_rec_ctx = AsyncMock()
+        mock_rec_ctx.__aenter__.return_value = mock_records
+        mock_records_with_session.return_value = mock_rec_ctx
+
+        result = await create_record(entity_id=str(entity_obj.id), data={"a": 1})
+
+        # Ensure correct types passed into service
+        call = mock_records.create_record.call_args[0]
+        assert call[0] is entity_obj  # entity
+        assert call[1].data == {"a": 1}  # RecordCreate
+
+        assert result["entity_id"] == str(entity_obj.id)
+        assert result["data"] == {"a": 1}
+
+    async def test_create_record_invalid_entity_id(self):
+        with pytest.raises(ValueError):
+            await create_record(entity_id="bad", data={})
+
+    @patch("tracecat_registry.core.records.EntityService.with_session")
+    async def test_create_record_entity_not_found(self, mock_entities_with_session):
+        mock_entities = AsyncMock()
+        mock_entities.get_entity.side_effect = TracecatNotFoundError("Entity not found")
+        mock_ent_ctx = AsyncMock()
+        mock_ent_ctx.__aenter__.return_value = mock_entities
+        mock_entities_with_session.return_value = mock_ent_ctx
+
+        with pytest.raises(TracecatNotFoundError):
+            await create_record(entity_id=str(uuid.uuid4()), data={})
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    @patch("tracecat_registry.core.records.EntityService.with_session")
+    async def test_create_record_bad_data(
+        self, mock_entities_with_session, mock_records_with_session
+    ):
+        # Entities returns an entity
+        mock_entities = AsyncMock()
+        entity_obj = MagicMock()
+        entity_obj.id = uuid.uuid4()
+        mock_entities.get_entity.return_value = entity_obj
+        mock_ent_ctx = AsyncMock()
+        mock_ent_ctx.__aenter__.return_value = mock_entities
+        mock_entities_with_session.return_value = mock_ent_ctx
+
+        # Records.create_record raises ValueError
+        mock_records = AsyncMock()
+        mock_records.create_record.side_effect = ValueError("bad data")
+        mock_rec_ctx = AsyncMock()
+        mock_rec_ctx.__aenter__.return_value = mock_records
+        mock_records_with_session.return_value = mock_rec_ctx
+
+        with pytest.raises(TypeError):
+            await create_record(entity_id=str(entity_obj.id), data={"bad": object()})
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    @patch("tracecat_registry.core.records.EntityService.with_session")
+    async def test_create_record_by_key(
+        self, mock_entities_with_session, mock_records_with_session
+    ):
+        # Entities by key
+        mock_entities = AsyncMock()
+        entity_obj = MagicMock()
+        entity_obj.id = uuid.uuid4()
+        mock_entities.get_entity_by_key.return_value = entity_obj
+        mock_ent_ctx = AsyncMock()
+        mock_ent_ctx.__aenter__.return_value = mock_entities
+        mock_entities_with_session.return_value = mock_ent_ctx
+
+        # Records
+        mock_records = AsyncMock()
+        created = MagicMock()
+        created.id = uuid.uuid4()
+        created.entity_id = entity_obj.id
+        created.data = {"b": 2}
+        created.created_at = datetime.now()
+        created.updated_at = datetime.now()
+        mock_records.create_record.return_value = created
+        mock_rec_ctx = AsyncMock()
+        mock_rec_ctx.__aenter__.return_value = mock_records
+        mock_records_with_session.return_value = mock_rec_ctx
+
+        result = await create_record_by_key(entity_key="user", data={"b": 2})
+
+        mock_entities.get_entity_by_key.assert_called_once_with("user")
+        assert result["entity_id"] == str(entity_obj.id)
+        assert result["data"] == {"b": 2}
+
+    @patch("tracecat_registry.core.records.EntityService.with_session")
+    async def test_create_record_by_key_entity_not_found(
+        self, mock_entities_with_session
+    ):
+        mock_entities = AsyncMock()
+        mock_entities.get_entity_by_key.side_effect = TracecatNotFoundError(
+            "Entity not found"
+        )
+        mock_ent_ctx = AsyncMock()
+        mock_ent_ctx.__aenter__.return_value = mock_entities
+        mock_entities_with_session.return_value = mock_ent_ctx
+
+        with pytest.raises(TracecatNotFoundError):
+            await create_record_by_key(entity_key="missing", data={})
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_update_record(self, mock_with_session, mock_record):
+        mock_service = AsyncMock()
+        mock_service.get_record_by_id.return_value = mock_record
+
+        updated = MagicMock()
+        updated.id = mock_record.id
+        updated.entity_id = mock_record.entity_id
+        updated.data = {"field": "new"}
+        updated.created_at = mock_record.created_at
+        updated.updated_at = datetime.now()
+        mock_service.update_record.return_value = updated
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        result = await update_entity_record(
+            record_id=str(mock_record.id), data={"field": "new"}
+        )
+
+        mock_service.get_record_by_id.assert_called_once()
+        mock_service.update_record.assert_called_once()
+        assert result["data"] == {"field": "new"}
+
+    async def test_update_record_invalid_id(self):
+        with pytest.raises(ValueError):
+            await update_entity_record(record_id="nope", data={})
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_update_record_not_found(self, mock_with_session):
+        mock_service = AsyncMock()
+        mock_service.get_record_by_id.side_effect = TracecatNotFoundError(
+            "Record not found"
+        )
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        with pytest.raises(TracecatNotFoundError):
+            await update_entity_record(record_id=str(uuid.uuid4()), data={})
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_update_record_bad_data(self, mock_with_session, mock_record):
+        mock_service = AsyncMock()
+        mock_service.get_record_by_id.return_value = mock_record
+        mock_service.update_record.side_effect = ValueError("bad data")
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        with pytest.raises(TypeError):
+            await update_entity_record(
+                record_id=str(mock_record.id), data={"x": object()}
+            )
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_delete_record(self, mock_with_session, mock_record):
+        mock_service = AsyncMock()
+        mock_service.get_record_by_id.return_value = mock_record
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        # Should not raise
+        await delete_record(record_id=str(mock_record.id))
+        mock_service.delete_record.assert_called_once_with(mock_record)
+
+    async def test_delete_record_invalid_id(self):
+        with pytest.raises(ValueError):
+            await delete_record(record_id="nope")
+
+    @patch("tracecat_registry.core.records.RecordService.with_session")
+    async def test_delete_record_not_found(self, mock_with_session):
+        mock_service = AsyncMock()
+        mock_service.get_record_by_id.side_effect = TracecatNotFoundError(
+            "Record not found"
+        )
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        with pytest.raises(TracecatNotFoundError):
+            await delete_record(record_id=str(uuid.uuid4()))
+
+
+@pytest.fixture
+def mock_case_record_link():
+    link = MagicMock()
+    link.id = uuid.uuid4()
+    link.case_id = uuid.uuid4()
+    link.entity_id = uuid.uuid4()
+    link.record_id = uuid.uuid4()
+    link.created_at = datetime.now()
+    link.updated_at = datetime.now()
+
+    # nested entity
+    entity = MagicMock()
+    entity.key = "user"
+    entity.display_name = "User"
+    link.entity = entity
+
+    # nested record
+    record = MagicMock()
+    record.data = {"u": "v"}
+    link.record = record
+    return link
+
+
+@pytest.mark.anyio
+class TestCaseRecordUDFs:
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_list_case_records(
+        self, mock_cr_with_session, mock_cases_class, mock_case, mock_case_record_link
+    ):
+        # CaseRecord service
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.list_case_records.return_value = [mock_case_record_link]
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        # Cases service instance
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        result = await list_case_records(case_id=str(mock_case.id))
+
+        mock_cases_instance.get_case.assert_called_once()
+        mock_cr_service.list_case_records.assert_called_once_with(mock_case)
+        assert result["total"] == 1
+        assert result["items"][0]["entity_key"] == "user"
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_list_case_records_case_not_found(
+        self, mock_cr_with_session, mock_cases_class, mock_case_record_link
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = None
+        mock_cases_class.return_value = mock_cases_instance
+
+        with pytest.raises(ValueError):
+            await list_case_records(case_id=str(uuid.uuid4()))
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_get_case_record(
+        self, mock_cr_with_session, mock_cases_class, mock_case, mock_case_record_link
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.get_case_record.return_value = mock_case_record_link
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        result = await get_case_record(
+            case_id=str(mock_case.id), case_record_id=str(mock_case_record_link.id)
+        )
+        assert result["id"] == str(mock_case_record_link.id)
+        assert result["record_id"] == str(mock_case_record_link.record_id)
+        assert result["entity_key"] == "user"
+
+    async def test_get_case_record_invalid_case_id(self):
+        with pytest.raises(ValueError):
+            await get_case_record(case_id="bad", case_record_id=str(uuid.uuid4()))
+
+    async def test_get_case_record_invalid_link_id(self):
+        with pytest.raises(ValueError):
+            await get_case_record(case_id=str(uuid.uuid4()), case_record_id="bad")
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_get_case_record_case_not_found(
+        self, mock_cr_with_session, mock_cases_class
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = None
+        mock_cases_class.return_value = mock_cases_instance
+
+        with pytest.raises(ValueError):
+            await get_case_record(
+                case_id=str(uuid.uuid4()), case_record_id=str(uuid.uuid4())
+            )
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_get_case_record_link_not_found(
+        self, mock_cr_with_session, mock_cases_class, mock_case
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.get_case_record.return_value = None
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        with pytest.raises(ValueError):
+            await get_case_record(
+                case_id=str(mock_case.id), case_record_id=str(uuid.uuid4())
+            )
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_create_case_record(
+        self, mock_cr_with_session, mock_cases_class, mock_case, mock_case_record_link
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.create_case_record.return_value = mock_case_record_link
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        result = await create_case_record(
+            case_id=str(mock_case.id), entity_key="user", data={"k": "v"}
+        )
+
+        # Validate service call param type
+        call = mock_cr_service.create_case_record.call_args[0]
+        assert call[0] is mock_case
+        assert call[1].entity_key == "user"
+        assert call[1].data == {"k": "v"}
+        assert result["entity_key"] == "user"
+
+    async def test_create_case_record_invalid_case_id(self):
+        with pytest.raises(ValueError):
+            await create_case_record(case_id="bad", entity_key="x", data={})
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_create_case_record_case_not_found(
+        self, mock_cr_with_session, mock_cases_class
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = None
+        mock_cases_class.return_value = mock_cases_instance
+
+        with pytest.raises(ValueError):
+            await create_case_record(case_id=str(uuid.uuid4()), entity_key="x", data={})
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_create_case_record_entity_missing(
+        self, mock_cr_with_session, mock_cases_class, mock_case
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.create_case_record.side_effect = TracecatNotFoundError(
+            "Entity not found"
+        )
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        with pytest.raises(TracecatNotFoundError):
+            await create_case_record(
+                case_id=str(mock_case.id), entity_key="missing", data={}
+            )
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_link_entity_record(
+        self, mock_cr_with_session, mock_cases_class, mock_case, mock_case_record_link
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.link_entity_record.return_value = mock_case_record_link
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        erid = uuid.uuid4()
+        result = await link_entity_record(
+            case_id=str(mock_case.id), entity_record_id=str(erid)
+        )
+
+        call = mock_cr_service.link_entity_record.call_args[0]
+        assert call[0] is mock_case
+        assert str(call[1].entity_record_id) == str(erid)
+        assert result["record_id"] == str(mock_case_record_link.record_id)
+
+    async def test_link_entity_record_invalid_ids(self):
+        with pytest.raises(ValueError):
+            await link_entity_record(case_id="bad", entity_record_id=str(uuid.uuid4()))
+        with pytest.raises(ValueError):
+            await link_entity_record(case_id=str(uuid.uuid4()), entity_record_id="bad")
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_link_entity_record_case_not_found(
+        self, mock_cr_with_session, mock_cases_class
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = None
+        mock_cases_class.return_value = mock_cases_instance
+
+        with pytest.raises(ValueError):
+            await link_entity_record(
+                case_id=str(uuid.uuid4()), entity_record_id=str(uuid.uuid4())
+            )
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_link_entity_record_missing_entity_record(
+        self, mock_cr_with_session, mock_cases_class, mock_case
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.link_entity_record.side_effect = TracecatNotFoundError(
+            "Record not found"
+        )
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        with pytest.raises(TracecatNotFoundError):
+            await link_entity_record(
+                case_id=str(mock_case.id), entity_record_id=str(uuid.uuid4())
+            )
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_update_case_record(
+        self, mock_cr_with_session, mock_cases_class, mock_case, mock_case_record_link
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.get_case_record.return_value = mock_case_record_link
+        mock_cr_service.update_case_record.return_value = mock_case_record_link
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        result = await update_case_record(
+            case_id=str(mock_case.id),
+            case_record_id=str(mock_case_record_link.id),
+            data={"f": "w"},
+        )
+
+        call = mock_cr_service.update_case_record.call_args[0]
+        assert call[0] is mock_case_record_link
+        assert call[1].data == {"f": "w"}
+        assert result["id"] == str(mock_case_record_link.id)
+
+    async def test_update_case_record_invalid_ids(self):
+        with pytest.raises(ValueError):
+            await update_case_record(
+                case_id="bad", case_record_id=str(uuid.uuid4()), data={}
+            )
+        with pytest.raises(ValueError):
+            await update_case_record(
+                case_id=str(uuid.uuid4()), case_record_id="bad", data={}
+            )
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_unlink_case_record(
+        self, mock_cr_with_session, mock_cases_class, mock_case, mock_case_record_link
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.get_case_record.return_value = mock_case_record_link
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        result = await unlink_case_record(
+            case_id=str(mock_case.id), case_record_id=str(mock_case_record_link.id)
+        )
+        mock_cr_service.unlink_case_record.assert_called_once_with(
+            mock_case_record_link
+        )
+        assert result["action"] == "unlink"
+        assert result["case_id"] == str(mock_case.id)
+        assert result["record_id"] == str(mock_case_record_link.record_id)
+
+    async def test_unlink_case_record_invalid_ids(self):
+        with pytest.raises(ValueError):
+            await unlink_case_record(case_id="bad", case_record_id=str(uuid.uuid4()))
+        with pytest.raises(ValueError):
+            await unlink_case_record(case_id=str(uuid.uuid4()), case_record_id="bad")
+
+    @patch("tracecat_registry.core.records.CasesService")
+    @patch("tracecat_registry.core.records.CaseRecordService.with_session")
+    async def test_delete_case_record(
+        self, mock_cr_with_session, mock_cases_class, mock_case, mock_case_record_link
+    ):
+        mock_cr_service = AsyncMock()
+        mock_cr_service.session = MagicMock()
+        mock_cr_service.role = MagicMock()
+        mock_cr_service.get_case_record.return_value = mock_case_record_link
+        mock_cr_ctx = AsyncMock()
+        mock_cr_ctx.__aenter__.return_value = mock_cr_service
+        mock_cr_with_session.return_value = mock_cr_ctx
+
+        mock_cases_instance = AsyncMock()
+        mock_cases_instance.get_case.return_value = mock_case
+        mock_cases_class.return_value = mock_cases_instance
+
+        result = await delete_case_record(
+            case_id=str(mock_case.id), case_record_id=str(mock_case_record_link.id)
+        )
+        mock_cr_service.delete_case_record.assert_called_once_with(
+            mock_case_record_link
+        )
+        assert result["action"] == "delete"
+        assert result["case_id"] == str(mock_case.id)
+        assert result["record_id"] == str(mock_case_record_link.record_id)
+
+    async def test_delete_case_record_invalid_ids(self):
+        with pytest.raises(ValueError):
+            await delete_case_record(case_id="bad", case_record_id=str(uuid.uuid4()))
+        with pytest.raises(ValueError):
+            await delete_case_record(case_id=str(uuid.uuid4()), case_record_id="bad")


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added registry UDFs to manage entity records and case-linked records, with consistent JSON responses and cursor-based pagination. This lets workflows list, create, update, delete, and link records to cases directly.

- **New Features**
  - Entity records: list (optional entity filter), get, create (by entity id/key), update, delete.
  - Pagination: cursor-based listing returns items, next/prev cursors, has_more/has_previous, total_estimate.
  - Case records: list/get, create new and link to case, link existing entity record, update linked record, unlink, and delete (with underlying record).
  - Input validation: UUID parsing for IDs; clear errors when cases, entities, or records are not found.

<!-- End of auto-generated description by cubic. -->

