### PR TITLE
feat(agents): Introduce max limits for tool calls and requests in age…

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -186,7 +186,11 @@ async def agent(
     model_settings: Annotated[
         dict[str, Any] | None, Doc("Model settings for the agent.")
     ] = None,
-    retries: Annotated[int, Doc("Number of retries for the agent.")] = 6,
+    max_tools_calls: Annotated[
+        int, Doc("Maximum number of tool calls for the agent.")
+    ] = 5,
+    max_requests: Annotated[int, Doc("Maximum number of requests for the agent.")] = 20,
+    retries: Annotated[int, Doc("Number of retries for the agent.")] = 3,
     base_url: Annotated[str | None, Doc("Base URL of the model to use.")] = None,
 ) -> Any:
     return await run_agent(
@@ -199,6 +203,8 @@ async def agent(
         output_type=output_type,
         model_settings=model_settings,
         retries=retries,
+        max_tools_calls=max_tools_calls,
+        max_requests=max_requests,
         base_url=base_url,
     )
 
@@ -242,6 +248,7 @@ async def action(
     model_settings: Annotated[
         dict[str, Any] | None, Doc("Model settings for the agent.")
     ] = None,
+    max_requests: Annotated[int, Doc("Maximum number of requests for the agent.")] = 20,
     retries: Annotated[int, Doc("Number of retries for the agent.")] = 6,
     base_url: Annotated[str | None, Doc("Base URL of the model to use.")] = None,
 ) -> Any:
@@ -253,5 +260,6 @@ async def action(
         output_type=output_type,
         model_settings=model_settings,
         retries=retries,
+        max_requests=max_requests,
         base_url=base_url,
     )

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -451,3 +451,12 @@ TRACECAT__FEATURE_FLAGS: set[FeatureFlag] = {
 # === Agent config === #
 TRACECAT__AGENT_MAX_TOOLS = int(os.environ.get("TRACECAT__AGENT_MAX_TOOLS", 10))
 """The maximum number of tools that can be used in an agent."""
+
+
+TRACECAT__AGENT_MAX_TOOL_CALLS = int(
+    os.environ.get("TRACECAT__AGENT_MAX_TOOL_CALLS", 30)
+)
+"""The maximum number of tool calls that can be made per agent run."""
+
+TRACECAT__AGENT_MAX_REQUESTS = int(os.environ.get("TRACECAT__AGENT_MAX_REQUESTS", 100))
+"""The maximum number of requests that can be made per agent run."""


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds per-run limits for agent tool calls and requests to prevent runaway loops and control costs. Limits are validated at runtime and configurable via environment variables.

- **New Features**
  - Added max_tools_calls and max_requests to agent() and action() (defaults: 5 and 20).
  - Enforced ceilings via TRACECAT__AGENT_MAX_TOOL_CALLS (default 30) and TRACECAT__AGENT_MAX_REQUESTS (default 100).
  - Passed UsageLimits to the runtime so models respect these caps.
  - agent() default retries set to 3.

<!-- End of auto-generated description by cubic. -->

