### PR TITLE
fix(integrations): Slack view templates to expect view payload objects

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/views/open_view.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/views/open_view.yml
@@ -8,9 +8,9 @@ definition:
   name: open_view
   expects:
     view:
-      type: list[dict[str, Any]]
+      type: dict[str, Any]
       description: >
-        List of blocks to open the view with.
+        View payload for the modal to open.
         See: https://docs.slack.dev/reference/views/modal-views
     trigger_id:
       type: str

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/views/update_view.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/views/update_view.yml
@@ -11,9 +11,9 @@ definition:
       type: str
       description: ID of the view to update.
     view:
-      type: list[dict[str, Any]]
+      type: dict[str, Any]
       description: >
-        List of blocks to update the view with.
+        Updated view payload for the modal.
         See: https://docs.slack.dev/reference/views/modal-views
   steps:
     - ref: update_view


### PR DESCRIPTION
## Summary
- update `tools.slack.open_view` template to accept a single view payload object
- update `tools.slack.update_view` template to accept a single view payload object

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165059cb8c8333963edcd7d355b1ea)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Slack view templates to expect a full view payload object instead of a list of blocks. This aligns with Slack’s modal API and prevents malformed requests when opening or updating views.

- **Bug Fixes**
  - tools.slack.open_view: `view` now expects `dict[str, Any]`; description updated.
  - tools.slack.update_view: `view` now expects `dict[str, Any]`; description updated.

<sup>Written for commit 817bd561584c3be4e7b5bb5d94430c0514182b3f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

