### PR TITLE
chore: update integration docs

### DIFF
--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -59,15 +59,20 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | tools.jamf             | list_computers                          | `jamf`, `ssl`             |
 | tools.jamf             | lock_device                             | `jamf`, `ssl`             |
 | tools.jira             | add_issue_comment                       | `jira`, `ssl`             |
+| tools.jira             | assign_issue                            | `jira`, `ssl`             |
 | tools.jira             | create_issue                            | `jira`, `ssl`             |
 | tools.jira             | get_fields                              | `jira`, `ssl`             |
+| tools.jira             | get_issue                               | `jira`, `ssl`             |
 | tools.jira             | get_priorities                          | `jira`, `ssl`             |
 | tools.jira             | get_priority_schemes                    | `jira`, `ssl`             |
 | tools.jira             | get_projects                            | `jira`, `ssl`             |
 | tools.jira             | get_transitions                         | `jira`, `ssl`             |
+| tools.jira             | get_user_id                             | `jira`, `ssl`             |
+| tools.jira             | search_issues                           | `jira`, `ssl`             |
 | tools.jira             | update_issue_description                | `jira`, `ssl`             |
 | tools.jira             | update_issue_fields                     | `jira`, `ssl`             |
 | tools.jira             | update_issue_status                     | `jira`, `ssl`             |
+| tools.jira             | upload_attachment                       | `jira`, `ssl`             |
 | tools.ldap             | add_entry                               | `ldap`                    |
 | tools.ldap             | delete_entry                            | `ldap`                    |
 | tools.ldap             | modify_entry                            | `ldap`                    |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -54,6 +54,10 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | tools.elastic_security | list_detection_signals                  | `elastic_security`, `ssl` |
 | tools.falconpy         | call_command                            | `crowdstrike`             |
 | tools.google_api       | get_access_token                        | `google_api`              |
+| tools.hackerone        | get_program                             | `hackerone`, `ssl`        |
+| tools.hackerone        | get_programs                            | `hackerone`, `ssl`        |
+| tools.hackerone        | get_report                              | `hackerone`, `ssl`        |
+| tools.hackerone        | get_reports                             | `hackerone`, `ssl`        |
 | tools.ipinfo           | lookup_ip_address                       | `ipinfo`, `ssl`           |
 | tools.jamf             | get_access_token                        | `jamf`                    |
 | tools.jamf             | list_computers                          | `jamf`, `ssl`             |
@@ -175,6 +179,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | `datadog`              | `DATADOG_API_KEY` `DATADOG_APP_KEY`                                            | -                                                                                                                  |
 | `elastic_security`     | `ELASTIC_API_KEY`                                                              | -                                                                                                                  |
 | `google_api`           | `GOOGLE_API_CREDENTIALS`                                                       | -                                                                                                                  |
+| `hackerone`            | `HACKERONE_API_USERNAME` `HACKERONE_API_TOKEN`                                 | -                                                                                                                  |
 | `ipinfo`               | `IPINFO_API_TOKEN`                                                             | -                                                                                                                  |
 | `jamf`                 | `JAMF_CLIENT_ID` `JAMF_CLIENT_SECRET`                                          | -                                                                                                                  |
 | `jira`                 | `JIRA_API_TOKEN` `JIRA_USEREMAIL`                                              | -                                                                                                                  |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -58,6 +58,12 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | tools.hackerone        | get_programs                            | `hackerone`, `ssl`        |
 | tools.hackerone        | get_report                              | `hackerone`, `ssl`        |
 | tools.hackerone        | get_reports                             | `hackerone`, `ssl`        |
+| tools.hibp             | check_email_breaches                    | `hibp`, `ssl`             |
+| tools.hibp             | check_email_pastes                      | `hibp`, `ssl`             |
+| tools.hibp             | get_all_breaches                        | `ssl`                     |
+| tools.hibp             | get_breach_details                      | `ssl`                     |
+| tools.hibp             | get_data_classes                        | `ssl`                     |
+| tools.hibp             | get_latest_breach                       | `ssl`                     |
 | tools.ipinfo           | lookup_ip_address                       | `ipinfo`, `ssl`           |
 | tools.jamf             | get_access_token                        | `jamf`                    |
 | tools.jamf             | list_computers                          | `jamf`, `ssl`             |
@@ -196,6 +202,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | `elastic_security`     | `ELASTIC_API_KEY`                                                              | -                                                                                                                  |
 | `google_api`           | `GOOGLE_API_CREDENTIALS`                                                       | -                                                                                                                  |
 | `hackerone`            | `HACKERONE_API_USERNAME` `HACKERONE_API_TOKEN`                                 | -                                                                                                                  |
