### PR TITLE
fix(ui): YAML view editor nullish check

### DIFF
--- a/frontend/src/components/editor/codemirror/yaml-editor.tsx
+++ b/frontend/src/components/editor/codemirror/yaml-editor.tsx
@@ -792,7 +792,7 @@ export function YamlViewOnlyEditor({
   const { appSettings } = useOrgAppSettings()
 
   const textValue = React.useMemo(() => {
-    if (!value) return ""
+    if (value == null) return ""
     return stripNewline(
       typeof value === "string"
         ? value


### PR DESCRIPTION
## Summary
- ensure the read-only YAML editor preserves falsy values when deriving the text to display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903899866a48320b4360871fc563638