### PR TITLE
feat(registry): Enhance UDF loading with database fallback and error

### DIFF
--- a/tests/unit/test_registry_loader_remote.py
+++ b/tests/unit/test_registry_loader_remote.py
@@ -1,0 +1,165 @@
+"""Test the improved registry loader functions."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from pydantic_core import PydanticUndefined
+
+from tracecat.db.schemas import RegistryAction
+from tracecat.registry.loaders import (
+    _load_action_from_database,
+    load_udf_impl,
+    get_bound_action_impl,
+)
+from tracecat.registry.actions.models import RegistryActionUDFImpl
+from tracecat.types.exceptions import RegistryError
+
+
+@pytest.mark.anyio
+async def test_load_action_from_database_success():
+    """Test successful database loading with valid schema."""
+    mock_action = MagicMock(spec=RegistryAction)
+    mock_action.name = "test_action"
+    mock_action.interface = {
+        "expects": {
+            "type": "object",
+            "properties": {
+                "message": {"type": "string"},
+                "recipient": {"type": "string"},
+                "optional_field": {"type": "string"},
+            },
+            "required": ["message", "recipient"],
+        }
+    }
+
+    result = _load_action_from_database(mock_action, "test_function")
+
+    assert result is not None
+    args_cls, rtype_adapter = result
+    assert rtype_adapter is None
+
+    # Test that the generated model has correct fields
+    fields = args_cls.model_fields
+    assert "message" in fields
+    assert "recipient" in fields
+    assert "optional_field" in fields
+
+    # Test that required fields have PydanticUndefined default
+    assert fields["message"].default is PydanticUndefined
+    assert fields["recipient"].default is PydanticUndefined
+    assert fields["optional_field"].default is None
+
+
+@pytest.mark.anyio
+async def test_load_action_from_database_invalid_schema():
+    """Test database loading with malformed schema."""
+    mock_action = MagicMock(spec=RegistryAction)
+    mock_action.name = "test_action"
+    # Malformed schema - properties is not a dict
+    mock_action.interface = {
+        "expects": {
+            "properties": "invalid",  # Should be dict
+            "required": ["message"],
+        }
+    }
+
+    result = _load_action_from_database(mock_action, "test_function")
+    assert result is None  # Should gracefully fail
+
+
+@pytest.mark.anyio
+async def test_load_action_from_database_missing_interface():
+    """Test database loading with missing interface."""
+    mock_action = MagicMock(spec=RegistryAction)
+    mock_action.interface = {}
+
+    result = _load_action_from_database(mock_action, "test_function")
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_load_udf_impl_remote_validation_mode():
+    """Test load_udf_impl with remote module in validation mode."""
+    impl = RegistryActionUDFImpl(
+        type="udf",
+        url="git+ssh://git@github.com/user/repo",
+        module="custom_registry.actions",
+        name="test_function"
+    )
+
+    mock_action = MagicMock(spec=RegistryAction)
+    mock_action.name = "test_action"
+    mock_action.interface = {
+        "expects": {
+            "type": "object",
+            "properties": {"param": {"type": "string"}},
+            "required": ["param"]
+        }
+    }
+
+    with patch('importlib.import_module', side_effect=ModuleNotFoundError("Module not found")):
+        result = load_udf_impl(impl, mock_action, mode="validation")
+
+        # Should return database fallback
+        assert isinstance(result, tuple)
+        args_cls, rtype_adapter = result
+        assert rtype_adapter is None
+        assert "param" in args_cls.model_fields
+
+
+@pytest.mark.anyio
+async def test_load_udf_impl_remote_execution_mode():
+    """Test load_udf_impl with remote module in execution mode."""
+    impl = RegistryActionUDFImpl(
+        type="udf",
+        url="git+ssh://git@github.com/user/repo",
+        module="custom_registry.actions",
+        name="test_function"
+    )
+
+    mock_action = MagicMock(spec=RegistryAction)
+
+    with patch('importlib.import_module', side_effect=ModuleNotFoundError("Module not found")):
+        with pytest.raises(RegistryError, match="Required module.*not found"):
+            load_udf_impl(impl, mock_action, mode="execution")
+
+
+
+@pytest.mark.anyio
+async def test_get_bound_action_impl_database_fallback():
+    """Test full get_bound_action_impl flow with database fallback."""
+    mock_action = MagicMock(spec=RegistryAction)
+    mock_action.name = "test_action"
+    mock_action.namespace = "custom"
+    mock_action.description = "Test action"
+    mock_action.secrets = []
+    mock_action.implementation = {
+        "type": "udf",
+        "url": "git+ssh://git@github.com/user/repo",
+        "module": "custom_registry.actions",
+        "name": "test_function"
+    }
+    mock_action.interface = {
+        "expects": {
+            "type": "object",
+            "properties": {"param": {"type": "string"}},
+            "required": ["param"]
+        }
+    }
+    mock_action.default_title = None
+    mock_action.display_group = None
+    mock_action.doc_url = None
+    mock_action.author = None
+    mock_action.deprecated = None
+    mock_action.origin = "test"
+
+    with patch('importlib.import_module', side_effect=ModuleNotFoundError("Module not found")):
+        bound_action = get_bound_action_impl(mock_action, mode="validation")
+
+        # Should have database-generated args_cls
+        assert bound_action.args_cls is not None
+        assert "param" in bound_action.args_cls.model_fields
+        assert bound_action.args_cls.model_fields["param"].default is PydanticUndefined
+
+        # Should have placeholder function
+        with pytest.raises(NotImplementedError, match="Module.*not available"):
+            bound_action.fn()

--- a/tracecat/registry/loaders.py
+++ b/tracecat/registry/loaders.py
@@ -4,7 +4,8 @@ import importlib
 from collections.abc import Callable
 from typing import Any, Literal, NoReturn
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, TypeAdapter, create_model
+from pydantic_core import PydanticUndefined
 from tracecat_registry import RegistrySecretTypeValidator
 
 from tracecat import config
@@ -24,6 +25,7 @@ from tracecat.registry.repository import (
     get_signature_docs,
     import_and_reload,
 )
+from tracecat.types.exceptions import RegistryError
 
 F = Callable[..., Any]
 
@@ -39,19 +41,40 @@ def get_bound_action_impl(
         for secret in action.secrets or []
     ]
     if impl.type == "udf":
-        fn = load_udf_impl(impl)
-        key = getattr(fn, "__tracecat_udf_key")
-        kwargs = getattr(fn, "__tracecat_udf_kwargs")
-        logger.trace("Binding UDF", key=key, name=action.name, kwargs=kwargs)
-        # Add validators to the function
-        validated_kwargs = RegisterKwargs.model_validate(kwargs)
-        if mode == "validation":
-            attach_validators(fn, TemplateValidator())
-        args_docs = get_signature_docs(fn)
-        # Generate the model from the function signature
-        args_cls, rtype, rtype_adapter = generate_model_from_function(
-            func=fn, udf_kwargs=validated_kwargs
-        )
+        result = load_udf_impl(impl, action, mode=mode)
+
+        # Check if we got a database fallback result (tuple) or a function
+        if isinstance(result, tuple):
+            # Database fallback case - result is (args_cls, None)
+            args_cls, _ = result
+
+            # Create a placeholder function that raises NotImplementedError
+            def placeholder_fn(**kwargs):
+                raise NotImplementedError(
+                    f"Module {impl.module} is not available. "
+                    f"This action ({action.name}) requires the module to be installed for execution."
+                )
+
+            fn = placeholder_fn
+            args_docs = {}
+            rtype = Any
+            rtype_adapter = None
+        else:
+            # Normal function loading case
+            fn = result
+            key = getattr(fn, "__tracecat_udf_key")
+            kwargs = getattr(fn, "__tracecat_udf_kwargs")
+            logger.trace("Binding UDF", key=key, name=action.name, kwargs=kwargs)
+            # Add validators to the function
+            validated_kwargs = RegisterKwargs.model_validate(kwargs)
+            if mode == "validation":
+                attach_validators(fn, TemplateValidator())
+            args_docs = get_signature_docs(fn)
+            # Generate the model from the function signature
+            args_cls, rtype, rtype_adapter = generate_model_from_function(
+                func=fn, udf_kwargs=validated_kwargs
+            )
+
         return BoundRegistryAction(
             fn=fn,
             type=impl.type,
@@ -101,7 +124,12 @@ def get_bound_action_impl(
         )
 
 
-def load_udf_impl(impl: RegistryActionUDFImpl) -> F:
+def load_udf_impl(
+    impl: RegistryActionUDFImpl,
+    action: RegistryAction | None = None,
+    *,
+    mode: LoaderMode = "validation"
+) -> F | tuple[type[BaseModel], Any]:
     """Load a UDF implementation."""
     module_path = impl.module
     function_name = impl.name
@@ -111,26 +139,84 @@ def load_udf_impl(impl: RegistryActionUDFImpl) -> F:
             "Force reloading local registry. You should only use this for development and not in production. "
             "In production, you should use a remote git repository."
         )
+        return _load_function_from_module(module_path, function_name)
+
+    # For remote/custom modules, try database first if we're in validation mode
+    if not module_path.startswith("tracecat_registry") and mode == "validation":
+        database_result = _load_action_from_database(action, function_name)
+        if database_result is not None:
+            logger.info(f"Using database interface for {module_path} in validation mode")
+            return database_result
+
+    # Try to import the module
+    try:
+        return _load_function_from_module(module_path, function_name)
+    except ModuleNotFoundError as e:
+        # Handle tracecat_registry import failures with reload fallback
+        if module_path.startswith("tracecat_registry"):
+            logger.warning(
+                "Recovering from tracecat_registry import error; attempting safe reload",
+                module=module_path,
+                error=str(e),
+            )
+            return _load_function_from_module(module_path, function_name, force_reload=True)
+
+        # Handle custom/remote module failures based on mode
+        if mode == "execution":
+            logger.error(
+                f"Module {module_path} not found and required for execution",
+                error=str(e)
+            )
+            raise RegistryError(
+                f"Required module '{module_path}' not found. "
+                f"The package containing this action must be installed on the executor."
+            ) from e
+
+        # Final fallback to empty model for validation mode
+        args_cls = create_model(f"{function_name}_Args")
+        return (args_cls, None)
+
+def _load_action_from_database(action: RegistryAction | None, function_name: str) -> tuple[type[BaseModel], Any] | None:
+    """Try to create args_cls from database interface."""
+    if not action or not action.interface or "expects" not in action.interface:
+        return None
+
+    try:
+        schema = action.interface["expects"]
+        properties = schema.get("properties", {})
+        required = set(schema.get("required", []))
+
+        # Build field definitions for create_model
+        fields = {}
+        for field_name, _field_schema in properties.items():
+            field_type = Any  # Default type
+            # Use PydanticUndefined for required fields so they show up as defaults
+            default = PydanticUndefined if field_name in required else None
+            fields[field_name] = (field_type, default)
+
+        model_name = action.name if action and action.name else function_name
+        args_cls = create_model(f"{model_name}_Args", **fields)
+        return (args_cls, None)
+    except Exception as e:
+        logger.warning(
+            "Failed to load action from database interface, schema may be malformed",
+            action_name=action.name if action else "unknown",
+            error=str(e)
+        )
+        return None
+
+
+def _load_function_from_module(module_path: str, function_name: str, force_reload: bool = False) -> F:
+    """Load a function from a module, with optional forced reload."""
+    if force_reload:
         mod = import_and_reload(module_path)
     else:
-        try:
-            mod = importlib.import_module(module_path)
-        except ModuleNotFoundError as e:
-            # Defensive fallback: if a concurrent reload temporarily disrupted imports,
-            # safely reload the target module and retry.
-            if module_path.startswith("tracecat_registry"):
-                logger.warning(
-                    "Recovering from module import error; attempting safe reload",
-                    module=module_path,
-                    error=str(e),
-                )
-                mod = import_and_reload(module_path)
-            else:
-                raise
+        mod = importlib.import_module(module_path)
+
     try:
-        fn = getattr(mod, function_name)
+        return getattr(mod, function_name)
     except AttributeError as e:
-        # Rare race if module was mid-reload; try one safe reload before failing
+        # Rare race condition - try one safe reload before failing
         logger.warning(
             "Function not found after import; attempting safe reload",
             module=module_path,
@@ -138,8 +224,7 @@ def load_udf_impl(impl: RegistryActionUDFImpl) -> F:
             error=str(e),
         )
         mod = import_and_reload(module_path)
-        fn = getattr(mod, function_name)
-    return fn
+        return getattr(mod, function_name)
 
 
 def _not_implemented() -> NoReturn:


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

### Summary
Resolves API server ModuleNotFoundError crashes when loading custom registry actions for UI purposes in multi-replica deployments. Implements mode-dependent loading where API servers use database fallback for validation while executors still require actual packages for execution.

### Problem
- API servers crashed with ModuleNotFoundError when custom registry packages weren't installed
- Multi-replica K8s deployments couldn't serve action schemas/defaults reliably
- UI couldn't display proper field defaults for custom actions
- No distinction between validation mode (UI) and execution mode (runtime)

### Flow Improvements
**Before**: API tries to import → crashes on missing module
**After**: if not tracecat_registry API tries database first→ falls back to empty model → continues gracefully

**Execution mode**: Still fails fast with clear error when modules missing
**Validation mode**: Uses database schema → creates proper UI defaults

## Related Issues

#1450

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA
Add the unit test
Tested with UI