### PR TITLE
feat(integrations): Support multiple OAuth grants in Microsoft Sentinel templates

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/create_or_update_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/create_or_update_alert_rule.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/delete_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/delete_alert_rule.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_rule.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_rule.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule_template.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates/${{ FN.url_encode(inputs.alert_rule_template_id) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_template.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rule_templates.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rule_templates.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -35,7 +40,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_templates.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rules.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/list_alert_rules.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -35,7 +40,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_rules.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/create_or_update_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/create_or_update_bookmark.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/delete_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/delete_bookmark.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_bookmark.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/get_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/get_bookmark.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_bookmark.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/list_bookmarks.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/list_bookmarks.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -35,7 +40,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_bookmarks.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_incident_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_incident_comment.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -44,7 +49,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident_relation.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -44,7 +49,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_incident.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_comment.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_comment.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_relation.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_relation.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_incident.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident_relation.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_relation.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_alerts.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/alerts
         method: POST
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_alerts.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_bookmarks.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_bookmarks.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/bookmarks
         method: POST
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_bookmarks.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_comments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_comments.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_comments.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_entities.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_entities.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/entities
         method: POST
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_entities.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_relations.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_relations.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_relations.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incidents.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incidents.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -72,6 +77,6 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.list_incidents.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/create_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/create_threat_intelligence_indicator.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/delete_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/delete_threat_intelligence_indicator.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_indicator.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/get_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/get_threat_intelligence_indicator.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_indicator.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/list_threat_intelligence_indicators.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/list_threat_intelligence_indicators.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -72,6 +77,6 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.list_indicators.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/query_threat_intelligence_indicators.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/query_threat_intelligence_indicators.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/queryIndicators
         method: POST
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist_item.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -44,7 +49,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
         method: PUT
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
           Content-Type: application/json
         params:
           api-version: ${{ inputs.api_version }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_watchlist.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist_item.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
         method: DELETE
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.delete_item.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_watchlist.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist_item.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -41,7 +46,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.get_item.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlist_items.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlist_items.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -38,7 +43,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_items.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlists.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlists.yml
@@ -10,6 +10,11 @@ definition:
     - type: oauth
       provider_id: microsoft_sentinel
       grant_type: authorization_code
+      optional: true
+    - type: oauth
+      provider_id: microsoft_sentinel
+      grant_type: client_credentials
+      optional: true
   expects:
     subscription_id:
       type: str
@@ -35,7 +40,7 @@ definition:
         url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists
         method: GET
         headers:
-          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN }}
+          Authorization: Bearer ${{ SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
         params:
           api-version: ${{ inputs.api_version }}
   returns: ${{ steps.list_watchlists.result.data }}


### PR DESCRIPTION
## Summary
- add optional OAuth client credentials secrets alongside delegated auth in Microsoft Sentinel tool templates
- allow Authorization headers to use either Microsoft Sentinel user or service tokens

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68f8db29f2348333b0332658c2e2a91c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Support both delegated and app-only OAuth across all Microsoft Sentinel tool templates. Requests now use either user or service tokens, enabling service principal automation without user context.

- **New Features**
  - Added optional client_credentials OAuth alongside authorization_code for microsoft_sentinel in all templates.
  - Updated Authorization headers to use MICROSOFT_SENTINEL_USER_TOKEN or fall back to MICROSOFT_SENTINEL_SERVICE_TOKEN.

<!-- End of auto-generated description by cubic. -->

