### PR TITLE
fix(agent): Regression bug in non-str output type

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import uuid
 from collections.abc import AsyncGenerator, Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
-from unittest.mock import patch
 
 import aioboto3
 import pytest
@@ -14,7 +13,6 @@ import tracecat_registry.integrations.aws_boto3 as boto3_module
 from dotenv import load_dotenv
 from minio import Minio
 from minio.error import S3Error
-from pydantic import SecretStr
 from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
@@ -34,24 +32,8 @@ from tracecat.logger import logger
 from tracecat.registry.repositories.models import RegistryRepositoryCreate
 from tracecat.registry.repositories.service import RegistryReposService
 from tracecat.secrets import secrets_manager
-from tracecat.secrets.models import SecretCreate, SecretKeyValue, SecretUpdate
-from tracecat.secrets.service import SecretsService
 from tracecat.types.auth import AccessLevel, Role, system_role
 from tracecat.workspaces.service import WorkspaceService
-
-# Define Slack test skip markers
-skip_if_no_slack_token = pytest.mark.skipif(
-    not os.getenv("SLACK_BOT_TOKEN"),
-    reason="SLACK_BOT_TOKEN must be set as environment variable",
-)
-
-skip_if_no_slack_credentials = pytest.mark.skipif(
-    not os.getenv("SLACK_BOT_TOKEN") or not os.getenv("SLACK_CHANNEL_ID"),
-    reason="SLACK_BOT_TOKEN and SLACK_CHANNEL_ID must be set as environment variables",
-)
-
-# Define a reusable usefixture marker for slack tests
-requires_slack_mocks = pytest.mark.usefixtures("mock_slack_secrets")
 
 # MinIO test configuration
 MINIO_ENDPOINT = "localhost:9002"
@@ -480,86 +462,6 @@ async def svc_admin_role(svc_workspace: Workspace) -> Role:
         user_id=uuid.uuid4(),
         service_id="tracecat-api",
     )
-
-
-@pytest.fixture
-async def mock_slack_secrets():
-    """Mock the secrets.get function for slack_sdk integration.
-
-    This fixture is used by both the agent builder tests and MCP slackbot tests.
-    It mocks the secrets.get function for direct SDK access.
-    """
-    slack_token = os.getenv("SLACK_BOT_TOKEN")
-    if not slack_token:
-        pytest.skip("SLACK_BOT_TOKEN not set in environment")
-
-    with patch("tracecat_registry.integrations.slack_sdk.secrets.get") as mock_get:
-
-        def side_effect(key):
-            if key == "SLACK_BOT_TOKEN":
-                return slack_token
-            return None
-
-        mock_get.side_effect = side_effect
-        yield mock_get
-
-
-@pytest.fixture
-async def slack_secret(test_role):
-    """Create a Slack secret in the Tracecat secrets manager for testing.
-
-    This fixture creates a temporary secret in the Tracecat secrets manager that
-    can be used by tests that need to access Slack via the Tracecat service.
-    """
-    slack_token = os.getenv("SLACK_BOT_TOKEN")
-    if not slack_token:
-        pytest.skip("SLACK_BOT_TOKEN not set in environment")
-
-    async with SecretsService.with_session(role=test_role) as svc:
-        # Check if slack secret already exists
-        try:
-            existing_secret = await svc.get_secret_by_name("slack")
-            if existing_secret:
-                # Update the existing secret
-                await svc.update_secret(
-                    existing_secret,
-                    SecretUpdate(
-                        keys=[
-                            SecretKeyValue(
-                                key="SLACK_BOT_TOKEN", value=SecretStr(slack_token)
-                            )
-                        ]
-                    ),
-                )
-                yield existing_secret
-                return
-        except Exception:
-            # Secret doesn't exist, create it
-            pass
-
-        # Create the slack secret
-        await svc.create_secret(
-            SecretCreate(
-                name="slack",
-                description="Slack bot token for testing",
-                environment="default",
-                keys=[
-                    SecretKeyValue(key="SLACK_BOT_TOKEN", value=SecretStr(slack_token))
-                ],
-            )
-        )
-
-        # Get the created secret to yield it
-        created_secret = await svc.get_secret_by_name("slack")
-
-        try:
-            yield created_secret
-        finally:
-            # Clean up the secret
-            try:
-                await svc.delete_secret(created_secret)
-            except Exception as e:
-                logger.warning(f"Failed to clean up slack secret: {e}")
 
 
 # MinIO and S3 testing fixtures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -653,3 +653,79 @@ async def test_worker_factory(
         )
 
     yield create_worker
