### PR TITLE
feat(agents): Add TLS support for agent connections

### DIFF
--- a/tracecat/agent/models.py
+++ b/tracecat/agent/models.py
@@ -29,6 +29,21 @@ class StreamingAgentDeps(Protocol):
 
 
 @dataclass(kw_only=True, slots=True)
+class AgentTLSConfig:
+    """TLS client configuration for providers and MCP connections."""
+
+    client_cert: str | None = None
+    client_key: str | None = None
+    client_key_password: str | None = None
+
+    def is_configured(self) -> bool:
+        return any(
+            value
+            for value in (self.client_cert, self.client_key, self.client_key_password)
+        )
+
+
+@dataclass(kw_only=True, slots=True)
 class AgentConfig:
     """Configuration for an agent."""
 
@@ -49,6 +64,7 @@ class AgentConfig:
     model_settings: dict[str, Any] | None = None
     retries: int = 3
     deps_type: type[StreamingAgentDeps] | type[None] | None = None
+    tls_config: AgentTLSConfig | None = None
 
 
 class RunAgentArgs(BaseModel):

--- a/tracecat/agent/providers.py
+++ b/tracecat/agent/providers.py
@@ -1,3 +1,4 @@
+import httpx
 import orjson
 from google.oauth2 import service_account
 from pydantic_ai.models import Model
