### PR TITLE
feat(ai): Enhance Reasoning component to auto-close based on streaming status

### DIFF
--- a/frontend/src/components/ai-elements/reasoning.tsx
+++ b/frontend/src/components/ai-elements/reasoning.tsx
@@ -61,6 +61,7 @@ export const Reasoning = memo(
       defaultProp: 0,
     })
 
+    const [shouldAutoClose, setShouldAutoClose] = useState(defaultOpen)
     const [hasAutoClosed, setHasAutoClosed] = useState(false)
     const [startTime, setStartTime] = useState<number | null>(null)
 
@@ -76,9 +77,18 @@ export const Reasoning = memo(
       }
     }, [isStreaming, startTime, setDuration])
 
+    // Ensure reasoning stays open while streaming and auto-close again afterwards.
+    useEffect(() => {
+      if (isStreaming) {
+        setIsOpen(true)
+        setShouldAutoClose(true)
+        setHasAutoClosed(false)
+      }
+    }, [isStreaming, setIsOpen])
+
     // Auto-open when streaming starts, auto-close when streaming ends (once only)
     useEffect(() => {
-      if (defaultOpen && !isStreaming && isOpen && !hasAutoClosed) {
+      if (shouldAutoClose && !isStreaming && isOpen && !hasAutoClosed) {
         // Add a small delay before closing to allow user to see the content
         const timer = setTimeout(() => {
           setIsOpen(false)
@@ -87,7 +97,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer)
       }
-    }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed])
+    }, [isStreaming, isOpen, shouldAutoClose, setIsOpen, hasAutoClosed])
 
     const handleOpenChange = (newOpen: boolean) => {
       setIsOpen(newOpen)

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -386,6 +386,7 @@ export function MessagePart({
       <Reasoning
         key={`${id}-${partIdx}`}
         className="w-full"
+        defaultOpen={status === "streaming" && isLastMessage}
         isStreaming={status === "streaming" && isLastMessage}
       >
         <ReasoningTrigger />


### PR DESCRIPTION
## Summary
Improves the Reasoning component's auto-close behavior to ensure the component stays open during streaming and properly resets the auto-close flag when streaming restarts.

## Changes
- Add `shouldAutoClose` state to track when auto-close should be triggered
- Ensure the Reasoning component stays open while streaming is active
- Reset `hasAutoClosed` flag when streaming starts again
- Pass `defaultOpen` prop based on streaming status in chat sessions

## Test plan
- Verify Reasoning component opens automatically when streaming starts
- Confirm it doesn't close prematurely while content is streaming
- Check that it closes appropriately after streaming completes
- Verify the behavior works correctly on subsequent messages
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Keep the Reasoning panel open while streaming and auto-close once streaming ends, with proper reset when a new stream starts. Prevents premature closing on reloads and across subsequent messages.

- **New Features**
  - Track shouldAutoClose to perform a one-time close after streaming.
  - Reset hasAutoClosed when streaming restarts.
  - Set defaultOpen in chat-session-pane when the last message is streaming.

<!-- End of auto-generated description by cubic. -->

