### PR TITLE
fix(api): Non-atomic case creation logic

### DIFF
--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -1945,7 +1945,7 @@ class TestCoreCreateCaseErrorHandling:
         # Should NOT contain technical DB details
         assert "row_id" not in error_msg.lower()
         assert (
-            "table" not in error_msg.lower() or "case_fields" not in error_msg.lower()
+            "table" not in error_msg.lower() and "case_fields" not in error_msg.lower()
         )
         assert "update" not in error_msg.lower() or "returning" not in error_msg.lower()
         assert "mappings().one()" not in error_msg.lower()

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -1862,3 +1862,126 @@ class TestCoreCaseTags:
 
         # Verify the result
         assert result == updated_case.model_dump.return_value
+
+
+@pytest.mark.anyio
+class TestCoreCreateCaseErrorHandling:
+    """Test error handling for create_case registry action."""
+
+    @patch("tracecat_registry.core.cases.CasesService.with_session")
+    async def test_create_case_with_invalid_field_shows_clear_error(
+        self, mock_with_session
+    ):
+        """Test that creating a case with an invalid field shows a clear error message."""
+        from tracecat.types.exceptions import TracecatException
+
+        # Set up the mock service context manager
+        mock_service = AsyncMock()
+        mock_service.create_case.side_effect = TracecatException(
+            "Failed to create case fields. One or more custom fields do not exist. "
+            "Please ensure these fields have been created and try again."
+        )
+
+        # Set up the context manager's __aenter__ to return the mock service
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        # Call create_case with invalid field
+        with pytest.raises(TracecatException) as exc_info:
+            await create_case(
+                summary="Test Case",
+                description="Test Description",
+                priority="medium",
+                severity="medium",
+                status="new",
+                fields={"invalid_field_name": "value"},
+            )
+
+        # Verify error message is clear and user-friendly
+        error_msg = str(exc_info.value)
+        assert "custom fields do not exist" in error_msg.lower()
+        assert "please ensure" in error_msg.lower()
+
+    @patch("tracecat_registry.core.cases.CasesService.with_session")
+    async def test_create_case_error_no_technical_jargon(self, mock_with_session):
+        """Test that error messages don't contain technical database details."""
+        from tracecat.types.exceptions import TracecatException
+
+        # Set up the mock service to raise TracecatNotFoundError (simulating field update failure)
+        mock_service = AsyncMock()
+        mock_service.create_case.side_effect = TracecatException(
+            "Failed to save custom field values for case. The field row was created but could not be updated. "
+            "Fields attempted: user_email, case_count. "
+            "Please verify all custom fields exist in Settings > Cases > Custom Fields and have correct data types."
+        )
+
+        # Set up the context manager's __aenter__ to return the mock service
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        # Call create_case
+        with pytest.raises(TracecatException) as exc_info:
+            await create_case(
+                summary="Test Case",
+                description="Test Description",
+                priority="medium",
+                severity="medium",
+                status="new",
+                fields={"user_email": "test@example.com", "case_count": 5},
+            )
+
+        # Verify error message is user-friendly
+        error_msg = str(exc_info.value)
+
+        # Should contain helpful guidance
+        assert "custom field" in error_msg.lower()
+        assert "settings" in error_msg.lower()
+
+        # Should mention the field names
+        assert "user_email" in error_msg or "case_count" in error_msg
+
+        # Should NOT contain technical DB details
+        assert "row_id" not in error_msg.lower()
+        assert (
+            "table" not in error_msg.lower() or "case_fields" not in error_msg.lower()
+        )
+        assert "update" not in error_msg.lower() or "returning" not in error_msg.lower()
+        assert "mappings().one()" not in error_msg.lower()
+
+    @patch("tracecat_registry.core.cases.CasesService.with_session")
+    async def test_create_case_atomicity_verified(self, mock_with_session):
+        """Test that case creation failure doesn't leave partial data."""
+        from tracecat.types.exceptions import TracecatException
+
+        # Set up mock to simulate field creation failure AFTER case creation
+        mock_service = AsyncMock()
+
+        # Simulate: case created but fields fail
+        # In reality, this should rollback the case too due to transaction atomicity
+        mock_service.create_case.side_effect = TracecatException(
+            "Failed to save custom field values for case."
+        )
+
+        # Set up the context manager
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        # Attempt to create case
+        with pytest.raises(TracecatException):
+            await create_case(
+                summary="Test Case",
+                description="Test Description",
+                priority="medium",
+                severity="medium",
+                status="new",
+                fields={"test_field": "value"},
+            )
+
+        # Verify create_case was called (and failed)
+        mock_service.create_case.assert_called_once()
+
+        # In production, the transaction should rollback, leaving no partial data
+        # This is verified by the service-level tests

