### PR TITLE
fix: enhance runbook execution and table metadata functionality

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/table.py
+++ b/packages/tracecat-registry/tracecat_registry/core/table.py
@@ -292,3 +292,17 @@ async def list_tables() -> list[dict[str, Any]]:
     async with TablesService.with_session() as service:
         tables = await service.list_tables()
     return [table.model_dump() for table in tables]
+
+
+@registry.register(
+    default_title="Get table metadata",
+    description="Get a table's metadata by name. This includes the columns and whether they are indexed.",
+    display_group="Tables",
+    namespace="core.table",
+)
+async def get_table_metadata(
+    name: Annotated[str, Doc("The name of the table to get.")],
+) -> dict[str, Any]:
+    async with TablesService.with_session() as service:
+        table = await service.get_table_by_name(name)
+    return table.model_dump(mode="json")

--- a/tracecat/middleware/auth.py
+++ b/tracecat/middleware/auth.py
@@ -43,7 +43,7 @@ class AuthorizationCacheMiddleware(BaseHTTPMiddleware):
             "user_id": None,  # The user ID this cache is for
         }
 
-        logger.debug(
+        logger.trace(
             "Authorization cache initialized",
             path=request.url.path,
             method=request.method,

--- a/tracecat/runbook/router.py
+++ b/tracecat/runbook/router.py
@@ -166,11 +166,21 @@ async def delete_runbook(
     await svc.delete_runbook(runbook)
 
 
+WorkspaceUserOrService = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=True,
+        require_workspace="yes",
+    ),
+]
+
+
 @router.post("/{runbook_id}/execute", response_model=RunbookExecuteResponse)
 async def execute_runbook(
     runbook_id: uuid.UUID,
     params: RunbookExecuteRequest,
-    role: WorkspaceUser,
+    role: WorkspaceUserOrService,
     session: AsyncDBSession,
 ) -> RunbookExecuteResponse:
     """Execute a runbook on multiple cases."""

--- a/tracecat/runbook/service.py
+++ b/tracecat/runbook/service.py
@@ -141,7 +141,7 @@ Here are the <Steps> to execute:
 2. Preserve the original <Step> order
 3. *NEVER reuse hardcoded or example inputs/outputs*; derive fresh values from <Alert>. Doing so means you are not executing the runbook on the incoming <Alert>.
 4. No conversational chatter, rationale, or chain-of-thought; keep outputs minimal and task-focused
-5. You should first read the case content and the <Alert> to determine if it is relevant to the <Steps>. If the case is clearly unrelated to these <Steps>, stop and output INAPPLICABLE
+5. You should first read the case content and the <Alert> to determine if it is relevant to the <Steps>. Only if the case is clearly unrelated to these <Steps>, stop and output INAPPLICABLE, with an explanation.
 6. Do not restate or summarize <Alert> or <Steps>
 7. Keep each message under ~150 tokens; do not dump large payloads; reference them instead
 </Rules>""")

--- a/tracecat/runbook/service.py
+++ b/tracecat/runbook/service.py
@@ -141,7 +141,7 @@ Here are the <Steps> to execute:
 2. Preserve the original <Step> order
 3. *NEVER reuse hardcoded or example inputs/outputs*; derive fresh values from <Alert>. Doing so means you are not executing the runbook on the incoming <Alert>.
 4. No conversational chatter, rationale, or chain-of-thought; keep outputs minimal and task-focused
-5. If the case is clearly unrelated to these <Steps>, stop and output INAPPLICABLE
+5. You should first read the case content and the <Alert> to determine if it is relevant to the <Steps>. If the case is clearly unrelated to these <Steps>, stop and output INAPPLICABLE
 6. Do not restate or summarize <Alert> or <Steps>
 7. Keep each message under ~150 tokens; do not dump large payloads; reference them instead
 </Rules>""")

--- a/tracecat/runbook/service.py
+++ b/tracecat/runbook/service.py
@@ -130,14 +130,16 @@ Here are the <Steps> to execute:
 
 <StepHandling>
 - user-prompt: follow the instruction
-- tool-call: use the named tool; infer inputs from <Alert> and prior returns; do not reuse example values
+- tool-call: use the named tool; infer inputs from <Alert> and prior returns
+    - You *MUST NOT* reuse hardcoded or example values. You *MUST* derive fresh values from <Alert>
+    - For example, if the <Alert> has a hostname `example.com`, during tool calls you *MUST NOT* use `example.com` as the hostname. You *MUST* use the actual hostname from the <Alert>
 - tool-return: note the type/shape, not literal example values
 </StepHandling>
 
 <Rules>
 1. Call tools only when a <Step> says so
 2. Preserve the original <Step> order
-3. Never reuse example inputs/outputs; derive fresh values from <Alert>
+3. *NEVER reuse hardcoded or example inputs/outputs*; derive fresh values from <Alert>. Doing so means you are not executing the runbook on the incoming <Alert>.
 4. No conversational chatter, rationale, or chain-of-thought; keep outputs minimal and task-focused
 5. If the case is clearly unrelated to these <Steps>, stop and output INAPPLICABLE
 6. Do not restate or summarize <Alert> or <Steps>


### PR DESCRIPTION
## Summary
- Enhanced runbook execution with Pydantic validation and improved role annotations
- Added table metadata indexing and table detail retrieval functions
- Lowered auth cache log level to reduce noise

## Changes
- Updated runbook execution to properly handle input values with clearer rules
- Implemented `get_table` function to retrieve table details by name
- Enhanced `get_table_metadata` to include index information
- Reduced auth middleware cache log level from info to debug
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improves runbook execution reliability and expands table metadata. Responses are now Pydantic-validated, service roles can execute runbooks, and table metadata includes index flags.

- **New Features**
  - Runbook execute: serialize entities with to_jsonable_python, validate API response with RunbookExecuteResponse, and return a consistent JSON shape.
  - Allow both user and service roles to execute runbooks.
  - Clarify runbook tool-call rules: never reuse hardcoded/example values; derive inputs from the incoming Alert.
  - Add get_table_metadata(name): returns table details with columns annotated with is_index.

- **Refactors**
  - Lower auth cache log level from debug to trace to reduce log noise.

<!-- End of auto-generated description by cubic. -->

