### PR TITLE
feat(agents): Add max limit to number of agent tools

### DIFF
--- a/tracecat/agent/observability.py
+++ b/tracecat/agent/observability.py
@@ -14,11 +14,13 @@ except ImportError:
 def init_langfuse(model_name: str | None, model_provider: str | None) -> str | None:
     """Initialize Langfuse client and return the trace id when Langfuse is available."""
 
-    if get_client is None or secrets.get("LANGFUSE_PUBLIC_KEY") is None:
+    if get_client is None or secrets.get_or_default("LANGFUSE_PUBLIC_KEY") is None:
         logger.info("Langfuse client not available; skipping trace initialization")
         return None
 
-    langfuse_client = get_client(public_key=secrets.get("LANGFUSE_PUBLIC_KEY"))
+    langfuse_client = get_client(
+        public_key=secrets.get_or_default("LANGFUSE_PUBLIC_KEY")
+    )
     logger.info("Found Langfuse credentials; initialized Langfuse client.")
 
     # Get workflow context for session_id

--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -11,6 +11,7 @@ from pydantic_ai.tools import Tool
 from pydantic_core import PydanticUndefined
 from tracecat_registry import RegistrySecretType
 
+from tracecat.config import TRACECAT__AGENT_MAX_TOOLS
 from tracecat.db.schemas import RegistryAction
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.executor.service import (
@@ -215,6 +216,7 @@ async def build_agent_tools(
     namespaces: list[str] | None = None,
     actions: list[str] | None = None,
     fixed_arguments: dict[str, dict[str, Any]] | None = None,
+    max_tools: int = TRACECAT__AGENT_MAX_TOOLS,
 ) -> BuildToolsResult:
     """Build tools from a list of actions."""
     tools: list[Tool] = []
@@ -287,6 +289,9 @@ async def build_agent_tools(
         raise ValueError(
             "Unable to build the requested tools:\n" + "\n\n".join(details)
         )
+
+    if max_tools and len(tools) > max_tools:
+        raise ValueError(f"Cannot request more than {max_tools} tools")
 
     return BuildToolsResult(
         tools=tools,

--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -290,7 +290,7 @@ async def build_agent_tools(
             "Unable to build the requested tools:\n" + "\n\n".join(details)
         )
 
-    if max_tools and len(tools) > max_tools:
+    if max_tools > 0 and len(tools) > max_tools:
         raise ValueError(f"Cannot request more than {max_tools} tools")
 
     return BuildToolsResult(

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -446,3 +446,8 @@ TRACECAT__FEATURE_FLAGS: set[FeatureFlag] = {
     if (f := flag.strip())
 }
 """Set of enabled feature flags."""
+
+
+# === Agent config === #
+TRACECAT__AGENT_MAX_TOOLS = int(os.environ.get("TRACECAT__AGENT_MAX_TOOLS", 10))
+"""The maximum number of tools that can be used in an agent."""


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Introduce a configurable max limit on agent tools to improve security and performance. The limit is enforced during tool building; agents also handle cases with no actions cleanly.

- **New Features**
  - Added TRACECAT__AGENT_MAX_TOOLS env var (default 10) to cap tools per agent.
  - build_agent_tools validates and raises an error when the requested tools exceed the limit.
  - build_agent uses an empty tool list when no actions are provided.

- **Bug Fixes**
  - Langfuse client init is tolerant of missing LANGFUSE_PUBLIC_KEY by using get_or_default.

<!-- End of auto-generated description by cubic. -->

