### PR TITLE
feat(ui+api): Multi-select conditions for case durations

### DIFF
--- a/frontend/src/components/cases/add-case-duration-dialog.tsx
+++ b/frontend/src/components/cases/add-case-duration-dialog.tsx
@@ -30,12 +30,10 @@ export function AddCaseDurationDialog({
 
       const startFieldFilters = buildFieldFilters(
         values.start.eventType,
-        values.start.filterValue,
         values.start.filterValues
       )
       const endFieldFilters = buildFieldFilters(
         values.end.eventType,
-        values.end.filterValue,
         values.end.filterValues
       )
 

--- a/frontend/src/components/cases/case-durations-table.tsx
+++ b/frontend/src/components/cases/case-durations-table.tsx
@@ -147,21 +147,31 @@ export function CaseDurationsTable({
     }
 
     return (
-      <div className="flex items-center gap-2 text-xs text-foreground">
-        <Icon className="size-3.5 text-muted-foreground" aria-hidden />
-        <span className="font-medium">{label}</span>
-        {valueLabels.map((displayValue, index) => (
+      <div className="flex flex-col gap-2 text-xs text-foreground">
+        <div className="flex items-center gap-2 whitespace-nowrap">
+          <Icon
+            className="h-4 w-4 flex-none text-muted-foreground"
+            aria-hidden
+          />
+          <span className="font-medium">{label}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {valueLabels.map((displayValue, index) => (
+            <Badge
+              key={`${anchor.event_type}-${displayValue}-${index}`}
+              variant="secondary"
+              className="px-2 py-0.5 whitespace-nowrap"
+            >
+              {displayValue}
+            </Badge>
+          ))}
           <Badge
-            key={`${anchor.event_type}-${displayValue}-${index}`}
-            variant="secondary"
-            className="px-2 py-0.5"
+            variant="outline"
+            className="border-dashed px-2 py-0.5 whitespace-nowrap"
           >
-            {displayValue}
+            {SELECTION_LABELS[selection]}
           </Badge>
-        ))}
-        <Badge variant="outline" className="border-dashed px-2 py-0.5">
-          {SELECTION_LABELS[selection]}
-        </Badge>
+        </div>
       </div>
     )
   }
@@ -208,6 +218,10 @@ export function CaseDurationsTable({
               ),
               enableSorting: true,
               enableHiding: false,
+              meta: {
+                headerStyle: { width: "18%" },
+                cellStyle: { width: "18%" },
+              },
             },
             {
               id: "start_anchor",
@@ -217,6 +231,10 @@ export function CaseDurationsTable({
               cell: ({ row }) => renderAnchor(row.original.start_anchor),
               enableSorting: false,
               enableHiding: false,
+              meta: {
+                headerStyle: { width: "41%" },
+                cellStyle: { width: "41%", verticalAlign: "top" },
+              },
             },
             {
               id: "end_anchor",
@@ -226,6 +244,10 @@ export function CaseDurationsTable({
               cell: ({ row }) => renderAnchor(row.original.end_anchor),
               enableSorting: false,
               enableHiding: false,
+              meta: {
+                headerStyle: { width: "41%" },
+                cellStyle: { width: "41%", verticalAlign: "top" },
+              },
             },
             {
               id: "actions",

--- a/frontend/src/components/cases/case-durations-view.tsx
+++ b/frontend/src/components/cases/case-durations-view.tsx
@@ -217,7 +217,7 @@ export function CaseDurationsView() {
 
   return (
     <div className="size-full overflow-auto">
-      <div className="container flex h-full max-w-[1000px] flex-col space-y-8 py-8">
+      <div className="flex h-full w-full flex-col space-y-8 p-8">
         <CaseDurationsTable
           durations={caseDurationDefinitions}
           onDeleteDuration={handleDelete}

--- a/frontend/src/components/cases/multiselect-case-filters.tsx
+++ b/frontend/src/components/cases/multiselect-case-filters.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { Check, ChevronsUpDown } from "lucide-react"
+import { type ComponentType, type ReactNode, useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+export interface CaseFilterOption<T extends string = string> {
+  value: T
+  label: string
+  icon?: ComponentType<{ className?: string }>
+  iconClassName?: string
+  description?: ReactNode
+}
+
+export interface CaseFilterMultiSelectProps<T extends string> {
+  placeholder: string
+  value: T[]
+  options: CaseFilterOption<T>[]
+  onChange: (value: T[]) => void
+  className?: string
+  emptyMessage?: string
+}
+
+export function CaseFilterMultiSelect<T extends string>({
+  placeholder,
+  value,
+  options,
+  onChange,
+  className,
+  emptyMessage = "No results found.",
+}: CaseFilterMultiSelectProps<T>) {
+  const [open, setOpen] = useState(false)
+
+  const valueSet = useMemo(() => new Set(value), [value])
+  const optionMap = useMemo(() => {
+    const map = new Map<T, CaseFilterOption<T>>()
+    for (const option of options) {
+      map.set(option.value, option)
+    }
+    return map
+  }, [options])
+
+  const selectedCount = value.length
+  const triggerLabel =
+    selectedCount === 0
+      ? placeholder
+      : selectedCount === 1
+        ? (optionMap.get(value[0])?.label ?? placeholder)
+        : `${placeholder} (${selectedCount})`
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          role="combobox"
+          className={cn("h-8 w-full justify-between px-3 text-xs", className)}
+        >
+          <span className="truncate text-left">{triggerLabel}</span>
+          <ChevronsUpDown className="ml-2 size-3 opacity-50" aria-hidden />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[220px] p-0 sm:w-[260px]"
+        align="start"
+        side="top"
+        sideOffset={6}
+        avoidCollisions={false}
+        style={{ width: "var(--radix-popover-trigger-width)" }}
+      >
+        <Command>
+          <CommandInput
+            placeholder={`Search ${placeholder.toLowerCase()}...`}
+            className="text-xs"
+          />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = valueSet.has(option.value)
+                const Icon = option.icon
+                return (
+                  <CommandItem
+                    key={option.value}
+                    value={`${option.label} ${option.value}`}
+                    className="flex items-center gap-2 text-xs"
+                    onSelect={() => {
+                      const nextValue = isSelected
+                        ? value.filter((item) => item !== option.value)
+                        : [...value, option.value]
+                      onChange(nextValue)
+                      setOpen(true)
+                    }}
+                  >
+                    <div
+                      className={cn(
+                        "mr-2 flex size-4 items-center justify-center rounded-sm border",
+                        isSelected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-muted text-muted-foreground"
+                      )}
+                    >
+                      <Check
+                        className={cn("size-3", !isSelected && "opacity-0")}
+                        aria-hidden
+                      />
+                    </div>
+                    {Icon ? (
+                      <Icon
+                        className={cn(
+                          "size-3.5 text-muted-foreground",
+                          option.iconClassName
+                        )}
+                        aria-hidden
+                      />
+                    ) : null}
+                    <span className="truncate">{option.label}</span>
+                    {option.description ? (
+                      <span className="ml-auto text-[11px] text-muted-foreground">
+                        {option.description}
+                      </span>
+                    ) : null}
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+        {selectedCount > 0 && (
+          <div className="border-t p-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-full text-xs"
+              onClick={() => onChange([])}
+            >
+              Clear selection
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/cases/update-case-duration-dialog.tsx
+++ b/frontend/src/components/cases/update-case-duration-dialog.tsx
@@ -64,14 +64,12 @@ const getInitialValues = (
     start: {
       selection: duration.start_anchor.selection ?? "first",
       eventType: duration.start_anchor.event_type,
-      filterValue: undefined,
       filterValues: startFilters,
     },
     end: {
       selection: duration.end_anchor.selection ?? "first",
       eventType: duration.end_anchor.event_type,
-      filterValue: endFilters[0],
-      filterValues: [],
+      filterValues: endFilters,
     },
   }
 }
@@ -96,12 +94,10 @@ export function UpdateCaseDurationDialog({
 
       const startFieldFilters = buildFieldFilters(
         values.start.eventType,
-        values.start.filterValue,
         values.start.filterValues
       )
       const endFieldFilters = buildFieldFilters(
         values.end.eventType,
-        values.end.filterValue,
         values.end.filterValues
       )
 

--- a/frontend/src/components/data-table/table.tsx
+++ b/frontend/src/components/data-table/table.tsx
@@ -190,7 +190,7 @@ export function DataTable<TData, TValue>({
 
   return (
     <div>
-      <div className="space-y-4">
+      <div className="space-y-4 w-full">
         {toolbarProps && (
           <DataTableToolbar
             table={table}
@@ -198,7 +198,7 @@ export function DataTable<TData, TValue>({
             onDeleteRows={onDeleteRows}
           />
         )}
-        <div className="rounded-md border">
+        <div className="rounded-md border w-full overflow-hidden">
           <Table>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds multi-select filters to case duration anchors in the UI and API, enabling conditions like Status is Resolved or Closed. Improves validation, display, and backend matching to handle lists correctly.

- New Features
  - Multi-select filters for start/end anchors; blocks duplicate values when both use the same event type.
  - Backend matches list filters (any-of); unit test for Status in [Resolved, Closed].
  - Table shows selected values as badges; submit disabled until name and required filters are set.

- Refactors
  - Replaced single-select with reusable CaseFilterMultiSelect; simplified schema and buildFieldFilters.
  - Tweaked table/view widths and overflow to fit multi-value displays.

<sup>Written for commit 1460165c6a826d042348edddbead8afec7d4f045. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

