### PR TITLE
feat(ui): Persist agent builder tab selection

### DIFF
--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -269,7 +269,7 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
   // Fetch full preset data when a preset is selected (not in create mode)
   const selectedPresetId =
     activePresetId === NEW_PRESET_ID ? null : activePresetId
-  const { preset: selectedPreset } = useAgentPreset(
+  const { preset: selectedPreset, presetIsLoading } = useAgentPreset(
     workspaceId,
     selectedPresetId,
     {
@@ -297,11 +297,15 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
     }
   }, [presets, handleSetSelectedPresetId, presetId, presetsIsLoading])
 
-  const chatTabDisabled = !selectedPreset
+  const chatTabDisabled =
+    !selectedPreset && !presetIsLoading && !featureFlagsLoading
 
   useEffect(() => {
     if (chatTabDisabled && sidebarTab === "chat") {
       setSidebarTab("presets")
+      if (!pathname) {
+        return
+      }
       const params = new URLSearchParams(searchParams?.toString())
       params.set("tab", "presets")
       const url = params.toString()
@@ -414,6 +418,9 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
               value={sidebarTab}
               onValueChange={(value) => {
                 if (value === "chat" && chatTabDisabled) {
+                  return
+                }
+                if (!pathname) {
                   return
                 }
                 const nextTab = value as "presets" | "chat"

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -235,10 +235,9 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
   const { registryActions } = useRegistryActions()
   const { providers } = useModelProviders()
   const { models } = useAgentModels()
-  const [sidebarTab, setSidebarTab] = useState<"presets" | "chat">(() => {
-    const tabParam = searchParams?.get("tab")
-    return tabParam === "chat" ? "chat" : "presets"
-  })
+
+  const currentTab = searchParams?.get("tab") === "chat" ? "chat" : "presets"
+
   const { createAgentPreset, createAgentPresetIsPending } =
     useCreateAgentPreset(workspaceId)
   const { updateAgentPreset, updateAgentPresetIsPending } =
@@ -257,13 +256,13 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
       }
       const nextPath = `/workspaces/${workspaceId}/agents/${normalizedId}`
       const params = new URLSearchParams(searchParams?.toString())
-      params.set("tab", sidebarTab)
+      params.set("tab", currentTab)
       const url = params.toString()
         ? `${nextPath}?${params.toString()}`
         : nextPath
       router.replace(url)
     },
-    [activePresetId, router, searchParams, sidebarTab, workspaceId]
+    [activePresetId, router, searchParams, currentTab, workspaceId]
   )
 
   // Fetch full preset data when a preset is selected (not in create mode)
@@ -301,8 +300,7 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
     !selectedPreset && !presetIsLoading && !featureFlagsLoading
 
   useEffect(() => {
-    if (chatTabDisabled && sidebarTab === "chat") {
-      setSidebarTab("presets")
+    if (chatTabDisabled && currentTab === "chat") {
       if (!pathname) {
         return
       }
@@ -313,17 +311,7 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
         : pathname
       router.replace(url)
     }
-  }, [chatTabDisabled, pathname, router, searchParams, sidebarTab])
-
-  useEffect(() => {
-    const tabParam = searchParams?.get("tab")
-    if (tabParam === "chat" && !chatTabDisabled && sidebarTab !== "chat") {
-      setSidebarTab("chat")
-    }
-    if (tabParam !== "chat" && sidebarTab !== "presets") {
-      setSidebarTab("presets")
-    }
-  }, [chatTabDisabled, searchParams, sidebarTab])
+  }, [chatTabDisabled, pathname, router, searchParams, currentTab])
 
   const actionSuggestions: Suggestion[] = useMemo(() => {
     if (!registryActions) {
@@ -415,7 +403,7 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
         <ResizablePanel defaultSize={26} minSize={18}>
           <div className="flex h-full flex-col border-r bg-muted/40">
             <Tabs
-              value={sidebarTab}
+              value={currentTab}
               onValueChange={(value) => {
                 if (value === "chat" && chatTabDisabled) {
                   return
@@ -424,7 +412,6 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
                   return
                 }
                 const nextTab = value as "presets" | "chat"
-                setSidebarTab(nextTab)
                 const params = new URLSearchParams(searchParams?.toString())
                 params.set("tab", nextTab)
                 const url = params.toString()

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -304,7 +304,9 @@ export function AgentPresetsBuilder({ presetId }: { presetId?: string }) {
       setSidebarTab("presets")
       const params = new URLSearchParams(searchParams?.toString())
       params.set("tab", "presets")
-      const url = params.toString() ? `${pathname}?${params.toString()}` : pathname
+      const url = params.toString()
+        ? `${pathname}?${params.toString()}`
+        : pathname
       router.replace(url)
     }
   }, [chatTabDisabled, pathname, router, searchParams, sidebarTab])


### PR DESCRIPTION
## Summary
- read the agent builder tab selection from the URL query parameters and sync state accordingly
- persist the current tab in the URL when switching tabs or navigating between presets
- normalize the tab parameter when the chat tab is unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d00271f988320b032db03814abfbf)







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the Agent Builder sidebar tab (presets/chat) in the URL and keep it synced across navigation. When the chat tab is unavailable, the tab is automatically normalized to presets.

- **New Features**
  - Read and sync the tab from the ?tab query param (on load and when it changes).
  - Update the URL when switching tabs and when navigating between presets.
  - Normalize to presets only after loading finishes if the chat tab is unavailable.

<sup>Written for commit 4fe907f898a5704e099acd1f1d2f2e8c9480e6a2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







