### PR TITLE
fix: ignore empty text parts when streaming and loading messages

### DIFF
--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -442,9 +442,11 @@ def convert_ui_message(
         for part in ui_message.parts:
             # Type narrowing for the union
             if is_text_ui_part(part):
-                model_response_parts.append(TextPart(content=part["text"]))
+                if part["text"]:  # Skip empty text parts
+                    model_response_parts.append(TextPart(content=part["text"]))
             elif is_reasoning_ui_part(part):
-                model_response_parts.append(ThinkingPart(content=part["text"]))
+                if part["text"]:  # Skip empty reasoning parts
+                    model_response_parts.append(ThinkingPart(content=part["text"]))
             elif is_dynamic_tool_part(part) or is_tool_part(part):
                 # Now we have proper type narrowing for tool parts
                 tool_name = _get_tool_name(part)


### PR DESCRIPTION
Relevant only for gpt-oss on bedrock

## Summary
Filters out empty text and reasoning parts from model responses to prevent validation errors when loading or streaming messages. Handles edge cases where empty parts are present.

## Changes
- Skip empty `TextPart` and `ThinkingPart` in `convert_ui_message` during streaming
- Filter empty text parts from model responses in `ChatService.get_messages_as_model_messages()`
- Prevents downstream validation errors from LLM providers like Bedrock

## Test plan
- Verify streaming messages display correctly without empty text parts
- Confirm loaded messages render properly in chat history
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skips empty text and reasoning parts in streamed and loaded model messages to prevent provider validation errors and ensure clean rendering.

- **Bug Fixes**
  - convert_ui_message: ignore blank TextPart and ThinkingPart during streaming.
  - list_messages: filter empty TextPart/ThinkingPart in ModelResponse before returning.

<!-- End of auto-generated description by cubic. -->

