### PR TITLE
feat: Support expression evaluation in workflow aliases

### DIFF
--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -751,8 +751,15 @@ class DSLWorkflow:
         return eval_templated_object(self.dsl.returns, operand=self.context)
 
     async def _resolve_workflow_alias(self, wf_alias: str) -> identifiers.WorkflowID:
+        # Evaluate the workflow alias as a templated expression
+        evaluated_alias = eval_templated_object(wf_alias, operand=self.get_context())
+        if not isinstance(evaluated_alias, str):
+            raise TypeError(
+                f"Workflow alias expression must evaluate to a string. Got {type(evaluated_alias).__name__}"
+            )
+
         activity_inputs = ResolveWorkflowAliasActivityInputs(
-            workflow_alias=wf_alias, role=self.role
+            workflow_alias=evaluated_alias, role=self.role
         )
         wf_id = await workflow.execute_activity(
             WorkflowsManagementService.resolve_workflow_alias_activity,
@@ -761,7 +768,7 @@ class DSLWorkflow:
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
         if not wf_id:
-            raise ValueError(f"Workflow alias {wf_alias} not found")
+            raise ValueError(f"Workflow alias {evaluated_alias!r} not found")
         return wf_id
 
     async def _get_workflow_definition(


### PR DESCRIPTION
## Summary
Enables dynamic subflow execution by evaluating templated expressions in workflow_alias parameters.

## Changes
- Evaluate workflow alias as templated expression before activity call in _resolve_workflow_alias
- Add type checking to ensure expression evaluates to string
- Add test case for expression-based alias resolution

## Example
Workflow aliases can now use expressions to dynamically determine which subflow to execute based on runtime data from previous actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enables dynamic child workflow selection by evaluating templated expressions in workflow_alias before resolving to a workflow ID. This lets workflows choose subflows at runtime using outputs from prior actions.

- **New Features**
  - Evaluate workflow_alias as a templated expression with the current workflow context.
  - Ensure the expression resolves to a string; raise a TypeError otherwise.
  - Add a unit test that validates expression-based alias resolution in a parent/child workflow.

<!-- End of auto-generated description by cubic. -->

