### PR TITLE
feat(ai): Improve ranker prompt robustness

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/ai.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ai.py
@@ -103,6 +103,8 @@ async def rank_documents(
             batch_size=batch_size,
             num_passes=num_passes,
             refinement_ratio=refinement_ratio,
+            min_items=1,
+            max_items=1,
         )
     elif algorithm == "single-pass":
         ranked_ids = await rank_items(
@@ -110,6 +112,8 @@ async def rank_documents(
             criteria_prompt=criteria_prompt,
             model_name=model_name,
             model_provider=model_provider,
+            min_items=1,
+            max_items=1,
         )
     else:
         raise ValueError(
@@ -185,6 +189,8 @@ async def select_field(
             criteria_prompt=criteria_prompt,
             model_name=model_name,
             model_provider=model_provider,
+            min_items=1,
+            max_items=1,
         )
     elif algorithm == "single-pass":
         ranked_ids = await rank_items(
@@ -192,6 +198,8 @@ async def select_field(
             criteria_prompt=criteria_prompt,
             model_name=model_name,
             model_provider=model_provider,
+            min_items=1,
+            max_items=1,
         )
 
     if not ranked_ids:
@@ -229,10 +237,14 @@ async def select_fields(
             'Criteria to rank the fields by. For example, "from most to least important."'
         ),
     ],
-    num_fields: Annotated[
+    min_fields: Annotated[
         int,
-        Doc("Number of fields to select from."),
-    ] = 3,
+        Doc("Minimum number of fields to select."),
+    ] = 5,
+    max_fields: Annotated[
+        int,
+        Doc("Maximum number of fields to select."),
+    ] = 30,
     flatten: Annotated[
         bool,
         Doc(
@@ -263,7 +275,7 @@ async def select_fields(
             f"Expected at most {MAX_KEYS} keys, got {len(json.keys())} keys."
         )
 
-    if num_fields < 2:
+    if max_fields < 2:
         raise ValueError("Number of fields to select must be at least 2.")
 
     # Get keys
@@ -275,6 +287,8 @@ async def select_fields(
             criteria_prompt=criteria_prompt,
             model_name=model_name,
             model_provider=model_provider,
+            min_items=min_fields,
+            max_items=max_fields,
         )
     elif algorithm == "single-pass":
         ranked_ids = await rank_items(
@@ -282,13 +296,16 @@ async def select_fields(
             criteria_prompt=criteria_prompt,
             model_name=model_name,
             model_provider=model_provider,
+            min_items=min_fields,
+            max_items=max_fields,
         )
+
     if not ranked_ids:
         raise ValueError("Ranking did not return any keys to select.")
 
     # Get most relevant keys
     selected_fields: dict[str, Any] = {}
-    for ranked_id in ranked_ids[:num_fields]:
+    for ranked_id in ranked_ids:
         key_str = str(ranked_id)
         if key_str in json:
             selected_fields[key_str] = json[key_str]
@@ -297,7 +314,7 @@ async def select_fields(
         else:
             continue
 
-        if len(selected_fields) >= num_fields:
+        if len(selected_fields) >= max_fields:
             break
 
     if not selected_fields:

--- a/tests/unit/test_ai_ranker.py
+++ b/tests/unit/test_ai_ranker.py
@@ -359,3 +359,60 @@ async def test_rank_items_live_openai() -> None:
         model_provider="openai",
     )
     assert ranked == ["high", "medium", "low"]
+
+
+@pytest.mark.anyio
+@requires_openai_mocks
+async def test_rank_items_min_max_live_openai_singleton() -> None:
+    items: list[ranker.RankableItem] = [
+        {"id": "high", "text": "priority: 3 (highest)"},
+        {"id": "medium", "text": "priority: 2"},
+        {"id": "low", "text": "priority: 1 (lowest)"},
+    ]
+
+    ranked = await ranker.rank_items(
+        items=items,
+        criteria_prompt=(
+            "Rank items by their numeric priority value from highest to lowest. "
+            "Each item's text contains 'priority: N'. The correct ordering is the IDs "
+            "whose priority numbers are sorted descending."
+        ),
+        model_name=MODEL_NAME,
+        model_provider="openai",
+        min_items=1,
+        max_items=1,
+    )
+
+    assert isinstance(ranked, list)
+    assert len(ranked) == 1
+    assert ranked[0] == "high"
+
+
+@pytest.mark.anyio
+@requires_openai_mocks
+async def test_rank_items_pairwise_min_max_live_openai_top_two() -> None:
+    items: list[ranker.RankableItem] = [
+        {"id": "high", "text": "priority: 3 (highest)"},
+        {"id": "medium", "text": "priority: 2"},
+        {"id": "low", "text": "priority: 1 (lowest)"},
+    ]
+
+    ranked = await ranker.rank_items_pairwise(
+        items=items,
+        criteria_prompt=(
+            "Rank items by their numeric priority value from highest to lowest. "
+            "Each item's text contains 'priority: N'. The correct ordering is the IDs "
+            "whose priority numbers are sorted descending."
+        ),
+        model_name=MODEL_NAME,
+        model_provider="openai",
+        batch_size=2,
+        num_passes=2,
+        refinement_ratio=0.5,
+        min_items=2,
+        max_items=2,
+    )
+
+    assert isinstance(ranked, list)
+    assert len(ranked) == 2
+    assert ranked == ["high", "medium"]

--- a/tracecat/ai/ranker.py
+++ b/tracecat/ai/ranker.py
@@ -21,7 +21,7 @@ from tracecat.logger import logger
 MAX_ITEMS: int = 100
 
 
-RANKING_SYSTEM_PROMPT = textwrap.dedent("""
+RANKING_SYSTEM_PROMPT_TEMPLATE = textwrap.dedent("""
 You are a ranking assistant. Your task is to rank items based on the given criteria.
 
 Criteria:
@@ -29,20 +29,19 @@ Criteria:
 
 Requirements:
 - Rank each item against the criteria from most to least relevant
-- Return ONLY a JSON array of IDs in ranked order: ["id1", "id2", "id3"]
-- Include ALL item IDs exactly as provided - do not skip, modify, or add IDs
-- Each ID must appear exactly once; the array length must equal the number of input items
+{length_requirement}
+- Return ONLY a JSON array of IDs in ranked order: ["id1", "id2", ...]
 - Do not include explanations, reasoning, markdown formatting, or other text
-- The response must be valid, parseable JSON
+- The response must be valid deserializable JSON array (start and ends with square brackets)
 """).strip()
 
 
-RANKING_USER_PROMPT = textwrap.dedent("""
+RANKING_USER_PROMPT_TEMPLATE = textwrap.dedent("""
 Rank these items:
 
 {items}
 
-Return a JSON array of IDs only, nothing else.
+{output_instruction}
 """).strip()
 
 
@@ -63,6 +62,63 @@ def format_items(items: list[RankableItem]) -> str:
     return "\n\n".join([f"id: `{item['id']}`\ntext: {item['text']}" for item in items])
 
 
+def _build_length_requirement(
+    min_items: int | None,
+    max_items: int | None,
+    force_return_all: bool,
+) -> str:
+    """Create length-related instructions for the system prompt.
+
+    If ``force_return_all`` is True or no limits are provided, enforces returning all IDs.
+    Otherwise, constrains the output length to the provided bounds.
+    """
+    if force_return_all or (min_items is None and max_items is None):
+        return (
+            "- Include ALL item IDs exactly as provided - do not skip, modify, or add IDs\n"
+            "- Each ID must appear exactly once; the array length must equal the number of input items"
+        )
+
+    if min_items == 1 and max_items == 1:
+        return (
+            "- Return exactly 1 ID (the single best match)\n"
+            "- Use one of the provided IDs; do not invent or modify IDs\n"
+            "- Do not include duplicate IDs"
+        )
+
+    parts: list[str] = [
+        "- Use only the provided IDs; do not invent or modify IDs",
+        "- Do not include duplicate IDs",
+    ]
+    if min_items is not None and max_items is not None:
+        parts.insert(
+            0,
+            f"- Return only the top IDs, length between {min_items} and {max_items} inclusive",
+        )
+    elif max_items is not None:
+        parts.insert(0, f"- Return only the top IDs, length at most {max_items}")
+    elif min_items is not None:
+        parts.insert(0, f"- Return only the top IDs, length at least {min_items}")
+    return "\n".join(parts)
+
+
+def _build_output_instruction(
+    min_items: int | None,
+    max_items: int | None,
+    force_return_all: bool,
+) -> str:
+    """Create the user prompt instruction for output shape."""
+    if force_return_all or (min_items is None and max_items is None):
+        return "Return a JSON array of IDs only, containing ALL items in ranked order."
+    if min_items == 1 and max_items == 1:
+        return "Return a JSON array with exactly 1 ID (the single best match)."
+    if min_items is not None and max_items is not None:
+        return f"Return a JSON array of IDs only, length between {min_items} and {max_items} inclusive."
+    if max_items is not None:
+        return f"Return a JSON array of IDs only, with at most {max_items} IDs."
+    # min only
+    return f"Return a JSON array of IDs only, with at least {min_items} IDs."
+
+
 async def _build_ranking_agent(
     criteria_prompt: str,
     model_name: str,
@@ -70,13 +126,34 @@ async def _build_ranking_agent(
     model_settings: dict[str, Any] | None = None,
     retries: int = 3,
     base_url: str | None = None,
+    *,
+    min_items: int | None = None,
+    max_items: int | None = None,
+    force_return_all: bool = False,
 ) -> Agent:
-    """Build an agent with ranking system instructions."""
+    """Build an agent with ranking system instructions.
+
+    Args:
+        criteria_prompt: Natural language criteria for ranking.
+        model_name: LLM model to use.
+        model_provider: LLM provider.
+        model_settings: Optional model settings.
+        retries: Number of retries on failure.
+        base_url: Optional base URL for custom providers.
+        min_items: Minimum number of items to return (optional).
+        max_items: Maximum number of items to return (optional).
+        force_return_all: If True, instructs the model to return all items regardless of min/max.
+    """
+    instructions = RANKING_SYSTEM_PROMPT_TEMPLATE.format(
+        criteria_prompt=criteria_prompt,
+        length_requirement=_build_length_requirement(
+            min_items, max_items, force_return_all
+        ),
+    )
+
     return await build_agent(
         AgentConfig(
-            instructions=RANKING_SYSTEM_PROMPT.format(
-                criteria_prompt=criteria_prompt,
-            ),
+            instructions=instructions,
             model_name=model_name,
             model_provider=model_provider,
             model_settings=model_settings,
@@ -90,9 +167,18 @@ async def _run_ranking_agent(
     agent: Agent[Any, Any],
     items: list[RankableItem],
     max_requests: int,
+    *,
+    min_items: int | None = None,
+    max_items: int | None = None,
+    force_return_all: bool = False,
 ) -> AgentOutput:
     """Run the ranking agent with items to rank."""
-    user_prompt = RANKING_USER_PROMPT.format(items=format_items(items))
+    user_prompt = RANKING_USER_PROMPT_TEMPLATE.format(
+        items=format_items(items),
+        output_instruction=_build_output_instruction(
+            min_items, max_items, force_return_all
+        ),
+    )
     return await run_agent_sync(agent, user_prompt, max_requests=max_requests)
 
 
@@ -105,6 +191,9 @@ async def rank_items(
     max_requests: int = 5,
     retries: int = 3,
     base_url: str | None = None,
+    *,
+    min_items: int | None = None,
+    max_items: int | None = None,
 ) -> list[str | int]:
     """Rank items using an LLM based on natural language criteria.
 
@@ -138,9 +227,28 @@ async def rank_items(
         model_settings=model_settings,
         retries=retries,
         base_url=base_url,
+        min_items=min_items,
+        max_items=max_items,
+        force_return_all=False,
     )
-    result = await _run_ranking_agent(agent, items, max_requests)
-    return result.output
+    result = await _run_ranking_agent(
+        agent,
+        items,
+        max_requests,
+        min_items=min_items,
+        max_items=max_items,
+        force_return_all=False,
+    )
+
+    valid_ids: set[str | int] = {item["id"] for item in items}
+    output: list[str | int] = _sanitize_ids(result.output, valid_ids)
+
+    # If the model returned more than max, trim locally for compliance
+    if max_items is not None and len(output) > max_items:
+        output = output[:max_items]
+
+    # If the model returned fewer than min, do not attempt to pad; callers may handle
+    return output
 
 
 def _create_batches(
@@ -181,6 +289,45 @@ def _assign_worst_scores(
         scores[item_id].append(float(worst_position))
 
 
+def _sanitize_ids(
+    returned_ids: list[str | int],
+    valid_ids: set[str | int],
+) -> list[str | int]:
+    """Normalize model outputs to valid IDs.
+
+    - Strip wrapping backticks from string IDs (e.g., `id` -> id)
+    - Convert purely numeric strings to int when appropriate
+    - Keep only IDs that exist in the provided valid set and drop duplicates, preserving order
+    """
+
+    def normalize(value: str | int) -> str | int:
+        if isinstance(value, int):
+            return value
+        s = value.strip()
+        if len(s) >= 2 and s.startswith("`") and s.endswith("`"):
+            s = s[1:-1]
+        # Prefer exact string match
+        if s in valid_ids:
+            return s
+        # Try converting to int if possible and valid
+        try:
+            num = int(s)
+            if num in valid_ids:
+                return num
+        except Exception:
+            pass
+        return s
+
+    seen: set[str | int] = set()
+    filtered: list[str | int] = []
+    for raw in returned_ids:
+        norm = normalize(raw)
+        if norm in valid_ids and norm not in seen:
+            filtered.append(norm)
+            seen.add(norm)
+    return filtered
+
+
 async def _rank_batch(
     batch: list[RankableItem],
     agent: Any,
@@ -199,8 +346,18 @@ async def _rank_batch(
     Raises:
         ValueError: If LLM response cannot be parsed or is invalid
     """
-    result = await _run_ranking_agent(agent, batch, max_requests)
-    return result.output
+    # For batch ranking within pairwise, we must rank ALL items in the batch
+    result = await _run_ranking_agent(
+        agent,
+        batch,
+        max_requests,
+        min_items=None,
+        max_items=None,
+        force_return_all=True,
+    )
+    batch_ids: set[str | int] = {item["id"] for item in batch}
+    sanitized = _sanitize_ids(result.output, batch_ids)
+    return sanitized
 
 
 async def rank_items_pairwise(
@@ -216,6 +373,9 @@ async def rank_items_pairwise(
     max_requests: int = 5,
     retries: int = 3,
     base_url: str | None = None,
+    *,
+    min_items: int | None = None,
+    max_items: int | None = None,
 ) -> list[str | int]:
     """Rank items using multi-pass pairwise ranking with progressive refinement.
 
@@ -284,6 +444,7 @@ async def rank_items_pairwise(
         model_settings=model_settings,
         retries=retries,
         base_url=base_url,
+        force_return_all=True,
     )
 
     # Perform multi-pass ranking with refinement
@@ -299,7 +460,11 @@ async def rank_items_pairwise(
         depth=0,
     )
 
-    return ranked_ids
+    # Apply output limits if provided
+    if min_items is None and max_items is None:
+        return ranked_ids
+
+    return ranked_ids[:max_items]
 
 
 async def _multi_pass_rank(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Strengthened the ranker by rewriting prompts and validating outputs, and added min/max item limits to support exact or top‑N results. This makes rankings more consistent and lets callers control how many items come back.

- **New Features**
  - Added min_items and max_items to rank_items and rank_items_pairwise; supports exact-1 and top‑N results, with local trimming to max.
  - Replaced ranking prompts with clear system/user templates and explicit output instructions; pairwise batches now force return of all IDs.
  - Sanitizes model output: normalizes IDs (e.g., backticks, numeric strings), removes duplicates/extras, and keeps only provided IDs.
  - Registry updates: select_fields now uses min_fields/max_fields; select_field and rank_documents enforce single-item ranking where appropriate. Descriptions now say “most to least relevant.”

- **Migration**
  - Replace select_fields(num_fields=...) with min_fields and max_fields (defaults: min=5, max=30).
  - If you need a single best item/field, pass min=max=1 via the new parameters.

<!-- End of auto-generated description by cubic. -->

