### PR TITLE
fix(worker): Prevent PydanticAIPlugin from overriding custom data converter

### DIFF
--- a/tracecat/dsl/plugins.py
+++ b/tracecat/dsl/plugins.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pydantic_ai.durable_exec.temporal import PydanticAIPlugin
+from temporalio.converter import DataConverter
+
+from tracecat import config
+from tracecat.dsl._converter import get_data_converter
+
+
+class TracecatPydanticAIPlugin(PydanticAIPlugin):
+    """Pydantic AI plugin that preserves Tracecat's custom data converter."""
+
+    def _get_new_data_converter(self, converter: DataConverter | None) -> DataConverter:
+        if converter is not None:
+            return converter
+
+        return get_data_converter(
+            compression_enabled=config.TRACECAT__CONTEXT_COMPRESSION_ENABLED
+        )

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -4,7 +4,6 @@ import os
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 
-from pydantic_ai.durable_exec.temporal import PydanticAIPlugin
 from temporalio import workflow
 from temporalio.worker import Worker
 from temporalio.worker.workflow_sandbox import (
@@ -25,6 +24,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.interceptor import SentryInterceptor
+    from tracecat.dsl.plugins import TracecatPydanticAIPlugin
     from tracecat.dsl.validation import validate_trigger_inputs_activity
     from tracecat.dsl.workflow import DSLWorkflow
     from tracecat.ee.interactions.service import InteractionService
@@ -81,7 +81,7 @@ def get_activities() -> list[Callable]:
 
 
 async def main() -> None:
-    client = await get_temporal_client(plugins=[PydanticAIPlugin()])
+    client = await get_temporal_client(plugins=[TracecatPydanticAIPlugin()])
 
     interceptors = []
     if sentry_dsn := os.environ.get("SENTRY_DSN"):


### PR DESCRIPTION
PydanticAIPlugin silently replaces our data converter (with compression). Override the logic to return our own data converter.
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
