### PR TITLE
feat: Make AgentConfig.retries use config for its default

### DIFF
--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -8,6 +8,7 @@ from pydantic import TypeAdapter
 from pydantic_ai import ModelResponse
 from pydantic_ai.messages import ModelMessage
 
+from tracecat import config
 from tracecat.chat.enums import MessageKind
 
 if TYPE_CHECKING:
@@ -91,6 +92,6 @@ class AgentConfig:
     mcp_server_url: str | None = None
     mcp_server_headers: dict[str, str] | None = None
     model_settings: dict[str, Any] | None = None
-    retries: int = 3
+    retries: int = config.TRACECAT__AGENT_MAX_RETRIES
     deps_type: type[Any] | None = None
     custom_tools: CustomToolList | None = None

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -472,3 +472,6 @@ TRACECAT__AGENT_MAX_TOOL_CALLS = int(
 
 TRACECAT__AGENT_MAX_REQUESTS = int(os.environ.get("TRACECAT__AGENT_MAX_REQUESTS", 120))
 """The maximum number of requests that can be made per agent run."""
+
+TRACECAT__AGENT_MAX_RETRIES = int(os.environ.get("TRACECAT__AGENT_MAX_RETRIES", 20))
+"""The maximum number of retries that can be made per agent run."""


### PR DESCRIPTION
Lets us control default number of tool retries in *chat.
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
AgentConfig.retries now reads from the config via TRACECAT__AGENT_MAX_RETRIES, making retry limits configurable. The default increases from 3 to 20 to improve resilience.

- **Migration**
  - Optional: set TRACECAT__AGENT_MAX_RETRIES to your desired limit. Use 3 to keep previous behavior.

<sup>Written for commit 8715f59801facd199642c0d0221aa7b0a5273987. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



