### PR TITLE
feat(ui): Add disableUnderline prop to TabsTrigger for improved styling

### DIFF
--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -304,10 +304,18 @@ function ActionEventContent({
                   placeholder={streamIdPlaceholder}
                 />
                 <TabsList className="h-8">
-                  <TabsTrigger value="session" className="h-6 text-xs">
+                  <TabsTrigger
+                    value="session"
+                    disableUnderline
+                    className="h-6 text-xs"
+                  >
                     Session
                   </TabsTrigger>
-                  <TabsTrigger value="result" className="h-6 text-xs">
+                  <TabsTrigger
+                    value="result"
+                    disableUnderline
+                    className="h-6 text-xs"
+                  >
                     Result
                   </TabsTrigger>
                 </TabsList>

--- a/frontend/src/components/organization/org-vcs-github.tsx
+++ b/frontend/src/components/organization/org-vcs-github.tsx
@@ -266,8 +266,12 @@ export function GitHubAppSetup() {
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
           <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="manifest">Create New App</TabsTrigger>
-            <TabsTrigger value="manual">Use Existing App</TabsTrigger>
+            <TabsTrigger value="manifest" disableUnderline>
+              Create new GitHub App
+            </TabsTrigger>
+            <TabsTrigger value="manual" disableUnderline>
+              Use existing GitHub App
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="manifest" className="space-y-6">

--- a/frontend/src/components/polymorphic-field.tsx
+++ b/frontend/src/components/polymorphic-field.tsx
@@ -133,6 +133,7 @@ export const PolyField = React.forwardRef<
                         <TabsTrigger
                           key={fieldType.value}
                           value={fieldType.value}
+                          disableUnderline
                           className="h-5 rounded-sm px-1.5 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-none"
                           title={fieldType.tooltip}
                         >

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -7,6 +7,12 @@ import { cn } from "@/lib/utils"
 
 const Tabs = TabsPrimitive.Root
 
+type TabsTriggerProps = React.ComponentPropsWithoutRef<
+  typeof TabsPrimitive.Trigger
+> & {
+  disableUnderline?: boolean
+}
+
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
@@ -24,12 +30,15 @@ TabsList.displayName = TabsPrimitive.List.displayName
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+  TabsTriggerProps
+>(({ className, disableUnderline = false, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "relative inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium text-muted-foreground ring-offset-background transition-all after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:bg-primary after:transition-transform after:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:after:scale-x-100",
+      "relative inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium text-muted-foreground ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-primary data-[state=active]:shadow-none",
+      disableUnderline
+        ? "after:content-none"
+        : "after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-full after:origin-center after:scale-x-0 after:bg-primary after:transition-transform after:content-[''] data-[state=active]:after:scale-x-100",
       className
     )}
     {...props}


### PR DESCRIPTION
<img width="670" height="370" alt="Screenshot 2025-10-17 at 2 18 38 PM" src="https://github.com/user-attachments/assets/984573e2-1cb8-4510-a6a6-3653b78af29c" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a disableUnderline prop to TabsTrigger to allow tabs without the animated underline. Updated a few UIs to use it for cleaner, compact styling.

- **New Features**
  - TabsTrigger supports disableUnderline (default false) to hide the underline.
  - Preserves active state styling and focus ring; underline is toggled via conditional classes.
  - Applied in EventsSelectedAction, GitHubAppSetup, and PolyField.

<!-- End of auto-generated description by cubic. -->

