### PR TITLE
revert: Add LLM templates

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/anthropic/call.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/anthropic/call.yml
@@ -1,0 +1,43 @@
+type: action
+definition:
+  title: Call Anthropic
+  description: Call an Anthropic LLM via Pydantic AI.
+  display_group: (Deprecated -> use ai.action instead) Anthropic
+  doc_url: https://docs.anthropic.com/en/docs/about-claude/models
+  namespace: llm.anthropic
+  name: call
+  secrets:
+    - name: anthropic
+      optional_keys: ["ANTHROPIC_API_KEY"]
+  expects:
+    prompt:
+      type: str
+      description: Prompt to send to the LLM.
+    model:
+      type: str
+      description: Model to use.
+    system:
+      type: str | None
+      description: System prompt to use for the LLM.
+      default: null
+    output_type:
+      type: str | dict[str, Any] | None
+      description: >
+        Output format to use. Either JSONSchema
+        or a supported type (bool, float, int, str, list[bool], list[float], list[int], list[str]).
+      default: null
+    model_settings:
+      type: dict[str, Any] | None
+      description: Model-specific settings.
+      default: null
+  steps:
+    - ref: call_anthropic
+      action: ai.action
+      args:
+        user_prompt: ${{ inputs.prompt }}
+        model_name: ${{ inputs.model }}
+        model_provider: anthropic
+        instructions: ${{ inputs.system }}
+        output_type: ${{ inputs.output_type }}
+        model_settings: ${{ inputs.model_settings }}
+  returns: ${{ steps.call_anthropic.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/bedrock/call.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/bedrock/call.yml
@@ -1,0 +1,43 @@
+type: action
+definition:
+  title: Call Bedrock
+  description: Call an LLM via AWS Bedrock.
+  display_group: (Deprecated -> use ai.action instead) Amazon Bedrock
+  doc_url: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+  namespace: llm.bedrock
+  name: call
+  secrets:
+    - name: amazon_bedrock
+      optional_keys: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_REGION"]
+  expects:
+    prompt:
+      type: str
+      description: Prompt to send to the LLM.
+    model:
+      type: str
+      description: Model to use.
+    instructions:
+      type: str | None
+      description: Instructions to use for the LLM.
+      default: null
+    output_type:
+      type: str | dict[str, Any] | None
+      description: >
+        Output format to use. Either JSONSchema
+        or a supported type (bool, float, int, str, list[bool], list[float], list[int], list[str]).
+      default: null
+    model_settings:
+      type: dict[str, Any] | None
+      description: Model-specific settings.
+      default: null
+  steps:
+    - ref: call_bedrock
+      action: ai.action
+      args:
+        user_prompt: ${{ inputs.prompt }}
+        model_name: ${{ inputs.model }}
+        model_provider: bedrock
+        instructions: ${{ inputs.instructions }}
+        output_type: ${{ inputs.output_type }}
+        model_settings: ${{ inputs.model_settings }}
+  returns: ${{ steps.call_bedrock.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gemini/call.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gemini/call.yml
@@ -1,0 +1,41 @@
+type: action
+definition:
+  title: Call Gemini
+  description: Call an LLM via Gemini API.
+  display_group: (Deprecated -> use ai.action instead) Gemini
+  doc_url: https://ai.google.dev/api/generate-content
+  namespace: llm.gemini
+  name: call
+  secrets:
+    - name: gemini
+      optional_keys: ["GEMINI_API_KEY"]
+  expects:
+    prompt:
+      type: str
+      description: Prompt to send to the LLM.
+    model:
+      type: str
+      description: Model to use.
+    instructions:
+      type: str | None
+      description: Instructions to use for the LLM.
+      default: null
+    output_type:
+      type: str | dict[str, Any] | None
+      description: Output type to use.
+      default: null
+    model_settings:
+      type: dict[str, Any] | None
+      description: Model-specific settings.
+      default: null
+  steps:
+    - ref: call_gemini
+      action: ai.action
+      args:
+        user_prompt: ${{ inputs.prompt }}
+        model_name: ${{ inputs.model }}
+        model_provider: google
+        instructions: ${{ inputs.instructions }}
+        output_type: ${{ inputs.output_type }}
+        model_settings: ${{ inputs.model_settings }}
+  returns: ${{ steps.call_gemini.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gemini/call_vertex.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gemini/call_vertex.yml
@@ -1,0 +1,41 @@
+type: action
+definition:
+  title: Call Gemini (Vertex AI)
+  description: Call an LLM via Gemini API (Vertex AI).
+  display_group: (Deprecated -> use ai.action instead) Gemini
+  doc_url: https://ai.google.dev/api/generate-content
+  namespace: llm.gemini_vertex
+  name: call
+  secrets:
+    - name: google
+      optional_keys: ["GOOGLE_API_CREDENTIALS"]
+  expects:
+    prompt:
+      type: str
+      description: Prompt to send to the LLM.
+    model:
+      type: str
+      description: Model to use.
+    instructions:
+      type: str | None
+      description: Instructions to use for the LLM.
+      default: null
+    output_type:
+      type: str | dict[str, Any] | None
+      description: Output type to use.
+      default: null
+    model_settings:
+      type: dict[str, Any] | None
+      description: Model-specific settings.
+      default: null
+  steps:
+    - ref: call_gemini
+      action: ai.action
+      args:
+        user_prompt: ${{ inputs.prompt }}
+        model_name: ${{ inputs.model }}
+        model_provider: google
+        instructions: ${{ inputs.instructions }}
+        output_type: ${{ inputs.output_type }}
+        model_settings: ${{ inputs.model_settings }}
+  returns: ${{ steps.call_gemini.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/ollama/call.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/ollama/call.yml
@@ -1,0 +1,45 @@
+type: action
+definition:
+  title: Call Ollama
+  description: Call a local LLM via Ollama.
+  display_group: (Deprecated -> use ai.action instead) Ollama
+  doc_url: https://github.com/ollama/ollama/blob/main/docs/api.md
+  namespace: llm.ollama
+  name: call
+  expects:
+    prompt:
+      type: str
+      description: Prompt to send to the LLM.
+    model:
+      type: str
+      description: Model to use (e.g., llama3.2, mistral, qwen2.5).
+    instructions:
+      type: str | None
+      description: System instructions for the LLM.
+      default: null
+    output_type:
+      type: str | dict[str, Any] | None
+      description: >
+        Output format to use. Either JSONSchema
+        or a supported type (bool, float, int, str, list[bool], list[float], list[int], list[str]).
+      default: null
+    model_settings:
+      type: dict[str, Any] | None
+      description: Model-specific settings.
+      default: null
+    base_url:
+      type: str
+      description: Base URL for Ollama API.
+      default: http://localhost:11434
+  steps:
+    - ref: call_ollama
+      action: ai.action
+      args:
+        user_prompt: ${{ inputs.prompt }}
+        model_name: ${{ inputs.model }}
+        model_provider: ollama
+        instructions: ${{ inputs.instructions }}
+        output_type: ${{ inputs.output_type }}
+        model_settings: ${{ inputs.model_settings }}
+        base_url: ${{ inputs.base_url }}
+  returns: ${{ steps.call_ollama.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/openai/chat_completion.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/openai/chat_completion.yml
@@ -1,0 +1,49 @@
+type: action
+definition:
+  title: Call OpenAI (chat)
+  description: Call an LLM via OpenAI chat completion API.
+  display_group: (Deprecated -> use ai.action instead) OpenAI
+  doc_url: https://platform.openai.com/docs/api-reference/chat/create
+  namespace: llm.openai
+  name: chat_completion
+  secrets:
+    - name: openai
+      optional_keys: ["OPENAI_API_KEY"]
+  expects:
+    prompt:
+      type: str
+      description: Prompt or conversation history to send to the LLM
+    model:
+      type: str
+      description: Model to use
+      default: gpt-4o-mini
+    system_prompt:
+      type: str | None
+      description: Insert a system message at the beginning of the conversation.
+      default: null
+    response_format:
+      type: str | dict[str, Any] | None
+      description: >
+        Output format to use. Either JSONSchema
+        or a supported type (bool, float, int, str, list[bool], list[float], list[int], list[str]).
+      default: null
+    model_settings:
+      type: dict[str, Any] | None
+      description: Model-specific settings.
+      default: null
+    base_url:
+      type: str | None
+      description: Base URL for OpenAI API. Defaults to OpenAI's API endpoint.
+      default: null
+  steps:
+    - ref: call_openai
+      action: ai.action
+      args:
+        user_prompt: ${{ inputs.prompt }}
+        model_name: ${{ inputs.model }}
+        model_provider: openai
+        instructions: ${{ inputs.system_prompt }}
+        output_type: ${{ inputs.response_format }}
+        model_settings: ${{ inputs.model_settings }}
+        base_url: ${{ inputs.base_url }}
+  returns: ${{ steps.call_openai.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/openai/responses.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/openai/responses.yml
@@ -1,0 +1,49 @@
+type: action
+definition:
+  title: Call OpenAI (responses)
+  description: Call an LLM via OpenAI responses API.
+  display_group: (Deprecated -> use ai.action instead) OpenAI
+  doc_url: https://platform.openai.com/docs/api-reference/responses/create
+  namespace: llm.openai
+  name: call
+  secrets:
+    - name: openai
+      optional_keys: ["OPENAI_API_KEY"]
+  expects:
+    prompt:
+      type: str
+      description: Prompt or conversation history to send to the LLM
+    model:
+      type: str
+      description: Model to use
+      default: gpt-4o-mini
+    instructions:
+      type: str | None
+      description: Insert a system message at the beginning of the conversation.
+      default: null
+    text_format:
+      type: str | dict[str, Any] | None
+      description: >
+        Output format to use. Either JSONSchema
+        or a supported type (bool, float, int, str, list[bool], list[float], list[int], list[str]).
+      default: null
+    model_settings:
+      type: dict[str, Any] | None
+      description: Model-specific settings.
+      default: null
+    base_url:
+      type: str | None
+      description: Base URL for OpenAI API. Defaults to OpenAI's API endpoint.
+      default: null
+  steps:
+    - ref: call_openai_responses
+      action: ai.action
+      args:
+        user_prompt: ${{ inputs.prompt }}
+        model_name: ${{ inputs.model }}
+        model_provider: openai_responses
+        instructions: ${{ inputs.instructions }}
+        output_type: ${{ inputs.text_format }}
+        model_settings: ${{ inputs.model_settings }}
+        base_url: ${{ inputs.base_url }}
+  returns: ${{ steps.call_openai_responses.result }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restore previously removed LLM templates as thin wrappers around ai.action to keep existing workflows working. These templates are deprecated and redirect to ai.action with no behavior changes.

- **Migration**
  - Switch to ai.action and set model_provider to one of: anthropic, openai, openai_responses, google, bedrock, ollama.
  - Input mapping: prompt -> user_prompt, model -> model_name, system/instructions -> instructions, response_format/output_type/text_format -> output_type, base_url -> base_url (where supported).
  - Deprecated templates (e.g., llm.*.call, llm.openai.chat_completion) still work for now but should be replaced.

<!-- End of auto-generated description by cubic. -->

