### PR TITLE
feat(ee): Case tasks udfs

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/cases/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/cases/__init__.py
@@ -1,1 +1,0 @@
-"""Tracecat Enterprise Edition - Case Management Features."""

--- a/packages/tracecat-ee/tracecat_ee/cases/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/cases/__init__.py
@@ -1,0 +1,1 @@
+"""Tracecat Enterprise Edition - Case Management Features."""

--- a/packages/tracecat-ee/tracecat_ee/cases/tasks.py
+++ b/packages/tracecat-ee/tracecat_ee/cases/tasks.py
@@ -1,0 +1,188 @@
+"""Enterprise Edition - Case Tasks CRUD Operations.
+
+This module provides User Defined Functions (UDFs) for managing case tasks.
+These functions are only available when the CASE_TASKS feature flag is enabled.
+"""
+
+from typing import Annotated, Any
+from uuid import UUID
+
+from tracecat_registry import registry
+from typing_extensions import Doc
+
+from tracecat.cases.models import CaseTaskCreate, CaseTaskRead, CaseTaskUpdate
+from tracecat.cases.service import CaseTasksService
+
+
+@registry.register(
+    default_title="Create case task",
+    display_group="Cases",
+    description="Create a new task for a case.",
+    namespace="core.cases",
+)
+async def create_case_task(
+    case_id: Annotated[
+        str,
+        Doc("The ID of the case to create a task for."),
+    ],
+    title: Annotated[
+        str,
+        Doc("The title of the task."),
+    ],
+    description: Annotated[
+        str | None,
+        Doc("The description of the task."),
+    ] = None,
+    priority: Annotated[
+        str,
+        Doc("The priority of the task (unknown, low, medium, high, critical)."),
+    ] = "unknown",
+    status: Annotated[
+        str,
+        Doc("The status of the task (todo, in_progress, blocked, completed)."),
+    ] = "todo",
+    assignee_id: Annotated[
+        str | None,
+        Doc("The ID of the user to assign the task to."),
+    ] = None,
+    workflow_id: Annotated[
+        str | None,
+        Doc("The ID of the workflow associated with this task."),
+    ] = None,
+) -> dict[str, Any]:
+    """Create a new task for a case."""
+    async with CaseTasksService.with_session() as service:
+        task = await service.create_task(
+            case_id=UUID(case_id),
+            params=CaseTaskCreate(
+                title=title,
+                description=description,
+                priority=priority,
+                status=status,
+                assignee_id=UUID(assignee_id) if assignee_id else None,
+                workflow_id=workflow_id,
+            ),
+        )
+
+    return CaseTaskRead.model_validate(task, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    default_title="Get case task",
+    display_group="Cases",
+    description="Get details of a specific case task by ID.",
+    namespace="core.cases",
+)
+async def get_case_task(
+    task_id: Annotated[
+        str,
+        Doc("The ID of the task to retrieve."),
+    ],
+) -> dict[str, Any]:
+    """Get a specific case task by ID."""
+    async with CaseTasksService.with_session() as service:
+        task = await service.get_task(UUID(task_id))
+
+    return CaseTaskRead.model_validate(task, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    default_title="List case tasks",
+    display_group="Cases",
+    description="List all tasks for a specific case.",
+    namespace="core.cases",
+)
+async def list_case_tasks(
+    case_id: Annotated[
+        str,
+        Doc("The ID of the case to list tasks for."),
+    ],
+) -> list[dict[str, Any]]:
+    """List all tasks for a case."""
+    async with CaseTasksService.with_session() as service:
+        tasks = await service.list_tasks(UUID(case_id))
+
+    return [
+        CaseTaskRead.model_validate(task, from_attributes=True).model_dump(mode="json")
+        for task in tasks
+    ]
+
+
+@registry.register(
+    default_title="Update case task",
+    display_group="Cases",
+    description="Update an existing case task.",
+    namespace="core.cases",
+)
+async def update_case_task(
+    task_id: Annotated[
+        str,
+        Doc("The ID of the task to update."),
+    ],
+    title: Annotated[
+        str | None,
+        Doc("The updated title of the task."),
+    ] = None,
+    description: Annotated[
+        str | None,
+        Doc("The updated description of the task."),
+    ] = None,
+    priority: Annotated[
+        str | None,
+        Doc("The updated priority of the task (unknown, low, medium, high, critical)."),
+    ] = None,
+    status: Annotated[
+        str | None,
+        Doc("The updated status of the task (todo, in_progress, blocked, completed)."),
+    ] = None,
+    assignee_id: Annotated[
+        str | None,
+        Doc("The ID of the user to assign the task to."),
+    ] = None,
+    workflow_id: Annotated[
+        str | None,
+        Doc("The ID of the workflow associated with this task."),
+    ] = None,
+) -> dict[str, Any]:
+    """Update an existing case task."""
+    params: dict[str, Any] = {}
+    if title is not None:
+        params["title"] = title
+    if description is not None:
+        params["description"] = description
+    if priority is not None:
+        params["priority"] = priority
+    if status is not None:
+        params["status"] = status
+    if assignee_id is not None:
+        params["assignee_id"] = UUID(assignee_id)
+    if workflow_id is not None:
+        params["workflow_id"] = workflow_id
+
+    async with CaseTasksService.with_session() as service:
+        task = await service.update_task(UUID(task_id), CaseTaskUpdate(**params))
+
+    return CaseTaskRead.model_validate(task, from_attributes=True).model_dump(
+        mode="json"
+    )
+
+
+@registry.register(
+    default_title="Delete case task",
+    display_group="Cases",
+    description="Delete a case task.",
+    namespace="core.cases",
+)
+async def delete_case_task(
+    task_id: Annotated[
+        str,
+        Doc("The ID of the task to delete."),
+    ],
+) -> None:
+    """Delete a case task."""
+    async with CaseTasksService.with_session() as service:
+        await service.delete_task(UUID(task_id))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds UDFs to create, read, list, update, and delete case tasks in Enterprise Edition. These functions let workflows manage case tasks when the CASE_TASKS feature flag is enabled.

- **New Features**
  - CRUD UDFs: create_case_task, get_case_task, list_case_tasks, update_case_task, delete_case_task.
  - Registered under namespace core.cases with display group "Cases".
  - Uses CaseTasksService and CaseTaskCreate/Update/Read models; returns JSON-friendly data.
  - UUID handling for task, case, and assignee IDs.
  - Feature-flagged: available only with CASE_TASKS enabled.

<!-- End of auto-generated description by cubic. -->