+| `hibp`                 | `HIBP_API_KEY`                                                                 | -                                                                                                                  |
 | `ipinfo`               | `IPINFO_API_TOKEN`                                                             | -                                                                                                                  |
 | `jamf`                 | `JAMF_CLIENT_ID` `JAMF_CLIENT_SECRET`                                          | -                                                                                                                  |
 | `jira`                 | `JIRA_API_TOKEN` `JIRA_USEREMAIL`                                              | -                                                                                                                  |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -148,6 +148,13 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | tools.wazuh            | active_response                         | `ssl`, `wazuh_wui`        |
 | tools.wazuh            | get_access_token                        | `wazuh_wui`               |
 | tools.wazuh            | update_agents                           | `ssl`, `wazuh_wui`        |
+| tools.zendesk          | get_group_users                         | `zendesk`, `ssl`          |
+| tools.zendesk          | get_groups                              | `zendesk`, `ssl`          |
+| tools.zendesk          | get_ticket                              | `zendesk`, `ssl`          |
+| tools.zendesk          | get_ticket_attachments                  | `zendesk`, `ssl`          |
+| tools.zendesk          | get_ticket_comments                     | `zendesk`, `ssl`          |
+| tools.zendesk          | get_twilio_recordings                   | `zendesk`, `ssl`          |
+| tools.zendesk          | search_tickets                          | `zendesk`, `ssl`          |
 
 ## Credentials
 
@@ -191,3 +198,4 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | `virustotal`           | `VIRUSTOTAL_API_KEY`                                                           | -                                                                                                                  |
 | `wazuh_wui`            | `WAZUH_WUI_PASSWORD` `WAZUH_WUI_USERNAME`                                      | -                                                                                                                  |
 | `wiz`                  | `WIZ_CLIENT_ID` `WIZ_CLIENT_SECRET`                                            | -                                                                                                                  |
+| `zendesk`              | `ZENDESK_EMAIL` `ZENDESK_API_TOKEN`                                            | -                                                                                                                  |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -5,165 +5,183 @@ description: A cheatsheet of core actions, integrations, and credentials support
 
 ## Core Actions
 
-<Note>
-Core action namespaces are prefixed with `core.`.
-</Note>
+<Note>Core action namespaces are prefixed with `core.`.</Note>
 
-| Namespace | Function | Secrets |
-| --- | --- | --- |
-| core | http_poll | `ssl` |
-| core | http_request | `ssl` |
-| core | require | - |
-| core | send_email_smtp | `smtp` |
-| core.cases | create_case | - |
-| core.cases | create_comment | - |
-| core.cases | get_case | - |
-| core.cases | list_cases | - |
-| core.cases | list_comments | - |
-| core.cases | update_case | - |
-| core.cases | update_comment | - |
-| core.table | delete_row | - |
-| core.table | insert_row | - |
-| core.table | lookup | - |
-| core.table | lookup_many | - |
-| core.table | update_row | - |
-| core.transform | apply | - |
-| core.transform | deduplicate | - |
-| core.transform | filter | - |
-| core.transform | is_in | - |
-| core.transform | map | - |
-| core.transform | not_in | - |
-| core.transform | reshape | - |
-| core.workflow | execute | - |
+| Namespace      | Function        | Secrets |
+| -------------- | --------------- | ------- |
+| core           | http_poll       | `ssl`   |
+| core           | http_request    | `ssl`   |
+| core           | require         | -       |
+| core           | send_email_smtp | `smtp`  |
+| core.cases     | create_case     | -       |
+| core.cases     | create_comment  | -       |
+| core.cases     | get_case        | -       |
+| core.cases     | list_cases      | -       |
+| core.cases     | list_comments   | -       |
+| core.cases     | update_case     | -       |
+| core.cases     | update_comment  | -       |
+| core.table     | delete_row      | -       |
+| core.table     | insert_row      | -       |
+| core.table     | lookup          | -       |
+| core.table     | lookup_many     | -       |
+| core.table     | update_row      | -       |
+| core.transform | apply           | -       |
+| core.transform | deduplicate     | -       |
+| core.transform | filter          | -       |
+| core.transform | is_in           | -       |
+| core.transform | map             | -       |
+| core.transform | not_in          | -       |
+| core.transform | reshape         | -       |
+| core.workflow  | execute         | -       |
 
 ## Integrations
 
-<Note>
-Integration namespaces are prefixed with `tools.`.
-</Note>
+<Note>Integration namespaces are prefixed with `tools.`.</Note>
 
