### PR TITLE
feat(integrations): Support govcloud endpoints in Microsoft integrations

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/azure_log_analytics/execute_cross_workspace_kql_query.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/azure_log_analytics/execute_cross_workspace_kql_query.yml
@@ -29,6 +29,10 @@ definition:
       type: str | None
       description: ISO8601 time period to limit query results (e.g., "P7D" for 7 days).
       default: null
+    base_url:
+      type: enum["https://api.loganalytics.io", "https://api.loganalytics.us"]
+      description: Base URL for the Azure Log Analytics API.
+      default: https://api.loganalytics.io
   steps:
     - ref: build_payload
       action: core.script.run_python
@@ -49,7 +53,7 @@ definition:
     - ref: execute_query
       action: core.http_request
       args:
-        url: https://api.loganalytics.io/v1/workspaces/${{ FN.url_encode(inputs.workspace_id) }}/query
+        url: ${{ inputs.base_url }}/v1/workspaces/${{ FN.url_encode(inputs.workspace_id) }}/query
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.azure_log_analytics.AZURE_LOG_ANALYTICS_USER_TOKEN || SECRETS.azure_log_analytics.AZURE_LOG_ANALYTICS_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/azure_log_analytics/execute_kql_query.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/azure_log_analytics/execute_kql_query.yml
@@ -26,6 +26,10 @@ definition:
       type: str | None
       description: ISO8601 time period to limit query results (e.g., "P7D" for 7 days, "PT1H" for 1 hour).
       default: null
+    base_url:
+      type: enum["https://api.loganalytics.io", "https://api.loganalytics.us"]
+      description: Base URL for the Azure Log Analytics API.
+      default: https://api.loganalytics.io
   steps:
     - ref: build_payload
       action: core.script.run_python
@@ -42,7 +46,7 @@ definition:
     - ref: execute_query
       action: core.http_request
       args:
-        url: https://api.loganalytics.io/v1/workspaces/${{ FN.url_encode(inputs.workspace_id) }}/query
+        url: ${{ inputs.base_url }}/v1/workspaces/${{ FN.url_encode(inputs.workspace_id) }}/query
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.azure_log_analytics.AZURE_LOG_ANALYTICS_USER_TOKEN || SECRETS.azure_log_analytics.AZURE_LOG_ANALYTICS_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_entra/get_user_id_by_email.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_entra/get_user_id_by_email.yml
@@ -14,11 +14,15 @@ definition:
     email:
       type: str
       description: The email address to search for.
+    base_url:
+      type: enum["https://graph.microsoft.com", "https://graph.microsoft.us"]
+      description: Base URL for the Microsoft Graph API.
+      default: https://graph.microsoft.com
   steps:
     - ref: get_user_id_by_email
       action: core.http_request
       args:
