### PR TITLE
feat(engine): Preserve Python types during execution validation

### DIFF
--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,7 +1,13 @@
 """Tests for registry UDFs, template actions, and git repository sync."""
 
 import os
+import sys
+import tempfile
 import textwrap
+from datetime import datetime
+from importlib.machinery import ModuleSpec
+from types import ModuleType
+from uuid import UUID
 
 import pytest
 
@@ -168,6 +174,106 @@ async def test_registry_async_function_can_be_called(mock_package):
     udf = repo.get("test.async_test_function")
     for i in range(10):
         assert await udf.fn(num=i) == i
+
+
+def test_validate_args_mode_parameter(tmp_path):
+    """Test that validate_args mode parameter works correctly with default and explicit values."""
+
+    # Create a new test module with datetime/UUID UDFs
+    test_module = ModuleType("test_mode_module")
+    module_spec = ModuleSpec("test_mode_module", None)
+    test_module.__spec__ = module_spec
+    test_module.__path__ = [str(tmp_path)]
+
+    try:
+        sys.modules["test_mode_module"] = test_module
+
+        # Create a file with UDF that accepts datetime
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", dir=tmp_path, delete=False
+        ) as f:
+            f.write(
+                textwrap.dedent(
+                    """
+                from datetime import datetime
+                from uuid import UUID
+                from tracecat_registry import registry
+
+                @registry.register(
+                    description="Test function with datetime",
+                    namespace="test",
+                    doc_url="https://example.com/docs",
+                    author="Tracecat",
+                )
+                def datetime_test(dt: datetime, uid: UUID) -> dict:
+                    return {"dt": dt, "uid": uid}
+            """
+                )
+            )
+
+        # Register the UDF
+        repo = Repository()
+        repo._register_udfs_from_package(test_module)
+        udf = repo.get("test.datetime_test")
+
+        # Test data
+        test_datetime = datetime(2024, 1, 15, 10, 30, 0)
+        test_uuid = UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+        # TEST 1: Default mode should be "json"
+        result_default = udf.validate_args(args={"dt": test_datetime, "uid": test_uuid})
+        assert isinstance(result_default["dt"], str), (
+            "Default mode should serialize datetime to string"
+        )
+        assert isinstance(result_default["uid"], str), (
+            "Default mode should serialize UUID to string"
+        )
+        assert result_default["dt"] == "2024-01-15T10:30:00"
+        assert result_default["uid"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+        # TEST 2: Explicit mode="json"
+        result_json = udf.validate_args(
+            args={"dt": test_datetime, "uid": test_uuid}, mode="json"
+        )
+        assert isinstance(result_json["dt"], str), (
+            "JSON mode should serialize datetime to string"
+        )
+        assert isinstance(result_json["uid"], str), (
+            "JSON mode should serialize UUID to string"
+        )
+        assert result_json["dt"] == "2024-01-15T10:30:00"
+        assert result_json["uid"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+        # TEST 3: Explicit mode="python"
+        result_python = udf.validate_args(
+            args={"dt": test_datetime, "uid": test_uuid}, mode="python"
+        )
+        assert isinstance(result_python["dt"], datetime), (
+            "Python mode should preserve datetime type"
+        )
+        assert isinstance(result_python["uid"], UUID), (
+            "Python mode should preserve UUID type"
+        )
+        assert result_python["dt"] == test_datetime
+        assert result_python["uid"] == test_uuid
+
+        # TEST 4: Template expressions work in both modes
+        # Should not raise RegistryValidationError
+        udf.validate_args(
+            args={"dt": "${{ INPUTS.timestamp }}", "uid": "${{ INPUTS.id }}"}
+        )
+        udf.validate_args(
+            args={"dt": "${{ INPUTS.timestamp }}", "uid": "${{ INPUTS.id }}"},
+            mode="json",
+        )
+        udf.validate_args(
+            args={"dt": "${{ INPUTS.timestamp }}", "uid": "${{ INPUTS.id }}"},
+            mode="python",
+        )
+
+    finally:
+        # Clean up
+        del sys.modules["test_mode_module"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -130,10 +130,10 @@ def test_udf_validate_args(mock_package):
     assert udf.author == "Tracecat"
 
     # Test the UDF
-    udf.validate_args(num="${{ path.to.number }}")
-    udf.validate_args(num=1)
+    udf.validate_args(args={"num": "${{ path.to.number }}"})
+    udf.validate_args(args={"num": 1})
     with pytest.raises(RegistryValidationError):
-        udf.validate_args(num="not a number")
+        udf.validate_args(args={"num": "not a number"})
 
 
 def test_deprecated_function_can_be_registered(mock_package):

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -52,8 +52,8 @@ def test_validator_function_wrap_handler():
 
     # Test the registered UDF
     udf = repo.get("test.f1")
-    udf.validate_args(num="${{ path.to.number }}")
-    udf.validate_args(num=1)
+    udf.validate_args(args={"num": "${{ path.to.number }}"})
+    udf.validate_args(args={"num": 1})
 
     @registry.register(
         description="This is a test function",
@@ -74,10 +74,10 @@ def test_validator_function_wrap_handler():
 
     # Test the UDF with an invalid object
     with pytest.raises(RegistryValidationError):
-        udf2.validate_args(obj={"a": "not a list"})
+        udf2.validate_args(args={"obj": {"a": "not a list"}})
 
     # Should not raise
-    udf2.validate_args(obj={"a": "${{ not a list }}"})
+    udf2.validate_args(args={"obj": {"a": "${{ not a list }}"}})
 
     @registry.register(
         description="This is a test function",
@@ -97,13 +97,13 @@ def test_validator_function_wrap_handler():
     udf3 = repo.get("test.f3")
 
     # Should not raise
-    udf3.validate_args(obj=[{"a": 1}])
+    udf3.validate_args(args={"obj": [{"a": 1}]})
     x = udf3.args_cls.model_validate({"obj": [{"a": 1}]})
     assert x.model_dump(warnings=True) == {"obj": [{"a": 1}]}
-    udf3.validate_args(obj=[{"a": "${{ a number }}"}])
+    udf3.validate_args(args={"obj": [{"a": "${{ a number }}"}]})
     x = udf3.args_cls.model_validate({"obj": [{"a": "${{ a number }}"}]})
     assert x.model_dump(warnings=True) == {"obj": [{"a": "${{ a number }}"}]}
-    udf3.validate_args(obj=["${{ a number }}", {"a": "${{ a number }}"}])
+    udf3.validate_args(args={"obj": ["${{ a number }}", {"a": "${{ a number }}"}]})
     x = udf3.args_cls.model_validate(
         {"obj": ["${{ a number }}", {"a": "${{ a number }}"}]}
     )
@@ -113,10 +113,10 @@ def test_validator_function_wrap_handler():
 
     # Should raise
     with pytest.raises(RegistryValidationError):
-        udf3.validate_args(obj=["string"])
+        udf3.validate_args(args={"obj": ["string"]})
 
     with pytest.raises(RegistryValidationError):
-        udf3.validate_args(obj=[{"a": "string"}])
+        udf3.validate_args(args={"obj": [{"a": "string"}]})
 
     # Test deeply nested types
     @registry.register(
@@ -138,19 +138,19 @@ def test_validator_function_wrap_handler():
 
     # Valid nested structure
     valid_obj = {"level1": [{"level2": [{"level3": 1}, {"level3": 2}]}]}
-    udf4.validate_args(complex_obj=valid_obj)
+    udf4.validate_args(args={"complex_obj": valid_obj})
 
     # Valid with template expressions
     template_obj = {"level1": [{"level2": "${{ template.level2 }}"}]}
-    udf4.validate_args(complex_obj=template_obj)
+    udf4.validate_args(args={"complex_obj": template_obj})
 
     template_obj = {"level1": [{"level2": [{"level3": "${{ template.level3 }}"}]}]}
-    udf4.validate_args(complex_obj=template_obj)
+    udf4.validate_args(args={"complex_obj": template_obj})
 
     # Invalid nested structure
     with pytest.raises(RegistryValidationError):
         invalid_obj = {"level1": [{"level2": [{"level3": "not an int"}]}]}
-        udf4.validate_args(complex_obj=invalid_obj)
+        udf4.validate_args(args={"complex_obj": invalid_obj})
 
     @registry.register(
         description="Test function with tuple and set types",
@@ -171,13 +171,13 @@ def test_validator_function_wrap_handler():
 
     # Valid nested collections
     valid_collections = {"data": ({1, 2, 3}, [{"strings": {"a", "b", "c"}}])}
-    udf5.validate_args(nested_collections=valid_collections)
+    udf5.validate_args(args={"nested_collections": valid_collections})
 
     # Valid with templates
     template_collections = {
         "data": ("${{ template.numbers }}", [{"strings": "${{ template.strings }}"}])
     }
-    udf5.validate_args(nested_collections=template_collections)
+    udf5.validate_args(args={"nested_collections": template_collections})
 
     # Invalid collections
     with pytest.raises(RegistryValidationError):
@@ -187,7 +187,7 @@ def test_validator_function_wrap_handler():
                 [{"strings": {1, 2, 3}}],  # Should be set of strings
             )
         }
-        udf5.validate_args(nested_collections=invalid_collections)
+        udf5.validate_args(args={"nested_collections": invalid_collections})
 
 
 @pytest.mark.anyio

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -155,7 +155,7 @@ async def _run_action_direct(*, action: BoundRegistryAction, args: ArgsT) -> Any
         # This should not be reachable
         raise ValueError("Templates cannot be executed directly")
 
-    validated_args = action.validate_args(**args)
+    validated_args = action.validate_args(args=args, mode="python")
     try:
         if action.is_async:
             logger.trace("Running UDF async")
@@ -209,7 +209,7 @@ async def run_template_action(
         "Validating template action arguments", expects=defn.expects, args=args
     )
     if defn.expects:
-        validated_args = action.validate_args(**args)
+        validated_args = action.validate_args(args=args)
 
     secrets_context = {}
     if context is not None:

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -129,18 +129,15 @@ class BoundRegistryAction(BaseModel):
         else:
             raise ValueError(f"Invalid registry action type: {self.type}")
 
-    def validate_args(self, *args, **kwargs) -> dict[str, Any]:
+    def validate_args(
+        self, args: Mapping[str, Any], *, mode: Literal["json", "python"] = "json"
+    ) -> dict[str, Any]:
         """Validate the input arguments for a Bound registry action.
 
         Checks:
         1. The Bound registry action must be called with keyword arguments only.
         2. The input arguments must be validated against the Bound registry action's model.
         """
-        if len(args) > 0:
-            raise RegistryValidationError(
-                "Bound registry action must be called with keyword arguments.",
-                key=self.action,
-            )
 
         # Validate the input arguments, fail early if the input is invalid
         # Note that we've added TemplateValidator to the list of validators
@@ -149,8 +146,10 @@ class BoundRegistryAction(BaseModel):
             # Note that we're allowing type coercion for the input arguments
             # Use cases would be transforming a UTC string to a datetime object
             # We return the validated input arguments as a dictionary
-            validated = self.args_cls.model_validate(kwargs)
-            validated_args = validated.model_dump(mode="json")
+            validated = self.args_cls.model_validate(args)
+            logger.warning("Validated arguments before", validated=validated)
+            validated_args = validated.model_dump(mode=mode)
+            logger.warning("Validated arguments after", validated_args=validated_args)
             return validated_args
         except ValidationError as e:
             msg = (

--- a/tracecat/registry/actions/models.py
+++ b/tracecat/registry/actions/models.py
@@ -147,9 +147,7 @@ class BoundRegistryAction(BaseModel):
             # Use cases would be transforming a UTC string to a datetime object
             # We return the validated input arguments as a dictionary
             validated = self.args_cls.model_validate(args)
-            logger.warning("Validated arguments before", validated=validated)
             validated_args = validated.model_dump(mode=mode)
-            logger.warning("Validated arguments after", validated_args=validated_args)
             return validated_args
         except ValidationError as e:
             msg = (

--- a/tracecat/registry/actions/service.py
+++ b/tracecat/registry/actions/service.py
@@ -445,7 +445,7 @@ async def validate_action_template(
 
         # (B) Validate that the step is correctly formatted
         try:
-            bound_action.validate_args(**step.args)
+            bound_action.validate_args(args=step.args)
         except RegistryValidationError as e:
             if isinstance(e.err, ValidationError):
                 details = []


### PR DESCRIPTION
Modified the validate_args method in BoundRegistryAction to accept a single 'args' dictionary instead of multiple keyword arguments. Updated corresponding test cases to reflect this change, ensuring consistent argument validation across the codebase.

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Preserves native Python types during action execution by validating with mode="python". Standardizes validate_args to accept a single args dictionary for consistent validation across the engine and registry.

- **Refactors**
  - Changed BoundRegistryAction.validate_args to validate_args(args: Mapping, mode: "json" | "python"), returning model_dump in the selected mode.
  - Executor uses mode="python" for direct runs to keep native types; template actions stay on default "json".
  - Updated tests and services to the new signature.

- **Migration**
  - Update all calls to validate_args to pass args={...}.
  - Use mode="python" when runtime needs native types; use default for template validation.

<!-- End of auto-generated description by cubic. -->