-| Namespace | Function | Secrets |
-| --- | --- | --- |
-| tools.amazon_s3 | download_object | `amazon_s3` |
-| tools.amazon_s3 | parse_uri | `amazon_s3` |
-| tools.ansible | run_playbook | `ansible` |
-| tools.aws_boto3 | call_api | `aws` |
-| tools.aws_boto3 | call_paginated_api | `aws` |
-| tools.crowdsec | lookup_ip_address | `crowdsec_cti`, `ssl` |
-| tools.crowdstrike | list_alerts | `crowdstrike` |
-| tools.crowdstrike | list_cases | `crowdstrike` |
-| tools.crowdstrike | list_detects | `crowdstrike` |
-| tools.datadog | list_security_signals | `datadog`, `ssl` |
-| tools.elastic_security | list_detection_signals | `elastic_security`, `ssl` |
-| tools.falconpy | call_command | `crowdstrike` |
-| tools.google_api | get_access_token | `google_api` |
-| tools.ipinfo | lookup_ip_address | `ipinfo`, `ssl` |
-| tools.jamf | get_access_token | `jamf` |
-| tools.jamf | list_computers | `jamf`, `ssl` |
-| tools.jamf | lock_device | `jamf`, `ssl` |
-| tools.jira | add_issue_comment | `jira`, `ssl` |
-| tools.jira | create_issue | `jira`, `ssl` |
-| tools.jira | get_fields | `jira`, `ssl` |
-| tools.jira | get_priorities | `jira`, `ssl` |
-| tools.jira | get_priority_schemes | `jira`, `ssl` |
-| tools.jira | get_projects | `jira`, `ssl` |
-| tools.jira | get_transitions | `jira`, `ssl` |
-| tools.jira | update_issue_description | `jira`, `ssl` |
-| tools.jira | update_issue_fields | `jira`, `ssl` |
-| tools.jira | update_issue_status | `jira`, `ssl` |
-| tools.ldap | add_entry | `ldap` |
-| tools.ldap | delete_entry | `ldap` |
-| tools.ldap | modify_entry | `ldap` |
-| tools.ldap | search_entries | `ldap` |
-| tools.microsoft_graph | get_access_token | `microsoft_graph` |
-| tools.okta | lookup_user_by_email | `okta`, `ssl` |
-| tools.okta | revoke_sessions | `okta`, `ssl` |
-| tools.pagerduty | acknowledge_event | - |
-| tools.pagerduty | get_all_schedules | `pagerduty` |
-| tools.pagerduty | get_contact_methods | `pagerduty` |
-| tools.pagerduty | get_incident_data | `pagerduty` |
-| tools.pagerduty | get_incidents | `pagerduty` |
-| tools.pagerduty | get_user_notification_rules | `pagerduty` |
-| tools.pagerduty | get_users_on_cll | `pagerduty` |
-| tools.pagerduty | resolve_event | - |
-| tools.pagerduty | trigger_event | - |
-| tools.phishlabs | get_case_data | `phishlabs` |
-| tools.phishlabs | get_feed_data | `phishlabs` |
-| tools.phishlabs | get_threat_data | `phishlabs` |
-| tools.pymongo | execute_operation | `mongodb` |
-| tools.sentinel_one | list_threats | `sentinel_one`, `ssl` |
-| tools.slack | ask_text_input | `slack` |
-| tools.slack | lookup_user_by_email | `slack` |
-| tools.slack | post_message | `slack` |
-| tools.slack | post_notification | `slack` |
-| tools.slack | post_update | `slack` |
-| tools.slack | revoke_sessions | `slack` |
-| tools.slack_blocks | format_choices | - |
-| tools.slack_blocks | format_fields | - |
-| tools.slack_blocks | format_fields_context | - |
-| tools.slack_blocks | format_links | - |
-| tools.slack_blocks | format_text_input | - |
-| tools.slack_elements | format_overflow_menu | - |
-| tools.slack_sdk | call_method | `slack` |
-| tools.slack_sdk | call_paginated_method | `slack` |
-| tools.splunk | search_events | `splunk`, `ssl` |
-| tools.thehive | add_case_comment | `ssl`, `thehive` |
-| tools.thehive | create_case | `ssl`, `thehive` |
-| tools.thehive | update_case_description | `ssl`, `thehive` |
-| tools.thehive | update_case_fields | `ssl`, `thehive` |
-| tools.thehive | update_case_status | `ssl`, `thehive` |
-| tools.threatstream | lookup_domain | `ssl`, `threatstream` |
-| tools.threatstream | lookup_email | `ssl`, `threatstream` |
-| tools.threatstream | lookup_file_hash | `ssl`, `threatstream` |
-| tools.threatstream | lookup_ip_address | `ssl`, `threatstream` |
-| tools.threatstream | lookup_url | `ssl`, `threatstream` |
-| tools.urlscan | lookup_url | `ssl`, `urlscan` |
-| tools.virustotal | lookup_domain | `ssl`, `virustotal` |
-| tools.virustotal | lookup_file_hash | `ssl`, `virustotal` |
-| tools.virustotal | lookup_ip_address | `ssl`, `virustotal` |
-| tools.virustotal | lookup_url | `ssl`, `virustotal` |
-| tools.wazuh | active_response | `ssl`, `wazuh_wui` |
-| tools.wazuh | get_access_token | `wazuh_wui` |
-| tools.wazuh | update_agents | `ssl`, `wazuh_wui` |
+| Namespace              | Function                                | Secrets                   |
+| ---------------------- | --------------------------------------- | ------------------------- |
+| tools.amazon_s3        | download_object                         | `amazon_s3`               |
+| tools.amazon_s3        | parse_uri                               | `amazon_s3`               |
+| tools.ansible          | run_playbook                            | `ansible`                 |
+| tools.aws_boto3        | call_api                                | `aws`                     |
+| tools.aws_boto3        | call_paginated_api                      | `aws`                     |
+| tools.crowdsec         | lookup_ip_address                       | `crowdsec_cti`, `ssl`     |
+| tools.crowdstrike      | list_alerts                             | `crowdstrike`             |
+| tools.crowdstrike      | list_cases                              | `crowdstrike`             |
+| tools.crowdstrike      | list_detects                            | `crowdstrike`             |
+| tools.datadog          | list_security_signals                   | `datadog`, `ssl`          |
+| tools.elastic_security | list_detection_signals                  | `elastic_security`, `ssl` |
+| tools.falconpy         | call_command                            | `crowdstrike`             |
+| tools.google_api       | get_access_token                        | `google_api`              |
+| tools.ipinfo           | lookup_ip_address                       | `ipinfo`, `ssl`           |
+| tools.jamf             | get_access_token                        | `jamf`                    |
+| tools.jamf             | list_computers                          | `jamf`, `ssl`             |
+| tools.jamf             | lock_device                             | `jamf`, `ssl`             |
+| tools.jira             | add_issue_comment                       | `jira`, `ssl`             |
+| tools.jira             | create_issue                            | `jira`, `ssl`             |
+| tools.jira             | get_fields                              | `jira`, `ssl`             |
+| tools.jira             | get_priorities                          | `jira`, `ssl`             |
+| tools.jira             | get_priority_schemes                    | `jira`, `ssl`             |
+| tools.jira             | get_projects                            | `jira`, `ssl`             |
+| tools.jira             | get_transitions                         | `jira`, `ssl`             |
+| tools.jira             | update_issue_description                | `jira`, `ssl`             |
+| tools.jira             | update_issue_fields                     | `jira`, `ssl`             |
+| tools.jira             | update_issue_status                     | `jira`, `ssl`             |
+| tools.ldap             | add_entry                               | `ldap`                    |
+| tools.ldap             | delete_entry                            | `ldap`                    |
+| tools.ldap             | modify_entry                            | `ldap`                    |
+| tools.ldap             | search_entries                          | `ldap`                    |
+| tools.microsoft_graph  | get_access_token                        | `microsoft_graph`         |
+| tools.okta             | activate_user                           | `okta`, `ssl`             |
+| tools.okta             | add_to_group                            | `okta`, `ssl`             |
+| tools.okta             | assign_group_to_app                     | `okta`, `ssl`             |
+| tools.okta             | clear_user_sessions                     | `okta`, `ssl`             |
+| tools.okta             | create_user                             | `okta`, `ssl`             |
+| tools.okta             | expire_password                         | `okta`, `ssl`             |
+| tools.okta             | expire_password_with_temporary_password | `okta`, `ssl`             |
+| tools.okta             | get_group_members                       | `okta`, `ssl`             |
+| tools.okta             | get_groups_assigned_to_user             | `okta`, `ssl`             |
+| tools.okta             | get_user                                | `okta`, `ssl`             |
+| tools.okta             | list_groups_in_org                      | `okta`, `ssl`             |
+| tools.okta             | list_users                              | `okta`, `ssl`             |
+| tools.okta             | lookup_user_by_email                    | `okta`, `ssl`             |
+| tools.okta             | remove_from_group                       | `okta`, `ssl`             |
+| tools.okta             | reset_password                          | `okta`, `ssl`             |
+| tools.okta             | revoke_sessions                         | `okta`, `ssl`             |
+| tools.okta             | search_users                            | `okta`, `ssl`             |
+| tools.okta             | suspend_user                            | `okta`, `ssl`             |
+| tools.okta             | unsuspend_user                          | `okta`, `ssl`             |
+| tools.okta_oar         | create_message                          | `okta`, `ssl`             |
+| tools.okta_oar         | get_requests                            | `okta`, `ssl`             |
+| tools.okta_oar         | get_specific_request                    | `okta`, `ssl`             |
+| tools.okta_oar         | get_user                                | `okta`, `ssl`             |
+| tools.pagerduty        | acknowledge_event                       | -                         |
+| tools.pagerduty        | get_all_schedules                       | `pagerduty`               |
+| tools.pagerduty        | get_contact_methods                     | `pagerduty`               |
+| tools.pagerduty        | get_incident_data                       | `pagerduty`               |
+| tools.pagerduty        | get_incidents                           | `pagerduty`               |
+| tools.pagerduty        | get_user_notification_rules             | `pagerduty`               |
+| tools.pagerduty        | get_users_on_cll                        | `pagerduty`               |
+| tools.pagerduty        | resolve_event                           | `pagerduty`               |
+| tools.pagerduty        | trigger_event                           | -                         |
+| tools.phishlabs        | get_case_data                           | `phishlabs`               |
+| tools.phishlabs        | get_feed_data                           | `phishlabs`               |
+| tools.phishlabs        | get_threat_data                         | `phishlabs`               |
+| tools.pymongo          | execute_operation                       | `mongodb`                 |
+| tools.sentinel_one     | list_threats                            | `sentinel_one`, `ssl`     |
+| tools.slack            | ask_text_input                          | `slack`                   |
+| tools.slack            | lookup_user_by_email                    | `slack`                   |
+| tools.slack            | post_message                            | `slack`                   |
+| tools.slack            | post_notification                       | `slack`                   |
+| tools.slack            | post_update                             | `slack`                   |
+| tools.slack            | revoke_sessions                         | `slack`                   |
+| tools.slack_blocks     | format_choices                          | -                         |
+| tools.slack_blocks     | format_fields                           | -                         |
+| tools.slack_blocks     | format_fields_context                   | -                         |
+| tools.slack_blocks     | format_links                            | -                         |
+| tools.slack_blocks     | format_text_input                       | -                         |
+| tools.slack_elements   | format_overflow_menu                    | -                         |
+| tools.slack_sdk        | call_method                             | `slack`                   |
+| tools.slack_sdk        | call_paginated_method                   | `slack`                   |
+| tools.splunk           | search_events                           | `splunk`, `ssl`           |
+| tools.thehive          | add_case_comment                        | `ssl`, `thehive`          |
+| tools.thehive          | create_case                             | `ssl`, `thehive`          |
+| tools.thehive          | update_case_description                 | `ssl`, `thehive`          |
+| tools.thehive          | update_case_fields                      | `ssl`, `thehive`          |
+| tools.thehive          | update_case_status                      | `ssl`, `thehive`          |
+| tools.threatstream     | lookup_domain                           | `ssl`, `threatstream`     |
+| tools.threatstream     | lookup_email                            | `ssl`, `threatstream`     |
+| tools.threatstream     | lookup_file_hash                        | `ssl`, `threatstream`     |
+| tools.threatstream     | lookup_ip_address                       | `ssl`, `threatstream`     |
+| tools.threatstream     | lookup_url                              | `ssl`, `threatstream`     |
+| tools.urlscan          | lookup_url                              | `ssl`, `urlscan`          |
+| tools.virustotal       | lookup_domain                           | `ssl`, `virustotal`       |
+| tools.virustotal       | lookup_file_hash                        | `ssl`, `virustotal`       |
+| tools.virustotal       | lookup_ip_address                       | `ssl`, `virustotal`       |
+| tools.virustotal       | lookup_url                              | `ssl`, `virustotal`       |
+| tools.wazuh            | active_response                         | `ssl`, `wazuh_wui`        |
+| tools.wazuh            | get_access_token                        | `wazuh_wui`               |
+| tools.wazuh            | update_agents                           | `ssl`, `wazuh_wui`        |
 
 ## Credentials
 
 <Note>
