### PR TITLE
feat(engine): Add scatter interval for rate-limited task execution

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/transform.py
+++ b/packages/tracecat-registry/tracecat_registry/core/transform.py
@@ -352,6 +352,10 @@ def scatter(
             " be a JSONPath expression to a collection or a list of items."
         ),
     ],
+    interval: Annotated[
+        float | None,
+        Doc("The interval in seconds between each scatter task."),
+    ] = None,
 ) -> Any:
     raise ActionIsInterfaceError()
 

--- a/tests/unit/test_scatter_interval.py
+++ b/tests/unit/test_scatter_interval.py
@@ -1,0 +1,542 @@
+"""Tests for scatter interval feature.
+
+This module tests the ability to stagger scatter tasks with configurable intervals.
+When a scatter operation has an `interval` parameter, each scattered task is delayed
+by `index * interval` seconds, allowing for rate-limiting and controlled parallel execution.
+"""
+
+import os
+import time
+from collections.abc import Callable
+
+import pytest
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from tests.shared import TEST_WF_ID, generate_test_exec_id
+from tracecat.dsl.common import RETRY_POLICIES, DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.models import ActionStatement, GatherArgs, ScatterArgs
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.types.auth import Role
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_scatter_with_interval_basic(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: Callable[[Client], Worker],
+):
+    """Test that scatter with interval staggers task execution.
+
+    This test verifies that when an interval is specified, each scattered task
+    is delayed by the appropriate amount (0s, interval, 2*interval, 3*interval).
+    """
+    test_name = f"{test_scatter_with_interval_basic.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    # Use a small interval for testing (0.5 seconds)
+    interval = 0.5
+    collection_size = 4
+
+    dsl = DSLInput(
+        title="Scatter with interval",
+        description="Test scatter tasks are staggered by interval",
+        entrypoint=DSLEntrypoint(ref="scatter"),
+        actions=[
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(
+                    collection="${{ [1, 2, 3, 4] }}",
+                    interval=interval,
+                ).model_dump(),
+            ),
+            ActionStatement(
+                ref="record_time",
+                action="core.transform.reshape",
+                depends_on=["scatter"],
+                args={
+                    "value": {
+                        "item": "${{ ACTIONS.scatter.result }}",
+                        # We can't directly capture time in the workflow,
+                        # but we can verify execution through the result
+                    }
+                },
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["record_time"],
+                args=GatherArgs(items="${{ ACTIONS.record_time.result }}").model_dump(),
+            ),
+        ],
+    )
+
+    run_args = DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID)
+    queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
+
+    start_time = time.time()
+
+    async with test_worker_factory(temporal_client):
+        result = await temporal_client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+
+    # Verify results are correct
+    gathered_results = result["ACTIONS"]["gather"]["result"]
+    assert len(gathered_results) == collection_size
+    assert all("item" in r for r in gathered_results)
+
+    # Verify timing: the last task should start at (collection_size - 1) * interval
+    # Total execution time should be at least this delay
+    expected_min_time = (collection_size - 1) * interval
+    assert elapsed >= expected_min_time, (
+        f"Execution time {elapsed:.2f}s should be at least {expected_min_time:.2f}s "
+        f"for {collection_size} tasks with {interval}s interval"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_scatter_without_interval(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: Callable[[Client], Worker],
+):
+    """Test that scatter without interval (None) behaves normally without delays."""
+    test_name = f"{test_scatter_without_interval.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    dsl = DSLInput(
+        title="Scatter without interval",
+        description="Test scatter without interval has no artificial delays",
+        entrypoint=DSLEntrypoint(ref="scatter"),
+        actions=[
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(
+                    collection="${{ [1, 2, 3, 4] }}",
+                    interval=None,  # Explicitly no interval
+                ).model_dump(),
+            ),
+            ActionStatement(
+                ref="add_one",
+                action="core.transform.reshape",
+                depends_on=["scatter"],
+                args={"value": "${{ FN.add(ACTIONS.scatter.result, 1) }}"},
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["add_one"],
+                args=GatherArgs(items="${{ ACTIONS.add_one.result }}").model_dump(),
+            ),
+        ],
+    )
+
+    run_args = DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID)
+    queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
+
+    start_time = time.time()
+
+    async with test_worker_factory(temporal_client):
+        result = await temporal_client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+
+    # Verify results
+    assert result["ACTIONS"]["gather"]["result"] == [2, 3, 4, 5]
+
+    # Without interval, execution should be relatively fast (< 2 seconds for simple ops)
+    assert elapsed < 2.0, (
+        f"Execution without interval should be fast, but took {elapsed:.2f}s"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_scatter_with_zero_interval(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: Callable[[Client], Worker],
+):
+    """Test that scatter with interval=0 has no delays."""
+    test_name = f"{test_scatter_with_zero_interval.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    dsl = DSLInput(
+        title="Scatter with zero interval",
+        description="Test scatter with interval=0 has no delays",
+        entrypoint=DSLEntrypoint(ref="scatter"),
+        actions=[
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(
+                    collection="${{ [1, 2, 3] }}",
+                    interval=0,
+                ).model_dump(),
+            ),
+            ActionStatement(
+                ref="double",
+                action="core.transform.reshape",
+                depends_on=["scatter"],
+                args={"value": "${{ FN.mul(ACTIONS.scatter.result, 2) }}"},
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["double"],
+                args=GatherArgs(items="${{ ACTIONS.double.result }}").model_dump(),
+            ),
+        ],
+    )
+
+    run_args = DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID)
+    queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
+
+    start_time = time.time()
+
+    async with test_worker_factory(temporal_client):
+        result = await temporal_client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+
+    # Verify results
+    assert result["ACTIONS"]["gather"]["result"] == [2, 4, 6]
+
+    # With zero interval, should execute quickly
+    assert elapsed < 2.0
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_scatter_interval_with_downstream_tasks(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: Callable[[Client], Worker],
+):
+    """Test that interval delays propagate to downstream tasks in scatter region."""
+    test_name = f"{test_scatter_interval_with_downstream_tasks.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    interval = 0.3
+
+    dsl = DSLInput(
+        title="Scatter interval with downstream tasks",
+        description="Test interval delays propagate through scatter region",
+        entrypoint=DSLEntrypoint(ref="scatter"),
+        actions=[
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(
+                    collection="${{ [10, 20, 30] }}",
+                    interval=interval,
+                ).model_dump(),
+            ),
+            # Multiple downstream tasks in the scatter region
+            ActionStatement(
+                ref="step1",
+                action="core.transform.reshape",
+                depends_on=["scatter"],
+                args={"value": "${{ FN.add(ACTIONS.scatter.result, 1) }}"},
+            ),
+            ActionStatement(
+                ref="step2",
+                action="core.transform.reshape",
+                depends_on=["step1"],
+                args={"value": "${{ FN.add(ACTIONS.step1.result, 1) }}"},
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["step2"],
+                args=GatherArgs(items="${{ ACTIONS.step2.result }}").model_dump(),
+            ),
+        ],
+    )
+
+    run_args = DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID)
+    queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
+
+    start_time = time.time()
+
+    async with test_worker_factory(temporal_client):
+        result = await temporal_client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+
+    # Verify results: 10+1+1=12, 20+1+1=22, 30+1+1=32
+    assert result["ACTIONS"]["gather"]["result"] == [12, 22, 32]
+
+    # Verify timing includes the staggered delays
+    expected_min_time = 2 * interval  # 3 items: delays at index 0, 1, 2
+    assert elapsed >= expected_min_time
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_nested_scatter_with_intervals(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: Callable[[Client], Worker],
+):
+    """Test nested scatter operations with intervals.
+
+    This test uses a simpler pattern matching the existing nested scatter tests.
+    Structure: scatter -> scatter2 -> process -> gather -> gather2
+    """
+    test_name = f"{test_nested_scatter_with_intervals.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    outer_interval = 0.3
+    inner_interval = 0.2
+
+    dsl = DSLInput(
+        title="Nested scatter with intervals",
+        description="Test nested scatter operations both with intervals",
+        entrypoint=DSLEntrypoint(ref="scatter"),
+        actions=[
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(
+                    collection="${{ [[1, 2], [3, 4]] }}",
+                    interval=outer_interval,
+                ).model_dump(),
+            ),
+            ActionStatement(
+                ref="scatter2",
+                action="core.transform.scatter",
+                depends_on=["scatter"],
+                args=ScatterArgs(
+                    collection="${{ ACTIONS.scatter.result }}",
+                    interval=inner_interval,
+                ).model_dump(),
+            ),
+            ActionStatement(
+                ref="process",
+                action="core.transform.reshape",
+                depends_on=["scatter2"],
+                args={"value": "${{ FN.mul(ACTIONS.scatter2.result, 10) }}"},
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["process"],
+                args=GatherArgs(items="${{ ACTIONS.process.result }}").model_dump(),
+            ),
+            ActionStatement(
+                ref="gather2",
+                action="core.transform.gather",
+                depends_on=["gather"],
+                args=GatherArgs(items="${{ ACTIONS.gather.result }}").model_dump(),
+            ),
+        ],
+    )
+
+    run_args = DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID)
+    queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
+
+    start_time = time.time()
+
+    async with test_worker_factory(temporal_client):
+        result = await temporal_client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+
+    # Verify results: [[10, 20], [30, 40]]
+    # Only the final gather (gather2) appears in ACTIONS
+    assert result["ACTIONS"]["gather2"]["result"] == [[10, 20], [30, 40]]
+
+    # Verify timing includes both outer and inner delays
+    # Outer: 2 items with outer_interval = 0.3s delay for 2nd item
+    # Inner: each outer item scatters 2 items with inner_interval = 0.2s delay for 2nd item
+    expected_min_time = outer_interval + inner_interval
+    assert elapsed >= expected_min_time
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_scatter_interval_with_empty_collection(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: Callable[[Client], Worker],
+):
+    """Test that scatter with interval and empty collection doesn't hang."""
+    test_name = f"{test_scatter_interval_with_empty_collection.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    dsl = DSLInput(
+        title="Scatter with interval and empty collection",
+        description="Test scatter with interval handles empty collection correctly",
+        entrypoint=DSLEntrypoint(ref="scatter"),
+        actions=[
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(
+                    collection=[],  # Plain empty list, not expression
+                    interval=1.0,  # Large interval shouldn't matter
+                ).model_dump(),
+            ),
+            ActionStatement(
+                ref="process",
+                action="core.transform.reshape",
+                depends_on=["scatter"],
+                args={"value": "${{ ACTIONS.scatter.result }}"},
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["process"],
+                args=GatherArgs(items="${{ ACTIONS.process.result }}").model_dump(),
+            ),
+        ],
+    )
+
+    run_args = DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID)
+    queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
+
+    start_time = time.time()
+
+    async with test_worker_factory(temporal_client):
+        result = await temporal_client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+
+    # Empty collection should result in empty gather
+    assert result["ACTIONS"]["gather"]["result"] == []
+
+    # Should complete quickly despite large interval
+    assert elapsed < 2.0
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_scatter_interval_rate_limiting_use_case(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: Callable[[Client], Worker],
+):
+    """Test realistic rate-limiting use case with scatter interval.
+
+    Simulates making API calls with rate limiting where we need to
+    space out requests to avoid hitting rate limits.
+    """
+    test_name = f"{test_scatter_interval_rate_limiting_use_case.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    # Simulate 5 API calls with 0.4s between each (2.5 calls/second)
+    num_calls = 5
+    interval = 0.4
+
+    dsl = DSLInput(
+        title="Rate-limited API calls with scatter",
+        description="Simulate rate-limited API calls using scatter interval",
+        entrypoint=DSLEntrypoint(ref="scatter_requests"),
+        actions=[
+            ActionStatement(
+                ref="scatter_requests",
+                action="core.transform.scatter",
+                args=ScatterArgs(
+                    collection="${{ [1, 2, 3, 4, 5] }}",
+                    interval=interval,
+                ).model_dump(),
+            ),
+            ActionStatement(
+                ref="make_request",
+                action="core.transform.reshape",
+                depends_on=["scatter_requests"],
+                args={
+                    "value": {
+                        "request_id": "${{ ACTIONS.scatter_requests.result }}",
+                        "status": "success",
+                    }
+                },
+            ),
+            ActionStatement(
+                ref="gather_responses",
+                action="core.transform.gather",
+                depends_on=["make_request"],
+                args=GatherArgs(
+                    items="${{ ACTIONS.make_request.result }}"
+                ).model_dump(),
+            ),
+        ],
+    )
+
+    run_args = DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID)
+    queue = os.environ["TEMPORAL__CLUSTER_QUEUE"]
+
+    start_time = time.time()
+
+    async with test_worker_factory(temporal_client):
+        result = await temporal_client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+
+    # Verify all requests completed
+    responses = result["ACTIONS"]["gather_responses"]["result"]
+    assert len(responses) == num_calls
+    assert all(r["status"] == "success" for r in responses)
+    assert [r["request_id"] for r in responses] == [1, 2, 3, 4, 5]
+
+    # Verify rate limiting timing
+    expected_min_time = (num_calls - 1) * interval  # 4 * 0.4 = 1.6s
+    assert elapsed >= expected_min_time, (
+        f"Rate limiting failed: {num_calls} requests with {interval}s interval "
+        f"should take at least {expected_min_time:.2f}s, but took {elapsed:.2f}s"
+    )

