### PR TITLE
feat(ui): Show triggering user email in workflow events

### DIFF
--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -34,6 +34,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useWorkspaceMembers } from "@/hooks/use-workspace"
 import {
   ERROR_EVENT_TYPES,
   getRelativeTime,
@@ -44,7 +45,6 @@ import {
   parseExecutionId,
 } from "@/lib/event-history"
 import { cn } from "@/lib/utils"
-import { useWorkspaceMembers } from "@/hooks/use-workspace"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 /**

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import React from "react"
 import JsonView from "react18-json-view"
 import type {
@@ -42,6 +44,8 @@ import {
   parseExecutionId,
 } from "@/lib/event-history"
 import { cn } from "@/lib/utils"
+import { useWorkspaceMembers } from "@/hooks/use-workspace"
+import { useWorkspaceId } from "@/providers/workspace-id"
 
 /**
  * Event history for a specific workflow execution
@@ -186,22 +190,53 @@ export function EventGeneralInfo({ event }: { event: WorkflowExecutionEvent }) {
   const eventTimeDate = new Date(event.event_time)
   const { max_attempts, timeout } = action_retry_policy || {}
 
+  const workspaceId = useWorkspaceId()
+  const { members } = useWorkspaceMembers(workspaceId)
+
+  const triggeredBy = React.useMemo(() => {
+    if (!role) {
+      return undefined
+    }
+
+    if (role.type === "user") {
+      const matchedMember = members?.find(
+        (member) => member.user_id === role.user_id
+      )
+
+      if (matchedMember?.email) {
+        return { text: matchedMember.email }
+      }
+
+      if (role.user_id) {
+        return { text: role.user_id }
+      }
+
+      return { text: "User" }
+    }
+
+    if (role.type === "service") {
+      return { text: role.service_id ?? "Service" }
+    }
+
+    return undefined
+  }, [members, role])
+
   // Construct the link within the same workspace to the related workflow execution
   const params = useParams()
-  const workspaceId = params?.workspaceId
+  const workspaceIdForLinks = params?.workspaceId ?? workspaceId
   let relatedWorkflowExecutionLink: string | undefined
   if (related_wf_exec_id) {
     const [relatedWorkflowId, relatedExecutionId] =
       parseExecutionId(related_wf_exec_id)
 
-    relatedWorkflowExecutionLink = `/workspaces/${workspaceId}/workflows/${relatedWorkflowId}/executions/${relatedExecutionId}`
+    relatedWorkflowExecutionLink = `/workspaces/${workspaceIdForLinks}/workflows/${relatedWorkflowId}/executions/${relatedExecutionId}`
   }
 
   let parentWorkflowExecutionLink: string | undefined
   if (parent_wf_exec_id) {
     const [parentWorkflowId, parentExecutionId] =
       parseExecutionId(parent_wf_exec_id)
-    parentWorkflowExecutionLink = `/workspaces/${workspaceId}/workflows/${parentWorkflowId}/executions/${parentExecutionId}`
+    parentWorkflowExecutionLink = `/workspaces/${workspaceIdForLinks}/workflows/${parentWorkflowId}/executions/${parentExecutionId}`
   }
 
   return (
@@ -302,16 +337,14 @@ export function EventGeneralInfo({ event }: { event: WorkflowExecutionEvent }) {
           }
         />
       </div>
-      <div className="space-x-2">
-        {role?.type && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">
-              Triggered By
-            </Label>
-            <DescriptorBadge text={role.type} className="capitalize" />
-          </>
-        )}
-      </div>
+      {triggeredBy && (
+        <div className="space-x-2">
+          <Label className="w-24 text-xs text-muted-foreground">
+            Triggered By
+          </Label>
+          <DescriptorBadge text={triggeredBy.text} />
+        </div>
+      )}
       {event_type == "WORKFLOW_EXECUTION_STARTED" && workflow_timeout && (
         <div className="space-x-2">
           <Label className="w-24 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- mark the workflow execution event details component as a client component and load workspace members
- map workflow event roles to known workspace members so user-triggered events show the actor's email
- keep fallbacks for service roles and unknown users to avoid empty metadata

## Testing
- pnpm --filter frontend lint *(fails: No projects matched the filters in "/workspace/tracecat")*

------
https://chatgpt.com/codex/tasks/task_e_68f10fff0c5483339d45b087a4f2bf9d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show the triggering user's email in workflow execution events by resolving event roles to workspace members. Improves clarity in the Event Details panel with safe fallbacks.

- **New Features**
  - Marked Event Details as a client component.
  - Loaded workspace members via useWorkspaceMembers/useWorkspaceId.
  - Displayed email for user-triggered events; fallbacks to user_id or "User". Service roles show service_id or "Service".

- **Bug Fixes**
  - Built related/parent execution links using the provider workspace ID when route params are missing.

<!-- End of auto-generated description by cubic. -->

