### PR TITLE
feat: add gpt-5 model support

### DIFF
--- a/tracecat/agent/config.py
+++ b/tracecat/agent/config.py
@@ -15,6 +15,30 @@ MODEL_CONFIGS = {
             "required": ["openai"],
         },
     ),
+    "gpt-5-mini": ModelConfig(
+        name="gpt-5-mini",
+        provider="openai",
+        org_secret_name="agent-openai-credentials",
+        secrets={
+            "required": ["openai"],
+        },
+    ),
+     "gpt-5-nano": ModelConfig(
+        name="gpt-5-nano",
+        provider="openai",
+        org_secret_name="agent-openai-credentials",
+        secrets={
+            "required": ["openai"],
+        },
+    ),
+     "gpt-5": ModelConfig(
+        name="gpt-5",
+        provider="openai",
+        org_secret_name="agent-openai-credentials",
+        secrets={
+            "required": ["openai"],
+        },
+    ),
     "claude-sonnet-4-5-20250929": ModelConfig(
         name="claude-sonnet-4-5-20250929",
         provider="anthropic",

--- a/tracecat/agent/config.py
+++ b/tracecat/agent/config.py
@@ -23,7 +23,7 @@ MODEL_CONFIGS = {
             "required": ["openai"],
         },
     ),
-     "gpt-5-nano": ModelConfig(
+    "gpt-5-nano": ModelConfig(
         name="gpt-5-nano",
         provider="openai",
         org_secret_name="agent-openai-credentials",
@@ -31,7 +31,7 @@ MODEL_CONFIGS = {
             "required": ["openai"],
         },
     ),
-     "gpt-5": ModelConfig(
+    "gpt-5": ModelConfig(
         name="gpt-5",
         provider="openai",
         org_secret_name="agent-openai-credentials",


### PR DESCRIPTION
## Summary
- Add gpt-5, gpt-5-mini, gpt-5-nano to possible model choice.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added support for OpenAI GPT-5 models (gpt-5, gpt-5-mini, gpt-5-nano) in the agent config so they can be selected with existing credentials. All use org secret "agent-openai-credentials" and require the "openai" secret.

<sup>Written for commit 0a443043252b39a3a80462c7ed70612120b633d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





