### PR TITLE
fix(ui): make delete table row modal bg translucent

### DIFF
--- a/frontend/src/components/tables/table-view-action-delete-dialog.tsx
+++ b/frontend/src/components/tables/table-view-action-delete-dialog.tsx
@@ -62,7 +62,7 @@ export function TableViewActionDeleteDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleDeleteRow}>
+          <AlertDialogAction variant="destructive" onClick={handleDeleteRow}>
             Delete
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/frontend/src/components/tables/table-view-action.tsx
+++ b/frontend/src/components/tables/table-view-action.tsx
@@ -66,12 +66,6 @@ export function TableViewAction({ row }: { row: Row<TableRowRead> }) {
         open={activeType === "delete"}
         onOpenChange={onOpenChange}
       />
-
-      <TableViewActionDeleteDialog
-        row={row}
-        open={activeType === "delete"}
-        onOpenChange={onOpenChange}
-      />
     </>
   )
 }


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

- Removed a duplicate of the `TableViewActionDeleteDialog` component because of which the dialog was rendered twice with an opaque background.

- Changed the `AlertDialogAction` for the 'Delete' button in the delete row modal to use the 'destructive' variant, making it visually stand out as an irreversible action.

## Related Issues
Fixes #997 

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

**After the fix:**
<img width="1488" height="809" alt="image" src="https://github.com/user-attachments/assets/49042f81-1f9b-4da5-a5df-62323b593d17" />

**Before the fix:**
<img width="3416" height="2038" alt="image" src="https://github.com/user-attachments/assets/221f85e8-165c-4c49-b765-3991a119408b" />


## Steps to QA
1. Navigate to the tables tab in the side nav
2. Create a table and add a column
3. Insert a row
4. Now try deleting the row by clicking on the 3 dot menu beside the row

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
6. Do this thing
7. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the delete row modal in Tables so the backdrop is translucent instead of opaque. The modal no longer renders twice, and the Delete button is marked as destructive.

- **Bug Fixes**
  - Removed the duplicated TableViewActionDeleteDialog to prevent double rendering and opaque backdrop.
  - Set the Delete action to variant="destructive" for a clearer irreversible action.

<!-- End of auto-generated description by cubic. -->

