### PR TITLE
fix: Use OrganizationUserRole for agent model/provider endpoints

### DIFF
--- a/tracecat/agent/router.py
+++ b/tracecat/agent/router.py
@@ -26,11 +26,20 @@ OrganizationAdminUserRole = Annotated[
     ),
 ]
 
+OrganizationUserRole = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="no",
+    ),
+]
+
 
 @router.get("/models")
 async def list_models(
     *,
-    role: OrganizationAdminUserRole,
+    role: OrganizationUserRole,
     session: AsyncDBSession,
 ) -> dict[str, ModelConfig]:
     """List all available AI models."""
@@ -41,7 +50,7 @@ async def list_models(
 @router.get("/providers")
 async def list_providers(
     *,
-    role: OrganizationAdminUserRole,
+    role: OrganizationUserRole,
     session: AsyncDBSession,
 ) -> list[str]:
     """List all available AI model providers."""
@@ -52,7 +61,7 @@ async def list_providers(
 @router.get("/providers/status")
 async def get_providers_status(
     *,
-    role: OrganizationAdminUserRole,
+    role: OrganizationUserRole,
     session: AsyncDBSession,
 ) -> dict[str, bool]:
     """Get credential status for all providers."""
@@ -149,7 +158,7 @@ async def delete_provider_credentials(
 @router.get("/default-model")
 async def get_default_model(
     *,
-    role: OrganizationAdminUserRole,
+    role: OrganizationUserRole,
     session: AsyncDBSession,
 ) -> str | None:
     """Get the organization's default AI model."""


### PR DESCRIPTION
## Summary
- Changes role requirement from `OrganizationAdminUserRole` to `OrganizationUserRole` for agent model and provider endpoints
- Allows all organization users (not just admins) to access model listings, provider listings, provider status, and default model information

## Changes
- Created new `OrganizationUserRole` type alias with `allow_user=True`, `require_workspace="no"`
- Updated role dependencies for:
  - `GET /models`
  - `GET /providers`
  - `GET /providers/status`
  - `GET /default-model`
  
  ## Testing
Verified that case chat works with a regular workspace editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Broadened access to agent model and provider read endpoints so any organization user can view models, providers, provider credential status, and the default model. Introduces OrganizationUserRole and switches the four GET routes to use it.

- **Refactors**
  - Added OrganizationUserRole RoleACL (allow_user=True, allow_service=False, require_workspace="no").
  - Updated GET /models, /providers, /providers/status, /default-model to use OrganizationUserRole instead of OrganizationAdminUserRole.

<!-- End of auto-generated description by cubic. -->

