### PR TITLE
feat(agents): Add response emoji reactions

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/agents/slack.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/agents/slack.py
@@ -22,7 +22,7 @@ async def _ack_app_mention(channel_id: str, ts: str):
     )
 
 
-async def _notify_error(channel_id: str, ts: str):
+async def _notify_error(channel_id: str, thread_ts: str, ts: str):
     # Remove the eyes emoji
     await call_method(
         sdk_method="reactions_remove",
@@ -39,6 +39,7 @@ async def _notify_error(channel_id: str, ts: str):
         params={
             "channel": channel_id,
             "text": "I'm having trouble responding to your message. Please try again.",
+            "thread_ts": thread_ts,
         },
     )
 
@@ -144,7 +145,7 @@ async def slackbot(
         )
     except Exception as e:
         # Send unexpected error message to Slack with the thread_ts
-        await _notify_error(channel_id, thread_ts)
+        await _notify_error(channel_id, thread_ts, ts)
         raise e
     else:
         await _remove_ack(channel_id, ts)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Slack emoji reactions for app mentions to show processing and errors. Users see "eyes" while the bot works; it's cleared on success, and a warning + message is sent on failures.

- **New Features**
  - Add "eyes" reaction on app mention; remove it after a successful reply.
  - On errors: remove "eyes", add "warning", and post a short retry message in the thread.
  - Add helper methods for ack/error handling and safer event parsing (ts/thread_ts) with logging.

<!-- End of auto-generated description by cubic. -->

