### PR TITLE
feat(core): Add wait UDF

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/transform.py
+++ b/packages/tracecat-registry/tracecat_registry/core/transform.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import redis.asyncio as redis
+import asyncio
 
 from tracecat_registry import ActionIsInterfaceError, registry
 
@@ -385,3 +386,13 @@ def gather(
     ] = "partition",
 ) -> list[Any]:
     raise ActionIsInterfaceError()
+
+
+@registry.register(
+    default_title="Wait",
+    description="Wait for a given number of seconds.",
+    display_group="Data Transform",
+    namespace="core.transform",
+)
+async def wait(seconds: Annotated[int, Doc("Number of seconds to wait.")]) -> None:
+    await asyncio.sleep(seconds)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added an async Wait UDF to core.transform to pause execution for a specified number of seconds. This gives workflows simple timing control between steps.

- **New Features**
  - Registered as "Wait" under Data Transform (namespace core.transform).
  - Accepts seconds (int) and awaits asyncio.sleep(seconds).

<!-- End of auto-generated description by cubic. -->

