### PR TITLE
refactor: Update runbook execution diction

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8329,7 +8329,7 @@ export const $RunbookCreate = {
         },
       ],
       title: "Chat Id",
-      description: "ID of the chat to freeze into a prompt",
+      description: "ID of the chat to freeze into a runbook",
     },
     meta: {
       anyOf: [
@@ -8343,7 +8343,7 @@ export const $RunbookCreate = {
       ],
       title: "Meta",
       description:
-        "Optional metadata to include with the prompt (e.g., case information)",
+        "Optional metadata to include with the runbook (e.g., case information)",
     },
     alias: {
       anyOf: [
@@ -8360,6 +8360,59 @@ export const $RunbookCreate = {
   type: "object",
   title: "RunbookCreate",
   description: "Request model for creating a runbook.",
+} as const
+
+export const $RunbookExecuteEntity = {
+  properties: {
+    entity_id: {
+      type: "string",
+      format: "uuid4",
+      title: "Entity Id",
+      description: "ID of the entity to run the runbook on",
+    },
+    entity_type: {
+      $ref: "#/components/schemas/ChatEntity",
+      description: "Type of the entity to run the runbook on",
+    },
+  },
+  type: "object",
+  required: ["entity_id", "entity_type"],
+  title: "RunbookExecuteEntity",
+  description: "Request model for running a runbook on an entity.",
+} as const
+
+export const $RunbookExecuteRequest = {
+  properties: {
+    entities: {
+      items: {
+        $ref: "#/components/schemas/RunbookExecuteEntity",
+      },
+      type: "array",
+      title: "Entities",
+      description: "Entities to run the runbook on",
+    },
+  },
+  type: "object",
+  required: ["entities"],
+  title: "RunbookExecuteRequest",
+  description: "Request model for running a runbook on cases.",
+} as const
+
+export const $RunbookExecuteResponse = {
+  properties: {
+    stream_urls: {
+      additionalProperties: {
+        type: "string",
+      },
+      type: "object",
+      title: "Stream Urls",
+      description: "Mapping of chat_id to SSE stream URL",
+    },
+  },
+  type: "object",
+  required: ["stream_urls"],
+  title: "RunbookExecuteResponse",
+  description: "Response model for runbook execution.",
 } as const
 
 export const $RunbookRead = {
@@ -8423,59 +8476,6 @@ export const $RunbookRead = {
   required: ["id", "title", "content", "tools", "created_at", "updated_at"],
   title: "RunbookRead",
   description: "Model for runbook details.",
-} as const
-
-export const $RunbookRunEntity = {
-  properties: {
-    entity_id: {
-      type: "string",
-      format: "uuid4",
-      title: "Entity Id",
-      description: "ID of the entity to run the runbook on",
-    },
-    entity_type: {
-      $ref: "#/components/schemas/ChatEntity",
-      description: "Type of the entity to run the runbook on",
-    },
-  },
-  type: "object",
-  required: ["entity_id", "entity_type"],
-  title: "RunbookRunEntity",
-  description: "Request model for running a runbook on an entity.",
-} as const
-
-export const $RunbookRunRequest = {
-  properties: {
-    entities: {
-      items: {
-        $ref: "#/components/schemas/RunbookRunEntity",
-      },
-      type: "array",
-      title: "Entities",
-      description: "Entities to run the runbook on",
-    },
-  },
-  type: "object",
-  required: ["entities"],
-  title: "RunbookRunRequest",
-  description: "Request model for running a runbook on cases.",
-} as const
-
-export const $RunbookRunResponse = {
-  properties: {
-    stream_urls: {
-      additionalProperties: {
-        type: "string",
-      },
-      type: "object",
-      title: "Stream Urls",
-      description: "Mapping of case_id to SSE stream URL",
-    },
-  },
-  type: "object",
-  required: ["stream_urls"],
-  title: "RunbookRunResponse",
-  description: "Response model for runbook execution.",
 } as const
 
 export const $RunbookUpdate = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -257,12 +257,12 @@ import type {
   RunbookCreateRunbookResponse,
   RunbookDeleteRunbookData,
   RunbookDeleteRunbookResponse,
+  RunbookExecuteRunbookData,
+  RunbookExecuteRunbookResponse,
   RunbookGetRunbookData,
   RunbookGetRunbookResponse,
   RunbookListRunbooksData,
   RunbookListRunbooksResponse,
-  RunbookRunRunbookData,
-  RunbookRunRunbookResponse,
   RunbookStreamRunbookExecutionData,
   RunbookStreamRunbookExecutionResponse,
   RunbookUpdateRunbookData,
@@ -5409,21 +5409,21 @@ export const runbookDeleteRunbook = (
 }
 
 /**
- * Run Runbook
+ * Execute Runbook
  * Execute a runbook on multiple cases.
  * @param data The data for the request.
  * @param data.runbookId
  * @param data.workspaceId
  * @param data.requestBody
- * @returns RunbookRunResponse Successful Response
+ * @returns RunbookExecuteResponse Successful Response
  * @throws ApiError
  */
-export const runbookRunRunbook = (
-  data: RunbookRunRunbookData
-): CancelablePromise<RunbookRunRunbookResponse> => {
+export const runbookExecuteRunbook = (
+  data: RunbookExecuteRunbookData
+): CancelablePromise<RunbookExecuteRunbookResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/runbook/{runbook_id}/run",
+    url: "/runbook/{runbook_id}/execute",
     path: {
       runbook_id: data.runbookId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2889,11 +2889,11 @@ export type RunbookAlias = string
  */
 export type RunbookCreate = {
   /**
-   * ID of the chat to freeze into a prompt
+   * ID of the chat to freeze into a runbook
    */
   chat_id?: string | null
   /**
-   * Optional metadata to include with the prompt (e.g., case information)
+   * Optional metadata to include with the runbook (e.g., case information)
    */
   meta?: {
     [key: string]: unknown
@@ -2902,6 +2902,42 @@ export type RunbookCreate = {
    * Alias for the runbook
    */
   alias?: RunbookAlias | null
+}
+
+/**
+ * Request model for running a runbook on an entity.
+ */
+export type RunbookExecuteEntity = {
+  /**
+   * ID of the entity to run the runbook on
+   */
+  entity_id: string
+  /**
+   * Type of the entity to run the runbook on
+   */
+  entity_type: ChatEntity
+}
+
+/**
+ * Request model for running a runbook on cases.
+ */
+export type RunbookExecuteRequest = {
+  /**
+   * Entities to run the runbook on
+   */
+  entities: Array<RunbookExecuteEntity>
+}
+
+/**
+ * Response model for runbook execution.
+ */
+export type RunbookExecuteResponse = {
+  /**
+   * Mapping of chat_id to SSE stream URL
+   */
+  stream_urls: {
+    [key: string]: string
+  }
 }
 
 /**
@@ -2942,42 +2978,6 @@ export type RunbookRead = {
    * A summary of the runbook.
    */
   summary?: string | null
-}
-
-/**
- * Request model for running a runbook on an entity.
- */
-export type RunbookRunEntity = {
-  /**
-   * ID of the entity to run the runbook on
-   */
-  entity_id: string
-  /**
-   * Type of the entity to run the runbook on
-   */
-  entity_type: ChatEntity
-}
-
-/**
- * Request model for running a runbook on cases.
- */
-export type RunbookRunRequest = {
-  /**
-   * Entities to run the runbook on
-   */
-  entities: Array<RunbookRunEntity>
-}
-
-/**
- * Response model for runbook execution.
- */
-export type RunbookRunResponse = {
-  /**
-   * Mapping of case_id to SSE stream URL
-   */
-  stream_urls: {
-    [key: string]: string
-  }
 }
 
 /**
@@ -5878,13 +5878,13 @@ export type RunbookDeleteRunbookData = {
 
 export type RunbookDeleteRunbookResponse = void
 
-export type RunbookRunRunbookData = {
-  requestBody: RunbookRunRequest
+export type RunbookExecuteRunbookData = {
+  requestBody: RunbookExecuteRequest
   runbookId: string
   workspaceId: string
 }
 
-export type RunbookRunRunbookResponse = RunbookRunResponse
+export type RunbookExecuteRunbookResponse = RunbookExecuteResponse
 
 export type RunbookStreamRunbookExecutionData = {
   caseId: string
@@ -8773,14 +8773,14 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/runbook/{runbook_id}/run": {
+  "/runbook/{runbook_id}/execute": {
     post: {
-      req: RunbookRunRunbookData
+      req: RunbookExecuteRunbookData
       res: {
         /**
          * Successful Response
          */
-        200: RunbookRunResponse
+        200: RunbookExecuteResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/cases/runbook-execute-dialog.tsx
+++ b/frontend/src/components/cases/runbook-execute-dialog.tsx
@@ -3,7 +3,7 @@
 import { formatDistanceToNow } from "date-fns"
 import { Calendar } from "lucide-react"
 import { useState } from "react"
-import type { RunbookRead, RunbookRunRequest } from "@/client"
+import type { RunbookExecuteRequest, RunbookRead } from "@/client"
 import { CaseCommentViewer } from "@/components/cases/case-description-editor"
 import { Button } from "@/components/ui/button"
 import {
@@ -43,7 +43,7 @@ export function RunbookExecuteDialog({
 
     setIsExecuting(true)
     try {
-      const request: RunbookRunRequest = {
+      const request: RunbookExecuteRequest = {
         entities: [
           {
             entity_id: entityId,

--- a/frontend/src/hooks/use-runbook.tsx
+++ b/frontend/src/hooks/use-runbook.tsx
@@ -2,15 +2,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   type ApiError,
   type RunbookCreate,
+  type RunbookExecuteRequest,
+  type RunbookExecuteResponse,
   type RunbookRead,
-  type RunbookRunRequest,
-  type RunbookRunResponse,
   type RunbookUpdate,
   runbookCreateRunbook,
   runbookDeleteRunbook,
+  runbookExecuteRunbook,
   runbookGetRunbook,
   runbookListRunbooks,
-  runbookRunRunbook,
   runbookUpdateRunbook,
 } from "@/client"
 import { toast } from "@/components/ui/use-toast"
@@ -132,12 +132,12 @@ export function useRunRunbook(workspaceId: string) {
   const queryClient = useQueryClient()
 
   const { mutateAsync: runRunbook, isPending: runRunbookPending } = useMutation<
-    RunbookRunResponse,
+    RunbookExecuteResponse,
     ApiError,
-    { runbookId: string; request: RunbookRunRequest }
+    { runbookId: string; request: RunbookExecuteRequest }
   >({
     mutationFn: ({ runbookId, request }) =>
-      runbookRunRunbook({
+      runbookExecuteRunbook({
         runbookId,
         workspaceId,
         requestBody: request,

--- a/packages/tracecat-registry/tracecat_registry/core/runbooks.py
+++ b/packages/tracecat-registry/tracecat_registry/core/runbooks.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from typing_extensions import Doc
 
 from tracecat.chat.enums import ChatEntity
-from tracecat.runbook.models import RunbookRead, RunbookRunEntity
+from tracecat.runbook.models import RunbookRead, RunbookExecuteEntity
 from tracecat.runbook.service import RunbookService
 from tracecat_registry import registry
 
@@ -83,7 +83,7 @@ async def execute(
             raise ValueError(f"Runbook with ID {runbook_id} not found")
 
         entities = [
-            RunbookRunEntity(entity_id=UUID(case_id), entity_type=ChatEntity.CASE)
+            RunbookExecuteEntity(entity_id=UUID(case_id), entity_type=ChatEntity.CASE)
             for case_id in case_ids
         ]
         responses = await svc.run_runbook(runbook, entities)

--- a/tracecat/runbook/models.py
+++ b/tracecat/runbook/models.py
@@ -86,15 +86,15 @@ class RunbookUpdate(BaseModel):
     )
 
 
-class RunbookRunRequest(BaseModel):
+class RunbookExecuteRequest(BaseModel):
     """Request model for running a runbook on cases."""
 
-    entities: list[RunbookRunEntity] = Field(
+    entities: list[RunbookExecuteEntity] = Field(
         ..., description="Entities to run the runbook on"
     )
 
 
-class RunbookRunEntity(BaseModel):
+class RunbookExecuteEntity(BaseModel):
     """Request model for running a runbook on an entity."""
 
     entity_id: UUID4 = Field(..., description="ID of the entity to run the runbook on")
@@ -103,7 +103,7 @@ class RunbookRunEntity(BaseModel):
     )
 
 
-class RunbookRunResponse(BaseModel):
+class RunbookExecuteResponse(BaseModel):
     """Response model for runbook execution."""
 
     stream_urls: dict[str, str] = Field(

--- a/tracecat/runbook/router.py
+++ b/tracecat/runbook/router.py
@@ -21,9 +21,9 @@ from tracecat.logger import logger
 from tracecat.redis.client import get_redis_client
 from tracecat.runbook.models import (
     RunbookCreate,
+    RunbookExecuteRequest,
+    RunbookExecuteResponse,
     RunbookRead,
-    RunbookRunRequest,
-    RunbookRunResponse,
     RunbookUpdate,
 )
 from tracecat.runbook.service import RunbookService
@@ -166,13 +166,13 @@ async def delete_runbook(
     await svc.delete_runbook(runbook)
 
 
-@router.post("/{runbook_id}/run", response_model=RunbookRunResponse)
-async def run_runbook(
+@router.post("/{runbook_id}/execute", response_model=RunbookExecuteResponse)
+async def execute_runbook(
     runbook_id: uuid.UUID,
-    params: RunbookRunRequest,
+    params: RunbookExecuteRequest,
     role: WorkspaceUser,
     session: AsyncDBSession,
-) -> RunbookRunResponse:
+) -> RunbookExecuteResponse:
     """Execute a runbook on multiple cases."""
     svc = RunbookService(session, role)
 
@@ -185,7 +185,7 @@ async def run_runbook(
 
     try:
         responses = await svc.run_runbook(runbook, params.entities)
-        return RunbookRunResponse(
+        return RunbookExecuteResponse(
             stream_urls={
                 str(response.chat_id): response.stream_url for response in responses
             }

--- a/tracecat/runbook/service.py
+++ b/tracecat/runbook/service.py
@@ -30,7 +30,7 @@ from tracecat.runbook.flows import execute_runbook_for_case
 from tracecat.runbook.models import (
     RunbookAlias,
     RunbookCreate,
-    RunbookRunEntity,
+    RunbookExecuteEntity,
     RunbookUpdate,
 )
 from tracecat.service import BaseWorkspaceService
@@ -301,7 +301,7 @@ Here are the <Steps> to execute:
     async def run_runbook(
         self,
         runbook: Runbook,
-        entities: list[RunbookRunEntity],
+        entities: list[RunbookExecuteEntity],
     ) -> list[ChatResponse]:
         """Execute a runbook on multiple cases."""
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized runbook terminology from “run” to “execute” across backend and frontend. Renamed the API route, models, and client types; behavior is unchanged.

- **Refactors**
  - Models: RunbookRun* → RunbookExecute*; updated docstrings and field descriptions (e.g., prompt → runbook, stream_urls keyed by chat_id).
  - Router: POST /runbook/{runbook_id}/run → /runbook/{runbook_id}/execute with new response type.
  - Service/Registry: Updated type usages and method signatures to ExecuteEntity.
  - Frontend: Regenerated types/services; runbookRunRunbook → runbookExecuteRunbook.
  - UI/hooks: Updated dialog and hook to use Execute request/response types.

- **Migration**
  - Replace API path /runbook/{runbook_id}/run with /runbook/{runbook_id}/execute.
  - Rename types: RunbookRunRequest/Entity/Response → RunbookExecuteRequest/Entity/Response.
  - Update client calls: runbookRunRunbook(...) → runbookExecuteRunbook(...).
  - Docs: stream_urls map is described by chat_id.

<!-- End of auto-generated description by cubic. -->

