### PR TITLE
feat(api+ui): Add datetime support to tables

### DIFF
--- a/tests/unit/test_tables_common.py
+++ b/tests/unit/test_tables_common.py
@@ -1,0 +1,52 @@
+"""Tests for helper functions in tracecat.tables.common."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tracecat.tables.common import ensure_tzaware_datetime, to_sql_clause
+from tracecat.tables.enums import SqlType
+
+
+class TestToSqlClauseTimestamptz:
+    """Tests for TIMESTAMPTZ handling in to_sql_clause."""
+
+    def test_naive_datetime_assumes_utc(self) -> None:
+        naive_datetime = datetime(2024, 1, 2, 3, 4, 5)
+
+        bind_param = to_sql_clause(naive_datetime, "event_time", SqlType.TIMESTAMPTZ)
+
+        assert bind_param.value.tzinfo is timezone.utc
+
+    def test_iso_string_with_z_suffix(self) -> None:
+        iso_value = "2024-01-02T03:04:05Z"
+
+        bind_param = to_sql_clause(iso_value, "event_time", SqlType.TIMESTAMPTZ)
+
+        assert bind_param.value.tzinfo is timezone.utc
+
+    def test_invalid_type_raises(self) -> None:
+        with pytest.raises(TypeError):
+            to_sql_clause(123, "event_time", SqlType.TIMESTAMPTZ)
+
+
+class TestEnsureTzawareDatetime:
+    """Tests for ensure_tzaware_datetime utility."""
+
+    def test_assumes_utc_for_naive_datetime(self) -> None:
+        naive_datetime = datetime(2024, 1, 2, 3, 4, 5)
+
+        result = ensure_tzaware_datetime(naive_datetime)
+
+        assert result.tzinfo is timezone.utc
+
+    def test_parses_iso_string_with_offset(self) -> None:
+        iso_value = "2024-01-02T03:04:05+02:00"
+
+        result = ensure_tzaware_datetime(iso_value)
+
+        assert result.tzinfo is not None
+
+    def test_invalid_string_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ensure_tzaware_datetime("not-a-date")


### PR DESCRIPTION
## Summary
- normalize TIMESTAMPTZ values in the tables service, assuming UTC for naive inputs
- update importer and add unit tests covering timezone-aware datetime handling

## Testing
- pytest tests/unit/test_table_csv_importer.py tests/unit/test_tables_common.py *(fails: missing aioboto3 dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68f00f26bfac8333adda8022020b94fd
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Ensure TIMESTAMPTZ values are timezone-aware across the tables service. Naive datetimes now default to UTC to avoid ambiguous timestamps and ensure consistent SQL bindings and CSV imports.

- **New Features**
  - Added ensure_tzaware_datetime with UTC fallback for naive inputs.
  - to_sql_clause now coerces TIMESTAMP/TIMESTAMPTZ and binds TIMESTAMPTZ with timezone=True.
  - Normalizes ISO strings with a "Z" suffix to +00:00 for parsing.
  - Updated CSVImporter convert_value to use the new datetime coercion.
  - Added unit tests covering TIMESTAMPTZ handling in importer and common utilities.

<!-- End of auto-generated description by cubic. -->

