### PR TITLE
Use short time display for case timestamps

### DIFF
--- a/frontend/src/components/cases/case-table-columns.tsx
+++ b/frontend/src/components/cases/case-table-columns.tsx
@@ -2,7 +2,7 @@
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import type { ColumnDef } from "@tanstack/react-table"
-import { format, formatDistanceToNow } from "date-fns"
+import { format } from "date-fns"
 import fuzzysort from "fuzzysort"
 import type { CaseReadMinimal } from "@/client"
 import { CaseBadge } from "@/components/cases/case-badge"
@@ -31,7 +31,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { User } from "@/lib/auth"
-import { capitalizeFirst } from "@/lib/utils"
+import { capitalizeFirst, shortTimeAgo } from "@/lib/utils"
 
 const NO_DATA = "--" as const
 
@@ -177,18 +177,16 @@ export function createColumns(
         const dt = new Date(
           row.getValue<CaseReadMinimal["created_at"]>("created_at")
         )
-        const timeAgo = capitalizeFirst(
-          formatDistanceToNow(dt, { addSuffix: true })
-        )
+        const shortTime = capitalizeFirst(shortTimeAgo(dt))
         const fullDateTime = format(dt, "PPpp") // e.g. "Apr 13, 2024, 2:30 PM EDT"
 
         return (
           <Tooltip>
             <TooltipTrigger>
-              <span className="truncate text-xs">{fullDateTime}</span>
+              <span className="truncate text-xs">{shortTime}</span>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{timeAgo}</p>
+              <p>{fullDateTime}</p>
             </TooltipContent>
           </Tooltip>
         )
@@ -208,18 +206,16 @@ export function createColumns(
         const dt = new Date(
           row.getValue<CaseReadMinimal["updated_at"]>("updated_at")
         )
-        const timeAgo = capitalizeFirst(
-          formatDistanceToNow(dt, { addSuffix: true })
-        )
+        const shortTime = capitalizeFirst(shortTimeAgo(dt))
         const fullDateTime = format(dt, "PPpp") // e.g. "Apr 13, 2024, 2:30 PM EDT"
 
         return (
           <Tooltip>
             <TooltipTrigger>
-              <span className="truncate text-xs">{fullDateTime}</span>
+              <span className="truncate text-xs">{shortTime}</span>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{timeAgo}</p>
+              <p>{fullDateTime}</p>
             </TooltipContent>
           </Tooltip>
         )


### PR DESCRIPTION
## Summary
- use the shared shortTimeAgo helper to display concise timestamps in the case table
- retain the full formatted timestamp in the tooltip for additional context

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6c6135658833391101fc201a9adc6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch case table timestamps to a short relative format using shortTimeAgo for Created and Updated columns, and move the full formatted date to the tooltip. This reduces visual noise and makes the table easier to scan.

<!-- End of auto-generated description by cubic. -->

