### PR TITLE
fix(integrations): LDAP search entry handling

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/ldap3.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/ldap3.py
@@ -109,16 +109,20 @@ class LdapClient:
         if isinstance(attributes, str):
             attributes = getattr(ldap3, attributes)
 
-        entries = self.connection.search(
+        result = self.connection.search(
             search_base=search_base,
             search_filter=search_filter,
             search_scope=scope,
             attributes=attributes,
             **kwargs,
         )
-        if entries:
-            return [orjson.loads(entry.entry_to_json()) for entry in entries]
-        return []
+        if not result:
+            return []
+
+        return [
+            orjson.loads(entry.entry_to_json())
+            for entry in getattr(self.connection, "entries", [])
+        ]
 
 
 def get_ldap_secrets() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- fix LDAP search to return parsed connection entries instead of iterating over the search result boolean
- ensure search failures return an empty list without raising unexpected errors
- Closes #1678 

## Testing
- python -m compileall packages/tracecat-registry/tracecat_registry/integrations/ldap3.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f283a9a348333ba1116ef5384d0cd)