-Tracecat uses secret keys associated with each integration for 3rd-party authentication.
-Find out more about how secrets work in Tracecat [here](/quickstart/secrets).
+  Tracecat uses secret keys associated with each integration for 3rd-party
+  authentication. Find out more about how secrets work in Tracecat
+  [here](/quickstart/secrets).
 </Note>
 
-| Secret Name | Required Keys | Optional Keys |
-| --- | --- | --- |
-| `amazon_s3` | - | `AWS_ACCESS_KEY_ID` `AWS_PROFILE` `AWS_REGION` `AWS_ROLE_ARN` `AWS_ROLE_SESSION_NAME` `AWS_SECRET_ACCESS_KEY` |
-| `ansible` | `ANSIBLE_SSH_KEY` | `ANSIBLE_PASSWORDS` |
-| `aws` | - | `AWS_ACCESS_KEY_ID` `AWS_PROFILE_NAME` `AWS_REGION` `AWS_ROLE_ARN` `AWS_ROLE_SESSION_NAME` `AWS_SECRET_ACCESS_KEY` |
-| `check_point_infinity` | `CHECKPOINT_ACCESS_KEY` `CHECKPOINT_CLIENT_ID` | - |
-| `crowdsec_cti` | `CTI_API_KEY` | - |
-| `crowdstrike` | `CROWDSTRIKE_CLIENT_ID` `CROWDSTRIKE_CLIENT_SECRET` | - |
-| `datadog` | `DATADOG_API_KEY` `DATADOG_APP_KEY` | - |
-| `elastic_security` | `ELASTIC_API_KEY` | - |
-| `google_api` | `GOOGLE_API_CREDENTIALS` | - |
-| `ipinfo` | `IPINFO_API_TOKEN` | - |
-| `jamf` | `JAMF_CLIENT_ID` `JAMF_CLIENT_SECRET` | - |
-| `jira` | `JIRA_API_TOKEN` `JIRA_USEREMAIL` | - |
-| `kubernetes` | `KUBECONFIG_BASE64` | - |
-| `ldap` | `LDAP_HOST` `LDAP_PASSWORD` `LDAP_PORT` `LDAP_USER` | - |
-| `microsoft_graph` | `MICROSOFT_GRAPH_CLIENT_ID` `MICROSOFT_GRAPH_CLIENT_SECRET` | - |
-| `mongodb` | `MONGODB_CONNECTION_STRING` | - |
-| `okta` | `OKTA_API_TOKEN` | - |
-| `openai` | `OPENAI_API_KEY` | - |
-| `opencti` | `OPENCTI_API_TOKEN` | - |
-| `pagerduty` | `PAGERDUTY_API_TOKEN` | - |
-| `phishlabs` | `PL_CLIENT_ID` `PL_CLIENT_SECRET` `PL_CUSTOMER_ID` `PL_PASSWORD` `PL_USERNAME` | - |
-| `sentinel_one` | `SENTINEL_ONE_API_TOKEN` | - |
-| `slack` | `SLACK_BOT_TOKEN` | - |
-| `smtp` | `SMTP_HOST` `SMTP_PASS` `SMTP_PORT` `SMTP_USER` | - |
-| `splunk` | `SPLUNK_API_KEY` | - |
-| `ssl` | - | `SSL_CLIENT_CERT` `SSL_CLIENT_KEY` `SSL_CLIENT_PASSWORD` |
-| `thehive` | `THEHIVE_API_KEY` | - |
-| `threatstream` | `ANOMALI_API_KEY` `ANOMALI_USERNAME` | - |
-| `urlscan` | `URLSCAN_API_KEY` | - |
-| `virustotal` | `VIRUSTOTAL_API_KEY` | - |
-| `wazuh_wui` | `WAZUH_WUI_PASSWORD` `WAZUH_WUI_USERNAME` | - |
-| `wiz` | `WIZ_CLIENT_ID` `WIZ_CLIENT_SECRET` | - |
+| Secret Name            | Required Keys                                                                  | Optional Keys                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `amazon_s3`            | -                                                                              | `AWS_ACCESS_KEY_ID` `AWS_PROFILE` `AWS_REGION` `AWS_ROLE_ARN` `AWS_ROLE_SESSION_NAME` `AWS_SECRET_ACCESS_KEY`      |
+| `ansible`              | `ANSIBLE_SSH_KEY`                                                              | `ANSIBLE_PASSWORDS`                                                                                                |
+| `aws`                  | -                                                                              | `AWS_ACCESS_KEY_ID` `AWS_PROFILE_NAME` `AWS_REGION` `AWS_ROLE_ARN` `AWS_ROLE_SESSION_NAME` `AWS_SECRET_ACCESS_KEY` |
+| `check_point_infinity` | `CHECKPOINT_ACCESS_KEY` `CHECKPOINT_CLIENT_ID`                                 | -                                                                                                                  |
+| `crowdsec_cti`         | `CTI_API_KEY`                                                                  | -                                                                                                                  |
+| `crowdstrike`          | `CROWDSTRIKE_CLIENT_ID` `CROWDSTRIKE_CLIENT_SECRET`                            | -                                                                                                                  |
+| `datadog`              | `DATADOG_API_KEY` `DATADOG_APP_KEY`                                            | -                                                                                                                  |
+| `elastic_security`     | `ELASTIC_API_KEY`                                                              | -                                                                                                                  |
+| `google_api`           | `GOOGLE_API_CREDENTIALS`                                                       | -                                                                                                                  |
+| `ipinfo`               | `IPINFO_API_TOKEN`                                                             | -                                                                                                                  |
+| `jamf`                 | `JAMF_CLIENT_ID` `JAMF_CLIENT_SECRET`                                          | -                                                                                                                  |
+| `jira`                 | `JIRA_API_TOKEN` `JIRA_USEREMAIL`                                              | -                                                                                                                  |
+| `kubernetes`           | `KUBECONFIG_BASE64`                                                            | -                                                                                                                  |
+| `ldap`                 | `LDAP_HOST` `LDAP_PASSWORD` `LDAP_PORT` `LDAP_USER`                            | -                                                                                                                  |
+| `microsoft_graph`      | `MICROSOFT_GRAPH_CLIENT_ID` `MICROSOFT_GRAPH_CLIENT_SECRET`                    | -                                                                                                                  |
+| `mongodb`              | `MONGODB_CONNECTION_STRING`                                                    | -                                                                                                                  |
+| `okta`                 | `OKTA_API_TOKEN`                                                               | -                                                                                                                  |
+| `openai`               | `OPENAI_API_KEY`                                                               | -                                                                                                                  |
+| `opencti`              | `OPENCTI_API_TOKEN`                                                            | -                                                                                                                  |
+| `pagerduty`            | `PAGERDUTY_API_TOKEN`                                                          | -                                                                                                                  |
+| `phishlabs`            | `PL_CLIENT_ID` `PL_CLIENT_SECRET` `PL_CUSTOMER_ID` `PL_PASSWORD` `PL_USERNAME` | -                                                                                                                  |
+| `sentinel_one`         | `SENTINEL_ONE_API_TOKEN`                                                       | -                                                                                                                  |
+| `slack`                | `SLACK_BOT_TOKEN`                                                              | -                                                                                                                  |
+| `smtp`                 | `SMTP_HOST` `SMTP_PASS` `SMTP_PORT` `SMTP_USER`                                | -                                                                                                                  |
+| `splunk`               | `SPLUNK_API_KEY`                                                               | -                                                                                                                  |
+| `ssl`                  | -                                                                              | `SSL_CLIENT_CERT` `SSL_CLIENT_KEY` `SSL_CLIENT_PASSWORD`                                                           |
+| `thehive`              | `THEHIVE_API_KEY`                                                              | -                                                                                                                  |
+| `threatstream`         | `ANOMALI_API_KEY` `ANOMALI_USERNAME`                                           | -                                                                                                                  |
+| `urlscan`              | `URLSCAN_API_KEY`                                                              | -                                                                                                                  |
+| `virustotal`           | `VIRUSTOTAL_API_KEY`                                                           | -                                                                                                                  |
+| `wazuh_wui`            | `WAZUH_WUI_PASSWORD` `WAZUH_WUI_USERNAME`                                      | -                                                                                                                  |
+| `wiz`                  | `WIZ_CLIENT_ID` `WIZ_CLIENT_SECRET`                                            | -                                                                                                                  |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -133,7 +133,23 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | tools.slack_elements   | format_overflow_menu                    | -                         |
 | tools.slack_sdk        | call_method                             | `slack`                   |
 | tools.slack_sdk        | call_paginated_method                   | `slack`                   |