--- a/tests/unit/test_case_fields_integration.py
+++ b/tests/unit/test_case_fields_integration.py
@@ -55,24 +55,31 @@ class TestCaseFieldsIntegration:
         assert created_case.summary == case_create_params.summary
         assert created_case.description == case_create_params.description
 
-        # Verify that no fields were created
-        assert created_case.fields is None
+        # Verify that a CaseFields row WAS created (new behavior: always create to ensure defaults)
+        assert created_case.fields is not None
 
-        # Query the database to verify no fields exist for this case
+        # Query the database to verify fields row exists for this case
         statement = select(CaseFields).where(CaseFields.case_id == created_case.id)
         result = await session.exec(statement)
         case_fields = result.one_or_none()
-        assert case_fields is None
+        assert case_fields is not None
 
-        # Verify get_fields returns None
+        # Verify get_fields returns the row with metadata but no custom fields
         fields_data = await cases_service.fields.get_fields(created_case)
-        assert fields_data is None
+        assert fields_data is not None
+        # Should have metadata fields but no custom fields
+        assert "id" in fields_data
+        assert "case_id" in fields_data
+        assert "created_at" in fields_data
+        assert "updated_at" in fields_data
+        # No other fields should be present (i.e., no custom fields)
+        assert len(fields_data) == 4
 
-        # Verify get_case returns the same case without fields
+        # Verify get_case returns the same case with fields row
         retrieved_case = await cases_service.get_case(created_case.id)
         assert retrieved_case is not None
         assert retrieved_case.id == created_case.id
-        assert retrieved_case.fields is None
+        assert retrieved_case.fields is not None
 
     async def test_create_case_with_fields_before_columns_exist(
         self, cases_service: CasesService, case_create_params: CaseCreate
@@ -92,9 +99,7 @@ class TestCaseFieldsIntegration:
         # Since we haven't created the fields yet, this should raise an error
         with pytest.raises(
             TracecatException,
-            match="Failed to create case fields."
-            ' Column "custom_field1" of table "case_fields" does not exist.'
-            " Please ensure these fields have been created and try again.",
+            match="Failed to create case fields. One or more custom fields do not exist. Please ensure these fields have been created and try again.",
         ):
             await cases_service.create_case(params_with_fields)
 
@@ -247,9 +252,7 @@ class TestCaseFieldsIntegration:
         # Update the case
         with pytest.raises(
             TracecatException,
-            match="Failed to update case fields."
-            ' Column "field3" of table "case_fields" does not exist.'
-            " Please ensure these fields have been created and try again.",
+            match="Failed to update case fields. One or more custom fields do not exist. Please ensure these fields have been created and try again.",
         ):
             await cases_service.update_case(created_case, update_params)
 

--- a/tracecat/cases/models.py
+++ b/tracecat/cases/models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, RootModel
 from tracecat.auth.models import UserRead
 from tracecat.cases.constants import RESERVED_CASE_FIELDS
 from tracecat.cases.enums import CaseEventType, CasePriority, CaseSeverity, CaseStatus
+from tracecat.tables.common import parse_postgres_default
 from tracecat.tables.enums import SqlType
 from tracecat.tables.models import TableColumnCreate, TableColumnUpdate
 from tracecat.tags.models import TagRead
@@ -88,7 +89,7 @@ class CaseFieldRead(BaseModel):
             type=SqlType(str(column["type"])),
             description=column.get("comment") or "",
             nullable=column["nullable"],
-            default=column.get("default"),
+            default=parse_postgres_default(column.get("default")),
             reserved=column["name"] in RESERVED_CASE_FIELDS,
         )
 


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
- Make case creation atomic and improve custom field handling. If fields fail, the whole transaction rolls back, and error messages are clear and non-technical.
- On case creation (manual and UDF), custom field row is now also created and field defaults are now parsed and applied correctly. Previously, this caused confusing behavior where a boolean custom field (with default true) would be show as "false" on case creation but then becomes "true" on refresh.

- **Bug Fixes**
  - Removed manual commits in create_case/update_case; atomic via session/context manager.
  - Always create the case_fields row; apply defaults even when no fields are provided (uses get_row).
  - Handle TracecatNotFoundError on field updates; raise a friendly error that lists attempted field names and guidance.
  - Replace DB-jargon errors with clear messages for undefined/missing custom fields.
  - Strip PostgreSQL type casts and quotes from default values using parse_postgres_default.
  - Added tests covering rollback on field errors and user-friendly messages.

<!-- End of auto-generated description by cubic. -->

