### PR TITLE
feat(integrations): Adding SSL Verification option to all GoPhish commands

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/create_campaign.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/create_campaign.yml
@@ -18,6 +18,10 @@ definition:
       type: dict[str, Any]
       description: The body of the campaign to create. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: create_campaign
       action: core.http_request
@@ -27,4 +31,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.create_campaign.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/delete_campaign.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/delete_campaign.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the campaign to delete.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: delete_campaign
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.delete_campaign.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/get_campaign.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/get_campaign.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the campaign to get.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_campaign
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_campaign.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/get_campaign_results.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/get_campaign_results.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the campaign to get results for.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_campaign_results
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_campaign_results.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/get_campaign_summary.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/get_campaign_summary.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the campaign to get summary for.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_campaign_summary
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_campaign_summary.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/list_campaigns.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/campaigns/list_campaigns.yml
@@ -14,6 +14,10 @@ definition:
       type: str
       description: The base URL of the Gophish instance.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: list_campaigns
       action: core.http_request
@@ -22,7 +26,7 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
-
+        verify_ssl: ${{ inputs.verify_ssl }}
     # This is needed because the API will return results and timelines for all campaigns. This can exceed the max size of workflow data steps very easily. For example a campaign with 1,000 recipients will return 11,000 lines of just results, in addition to the at least 1000 timeline items which are each another 8 lines of data. Very quickly this can exceed the max size of workflow data steps.
     - ref: parse_campaigns_list
       action: core.script.run_python

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/create_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/create_group.yml
@@ -18,6 +18,10 @@ definition:
       type: dict[str, Any]
       description: The body of the group to create. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: create_group
       action: core.http_request
@@ -27,4 +31,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.create_group.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/delete_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/delete_group.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the group to delete.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: delete_group
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.delete_group.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/get_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/get_group.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the group to get.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_group
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_group.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/get_group_summary.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/get_group_summary.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the group to get.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_group_summary
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_group_summary.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/list_groups.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/list_groups.yml
@@ -14,6 +14,10 @@ definition:
       type: str
       description: The base URL of the Gophish instance.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: list_groups
       action: core.http_request
@@ -22,4 +26,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.list_groups.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/list_groups_summary.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/list_groups_summary.yml
@@ -14,6 +14,10 @@ definition:
       type: str
       description: The base URL of the Gophish instance.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: list_groups_summary
       action: core.http_request
@@ -22,4 +26,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.list_groups_summary.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/modify_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/groups/modify_group.yml
@@ -22,6 +22,10 @@ definition:
       type: dict[str, Any]
       description: The body of the group to modify. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: modify_group
       action: core.http_request
@@ -31,4 +35,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.modify_group.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/create_landing_page.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/create_landing_page.yml
@@ -18,6 +18,10 @@ definition:
       type: dict[str, Any]
       description: The body of the landing page to create. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: create_landing_page
       action: core.http_request
@@ -27,4 +31,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.create_landing_page.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/delete_landing_page.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/delete_landing_page.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the landing page to delete.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: delete_landing_page
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.delete_landing_page.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/get_landing_page.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/get_landing_page.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the landing page to get.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_landing_page
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_landing_page.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/list_landing_pages.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/list_landing_pages.yml
@@ -14,6 +14,10 @@ definition:
       type: str
       description: The base URL of the Gophish instance.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: list_landing_pages
       action: core.http_request
@@ -22,4 +26,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.list_landing_pages.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/modify_landing_page.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/landing_pages/modify_landing_page.yml
@@ -22,6 +22,10 @@ definition:
       type: dict[str, Any]
       description: The body of the landing page to modify. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: modify_landing_page
       action: core.http_request
@@ -31,4 +35,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.modify_landing_page.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/create_sending_profile.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/create_sending_profile.yml
@@ -18,6 +18,10 @@ definition:
       type: dict[str, Any]
       description: The body of the sending profile to create. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: create_sending_profile
       action: core.http_request
@@ -27,4 +31,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.create_sending_profile.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/delete_sending_profile.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/delete_sending_profile.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the sending profile to delete.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: delete_sending_profile
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.delete_sending_profile.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/get_sending_profile.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/get_sending_profile.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the sending profile to get.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_sending_profile
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_sending_profile.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/list_sending_profiles.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/list_sending_profiles.yml
@@ -14,6 +14,10 @@ definition:
       type: str
       description: The base URL of the Gophish instance.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: list_sending_profiles
       action: core.http_request
@@ -22,4 +26,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.list_sending_profiles.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/modify_sending_profile.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/sending_profiles/modify_sending_profile.yml
@@ -22,6 +22,10 @@ definition:
       type: dict[str, Any]
       description: The body of the sending profile to modify. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: modify_sending_profile
       action: core.http_request
@@ -31,4 +35,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.modify_sending_profile.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/create_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/create_template.yml
@@ -18,6 +18,10 @@ definition:
       type: dict[str, Any]
       description: The body of the template to create. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: create_template
       action: core.http_request
@@ -27,4 +31,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.create_template.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/delete_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/delete_template.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the template to delete.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: delete_template
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.delete_template.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/get_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/get_template.yml
@@ -18,6 +18,10 @@ definition:
       type: int
       description: The ID of the template to get.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: get_template
       action: core.http_request
@@ -26,4 +30,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.get_template.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/list_templates.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/list_templates.yml
@@ -14,6 +14,10 @@ definition:
       type: str
       description: The base URL of the Gophish instance.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: list_templates
       action: core.http_request
@@ -22,4 +26,5 @@ definition:
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.list_templates.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/modify_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/gophish/templates/modify_template.yml
@@ -22,6 +22,10 @@ definition:
       type: dict[str, Any]
       description: The body of the template to modify. Look at the Gophish API documentation for the expected body.
       required: true
+    verify_ssl:
+      type: bool
+      description: If False, disables SSL verification for internal networks.
+      default: true
   steps:
     - ref: modify_template
       action: core.http_request
@@ -31,4 +35,5 @@ definition:
         payload: ${{ inputs.payload }}
         headers:
           Authorization: Bearer ${{ SECRETS.gophish.GOPHISH_API_KEY }}
+        verify_ssl: ${{ inputs.verify_ssl }}
   returns: ${{ steps.modify_template.result.data }}


### PR DESCRIPTION
## Description

Updating GoPhish templates to allow users to specify verifying SSL in the HTTP request.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a verify_ssl option to all GoPhish templates so users can disable SSL verification for internal or self-hosted instances. Default is true to keep current behavior unchanged.

- **New Features**
  - Added verify_ssl input to all GoPhish commands and passed it to core.http_request.
  - Supports self-signed certs and internal networks without SSL errors.

<!-- End of auto-generated description by cubic. -->

