### PR TITLE
chore: Improve OpenAPI client generation for CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: gen-client
         name: update frontend client
-        entry: bash -c "pnpm -C frontend generate-client && pnpm -C frontend check"
+        entry: bash -c "pnpm -C frontend generate-client-ci && pnpm -C frontend check"
         language: system
         files: ^(tracecat|packages)
         require_serial: true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit --incremental",
     "test": "jest",
     "generate-client": "openapi-ts --input ${TRACECAT__PUBLIC_API_URL:-http://localhost/api}/openapi.json --output ./src/client --client axios",
+    "generate-client-ci": "uv run --directory .. scripts/generate-openapi.py /tmp/tracecat-openapi.json && openapi-ts --input /tmp/tracecat-openapi.json --output ./src/client --client axios && rm /tmp/tracecat-openapi.json",
     "upgrade:next": "pnpm add next@14 react@18 react-dom@18 && pnpm add -D eslint-config-next@14 eslint@8"
   },
   "dependencies": {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -13363,6 +13363,7 @@ export const $login = {
     },
     password: {
       type: "string",
+      format: "password",
       title: "Password",
     },
     scope: {
@@ -13390,6 +13391,7 @@ export const $login = {
           type: "null",
         },
       ],
+      format: "password",
       title: "Client Secret",
     },
   },

--- a/justfile
+++ b/justfile
@@ -50,6 +50,9 @@ mypy path:
 gen-client:
 	pnpm -C frontend generate-client
 	just lint-fix
+gen-client-ci:
+	pnpm -C frontend generate-client-ci
+	just lint-fix
 # Update version number. If no version is provided, increments patch version.
 update-version *after='':
 	@-./scripts/update-version.sh {{after}}

--- a/scripts/generate-openapi.py
+++ b/scripts/generate-openapi.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Generate OpenAPI spec from FastAPI app without running server."""
+
+import json
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import and configure logger before importing the app
+from tracecat.logger import logger  # noqa: E402
+
+logger.remove()  # Remove all handlers
+logger.add(lambda _: None)  # Add a no-op handler to prevent any output
+
+
+def main() -> None:
+    """Generate OpenAPI spec and write to stdout or file."""
+    from tracecat.api.app import app
+
+    openapi_spec = app.openapi()
+
+    if len(sys.argv) > 1:
+        # Write to file if path provided
+        output_path = Path(sys.argv[1])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(openapi_spec, indent=2))
+        print(f"OpenAPI spec written to {output_path}", file=sys.stderr)
+    else:
+        # Write to stdout
+        print(json.dumps(openapi_spec, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Improves OpenAPI client generation process for CI/CD by generating spec directly from FastAPI app instead of requiring a running server.

## Changes
- Add `scripts/generate-openapi.py` to generate OpenAPI spec without server
- Add `generate-client-ci` pnpm script for CI environments
- Update pre-commit hook to use new CI-friendly generation method
- Add `gen-client-ci` justfile recipe

## Benefits
- No need to spin up API server in CI
- Faster client generation
- More reliable in CI environments
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Generates the OpenAPI spec directly from the FastAPI app in CI, removing the need to run a server. This makes client generation faster and more reliable in CI and pre-commit.

- **New Features**
  - Added scripts/generate-openapi.py to emit the OpenAPI spec without starting the server.
  - Added pnpm generate-client-ci to build the client from the generated spec.
  - Updated pre-commit and just to use generate-client-ci; regenerated client adds password format to relevant fields.

<!-- End of auto-generated description by cubic. -->

