### PR TITLE
feat: Evaluate expressions in agent tool arguments

### DIFF
--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -110,8 +110,8 @@ async def call_tracecat_action(
     context[ExprContext.VARS] = ws_vars
 
     flattened_secrets = secrets_manager.flatten_secrets(secrets)
-    args = eval_templated_object(args, operand=context)
     try:
+        args = eval_templated_object(args, operand=context)
         with secrets_manager.env_sandbox(flattened_secrets):
             # Call directly based on action type
             if bound_action.is_template:


### PR DESCRIPTION
## Summary
Adds expression evaluation for arguments passed to Tracecat tools when called from agents.

## Changes
- Import `eval_templated_object` in `tracecat/agent/tools.py`
- Evaluate `args` against the expression context before passing to template actions
- Enables template expressions in agent tool arguments

## Impact
Agents can now use template expressions (e.g., `${{ SECRETS.api.TOKEN }}`, `${{ VARS.some_value }}`) in their tool call arguments, matching the behavior of regular workflow actions.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agents can now use template expressions in tool arguments, so values like ${{ SECRETS.api.TOKEN }} and ${{ VARS.some_value }} resolve before the tool runs. This brings agent tool calls in line with workflow actions.

- **New Features**
  - Evaluate tool args with eval_templated_object using the agent expression context.
  - Behavior matches regular workflow actions for secrets and vars.

<sup>Written for commit 0c4fe7cdd61203e30bbd0b07245e08f9931ac3d4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