+| tools.splunk           | add_kv_fields                           | `splunk`, `ssl`           |
+| tools.splunk           | create_kv_collection                    | `splunk`, `ssl`           |
+| tools.splunk           | create_kv_entry                         | `splunk`, `ssl`           |
+| tools.splunk           | delete_kv_collection                    | `splunk`, `ssl`           |
+| tools.splunk           | delete_kv_entry                         | `splunk`, `ssl`           |
+| tools.splunk           | discover_fields                         | `splunk`, `ssl`           |
+| tools.splunk           | get_kv_collection                       | `splunk`, `ssl`           |
+| tools.splunk           | get_kv_entry                            | `splunk`, `ssl`           |
+| tools.splunk           | list_data_models                        | `splunk`, `ssl`           |
+| tools.splunk           | list_field_extractions                  | `splunk`, `ssl`           |
+| tools.splunk           | list_indexes                            | `splunk`, `ssl`           |
+| tools.splunk           | list_kv_collections                     | `splunk`, `ssl`           |
+| tools.splunk           | list_kv_entries                         | `splunk`, `ssl`           |
+| tools.splunk           | list_sourcetypes                        | `splunk`, `ssl`           |
 | tools.splunk           | search_events                           | `splunk`, `ssl`           |
+| tools.splunk           | submit_hec_event                        | `splunk_hec`, `ssl`       |
+| tools.splunk           | update_kv_entry                         | `splunk`, `ssl`           |
 | tools.thehive          | add_case_comment                        | `ssl`, `thehive`          |
 | tools.thehive          | create_case                             | `ssl`, `thehive`          |
 | tools.thehive          | update_case_description                 | `ssl`, `thehive`          |
