### PR TITLE
feat(integrations): Implement github oauth authorization code flow

### DIFF
--- a/tracecat/integrations/providers/__init__.py
+++ b/tracecat/integrations/providers/__init__.py
@@ -2,8 +2,8 @@ from typing import Final
 
 from tracecat.integrations.models import ProviderKey
 from tracecat.integrations.providers.base import BaseOAuthProvider
-from tracecat.integrations.providers.github.oauth import GitHubCCProvider
 from tracecat.integrations.providers.github.mcp import GitHubMCPProvider
+from tracecat.integrations.providers.github.oauth import GitHubOAuthProvider
 from tracecat.integrations.providers.linear.mcp import LinearMCPProvider
 from tracecat.integrations.providers.microsoft.graph import (
     MicrosoftGraphACProvider,
@@ -22,7 +22,7 @@ _PROVIDER_CLASSES: list[type[BaseOAuthProvider]] = [
     MicrosoftGraphCCProvider,
     MicrosoftTeamsACProvider,
     MicrosoftTeamsCCProvider,
-    GitHubCCProvider,
+    GitHubOAuthProvider,
     GitHubMCPProvider,
     LinearMCPProvider,
     NotionMCPProvider,

--- a/tracecat/integrations/providers/__init__.py
+++ b/tracecat/integrations/providers/__init__.py
@@ -2,6 +2,7 @@ from typing import Final
 
 from tracecat.integrations.models import ProviderKey
 from tracecat.integrations.providers.base import BaseOAuthProvider
+from tracecat.integrations.providers.github.oauth import GitHubCCProvider
 from tracecat.integrations.providers.github.mcp import GitHubMCPProvider
 from tracecat.integrations.providers.linear.mcp import LinearMCPProvider
 from tracecat.integrations.providers.microsoft.graph import (
@@ -21,6 +22,7 @@ _PROVIDER_CLASSES: list[type[BaseOAuthProvider]] = [
     MicrosoftGraphCCProvider,
     MicrosoftTeamsACProvider,
     MicrosoftTeamsCCProvider,
+    GitHubCCProvider,
     GitHubMCPProvider,
     LinearMCPProvider,
     NotionMCPProvider,

--- a/tracecat/integrations/providers/github/oauth.py
+++ b/tracecat/integrations/providers/github/oauth.py
@@ -1,0 +1,92 @@
+"""GitHub OAuth provider using client credentials flow.
+
+Note: This provider follows the same structure as Microsoft Graph's
+client-credentials implementation to fit Tracecat's integration model.
+It uses GitHub's OAuth token endpoint and requires a client ID and secret.
+
+Intended usage: Acquire an access token to be used for HTTPS git operations
+from UDFs, e.g. using:
+  https://x-access-token:<token>@github.com/<owner>/<repo>.git
+"""
+
+from typing import ClassVar
+
+from pydantic import BaseModel, Field
+
+from tracecat.integrations.models import ProviderMetadata, ProviderScopes
+from tracecat.integrations.providers.base import ClientCredentialsOAuthProvider
+
+
+class GitHubOAuthConfig(BaseModel):
+    """Configuration model for GitHub OAuth provider.
+
+    For GitHub Enterprise Server, set ``base_url`` to your enterprise hostname.
+    """
+
+    base_url: str = Field(
+        default="https://github.com",
+        description=(
+            "Base URL for GitHub. Use your enterprise hostname, e.g. "
+            "'https://github.mycompany.com' for GHES."
+        ),
+        min_length=8,
+        max_length=200,
+    )
+
+
+def _auth_endpoint(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}/login/oauth/authorize"
+
+
+def _token_endpoint(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}/login/oauth/access_token"
+
+
+CC_SCOPES = ProviderScopes(
+    # Scopes commonly needed for repository clone and read operations
+    # Adjust per your organization policy.
+    default=["repo"],
+)
+
+CC_METADATA = ProviderMetadata(
+    id="github",
+    name="GitHub (Service account)",
+    description=(
+        "GitHub OAuth provider using client credentials for service account flows"
+    ),
+    setup_steps=[
+        "Create an OAuth application in GitHub settings",
+        "Copy Client ID and Client Secret",
+        "Configure credentials in Tracecat",
+        "Use the access token for HTTPS git clone in UDFs",
+    ],
+    enabled=True,
+    api_docs_url="https://docs.github.com/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps",
+    setup_guide_url="https://docs.github.com/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app",
+    troubleshooting_url="https://docs.github.com/authentication/troubleshooting-oauth-app-access-token-request-errors",
+)
+
+
+class GitHubCCProvider(ClientCredentialsOAuthProvider):
+    """GitHub OAuth provider using client credentials for application access."""
+
+    id: ClassVar[str] = "github"
+    scopes: ClassVar[ProviderScopes] = CC_SCOPES
+    config_model: ClassVar[type[BaseModel]] = GitHubOAuthConfig
+    metadata: ClassVar[ProviderMetadata] = CC_METADATA
+
+    def __init__(self, *, base_url: str = "https://github.com", **kwargs):
+        self._base_url = base_url
+        # Set endpoints dynamically from base_url
+        self._authorization_endpoint = _auth_endpoint(self._base_url)
+        self._token_endpoint = _token_endpoint(self._base_url)
+        super().__init__(**kwargs)
+
+    @property
+    def authorization_endpoint(self) -> str:
+        return self._authorization_endpoint
+
+    @property
+    def token_endpoint(self) -> str:
+        return self._token_endpoint
+


### PR DESCRIPTION
**This is actually authorization code flow not client credentials flow**
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR introduces a new GitHub OAuth provider that uses the client credentials flow, mirroring the existing Microsoft Graph client credentials integration.

The primary objective is to enable User-Defined Functions (UDFs) to perform `git clone` operations using an OAuth-generated access token.

Key changes include:
- **New file:** `tracecat/integrations/providers/github/oauth.py` containing the `GitHubCCProvider` class.
- `GitHubCCProvider` extends `ClientCredentialsOAuthProvider` and dynamically constructs GitHub's OAuth authorization and token endpoints.
- **Configuration:** `GitHubOAuthConfig` allows specifying a custom `base_url` to support GitHub Enterprise Server (GHES) instances.
- **Registration:** The new provider is registered in `tracecat/integrations/providers/__init__.py`.

Upon successful connection, the integration will provide an access token that can be used to construct HTTPS git clone URLs in UDFs, e.g., `https://x-access-token:<token>@github.com/<owner>/<repo>.git`.

**Note:** While this implementation follows the requested client credentials pattern, GitHub's OAuth Apps typically require user authorization for repository access. For non-interactive server-side access, a GitHub App-based flow might be more suitable in the future.

## Related Issues

N/A

## Screenshots / Recordings

N/A (No visual changes)

## Steps to QA

1. Create a new GitHub OAuth App (or use an existing one) and obtain its Client ID and Client Secret.
2. In Tracecat, create a new integration using the "GitHub (Service account)" provider.
3. Configure the integration with the Client ID, Client Secret, and optionally a `base_url` for GHES.
4. Test the connection.
5. Verify that an access token is successfully acquired and stored.
6. (Optional) Create a UDF that attempts to `git clone` a repository using the obtained access token in the format `https://x-access-token:<token>@github.com/<owner>/<repo>.git`.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-64f5a01d-a9e7-4eb7-9957-c8b83c83b4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64f5a01d-a9e7-4eb7-9957-c8b83c83b4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



## Summary by cubic
Adds a GitHub OAuth client-credentials provider to issue access tokens for non-interactive git operations from UDFs. Supports GitHub.com and GitHub Enterprise via a configurable base_url.

- **New Features**
  - New GitHubCCProvider (client-credentials) with dynamic auth/token endpoints.
  - GitHubOAuthConfig supports base_url for GHES; default scope is repo.
  - Provider registered in tracecat.integrations.providers.

