### PR TITLE
Migrate search_records to search_rows function

### DIFF
--- a/alembic/versions/e1f2a3b4c5d6_rename_core_table_search_records_to_search_rows.py
+++ b/alembic/versions/e1f2a3b4c5d6_rename_core_table_search_records_to_search_rows.py
@@ -1,0 +1,226 @@
+"""rename_core_table_search_records_to_search_rows
+
+Revision ID: e1f2a3b4c5d6
+Revises: d8f3e9a1b2c4
+Create Date: 2025-10-08 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c5d6"
+down_revision: str | None = "d8f3e9a1b2c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Mapping of old action names to new action names
+ACTION_RENAMES = {
+    "core.table.search_records": "core.table.search_rows",
+}
+
+
+def upgrade() -> None:
+    """Rename core.table.search_records references in database to core.table.search_rows."""
+
+    # Build CASE statements for efficient single-pass updates
+    action_case_parts = []
+    for old_name, new_name in ACTION_RENAMES.items():
+        action_case_parts.append(f"WHEN '{old_name}' THEN '{new_name}'")
+    action_case_sql = "\n                ".join(action_case_parts)
+
+    # 1. Update action.type column (single query for all renames)
+    old_names_list = "', '".join(ACTION_RENAMES.keys())
+    op.execute(
+        f"""
+        UPDATE action
+        SET type = CASE type
+            {action_case_sql}
+        END
+        WHERE type IN ('{old_names_list}')
+        """
+    )
+
+    # 2. Update workflow.object column (single query for all renames)
+    # Build CASE statement for node type replacements
+    node_case_parts = []
+    for old_name, new_name in ACTION_RENAMES.items():
+        node_case_parts.append(
+            f"WHEN node_item.node->'data'->>'type' = '{old_name}' "
+            f"THEN jsonb_set(node_item.node, '{{data,type}}', '\"{new_name}\"'::jsonb)"
+        )
+    node_case_sql = "\n                            ".join(node_case_parts)
+
+    op.execute(
+        f"""
+        UPDATE workflow
+        SET object = jsonb_set(
+            object,
+            '{{nodes}}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        {node_case_sql}
+                        ELSE node_item.node
+                    END
+                    ORDER BY node_item.ord
+                )
+                FROM jsonb_array_elements(object->'nodes') WITH ORDINALITY AS node_item(node, ord)
+            )
+        )
+        WHERE object IS NOT NULL
+        AND object ? 'nodes'
+        AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(object->'nodes') AS node
+            WHERE node->'data'->>'type' IN ('{old_names_list}')
+        )
+        """
+    )
+
+    # 3. Update workflowdefinition.content column (single query for all renames)
+    # OPTIMIZATION: Only update the latest version of each workflow definition
+    # This uses workflow.version to identify which definition is current
+    action_def_case_parts = []
+    for old_name, new_name in ACTION_RENAMES.items():
+        action_def_case_parts.append(
+            f"WHEN action_item.action->>'action' = '{old_name}' "
+            f"THEN jsonb_set(action_item.action, '{{action}}', '\"{new_name}\"'::jsonb)"
+        )
+    action_def_case_sql = "\n                            ".join(action_def_case_parts)
+
+    op.execute(
+        f"""
+        UPDATE workflowdefinition wd
+        SET content = jsonb_set(
+            content,
+            '{{actions}}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        {action_def_case_sql}
+                        ELSE action_item.action
+                    END
+                    ORDER BY action_item.ord
+                )
+                FROM jsonb_array_elements(content->'actions') WITH ORDINALITY AS action_item(action, ord)
+            )
+        )
+        FROM workflow w
+        WHERE wd.workflow_id = w.id
+        AND wd.version = w.version
+        AND wd.content IS NOT NULL
+        AND wd.content ? 'actions'
+        AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(wd.content->'actions') AS action
+            WHERE action->>'action' IN ('{old_names_list}')
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Revert core.table.search_rows back to core.table.search_records."""
+
+    # Reverse the mapping for downgrade
+    reverse_mapping = {new: old for old, new in ACTION_RENAMES.items()}
+
+    # Build CASE statements for efficient single-pass updates
+    action_case_parts = []
+    for new_name, old_name in reverse_mapping.items():
+        action_case_parts.append(f"WHEN '{new_name}' THEN '{old_name}'")
+    action_case_sql = "\n                ".join(action_case_parts)
+
+    # 1. Update action.type column (single query for all renames)
+    new_names_list = "', '".join(reverse_mapping.keys())
+    op.execute(
+        f"""
+        UPDATE action
+        SET type = CASE type
+            {action_case_sql}
+        END
+        WHERE type IN ('{new_names_list}')
+        """
+    )
+
+    # 2. Update workflow.object column (single query for all renames)
+    # Build CASE statement for node type replacements
+    node_case_parts = []
+    for new_name, old_name in reverse_mapping.items():
+        node_case_parts.append(
+            f"WHEN node_item.node->'data'->>'type' = '{new_name}' "
+            f"THEN jsonb_set(node_item.node, '{{data,type}}', '\"{old_name}\"'::jsonb)"
+        )
+    node_case_sql = "\n                            ".join(node_case_parts)
+
+    op.execute(
+        f"""
+        UPDATE workflow
+        SET object = jsonb_set(
+            object,
+            '{{nodes}}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        {node_case_sql}
+                        ELSE node_item.node
+                    END
+                    ORDER BY node_item.ord
+                )
+                FROM jsonb_array_elements(object->'nodes') WITH ORDINALITY AS node_item(node, ord)
+            )
+        )
+        WHERE object IS NOT NULL
+        AND object ? 'nodes'
+        AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(object->'nodes') AS node
+            WHERE node->'data'->>'type' IN ('{new_names_list}')
+        )
+        """
+    )
+
+    # 3. Update workflowdefinition.content column (single query for all renames)
+    # OPTIMIZATION: Only update the latest version of each workflow definition
+    action_def_case_parts = []
+    for new_name, old_name in reverse_mapping.items():
+        action_def_case_parts.append(
+            f"WHEN action_item.action->>'action' = '{new_name}' "
+            f"THEN jsonb_set(action_item.action, '{{action}}', '\"{old_name}\"'::jsonb)"
+        )
+    action_def_case_sql = "\n                            ".join(action_def_case_parts)
+
+    op.execute(
+        f"""
+        UPDATE workflowdefinition wd
+        SET content = jsonb_set(
+            content,
+            '{{actions}}',
+            (
+                SELECT jsonb_agg(
+                    CASE
+                        {action_def_case_sql}
+                        ELSE action_item.action
+                    END
+                    ORDER BY action_item.ord
+                )
+                FROM jsonb_array_elements(content->'actions') WITH ORDINALITY AS action_item(action, ord)
+            )
+        )
+        FROM workflow w
+        WHERE wd.workflow_id = w.id
+        AND wd.version = w.version
+        AND wd.content IS NOT NULL
+        AND wd.content ? 'actions'
+        AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(wd.content->'actions') AS action
+            WHERE action->>'action' IN ('{new_names_list}')
+        )
+        """
+    )
+


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)? (N/A for migration, but migration logic should be tested manually)
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds a new Alembic migration to rename `core.table.search_records` to `core.table.search_rows`. This is necessary to prevent breaking changes in existing workflow definitions and content following the action rename.

The migration updates references in:
- `action.type` column.
- `workflow.object` JSONB field (specifically `nodes`' `data.type`).
- `workflowdefinition.content` JSONB field (specifically `actions`' `action` field).

It uses `CASE` statements and `jsonb_set` for efficient, targeted updates in both `upgrade` and `downgrade` functions.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1.  Ensure you have existing workflows or actions that use `core.table.search_records`. If not, create one.
2.  Run `alembic upgrade head` to apply the migration.
3.  Verify that `action.type` entries, `workflow.object` node types, and `workflowdefinition.content` action fields have been updated from `core.table.search_records` to `core.table.search_rows`.
4.  Run `alembic downgrade -1` to revert the migration.
5.  Verify that the changes are reverted, i.e., `core.table.search_rows` is changed back to `core.table.search_records` in the affected columns.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ee3ff1c-89b6-44ef-b34d-30d5bc5b9d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ee3ff1c-89b6-44ef-b34d-30d5bc5b9d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

