### PR TITLE
fix(ui): prevent opening multiple context menus

### DIFF
--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -179,6 +179,7 @@ export const WorkflowCanvas = React.forwardRef<
   >([])
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const { deleteAction } = useDeleteAction()
+  const openContextMenuId = useRef<string | null>(null)
   /**
    * Load the saved workflow
    */
@@ -259,7 +260,10 @@ export const WorkflowCanvas = React.forwardRef<
         origin: [0.5, 0.0],
       }
 
-      setNodes((nds) => nds.concat(newNode))
+      setNodes((nds) =>
+        nds.concat(newNode).filter((n) => n.id !== openContextMenuId.current)
+      )
+      openContextMenuId.current = id
       return newNode
     },
     [screenToFlowPosition]

--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -259,9 +259,9 @@ export const WorkflowCanvas = React.forwardRef<
         data: { type: "selector" },
         origin: [0.5, 0.0],
       }
-
+      const prevContextMenuId = openContextMenuId.current
       setNodes((nds) =>
-        nds.concat(newNode).filter((n) => n.id !== openContextMenuId.current)
+        nds.concat(newNode).filter((n) => n.id !== prevContextMenuId)
       )
       openContextMenuId.current = id
       return newNode


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->


- Added an `openContextMenuId` ref to track the currently open context menu node
- Updated the `dropSelectorNode` function to filter out the old selector node with the open context menu ID before adding a new selector node

## Related Issues
Fixes #1539 
<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

1. Right-click multiple times in diff locations in the workflow creation canvas
<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents opening multiple context menus in the workflow canvas so only one menu is visible at a time. Fixes #1539.

- **Bug Fixes**
  - Track the open menu with openContextMenuId.
  - Remove the previous selector node by id before adding a new one.

<!-- End of auto-generated description by cubic. -->

