### PR TITLE
feat(ui): Add multi-select case tags view

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -2,16 +2,41 @@
 
 import { useEffect } from "react"
 import CaseTable from "@/components/cases/case-table"
+import { CaseTagsSidebar } from "@/components/cases/case-tags-sidebar"
+import { CasesViewMode } from "@/components/cases/cases-view-toggle"
+import { useWorkspaceId } from "@/providers/workspace-id"
+import { useSearchParams } from "next/navigation"
 
 export default function CasesPage() {
+  const searchParams = useSearchParams()
+  const workspaceId = useWorkspaceId()
+
   useEffect(() => {
     if (typeof window !== "undefined") {
       document.title = "Cases"
     }
   }, [])
 
+  const viewParam = searchParams?.get("view") as CasesViewMode | null
+  const view = viewParam ?? CasesViewMode.Cases
+
+  if (view === CasesViewMode.Tags) {
+    return (
+      <div className="size-full overflow-auto px-3 py-6">
+        <div className="flex h-full flex-row gap-4">
+          <div className="w-48">
+            <CaseTagsSidebar workspaceId={workspaceId} />
+          </div>
+          <div className="flex-1">
+            <CaseTable />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <div className="size-full overflow-auto p-6 space-y-6">
+    <div className="size-full overflow-auto px-3 py-6 space-y-6">
       <CaseTable />
     </div>
   )

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -1,11 +1,11 @@
 "use client"
 
+import { useSearchParams } from "next/navigation"
 import { useEffect } from "react"
 import CaseTable from "@/components/cases/case-table"
 import { CaseTagsSidebar } from "@/components/cases/case-tags-sidebar"
 import { CasesViewMode } from "@/components/cases/cases-view-toggle"
 import { useWorkspaceId } from "@/providers/workspace-id"
-import { useSearchParams } from "next/navigation"
 
 export default function CasesPage() {
   const searchParams = useSearchParams()

--- a/frontend/src/components/cases/case-table.tsx
+++ b/frontend/src/components/cases/case-table.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { Row } from "@tanstack/react-table"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import type {
   CasePriority,
@@ -28,6 +28,8 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 export default function CaseTable() {
   const { user } = useAuth()
   const workspaceId = useWorkspaceId()
+  const searchParams = useSearchParams()
+  const tagFilters = searchParams?.getAll("tag") ?? []
   const [pageSize, setPageSize] = useState(20)
   const [selectedCase, setSelectedCase] = useState<CaseReadMinimal | null>(null)
   const [selectedRows, setSelectedRows] = useState<Row<CaseReadMinimal>[]>([])
@@ -71,6 +73,7 @@ export default function CaseTable() {
             value === UNASSIGNED ? "unassigned" : value
           )
         : null,
+    tags: tagFilters.length > 0 ? tagFilters : null,
   })
   const { toast } = useToast()
   const [isDeleting, setIsDeleting] = useState(false)

--- a/frontend/src/components/cases/case-tags-sidebar.tsx
+++ b/frontend/src/components/cases/case-tags-sidebar.tsx
@@ -114,7 +114,9 @@ export function CaseTagsSidebar({ workspaceId }: { workspaceId: string }) {
     }
     const queryString = params.toString()
     router.push(
-      queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
+      queryString
+        ? `${window.location.pathname}?${queryString}`
+        : window.location.pathname
     )
   }
 

--- a/frontend/src/components/cases/case-tags-sidebar.tsx
+++ b/frontend/src/components/cases/case-tags-sidebar.tsx
@@ -107,11 +107,17 @@ export function CaseTagsSidebar({ workspaceId }: { workspaceId: string }) {
 
   const handleSelectTag = ({ ref }: CaseTagRead) => {
     const params = new URLSearchParams(window.location.search)
-    if (activeTagRefs.includes(ref)) {
-      params.delete("tag")
-    } else {
-      params.set("tag", ref)
-    }
+    const currentTags = params.getAll("tag")
+    const isActive = currentTags.includes(ref)
+    const nextTags = isActive
+      ? currentTags.filter((tagRef) => tagRef !== ref)
+      : Array.from(new Set([...currentTags, ref]))
+
+    params.delete("tag")
+    nextTags.forEach((tagRef) => {
+      params.append("tag", tagRef)
+    })
+
     const queryString = params.toString()
     router.push(
       queryString

--- a/frontend/src/components/cases/case-tags-sidebar.tsx
+++ b/frontend/src/components/cases/case-tags-sidebar.tsx
@@ -1,0 +1,490 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { EllipsisIcon, PencilIcon, Plus, Tag, Trash2Icon } from "lucide-react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useState } from "react"
+import { useForm } from "react-hook-form"
+import z from "zod"
+import type { CaseTagRead, TagCreate, TagUpdate } from "@/client"
+import { ColorPicker } from "@/components/color-picker"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { useCaseTagCatalog } from "@/lib/hooks"
+import { cn } from "@/lib/utils"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+const createTagSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Tag name cannot be empty")
+    .max(50, "Tag name cannot be longer than 50 characters")
+    .trim()
+    .refine(
+      (name) => name.trim().length > 0,
+      "Tag name cannot be only whitespace"
+    ),
+  color: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/, "Color must be a valid hex color code"),
+})
+
+export function CaseTagsSidebar({ workspaceId }: { workspaceId: string }) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { caseTags, createCaseTag, caseTagsIsLoading } =
+    useCaseTagCatalog(workspaceId)
+  const [showTagDialog, setShowTagDialog] = useState(false)
+  const activeTagRefs = searchParams?.getAll("tag") ?? []
+
+  const methods = useForm<TagCreate>({
+    resolver: zodResolver(createTagSchema),
+    defaultValues: {
+      name: "",
+      color: "#aabbcc",
+    },
+  })
+
+  const handleCreateTag = async (params: TagCreate) => {
+    try {
+      const tagExists = caseTags?.some(
+        (tag) => tag.name.toLowerCase() === params.name.trim().toLowerCase()
+      )
+
+      if (tagExists) {
+        methods.setError("name", {
+          type: "manual",
+          message: "A tag with this name already exists",
+        })
+        return
+      }
+
+      await createCaseTag({
+        workspaceId,
+        requestBody: params,
+      })
+      methods.reset()
+      setShowTagDialog(false)
+    } catch (error) {
+      console.error("Error creating case tag", error)
+    }
+  }
+
+  const handleSelectTag = ({ ref }: CaseTagRead) => {
+    const params = new URLSearchParams(window.location.search)
+    if (activeTagRefs.includes(ref)) {
+      params.delete("tag")
+    } else {
+      params.set("tag", ref)
+    }
+    const queryString = params.toString()
+    router.push(
+      queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname
+    )
+  }
+
+  if (caseTagsIsLoading) return null
+
+  return (
+    <Dialog open={showTagDialog} onOpenChange={setShowTagDialog}>
+      <div className="shrink-0 overflow-auto rounded-lg text-muted-foreground">
+        <div className="sticky top-0 flex items-center justify-between bg-background p-2">
+          <h2 className="text-xs font-semibold text-muted-foreground">Tags</h2>
+          <div>
+            <DialogTrigger asChild>
+              <Button variant="ghost" size="icon" className="size-7">
+                <Plus className="size-4" />
+                <span className="sr-only">Add case tag</span>
+              </Button>
+            </DialogTrigger>
+          </div>
+        </div>
+        <div className="h-full space-y-1 p-2">
+          {caseTags && caseTags.length > 0 ? (
+            caseTags.map((tag) => (
+              <TagItem
+                key={tag.id}
+                tag={tag}
+                isActive={activeTagRefs.includes(tag.ref)}
+                onSelect={() => handleSelectTag(tag)}
+              />
+            ))
+          ) : (
+            <div className="flex aspect-square h-full items-center justify-center rounded-lg border border-dashed border-muted-foreground/25 bg-muted-foreground/5 p-8">
+              <div className="text-center text-xs text-muted-foreground/60">
+                Use tags to organize your cases
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create new case tag</DialogTitle>
+          <DialogDescription>
+            Enter a name for your new case tag.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...methods}>
+          <form onSubmit={methods.handleSubmit(handleCreateTag)}>
+            <div className="space-y-4">
+              <FormField
+                key="name"
+                control={methods.control}
+                name="name"
+                render={() => (
+                  <FormItem>
+                    <FormLabel className="text-sm">Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        className="text-sm"
+                        placeholder="Name"
+                        {...methods.register("name")}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Max 50 alphanumeric characters
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                key="color"
+                control={methods.control}
+                name="color"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-sm">Color</FormLabel>
+                    <div className="flex gap-2">
+                      <FormControl>
+                        <Input
+                          className="max-w-24 font-mono text-sm"
+                          placeholder="#000000"
+                          value={field.value ?? "#000000"}
+                          onChange={(e) => field.onChange(e.target.value)}
+                        />
+                      </FormControl>
+                      <ColorPicker
+                        value={field.value ?? "#000000"}
+                        onChange={(color) => field.onChange(color)}
+                      />
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button className="ml-auto space-x-2" type="submit">
+                  Create Tag
+                </Button>
+              </DialogFooter>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+enum TagItemAction {
+  Edit = "edit",
+  Delete = "delete",
+}
+
+const updateTagSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Tag name cannot be empty")
+    .max(50, "Tag name cannot be longer than 50 characters")
+    .trim()
+    .refine(
+      (name) => name.trim().length > 0,
+      "Tag name cannot be only whitespace"
+    )
+    .optional(),
+  color: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/, "Color must be a valid hex color code")
+    .optional(),
+})
+
+function TagItem({
+  tag,
+  isActive,
+  onSelect,
+}: {
+  tag: CaseTagRead
+  isActive: boolean
+  onSelect: () => void
+}) {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [action, setAction] = useState<TagItemAction | null>(null)
+
+  return (
+    <AlertDialog>
+      <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+        <div className="group relative">
+          <div
+            onClick={() => onSelect()}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-1 text-sm hover:cursor-pointer hover:bg-accent hover:text-accent-foreground",
+              (isDropdownOpen || isActive) && "bg-accent text-accent-foreground"
+            )}
+          >
+            <Tag
+              className="size-4 stroke-white"
+              style={{
+                fill: tag.color || "rgb(var(--muted-foreground) / 0.8)",
+              }}
+            />
+            <span className="truncate text-xs font-medium">{tag.name}</span>
+
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className={cn(
+                  "absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1",
+                  "opacity-0 group-hover:opacity-100",
+                  (isDropdownOpen || isActive) && "opacity-100",
+                  "hover:bg-transparent focus:ring-0 focus-visible:ring-0"
+                )}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <EllipsisIcon className="size-3 text-muted-foreground" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" side="right">
+              <AlertDialogTrigger asChild>
+                <DropdownMenuItem
+                  className="text-xs"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setAction(TagItemAction.Edit)
+                  }}
+                >
+                  <PencilIcon className="mr-2 size-3" />
+                  Edit
+                </DropdownMenuItem>
+              </AlertDialogTrigger>
+              <AlertDialogTrigger asChild>
+                <DropdownMenuItem
+                  className="text-xs text-destructive"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setAction(TagItemAction.Delete)
+                  }}
+                >
+                  <Trash2Icon className="mr-2 size-3" />
+                  Delete
+                </DropdownMenuItem>
+              </AlertDialogTrigger>
+            </DropdownMenuContent>
+          </div>
+        </div>
+      </DropdownMenu>
+      <TagItemActionDialogContent action={action} tag={tag} />
+    </AlertDialog>
+  )
+}
+
+function TagItemActionDialogContent({
+  action,
+  tag,
+}: {
+  action: TagItemAction | null
+  tag: CaseTagRead
+}) {
+  const router = useRouter()
+  const workspaceId = useWorkspaceId()
+  const { updateCaseTag, deleteCaseTag } = useCaseTagCatalog(workspaceId)
+  const methods = useForm<TagUpdate>({
+    resolver: zodResolver(updateTagSchema),
+    defaultValues: {
+      name: tag.name,
+      color: tag.color || "#aabbcc",
+    },
+  })
+
+  const onEdit = useCallback(
+    async (params: TagUpdate) => {
+      try {
+        await updateCaseTag({
+          tagId: tag.id,
+          workspaceId,
+          requestBody: {
+            name: params.name || undefined,
+            color: params.color || undefined,
+          },
+        })
+      } catch (error) {
+        console.error("Error updating case tag", error)
+        methods.setError("name", {
+          type: "manual",
+          message: `Error updating tag: ${String(error)}`,
+        })
+      }
+    },
+    [tag.id, workspaceId]
+  )
+
+  const onDelete = useCallback(async () => {
+    try {
+      await deleteCaseTag({ tagId: tag.id, workspaceId })
+      const params = new URLSearchParams(window.location.search)
+      const selectedTags = params.getAll("tag")
+      if (selectedTags.includes(tag.ref)) {
+        params.delete("tag")
+      }
+      const queryString = params.toString()
+      router.push(
+        queryString
+          ? `${window.location.pathname}?${queryString}`
+          : window.location.pathname
+      )
+    } catch (error) {
+      console.error("Error deleting case tag", error)
+    }
+  }, [deleteCaseTag, router, tag.id, tag.ref, workspaceId])
+
+  switch (action) {
+    case TagItemAction.Delete:
+      return (
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete tag</AlertDialogTitle>
+            <AlertDialogDescription>
+              You are about to delete the tag{" "}
+              <span className="font-bold text-foreground">{tag.name}</span>.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="flex items-center gap-2"
+              onClick={async () => {
+                await onDelete()
+              }}
+            >
+              <Trash2Icon className="size-4" />
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      )
+    case TagItemAction.Edit:
+      return (
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Edit Tag</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogDescription>
+            Edit the name and color of the tag.
+          </AlertDialogDescription>
+          <Form {...methods}>
+            <form onSubmit={methods.handleSubmit(onEdit)}>
+              <div className="space-y-4">
+                <FormField
+                  key="name"
+                  control={methods.control}
+                  name="name"
+                  defaultValue={tag.name}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-sm">Name</FormLabel>
+                      <FormControl>
+                        <Input
+                          className="text-sm"
+                          placeholder="Name"
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Max 50 alphanumeric characters
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  key="color"
+                  control={methods.control}
+                  name="color"
+                  defaultValue={tag.color}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-sm">Color</FormLabel>
+                      <div className="flex gap-2">
+                        <FormControl>
+                          <Input
+                            className="max-w-24 font-mono text-sm"
+                            placeholder="#000000"
+                            {...field}
+                            value={field.value ?? "#000000"}
+                          />
+                        </FormControl>
+                        <ColorPicker
+                          value={field.value ?? "#000000"}
+                          onChange={(color) => field.onChange(color)}
+                        />
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    type="submit"
+                    className="flex items-center gap-2"
+                  >
+                    <PencilIcon className="size-4" />
+                    Save Changes
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </div>
+            </form>
+          </Form>
+        </AlertDialogContent>
+      )
+    default:
+      return null
+  }
+}