@@ -196,6 +212,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | `slack`                | `SLACK_BOT_TOKEN`                                                              | -                                                                                                                  |
 | `smtp`                 | `SMTP_HOST` `SMTP_PASS` `SMTP_PORT` `SMTP_USER`                                | -                                                                                                                  |
 | `splunk`               | `SPLUNK_API_KEY`                                                               | -                                                                                                                  |
+| `splunk_hec`           | `SPLUNK_HEC_TOKEN`                                                             | -                                                                                                                  |
 | `ssl`                  | -                                                                              | `SSL_CLIENT_CERT` `SSL_CLIENT_KEY` `SSL_CLIENT_PASSWORD`                                                           |
 | `thehive`              | `THEHIVE_API_KEY`                                                              | -                                                                                                                  |
 | `threatstream`         | `ANOMALI_API_KEY` `ANOMALI_USERNAME`                                           | -                                                                                                                  |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -126,7 +126,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | tools.pagerduty        | get_incident_data                       | `pagerduty`               |
 | tools.pagerduty        | get_incidents                           | `pagerduty`               |
 | tools.pagerduty        | get_user_notification_rules             | `pagerduty`               |
-| tools.pagerduty        | get_users_on_cll                        | `pagerduty`               |
+| tools.pagerduty        | get_users_on_call                       | `pagerduty`               |
 | tools.pagerduty        | resolve_event                           | `pagerduty`               |
 | tools.pagerduty        | trigger_event                           | -                         |
 | tools.phishlabs        | get_case_data                           | `phishlabs`               |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -54,6 +54,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | tools.elastic_security | list_detection_signals                  | `elastic_security`, `ssl` |
 | tools.falconpy         | call_command                            | `crowdstrike`             |
 | tools.google_api       | get_access_token                        | `google_api`              |
