### PR TITLE
fix(integrations): `key` parse logic in Slack paginated APIs

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py
@@ -86,10 +86,18 @@ async def call_paginated_method(
     client = AsyncWebClient(token=bot_token)
     members = []
     params = params or {}
-    key = None
+    key = key or None
     async for page in await getattr(client, sdk_method)(**params, limit=limit):
         data = page.data
-        members.extend(data[key] if key else data)
+        if key:
+            try:
+                members.extend(data[key])
+            except KeyError:
+                raise ValueError(
+                    f"Key {key} not found in data with fields {data.keys()}"
+                )
+        else:
+            members.append(data)
     return members
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes key parsing in Slack paginated API calls to correctly collect results and provide clear errors when expected keys are missing. Prevents incorrect list building when no key is supplied.

- **Bug Fixes**
  - If a key is provided, extract data[key]; if missing, raise a ValueError with available fields.
  - If no key is provided, append the whole page data instead of extending a dict.

<!-- End of auto-generated description by cubic. -->