-        url: https://graph.microsoft.com/beta/users
+        url: ${{ inputs.base_url }}/beta/users
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_entra_oauth.MICROSOFT_ENTRA_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/create_or_update_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/create_or_update_alert_rule.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_update_rule
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/delete_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/delete_alert_rule.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_rule
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_rule
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule_template.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_template
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates/${{ FN.url_encode(inputs.alert_rule_template_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates/${{ FN.url_encode(inputs.alert_rule_template_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rule_templates.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rule_templates.yml
@@ -24,11 +24,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_templates
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rules.yml
@@ -24,11 +24,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_rules
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/create_or_update_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/create_or_update_bookmark.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_update_bookmark
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/delete_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/delete_bookmark.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_bookmark
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/get_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/get_bookmark.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_bookmark
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/list_bookmarks.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/list_bookmarks.yml
@@ -24,11 +24,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_bookmarks
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_incident_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_incident_comment.yml
@@ -33,11 +33,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_comment
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_update_incident
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident_relation.yml
@@ -33,11 +33,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_update_relation
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_incident
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_comment.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_comment
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_relation.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_relation
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_incident
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident_relation.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_relation
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_alerts.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_alerts
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/alerts
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/alerts
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_bookmarks.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_bookmarks.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_bookmarks
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/bookmarks
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/bookmarks
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_comments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_comments.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_comments
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_entities.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_entities.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_entities
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/entities
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/entities
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_relations.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_relations.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_relations
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incidents.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incidents.yml
@@ -40,6 +40,10 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: build_params
       action: core.script.run_python
@@ -65,7 +69,7 @@ definition:
     - ref: list_incidents
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/create_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/create_threat_intelligence_indicator.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_indicator
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/delete_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/delete_threat_intelligence_indicator.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_indicator
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/get_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/get_threat_intelligence_indicator.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_indicator
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/list_threat_intelligence_indicators.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/list_threat_intelligence_indicators.yml
@@ -40,6 +40,10 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: build_params
       action: core.script.run_python
@@ -65,7 +69,7 @@ definition:
     - ref: list_indicators
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/query_threat_intelligence_indicators.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/query_threat_intelligence_indicators.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: query_indicators
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/queryIndicators
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/queryIndicators
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_update_watchlist
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist_item.yml
@@ -33,11 +33,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: create_update_item
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_watchlist
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist_item.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: delete_item
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_watchlist
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist_item.yml
@@ -30,11 +30,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: get_item
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlist_items.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlist_items.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_items
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlists.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlists.yml
@@ -24,11 +24,15 @@ definition:
       type: str
       description: API version.
       default: "2025-09-01"
+    base_url:
+      type: enum["https://management.azure.com", "https://management.usgovcloudapi.net"]
+      description: Base URL for the Azure Management API.
+      default: https://management.azure.com
   steps:
     - ref: list_watchlists
       action: core.http_request
       args:
-        url: https://management.azure.com/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/create_channel.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/create_channel.yml
@@ -29,6 +29,10 @@ definition:
       type: list[str] | None
       description: List of user IDs to add as owners (required for private channels).
       default: null
+    base_url:
+      type: enum["https://graph.microsoft.com", "https://graph.microsoft.us"]
+      description: Base URL for the Microsoft Graph API.
+      default: https://graph.microsoft.com
   steps:
     - ref: build_payload
       action: core.script.run_python
@@ -38,8 +42,10 @@ definition:
           description: ${{ inputs.description }}
           is_private: ${{ inputs.is_private }}
           owner_user_ids: ${{ inputs.owner_user_ids }}
+          base_url: ${{ inputs.base_url }}
         script: |
-          def main(display_name, description, is_private, owner_user_ids):
+          def main(display_name, description, is_private, owner_user_ids, base_url):
+              base_url = base_url.rstrip("/")
               if is_private:
                   if not owner_user_ids:
                       raise ValueError("Private channels require at least one owner in owner_user_ids")
@@ -49,7 +55,7 @@ definition:
                       members.append({
                           "@odata.type": "#microsoft.graph.aadUserConversationMember",
                           "roles": ["owner"],
-                          "user@odata.bind": f"https://graph.microsoft.com/beta/users('{user_id}')"
+                          "user@odata.bind": f"{base_url}/beta/users('{user_id}')"
                       })
 
                   return {
@@ -68,7 +74,7 @@ definition:
     - ref: create_channel
       action: core.http_request
       args:
-        url: https://graph.microsoft.com/beta/teams/${{ inputs.team_id }}/channels
+        url: ${{ inputs.base_url }}/beta/teams/${{ inputs.team_id }}/channels
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_teams.MICROSOFT_TEAMS_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/delete_channel.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/delete_channel.yml
@@ -17,11 +17,15 @@ definition:
     channel_id:
       type: str
       description: The ID of the channel.
+    base_url:
+      type: enum["https://graph.microsoft.com", "https://graph.microsoft.us"]
+      description: Base URL for the Microsoft Graph API.
+      default: https://graph.microsoft.com
   steps:
     - ref: delete_channel
       action: core.http_request
       args:
-        url: https://graph.microsoft.com/beta/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}
+        url: ${{ inputs.base_url }}/beta/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_teams.MICROSOFT_TEAMS_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/list_channel_messages.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/list_channel_messages.yml
@@ -25,6 +25,10 @@ definition:
       type: bool
       description: Whether to expand replies for each message.
       default: false
+    base_url:
+      type: enum["https://graph.microsoft.com", "https://graph.microsoft.us"]
+      description: Base URL for the Microsoft Graph API.
+      default: https://graph.microsoft.com
   steps:
     - ref: build_params
       action: core.script.run_python
@@ -46,7 +50,7 @@ definition:
     - ref: list_messages
       action: core.http_request
       args:
-        url: https://graph.microsoft.com/beta/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages
+        url: ${{ inputs.base_url }}/beta/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_teams.MICROSOFT_TEAMS_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/post_replies.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/post_replies.yml
@@ -27,11 +27,15 @@ definition:
       type: str
       description: The content type of the reply message.
       default: html
+    base_url:
+      type: enum["https://graph.microsoft.com", "https://graph.microsoft.us"]
+      description: Base URL for the Microsoft Graph API.
+      default: https://graph.microsoft.com
   steps:
     - ref: post_replies
       action: core.http_request
       args:
-        url: https://graph.microsoft.com/v1.0/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages/${{ inputs.message_id }}/replies
+        url: ${{ inputs.base_url }}/v1.0/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages/${{ inputs.message_id }}/replies
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_teams.MICROSOFT_TEAMS_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/send_adaptive_card.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/send_adaptive_card.yml
@@ -24,6 +24,10 @@ definition:
       type: str | None
       description: Title for the card (appears as subject).
       default: null
+    base_url:
+      type: enum["https://graph.microsoft.com", "https://graph.microsoft.us"]
+      description: Base URL for the Microsoft Graph API.
+      default: https://graph.microsoft.com
   steps:
     - ref: build_message
       action: core.script.run_python
@@ -69,7 +73,7 @@ definition:
     - ref: send_adaptive_card
       action: core.http_request
       args:
-        url: https://graph.microsoft.com/v1.0/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages
+        url: ${{ inputs.base_url }}/v1.0/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_teams.MICROSOFT_TEAMS_USER_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/send_message.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/send_message.yml
@@ -20,11 +20,15 @@ definition:
     message:
       type: str
       description: The message to send.
+    base_url:
+      type: enum["https://graph.microsoft.com", "https://graph.microsoft.us"]
+      description: Base URL for the Microsoft Graph API.
+      default: https://graph.microsoft.com
   steps:
     - ref: send_message
       action: core.http_request
       args:
-        url: https://graph.microsoft.com/v1.0/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages
+        url: ${{ inputs.base_url }}/v1.0/teams/${{ inputs.team_id }}/channels/${{ inputs.channel_id }}/messages
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_teams.MICROSOFT_TEAMS_USER_TOKEN }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds GovCloud endpoint support across Azure Log Analytics, Microsoft Graph (Teams, Entra), and Microsoft Sentinel templates via a new base_url input. Tenants can now switch between commercial and US Gov endpoints without code changes.

- **New Features**
  - Added base_url enums to all affected templates (defaults to commercial):
    - Log Analytics: https://api.loganalytics.io or https://api.loganalytics.us
    - Microsoft Graph: https://graph.microsoft.com or https://graph.microsoft.us
    - Azure Management: https://management.azure.com or https://management.usgovcloudapi.net
  - Updated all HTTP requests and Microsoft Teams channel payloads (user@odata.bind) to use base_url.

- **Migration**
  - No action needed for commercial tenants.
  - US Gov tenants: set base_url to the US endpoint when using these tools and ensure tokens are scoped for GovCloud.

<!-- End of auto-generated description by cubic. -->

