### PR TITLE
fix: Remove premature break in error event handling

### DIFF
--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -1113,7 +1113,6 @@ async def sse_vercel(events: AsyncIterable[StreamEvent]) -> AsyncIterable[str]:
                     yield format_sse(TextDeltaEventPayload(id=error_part_id, delta=msg))
                     yield format_sse(TextEndEventPayload(id=error_part_id))
                     yield format_sse(ErrorEventPayload(errorText=msg))
-                    break
                 case StreamEnd():
                     # End of stream marker from Redis
                     logger.debug("End-of-stream marker from Redis")


### PR DESCRIPTION
## Summary
Removes a premature `break` statement in the error event handling logic that was causing the stream to end too early, preventing proper error cleanup and subsequent events from being processed.

## Changes
- Remove `break` statement after error event emission in `sse_vercel` function

## Screens
### Before
Stream would break on error, see how after the first error message the assistant error message didn't appear until I sent the next message.

https://github.com/user-attachments/assets/dda829e9-d7fe-436f-8c80-50927d608eec


### After

https://github.com/user-attachments/assets/0b7e63e1-d3fd-4cc8-b83f-3276e39e0fd5



## Test plan
- Verify error events are properly handled without prematurely ending the stream
- Confirm subsequent events after errors are processed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a premature break in SSE error handling so the stream doesn’t end early. Errors now clean up correctly, and subsequent events continue after an error.

<!-- End of auto-generated description by cubic. -->

