### PR TITLE
test: Add API router tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,7 +364,11 @@ async def test_admin_role(test_workspace, mock_org_id):
         access_level=AccessLevel.ADMIN,
         service_id="tracecat-runner",
     )
-    yield admin_role
+    token = ctx_role.set(admin_role)
+    try:
+        yield admin_role
+    finally:
+        ctx_role.reset(token)
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -7,10 +7,36 @@ import pytest
 from fastapi.testclient import TestClient
 from syrupy.assertion import SnapshotAssertion
 
+from tracecat.agent.router import (
+    OrganizationAdminUserRole,
+    OrganizationUserRole,
+)
 from tracecat.api.app import app
 from tracecat.auth.dependencies import WorkspaceUserRole
 from tracecat.auth.types import Role
+from tracecat.cases.router import WorkspaceUser
 from tracecat.contexts import ctx_role
+from tracecat.secrets.router import (
+    OrgAdminUser,
+    WorkspaceAdminUser,
+)
+from tracecat.secrets.router import (
+    WorkspaceUser as SecretsWorkspaceUser,
+)
+from tracecat.tables.router import (
+    WorkspaceAdminUser as TablesWorkspaceAdminUser,
+)
+from tracecat.tables.router import (
+    WorkspaceUser as TablesWorkspaceUser,
+)
+from tracecat.workspaces.router import (
+    OrgAdminUser as WorkspacesOrgAdminUser,
+)
+from tracecat.workspaces.router import (
+    OrgUser,
+    WorkspaceAdminUserInPath,
+    WorkspaceUserInPath,
+)
 
 
 def override_role_dependency() -> Role:
@@ -28,11 +54,23 @@ def client() -> Generator[TestClient, None, None]:
     Uses the existing app instance and relies on ctx_role context
     from test_role/test_admin_role fixtures for authentication.
     """
-    # Import WorkspaceUser from cases router
-    from tracecat.cases.router import WorkspaceUser
 
     # List of Annotated role dependencies to override
-    role_dependencies = [WorkspaceUserRole, WorkspaceUser]
+    role_dependencies = [
+        WorkspaceUserRole,
+        WorkspaceUser,
+        WorkspaceUserInPath,
+        WorkspaceAdminUserInPath,
+        OrganizationUserRole,
+        OrganizationAdminUserRole,
+        OrgUser,
+        WorkspacesOrgAdminUser,
+        SecretsWorkspaceUser,
+        WorkspaceAdminUser,
+        OrgAdminUser,
+        TablesWorkspaceUser,
+        TablesWorkspaceAdminUser,
+    ]
 
     for annotated_type in role_dependencies:
         # Extract the Depends object from the Annotated type

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -5,7 +5,6 @@ from typing import get_args
 
 import pytest
 from fastapi.testclient import TestClient
-from syrupy.assertion import SnapshotAssertion
 
 from tracecat.agent.router import (
     OrganizationAdminUserRole,
@@ -84,9 +83,3 @@ def client() -> Generator[TestClient, None, None]:
     yield client
     # Clean up overrides
     app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def snapshot(snapshot: SnapshotAssertion) -> Generator[SnapshotAssertion, None, None]:
-    """Provide snapshot fixture with proper type hints."""
-    yield snapshot

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -1,0 +1,54 @@
+"""Minimal fixtures for HTTP-level API route testing."""
+
+from collections.abc import Generator
+from typing import get_args
+
+import pytest
+from fastapi.testclient import TestClient
+from syrupy.assertion import SnapshotAssertion
+
+from tracecat.api.app import app
+from tracecat.auth.dependencies import WorkspaceUserRole
+from tracecat.auth.types import Role
+from tracecat.contexts import ctx_role
+
+
+def override_role_dependency() -> Role:
+    """Override role dependencies to use ctx_role from test fixtures."""
+    role = ctx_role.get()
+    if role is None:
+        raise RuntimeError("No role set in ctx_role context")
+    return role
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create FastAPI test client.
+
+    Uses the existing app instance and relies on ctx_role context
+    from test_role/test_admin_role fixtures for authentication.
+    """
+    # Import WorkspaceUser from cases router
+    from tracecat.cases.router import WorkspaceUser
+
+    # List of Annotated role dependencies to override
+    role_dependencies = [WorkspaceUserRole, WorkspaceUser]
+
+    for annotated_type in role_dependencies:
+        # Extract the Depends object from the Annotated type
+        metadata = get_args(annotated_type)
+        if metadata and hasattr(metadata[1], "dependency"):
+            original_dependency = metadata[1].dependency
+            # Override the actual dependency function
+            app.dependency_overrides[original_dependency] = override_role_dependency
+
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+    # Clean up overrides
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def snapshot(snapshot: SnapshotAssertion) -> Generator[SnapshotAssertion, None, None]:
+    """Provide snapshot fixture with proper type hints."""
+    yield snapshot

