### PR TITLE
feat(integrations): Add Exa templates

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/answer.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/answer.yml
@@ -1,0 +1,26 @@
+type: action
+definition:
+  title: Answer
+  description: Answer a question with Exa.
+  display_group: Exa
+  doc_url: https://docs.exa.ai/reference/answer
+  namespace: tools.exa
+  name: answer
+  secrets:
+    - name: exa
+      keys: ["EXA_API_KEY"]
+  expects:
+    query:
+      type: str
+      description: The question to answer.
+  steps:
+    - ref: answer
+      action: core.http_request
+      args:
+        url: https://api.exa.ai/v1/answer
+        method: POST
+        headers:
+          x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}
+        payload:
+          query: ${{ inputs.query }}
+  returns: ${{ steps.answer.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_contents.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_contents.yml
@@ -1,7 +1,7 @@
 type: action
 definition:
   title: Get contents
-  description: Get full page contents, summaries, and metadat for a list of URLs.
+  description: Get full page contents, summaries, and metadata for a list of URLs.
   display_group: Exa
   doc_url: https://docs.exa.ai/reference/get-contents
   namespace: tools.exa

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_contents.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_contents.yml
@@ -1,0 +1,26 @@
+type: action
+definition:
+  title: Get contents
+  description: Get full page contents, summaries, and metadat for a list of URLs.
+  display_group: Exa
+  doc_url: https://docs.exa.ai/reference/get-contents
+  namespace: tools.exa
+  name: get_contents
+  secrets:
+    - name: exa
+      keys: ["EXA_API_KEY"]
+  expects:
+    urls:
+      type: list[str]
+      description: The URLs to get the contents for.
+  steps:
+    - ref: get_contents
+      action: core.http_request
+      args:
+        url: https://api.exa.ai/v1/contents
+        method: POST
+        headers:
+          x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}
+        payload:
+          urls: ${{ inputs.urls }}
+  returns: ${{ steps.get_contents.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/search.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/search.yml
@@ -1,0 +1,26 @@
+type: action
+definition:
+  title: Search the web
+  description: Search the web with Exa.
+  display_group: Exa
+  doc_url: https://docs.exa.ai/reference/search
+  namespace: tools.exa
+  name: search
+  secrets:
+    - name: exa
+      keys: ["EXA_API_KEY"]
+  expects:
+    query:
+      type: str
+      description: The query to search for.
+  steps:
+    - ref: search
+      action: core.http_request
+      args:
+        url: https://api.exa.ai/v1/search
+        method: POST
+        headers:
+          x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}
+        payload:
+          query: ${{ inputs.query }}
+  returns: ${{ steps.search.result.data }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add Exa integration templates for web search, Q&A, and fetching page contents. These actions call Exa’s API via core.http_request and return the API response data.

- **New Features**
  - tools.exa.search → POST /v1/search (query: str)
  - tools.exa.answer → POST /v1/answer (query: str)
  - tools.exa.get_contents → POST /v1/contents (urls: list[str])

- **Migration**
  - Add secret exa.EXA_API_KEY to enable requests.

<!-- End of auto-generated description by cubic. -->

