### PR TITLE
chore: Reduce Redis stream TTL from 30 days to 3 days

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -353,9 +353,9 @@ TRACECAT__WORKFLOW_RETURN_STRATEGY = os.environ.get(
 
 # === Redis config === #
 REDIS_CHAT_TTL_SECONDS = int(
-    os.environ.get("REDIS_CHAT_TTL_SECONDS", 30 * 24 * 60 * 60)  # 30 days
+    os.environ.get("REDIS_CHAT_TTL_SECONDS", 3 * 24 * 60 * 60)  # 3 days
 )
-"""TTL for Redis chat history streams in seconds. Defaults to 30 days."""
+"""TTL for Redis chat history streams in seconds. Defaults to 3 days."""
 
 # === File limits === #
 TRACECAT__MAX_ATTACHMENT_SIZE_BYTES = int(


### PR DESCRIPTION
## Summary
- Reduces default Redis chat stream TTL from 30 days to 3 days
- Optimizes memory usage while maintaining sufficient history for debugging

## Rationale
- 30 days is excessive for ephemeral streaming data
- 3 days provides a good balance between retention and resource usage
- Streams are already capped at 10,000 entries per session
- Can still be overridden via `REDIS_CHAT_TTL_SECONDS` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduce the default TTL for Redis chat history streams from 30 days to 3 days to lower memory usage while keeping enough recent history for debugging. The TTL remains configurable via the REDIS_CHAT_TTL_SECONDS env var.

<!-- End of auto-generated description by cubic. -->

