### PR TITLE
fix(agents): Add transfer-encoding and content-encoding headers

### DIFF
--- a/tracecat/chat/router.py
+++ b/tracecat/chat/router.py
@@ -263,12 +263,16 @@ async def chat_with_vercel_streaming(
         )
 
         # Create stream and return with Vercel format
+        # https://ai-sdk.dev/docs/troubleshooting/streaming-not-working-when-deployed
+        # https://ai-sdk.dev/docs/troubleshooting/streaming-not-working-when-proxied
         stream = AgentStream(await get_redis_client(), chat_id)
         return StreamingResponse(
             stream.sse(http_request, last_id=start_id, format="vercel"),
             media_type="text/event-stream",
             headers={
+                "Transfer-Encoding": "chunked",
                 "Cache-Control": "no-cache",
+                "Content-Encoding": "none",
                 "Connection": "keep-alive",
                 "X-Accel-Buffering": "no",  # Disable nginx buffering
                 "x-vercel-ai-ui-message-stream": "v1",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ensure Vercel SSE streaming works in production and behind proxies by adding Transfer-Encoding: chunked and Content-Encoding: none to the StreamingResponse headers. This prevents proxy buffering/compression that previously broke live updates.

<!-- End of auto-generated description by cubic. -->