+
+
+# ---------------------------------------------------------------------------
+# 3rd party credentials
+# Loaded in either via dotenv or env vars into the mocked Tracecat secrets manager
+# ---------------------------------------------------------------------------
+
+### OpenAI
+
+
+@pytest.fixture
+def mock_openai_secrets():
+    """Set up env_sandbox with OpenAI API key from environment."""
+    openai_key = os.getenv("OPENAI_API_KEY")
+    if not openai_key:
+        pytest.skip("OPENAI_API_KEY not found in environment")
+
+    # Use env_sandbox to set up the secret in the context
+    with secrets_manager.env_sandbox({"OPENAI_API_KEY": openai_key}):
+        yield
+
+
+### Anthropic
+
+
+@pytest.fixture
+def mock_anthropic_secrets():
+    """Set up env_sandbox with Anthropic API key from environment."""
+    anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+    if not anthropic_key:
+        pytest.skip("ANTHROPIC_API_KEY not found in environment")
+
+    # Use env_sandbox to set up the secret in the context
+    with secrets_manager.env_sandbox({"ANTHROPIC_API_KEY": anthropic_key}):
+        yield
+
+
+### Bedrock
+
+
+@pytest.fixture
+def mock_bedrock_secrets():
+    """Set up env_sandbox with AWS credentials from environment for Bedrock."""
+    aws_access_key = os.getenv("AWS_ACCESS_KEY_ID")
+    aws_secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    aws_region = os.getenv("AWS_REGION", "us-east-1")
+
+    if not aws_access_key or not aws_secret_key:
+        pytest.skip(
+            "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY not found in environment"
+        )
+
+    # Use env_sandbox to set up the secrets in the context
+    with secrets_manager.env_sandbox(
+        {
+            "AWS_ACCESS_KEY_ID": aws_access_key,
+            "AWS_SECRET_ACCESS_KEY": aws_secret_key,
+            "AWS_REGION": aws_region,
+        }
+    ):
+        yield
+
+
+### Slack
+
+
+@pytest.fixture
+def mock_slack_secrets():
+    """Set up env_sandbox with Slack bot token from environment."""
+    slack_token = os.getenv("SLACK_BOT_TOKEN")
+    if not slack_token:
+        pytest.skip("SLACK_BOT_TOKEN not found in environment")
+
+    # Use env_sandbox to set up the secret in the context
+    with secrets_manager.env_sandbox({"SLACK_BOT_TOKEN": slack_token}):
+        yield

--- a/tests/registry/test_agent.py
+++ b/tests/registry/test_agent.py
@@ -39,7 +39,7 @@ def _prompt_for_output_type(output_type: Any, base_prompt: str) -> str:
     return base_prompt
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @requires_openai_mocks
 @pytest.mark.parametrize("output_type", PRIMITIVE_OUTPUT_TYPES)
 async def test_agent_primitives(output_type):
@@ -85,7 +85,7 @@ async def test_agent_primitives(output_type):
         assert all(isinstance(x, str) and x for x in output)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @requires_openai_mocks
 @pytest.mark.parametrize("output_type", JSON_SCHEMA_OUTPUT_TYPES)
 async def test_agent_json_schema(output_type):
@@ -129,7 +129,7 @@ async def test_agent_json_schema(output_type):
     assert "summary" in output and isinstance(output["summary"], str)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @requires_openai_mocks
 @pytest.mark.parametrize("output_type", PRIMITIVE_OUTPUT_TYPES)
 async def test_action_primitives(output_type):
@@ -162,7 +162,7 @@ async def test_action_primitives(output_type):
         assert all(isinstance(x, str) and x for x in output)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @requires_openai_mocks
 @pytest.mark.parametrize("output_type", JSON_SCHEMA_OUTPUT_TYPES)
 async def test_action_json_schema(output_type):

