### PR TITLE
Normalize naive datetime filters before case and table searches

### DIFF
--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -1425,6 +1425,11 @@ class TestCoreSearchCasesWithDateFilters:
         updated_after = datetime.now(UTC) - timedelta(hours=1)
         updated_before = datetime.now(UTC) + timedelta(hours=1)
 
+        naive_start = start_time.replace(tzinfo=None)
+        naive_end = end_time.replace(tzinfo=None)
+        naive_updated_after = updated_after.replace(tzinfo=None)
+        naive_updated_before = updated_before.replace(tzinfo=None)
+
         # Call the search_cases function with date filters
         result = await search_cases(
             search_term="test",
@@ -1434,10 +1439,10 @@ class TestCoreSearchCasesWithDateFilters:
             limit=10,
             order_by="updated_at",
             sort="asc",
-            start_time=start_time,
-            end_time=end_time,
-            updated_after=updated_after,
-            updated_before=updated_before,
+            start_time=naive_start,
+            end_time=naive_end,
+            updated_after=naive_updated_after,
+            updated_before=naive_updated_before,
         )
 
         # Assert search_cases was called with expected parameters including date filters
@@ -1451,10 +1456,14 @@ class TestCoreSearchCasesWithDateFilters:
         assert call_args["limit"] == 10
         assert call_args["order_by"] == "updated_at"
         assert call_args["sort"] == "asc"
-        assert call_args["start_time"] == start_time
-        assert call_args["end_time"] == end_time
-        assert call_args["updated_after"] == updated_after
-        assert call_args["updated_before"] == updated_before
+        assert call_args["start_time"].tzinfo == UTC
+        assert call_args["end_time"].tzinfo == UTC
+        assert call_args["updated_after"].tzinfo == UTC
+        assert call_args["updated_before"].tzinfo == UTC
+        assert call_args["start_time"].isoformat() == start_time.isoformat()
+        assert call_args["end_time"].isoformat() == end_time.isoformat()
+        assert call_args["updated_after"].isoformat() == updated_after.isoformat()
+        assert call_args["updated_before"].isoformat() == updated_before.isoformat()
 
         # Verify result structure
         assert len(result) == 1

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -690,6 +690,17 @@ class TestCasesService:
         assert second_case.id in case_ids
         assert first_case.id not in case_ids  # Different priority
 
+        # Naive ISO string inputs should be coerced to UTC-aware values
+        cases = await cases_service.search_cases(
+            start_time=first_created.replace(tzinfo=None).isoformat(),
+            end_time=second_created.replace(tzinfo=None).isoformat(),
+            updated_after=first_created.replace(tzinfo=None).isoformat(),
+            updated_before=second_created.replace(tzinfo=None).isoformat(),
+        )
+        case_ids = {case.id for case in cases}
+        assert first_case.id in case_ids
+        assert second_case.id in case_ids
+
     async def test_create_case_with_nonexistent_field(
         self, cases_service: CasesService
     ) -> None:

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -180,6 +180,28 @@ class TestTablesService:
                 ),
             )
 
