### PR TITLE
feat(agents): Improve LLM streaming failure message in ai actions

### DIFF
--- a/tracecat/agent/executor/aio.py
+++ b/tracecat/agent/executor/aio.py
@@ -31,7 +31,11 @@ class AioAgentRunHandle[T](BaseAgentRunHandle[T]):
     async def result(self) -> T:
         res = await self._task
         if res is None:
-            raise RuntimeError("Streaming agent run did not complete successfully.")
+            raise RuntimeError(
+                "Streaming agent run did not complete successfully. The selected "
+                "model may not support streaming responses. Try switching to a "
+                "model with streaming support or disable streaming."
+            )
         return res
 
     async def cancel(self) -> None:

--- a/tracecat/agent/runtime.py
+++ b/tracecat/agent/runtime.py
@@ -181,7 +181,9 @@ async def run_agent(
         result = await handle.result()
         if result is None:
             raise RuntimeError(
-                "Action: Streaming agent run did not complete successfully."
+                "Action: Streaming agent run did not complete successfully. The "
+                "selected model may not support streaming responses. Try switching "
+                "to a model with streaming support or disable streaming."
             )
         end_time = default_timer()
         return AgentOutput(


### PR DESCRIPTION
## Summary
- clarify the runtime error returned when a streaming agent run completes with no result
- mention that the selected model may not support streaming and suggest next steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef073d13ac833394c098c5a7bef661
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the streaming agent failure message to clearly explain why a run may return no result and how to fix it. The error now notes when the selected model doesn’t support streaming and suggests switching to a streaming-capable model or disabling streaming.

<!-- End of auto-generated description by cubic. -->

