### PR TITLE
Changed Okta API doc reference to the new Okta API doc portal and aligned template names to common Okta language

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/activate_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/activate_user.yml
@@ -3,7 +3,7 @@ definition:
   title: Activate user
   description: Activate a user account in Okta.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/users/#activate-user
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserLifecycle/#tag/UserLifecycle/operation/activateUser
   namespace: tools.okta
   name: activate_user
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/assign_group_to_app.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/assign_group_to_app.yml
@@ -3,7 +3,7 @@ definition:
   title: Assign group to application
   description: Assign a group to an application in Okta.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/apps/#assign-group-to-application
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/ApplicationGroups/#tag/ApplicationGroups/operation/updateGroupAssignmentToApplication
   namespace: tools.okta
   name: assign_group_to_app
   secrets:
@@ -40,7 +40,7 @@ definition:
               if priority is not None:
                   return {**assignment, "priority": priority}
               return assignment
-    - ref: assign_group
+    - ref: assign_group_to_app
       action: core.http_request
       args:
         method: PUT
@@ -50,4 +50,4 @@ definition:
           Accept: "application/json"
           Content-Type: "application/json"
         payload: ${{ steps.add_priority.result }}
-  returns: ${{ steps.assign_group.result.data }}
+  returns: ${{ steps.assign_group_to_app.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/assign_user_to_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/assign_user_to_group.yml
@@ -1,11 +1,11 @@
 type: action
 definition:
-  title: Add user to group
-  description: Add a user to a specific group in Okta.
+  title: Assign user to group
+  description: Assign a user to a specific group in Okta.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/groups/#add-user-to-group
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/assignUserToGroup
   namespace: tools.okta
-  name: add_to_group
+  name: assign_to_group
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
@@ -15,12 +15,12 @@ definition:
       description: Okta domain base URL (e.g., 'https://dev-12345.okta.com')
     user_id:
       type: str
-      description: User ID, login, or email to add to the group
+      description: User ID, login, or email to assign to the group
     group_id:
       type: str
-      description: ID of the group to add the user to
+      description: ID of the group to assign the user to
   steps:
-    - ref: add_user
+    - ref: assign_user
       action: core.http_request
       args:
         method: PUT
@@ -29,4 +29,4 @@ definition:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
           Content-Type: "application/json"
-  returns: ${{ steps.add_user.result.data }}
+  returns: ${{ steps.assign_user.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/clear_user_sessions.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/clear_user_sessions.yml
@@ -3,7 +3,7 @@ definition:
   title: Clear user sessions
   description: Clear all active sessions for a user in Okta.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/users/#clear-user-sessions
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserSessions/#tag/UserSessions/operation/revokeUserSessions
   namespace: tools.okta
   name: clear_user_sessions
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/create_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/create_user.yml
@@ -3,7 +3,7 @@ definition:
   title: Create user
   description: Create a new user in your Okta organization.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/users/#create-user
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/createUser
   namespace: tools.okta
   name: create_user
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_group_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_group_members.yml
@@ -3,7 +3,7 @@ definition:
   title: Get group members
   description: List all users that are members of a specific group.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/groups/#list-group-members
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroupUsers
   namespace: tools.okta
   name: get_group_members
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_groups_assigned_to_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_groups_assigned_to_user.yml
@@ -3,7 +3,7 @@ definition:
   title: Get groups assigned to user
   description: List all groups that a user is a member of.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/users/#get-user-groups
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserResources/#tag/UserResources/operation/listUserGroups
   namespace: tools.okta
   name: get_groups_assigned_to_user
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_user.yml
@@ -3,7 +3,7 @@ definition:
   title: Get user
   description: Retrieve a specific user by ID, login, or email from your Okta organization.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/users/#get-user
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/getUser
   namespace: tools.okta
   name: get_user
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_groups_in_org.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_groups_in_org.yml
@@ -3,7 +3,7 @@ definition:
   title: List groups in organization
   description: List all groups in your Okta organization with optional filtering.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/groups/#list-groups
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroups
   namespace: tools.okta
   name: list_groups_in_org
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_users.yml
@@ -3,7 +3,7 @@ definition:
   title: List users
   description: List all users in your Okta organization with optional filtering and search.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/users/#list-users
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers
   namespace: tools.okta
   name: list_users
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/search_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/search_users.yml
@@ -3,7 +3,7 @@ definition:
   title: Search users
   description: Search for users using a query string that matches login, email, firstName, or lastName.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/users/#list-users
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers
   namespace: tools.okta
   name: search_users
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/unassign_from_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/unassign_from_group.yml
@@ -1,11 +1,11 @@
 type: action
 definition:
-  title: Remove user from group
-  description: Remove a user from a specific group in Okta.
+  title: Unassign user from group
+  description: Unassign a user from a specific group in Okta.
   display_group: Okta
-  doc_url: https://developer.okta.com/docs/reference/api/groups/#remove-user-from-group
+  doc_url: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/unassignUserFromGroup
   namespace: tools.okta
-  name: remove_from_group
+  name: unassign_from_group
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
@@ -15,12 +15,12 @@ definition:
       description: Okta domain base URL (e.g., 'https://dev-12345.okta.com')
     user_id:
       type: str
-      description: User ID, login, or email to remove from the group
+      description: User ID, login, or email to unassign from the group
     group_id:
       type: str
-      description: ID of the group to remove the user from
+      description: ID of the group to unassign the user from
   steps:
-    - ref: remove_user
+    - ref: unassign_user
       action: core.http_request
       args:
         method: DELETE
@@ -29,4 +29,4 @@ definition:
           Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
           Content-Type: "application/json"
-  returns: ${{ steps.remove_user.result.data }}
+  returns: ${{ steps.unassign_user.result.data }}


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Changed the Okta templates doc reference to the new Okta API doc portal.

Changed 2 Okta templates name to align with common Okta language,.
 - Reasoning is to make it easier to find for Okta administrators.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

N/A