+| tools.google_maps      | get_location_data                       | `google_maps`, `ssl`      |
 | tools.hackerone        | get_program                             | `hackerone`, `ssl`        |
 | tools.hackerone        | get_programs                            | `hackerone`, `ssl`        |
 | tools.hackerone        | get_report                              | `hackerone`, `ssl`        |
@@ -201,6 +202,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | `datadog`              | `DATADOG_API_KEY` `DATADOG_APP_KEY`                                            | -                                                                                                                  |
 | `elastic_security`     | `ELASTIC_API_KEY`                                                              | -                                                                                                                  |
 | `google_api`           | `GOOGLE_API_CREDENTIALS`                                                       | -                                                                                                                  |
+| `google_maps`          | `GOOGLE_MAPS_API_KEY`                                                          | -                                                                                                                  |
 | `hackerone`            | `HACKERONE_API_USERNAME` `HACKERONE_API_TOKEN`                                 | -                                                                                                                  |
 | `hibp`                 | `HIBP_API_KEY`                                                                 | -                                                                                                                  |
 | `ipinfo`               | `IPINFO_API_TOKEN`                                                             | -                                                                                                                  |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -20,6 +20,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | core.cases     | list_comments   | -       |
 | core.cases     | update_case     | -       |
 | core.cases     | update_comment  | -       |
