### PR TITLE
codex(proposal): similar and merged cases

### DIFF
--- a/alembic/versions/6b2c2f9565da_add_case_relations_and_merges.py
+++ b/alembic/versions/6b2c2f9565da_add_case_relations_and_merges.py
@@ -1,0 +1,104 @@
+"""Add case relations and merges tables
+
+Revision ID: 6b2c2f9565da
+Revises: c2a4f8a5cf72, f04f005837c9
+Create Date: 2025-10-15 12:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6b2c2f9565da"
+down_revision: tuple[str, ...] | str | None = ("c2a4f8a5cf72", "f04f005837c9")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "case_relations",
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column("owner_id", sqlmodel.sql.sqltypes.GUID(), nullable=False),
+        sa.Column("case_id", sa.UUID(), nullable=False),
+        sa.Column("related_case_id", sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["related_case_id"], ["cases.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.CheckConstraint("case_id <> related_case_id", name="ck_case_relations_no_self"),
+        sa.CheckConstraint("case_id < related_case_id", name="ck_case_relations_ordered"),
+        sa.UniqueConstraint("case_id", "related_case_id", name="uq_case_relations_pair"),
+    )
+    op.create_index(
+        "ix_case_relations_case_id",
+        "case_relations",
+        ["case_id"],
+    )
+    op.create_index(
+        "ix_case_relations_related_case_id",
+        "case_relations",
+        ["related_case_id"],
+    )
+
+    op.create_table(
+        "case_merges",
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column("owner_id", sqlmodel.sql.sqltypes.GUID(), nullable=False),
+        sa.Column("primary_case_id", sa.UUID(), nullable=False),
+        sa.Column("merged_case_id", sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(["primary_case_id"], ["cases.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["merged_case_id"], ["cases.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.CheckConstraint("primary_case_id <> merged_case_id", name="ck_case_merges_no_self"),
+        sa.UniqueConstraint("merged_case_id", name="uq_case_merges_secondary"),
+        sa.UniqueConstraint(
+            "primary_case_id", "merged_case_id", name="uq_case_merges_pair"
+        ),
+    )
+    op.create_index(
+        "ix_case_merges_primary_case_id",
+        "case_merges",
+        ["primary_case_id"],
+    )
+    op.create_index(
+        "ix_case_merges_merged_case_id",
+        "case_merges",
+        ["merged_case_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_case_merges_merged_case_id", table_name="case_merges")
+    op.drop_index("ix_case_merges_primary_case_id", table_name="case_merges")
+    op.drop_table("case_merges")
+    op.drop_index("ix_case_relations_related_case_id", table_name="case_relations")
+    op.drop_index("ix_case_relations_case_id", table_name="case_relations")
+    op.drop_table("case_relations")

--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -8,3 +8,12 @@ title: Overview
 
 The REST API provides programmatic access to Tracecat data and functionality.
 Run and manage workflows, create and manage secrets, all via the API.
+
+## Case relations and merges
+
+The cases API now exposes dedicated endpoints for managing relational workflows:
+
+- `POST /cases/{case_id}/similar` and `DELETE /cases/{case_id}/similar/{related_case_id}` to annotate two records as similar.
+- `POST /cases/{case_id}/merge` and `DELETE /cases/{case_id}/merge/{merged_case_id}` to fold duplicate investigations into a single primary.
+
+Merged cases inherit their primary's lifecycle. By default, listing endpoints hide merged secondaries—pass the `include_merged=true` query parameter to surface them when required.

--- a/tests/unit/test_case_relations.py
+++ b/tests/unit/test_case_relations.py
@@ -1,0 +1,82 @@
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.models import CaseCreate, CaseUpdate
+from tracecat.cases.service import CasesService
+from tracecat.types.auth import Role
+from tracecat.types.exceptions import TracecatException
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def cases_service(session: AsyncSession, svc_role: Role) -> CasesService:
+    return CasesService(session=session, role=svc_role)
+
+
+@pytest.fixture
+def case_params() -> CaseCreate:
+    return CaseCreate(
+        summary="Case",
+        description="Test",
+        status=CaseStatus.NEW,
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.MEDIUM,
+    )
+
+
+@pytest.mark.anyio
+async def test_similar_case_relationship(cases_service: CasesService, case_params: CaseCreate) -> None:
+    primary = await cases_service.create_case(case_params)
+    other_params = case_params.model_copy(update={"summary": "Case B"})
+    secondary = await cases_service.create_case(other_params)
+
+    await cases_service.add_similar_case(primary.id, secondary.id)
+
+    similar_cases, merged_cases, merged_into = await cases_service.get_case_relations(primary.id)
+    assert merged_cases == []
+    assert merged_into is None
+    assert {case.id for case in similar_cases} == {secondary.id}
+
+    await cases_service.remove_similar_case(primary.id, secondary.id)
+    similar_cases, _, _ = await cases_service.get_case_relations(primary.id)
+    assert similar_cases == []
+
+
+@pytest.mark.anyio
+async def test_merge_case_cascades_status(cases_service: CasesService, case_params: CaseCreate) -> None:
+    primary = await cases_service.create_case(case_params)
+    secondary_params = case_params.model_copy(update={"summary": "Secondary"})
+    secondary = await cases_service.create_case(secondary_params)
+
+    primary_obj = await cases_service.get_case(primary.id)
+    assert primary_obj is not None
+    await cases_service.update_case(primary_obj, CaseUpdate(status=CaseStatus.IN_PROGRESS))
+
+    await cases_service.merge_case(primary.id, secondary.id)
+
+    _, merged_cases, _ = await cases_service.get_case_relations(primary.id)
+    assert {case.id for case in merged_cases} == {secondary.id}
+
+    merged_primary = await cases_service.get_case(primary.id)
+    merged_secondary = await cases_service.get_case(secondary.id)
+    assert merged_primary is not None
+    assert merged_secondary is not None
+    assert merged_secondary.status == merged_primary.status == CaseStatus.IN_PROGRESS
+
+    merged_primary = await cases_service.get_case(primary.id)
+    assert merged_primary is not None
+    await cases_service.update_case(merged_primary, CaseUpdate(status=CaseStatus.CLOSED))
+
+    refreshed_secondary = await cases_service.get_case(secondary.id)
+    assert refreshed_secondary is not None
+    assert refreshed_secondary.status == CaseStatus.CLOSED
+
+    with pytest.raises(TracecatException):
+        secondary_obj = await cases_service.get_case(secondary.id)
+        assert secondary_obj is not None
+        await cases_service.update_case(
+            secondary_obj,
+            CaseUpdate(status=CaseStatus.NEW),
+        )

--- a/tracecat/cases/models.py
+++ b/tracecat/cases/models.py
@@ -27,6 +27,16 @@ class CaseReadMinimal(BaseModel):
     severity: CaseSeverity
     assignee: UserRead | None = None
     tags: list[CaseTagRead] = Field(default_factory=list)
+    merged_case_count: int = 0
+    merged_into_case_id: uuid.UUID | None = None
+    is_merged: bool = False
+
+
+class CaseRelationSummary(BaseModel):
+    id: uuid.UUID
+    short_id: str
+    summary: str
+    status: CaseStatus
 
 
 class CaseRead(BaseModel):
@@ -43,6 +53,9 @@ class CaseRead(BaseModel):
     assignee: UserRead | None = None
     payload: dict[str, Any] | None
     tags: list[CaseTagRead] = Field(default_factory=list)
+    similar_cases: list[CaseRelationSummary] = Field(default_factory=list)
+    merged_cases: list[CaseRelationSummary] = Field(default_factory=list)
+    merged_into_case: CaseRelationSummary | None = None
 
 
 class CaseCreate(BaseModel):
@@ -127,6 +140,14 @@ class CaseCommentCreate(BaseModel):
 class CaseCommentUpdate(BaseModel):
     content: str | None = Field(default=None, min_length=1, max_length=5_000)
     parent_id: uuid.UUID | None = Field(default=None)
+
+
+class CaseRelationMutation(BaseModel):
+    related_case_id: uuid.UUID
+
+
+class CaseMergeMutation(BaseModel):
+    target_case_id: uuid.UUID
 
 
 # Case Events


### PR DESCRIPTION
## Summary
- add ORM schemas and migration for case relations and merge tracking
- extend case service and API to manage similar/merged cases with cascade status handling and filtering
- document the new endpoints and add unit tests covering relation and merge workflows

## Testing
- pytest tests/unit/test_case_relations.py *(fails: ModuleNotFoundError: No module named 'tracecat_registry')*

------
https://chatgpt.com/codex/tasks/task_e_68e97a29d66c83339b1e444c733f933d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds case-to-case relations and merge workflows to the Cases API. You can mark cases as similar, merge duplicates into a primary with status cascading, and control visibility of merged cases in listings.

- **New Features**
  - Added case_relations and case_merges tables with constraints and indexes (Alembic migration).
  - New endpoints: POST/DELETE /cases/{id}/similar and POST/DELETE /cases/{id}/merge (includes unmerge).
  - Listing and search exclude merged secondaries by default; pass include_merged=true to show them.
  - Case reads now include relation summaries: similar_cases, merged_cases, merged_into_case; minimal reads add merged_case_count, merged_into_case_id, is_merged.
  - Service enforces rules: no self-relations, uniqueness, prevent status changes on merged secondaries, and cascades primary status to merged cases; short_id falls back to UUID when case_number is missing.
  - Docs updated; unit tests cover relation and merge workflows.

- **Migration**
  - Run Alembic upgrade to create new tables.
  - No breaking API changes; visibility of merged cases is opt-in via include_merged=true.
  - Note: merged secondaries’ status is read-only; unmerge to edit their status.

<!-- End of auto-generated description by cubic. -->

