### PR TITLE
feat: Add at() function for sequence indexing

### DIFF
--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -51,6 +51,7 @@ from tracecat.expressions.functions import (
     hash_sha256,
     hash_sha512,
     hours_between,
+    index,
     intersection,
     ipv4_in_subnet,
     ipv4_is_public,
@@ -471,6 +472,62 @@ def test_set_operations(func, a: Any, b: Any, expected: list[Any]) -> None:
     # Compare as multisets (order-independent, preserves multiplicity)
     # Ref: https://stackoverflow.com/questions/7828867/how-to-efficiently-compare-two-unordered-lists-not-sets
     assert Counter(result) == Counter(expected)
+
+
+@pytest.mark.parametrize(
+    "sequence,idx,expected",
+    [
+        # List indexing
+        ([1, 2, 3, 4, 5], 0, 1),
+        ([1, 2, 3, 4, 5], 2, 3),
+        ([1, 2, 3, 4, 5], 4, 5),
+        ([1, 2, 3, 4, 5], -1, 5),
+        ([1, 2, 3, 4, 5], -2, 4),
+        (["a", "b", "c"], 0, "a"),
+        (["a", "b", "c"], 1, "b"),
+        (["a", "b", "c"], -1, "c"),
+        # String indexing
+        ("hello", 0, "h"),
+        ("hello", 1, "e"),
+        ("hello", 4, "o"),
+        ("hello", -1, "o"),
+        ("hello", -5, "h"),
+        # Tuple indexing
+        ((10, 20, 30), 0, 10),
+        ((10, 20, 30), 1, 20),
+        ((10, 20, 30), -1, 30),
+        # Mixed types in list
+        ([1, "two", 3.0, None], 0, 1),
+        ([1, "two", 3.0, None], 1, "two"),
+        ([1, "two", 3.0, None], 2, 3.0),
+        ([1, "two", 3.0, None], 3, None),
+        # Nested structures
+        ([[1, 2], [3, 4]], 0, [1, 2]),
+        ([[1, 2], [3, 4]], 1, [3, 4]),
+        ([{"a": 1}, {"b": 2}], 0, {"a": 1}),
+        ([{"a": 1}, {"b": 2}], -1, {"b": 2}),
+    ],
+)
+def test_index(sequence: Any, idx: int, expected: Any) -> None:
+    """Test index function with various sequence types and indices."""
+    assert index(sequence, idx) == expected
+
+
+@pytest.mark.parametrize(
+    "sequence,idx",
+    [
+        ([1, 2, 3], 5),  # Index too large
+        ([1, 2, 3], -10),  # Negative index too large
+        ("hello", 10),  # String index out of range
+        ([], 0),  # Empty list
+        ("", 0),  # Empty string
+        ((), 0),  # Empty tuple
+    ],
+)
+def test_index_out_of_range(sequence: Any, idx: int) -> None:
+    """Test that index raises IndexError for out-of-range indices."""
+    with pytest.raises(IndexError):
+        index(sequence, idx)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -11,6 +11,7 @@ from tracecat.expressions.functions import (
     add_prefix,
     add_suffix,
     and_,
+    at,
     b64_to_str,
     b64url_to_str,
     capitalize,
@@ -51,7 +52,6 @@ from tracecat.expressions.functions import (
     hash_sha256,
     hash_sha512,
     hours_between,
-    index,
     intersection,
     ipv4_in_subnet,
     ipv4_is_public,
@@ -508,9 +508,9 @@ def test_set_operations(func, a: Any, b: Any, expected: list[Any]) -> None:
         ([{"a": 1}, {"b": 2}], -1, {"b": 2}),
     ],
 )
-def test_index(sequence: Any, idx: int, expected: Any) -> None:
-    """Test index function with various sequence types and indices."""
-    assert index(sequence, idx) == expected
+def test_at(sequence: Any, idx: int, expected: Any) -> None:
+    """Test at function with various sequence types and indices."""
+    assert at(sequence, idx) == expected
 
 
 @pytest.mark.parametrize(
@@ -524,10 +524,10 @@ def test_index(sequence: Any, idx: int, expected: Any) -> None:
         ((), 0),  # Empty tuple
     ],
 )
-def test_index_out_of_range(sequence: Any, idx: int) -> None:
-    """Test that index raises IndexError for out-of-range indices."""
+def test_at_out_of_range(sequence: Any, idx: int) -> None:
+    """Test that at raises IndexError for out-of-range indices."""
     with pytest.raises(IndexError):
-        index(sequence, idx)
+        at(sequence, idx)
 
 
 @pytest.mark.parametrize(

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -133,6 +133,11 @@ def slice_str(x: str, start_index: int, length: int) -> str:
     return x[start_index : start_index + length]
 
 
+def index(sequence: Sequence[Any], index: int) -> Any:
+    """Return the element at the given index."""
+    return sequence[index]
+
+
 def endswith(x: str, suffix: str) -> bool:
     """Check if a string ends with a specified suffix."""
     return x.endswith(suffix)
@@ -1021,6 +1026,7 @@ _FUNCTION_MAPPING = {
     "union": union,
     "unique": unique,
     "zip_map": zip_map,  # Inspired by Terraform: https://developer.hashicorp.com/terraform/language/functions/zipmap
+    "index": index,
     # Math
     "add": add,
     "sub": sub,

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -133,7 +133,7 @@ def slice_str(x: str, start_index: int, length: int) -> str:
     return x[start_index : start_index + length]
 
 
-def index(sequence: Sequence[Any], index: int) -> Any:
+def at(sequence: Sequence[Any], index: int) -> Any:
     """Return the element at the given index."""
     return sequence[index]
 
@@ -1026,7 +1026,7 @@ _FUNCTION_MAPPING = {
     "union": union,
     "unique": unique,
     "zip_map": zip_map,  # Inspired by Terraform: https://developer.hashicorp.com/terraform/language/functions/zipmap
-    "index": index,
+    "at": at,
     # Math
     "add": add,
     "sub": sub,


### PR DESCRIPTION
## Summary
Adds a new `at()` function to the expression functions library for indexing into sequences (lists, strings, tuples).

## Changes
- Add `at(sequence, index)` function that returns the element at the given index
- Support for positive and negative indices
- Works with lists, strings, tuples, and nested structures
- Comprehensive test coverage for various sequence types and edge cases

## Test plan
- Unit tests verify correct indexing behavior for all sequence types
- Out-of-range index handling properly raises IndexError
- Negative indexing works as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added at(sequence, index) to the expression library to read a single element from any sequence. This enables simple indexing in expressions without custom code.

- **New Features**
  - Supports positive and negative indices; raises IndexError when out of range.
  - Works with lists, strings, tuples, and nested structures.
  - Registered as "at" in the functions map.
  - Unit tests cover common types and edge cases.

<sup>Written for commit b441226. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

