### PR TITLE
feat: Add runbooks feature flag

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/runbooks/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/runbooks/page.tsx
@@ -1,13 +1,35 @@
 "use client"
 
+import { useRouter } from "next/navigation"
 import { Suspense, useEffect } from "react"
 import { RunbooksDashboard } from "@/components/dashboard/runbooks-dashboard"
 import { CenteredSpinner } from "@/components/loading/spinner"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 
 export default function RunbooksDashboardPage() {
+  const router = useRouter()
+  const { isFeatureEnabled, isLoading } = useFeatureFlag()
+  const runbooksEnabled = isFeatureEnabled("runbooks")
+
   useEffect(() => {
-    document.title = "Runbooks"
-  }, [])
+    if (!isLoading && !runbooksEnabled) {
+      router.replace("/not-found")
+    }
+  }, [isLoading, runbooksEnabled, router])
+
+  useEffect(() => {
+    if (runbooksEnabled) {
+      document.title = "Runbooks"
+    }
+  }, [runbooksEnabled])
+
+  if (isLoading) {
+    return <CenteredSpinner />
+  }
+
+  if (!runbooksEnabled) {
+    return <CenteredSpinner />
+  }
 
   return (
     <Suspense fallback={<CenteredSpinner />}>

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4712,7 +4712,7 @@ export const $ExpressionValidationResponse = {
 
 export const $FeatureFlag = {
   type: "string",
-  enum: ["git-sync", "agent-sandbox"],
+  enum: ["git-sync", "agent-sandbox", "runbooks"],
   title: "FeatureFlag",
   description: "Feature flag enum.",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1565,7 +1565,7 @@ export type ExpressionValidationResponse = {
 /**
  * Feature flag enum.
  */
-export type FeatureFlag = "git-sync" | "agent-sandbox"
+export type FeatureFlag = "git-sync" | "agent-sandbox" | "runbooks"
 
 /**
  * Response model for feature flags.

--- a/frontend/src/components/cases/runbook-dropdown.tsx
+++ b/frontend/src/components/cases/runbook-dropdown.tsx
@@ -25,6 +25,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useListRunbooks } from "@/hooks/use-runbook"
 import { capitalizeFirst } from "@/lib/utils"
 
@@ -41,6 +42,8 @@ export function RunbookDropdown({
   entityId,
   disabled,
 }: RunbookDropdownProps) {
+  const { isFeatureEnabled, isLoading: isFeatureLoading } = useFeatureFlag()
+  const runbooksEnabled = isFeatureEnabled("runbooks")
   const [open, setOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedRunbook, setSelectedRunbook] = useState<RunbookRead | null>(
@@ -52,7 +55,11 @@ export function RunbookDropdown({
     data: runbooks,
     isLoading: runbooksLoading,
     error: runbooksError,
-  } = useListRunbooks({ workspaceId })
+  } = useListRunbooks({ workspaceId, enabled: runbooksEnabled })
+
+  if (isFeatureLoading || !runbooksEnabled) {
+    return null
+  }
 
   const filteredRunbooks =
     runbooks?.filter(

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -4,6 +4,7 @@ import {
   BoxIcon,
   KeyRoundIcon,
   ListTodoIcon,
+  type LucideIcon,
   ShapesIcon,
   SquareStackIcon,
   Table2Icon,
@@ -29,6 +30,7 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from "@/components/ui/sidebar"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 function SidebarHeaderContent({ workspaceId }: { workspaceId: string }) {
@@ -38,9 +40,18 @@ function SidebarHeaderContent({ workspaceId }: { workspaceId: string }) {
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname()
   const workspaceId = useWorkspaceId()
+  const { isFeatureEnabled } = useFeatureFlag()
   const basePath = `/workspaces/${workspaceId}`
 
-  const navMain = [
+  type NavItem = {
+    title: string
+    url: string
+    icon: LucideIcon
+    isActive?: boolean
+    visible?: boolean
+  }
+
+  const navMain: NavItem[] = [
     {
       title: "Cases",
       url: `${basePath}/cases`,
@@ -52,6 +63,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       url: `${basePath}/runbooks`,
       icon: ListTodoIcon,
       isActive: pathname?.startsWith(`${basePath}/runbooks`),
+      visible: isFeatureEnabled("runbooks"),
     },
     {
       title: "Workflows",
@@ -109,16 +121,18 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {navMain.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={item.isActive}>
-                    <Link href={item.url}>
-                      <item.icon />
-                      <span>{item.title}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
+              {navMain
+                .filter((item) => item.visible !== false)
+                .map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild isActive={item.isActive}>
+                      <Link href={item.url}>
+                        <item.icon />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/frontend/src/hooks/use-runbook.tsx
+++ b/frontend/src/hooks/use-runbook.tsx
@@ -55,15 +55,18 @@ export function useListRunbooks({
   limit = 50,
   sortBy = "created_at",
   order = "desc",
+  enabled = true,
 }: {
   workspaceId: string
   limit?: number
   sortBy?: "created_at" | "updated_at"
   order?: "asc" | "desc"
+  enabled?: boolean
 }) {
   return useQuery<RunbookRead[], ApiError>({
     queryKey: ["runbooks", workspaceId, limit, sortBy, order],
     queryFn: () => runbookListRunbooks({ workspaceId, limit, sortBy, order }),
+    enabled: enabled && !!workspaceId,
   })
 }
 
@@ -71,14 +74,16 @@ export function useListRunbooks({
 export function useGetRunbook({
   workspaceId,
   runbookId,
+  enabled = true,
 }: {
   workspaceId: string
   runbookId: string
+  enabled?: boolean
 }) {
   return useQuery<RunbookRead, ApiError>({
     queryKey: ["runbooks", workspaceId, runbookId],
     queryFn: () => runbookGetRunbook({ workspaceId, runbookId }),
-    enabled: !!runbookId && !!workspaceId,
+    enabled: !!runbookId && !!workspaceId && enabled,
   })
 }
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -223,7 +223,10 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(case_attachments_router)
     app.include_router(case_records_router)
     app.include_router(chat_router)
-    app.include_router(runbook_router)
+    app.include_router(
+        runbook_router,
+        dependencies=[Depends(feature_flag_dep("runbooks"))],
+    )
     app.include_router(workflow_folders_router)
     app.include_router(integrations_router)
     app.include_router(providers_router)

--- a/tracecat/feature_flags/enums.py
+++ b/tracecat/feature_flags/enums.py
@@ -6,3 +6,4 @@ class FeatureFlag(StrEnum):
 
     GIT_SYNC = "git-sync"
     AGENT_SANDBOX = "agent-sandbox"
+    RUNBOOKS = "runbooks"


### PR DESCRIPTION
## Summary
- Add RUNBOOKS feature flag to control runbooks functionality visibility
- Apply feature flag checks to backend API and frontend components
- Hide runbooks UI elements when feature is disabled

## Changes
- Backend: Add RUNBOOKS to FeatureFlag enum and apply to runbook router
- Frontend: Add feature flag checks to runbooks pages with proper loading states and redirects
- Frontend: Conditionally show/hide runbooks UI elements in sidebar, navigation, cases, and chat components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a "runbooks" feature flag and conditionally enable runbook API routes, pages, UI controls, and data fetching across frontend and backend.
> 
> - **Backend**:
>   - Add `FeatureFlag.RUNBOOKS`; wrap `runbook_router` with `feature_flag_dep("runbooks")` in `tracecat/api/app.py`.
> - **Frontend**:
>   - Extend generated `FeatureFlag` schema/types with `"runbooks"`.
>   - Gate runbooks pages (`runbooks/` and `runbooks/[id]`) via `useFeatureFlag`: show loading, set title conditionally, and redirect to `/not-found` when disabled.
>   - Update hooks `useGetRunbook`/`useListRunbooks` to accept `enabled`; use it to avoid fetching when disabled.
>   - Conditionally render runbook UI: hide `RunbookDropdown`, chat "Generate runbook" action, and sidebar "Runbooks" item when flag is off.
>   - Make `ControlsHeader` aware of `runbooksEnabled` and suppress runbooks header/actions when disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f486132b9ac33951039b3eafd8e6ebf52e8cf072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->