### PR TITLE
perf: Increase ray and worker execution timeouts

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -23,11 +23,13 @@ TRACECAT__EXECUTOR_URL = os.environ.get(
     "TRACECAT__EXECUTOR_URL", "http://executor:8000"
 )
 TRACECAT__EXECUTOR_CLIENT_TIMEOUT = float(
-    os.environ.get("TRACECAT__EXECUTOR_CLIENT_TIMEOUT") or 120.0
+    os.environ.get("TRACECAT__EXECUTOR_CLIENT_TIMEOUT") or 900.0
 )
-"""Timeout for the executor client in seconds (default 120s).
+"""Timeout for the executor client in seconds (default 900s).
 
 The `httpx.Client` default is 5s, which doesn't work for long-running actions.
+This value is also used when waiting for Ray task execution so the outbound
+client timeout and Ray task await timeout remain aligned.
 """
 TRACECAT__LOOP_MAX_BATCH_SIZE = int(os.environ.get("TRACECAT__LOOP_MAX_BATCH_SIZE", 64))
 """Maximum number of parallel requests to the worker service."""
@@ -180,11 +182,11 @@ TEMPORAL__CLUSTER_QUEUE = os.environ.get(
 )
 TEMPORAL__API_KEY__ARN = os.environ.get("TEMPORAL__API_KEY__ARN")
 TEMPORAL__API_KEY = os.environ.get("TEMPORAL__API_KEY")
-TEMPORAL__CLIENT_RPC_TIMEOUT = os.environ.get("TEMPORAL__CLIENT_RPC_TIMEOUT")
-"""RPC timeout for Temporal workflows in seconds."""
+TEMPORAL__CLIENT_RPC_TIMEOUT = os.environ.get("TEMPORAL__CLIENT_RPC_TIMEOUT") or "900"
+"""RPC timeout for Temporal workflows in seconds (default 900 seconds)."""
 
-TEMPORAL__TASK_TIMEOUT = os.environ.get("TEMPORAL__TASK_TIMEOUT")
-"""Temporal workflow task timeout in seconds (default 10 seconds)."""
+TEMPORAL__TASK_TIMEOUT = os.environ.get("TEMPORAL__TASK_TIMEOUT") or "900"
+"""Temporal workflow task timeout in seconds (default 900 seconds)."""
 
 TEMPORAL__METRICS_PORT = os.environ.get("TEMPORAL__METRICS_PORT")
 """Port for the Temporal metrics server."""

--- a/tracecat/executor/engine.py
+++ b/tracecat/executor/engine.py
@@ -7,7 +7,6 @@ import ray
 from tracecat import config
 from tracecat.logger import logger
 
-EXECUTION_TIMEOUT = 300
 DEFAULT_NUM_WORKERS = min(os.cpu_count() or 8, 8)
 
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -33,7 +33,6 @@ from tracecat.dsl.models import (
     RunActionInput,
     TaskResult,
 )
-from tracecat.executor.engine import EXECUTION_TIMEOUT
 from tracecat.executor.models import DispatchActionContext, ExecutorActionErrorInfo
 from tracecat.expressions.common import ExprContext, ExprOperand
 from tracecat.expressions.eval import (
@@ -539,7 +538,9 @@ async def run_action_on_ray_cluster(
     obj_ref = run_action_task.options(runtime_env=runtime_env).remote(input, ctx.role)
     try:
         coro = asyncio.to_thread(ray.get, obj_ref)
-        exec_result = await asyncio.wait_for(coro, timeout=EXECUTION_TIMEOUT)
+        exec_result = await asyncio.wait_for(
+            coro, timeout=config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT
+        )
     except TimeoutError as e:
         logger.error("Action timed out, cancelling task", error=e)
         ray.cancel(obj_ref, force=True)


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
We need this for long running AI agents.

## Summary by cubic
Raised default execution timeouts to 900 seconds and clarified that the executor client timeout also controls Ray task await time. This aligns components and removes the hardcoded executor timeout to meet the “increase task execution timeouts to 900 seconds” requirement.

- **Refactors**
  - Set TRACECAT__EXECUTOR_CLIENT_TIMEOUT default to 900s; docstring notes it governs Ray task waits.
  - Use config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT for Ray task wait; removed EXECUTION_TIMEOUT constant.
  - Set Temporal CLIENT_RPC_TIMEOUT and TASK_TIMEOUT defaults to 900s; updated docstrings.

<!-- End of auto-generated description by cubic. -->