+| core.cases     | search_cases    | -       |
 | core.table     | delete_row      | -       |
 | core.table     | insert_row      | -       |
 | core.table     | lookup          | -       |

--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -41,6 +41,14 @@ description: A cheatsheet of core actions, integrations, and credentials support
 
 | Namespace              | Function                                | Secrets                   |
 | ---------------------- | --------------------------------------- | ------------------------- |
+| tools.alertmedia       | create_trip                             | `alertmedia`, `ssl`       |
+| tools.alertmedia       | delete_trip                             | `alertmedia`, `ssl`       |
+| tools.alertmedia       | get_travel_events                       | `alertmedia`, `ssl`       |
+| tools.alertmedia       | get_user_trip_by_id                     | `alertmedia`, `ssl`       |
+| tools.alertmedia       | get_user_trips                          | `alertmedia`, `ssl`       |
+| tools.alertmedia       | search_trips                            | `alertmedia`, `ssl`       |
+| tools.alertmedia       | search_users                            | `alertmedia`, `ssl`       |
+| tools.alertmedia       | update_trip                             | `alertmedia`, `ssl`       |
 | tools.amazon_s3        | download_object                         | `amazon_s3`               |
 | tools.amazon_s3        | parse_uri                               | `amazon_s3`               |
 | tools.ansible          | run_playbook                            | `ansible`                 |
@@ -193,6 +201,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 
 | Secret Name            | Required Keys                                                                  | Optional Keys                                                                                                      |
 | ---------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `alertmedia`           | `ALERTMEDIA_API_KEY`                                                           | -                                                                                                                  |
 | `amazon_s3`            | -                                                                              | `AWS_ACCESS_KEY_ID` `AWS_PROFILE` `AWS_REGION` `AWS_ROLE_ARN` `AWS_ROLE_SESSION_NAME` `AWS_SECRET_ACCESS_KEY`      |
 | `ansible`              | `ANSIBLE_SSH_KEY`                                                              | `ANSIBLE_PASSWORDS`                                                                                                |
 | `aws`                  | -                                                                              | `AWS_ACCESS_KEY_ID` `AWS_PROFILE_NAME` `AWS_REGION` `AWS_ROLE_ARN` `AWS_ROLE_SESSION_NAME` `AWS_SECRET_ACCESS_KEY` |


### PR DESCRIPTION
## Description

Updated Documentation of missing commands and integrations.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the integrations cheatsheet to include new tools, actions, and required secrets, and added the missing core.cases.search_cases action. This improves coverage for AlertMedia, Google Maps, HackerOne, HIBP, Zendesk, Jira, Okta, and Splunk.

- **New Features**
  - Added core.cases.search_cases.
  - Documented new integrations: AlertMedia, Google Maps, HackerOne, HIBP, Zendesk.
  - Expanded Jira, Okta (+ Okta OAR), and Splunk (KV store + HEC) actions.
  - Updated secrets: alertmedia, google_maps, hackerone, hibp, splunk_hec, zendesk.
  - Tidied tables and inline Note formatting.

<!-- End of auto-generated description by cubic. -->

