### PR TITLE
feat(integrations): Support manual refresh token in OAuth providers

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/[providerId]/page.tsx
@@ -378,7 +378,9 @@ function ProviderDetailContent({ provider }: { provider: ProviderRead }) {
                       ) : (
                         <Zap className="mr-1 h-3 w-3" />
                       )}
-                      {isAuthCodeGrant ? "Reconnect with OAuth" : "Refresh token"}
+                      {isAuthCodeGrant
+                        ? "Reconnect with OAuth"
+                        : "Refresh token"}
                     </Button>
                     <DeleteIntegrationButton compact />
                   </>
@@ -389,7 +391,9 @@ function ProviderDetailContent({ provider }: { provider: ProviderRead }) {
                       size="sm"
                       className="h-[22px] px-2 py-0 text-xs font-medium"
                       onClick={
-                        isAuthCodeGrant ? handleOAuthConnect : handleTestConnection
+                        isAuthCodeGrant
+                          ? handleOAuthConnect
+                          : handleTestConnection
                       }
                       disabled={!isEnabled || connectOrRefreshIsPending}
                     >


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds manual credential refresh for integrations. Users can reconnect OAuth (authorization_code) or refresh tokens (client_credentials) directly from the provider page with clearer UI and states.

- **New Features**
  - Added a single “Reconnect with OAuth”/“Refresh token” button when connected.
  - Unified pending state for connect/refresh to simplify loading and disabling.
  - Disconnect button shown only for authorization_code providers.
  - Correct grant-type badge display for Authorization code vs Client credentials.
  - Clear action labels when configured but not connected: “Connect with OAuth” or “Fetch token”.

<sup>Written for commit 924d4f378eae7b51690458aa30680fa0772b85cf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