--- a/tests/registry/test_agent.py
+++ b/tests/registry/test_agent.py
@@ -1,0 +1,190 @@
+import textwrap
+from typing import Any
+
+import pytest
+from tracecat_registry.core.agent import action, agent
+
+requires_openai_mocks = pytest.mark.usefixtures("mock_openai_secrets")
+
+
+PRIMITIVE_OUTPUT_TYPES = [
+    pytest.param(None, id="default-str"),
+    pytest.param("list[str]", id="primitive-list"),
+]
+
+JSON_SCHEMA_OUTPUT_TYPES = [
+    pytest.param(
+        {
+            "name": "IncidentSummary",
+            "type": "object",
+            "description": "Summarized incident report.",
+            "properties": {
+                "summary": {"type": "string"},
+                "confidence": {"type": "number"},
+            },
+            "required": ["summary"],
+            "additionalProperties": False,
+        },
+        id="json-schema",
+    )
+]
+
+
+def _prompt_for_output_type(output_type: Any, base_prompt: str) -> str:
+    """Craft a targeted prompt to help the model satisfy the output_type."""
+    if isinstance(output_type, str) and output_type == "list[str]":
+        return f"{base_prompt} Respond only with a Python list of short strings (3-5 items)."
+    if isinstance(output_type, dict):
+        return f"{base_prompt} Respond as a JSON object with keys 'summary' and 'confidence'."
+    return base_prompt
+
+
+@pytest.mark.asyncio
+@requires_openai_mocks
+@pytest.mark.parametrize("output_type", PRIMITIVE_OUTPUT_TYPES)
+async def test_agent_primitives(output_type):
+    # Import here to avoid any accidental test-time patching/import shenanigans
+
+    user_prompt = _prompt_for_output_type(
+        output_type,
+        "Summarize the latest incident in 1-2 sentences:\n\n"
+        + textwrap.dedent("""
+        ```json
+        {
+            "title": "Latest Incident Report",
+            "summary": "Systems experienced a brief outage; services recovered within 5 minutes.",
+            "recommendations": ["Review auto-scaling thresholds", "Notify affected customers"],
+        }
+        ```
+        """),
+    )
+
+    result = await agent(
+        user_prompt=user_prompt,
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        actions=[],
+        instructions="Be concise and factual.",
+        output_type=output_type,
+        max_tools_calls=0,
+        max_requests=3,
+    )
+
+    assert isinstance(result, dict)
+    assert "output" in result
+    assert "message_history" in result
+    assert isinstance(result["message_history"], list)
+
+    output = result["output"]
+    if output_type is None:
+        assert isinstance(output, str)
+        assert len(output) > 0
+    elif output_type == "list[str]":
+        assert isinstance(output, list)
+        assert len(output) >= 1
+        assert all(isinstance(x, str) and x for x in output)
+
+
+@pytest.mark.asyncio
+@requires_openai_mocks
+@pytest.mark.parametrize("output_type", JSON_SCHEMA_OUTPUT_TYPES)
+async def test_agent_json_schema(output_type):
+    # Import here to avoid any accidental test-time patching/import shenanigans
+
+    user_prompt = _prompt_for_output_type(
+        output_type,
+        "Summarize the latest incident in 1-2 sentences:\n\n"
+        + textwrap.dedent(
+            """
+        ```json
+        {
+            "title": "Latest Incident Report",
+            "summary": "Systems experienced a brief outage; services recovered within 5 minutes.",
+            "recommendations": ["Review auto-scaling thresholds", "Notify affected customers"],
+        }
+        ```
+        """
+        ),
+    )
+
+    result = await agent(
+        user_prompt=user_prompt,
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        actions=[],
+        instructions="Be concise and factual.",
+        output_type=output_type,
+        max_tools_calls=0,
+        max_requests=3,
+    )
+
+    assert isinstance(result, dict)
+    assert "output" in result
+    assert "message_history" in result
+    assert isinstance(result["message_history"], list)
+
+    output = result["output"]
+    assert isinstance(output, dict)
+    # At minimum, the schema requires 'summary'
+    assert "summary" in output and isinstance(output["summary"], str)
+
+
+@pytest.mark.asyncio
+@requires_openai_mocks
+@pytest.mark.parametrize("output_type", PRIMITIVE_OUTPUT_TYPES)
+async def test_action_primitives(output_type):
+    user_prompt = _prompt_for_output_type(
+        output_type,
+        "Draft a brief, empathetic customer update about a resolved incident.",
+    )
+
+    result = await action(
+        user_prompt=user_prompt,
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        instructions="Be empathetic and concise.",
+        output_type=output_type,
+        max_requests=3,
+    )
+
+    assert isinstance(result, dict)
+    assert "output" in result
+    assert "message_history" in result
+    assert isinstance(result["message_history"], list)
+
+    output = result["output"]
+    if output_type is None:
+        assert isinstance(output, str)
+        assert len(output) > 0
+    elif output_type == "list[str]":
+        assert isinstance(output, list)
+        assert len(output) >= 1
+        assert all(isinstance(x, str) and x for x in output)
+
+
+@pytest.mark.asyncio
+@requires_openai_mocks
+@pytest.mark.parametrize("output_type", JSON_SCHEMA_OUTPUT_TYPES)
+async def test_action_json_schema(output_type):
+    user_prompt = _prompt_for_output_type(
+        output_type,
+        "Draft a brief, empathetic customer update about a resolved incident.",
+    )
+
+    result = await action(
+        user_prompt=user_prompt,
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        instructions="Be empathetic and concise.",
+        output_type=output_type,
+        max_requests=3,
+    )
+
+    assert isinstance(result, dict)
+    assert "output" in result
+    assert "message_history" in result
+    assert isinstance(result["message_history"], list)
+
+    output = result["output"]
+    assert isinstance(output, dict)
+    assert "summary" in output and isinstance(output["summary"], str)

