### PR TITLE
Add webhook and schedule shortcuts to workflow dashboard

### DIFF
--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -264,7 +264,7 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
         ]}
       >
         {/* Webhooks */}
-        <AccordionItem value="trigger-webhooks">
+        <AccordionItem value="trigger-webhooks" id="trigger-webhooks">
           <AccordionTrigger className="px-4 text-xs font-bold">
             <div className="flex items-center">
               <WebhookIcon className="mr-3 size-4" />
@@ -282,7 +282,7 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
         </AccordionItem>
 
         {/* Schedules */}
-        <AccordionItem value="trigger-schedules">
+        <AccordionItem value="trigger-schedules" id="trigger-schedules">
           <AccordionTrigger className="px-4 text-xs font-bold">
             <div className="flex items-center">
               <CalendarClockIcon className="mr-3 size-4" />

--- a/frontend/src/components/dashboard/table-actions.tsx
+++ b/frontend/src/components/dashboard/table-actions.tsx
@@ -7,8 +7,10 @@ import {
   FolderKanban,
   FolderUp,
   Pencil,
+  CalendarClockIcon,
   TagsIcon,
   Trash2,
+  WebhookIcon,
 } from "lucide-react"
 import Link from "next/link"
 import type {
@@ -36,6 +38,7 @@ import {
   useWorkflowTags,
 } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
+import { useAuth } from "@/hooks/use-auth"
 
 export function WorkflowActions({
   view,
@@ -51,6 +54,10 @@ export function WorkflowActions({
   const { appSettings } = useOrgAppSettings()
   const workspaceId = useWorkspaceId()
   const { tags } = useWorkflowTags(workspaceId)
+  const { user } = useAuth()
+  const isAdmin = user?.isOrgAdmin() ?? false
+  const webhookLabel = isAdmin ? "Manage webhook" : "View webhook"
+  const scheduleLabel = isAdmin ? "Manage schedules" : "View schedules"
 
   const { addWorkflowTag, removeWorkflowTag } = useWorkflowManager()
   const enabledExport = appSettings?.app_workflow_export_enabled ?? false
@@ -69,6 +76,34 @@ export function WorkflowActions({
         >
           <ExternalLink className="mr-2 size-3.5" />
           Open in new tab
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        className="text-xs"
+        onClick={(e) => e.stopPropagation()}
+        asChild
+      >
+        <Link
+          href={`/workspaces/${workspaceId}/workflows/${item.id}#trigger-webhooks`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <WebhookIcon className="mr-2 size-3.5" />
+          {webhookLabel}
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        className="text-xs"
+        onClick={(e) => e.stopPropagation()}
+        asChild
+      >
+        <Link
+          href={`/workspaces/${workspaceId}/workflows/${item.id}#trigger-schedules`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <CalendarClockIcon className="mr-2 size-3.5" />
+          {scheduleLabel}
         </Link>
       </DropdownMenuItem>
       {item.alias && (


### PR DESCRIPTION
## Summary
- add dropdown shortcuts for webhooks and schedules from the workflows dashboard, with admin-aware labeling
- link shortcuts to the webhook and schedule sections within the workflow builder via anchors
- mark webhook and schedule panels with anchors for direct navigation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8b9f14b08320a8bc59e7ee997663)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added dashboard shortcuts to jump directly to Webhooks and Schedules in the workflow builder. Labels adapt to admin status, and panels now support deep links for faster navigation.

- **New Features**
  - Added “Manage/View webhook” and “Manage/View schedules” actions in the workflow dropdown that open the builder at the correct section in a new tab.
  - Added anchors to the Webhooks and Schedules panels to enable direct navigation from the dashboard.

<sup>Written for commit a6076e70896308ca713fbe7f00fe4982a8faac8e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



