### PR TITLE
fix: Add back progress dots

### DIFF
--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -23,7 +23,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
-import { CodeBlock } from "./code-block"
+import { CodeBlock, CodeBlockCopyButton } from "./code-block"
 
 export type ToolProps = ComponentProps<typeof Collapsible>
 
@@ -129,7 +129,9 @@ export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
       Parameters
     </h4>
     <div className="rounded-md bg-muted/50">
-      <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
+      <CodeBlock code={JSON.stringify(input, null, 2)} language="json">
+        <CodeBlockCopyButton />
+      </CodeBlock>
     </div>
   </div>
 )
@@ -174,10 +176,16 @@ export const ToolOutput = ({
       Output = null
     } else if (typeof output === "object") {
       Output = (
-        <CodeBlock code={JSON.stringify(output, null, 2)} language="json" />
+        <CodeBlock code={JSON.stringify(output, null, 2)} language="json">
+          <CodeBlockCopyButton />
+        </CodeBlock>
       )
     } else if (typeof output === "string") {
-      Output = <CodeBlock code={output} language="json" />
+      Output = (
+        <CodeBlock code={output} language="json">
+          <CodeBlockCopyButton />
+        </CodeBlock>
+      )
     } else {
       Output = <div>{output as ReactNode}</div>
     }


### PR DESCRIPTION
- **first pass**
- **feat: Enhance Tool component with CodeBlockCopyButton and refine ChatSessionPane logic**

<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores progress dots while the assistant is generating a response and makes Tool code blocks easy to copy. Also simplifies assistant message actions to only show Retry when appropriate.

- **Bug Fixes**
  - Reintroduces waiting/streaming indicator with a robust isWaitingForResponse check (text, reasoning, tool input-streaming; excludes approval requests).
  - Hides assistant actions during streaming and shows Retry only for the latest finished message.

- **New Features**
  - Adds CodeBlockCopyButton to Tool input/output CodeBlocks.

<sup>Written for commit 2ff9dd93e116e62ce5bb9808896eb4b59ded9852. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