--- a/tests/unit/api/test_api_agents.py
+++ b/tests/unit/api/test_api_agents.py
@@ -1,0 +1,397 @@
+"""HTTP-level tests for agent management API endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.agent.schemas import (
+    ModelConfig,
+    ProviderCredentialConfig,
+    ProviderCredentialField,
+)
+from tracecat.auth.types import Role
+
+
+@pytest.mark.anyio
+async def test_list_models_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/models returns available models."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_models = {
+            "gpt-4": ModelConfig(
+                provider="openai",
+                name="gpt-4",
+                org_secret_name="agent-openai-credentials",
+                secrets={"required": ["openai"]},
+            ),
+            "claude-3": ModelConfig(
+                provider="anthropic",
+                name="claude-3",
+                org_secret_name="agent-anthropic-credentials",
+                secrets={"required": ["anthropic"]},
+            ),
+        }
+        mock_svc.list_models.return_value = mock_models
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/models")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "gpt-4" in data
+        assert "claude-3" in data
+        assert data["gpt-4"]["provider"] == "openai"
+        assert data["claude-3"]["provider"] == "anthropic"
+
+
+@pytest.mark.anyio
+async def test_list_providers_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/providers returns available providers."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_providers = ["openai", "anthropic", "google"]
+        mock_svc.list_providers.return_value = mock_providers
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/providers")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data == mock_providers
+        assert "openai" in data
+        assert "anthropic" in data
+
+
+@pytest.mark.anyio
+async def test_get_providers_status_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/providers/status returns credential status."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_status = {
+            "openai": True,
+            "anthropic": False,
+            "google": True,
+        }
+        mock_svc.get_providers_status.return_value = mock_status
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/providers/status")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data == mock_status
+        assert data["openai"] is True
+        assert data["anthropic"] is False
+
+
+@pytest.mark.anyio
+async def test_list_provider_credential_configs_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/providers/configs returns credential configs."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_configs = [
+            ProviderCredentialConfig(
+                provider="openai",
+                label="OpenAI",
+                fields=[
+                    ProviderCredentialField(
+                        key="api_key",
+                        label="API Key",
+                        type="password",
+                        description="OpenAI API key",
+                    )
+                ],
+            ),
+        ]
+        mock_svc.list_provider_credential_configs.return_value = mock_configs
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/providers/configs")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["provider"] == "openai"
+
+
+@pytest.mark.anyio
+async def test_get_provider_credential_config_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/providers/{provider}/config returns provider config."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_config = ProviderCredentialConfig(
+            provider="openai",
+            label="OpenAI",
+            fields=[
+                ProviderCredentialField(
+                    key="api_key",
+                    label="API Key",
+                    type="password",
+                    description="OpenAI API key",
+                )
+            ],
+        )
+        mock_svc.get_provider_credential_config.return_value = mock_config
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/providers/openai/config")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["provider"] == "openai"
+        assert "fields" in data
+
+
+@pytest.mark.anyio
+async def test_get_provider_credential_config_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/providers/{provider}/config with invalid provider returns 404."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        from tracecat.exceptions import TracecatNotFoundError
+
+        mock_svc = AsyncMock()
+        mock_svc.get_provider_credential_config.side_effect = TracecatNotFoundError(
+            "Provider not found"
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/providers/invalid/config")
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_create_provider_credentials_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /agent/credentials creates provider credentials."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_provider_credentials.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            "/agent/credentials",
+            json={
+                "provider": "openai",
+                "credentials": {"api_key": "sk-test-key"},
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert "message" in data
+        assert "openai" in data["message"]
+
+
+@pytest.mark.anyio
+async def test_create_provider_credentials_error(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /agent/credentials with error returns 400."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_provider_credentials.side_effect = Exception(
+            "Invalid credentials"
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            "/agent/credentials",
+            json={
+                "provider": "openai",
+                "credentials": {"api_key": "invalid"},
+            },
+        )
+
+        # Should return 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_update_provider_credentials_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test PUT /agent/credentials/{provider} updates credentials."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.update_provider_credentials.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.put(
+            "/agent/credentials/openai",
+            json={"credentials": {"api_key": "sk-new-key"}},
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "message" in data
+        assert "openai" in data["message"]
+
+
+@pytest.mark.anyio
+async def test_update_provider_credentials_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test PUT /agent/credentials/{provider} with non-existent provider returns 404."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        from tracecat.exceptions import TracecatNotFoundError
+
+        mock_svc = AsyncMock()
+        mock_svc.update_provider_credentials.side_effect = TracecatNotFoundError(
+            "Credentials not found"
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.put(
+            "/agent/credentials/invalid",
+            json={"credentials": {"api_key": "test"}},
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_delete_provider_credentials_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test DELETE /agent/credentials/{provider} deletes credentials."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.delete_provider_credentials.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.delete("/agent/credentials/openai")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "message" in data
+        assert "openai" in data["message"]
+
+
+@pytest.mark.anyio
+async def test_get_default_model_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/default-model returns default model."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_default_model.return_value = "gpt-4"
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/default-model")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data == "gpt-4"
+
+
+@pytest.mark.anyio
+async def test_get_default_model_none(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /agent/default-model when no default is set."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_default_model.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/agent/default-model")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data is None
+
+
+@pytest.mark.anyio
+async def test_set_default_model_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test PUT /agent/default-model sets default model."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.set_default_model.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.put("/agent/default-model?model_name=gpt-4")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "message" in data
+        assert "gpt-4" in data["message"]
+
+
+@pytest.mark.anyio
+async def test_set_default_model_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test PUT /agent/default-model with invalid model returns 404."""
+    with patch("tracecat.agent.router.AgentManagementService") as MockService:
+        from tracecat.exceptions import TracecatNotFoundError
+
+        mock_svc = AsyncMock()
+        mock_svc.set_default_model.side_effect = TracecatNotFoundError(
+            "Model not found"
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.put("/agent/default-model?model_name=invalid-model")
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/unit/api/test_api_agents.py
+++ b/tests/unit/api/test_api_agents.py
@@ -12,6 +12,7 @@ from tracecat.agent.schemas import (
     ProviderCredentialField,
 )
 from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatNotFoundError
 
 
 @pytest.mark.anyio
@@ -176,8 +177,6 @@ async def test_get_provider_credential_config_not_found(
 ) -> None:
     """Test GET /agent/providers/{provider}/config with invalid provider returns 404."""
     with patch("tracecat.agent.router.AgentManagementService") as MockService:
-        from tracecat.exceptions import TracecatNotFoundError
-
         mock_svc = AsyncMock()
         mock_svc.get_provider_credential_config.side_effect = TracecatNotFoundError(
             "Provider not found"
@@ -275,8 +274,6 @@ async def test_update_provider_credentials_not_found(
 ) -> None:
     """Test PUT /agent/credentials/{provider} with non-existent provider returns 404."""
     with patch("tracecat.agent.router.AgentManagementService") as MockService:
-        from tracecat.exceptions import TracecatNotFoundError
-
         mock_svc = AsyncMock()
         mock_svc.update_provider_credentials.side_effect = TracecatNotFoundError(
             "Credentials not found"
@@ -382,8 +379,6 @@ async def test_set_default_model_not_found(
 ) -> None:
     """Test PUT /agent/default-model with invalid model returns 404."""
     with patch("tracecat.agent.router.AgentManagementService") as MockService:
-        from tracecat.exceptions import TracecatNotFoundError
-
         mock_svc = AsyncMock()
         mock_svc.set_default_model.side_effect = TracecatNotFoundError(
             "Model not found"

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -1,0 +1,400 @@
+"""HTTP-level tests for cases API endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.schemas import CaseReadMinimal
+from tracecat.db.models import Case, CaseTag
+from tracecat.pagination import CursorPaginatedResponse
+
+
+@pytest.fixture
+def mock_case(test_workspace) -> Case:
+    """Create a mock case DB object."""
+    case = Case(
+        owner_id=test_workspace.id,
+        summary="Test Case Summary",
+        description="Test case description with details",
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.MEDIUM,
+        status=CaseStatus.NEW,  # Changed from OPEN to NEW
+        payload={"source": "test"},
+        assignee_id=None,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    # Set attributes that are auto-generated or relationships
+    case.id = uuid.UUID("cccccccc-cccc-4ccc-cccc-cccccccccccc")
+    case.case_number = 1
+    case.tags = []
+    return case
+
+
+@pytest.fixture
+def mock_case_tag(test_workspace) -> CaseTag:
+    """Create a mock case tag DB object."""
+    return CaseTag(
+        id=uuid.uuid4(),
+        name="incident",
+        ref="incident",  # Changed from slug to ref
+        color="#FF0000",
+        owner_id=test_workspace.id,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+
+@pytest.mark.anyio
+async def test_list_cases_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test GET /cases returns paginated list of cases."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        # Create mock service instance
+        mock_svc = AsyncMock()
+
+        # Mock paginated response with CaseReadMinimal instances
+        mock_case_read = CaseReadMinimal(
+            id=mock_case.id,
+            created_at=mock_case.created_at,
+            updated_at=mock_case.updated_at,
+            short_id=f"CASE-{mock_case.case_number:04d}",
+            summary=mock_case.summary,
+            status=mock_case.status,
+            priority=mock_case.priority,
+            severity=mock_case.severity,
+            assignee=None,
+            tags=[],
+            num_tasks_completed=0,
+            num_tasks_total=0,
+        )
+
+        mock_response = CursorPaginatedResponse(
+            items=[mock_case_read],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_svc.list_cases_paginated.return_value = mock_response
+
+        # Set up service mock
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(f"/cases?workspace_id={test_admin_role.workspace_id}")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify response structure
+        assert "items" in data
+        assert len(data["items"]) == 1
+        assert "has_more" in data
+        assert "next_cursor" in data
+
+        # Verify case data
+        case = data["items"][0]
+        assert case["summary"] == "Test Case Summary"
+        assert case["status"] == "new"
+        assert case["priority"] == "medium"
+        assert case["severity"] == "medium"
+        assert "short_id" in case
+
+
+@pytest.mark.anyio
+async def test_list_cases_with_filters(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test GET /cases with filtering by status, priority, severity."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_case_read = CaseReadMinimal(
+            id=mock_case.id,
+            created_at=mock_case.created_at,
+            updated_at=mock_case.updated_at,
+            short_id=f"CASE-{mock_case.case_number:04d}",
+            summary=mock_case.summary,
+            status=mock_case.status,
+            priority=mock_case.priority,
+            severity=mock_case.severity,
+            assignee=None,
+            tags=[],
+            num_tasks_completed=0,
+            num_tasks_total=0,
+        )
+
+        mock_response = CursorPaginatedResponse(
+            items=[mock_case_read],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_svc.list_cases_paginated.return_value = mock_response
+        MockService.return_value = mock_svc
+
+        # Make request with filters
+        response = client.get(
+            f"/cases?workspace_id={test_admin_role.workspace_id}&status=new&priority=medium&severity=medium&search_term=Test"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["items"]) == 1
+
+
+@pytest.mark.anyio
+async def test_create_case_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test POST /cases creates a new case."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.create_case.return_value = mock_case
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            f"/cases?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "summary": "Test Case Summary",
+                "description": "Test case description with details",
+                "priority": "medium",
+                "severity": "medium",
+                "status": "new",  # Changed from "open" to "new"
+                "payload": {"source": "test"},
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Verify service was called
+        mock_svc.create_case.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_create_case_validation_error(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /cases with invalid data returns 422."""
+    # Make request with missing required fields
+    response = client.post(
+        f"/cases?workspace_id={test_admin_role.workspace_id}",
+        json={
+            "summary": "Test",
+            # Missing required fields: description, priority, severity
+        },
+    )
+
+    # Should return validation error
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.anyio
+async def test_get_case_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test GET /cases/{id} returns case details."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_case.return_value = mock_case
+        # Mock fields service
+        mock_svc.fields = AsyncMock()
+        mock_svc.fields.get_fields.return_value = {}
+        mock_svc.fields.list_fields.return_value = []
+        MockService.return_value = mock_svc
+
+        # Make request
+        case_id = str(mock_case.id)
+        response = client.get(
+            f"/cases/{case_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify case data
+        assert data["summary"] == "Test Case Summary"
+        assert data["description"] == "Test case description with details"
+        assert data["status"] == "new"
+        assert data["priority"] == "medium"
+        assert data["severity"] == "medium"
+        assert data["short_id"] == "CASE-0001"
+        assert "id" in data
+        assert "created_at" in data
+
+
+@pytest.mark.anyio
+async def test_get_case_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /cases/{id} with non-existent ID returns 404."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_case.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request with non-existent ID
+        fake_id = str(uuid.uuid4())
+        response = client.get(
+            f"/cases/{fake_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_update_case_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test PATCH /cases/{id} updates case."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_case.return_value = mock_case
+        mock_svc.update_case.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        case_id = str(mock_case.id)
+        response = client.patch(
+            f"/cases/{case_id}?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "summary": "Updated Summary",
+                "status": "in_progress",
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # Verify service was called
+        mock_svc.update_case.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_update_case_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test PATCH /cases/{id} with non-existent ID returns 404."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_case.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        fake_id = str(uuid.uuid4())
+        response = client.patch(
+            f"/cases/{fake_id}?workspace_id={test_admin_role.workspace_id}",
+            json={"summary": "Updated Summary"},
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_get_case_with_tags(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+    mock_case_tag: CaseTag,
+) -> None:
+    """Test GET /cases/{id} properly serializes tags relationship."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+
+        # Add tags to case
+        mock_case.tags = [mock_case_tag]
+
+        mock_svc.get_case.return_value = mock_case
+        mock_svc.fields = AsyncMock()
+        mock_svc.fields.get_fields.return_value = {}
+        mock_svc.fields.list_fields.return_value = []
+        MockService.return_value = mock_svc
+
+        # Make request
+        case_id = str(mock_case.id)
+        response = client.get(
+            f"/cases/{case_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify tags are properly serialized
+        assert "tags" in data
+        assert len(data["tags"]) == 1
+        assert data["tags"][0]["name"] == "incident"
+        assert data["tags"][0]["ref"] == "incident"  # Changed from slug to ref
+        assert data["tags"][0]["color"] == "#FF0000"
+
+
+@pytest.mark.anyio
+async def test_search_cases_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test GET /cases/search with search term."""
+    with (
+        patch("tracecat.cases.router.CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.search_cases.return_value = [mock_case]
+        mock_svc.get_task_counts.return_value = {
+            mock_case.id: {"completed": 0, "total": 0}
+        }
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(
+            f"/cases/search?workspace_id={test_admin_role.workspace_id}&search_term=Test&limit=10"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["summary"] == "Test Case Summary"

--- a/tests/unit/api/test_api_secrets.py
+++ b/tests/unit/api/test_api_secrets.py
@@ -1,0 +1,451 @@
+"""HTTP-level tests for secrets API endpoints."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from sqlalchemy.exc import IntegrityError
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Secret
+from tracecat.secrets.enums import SecretType
+from tracecat.secrets.schemas import SecretKeyValue
+
+
+@pytest.fixture
+def mock_secret(test_workspace) -> Secret:
+    """Create a mock secret DB object."""
+    secret = Secret(
+        id="secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        owner_id=test_workspace.id,
+        name="test_secret",
+        type=SecretType.CUSTOM,
+        description="Test secret description",
+        encrypted_keys=b"encrypted_data",
+        environment="default",
+        tags=None,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    return secret
+
+
+@pytest.mark.anyio
+async def test_list_secrets_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_secret: Secret,
+) -> None:
+    """Test GET /secrets returns list of secrets."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_secrets.return_value = [mock_secret]
+        mock_svc.decrypt_keys = MagicMock(
+            return_value=[SecretKeyValue(key="api_key", value=SecretStr("***"))]
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(f"/secrets?workspace_id={test_admin_role.workspace_id}")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "test_secret"
+        assert data[0]["type"] == "custom"
+
+
+@pytest.mark.anyio
+async def test_list_secrets_with_type_filter(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_secret: Secret,
+) -> None:
+    """Test GET /secrets with type filter."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_secrets.return_value = [mock_secret]
+        mock_svc.decrypt_keys = MagicMock(
+            return_value=[SecretKeyValue(key="api_key", value=SecretStr("***"))]
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(
+            f"/secrets?workspace_id={test_admin_role.workspace_id}&type=custom"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+
+
+@pytest.mark.anyio
+async def test_search_secrets_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_secret: Secret,
+) -> None:
+    """Test GET /secrets/search with filters."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.search_secrets.return_value = [mock_secret]
+        mock_svc.decrypt_keys = MagicMock(
+            return_value=[SecretKeyValue(key="api_key", value=SecretStr("***"))]
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(
+            f"/secrets/search?workspace_id={test_admin_role.workspace_id}&environment=default&name=test_secret"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "test_secret"
+
+
+@pytest.mark.anyio
+async def test_get_secret_by_name_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_secret: Secret,
+) -> None:
+    """Test GET /secrets/{secret_name} returns secret details."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_secret_by_name.return_value = mock_secret
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(
+            f"/secrets/test_secret?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == "test_secret"
+        assert data["type"] == "custom"
+
+
+@pytest.mark.anyio
+async def test_get_secret_by_name_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /secrets/{secret_name} with non-existent name returns 404."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        from tracecat.exceptions import TracecatNotFoundError
+
+        mock_svc = AsyncMock()
+        mock_svc.get_secret_by_name.side_effect = TracecatNotFoundError(
+            "Secret not found"
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(
+            f"/secrets/nonexistent?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_create_secret_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /secrets creates a new secret."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_secret.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            f"/secrets?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "name": "new_secret",
+                "type": "custom",
+                "description": "New test secret",
+                "keys": [{"key": "api_key", "value": "secret_value"}],
+                "environment": "default",
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.anyio
+async def test_create_secret_conflict(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /secrets with duplicate name returns 409."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_secret.side_effect = IntegrityError(
+            "", {}, Exception("Duplicate")
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            f"/secrets?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "name": "duplicate_secret",
+                "type": "custom",
+                "keys": [{"key": "api_key", "value": "secret_value"}],
+                "environment": "default",
+            },
+        )
+
+        # Should return 409
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_update_secret_by_id_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_secret: Secret,
+) -> None:
+    """Test POST /secrets/{secret_id} updates secret."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_secret.return_value = mock_secret
+        mock_svc.update_secret.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        secret_id = str(mock_secret.id)
+        response = client.post(
+            f"/secrets/{secret_id}?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "description": "Updated description",
+                "keys": [{"key": "api_key", "value": "new_value"}],
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_update_secret_by_id_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /secrets/{secret_id} with non-existent ID returns 404."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        from tracecat.exceptions import TracecatNotFoundError
+
+        mock_svc = AsyncMock()
+        mock_svc.get_secret.side_effect = TracecatNotFoundError("Secret not found")
+        MockService.return_value = mock_svc
+
+        # Make request
+        fake_id = "secret-00000000000000000000000000000000"
+        response = client.post(
+            f"/secrets/{fake_id}?workspace_id={test_admin_role.workspace_id}",
+            json={"description": "Updated"},
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_delete_secret_by_id_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_secret: Secret,
+) -> None:
+    """Test DELETE /secrets/{secret_id} deletes secret."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_secret.return_value = mock_secret
+        mock_svc.delete_secret.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        secret_id = str(mock_secret.id)
+        response = client.delete(
+            f"/secrets/{secret_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_delete_secret_by_id_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test DELETE /secrets/{secret_id} with non-existent ID returns 404."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        from tracecat.exceptions import TracecatNotFoundError
+
+        mock_svc = AsyncMock()
+        mock_svc.get_secret.side_effect = TracecatNotFoundError("Secret not found")
+        MockService.return_value = mock_svc
+
+        # Make request
+        fake_id = "secret-00000000000000000000000000000000"
+        response = client.delete(
+            f"/secrets/{fake_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+# Organization secrets tests
+
+
+@pytest.fixture
+def mock_org_secret(mock_org_id) -> Secret:
+    """Create a mock organization secret DB object."""
+    secret = Secret(
+        id="secret-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        owner_id=mock_org_id,
+        name="org_secret",
+        type=SecretType.CUSTOM,
+        description="Organization secret description",
+        encrypted_keys=b"encrypted_org_data",
+        environment="default",
+        tags=None,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    return secret
+
+
+@pytest.mark.anyio
+async def test_list_org_secrets_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_org_secret: Secret,
+) -> None:
+    """Test GET /organization/secrets returns org secrets."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_org_secrets.return_value = [mock_org_secret]
+        mock_svc.decrypt_keys = MagicMock(
+            return_value=[SecretKeyValue(key="api_key", value=SecretStr("***"))]
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/organization/secrets")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "org_secret"
+
+
+@pytest.mark.anyio
+async def test_create_org_secret_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /organization/secrets creates org secret."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_org_secret.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            "/organization/secrets",
+            json={
+                "name": "new_org_secret",
+                "type": "custom",
+                "description": "New org secret",
+                "keys": [{"key": "api_key", "value": "secret_value"}],
+                "environment": "default",
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.anyio
+async def test_get_org_secret_by_name_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_org_secret: Secret,
+) -> None:
+    """Test GET /organization/secrets/{secret_name} returns org secret."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_org_secret_by_name.return_value = mock_org_secret
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/organization/secrets/org_secret")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == "org_secret"
+
+
+@pytest.mark.anyio
+async def test_update_org_secret_by_id_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_org_secret: Secret,
+) -> None:
+    """Test POST /organization/secrets/{secret_id} updates org secret."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_org_secret.return_value = mock_org_secret
+        mock_svc.update_org_secret.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        secret_id = str(mock_org_secret.id)
+        response = client.post(
+            f"/organization/secrets/{secret_id}",
+            json={"description": "Updated org secret"},
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_delete_org_secret_by_id_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_org_secret: Secret,
+) -> None:
+    """Test DELETE /organization/secrets/{secret_id} deletes org secret."""
+    with patch("tracecat.secrets.router.SecretsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_org_secret.return_value = mock_org_secret
+        mock_svc.delete_org_secret.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        secret_id = str(mock_org_secret.id)
+        response = client.delete(f"/organization/secrets/{secret_id}")
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/tests/unit/api/test_api_secrets.py
+++ b/tests/unit/api/test_api_secrets.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 
 from tracecat.auth.types import Role
 from tracecat.db.models import Secret
+from tracecat.exceptions import TracecatNotFoundError
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import SecretKeyValue
 
@@ -143,8 +144,6 @@ async def test_get_secret_by_name_not_found(
 ) -> None:
     """Test GET /secrets/{secret_name} with non-existent name returns 404."""
     with patch("tracecat.secrets.router.SecretsService") as MockService:
-        from tracecat.exceptions import TracecatNotFoundError
-
         mock_svc = AsyncMock()
         mock_svc.get_secret_by_name.side_effect = TracecatNotFoundError(
             "Secret not found"
@@ -249,8 +248,6 @@ async def test_update_secret_by_id_not_found(
 ) -> None:
     """Test POST /secrets/{secret_id} with non-existent ID returns 404."""
     with patch("tracecat.secrets.router.SecretsService") as MockService:
-        from tracecat.exceptions import TracecatNotFoundError
-
         mock_svc = AsyncMock()
         mock_svc.get_secret.side_effect = TracecatNotFoundError("Secret not found")
         MockService.return_value = mock_svc
@@ -296,8 +293,6 @@ async def test_delete_secret_by_id_not_found(
 ) -> None:
     """Test DELETE /secrets/{secret_id} with non-existent ID returns 404."""
     with patch("tracecat.secrets.router.SecretsService") as MockService:
-        from tracecat.exceptions import TracecatNotFoundError
-
         mock_svc = AsyncMock()
         mock_svc.get_secret.side_effect = TracecatNotFoundError("Secret not found")
         MockService.return_value = mock_svc

--- a/tests/unit/api/test_api_tables.py
+++ b/tests/unit/api/test_api_tables.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import ProgrammingError
 
 from tracecat.auth.types import Role
 from tracecat.db.models import Table
+from tracecat.exceptions import TracecatNotFoundError
 from tracecat.pagination import CursorPaginatedResponse
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import TableRowRead
@@ -143,8 +144,6 @@ async def test_get_table_not_found(
 ) -> None:
     """Test GET /tables/{table_id} with non-existent ID returns 404."""
     with patch("tracecat.tables.router.TablesService") as MockService:
-        from tracecat.exceptions import TracecatNotFoundError
-
         mock_svc = AsyncMock()
         mock_svc.get_table.side_effect = TracecatNotFoundError("Table not found")
         MockService.return_value = mock_svc

--- a/tests/unit/api/test_api_tables.py
+++ b/tests/unit/api/test_api_tables.py
@@ -1,0 +1,309 @@
+"""HTTP-level tests for tables API endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from asyncpg import DuplicateTableError
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import ProgrammingError
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Table
+from tracecat.pagination import CursorPaginatedResponse
+from tracecat.tables.enums import SqlType
+from tracecat.tables.schemas import TableRowRead
+
+
+@pytest.fixture
+def mock_table(test_workspace) -> Table:
+    """Create a mock table DB object."""
+    table = Table(
+        id=uuid.UUID("ffffffff-ffff-4fff-ffff-ffffffffffff"),
+        owner_id=test_workspace.id,
+        name="test_table",
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    table.columns = []
+    return table
+
+
+@pytest.mark.anyio
+async def test_list_tables_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Test GET /tables returns list of tables."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_tables.return_value = [mock_table]
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(f"/tables?workspace_id={test_admin_role.workspace_id}")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "test_table"
+
+
+@pytest.mark.anyio
+async def test_create_table_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /tables creates a new table."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_table.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            f"/tables?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "name": "new_table",
+                "description": "New test table",
+                "columns": [
+                    {"name": "id", "type": SqlType.TEXT.value},
+                    {"name": "value", "type": SqlType.TEXT.value},
+                ],
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.anyio
+async def test_create_table_duplicate(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /tables with duplicate name returns 409."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        # Create a nested exception chain to match the actual code
+        duplicate_error = DuplicateTableError("Table already exists")
+        programming_error = ProgrammingError("", {}, duplicate_error)
+        programming_error.__cause__ = duplicate_error
+        mock_svc.create_table.side_effect = programming_error
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            f"/tables?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "name": "duplicate_table",
+                "description": "Duplicate table",
+                "columns": [{"name": "id", "type": SqlType.TEXT.value}],
+            },
+        )
+
+        # Should return 409
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_get_table_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Test GET /tables/{table_id} returns table details."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.get_index.return_value = []
+        MockService.return_value = mock_svc
+
+        # Make request
+        table_id = str(mock_table.id)
+        response = client.get(
+            f"/tables/{table_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == "test_table"
+        assert "columns" in data
+
+
+@pytest.mark.anyio
+async def test_get_table_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /tables/{table_id} with non-existent ID returns 404."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        from tracecat.exceptions import TracecatNotFoundError
+
+        mock_svc = AsyncMock()
+        mock_svc.get_table.side_effect = TracecatNotFoundError("Table not found")
+        MockService.return_value = mock_svc
+
+        # Make request
+        fake_id = str(uuid.uuid4())
+        response = client.get(
+            f"/tables/{fake_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_update_table_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Test PATCH /tables/{table_id} updates table."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.update_table.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        table_id = str(mock_table.id)
+        response = client.patch(
+            f"/tables/{table_id}?workspace_id={test_admin_role.workspace_id}",
+            json={"description": "Updated description"},
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_delete_table_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Test DELETE /tables/{table_id} deletes table."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.delete_table.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        table_id = str(mock_table.id)
+        response = client.delete(
+            f"/tables/{table_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_insert_table_row_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Test POST /tables/{table_id}/rows inserts a row."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.insert_row.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        table_id = str(mock_table.id)
+        response = client.post(
+            f"/tables/{table_id}/rows?workspace_id={test_admin_role.workspace_id}",
+            json={"data": {"id": "row-1", "value": "test"}},
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.anyio
+async def test_insert_table_rows_batch_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Test POST /tables/{table_id}/rows/batch inserts multiple rows."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.batch_insert_rows.return_value = 2
+        MockService.return_value = mock_svc
+
+        # Make request
+        table_id = str(mock_table.id)
+        response = client.post(
+            f"/tables/{table_id}/rows/batch?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "rows": [
+                    {"id": "row-1", "value": "test1"},
+                    {"id": "row-2", "value": "test2"},
+                ]
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["rows_inserted"] == 2
+
+
+@pytest.mark.anyio
+async def test_list_table_rows_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Test GET /tables/{table_id}/rows returns table rows."""
+    with patch("tracecat.tables.router.TablesService") as MockService:
+        mock_svc = AsyncMock()
+        row_id_1 = uuid.uuid4()
+        row_id_2 = uuid.uuid4()
+        mock_rows = [
+            TableRowRead(
+                id=row_id_1,
+                value="test1",  # pyright: ignore[reportCallIssue]
+                created_at=datetime(2024, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+            ),
+            TableRowRead(
+                id=row_id_2,
+                value="test2",  # pyright: ignore[reportCallIssue]
+                created_at=datetime(2024, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+            ),
+        ]
+        mock_response = CursorPaginatedResponse(
+            items=mock_rows,
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.list_rows_paginated.return_value = mock_response
+        MockService.return_value = mock_svc
+
+        # Make request
+        table_id = str(mock_table.id)
+        response = client.get(
+            f"/tables/{table_id}/rows?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["items"]) == 2
+        assert data["items"][0]["value"] == "test1"

--- a/tests/unit/api/test_api_workflow_actions.py
+++ b/tests/unit/api/test_api_workflow_actions.py
@@ -8,7 +8,9 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from tracecat.api.app import app
 from tracecat.auth.types import Role
+from tracecat.db.engine import get_async_session
 from tracecat.db.models import Action, Workflow
 
 
@@ -66,9 +68,6 @@ async def test_list_actions_success(
     mock_action: Action,
 ) -> None:
     """Test GET /actions returns list of actions."""
-    from tracecat.api.app import app
-    from tracecat.db.engine import get_async_session
-
     mock_session = AsyncMock()
     mock_result = AsyncMock()
     mock_result.all = MagicMock(return_value=[mock_action])
@@ -105,9 +104,6 @@ async def test_create_action_success(
     mock_workflow,
 ) -> None:
     """Test POST /actions creates a new action."""
-    from tracecat.api.app import app
-    from tracecat.db.engine import get_async_session
-
     mock_session = AsyncMock()
     mock_session.add = MagicMock()
     mock_session.commit = AsyncMock()
@@ -149,9 +145,6 @@ async def test_create_action_conflict(
     mock_workflow,
 ) -> None:
     """Test POST /actions with duplicate ref returns 409."""
-    from tracecat.api.app import app
-    from tracecat.db.engine import get_async_session
-
     mock_session = AsyncMock()
     mock_session.add = MagicMock()
     mock_session.commit = AsyncMock()
@@ -233,9 +226,6 @@ async def test_delete_action_success(
     mock_action: Action,
 ) -> None:
     """Test DELETE /actions/{action_id} deletes action."""
-    from tracecat.api.app import app
-    from tracecat.db.engine import get_async_session
-
     workflow_id = str(mock_workflow.id)
 
     mock_session = AsyncMock()

--- a/tests/unit/api/test_api_workflow_actions.py
+++ b/tests/unit/api/test_api_workflow_actions.py
@@ -1,0 +1,261 @@
+"""HTTP-level tests for workflow actions API endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Action, Workflow
+
+
+@pytest.fixture
+def mock_workflow(test_workspace) -> Workflow:
+    """Create a mock workflow DB object."""
+    workflow_id = uuid.UUID("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
+    return Workflow(
+        id=workflow_id,
+        title="Test Workflow",
+        description="Test workflow description",
+        status="online",
+        version=1,
+        owner_id=test_workspace.id,
+        entrypoint="action-1",
+        expects={"input": {"type": "string"}},
+        returns=None,
+        object={"nodes": [], "edges": []},
+        config={},
+        alias="test-workflow",
+        error_handler=None,
+        icon_url="https://example.com/icon.png",
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        tags=[],
+    )
+
+
+@pytest.fixture
+def mock_action(test_workspace, mock_workflow) -> Action:
+    """Create a mock action DB object."""
+    action = Action(
+        id="act-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        owner_id=test_workspace.id,
+        workflow_id=mock_workflow.id,
+        type="core.http_request",
+        title="Test Action",
+        description="Test action description",
+        status="online",
+        inputs="url: https://example.com\nmethod: GET",
+        control_flow={},
+        is_interactive=False,
+        interaction=None,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    return action
+
+
+@pytest.mark.anyio
+async def test_list_actions_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow,
+    mock_action: Action,
+) -> None:
+    """Test GET /actions returns list of actions."""
+    from tracecat.api.app import app
+    from tracecat.db.engine import get_async_session
+
+    mock_session = AsyncMock()
+    mock_result = AsyncMock()
+    mock_result.all = MagicMock(return_value=[mock_action])
+    mock_session.exec.return_value = mock_result
+
+    # Override get_async_session dependency
+    async def get_mock_session() -> AsyncMock:
+        return mock_session
+
+    app.dependency_overrides[get_async_session] = get_mock_session
+
+    try:
+        # Make request
+        workflow_id = str(mock_workflow.id)
+        response = client.get(
+            f"/actions?workspace_id={test_admin_role.workspace_id}&workflow_id={workflow_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "Test Action"
+        assert data[0]["type"] == "core.http_request"
+    finally:
+        # Clean up override
+        app.dependency_overrides.pop(get_async_session, None)
+
+
+@pytest.mark.anyio
+async def test_create_action_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow,
+) -> None:
+    """Test POST /actions creates a new action."""
+    from tracecat.api.app import app
+    from tracecat.db.engine import get_async_session
+
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.commit = AsyncMock()
+    mock_session.refresh = AsyncMock()
+    mock_result = AsyncMock()
+    mock_result.first = MagicMock(return_value=None)
+    mock_session.exec.return_value = mock_result
+
+    async def get_mock_session() -> AsyncMock:
+        return mock_session
+
+    app.dependency_overrides[get_async_session] = get_mock_session
+
+    # Make request
+    workflow_id = str(mock_workflow.id)
+    try:
+        response = client.post(
+            f"/actions?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "workflow_id": workflow_id,
+                "type": "core.http_request",
+                "title": "New Action",
+                "inputs": "url: https://example.com\nmethod: GET",
+                "is_interactive": False,
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_async_session, None)
+
+    # Assertions - This will actually hit the database
+    # Just check it doesn't error
+    assert response.status_code in [status.HTTP_200_OK, status.HTTP_201_CREATED]
+
+
+@pytest.mark.anyio
+async def test_create_action_conflict(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow,
+) -> None:
+    """Test POST /actions with duplicate ref returns 409."""
+    from tracecat.api.app import app
+    from tracecat.db.engine import get_async_session
+
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.commit = AsyncMock()
+    mock_session.refresh = AsyncMock()
+    mock_result = AsyncMock()
+    mock_result.first = MagicMock(return_value=object())
+    mock_session.exec.return_value = mock_result
+
+    async def get_mock_session() -> AsyncMock:
+        return mock_session
+
+    app.dependency_overrides[get_async_session] = get_mock_session
+
+    workflow_id = str(mock_workflow.id)
+    try:
+        response = client.post(
+            f"/actions?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "workflow_id": workflow_id,
+                "type": "core.http_request",
+                "title": "Test Action",
+                "inputs": "url: https://example.com\nmethod: GET",
+                "is_interactive": False,
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_async_session, None)
+
+    # Should return 409 conflict
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_get_action_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow,
+) -> None:
+    """Test GET /actions/{action_id} with non-existent ID returns 404."""
+    workflow_id = str(mock_workflow.id)
+    # Use proper action ID format: act-[0-9a-f]{32}
+    fake_action_id = "act-00000000000000000000000000000000"
+
+    # Make request
+    response = client.get(
+        f"/actions/{fake_action_id}?workspace_id={test_admin_role.workspace_id}&workflow_id={workflow_id}"
+    )
+
+    # Should return 404
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_update_action_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /actions/{action_id} with non-existent ID returns 404."""
+    # Use proper action ID format: act-[0-9a-f]{32}
+    fake_action_id = "act-00000000000000000000000000000000"
+
+    # Make request
+    response = client.post(
+        f"/actions/{fake_action_id}?workspace_id={test_admin_role.workspace_id}",
+        json={
+            "title": "Updated Title",
+        },
+    )
+
+    # Should return 404
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_delete_action_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow,
+    mock_action: Action,
+) -> None:
+    """Test DELETE /actions/{action_id} deletes action."""
+    from tracecat.api.app import app
+    from tracecat.db.engine import get_async_session
+
+    workflow_id = str(mock_workflow.id)
+
+    mock_session = AsyncMock()
+    mock_result = AsyncMock()
+    mock_result.one = MagicMock(return_value=mock_action)
+    mock_session.exec.return_value = mock_result
+    mock_session.delete = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def get_mock_session() -> AsyncMock:
+        return mock_session
+
+    app.dependency_overrides[get_async_session] = get_mock_session
+
+    try:
+        delete_response = client.delete(
+            f"/actions/{mock_action.id}?workspace_id={test_admin_role.workspace_id}&workflow_id={workflow_id}"
+        )
+    finally:
+        app.dependency_overrides.pop(get_async_session, None)
+
+    # Assertions
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -1,0 +1,538 @@
+"""HTTP-level tests for workflow management API endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from asyncpg import UniqueViolationError as AsyncpgUniqueViolationError
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError, NoResultFound
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Action, Schedule, Tag, Webhook, Workflow, Workspace
+from tracecat.pagination import CursorPaginatedResponse
+from tracecat.workflow.management.types import WorkflowDefinitionMinimal
+
+
+@pytest.fixture
+def mock_workflow(test_workspace: Workspace) -> Workflow:
+    """Create a mock workflow DB object."""
+    workflow_id = uuid.UUID("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa")
+    return Workflow(
+        id=workflow_id,
+        title="Test Workflow",
+        description="Test workflow description",
+        status="online",
+        version=1,
+        owner_id=test_workspace.id,
+        entrypoint="action-1",
+        expects={"input": {"type": "string"}},
+        returns=None,
+        object={"nodes": [], "edges": []},
+        config={},
+        alias="test-workflow",
+        error_handler=None,
+        icon_url="https://example.com/icon.png",
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        tags=[],
+    )
+
+
+@pytest.fixture
+def mock_webhook(test_workspace: Workspace, mock_workflow: Workflow) -> Webhook:
+    """Create a mock webhook DB object."""
+    return Webhook(
+        owner_id=test_workspace.id,
+        workflow_id=mock_workflow.id,
+        status="online",
+        filters={},
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+
+@pytest.mark.anyio
+async def test_list_workflows_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test GET /workflows returns paginated list of workflows."""
+    # Mock service layer
+    with patch(
+        "tracecat.workflow.management.router.WorkflowsManagementService"
+    ) as MockService:
+        # Create mock service instance
+        mock_svc = AsyncMock()
+        mock_definition = WorkflowDefinitionMinimal(
+            id=str(uuid.uuid4()),
+            version=1,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+        # Mock paginated response
+        mock_response = CursorPaginatedResponse(
+            items=[(mock_workflow, mock_definition)],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_svc.list_workflows_paginated.return_value = mock_response
+
+        # Set up service mock
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get(f"/workflows?workspace_id={test_admin_role.workspace_id}")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify response structure
+        assert "items" in data
+        assert len(data["items"]) == 1
+        assert "has_more" in data
+        assert "next_cursor" in data
+
+        # Verify workflow data
+        workflow = data["items"][0]
+        assert workflow["title"] == "Test Workflow"
+        assert workflow["description"] == "Test workflow description"
+        assert workflow["status"] == "online"
+        assert workflow["alias"] == "test-workflow"
+        assert "latest_definition" in workflow
+
+
+@pytest.mark.anyio
+async def test_list_workflows_with_pagination(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test GET /workflows with pagination parameters."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_response = CursorPaginatedResponse(
+            items=[(mock_workflow, None)],
+            next_cursor="next-cursor",
+            prev_cursor=None,
+            has_more=True,
+            has_previous=False,
+        )
+        mock_svc.list_workflows_paginated.return_value = mock_response
+        MockService.return_value = mock_svc
+
+        # Make request with pagination params
+        response = client.get(
+            f"/workflows?workspace_id={test_admin_role.workspace_id}&limit=10&cursor=some-cursor"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["has_more"] is True
+        assert data["next_cursor"] == "next-cursor"
+
+
+@pytest.mark.anyio
+async def test_list_workflows_with_tag_filter(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test GET /workflows with tag filtering."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        # Add tag to workflow
+        mock_tag = Tag(
+            id=uuid.uuid4(),
+            name="test-tag",
+            ref="test-tag",
+            owner_id=mock_workflow.owner_id,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        mock_workflow.tags = [mock_tag]
+
+        mock_response = CursorPaginatedResponse(
+            items=[(mock_workflow, None)],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_svc.list_workflows_paginated.return_value = mock_response
+        MockService.return_value = mock_svc
+
+        # Make request with tag filter
+        response = client.get(
+            f"/workflows?workspace_id={test_admin_role.workspace_id}&tag=test-tag"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["tags"][0]["name"] == "test-tag"
+
+
+@pytest.mark.anyio
+async def test_create_workflow_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test POST /workflows creates a new workflow."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.create_workflow.return_value = mock_workflow
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.post(
+            f"/workflows?workspace_id={test_admin_role.workspace_id}",
+            data={
+                "title": "Test Workflow",
+                "description": "Test workflow description",
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+
+        # Verify workflow data
+        assert data["title"] == "Test Workflow"
+        assert data["description"] == "Test workflow description"
+        assert data["status"] == "online"
+        assert "id" in data
+        assert "created_at" in data
+
+
+@pytest.mark.anyio
+async def test_create_workflow_validation_error(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows with invalid data returns 422."""
+    # Make request with title that's too long (> 100 chars)
+    response = client.post(
+        f"/workflows?workspace_id={test_admin_role.workspace_id}",
+        data={
+            "title": "a" * 101,
+            "description": "Test description",
+        },
+    )
+
+    # Should return validation error
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.anyio
+async def test_get_workflow_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+    mock_webhook: Webhook,
+) -> None:
+    """Test GET /workflows/{id} returns workflow details."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        # Add relationships
+        mock_workflow.actions = []
+        mock_workflow.webhook = mock_webhook
+        mock_workflow.schedules = []
+        mock_svc.get_workflow.return_value = mock_workflow
+        MockService.return_value = mock_svc
+
+        # Make request
+        workflow_id = str(mock_workflow.id)
+        response = client.get(
+            f"/workflows/{workflow_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify workflow data
+        assert data["title"] == "Test Workflow"
+        assert data["description"] == "Test workflow description"
+        assert data["status"] == "online"
+        assert data["version"] == 1
+        assert "webhook" in data
+        assert "actions" in data
+        assert "schedules" in data
+
+
+@pytest.mark.anyio
+async def test_get_workflow_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workflows/{id} with non-existent ID returns 404."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_workflow.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request with non-existent ID
+        fake_id = str(uuid.uuid4())
+        response = client.get(
+            f"/workflows/{fake_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.anyio
+async def test_update_workflow_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test PATCH /workflows/{id} updates workflow."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.update_workflow.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        workflow_id = str(mock_workflow.id)
+        response = client.patch(
+            f"/workflows/{workflow_id}?workspace_id={test_admin_role.workspace_id}",
+            json={
+                "title": "Updated Title",
+                "description": "Updated description",
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # Verify service was called with correct params
+        mock_svc.update_workflow.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_update_workflow_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test PATCH /workflows/{id} with non-existent ID returns 404."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.update_workflow.side_effect = NoResultFound("Workflow not found")
+        MockService.return_value = mock_svc
+
+        # Make request
+        fake_id = str(uuid.uuid4())
+        response = client.patch(
+            f"/workflows/{fake_id}?workspace_id={test_admin_role.workspace_id}",
+            json={"title": "Updated Title"},
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_update_workflow_duplicate_alias(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test PATCH /workflows/{id} with duplicate alias returns 409."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        # Create a proper IntegrityError with UniqueViolationError as cause
+        unique_error = AsyncpgUniqueViolationError("uq_workflow_alias_owner_id")
+        integrity_error = IntegrityError("", {}, unique_error)
+        mock_svc.update_workflow.side_effect = integrity_error
+        MockService.return_value = mock_svc
+
+        # Make request
+        workflow_id = str(mock_workflow.id)
+        response = client.patch(
+            f"/workflows/{workflow_id}?workspace_id={test_admin_role.workspace_id}",
+            json={"alias": "duplicate-alias"},
+        )
+
+        # Should return 409 conflict
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_delete_workflow_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test DELETE /workflows/{id} deletes workflow."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.delete_workflow.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        workflow_id = str(mock_workflow.id)
+        response = client.delete(
+            f"/workflows/{workflow_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # Verify service was called
+        mock_svc.delete_workflow.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_delete_workflow_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test DELETE /workflows/{id} with non-existent ID returns 404."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.delete_workflow.side_effect = NoResultFound("Workflow not found")
+        MockService.return_value = mock_svc
+
+        # Make request
+        fake_id = str(uuid.uuid4())
+        response = client.delete(
+            f"/workflows/{fake_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_get_workflow_with_relationships(
+    client: TestClient,
+    test_admin_role: Role,
+    test_workspace: Workspace,
+    mock_workflow: Workflow,
+    mock_webhook: Webhook,
+) -> None:
+    """Test GET /workflows/{id} properly serializes relationships (tags, actions, schedules)."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockService,
+    ):
+        mock_svc = AsyncMock()
+
+        # Add relationships to workflow
+        mock_tag = Tag(
+            id=uuid.uuid4(),
+            name="production",
+            ref="production",
+            owner_id=test_workspace.id,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        mock_action = Action(
+            id="act-12345678901234567890123456789012",
+            type="webhook",
+            title="Test Action",
+            description="Test action description",
+            status="online",
+            inputs="",  # inputs is a YAML string, not dict
+            control_flow={},
+            owner_id=test_workspace.id,
+            workflow_id=mock_workflow.id,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        mock_schedule = Schedule(
+            owner_id=test_workspace.id,
+            workflow_id=mock_workflow.id,
+            cron="0 0 * * *",
+            inputs={},
+            offset=None,
+            start_at=None,
+            end_at=None,
+            timeout=None,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+        mock_workflow.tags = [mock_tag]
+        mock_workflow.actions = [mock_action]
+        mock_workflow.schedules = [mock_schedule]
+        mock_workflow.webhook = mock_webhook
+
+        mock_svc.get_workflow.return_value = mock_workflow
+        MockService.return_value = mock_svc
+
+        # Make request
+        workflow_id = str(mock_workflow.id)
+        response = client.get(
+            f"/workflows/{workflow_id}?workspace_id={test_admin_role.workspace_id}"
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Verify relationships are properly serialized
+        assert "actions" in data
+        assert "act-12345678901234567890123456789012" in data["actions"]
+        assert (
+            data["actions"]["act-12345678901234567890123456789012"]["title"]
+            == "Test Action"
+        )
+
+        assert "schedules" in data
+        assert len(data["schedules"]) == 1
+        assert data["schedules"][0]["cron"] == "0 0 * * *"
+
+        assert "webhook" in data
+        assert data["webhook"]["status"] == "online"

--- a/tests/unit/api/test_api_workspaces.py
+++ b/tests/unit/api/test_api_workspaces.py
@@ -68,7 +68,9 @@ async def test_list_workspaces_user_success(
         # Assertions
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert len(data) >= 0  # Could be 0 or more based on membership
+        assert len(data) == 1
+        assert data[0]["id"] == str(test_workspace.id)
+        assert data[0]["name"] == test_workspace.name
 
 
 @pytest.mark.anyio
@@ -243,27 +245,3 @@ async def test_delete_workspace_success(
 
         # Assertions
         assert response.status_code == status.HTTP_204_NO_CONTENT
-
-
-@pytest.mark.anyio
-async def test_get_workspace_settings_success(
-    client: TestClient,
-    test_admin_role: Role,
-    mock_workspace_data: Workspace,
-) -> None:
-    """Test GET /workspaces/{workspace_id}/settings returns settings."""
-    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
-        mock_svc = AsyncMock()
-        mock_settings = {
-            "notifications_enabled": True,
-            "default_timezone": "UTC",
-        }
-        mock_svc.get_workspace_settings.return_value = mock_settings
-        MockService.return_value = mock_svc
-
-        # Make request
-        workspace_id = str(mock_workspace_data.id)
-        response = client.get(f"/workspaces/{workspace_id}/settings")
-
-        # Assertions - might be 200 or 404 depending on implementation
-        assert response.status_code in [status.HTTP_200_OK, status.HTTP_404_NOT_FOUND]

--- a/tests/unit/api/test_api_workspaces.py
+++ b/tests/unit/api/test_api_workspaces.py
@@ -1,0 +1,269 @@
+"""HTTP-level tests for workspaces API endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from tracecat.auth.types import Role
+from tracecat.authz.enums import WorkspaceRole
+from tracecat.db.models import Workspace
+from tracecat.logger import logger
+
+
+@pytest.fixture
+def mock_workspace_data() -> Workspace:
+    """Create a mock workspace DB object."""
+    workspace = Workspace(
+        id=uuid.UUID("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"),
+        name="Test Workspace",
+        owner_id=uuid.uuid4(),
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    return workspace
+
+
+@pytest.mark.anyio
+async def test_list_workspaces_admin_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workspace_data: Workspace,
+) -> None:
+    """Test GET /workspaces returns all workspaces for admin."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.admin_list_workspaces.return_value = [mock_workspace_data]
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/workspaces")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Test Workspace"
+
+
+@pytest.mark.anyio
+async def test_list_workspaces_user_success(
+    client: TestClient,
+    test_role: Role,
+    test_workspace: Workspace,
+) -> None:
+    """Test GET /workspaces returns user's workspaces."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_workspaces.return_value = [test_workspace]
+        MockService.return_value = mock_svc
+
+        # Make request - test_role fixture is used for non-admin user
+        response = client.get("/workspaces")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) >= 0  # Could be 0 or more based on membership
+
+
+@pytest.mark.anyio
+async def test_create_workspace_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workspace_data: Workspace,
+) -> None:
+    """Test POST /workspaces creates a new workspace."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_workspace.return_value = mock_workspace_data
+        MockService.return_value = mock_svc
+
+        # Make request
+        owner_id = str(uuid.uuid4())
+        response = client.post(
+            "/workspaces",
+            json={
+                "name": "New Workspace",
+                "owner_id": owner_id,
+            },
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["name"] == "Test Workspace"
+
+
+@pytest.mark.anyio
+async def test_create_workspace_conflict(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workspaces with duplicate name returns 409."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_workspace.side_effect = IntegrityError(
+            "", {}, Exception("Duplicate")
+        )
+        MockService.return_value = mock_svc
+
+        # Make request
+        owner_id = str(uuid.uuid4())
+        response = client.post(
+            "/workspaces",
+            json={
+                "name": "Duplicate Workspace",
+                "owner_id": owner_id,
+            },
+        )
+
+        # Should return 409
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_search_workspaces_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workspace_data: Workspace,
+) -> None:
+    """Test GET /workspaces/search with search term."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.search_workspaces.return_value = [mock_workspace_data]
+        MockService.return_value = mock_svc
+
+        # Make request
+        response = client.get("/workspaces/search?name=Test")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Test Workspace"
+
+
+@pytest.mark.anyio
+async def test_get_workspace_success(
+    client: TestClient, test_admin_role: Role, mock_workspace_data: Workspace
+) -> None:
+    """Test GET /workspaces/{workspace_id} returns workspace details."""
+    with (
+        patch("tracecat.workspaces.router.WorkspaceService") as MockService,
+        patch("tracecat.auth.credentials.MembershipService") as MockMembershipService,
+    ):
+        # Mock workspace service
+        mock_svc = AsyncMock()
+        mock_svc.get_workspace.return_value = mock_workspace_data
+        MockService.return_value = mock_svc
+
+        # Mock membership service to allow access
+        mock_membership_svc = AsyncMock()
+        mock_membership = AsyncMock()
+        mock_membership.user_id = test_admin_role.user_id
+        mock_membership.workspace_id = mock_workspace_data.id
+        mock_membership.role = WorkspaceRole.ADMIN
+        mock_membership_svc.get_membership.return_value = mock_membership
+        MockMembershipService.return_value = mock_membership_svc
+
+        # Make request - use test_workspace which matches the test_admin_role's workspace
+        workspace_id = str(mock_workspace_data.id)
+        response = client.get(f"/workspaces/{workspace_id}")
+
+        # Assertions
+        data = response.json()
+        logger.info("DATA", data=data)
+        assert response.status_code == status.HTTP_200_OK
+        assert data["name"] == mock_workspace_data.name
+
+
+@pytest.mark.anyio
+async def test_get_workspace_not_found(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workspaces/{workspace_id} with non-existent ID returns 404."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        # Return None to mimic service behavior when workspace is not found
+        mock_svc.get_workspace.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/workspaces/{fake_id}")
+
+        # Should return 404
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_update_workspace_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workspace_data: Workspace,
+) -> None:
+    """Test PATCH /workspaces/{workspace_id} updates workspace."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.update_workspace.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        workspace_id = str(mock_workspace_data.id)
+        response = client.patch(
+            f"/workspaces/{workspace_id}",
+            json={"name": "Updated Workspace Name"},
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_delete_workspace_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workspace_data: Workspace,
+) -> None:
+    """Test DELETE /workspaces/{workspace_id} deletes workspace."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.delete_workspace.return_value = None
+        MockService.return_value = mock_svc
+
+        # Make request
+        workspace_id = str(mock_workspace_data.id)
+        response = client.delete(f"/workspaces/{workspace_id}")
+
+        # Assertions
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_get_workspace_settings_success(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workspace_data: Workspace,
+) -> None:
+    """Test GET /workspaces/{workspace_id}/settings returns settings."""
+    with patch("tracecat.workspaces.router.WorkspaceService") as MockService:
+        mock_svc = AsyncMock()
+        mock_settings = {
+            "notifications_enabled": True,
+            "default_timezone": "UTC",
+        }
+        mock_svc.get_workspace_settings.return_value = mock_settings
+        MockService.return_value = mock_svc
+
+        # Make request
+        workspace_id = str(mock_workspace_data.id)
+        response = client.get(f"/workspaces/{workspace_id}/settings")
+
+        # Assertions - might be 200 or 404 depending on implementation
+        assert response.status_code in [status.HTTP_200_OK, status.HTTP_404_NOT_FOUND]


### PR DESCRIPTION
Need this to prepare for sqlmodel migration to prevent regressions.
- **cases, workflows**
- **add more router tests**

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive HTTP-level tests for API routers (agents, cases, workflows, workflow actions, secrets, tables, workspaces) to lock current behavior and prevent regressions ahead of the sqlmodel migration. Also updates the admin role fixture to reliably set/reset ctx_role for dependency overrides.

- **Migration**
  - Adds tests covering success/error paths, pagination, filtering, and proper 4xx mapping (400/404/409/422) across routers.
  - Introduces tests/unit/api/conftest.py to override role dependencies via ctx_role, mock get_async_session to avoid hitting Postgres, and provide a shared TestClient.
  - Updates tests/conftest.py to set and reset ctx_role in the admin role fixture to avoid context leakage.

<sup>Written for commit e76aaff818a21aeb8d3b658182898f6a85a1dbbd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