--- a/tests/unit/test_scatter_interval_models.py
+++ b/tests/unit/test_scatter_interval_models.py
@@ -1,0 +1,147 @@
+"""Unit tests for scatter interval model changes.
+
+Tests the Task.delay and ScatterArgs.interval fields added for the scatter
+interval feature.
+"""
+
+from tracecat.dsl.models import ScatterArgs, StreamID, Task
+
+
+class TestTaskModel:
+    """Test Task model with delay field."""
+
+    def test_task_without_delay(self):
+        """Test Task can be created without delay (default 0.0)."""
+        task = Task(ref="test_task", stream_id=StreamID("root:0"))
+        assert task.ref == "test_task"
+        assert task.delay == 0.0
+
+    def test_task_with_delay(self):
+        """Test Task can be created with delay."""
+        task = Task(
+            ref="test_task",
+            stream_id=StreamID("root:0"),
+            delay=1.5,
+        )
+        assert task.ref == "test_task"
+        assert task.delay == 1.5
+
+    def test_task_with_zero_delay(self):
+        """Test Task can have zero delay."""
+        task = Task(
+            ref="test_task",
+            stream_id=StreamID("root:0"),
+            delay=0.0,
+        )
+        assert task.delay == 0.0
+
+    def test_task_delay_negative_value(self):
+        """Test Task with negative delay is allowed (validation happens elsewhere)."""
+        # Note: The model doesn't enforce positive values, but the scheduler should
+        task = Task(
+            ref="test_task",
+            stream_id=StreamID("root:0"),
+            delay=-1.0,
+        )
+        assert task.delay == -1.0
+
+
+class TestScatterArgsModel:
+    """Test ScatterArgs model with interval field."""
+
+    def test_scatter_args_without_interval(self):
+        """Test ScatterArgs can be created without interval (default None)."""
+        args = ScatterArgs(collection=[1, 2, 3])
+        assert args.collection == [1, 2, 3]
+        assert args.interval is None
+
+    def test_scatter_args_with_interval(self):
+        """Test ScatterArgs can be created with interval."""
+        args = ScatterArgs(collection=[1, 2, 3], interval=0.5)
+        assert args.collection == [1, 2, 3]
+        assert args.interval == 0.5
+
+    def test_scatter_args_with_zero_interval(self):
+        """Test ScatterArgs can have zero interval."""
+        args = ScatterArgs(collection=[1, 2, 3], interval=0)
+        assert args.interval == 0
+
+    def test_scatter_args_with_expression_collection(self):
+        """Test ScatterArgs with expression string collection."""
+        args = ScatterArgs(
+            collection="${{ ACTIONS.previous.result }}",
+            interval=1.0,
+        )
+        assert args.collection == "${{ ACTIONS.previous.result }}"
+        assert args.interval == 1.0
+
+    def test_scatter_args_interval_float(self):
+        """Test ScatterArgs interval accepts various float values."""
+        test_intervals = [0.1, 0.5, 1.0, 2.5, 10.0]
+        for interval in test_intervals:
+            args = ScatterArgs(collection=[], interval=interval)
+            assert args.interval == interval
+
+    def test_scatter_args_model_dump(self):
+        """Test ScatterArgs.model_dump() includes interval."""
+        args = ScatterArgs(collection=[1, 2, 3], interval=0.5)
+        dumped = args.model_dump()
+        assert "collection" in dumped
+        assert "interval" in dumped
+        assert dumped["interval"] == 0.5
+
+    def test_scatter_args_model_dump_without_interval(self):
+        """Test ScatterArgs.model_dump() with None interval."""
+        args = ScatterArgs(collection=[1, 2, 3])
+        dumped = args.model_dump()
+        assert "collection" in dumped
+        assert dumped["interval"] is None
+
+
+class TestTaskEquality:
+    """Test Task equality with delay field.
+
+    Note: delay field is excluded from equality checks (compare=False)
+    so tasks with different delays are still considered equal.
+    """
+
+    def test_tasks_equal_without_delay(self):
+        """Test two tasks are equal when both have no delay."""
+        stream_id = StreamID("root:0")
+        task1 = Task(ref="test", stream_id=stream_id)
+        task2 = Task(ref="test", stream_id=stream_id)
+        assert task1 == task2
+
+    def test_tasks_equal_with_same_delay(self):
+        """Test two tasks are equal when they have the same delay."""
+        stream_id = StreamID("root:0")
+        task1 = Task(ref="test", stream_id=stream_id, delay=1.0)
+        task2 = Task(ref="test", stream_id=stream_id, delay=1.0)
+        assert task1 == task2
+
+    def test_tasks_equal_different_delay(self):
+        """Test two tasks are equal even with different delays (delay not compared)."""
+        stream_id = StreamID("root:0")
+        task1 = Task(ref="test", stream_id=stream_id, delay=1.0)
+        task2 = Task(ref="test", stream_id=stream_id, delay=2.0)
+        assert task1 == task2  # Equal because delay is not compared
+
+    def test_tasks_equal_one_with_delay(self):
+        """Test tasks are equal even when only one has a delay (delay not compared)."""
+        stream_id = StreamID("root:0")
+        task1 = Task(ref="test", stream_id=stream_id, delay=1.0)
+        task2 = Task(ref="test", stream_id=stream_id)
+        assert task1 == task2  # Equal because delay is not compared
+
+    def test_tasks_hashable_with_delay(self):
+        """Test tasks with delays can be used as dict keys."""
+        stream_id = StreamID("root:0")
+        task1 = Task(ref="test", stream_id=stream_id, delay=1.0)
+        task2 = Task(ref="test", stream_id=stream_id, delay=2.0)
+
+        # Both should hash to the same value
+        assert hash(task1) == hash(task2)
+
+        # Can use as dict keys
+        task_dict = {task1: "value1"}
+        assert task_dict[task2] == "value1"  # task2 should find task1's value

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Any, ClassVar, Literal, NotRequired, Required, Self, TypedDict
 