+    async def test_search_rows_coerces_naive_filters(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Naive datetime strings should be coerced before querying."""
+
+        inserted = await tables_service.insert_row(
+            table,
+            TableRowInsert(data={"name": "Alice", "age": 30}),
+        )
+
+        naive_timestamp = inserted["created_at"].replace(tzinfo=None).isoformat()
+
+        results = await tables_service.search_rows(
+            table=table,
+            start_time=naive_timestamp,
+            end_time=naive_timestamp,
+            updated_after=naive_timestamp,
+            updated_before=naive_timestamp,
+        )
+
+        assert any(row["id"] == inserted["id"] for row in results)
+
 
 class TestParsePostgresDefault:
     @pytest.fixture

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 from uuid import UUID
 
@@ -834,10 +834,10 @@ class BaseTablesService(BaseService):
         table: Table,
         *,
         search_term: str | None = None,
-        start_time: datetime | None = None,
-        end_time: datetime | None = None,
-        updated_before: datetime | None = None,
-        updated_after: datetime | None = None,
+        start_time: datetime | date | str | int | float | None = None,
+        end_time: datetime | date | str | int | float | None = None,
+        updated_before: datetime | date | str | int | float | None = None,
+        updated_after: datetime | date | str | int | float | None = None,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
@@ -918,13 +918,21 @@ class BaseTablesService(BaseService):
 
         # Add date filters
         if start_time:
-            where_conditions.append(sa.column("created_at") >= start_time)
+            where_conditions.append(
+                sa.column("created_at") >= coerce_to_utc_datetime(start_time)
+            )
         if end_time:
-            where_conditions.append(sa.column("created_at") <= end_time)
+            where_conditions.append(
+                sa.column("created_at") <= coerce_to_utc_datetime(end_time)
+            )
         if updated_after:
-            where_conditions.append(sa.column("updated_at") >= updated_after)
+            where_conditions.append(
+                sa.column("updated_at") >= coerce_to_utc_datetime(updated_after)
+            )
         if updated_before:
-            where_conditions.append(sa.column("updated_at") <= updated_before)
+            where_conditions.append(
+                sa.column("updated_at") <= coerce_to_utc_datetime(updated_before)
+            )
 
         # Apply WHERE conditions if any
         if where_conditions:
@@ -1043,13 +1051,21 @@ class BaseTablesService(BaseService):
 
         # Add date filters
         if start_time:
-            where_conditions.append(sa.column("created_at") >= start_time)
+            where_conditions.append(
+                sa.column("created_at") >= coerce_to_utc_datetime(start_time)
+            )
         if end_time:
-            where_conditions.append(sa.column("created_at") <= end_time)
+            where_conditions.append(
+                sa.column("created_at") <= coerce_to_utc_datetime(end_time)
+            )
         if updated_after:
-            where_conditions.append(sa.column("updated_at") >= updated_after)
+            where_conditions.append(
+                sa.column("updated_at") >= coerce_to_utc_datetime(updated_after)
+            )
         if updated_before:
-            where_conditions.append(sa.column("updated_at") <= updated_before)
+            where_conditions.append(
+                sa.column("updated_at") <= coerce_to_utc_datetime(updated_before)
+            )
 
         # Apply WHERE conditions if any
         if where_conditions:

--- a/tracecat/types/datetime.py
+++ b/tracecat/types/datetime.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+
+def ensure_aware_datetime(value: Any) -> datetime:
+    """Coerce supported datetime-like inputs to timezone-aware UTC datetimes."""
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, date):
+        dt = datetime(value.year, value.month, value.day)
+    elif isinstance(value, str):
+        text = value.strip()
+        if text.endswith(("Z", "z")):
+            text = f"{text[:-1]}+00:00"
+        try:
+            dt = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise TypeError(f"Invalid ISO datetime string: {value!r}") from exc
+    elif isinstance(value, (int, float)):
+        dt = datetime.fromtimestamp(value, tz=UTC)
+    else:
+        raise TypeError(
+            "Unsupported value for datetime conversion: " f"{type(value).__name__}"
+        )
+
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+


### PR DESCRIPTION
## Summary
- normalize case and table search date filters with a shared timezone-aware datetime coercion helper
- convert incoming case and table search parameters to UTC-aware datetimes inside API routes, registry UDFs, and services instead of new Pydantic models
- expand existing case and table service/UDF tests to cover naive datetime inputs and remove the unused datetime test stub

## Testing
- `PYTHONPATH=packages/tracecat-registry pytest tests/unit/test_cases_service.py tests/unit/test_tables_service.py tests/registry/test_core_cases.py tests/registry/test_core_table.py` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68fa17fe227083338472234c5f629849
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Normalize datetime filters for case and table searches by coercing all inputs to UTC-aware values with a shared helper. This fixes errors with naive datetimes and lets filters accept ISO strings, dates, and timestamps.

- **Bug Fixes**
  - Added ensure_aware_datetime and used it in API routes, registry UDFs, and services for start_time, end_time, updated_before, and updated_after.
  - Invalid datetime filters now return HTTP 400 from the cases search endpoint.
  - Expanded service params to accept datetime | date | str | int | float and applied coercion before querying.
  - Updated unit and registry tests to cover naive inputs and removed the unused datetime test stub.

<!-- End of auto-generated description by cubic. -->

