### PR TITLE
feat: Add Exa tools integration and fix API endpoints

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -142,7 +142,9 @@ services:
       TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
       TRACECAT__DB_URI: ${TRACECAT__DB_URI} # Sensitive
       TRACECAT__SERVICE_KEY: ${TRACECAT__SERVICE_KEY} # Sensitive
+      TRACECAT__SIGNING_SECRET: ${TRACECAT__SIGNING_SECRET} # Sensitive
       TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
+      TRACECAT__API_URL: ${TRACECAT__API_URL:-http://api:8000}
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
@@ -150,6 +152,8 @@ services:
       REDIS_HOST: ${REDIS_HOST}
       REDIS_PORT: ${REDIS_PORT}
       REDIS_URL: ${REDIS_URL}
+      # TMP
+      HEALTHCHECK_TMP_THRESHOLD: ${HEALTHCHECK_TMP_THRESHOLD}
     volumes:
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     command:
@@ -247,7 +251,7 @@ services:
       - temporal_postgres_db
 
   temporal_ui:
-    image: temporalio/ui:${TEMPORAL__UI_VERSION}
+    image: temporalio/ui:${TEMPORAL__UI_VERSION:-latest}
     container_name: temporal_ui
     restart: unless-stopped
     networks:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/answer.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/answer.yml
@@ -17,7 +17,7 @@ definition:
     - ref: answer
       action: core.http_request
       args:
-        url: https://api.exa.ai/v1/answer
+        url: https://api.exa.ai/answer
         method: POST
         headers:
           x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_contents.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_contents.yml
@@ -17,7 +17,7 @@ definition:
     - ref: get_contents
       action: core.http_request
       args:
-        url: https://api.exa.ai/v1/contents
+        url: https://api.exa.ai/contents
         method: POST
         headers:
           x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/search.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/search.yml
@@ -17,7 +17,7 @@ definition:
     - ref: search
       action: core.http_request
       args:
-        url: https://api.exa.ai/v1/search
+        url: https://api.exa.ai/search
         method: POST
         headers:
           x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}

--- a/tracecat/chat/tools.py
+++ b/tracecat/chat/tools.py
@@ -13,6 +13,9 @@ TOOL_DEFAULTS = {
         "core.runbooks.get_runbook",
         "core.runbooks.list_runbooks",
         "core.runbooks.update_runbook",
+        "tools.exa.search",
+        "tools.exa.answer",
+        "tools.exa.get_contents",
     ],
 }
 


### PR DESCRIPTION
## Summary
Adds Exa tools to chat tools defaults and fixes API endpoint URLs.

## Changes
- Fixed Exa API endpoint URLs by removing `/v1` from paths in templates
- Added Exa tools (search, answer, get_contents) to TOOL_DEFAULTS in chat/tools.py
- Updated docker-compose.local.yml with new environment variables

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>