@@ -365,7 +365,7 @@ class Task:
     """The task action reference"""
     stream_id: StreamID
     """The stream ID of the task"""
-    delay: float | None = None
+    delay: float = field(default=0.0, compare=False)
     """Delay in seconds before scheduling an action."""
 
 

--- a/tracecat/dsl/models.py
+++ b/tracecat/dsl/models.py
@@ -365,11 +365,16 @@ class Task:
     """The task action reference"""
     stream_id: StreamID
     """The stream ID of the task"""
+    delay: float | None = None
+    """Delay in seconds before scheduling an action."""
 
 
 class ScatterArgs(BaseModel):
     collection: ExpressionStr | list[Any] = Field(
         ..., description="The collection to scatter"
+    )
+    interval: float | None = Field(
+        default=None, description="The interval in seconds between each scatter task"
     )
 
 

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -696,7 +696,7 @@ class DSLScheduler:
             "Scattering collection",
             task=task,
             collection_size=len(collection),
-            delay=args.interval,
+            interval=args.interval,
         )
 
         # Create stream for each collection item
@@ -717,7 +717,7 @@ class DSLScheduler:
 
             # Create tasks for all tasks in this stream
             # Calculate the task delay
-            delay = i * (args.interval) if args.interval else None
+            delay = i * (args.interval or 0)
             new_scoped_task = Task(ref=task.ref, stream_id=new_stream_id, delay=delay)
             self.logger.debug(
                 "Creating stream",

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -405,8 +405,8 @@ class DSLScheduler:
 
             # 4) If we made it here, the task is reachable and not force-skipped.
 
-            # Respsect the task delay if it exists. We need this to stagger tasks for scatter.
-            if task.delay:
+            # Respect the task delay if it exists. We need this to stagger tasks for scatter.
+            if task.delay > 0:
                 self.logger.info(
                     "Task has delay, sleeping", task=task, delay=task.delay
                 )

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any, cast
 
@@ -411,6 +411,8 @@ class DSLScheduler:
                     "Task has delay, sleeping", task=task, delay=task.delay
                 )
                 await asyncio.sleep(task.delay)
