### PR TITLE
fix: add field validator for case task read

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/cases/tasks.py
+++ b/packages/tracecat-ee/tracecat_ee/cases/tasks.py
@@ -60,7 +60,7 @@ async def create_task(
                 priority=priority_enum,
                 status=status_enum,
                 assignee_id=UUID(assignee_id) if assignee_id else None,
-                workflow_id=workflow_id,
+                workflow_id=workflow_id or None,
             ),
         )
 


### PR DESCRIPTION
## Summary

Add field validator to CaseTaskRead to enforce workflow id's being of WorkflowIDShort





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize CaseTaskRead.workflow_id to the short workflow ID format and treat empty values as None during task creation. This ensures consistent API responses and prevents invalid IDs.

- **Bug Fixes**
  - Added a field_validator to convert any workflow ID to WorkflowIDShort.
  - In create_task, pass None when workflow_id is falsy.

<sup>Written for commit 398109ad9c3f8fa92fa89ac591ff16531fbaa860. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize `CaseTaskRead.workflow_id` to short IDs and treat falsy `workflow_id` as `None` when creating tasks.
> 
> - **Cases Schemas**:
>   - Add `@field_validator` on `CaseTaskRead.workflow_id` to convert any workflow ID to `WorkflowIDShort` via `WorkflowUUID`.
> - **EE Tasks**:
>   - In `packages/tracecat-ee/tracecat_ee/cases/tasks.py#create_task`, send `workflow_id or None` to `CaseTaskCreate` to nullify falsy IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 398109ad9c3f8fa92fa89ac591ff16531fbaa860. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->