### PR TITLE
feat(integrations): Hybrid Analysis and Any.run

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/anyrun/get_analysis.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/anyrun/get_analysis.yml
@@ -1,0 +1,26 @@
+type: action
+definition:
+  title: Get analysis
+  description: Retrieve details for an ANY.RUN analysis by ID.
+  display_group: ANY.RUN
+  doc_url: https://any.run/api-documentation/#tag/analysis/GET/v1/analysis/{analysis_id}
+  namespace: tools.anyrun
+  name: get_analysis
+  secrets:
+    - name: anyrun
+      keys:
+        - ANYRUN_API_KEY
+  expects:
+    analysis_id:
+      type: str
+      description: Identifier of the analysis task.
+  steps:
+    - ref: get_analysis
+      action: core.http_request
+      args:
+        url: https://api.any.run/v1/analysis/${{ FN.url_encode(inputs.analysis_id) }}
+        method: GET
+        headers:
+          Accept: application/json
+          X-API-Key: ${{ SECRETS.anyrun.ANYRUN_API_KEY }}
+  returns: ${{ steps.get_analysis.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/anyrun/list_analyses.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/anyrun/list_analyses.yml
@@ -1,0 +1,39 @@
+type: action
+definition:
+  title: List analyses
+  description: List ANY.RUN analyses with optional status filtering.
+  display_group: ANY.RUN
+  doc_url: https://any.run/api-documentation/#tag/analysis/GET/v1/analysis/
+  namespace: tools.anyrun
+  name: list_analyses
+  secrets:
+    - name: anyrun
+      keys:
+        - ANYRUN_API_KEY
+  expects:
+    status:
+      type: str
+      description: Optional analysis status to filter by (e.g. finished, running).
+      required: false
+    limit:
+      type: int
+      description: Maximum number of analyses to return.
+      default: 50
+    offset:
+      type: int
+      description: Pagination offset.
+      default: 0
+  steps:
+    - ref: list_analyses
+      action: core.http_request
+      args:
+        url: https://api.any.run/v1/analysis
+        method: GET
+        headers:
+          Accept: application/json
+          X-API-Key: ${{ SECRETS.anyrun.ANYRUN_API_KEY }}
+        params:
+          status: ${{ inputs.status }}
+          limit: ${{ inputs.limit }}
+          offset: ${{ inputs.offset }}
+  returns: ${{ steps.list_analyses.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/anyrun/submit_analysis.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/anyrun/submit_analysis.yml
@@ -1,0 +1,45 @@
+type: action
+definition:
+  title: Submit analysis
+  description: Create an ANY.RUN analysis task for a file hash, URL, or file reference.
+  display_group: ANY.RUN
+  doc_url: https://any.run/api-documentation/#tag/analysis/POST/v1/analysis/
+  namespace: tools.anyrun
+  name: submit_analysis
+  secrets:
+    - name: anyrun
+      keys:
+        - ANYRUN_API_KEY
+  expects:
+    object_type:
+      type: str
+      description: Type of object to analyze (url, hash, or file).
+      enum: [url, hash, file]
+      default: url
+    object_value:
+      type: str
+      description: Value of the object to analyze (URL, hash, or file UUID).
+    platform:
+      type: str
+      description: Execution environment to use (e.g. win10).
+      default: win10
+    interactive:
+      type: bool
+      description: Whether to run the analysis in interactive mode.
+      default: false
+  steps:
+    - ref: submit_analysis
+      action: core.http_request
+      args:
+        url: https://api.any.run/v1/analysis
+        method: POST
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+          X-API-Key: ${{ SECRETS.anyrun.ANYRUN_API_KEY }}
+        payload:
+          object_type: ${{ inputs.object_type }}
+          object: ${{ inputs.object_value }}
+          platform: ${{ inputs.platform }}
+          interactive: ${{ inputs.interactive }}
+  returns: ${{ steps.submit_analysis.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/hybrid_analysis/get_report_summary.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/hybrid_analysis/get_report_summary.yml
@@ -1,0 +1,27 @@
+type: action
+definition:
+  title: Get report summary
+  description: Retrieve a Hybrid Analysis report summary by report ID.
+  display_group: Hybrid Analysis
+  doc_url: https://hybrid-analysis.com/docs/api/v2#/Report/get_report__report_id__summary
+  namespace: tools.hybrid_analysis
+  name: get_report_summary
+  secrets:
+    - name: hybrid_analysis
+      keys:
+        - HYBRID_ANALYSIS_API_KEY
+  expects:
+    report_id:
+      type: str
+      description: Hybrid Analysis report identifier (e.g. SHA256 or submission ID).
+  steps:
+    - ref: get_summary
+      action: core.http_request
+      args:
+        url: https://www.hybrid-analysis.com/api/v2/report/${{ FN.url_encode(inputs.report_id) }}/summary
+        method: GET
+        headers:
+          accept: application/json
+          api-key: ${{ SECRETS.hybrid_analysis.HYBRID_ANALYSIS_API_KEY }}
+          user-agent: Tracecat
+  returns: ${{ steps.get_summary.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/hybrid_analysis/search_hash.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/hybrid_analysis/search_hash.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Search hash
+  description: Search Hybrid Analysis for a file hash and return matching submissions.
+  display_group: Hybrid Analysis
+  doc_url: https://hybrid-analysis.com/docs/api/v2#/Search/post_search_hash
+  namespace: tools.hybrid_analysis
+  name: search_hash
+  secrets:
+    - name: hybrid_analysis
+      keys:
+        - HYBRID_ANALYSIS_API_KEY
+  expects:
+    hash:
+      type: str
+      description: File hash to search for.
+  steps:
+    - ref: search_hash
+      action: core.http_request
+      args:
+        url: https://www.hybrid-analysis.com/api/v2/search/hash
+        method: POST
+        headers:
+          accept: application/json
+          api-key: ${{ SECRETS.hybrid_analysis.HYBRID_ANALYSIS_API_KEY }}
+          user-agent: Tracecat
+        form_data:
+          hash: ${{ inputs.hash }}
+  returns: ${{ steps.search_hash.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/hybrid_analysis/submit_url.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/hybrid_analysis/submit_url.yml
@@ -1,0 +1,54 @@
+type: action
+definition:
+  title: Submit URL for analysis
+  description: Submit a URL to Hybrid Analysis for detonation and wait for the report summary.
+  display_group: Hybrid Analysis
+  doc_url: https://hybrid-analysis.com/docs/api/v2#/Submission/post_submit_url
+  namespace: tools.hybrid_analysis
+  name: submit_url
+  secrets:
+    - name: hybrid_analysis
+      keys:
+        - HYBRID_ANALYSIS_API_KEY
+  expects:
+    url:
+      type: str
+      description: URL to submit for analysis.
+    environment_id:
+      type: int
+      description: Execution environment ID (e.g. 160 for Windows 10 64-bit).
+      default: 160
+    no_share:
+      type: bool
+      description: Whether to prevent sharing the submission with the community.
+      default: true
+  steps:
+    - ref: submit_url
+      action: core.http_request
+      args:
+        url: https://www.hybrid-analysis.com/api/v2/submit/url
+        method: POST
+        headers:
+          accept: application/json
+          api-key: ${{ SECRETS.hybrid_analysis.HYBRID_ANALYSIS_API_KEY }}
+          user-agent: Tracecat
+        form_data:
+          url: ${{ inputs.url }}
+          environment_id: ${{ inputs.environment_id }}
+          no_share_third_party: ${{ inputs.no_share }}
+    - ref: get_report_summary
+      action: core.http_poll
+      args:
+        url: https://www.hybrid-analysis.com/api/v2/report/${{ FN.url_encode(steps.submit_url.result.data.sha256) }}/summary
+        method: GET
+        headers:
+          accept: application/json
+          api-key: ${{ SECRETS.hybrid_analysis.HYBRID_ANALYSIS_API_KEY }}
+          user-agent: Tracecat
+        poll_retry_codes:
+          - 404
+        poll_wait_seconds: 10
+        poll_timeout_seconds: 600
+  returns:
+    submission: ${{ steps.submit_url.result.data }}
+    summary: ${{ steps.get_report_summary.result.data }}


### PR DESCRIPTION
## Summary
- URL-encode dynamic Hybrid Analysis report identifiers before polling for summaries
- URL-encode ANY.RUN analysis IDs when building request paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eead1e1fc48333a4c62a0ee27240a9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds ANY.RUN and Hybrid Analysis integration templates and URL-encodes dynamic IDs in request paths. This prevents failures when IDs include special characters and enables submitting, listing, and fetching analyses.

- **New Features**
  - ANY.RUN: list_analyses, submit_analysis, get_analysis.
  - Hybrid Analysis: submit_url (with summary polling), search_hash, get_report_summary.

- **Bug Fixes**
  - URL-encode Hybrid Analysis report_id in get_report_summary and submit_url polling.
  - URL-encode ANY.RUN analysis_id in get_analysis.

<!-- End of auto-generated description by cubic. -->