+                # Reset the delay to 0.0 so it doesn't propagate to the next task
+                task = replace(task, delay=0.0)
 
             # -- If this is a control flow action (scatter), we need to
             # handle it differently.


### PR DESCRIPTION
## Summary
Adds support for staggered scatter task execution with configurable intervals, enabling rate-limiting and controlled parallel execution.

## Changes
- Added `interval` parameter to `core.transform.scatter` action
- Added `delay` field to `Task` model (excluded from equality checks)
- Modified scheduler to respect task delays before execution
- Task delays are inherited by downstream tasks in scatter regions


## Usage
```yaml
- ref: scatter_requests
  action: core.transform.scatter
  args:
    collection: ${{ [1, 2, 3, 4, 5] }}
    interval: 0.5  # 0.5s delay between each task
```

With `interval: 0.5`, tasks are scheduled with delays:
- Task 0: 0s delay
- Task 1: 0.5s delay
- Task 2: 1.0s delay
- Task 3: 1.5s delay
- Task 4: 2.0s delay

## Screens
### interval=3 
Produces the following Temporal task execution
<img width="1501" height="414" alt="image" src="https://github.com/user-attachments/assets/41d4b318-25dc-46f8-89b9-eb32f778d239" />

Implementation doesn't propagate the `Task.delay` (expected behavior) when there are multiple actions in the stream.

https://github.com/user-attachments/assets/f714ec4d-1492-4ab9-9687-7e909649d952






## Tests
- 7 integration tests covering basic, nested, and edge cases
- 16 unit tests for model changes
- All tests passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `interval` to `core.transform.scatter` to stagger tasks, introduces `Task.delay`, and updates scheduler to respect delays with extensive tests.
> 
> - **DSL/Scheduler**:
>   - `tracecat/dsl/models.py`: Add `Task.delay` (excluded from equality) and `ScatterArgs.interval`.
>   - `tracecat/dsl/scheduler.py`: Respect per-task delays (sleep before execute), inherit and normalize delays across queued tasks, and compute scatter delays as `index * interval`.
> - **Registry Interface**:
>   - `packages/tracecat-registry/tracecat_registry/core/transform.py`: Extend `core.transform.scatter` signature with optional `interval` arg.
> - **Tests**:
>   - Add integration tests for staggered scatter execution, nested scatters, zero/none interval, empty collections, and rate-limiting behavior (`tests/unit/test_scatter_interval.py`).
>   - Add unit tests for `Task.delay` and `ScatterArgs.interval` models (`tests/unit/test_scatter_interval_models.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1a3d23e2b0eee9456100e6676e8d7bfc5d18d0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->