### PR TITLE
feat(tests): Integrate TracecatPydanticAIPlugin into temporal client setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_engine, get_async_session_context_manager
 from tracecat.db.models import Workspace
 from tracecat.dsl.client import get_temporal_client
+from tracecat.dsl.plugins import TracecatPydanticAIPlugin
 from tracecat.dsl.worker import get_activities, new_sandbox_runner
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.logger import logger
@@ -397,7 +398,9 @@ def temporal_client():
         policy = asyncio.get_event_loop_policy()
         loop = policy.new_event_loop()
 
-    client = loop.run_until_complete(get_temporal_client())
+    client = loop.run_until_complete(
+        get_temporal_client(plugins=[TracecatPydanticAIPlugin()])
+    )
     return client
 
 


### PR DESCRIPTION
## Summary
Adds `TracecatPydanticAIPlugin` to the temporal client fixture in `conftest.py` to ensure proper plugin initialization during tests.

## Changes
- Updated `temporal_client` fixture to include `TracecatPydanticAIPlugin` when initializing the Temporal client

## Test plan
- Existing tests should pass with the plugin properly configured

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added TracecatPydanticAIPlugin to the Temporal test client so plugin-dependent workflows initialize correctly in tests. This aligns the test setup with production and prevents plugin-related failures.

<sup>Written for commit 954a13479e0cec1dce622604e25c44d2e2b871c4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