--- a/tracecat/agent/parsers.py
+++ b/tracecat/agent/parsers.py
@@ -6,6 +6,9 @@ from pydantic_core import from_json
 
 
 def try_parse_json(x: Any) -> Json[Any] | str:
+    if not isinstance(x, (str, bytes)):
+        return x
+
     try:
         return orjson.loads(x)
     except orjson.JSONDecodeError:

--- a/tracecat/agent/parsers.py
+++ b/tracecat/agent/parsers.py
@@ -6,7 +6,7 @@ from pydantic_core import from_json
 
 
 def try_parse_json(x: Any) -> Json[Any] | str:
-    if not isinstance(x, (str, bytes)):
+    if not isinstance(x, (str, bytes, bytearray)):
         return x
 
     try:

--- a/tracecat/agent/runtime.py
+++ b/tracecat/agent/runtime.py
@@ -170,6 +170,24 @@ async def build_agent(
     return agent
 
 
+async def run_agent_sync(
+    agent: Agent,
+    user_prompt: str,
+    max_requests: int,
+    max_tools_calls: int | None = None,
+) -> AgentOutput:
+    start_time = timeit()
+    usage = UsageLimits(request_limit=max_requests, tool_calls_limit=max_tools_calls)
+    result = await agent.run(user_prompt, usage_limits=usage)
+    end_time = timeit()
+    return AgentOutput(
+        output=try_parse_json(result.output),
+        message_history=result.all_messages(),
+        duration=end_time - start_time,
+        usage=result.usage(),
+    )
+
+
 @observe()
 async def run_agent(
     user_prompt: str,

--- a/tracecat/agent/runtime.py
+++ b/tracecat/agent/runtime.py
@@ -1,6 +1,6 @@
 """Pydantic AI agents with tool calling."""
 
-from timeit import timeit
+from timeit import default_timer
 from typing import Any, Literal, TypeVar
 
 import orjson
@@ -187,10 +187,10 @@ async def run_agent_sync(
             f"Cannot request more than {TRACECAT__AGENT_MAX_REQUESTS} requests"
         )
 
-    start_time = timeit()
+    start_time = default_timer()
     usage = UsageLimits(request_limit=max_requests, tool_calls_limit=max_tools_calls)
     result = await agent.run(user_prompt, usage_limits=usage)
-    end_time = timeit()
+    end_time = default_timer()
     return AgentOutput(
         output=try_parse_json(result.output),
         message_history=result.all_messages(),
@@ -312,7 +312,7 @@ async def run_agent(
         base_url=base_url,
     )
 
-    start_time = timeit()
+    start_time = default_timer()
     # Set up Redis streaming if both parameters are provided
     redis_client = None
     stream_key = None
@@ -459,7 +459,7 @@ async def run_agent(
             except Exception as e:
                 logger.warning("Failed to add end-of-stream marker", error=str(e))
 
-        end_time = timeit()
+        end_time = default_timer()
         output = AgentOutput(
             output=try_parse_json(result.output),
             message_history=result.all_messages(),

--- a/tracecat/agent/runtime.py
+++ b/tracecat/agent/runtime.py
@@ -176,6 +176,17 @@ async def run_agent_sync(
     max_requests: int,
     max_tools_calls: int | None = None,
 ) -> AgentOutput:
+    """Run an agent synchronously."""
+
+    if max_tools_calls and max_tools_calls > TRACECAT__AGENT_MAX_TOOL_CALLS:
+        raise ValueError(
+            f"Cannot request more than {TRACECAT__AGENT_MAX_TOOL_CALLS} tool calls"
+        )
+    if max_requests > TRACECAT__AGENT_MAX_REQUESTS:
+        raise ValueError(
+            f"Cannot request more than {TRACECAT__AGENT_MAX_REQUESTS} requests"
+        )
+
     start_time = timeit()
     usage = UsageLimits(request_limit=max_requests, tool_calls_limit=max_tools_calls)
     result = await agent.run(user_prompt, usage_limits=usage)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes agent runtime to correctly handle structured (non-string) outputs and async execution, preventing JSON parsing errors and event loop conflicts. Adds targeted tests and simplifies secret fixtures to ensure reliable agent behavior across output types.

- Bug Fixes
  - Structured outputs: try_parse_json now returns non-str inputs as-is, avoiding TypeError when models return dict/list for JSON schema outputs.
  - Async execution: introduced async run_agent_sync that awaits agent.run; agent() and action() updated to use it, removing nested event loop issues.

- Refactors
  - Split agent creation and execution (build_agent + run_agent_sync) and return a consistent dict via AgentOutput.model_dump.
  - Tests/fixtures: added agent/action tests for primitive and JSON schema outputs; unified OpenAI/Anthropic/Bedrock/Slack fixtures using secrets_manager.env_sandbox with auto-skip when creds are missing.

<!-- End of auto-generated description by cubic. -->

