### PR TITLE
ci: Move frontend client generation from pre-commit to CI

### DIFF
--- a/.github/workflows/check-frontend-client.yml
+++ b/.github/workflows/check-frontend-client.yml
@@ -1,0 +1,88 @@
+name: Check Frontend Client
+
+on:
+  pull_request:
+    paths:
+      - tracecat/**
+      - packages/**
+      - .github/workflows/check-frontend-client.yml
+  push:
+    branches:
+      - main
+    paths:
+      - tracecat/**
+      - packages/**
+      - .github/workflows/check-frontend-client.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-client-sync:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        working-directory: frontend
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate frontend client
+        working-directory: frontend
+        run: pnpm generate-client
+
+      - name: Run Biome check
+        working-directory: frontend
+        run: pnpm check
+
+      - name: Check for changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "❌ Frontend client is out of sync with backend API!"
+            echo ""
+            echo "The following files have changes:"
+            git status --short
+            echo ""
+            echo "Please run 'just gen-client' locally and commit the changes."
+            exit 1
+          else
+            echo "✅ Frontend client is in sync with backend API"
+          fi
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "✅ Frontend client sync check completed successfully!"
+          echo "📝 Steps completed:"
+          echo "  - Frontend client generation"
+          echo "  - Biome linting and formatting"
+          echo "  - Git diff verification"
+          echo ""
+          echo "🎉 Frontend client is properly synchronized!"

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -30,11 +30,11 @@ jobs:
         working-directory: frontend
         run: biome ci .
 
-      # Typescrtip typechecking
+      # TypeScript typechecking
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,12 +39,3 @@ repos:
       - id: uv-lock
       # Optionally export a requirements.txt reflecting uv.lock
       - id: uv-export
-  - repo: local
-    hooks:
-      - id: gen-client
-        name: update frontend client
-        entry: bash -c "pnpm -C frontend generate-client && pnpm -C frontend check"
-        language: system
-        files: ^(tracecat|packages)
-        require_serial: true
-        pass_filenames: false


### PR DESCRIPTION
Running `gen-client` in pre-commit was very poor DX.

## Summary
- Removes slow `gen-client` hook from pre-commit that blocks commits
- Adds dedicated CI workflow to verify frontend client sync with backend API
- Workflow triggers on `tracecat/**` or `packages/**` changes
- Generates client, runs Biome check, and fails if files differ

## Test plan
- [ ] Verify workflow triggers on backend API changes
- [ ] Confirm it catches out-of-sync client code