--- a/frontend/src/components/cases/cases-view-toggle.tsx
+++ b/frontend/src/components/cases/cases-view-toggle.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { BracesIcon, SquareStackIcon } from "lucide-react"
+import { BracesIcon, SquareStackIcon, TagIcon } from "lucide-react"
 import Link from "next/link"
 import {
   Tooltip,
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils"
 
 export enum CasesViewMode {
   Cases = "cases",
+  Tags = "tags",
   CustomFields = "custom-fields",
 }
 
@@ -20,6 +21,7 @@ interface CasesViewToggleProps {
   onViewChange?: (view: CasesViewMode) => void
   className?: string
   casesHref?: string
+  tagsHref?: string
   customFieldsHref?: string
 }
 
@@ -28,13 +30,37 @@ export function CasesViewToggle({
   onViewChange,
   className,
   casesHref,
+  tagsHref,
   customFieldsHref,
 }: CasesViewToggleProps) {
   const handleViewChange = (view: CasesViewMode) => {
     onViewChange?.(view)
   }
 
-  // Minimal toggle similar to workflows
+  const toggleItems = [
+    {
+      mode: CasesViewMode.Cases,
+      icon: SquareStackIcon,
+      tooltip: "Cases table",
+      href: casesHref,
+      ariaLabel: "Cases view",
+    },
+    {
+      mode: CasesViewMode.Tags,
+      icon: TagIcon,
+      tooltip: "Tags",
+      href: tagsHref,
+      ariaLabel: "Tags view",
+    },
+    {
+      mode: CasesViewMode.CustomFields,
+      icon: BracesIcon,
+      tooltip: "Custom fields",
+      href: customFieldsHref,
+      ariaLabel: "Custom fields view",
+    },
+  ] as const
+
   return (
     <div
       className={cn(
@@ -43,86 +69,55 @@ export function CasesViewToggle({
       )}
     >
       <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {casesHref ? (
-              <Link
-                href={casesHref}
-                onClick={() => handleViewChange(CasesViewMode.Cases)}
-                className={cn(
-                  "flex size-7 items-center justify-center rounded-l-sm transition-colors",
-                  view === CasesViewMode.Cases
-                    ? "bg-background text-accent-foreground"
-                    : "bg-accent text-muted-foreground hover:bg-muted/50"
-                )}
-                aria-current={view === CasesViewMode.Cases ? "page" : undefined}
-                aria-label="Cases view"
-              >
-                <SquareStackIcon className="size-3.5" />
-              </Link>
-            ) : (
-              <button
-                type="button"
-                onClick={() => handleViewChange(CasesViewMode.Cases)}
-                className={cn(
-                  "flex size-7 items-center justify-center rounded-l-sm transition-colors",
-                  view === CasesViewMode.Cases
-                    ? "bg-background text-accent-foreground"
-                    : "bg-accent text-muted-foreground hover:bg-muted/50"
-                )}
-                aria-current={view === CasesViewMode.Cases}
-                aria-label="Cases view"
-              >
-                <SquareStackIcon className="size-3.5" />
-              </button>
-            )}
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Cases table</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {customFieldsHref ? (
-              <Link
-                href={customFieldsHref}
-                onClick={() => handleViewChange(CasesViewMode.CustomFields)}
-                className={cn(
-                  "flex size-7 items-center justify-center rounded-r-sm transition-colors",
-                  view === CasesViewMode.CustomFields
-                    ? "bg-background text-accent-foreground"
-                    : "bg-accent text-muted-foreground hover:bg-muted/50"
-                )}
-                aria-current={
-                  view === CasesViewMode.CustomFields ? "page" : undefined
-                }
-                aria-label="Custom fields view"
-              >
-                <BracesIcon className="size-3.5" />
-              </Link>
-            ) : (
-              <button
-                type="button"
-                onClick={() => handleViewChange(CasesViewMode.CustomFields)}
-                className={cn(
-                  "flex size-7 items-center justify-center rounded-r-sm transition-colors",
-                  view === CasesViewMode.CustomFields
-                    ? "bg-background text-accent-foreground"
-                    : "bg-accent text-muted-foreground hover:bg-muted/50"
-                )}
-                aria-current={view === CasesViewMode.CustomFields}
-                aria-label="Custom fields view"
-              >
-                <BracesIcon className="size-3.5" />
-              </button>
-            )}
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Custom fields</p>
-          </TooltipContent>
-        </Tooltip>
+        {toggleItems.map((item, index) => {
+          const Icon = item.icon
+          const isActive = view === item.mode
+          const isFirst = index === 0
+          const isLast = index === toggleItems.length - 1
+          const roundedClass = cn({
+            "rounded-l-sm": isFirst,
+            "rounded-none": !isFirst && !isLast,
+            "rounded-r-sm": isLast,
+          })
+          const baseClasses = cn(
+            "flex size-7 items-center justify-center transition-colors",
+            roundedClass,
+            isActive
+              ? "bg-background text-accent-foreground"
+              : "bg-accent text-muted-foreground hover:bg-muted/50"
+          )
+
+          const content = item.href ? (
+            <Link
+              href={item.href}
+              onClick={() => handleViewChange(item.mode)}
+              className={baseClasses}
+              aria-current={isActive ? "page" : undefined}
+              aria-label={item.ariaLabel}
+            >
+              <Icon className="size-3.5" />
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => handleViewChange(item.mode)}
+              className={baseClasses}
+              aria-current={isActive}
+              aria-label={item.ariaLabel}
+            >
+              <Icon className="size-3.5" />
+            </button>
+          )
+
+          return (
+            <Tooltip key={item.mode}>
+              <TooltipTrigger asChild>{content}</TooltipTrigger>
+              <TooltipContent>
+                <p>{item.tooltip}</p>
+              </TooltipContent>
+            </Tooltip>
+          )
+        })}
       </TooltipProvider>
     </div>
   )

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -182,14 +182,24 @@ function TablesActions() {
 
 function CasesActions() {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const workspaceId = useWorkspaceId()
   const [dialogOpen, setDialogOpen] = useState(false)
 
   const view = pathname?.includes("/cases/custom-fields")
     ? CasesViewMode.CustomFields
-    : CasesViewMode.Cases
+    : searchParams?.get("view") === CasesViewMode.Tags
+      ? CasesViewMode.Tags
+      : CasesViewMode.Cases
 
   const casesHref = workspaceId ? `/workspaces/${workspaceId}/cases` : undefined
+  const tagsHref = (() => {
+    if (!workspaceId || !casesHref) return undefined
+    const params = new URLSearchParams(searchParams?.toString())
+    params.set("view", CasesViewMode.Tags)
+    const queryString = params.toString()
+    return queryString ? `${casesHref}?${queryString}` : casesHref
+  })()
   const customFieldsHref = workspaceId
     ? `/workspaces/${workspaceId}/cases/custom-fields`
     : undefined
@@ -199,6 +209,7 @@ function CasesActions() {
       <CasesViewToggle
         view={view}
         casesHref={casesHref}
+        tagsHref={tagsHref}
         customFieldsHref={customFieldsHref}
       />
       {view === CasesViewMode.CustomFields ? (


### PR DESCRIPTION

<img width="1508" height="653" alt="Screenshot 2025-10-06 at 6 56 18 AM" src="https://github.com/user-attachments/assets/3a654892-0495-49d4-95e4-2ce8d481f169" />

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new Tags view for Cases with a sidebar to manage tags and filter the case table. This improves case organization and makes it easy to find tagged cases.

- New Features
  - Tags view with a sidebar to browse and manage case tags.
  - Create, edit, and delete tags with color selection and name validation.
  - Clicking a tag updates the URL (?tag=...) and filters the case table; CaseTable reads tag filters from search params.
  - View toggle now includes a Tags option; header links preserve existing query params.

<!-- End of auto-generated description by cubic. -->