@@ -15,7 +16,10 @@ from tracecat_registry.integrations.aws_boto3 import get_sync_session
 
 
 def get_model(
-    model_name: str, model_provider: str, base_url: str | None = None
+    model_name: str,
+    model_provider: str,
+    base_url: str | None = None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> Model:
     """Get a pydantic-ai Model instance for the specified provider and model.
 
@@ -45,31 +49,40 @@ def get_model(
                 provider=OpenAIProvider(
                     base_url=effective_base_url,
                     api_key=secrets.get_or_default("CUSTOM_MODEL_PROVIDER_API_KEY"),
+                    http_client=http_client,
                 ),
             )
         case "openai":
             model = OpenAIChatModel(
                 model_name=model_name,
                 provider=OpenAIProvider(
-                    base_url=base_url, api_key=secrets.get("OPENAI_API_KEY")
+                    base_url=base_url,
+                    api_key=secrets.get("OPENAI_API_KEY"),
+                    http_client=http_client,
                 ),
             )
         case "ollama":
             model = OpenAIChatModel(
                 model_name=model_name,
-                provider=OllamaProvider(base_url=base_url),
+                provider=OllamaProvider(base_url=base_url, http_client=http_client),
             )
         case "openai_responses":
             model = OpenAIResponsesModel(
                 model_name=model_name,
                 provider=OpenAIProvider(
-                    base_url=base_url, api_key=secrets.get("OPENAI_API_KEY")
+                    base_url=base_url,
+                    api_key=secrets.get("OPENAI_API_KEY"),
+                    http_client=http_client,
                 ),
             )
         case "anthropic":
             model = AnthropicModel(
                 model_name=model_name,
-                provider=AnthropicProvider(api_key=secrets.get("ANTHROPIC_API_KEY")),
+                provider=AnthropicProvider(
+                    api_key=secrets.get("ANTHROPIC_API_KEY"),
+                    base_url=base_url,
+                    http_client=http_client,
+                ),
             )
         case "gemini":
             model = GoogleModel(

--- a/tracecat/agent/runtime.py
+++ b/tracecat/agent/runtime.py
@@ -14,6 +14,7 @@ from tracecat.agent.executor.aio import AioStreamingAgentExecutor
 from tracecat.agent.models import (
     AgentConfig,
     AgentOutput,
+    AgentTLSConfig,
     OutputType,
     RunAgentArgs,
 )
@@ -74,6 +75,9 @@ async def run_agent(
     max_requests: int = 20,
     retries: int = 3,
     base_url: str | None = None,
+    client_cert: str | None = None,
+    client_key: str | None = None,
+    client_key_password: str | None = None,
 ) -> AgentOutput:
     """Run an AI agent with specified configuration and actions.
 
@@ -157,6 +161,15 @@ async def run_agent(
         session_id, role.workspace_id, persistent=False
     )
     executor = AioStreamingAgentExecutor(deps=deps, role=role)
+    tls_config = (
+        AgentTLSConfig(
+            client_cert=client_cert,
+            client_key=client_key,
+            client_key_password=client_key_password,
+        )
+        if any(value for value in (client_cert, client_key, client_key_password))
+        else None
+    )
     try:
         args = RunAgentArgs(
             user_prompt=user_prompt,
@@ -173,6 +186,7 @@ async def run_agent(
                 mcp_server_url=mcp_server_url,
                 mcp_server_headers=mcp_server_headers,
                 actions=actions,
+                tls_config=tls_config,
             ),
             max_requests=max_requests,
             max_tool_calls=max_tool_calls,

--- a/tracecat/agent/tls.py
+++ b/tracecat/agent/tls.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+import httpx
+
+from tracecat.agent.models import AgentTLSConfig
+from tracecat.logger import logger
+
+
+@dataclass(slots=True)
+class TLSHttpClients:
+    """Container for TLS-enabled HTTP clients used by the agent runtime."""
+
+    provider: httpx.AsyncClient | None
+    mcp: httpx.AsyncClient | None
+
+
+class TemporaryClientCertificate:
+    """Manage temporary files for client certificate and key materials."""
+
+    def __init__(
+        self,
+        client_cert_str: str | None = None,
+        client_key_str: str | None = None,
+        client_key_password: str | None = None,
+    ):
+        self.client_cert_str = client_cert_str
+        self.client_key_str = client_key_str
+        self.client_key_password = client_key_password
+        self._temp_files: list[tempfile._TemporaryFileWrapper] = []
+
+    def __enter__(self) -> str | tuple[str, str] | tuple[str, str, str] | None:
+        cert_path: str | None = None
+        key_path: str | None = None
+
+        if self.client_cert_str:
+            cert_file = tempfile.NamedTemporaryFile(
+                mode="w", delete=True, encoding="utf-8"
+            )
+            self._temp_files.append(cert_file)
+            cert_file.write(self.client_cert_str)
+            cert_file.flush()
+            cert_path = cert_file.name
+
+        if self.client_key_str:
+            key_file = tempfile.NamedTemporaryFile(
+                mode="w", delete=True, encoding="utf-8"
+            )
+            self._temp_files.append(key_file)
+            key_file.write(self.client_key_str)
+            key_file.flush()
+            key_path = key_file.name
+
+        if cert_path and key_path:
+            if self.client_key_password:
+                return (cert_path, key_path, self.client_key_password)
+            return cert_path, key_path
+        if cert_path:
+            # PEM file containing both cert and key
+            return cert_path
+
+        return None
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for temp_file in self._temp_files:
+            try:
+                temp_file.close()
+            except Exception:
+                logger.error(
+                    "Error closing temporary TLS certificate file",
+                    temp_file=temp_file.name,
+                    exc_info=True,
+                )
+
+
+@asynccontextmanager
+async def agent_tls_clients(
+    tls_config: AgentTLSConfig | None,
+    *,
+    include_provider: bool,
+    include_mcp: bool,
+    mcp_headers: dict[str, str] | None = None,
+) -> AsyncIterator[TLSHttpClients]:
+    """Yield TLS-enabled HTTP clients for provider and MCP connections."""
+
+    if tls_config is None or not tls_config.is_configured():
+        yield TLSHttpClients(provider=None, mcp=None)
+        return
+
+    with TemporaryClientCertificate(
+        client_cert_str=tls_config.client_cert,
+        client_key_str=tls_config.client_key,
+        client_key_password=tls_config.client_key_password,
+    ) as cert_for_httpx:
+        provider_client: httpx.AsyncClient | None = None
+        mcp_client: httpx.AsyncClient | None = None
+        clients_to_close: list[httpx.AsyncClient] = []
+        try:
+            if include_provider:
+                provider_client = httpx.AsyncClient(cert=cert_for_httpx)
+                clients_to_close.append(provider_client)
+
+            if include_mcp:
+                mcp_client = httpx.AsyncClient(cert=cert_for_httpx, headers=mcp_headers)
+                clients_to_close.append(mcp_client)
+
+            yield TLSHttpClients(provider=provider_client, mcp=mcp_client)
+        finally:
+            for client in clients_to_close:
+                try:
+                    await client.aclose()
+                except Exception:
+                    logger.error(
+                        "Failed to close TLS-enabled HTTP client", exc_info=True
+                    )


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds TLS (mTLS) support for agent provider and MCP connections to enable secure client‑certificate auth without changing agent code. Integrates registry secrets and runtime helpers for simple configuration and safe client cleanup.

- **New Features**
  - Introduced AgentTLSConfig and agent_tls_clients to create TLS-enabled httpx clients (provider + MCP) with temporary cert/key files and automatic cleanup.
  - Registry actions now include ssl_secret and pass SSL_CLIENT_CERT/KEY/PASSWORD into agent runs.
  - build_agent and provider adapters accept custom httpx clients; executor/runtime wire TLS clients through to providers and MCP servers.

- **Migration**
  - Set secrets: SSL_CLIENT_CERT, SSL_CLIENT_KEY, SSL_CLIENT_PASSWORD (optional).
  - No changes needed for existing agents; optionally pass tls_config in AgentConfig or client_cert/key/password to run_agent.

<!-- End of auto-generated description by cubic. -->

