### PR TITLE
feat(ui+api): Add 'case_viewed' event to durations

### DIFF
--- a/frontend/src/components/cases/case-duration-options.ts
+++ b/frontend/src/components/cases/case-duration-options.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react"
 import {
   CircleCheck,
+  Eye,
   FilePlus2,
   Flag,
   Flame,
@@ -42,6 +43,11 @@ export const CASE_EVENT_OPTIONS: CaseEventOption[] = [
     value: "case_reopened",
     label: "Case reopened",
     icon: RotateCcw,
+  },
+  {
+    value: "case_viewed",
+    label: "Case viewed",
+    icon: Eye,
   },
   {
     value: "priority_changed",

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -497,11 +497,12 @@ class CasesService(BaseWorkspaceService):
             else:
                 if created_event is not None:
                     try:
+                        await self.durations.sync_case_durations(case)
                         await self.session.commit()
                     except Exception:
                         await self.session.rollback()
                         self.logger.exception(
-                            "Failed to commit case viewed event",
+                            "Failed to persist case viewed tracking updates",
                             case_id=case_id,
                             user_id=self.role.user_id,
                         )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a "case_viewed" event to case event options (Eye icon) and now sync case durations when a case is viewed to track views reliably. Updated error logging to clearly indicate failures when persisting case view tracking.

<sup>Written for commit bcb2f779ef065ffb639fdfcace12e9e84de4bf59. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

