### PR TITLE
feat(registry): Add runbook udfs

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/runbooks.py
+++ b/packages/tracecat-registry/tracecat_registry/core/runbooks.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from typing_extensions import Doc
+
+from tracecat.chat.enums import ChatEntity
+from tracecat.prompt.models import PromptRead, PromptRunEntity
+from tracecat.prompt.service import PromptService
+from tracecat_registry import registry
+
+
+@registry.register(
+    namespace="core.runbooks",
+    description="List runbooks (prompts) in the current workspace.",
+    default_title="List runbooks",
+    display_group="Runbooks",
+)
+async def list_runbooks(
+    limit: Annotated[
+        int,
+        Doc("Maximum number of runbooks to return (1-100)."),
+    ] = 50,
+    sort_by: Annotated[
+        Literal["created_at", "updated_at"],
+        Doc("Field to sort by: 'created_at' or 'updated_at'."),
+    ] = "created_at",
+    order: Annotated[
+        Literal["asc", "desc"],
+        Doc("Sort order: 'asc' or 'desc'."),
+    ] = "desc",
+) -> list[dict[str, Any]]:
+    async with PromptService.with_session() as svc:
+        prompts = await svc.list_prompts(limit=limit, sort_by=sort_by, order=order)
+    # Normalize to API shape using PromptRead
+    return [
+        PromptRead.model_validate(p, from_attributes=True).model_dump(mode="json")
+        for p in prompts
+    ]
+
+
+@registry.register(
+    namespace="core.runbooks",
+    description="Get a single runbook (prompt) by ID.",
+    default_title="Get runbook",
+    display_group="Runbooks",
+)
+async def get_runbook(
+    runbook_id: Annotated[
+        str,
+        Doc("The runbook ID (UUID)."),
+    ],
+) -> dict[str, Any]:
+    async with PromptService.with_session() as svc:
+        prompt = await svc.get_prompt(UUID(runbook_id))
+    if not prompt:
+        raise ValueError(f"Runbook with ID {runbook_id} not found")
+    return PromptRead.model_validate(prompt, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    namespace="core.runbooks",
+    description="Execute a runbook on one or more cases.",
+    default_title="Execute runbook",
+    display_group="Runbooks",
+)
+async def execute(
+    runbook_id: Annotated[
+        str,
+        Doc("The runbook ID (UUID) to execute."),
+    ],
+    case_ids: Annotated[
+        list[str],
+        Doc("List of case IDs (UUID strings) to run the runbook on."),
+    ],
+) -> list[dict[str, Any]]:
+    async with PromptService.with_session() as svc:
+        prompt = await svc.get_prompt(UUID(runbook_id))
+        if not prompt:
+            raise ValueError(f"Runbook with ID {runbook_id} not found")
+
+        entities = [
+            PromptRunEntity(entity_id=UUID(case_id), entity_type=ChatEntity.CASE)
+            for case_id in case_ids
+        ]
+        responses = await svc.run_prompt(prompt, entities)
+
+    # Return a list of chat execution descriptors
+    return [
+        {"chat_id": str(resp.chat_id), "stream_url": resp.stream_url}
+        for resp in responses
+    ]


### PR DESCRIPTION
# Todos
- [ ] Alias

- Added three asynchronous functions: `list_runbooks`, `get_runbook`, and `execute` to manage runbooks in the current workspace.
- `list_runbooks` retrieves a list of runbooks with options for limiting, sorting, and ordering results.
- `get_runbook` fetches a specific runbook by its UUID, raising an error if not found.
- `execute` runs a specified runbook on a list of case IDs, returning execution descriptors.

These enhancements provide a structured way to interact with runbooks, improving the overall functionality of the application.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds runbook UDFs to list, fetch, and execute runbooks in the current workspace. Enables running a runbook on case IDs and returns chat execution descriptors for streaming.

- **New Features**
  - list_runbooks(limit 1–100, sort_by created_at|updated_at, order asc|desc); returns normalized PromptRead JSON.
  - get_runbook(runbook_id UUID); returns the runbook or raises if not found.
  - execute(runbook_id, case_ids[] UUID); validates runbook, runs prompt per case, returns [{chat_id, stream_url}].

<!-- End of auto-generated description by cubic. -->

