### PR TITLE
build: Use module entrypoint for worker

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -111,7 +111,7 @@ services:
       - ./tracecat:/app/tracecat
       - ./packages/tracecat-registry:/app/packages/tracecat-registry
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
-    command: ["python", "tracecat/dsl/worker.py"]
+    command: ["python", "-m", "tracecat.dsl.worker"]
     depends_on:
       - api
       - temporal

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -120,7 +120,7 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
     volumes:
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
-    command: ["python", "tracecat/dsl/worker.py"]
+    command: ["python", "-m", "tracecat.dsl.worker"]
     depends_on:
       - api
       - temporal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
     volumes:
       - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
-    command: ["python", "tracecat/dsl/worker.py"]
+    command: ["python", "-m", "tracecat.dsl.worker"]
     depends_on:
       - api
       - temporal


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

- Switch every worker entrypoint (compose variants, ECS/Fargate task, and Helm chart) to run `python -m tracecat.dsl.worker`.
- Running the worker as a script (`python tracecat/dsl/worker.py`) put `tracecat/dsl` at the front of `sys.path`, so stdlib imports (e.g. `types.GenericAlias`) resolved against our package module and raised an `ImportError`.
- Launching via the module keeps the package root on `sys.path` instead, letting the stdlib `types` module load correctly while preserving the consistent `types` naming pattern across services.

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

1. Rebuild/redeploy the worker (compose, Helm, or Fargate).
2. Start the worker and confirm it boots without `ImportError: cannot import name 'GenericAlias' from partially initialized module 'types'`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the DSL worker using Python’s module entrypoint (python -m tracecat.dsl.worker) across all docker-compose files. This prevents path-based import issues and keeps startup consistent in dev, local, and prod.

<sup>Written for commit 96cb148156241b290cd4d720eb71cbe3e0a5733c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
