### PR TITLE
feat: Add OAuth secret expression handling and template action validation

### DIFF
--- a/tests/unit/test_executor_service.py
+++ b/tests/unit/test_executor_service.py
@@ -327,9 +327,12 @@ async def test_get_action_secrets_skips_optional_oauth(mocker):
 
     secrets = await get_action_secrets({}, action_secrets)
     assert (
-        secrets["azure_log_analytics"]["AZURE_LOG_ANALYTICS_USER_TOKEN"] == "user-token"
+        secrets["azure_log_analytics_oauth"]["AZURE_LOG_ANALYTICS_USER_TOKEN"]
+        == "user-token"
     )
-    assert "AZURE_LOG_ANALYTICS_SERVICE_TOKEN" not in secrets["azure_log_analytics"]
+    assert (
+        "AZURE_LOG_ANALYTICS_SERVICE_TOKEN" not in secrets["azure_log_analytics_oauth"]
+    )
 
 
 @pytest.mark.anyio
@@ -392,10 +395,11 @@ async def test_get_action_secrets_merges_multiple_oauth_tokens(mocker):
 
     secrets = await get_action_secrets({}, action_secrets)
     assert (
-        secrets["azure_log_analytics"]["AZURE_LOG_ANALYTICS_USER_TOKEN"] == "user-token"
+        secrets["azure_log_analytics_oauth"]["AZURE_LOG_ANALYTICS_USER_TOKEN"]
+        == "user-token"
     )
     assert (
-        secrets["azure_log_analytics"]["AZURE_LOG_ANALYTICS_SERVICE_TOKEN"]
+        secrets["azure_log_analytics_oauth"]["AZURE_LOG_ANALYTICS_SERVICE_TOKEN"]
         == "service-token"
     )
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -264,24 +264,37 @@ async def get_action_secrets(
     # Handle secrets from the task args
     args_secrets = extract_templated_secrets(args)
     # Get oauth integrations from the action secrets
-    args_oauth_secrets: set[str] = set()
+    args_oauth_secrets: dict[ProviderKey, RegistryOAuthSecret] = {}
     args_basic_secrets: set[str] = set()
     for secret in args_secrets:
-        if secret.endswith("_oauth"):
-            args_oauth_secrets.add(secret)
+        name, key = secret.split(".", 1)
+        if name.endswith("_oauth"):
+            provider_id = name.removesuffix("_oauth")
+            if key.endswith("SERVICE_TOKEN"):
+                grant_type = OAuthGrantType.CLIENT_CREDENTIALS
+            elif key.endswith("USER_TOKEN"):
+                grant_type = OAuthGrantType.AUTHORIZATION_CODE
+            else:
+                raise ValueError(f"Invalid OAuth token type: {key}")
+            provider_key = ProviderKey(id=provider_id, grant_type=grant_type)
+            args_oauth_secrets[provider_key] = RegistryOAuthSecret(
+                provider_id=provider_id,
+                grant_type=grant_type.value,
+                optional=False,
+            )
         else:
             args_basic_secrets.add(secret)
 
     # Handle secrets from the action
     required_basic_secrets: set[str] = set()
     optional_basic_secrets: set[str] = set()
-    oauth_secrets: dict[ProviderKey, RegistryOAuthSecret] = {}
+    action_oauth_secrets: dict[ProviderKey, RegistryOAuthSecret] = {}
     for secret in action_secrets:
         if secret.type == "oauth":
             key = ProviderKey(
                 id=secret.provider_id, grant_type=OAuthGrantType(secret.grant_type)
             )
-            oauth_secrets[key] = secret
+            action_oauth_secrets[key] = secret
         elif secret.optional:
             optional_basic_secrets.add(secret.name)
         else:
@@ -291,11 +304,12 @@ async def get_action_secrets(
     all_basic_secrets = (
         required_basic_secrets | args_basic_secrets | optional_basic_secrets
     )
+    oauth_secrets = action_oauth_secrets | args_oauth_secrets
     logger.info(
         "Handling secrets",
         required_basic_secrets=required_basic_secrets,
         optional_basic_secrets=optional_basic_secrets,
-        oauth_provider_ids=oauth_secrets,
+        oauth_secrets=oauth_secrets,
         args_secrets=args_secrets,
         secrets_to_fetch=all_basic_secrets,
     )
@@ -327,11 +341,11 @@ async def get_action_secrets(
                     try:
                         if access_token := await service.get_access_token(integration):
                             secret = oauth_secrets[provider_key]
-                            # SECRETS.<provider_id>.[<prefix>_[SERVICE|USER]_TOKEN]
+                            # SECRETS.<provider_id>_oauth.[<prefix>_[SERVICE|USER]_TOKEN]
                             # NOTE: We are overriding the provider_id key here assuming its unique
                             # <prefix> is the provider_id in uppercase.
                             provider_secrets = secrets.setdefault(
-                                integration.provider_id, {}
+                                f"{integration.provider_id}_oauth", {}
                             )
                             provider_secrets[secret.token_name] = (
                                 access_token.get_secret_value()
@@ -374,6 +388,7 @@ async def get_action_secrets(
             raise
         except Exception as e:
             logger.warning("Could not get oauth secrets", error=e)
+    logger.warning("Secrets", secrets=secrets)
     return secrets
 
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -267,6 +267,10 @@ async def get_action_secrets(
     args_oauth_secrets: dict[ProviderKey, RegistryOAuthSecret] = {}
     args_basic_secrets: set[str] = set()
     for secret in args_secrets:
+        if "." not in secret:
+            # Single-segment secret like "my_secret"
+            args_basic_secrets.add(secret)
+            continue
         name, key = secret.split(".", 1)
         if name.endswith("_oauth"):
             provider_id = name.removesuffix("_oauth")

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -388,7 +388,6 @@ async def get_action_secrets(
             raise
         except Exception as e:
             logger.warning("Could not get oauth secrets", error=e)
-    logger.warning("Secrets", secrets=secrets)
     return secrets
 
 


### PR DESCRIPTION
## Summary
Implements OAuth secret handling in expressions and adds comprehensive validation for template action expressions to ensure proper type compatibility.

## Changes
- Implement OAuth secret expression handling in `executor/service.py`
- Add validation for template action expressions in `expressions/validator/validator.py`
- Add integration tests for OAuth template action handling

## Screens

https://github.com/user-attachments/assets/3d905350-0d21-4aa9-9f01-c58a0bd85a00



## Test plan
- Run tests: `just test`
- Verify OAuth template actions work correctly with new validation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds first-class OAuth token handling for template actions and validates token expressions end-to-end. Template actions can now resolve provider tokens via SECRETS.<provider>_oauth.[<PROVIDER>_(SERVICE|USER)_TOKEN] with grant-type checks.

- **New Features**
  - Executor: resolves OAuth tokens from both action definitions and args, and exposes them under SECRETS.<provider>_oauth.[...].
  - Validator: enforces token key shape, infers grant type (SERVICE=client credentials, USER=authorization code), and verifies the provider integration exists.
  - Tests: adds integration test covering OAuth token resolution in template actions.

<!-- End of auto-generated description by cubic. -->

