### PR TITLE
feat(ui): Implement bulk delete functionality in case table

### DIFF
--- a/frontend/src/components/cases/case-table-filters.tsx
+++ b/frontend/src/components/cases/case-table-filters.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Cross2Icon } from "@radix-ui/react-icons"
+import { Trash2Icon } from "lucide-react"
 import type { CasePriority, CaseSeverity, CaseStatus } from "@/client"
 import {
   PRIORITIES,
@@ -8,6 +9,18 @@ import {
   STATUSES,
 } from "@/components/cases/case-categories"
 import { UNASSIGNED } from "@/components/cases/case-panel-selectors"
+import { Spinner } from "@/components/loading/spinner"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -32,6 +45,9 @@ interface CaseTableFiltersProps {
   onSeverityChange: (value: CaseSeverity | null) => void
   assigneeFilter: string | null
   onAssigneeChange: (value: string | null) => void
+  selectedCount: number
+  onDeleteSelected?: () => Promise<void>
+  isDeleting?: boolean
 }
 
 export function CaseTableFilters({
@@ -46,6 +62,9 @@ export function CaseTableFilters({
   onSeverityChange,
   assigneeFilter,
   onAssigneeChange,
+  selectedCount,
+  onDeleteSelected,
+  isDeleting,
 }: CaseTableFiltersProps) {
   const { members } = useWorkspaceMembers(workspaceId)
 
@@ -64,8 +83,10 @@ export function CaseTableFilters({
     onAssigneeChange(null)
   }
 
+  const showDeleteButton = onDeleteSelected && selectedCount > 0
+
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       <Input
         placeholder="Filter cases..."
         value={searchTerm}
@@ -163,6 +184,50 @@ export function CaseTableFilters({
           Reset
           <Cross2Icon className="ml-2 size-4" />
         </Button>
+      )}
+      {showDeleteButton && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2 text-foreground/70 lg:px-3"
+            >
+              <span className="flex items-center">
+                <Trash2Icon className="size-4" />
+                <span className="ml-2">Delete</span>
+              </span>
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Confirm deletion</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete {selectedCount} selected case
+                {selectedCount > 1 ? "s" : ""}? This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                variant="destructive"
+                disabled={isDeleting}
+                onClick={async () => {
+                  await onDeleteSelected()
+                }}
+              >
+                {isDeleting ? (
+                  <span className="flex items-center">
+                    <Spinner className="size-4" />
+                    <span className="ml-2">Deleting...</span>
+                  </span>
+                ) : (
+                  "Delete"
+                )}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       )}
     </div>
   )

--- a/frontend/src/components/data-table/table.tsx
+++ b/frontend/src/components/data-table/table.tsx
@@ -61,9 +61,10 @@ interface DataTableProps<TData, TValue> {
   initialSortingState?: SortingState
   initialColumnVisibility?: VisibilityState
   tableId?: string
-  onDeleteRows?: (selectedRows: Row<TData>[]) => void
+  onDeleteRows?: (selectedRows: Row<TData>[]) => Promise<void> | void
   onSelectionChange?: (selectedRows: Row<TData>[]) => void
   serverSidePagination?: ServerSidePaginationProps
+  clearSelectionTrigger?: number
 }
 
 export function DataTable<TData, TValue>({
@@ -84,6 +85,7 @@ export function DataTable<TData, TValue>({
   onDeleteRows,
   onSelectionChange,
   serverSidePagination,
+  clearSelectionTrigger,
 }: DataTableProps<TData, TValue>) {
   const [tableState, setTableState] = useLocalStorage<Partial<TableState>>(
     `table-state:${tableId}`,
@@ -160,6 +162,11 @@ export function DataTable<TData, TValue>({
       onSelectionChange(selectedRows)
     }
   }, [rowSelection, onSelectionChange, table])
+
+  React.useEffect(() => {
+    if (clearSelectionTrigger === undefined) return
+    setRowSelection({})
+  }, [clearSelectionTrigger])
 
   // Handle initial sync when data is first loaded
   const [hasData, setHasData] = React.useState(false)


### PR DESCRIPTION
- Add delete confirmation dialog in CaseTableFilters component
- Integrate bulk delete handling in CaseTable component
- Update DataTable and DataTableToolbar to support async delete operations
- Enhance state management for selected rows and clear selection trigger

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds bulk delete to the Cases table with a confirmation dialog, async handling, and automatic refresh and selection reset. Users can delete selected cases in one action with clear feedback and error handling.

- New Features
  - Delete button appears when rows are selected; confirms action and shows a spinner while deleting.
  - After deletion, the cases list refetches and the selection clears.

- Refactors
  - DataTable and Toolbar accept async onDeleteRows and expose onSelectionChange plus a clearSelectionTrigger to reset selection.

<!-- End of auto-generated description by cubic. -->

