### PR TITLE
feat(integrations): Add verify_ssl to elastic integrations

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/list_detection_signals.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elastic_security/list_detection_signals.yml
@@ -27,6 +27,10 @@ definition:
     base_url:
       type: str
       description: Kibana endpoint URL (e.g. https://localhost:5601).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
   steps:
     - ref: search_query
       action: core.transform.reshape
@@ -47,6 +51,7 @@ definition:
       args:
         url: ${{ inputs.base_url }}/api/detection_engine/signals/search
         method: POST
+        verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           kbn-xsrf: kibana
           Authorization: ApiKey ${{ SECRETS.elastic_security.ELASTIC_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/get_index_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/get_index_template.yml
@@ -16,12 +16,17 @@ definition:
     template_name:
       type: str
       description: Name of the index template to retrieve.
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
   steps:
     - ref: get_index_template_request
       action: core.http_request
       args:
         url: ${{ inputs.base_url }}/_index_template/${{ inputs.template_name }}
         method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
   returns: ${{ steps.get_index_template_request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/get_mapping.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/get_mapping.yml
@@ -16,12 +16,17 @@ definition:
     index:
       type: str
       description: Name of the index to get the mapping for.
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
   steps:
     - ref: get_mapping_request
       action: core.http_request
       args:
         url: ${{ inputs.base_url }}/${{ inputs.index }}/_mapping
         method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
   returns: ${{ steps.get_mapping_request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/list_aliases.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/list_aliases.yml
@@ -13,12 +13,17 @@ definition:
     base_url:
       type: str
       description: Elasticsearch base URL (e.g. https://your-cluster.es.io:443).
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
   steps:
     - ref: list_aliases_request
       action: core.http_request
       args:
         url: ${{ inputs.base_url }}/_alias
         method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
   returns: ${{ steps.list_aliases_request.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/list_indices.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/list_indices.yml
@@ -17,12 +17,17 @@ definition:
       type: bool
       description: Whether to include column headers in the response.
       default: true
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
   steps:
     - ref: list_indices_request
       action: core.http_request
       args:
         url: ${{ inputs.base_url }}/_cat/indices
         method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
         params:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/search_events.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/elasticsearch/search_events.yml
@@ -52,12 +52,17 @@ definition:
       type: list[str]
       description: Source fields to return (improves performance, reduces data exposure).
       default: []
+    verify_ssl:
+      type: bool
+      description: Whether to verify SSL certificates.
+      default: true
   steps:
     - ref: search_request
       action: core.http_request
       args:
         url: ${{ inputs.base_url }}/${{ inputs.index }}/_search
         method: GET
+        verify_ssl: ${{ inputs.verify_ssl }}
         headers:
           Authorization: ApiKey ${{ SECRETS.elasticsearch.ELASTICSEARCH_API_KEY }}
           Content-Type: application/json


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a verify_ssl option to Elasticsearch and Elastic Security templates to control TLS certificate verification. Defaults to true for secure behavior, with the option to disable for self-signed clusters.

- New Features
  - Added verify_ssl (bool, default true) to:
    - elastic_security/list_detection_signals
    - elasticsearch/get_index_template, get_mapping, list_aliases, list_indices, search_events
  - Passed inputs.verify_ssl to core.http_request.
  - Backward compatible: behavior unchanged unless verify_ssl is set to false.

<!-- End of auto-generated description by cubic. -->

