### PR TITLE
Remove legacy custom registry repository

### DIFF
--- a/alembic/versions/e5024a57ff6e_remove_custom_registry_repository.py
+++ b/alembic/versions/e5024a57ff6e_remove_custom_registry_repository.py
@@ -1,0 +1,39 @@
+"""Remove legacy custom registry repository
+
+Revision ID: e5024a57ff6e
+Revises: fe20e84914ad
+Create Date: 2026-01-14 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e5024a57ff6e"
+down_revision: str | None = "fe20e84914ad"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "DELETE FROM registryaction "
+            "WHERE repository_id IN (SELECT id FROM registryrepository WHERE origin = 'custom')"
+        )
+    )
+    op.execute(sa.text("DELETE FROM registryrepository WHERE origin = 'custom'"))
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "INSERT INTO registryrepository (id, origin, last_synced_at, commit_sha) "
+            "VALUES (:id, 'custom', NULL, NULL) ON CONFLICT (origin) DO NOTHING"
+        ),
+        {"id": str(uuid.uuid4())},
+    )

--- a/tracecat/registry/common.py
+++ b/tracecat/registry/common.py
@@ -8,11 +8,7 @@ from tracecat.auth.types import Role
 from tracecat.logger import logger
 from tracecat.parse import safe_url
 from tracecat.registry.actions.service import RegistryActionsService
-from tracecat.registry.constants import (
-    CUSTOM_REPOSITORY_ORIGIN,
-    DEFAULT_LOCAL_REGISTRY_ORIGIN,
-    DEFAULT_REGISTRY_ORIGIN,
-)
+from tracecat.registry.constants import DEFAULT_LOCAL_REGISTRY_ORIGIN, DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.repositories.schemas import RegistryRepositoryCreate
 from tracecat.registry.repositories.service import RegistryReposService
 from tracecat.settings.service import get_setting
@@ -38,21 +34,6 @@ async def reload_registry(session: AsyncSession, role: Role):
             await actions_service.sync_actions_from_repository(base_repo)
     else:
         logger.info("Base registry repository already exists", origin=base_origin)
-
-    # Setup custom repository
-    # This is where custom template actions are created and stored
-    custom_origin = CUSTOM_REPOSITORY_ORIGIN
-    if await repos_service.get_repository(custom_origin) is None:
-        try:
-            await repos_service.create_repository(
-                RegistryRepositoryCreate(origin=custom_origin)
-            )
-        except Exception as e:
-            logger.error("Error creating custom registry repository", error=e)
-        else:
-            logger.info("Created custom repository", origin=custom_origin)
-    else:
-        logger.info("Custom repository already exists", origin=custom_origin)
 
     # Setup local repository
     if config.TRACECAT__LOCAL_REPOSITORY_ENABLED:

--- a/tracecat/registry/constants.py
+++ b/tracecat/registry/constants.py
@@ -1,7 +1,6 @@
 DEFAULT_REGISTRY_ORIGIN = "tracecat_registry"
 DEFAULT_REMOTE_REGISTRY_ORIGIN = "remote"
 DEFAULT_LOCAL_REGISTRY_ORIGIN = "local"
-CUSTOM_REPOSITORY_ORIGIN = "custom"
 REGISTRY_GIT_SSH_KEY_SECRET_NAME = "github-ssh-key"
 """Name of the SSH key secret for the registry."""
 

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -19,11 +19,7 @@ from tracecat.logger import logger
 from tracecat.registry.actions.schemas import RegistryActionRead
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.registry.common import reload_registry
-from tracecat.registry.constants import (
-    CUSTOM_REPOSITORY_ORIGIN,
-    DEFAULT_REGISTRY_ORIGIN,
-    REGISTRY_REPOS_PATH,
-)
+from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN, REGISTRY_REPOS_PATH
 from tracecat.registry.repositories.schemas import (
     GitCommitInfo,
     RegistryRepositoryCreate,
@@ -407,7 +403,7 @@ async def delete_registry_repository(
             detail="Registry repository not found",
         ) from e
     logger.info("Deleting registry repository", repository_id=repository_id)
-    if repository.origin in (DEFAULT_REGISTRY_ORIGIN, CUSTOM_REPOSITORY_ORIGIN):
+    if repository.origin == DEFAULT_REGISTRY_ORIGIN:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"The {repository.origin!r} repository cannot be deleted.",

--- a/tracecat/registry/repositories/schemas.py
+++ b/tracecat/registry/repositories/schemas.py
@@ -8,11 +8,7 @@ from tracecat.registry.actions.schemas import (
     RegistryActionRead,
     RegistryActionValidationErrorInfo,
 )
-from tracecat.registry.constants import (
-    CUSTOM_REPOSITORY_ORIGIN,
-    DEFAULT_LOCAL_REGISTRY_ORIGIN,
-    DEFAULT_REGISTRY_ORIGIN,
-)
+from tracecat.registry.constants import DEFAULT_LOCAL_REGISTRY_ORIGIN, DEFAULT_REGISTRY_ORIGIN
 
 
 class RegistryRepositoryRead(BaseModel):
@@ -53,7 +49,6 @@ class RegistryRepositoryCreate(BaseModel):
         """
         if v in (
             DEFAULT_REGISTRY_ORIGIN,
-            CUSTOM_REPOSITORY_ORIGIN,
             DEFAULT_LOCAL_REGISTRY_ORIGIN,
         ):
             return v

--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -38,11 +38,7 @@ from tracecat.git.utils import GitUrl, get_git_repository_sha, parse_git_url
 from tracecat.logger import logger
 from tracecat.parse import safe_url
 from tracecat.registry.actions.schemas import BoundRegistryAction, TemplateAction
-from tracecat.registry.constants import (
-    CUSTOM_REPOSITORY_ORIGIN,
-    DEFAULT_LOCAL_REGISTRY_ORIGIN,
-    DEFAULT_REGISTRY_ORIGIN,
-)
+from tracecat.registry.constants import DEFAULT_LOCAL_REGISTRY_ORIGIN, DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.dependencies import (
     RegistryDependencyConflictError,
     get_conflict_summary,
@@ -337,8 +333,6 @@ class Repository:
             self._load_base_template_actions()
             return None
 
-        elif self._origin == CUSTOM_REPOSITORY_ORIGIN:
-            raise RegistryError("This repository cannot be synced.")
         # Handle local git repositories
         elif self._origin == DEFAULT_LOCAL_REGISTRY_ORIGIN:
             # The local repo doesn't have to be a git repo, but it should be a directory


### PR DESCRIPTION
## Summary
- remove the legacy custom registry repository handling and validation
- simplify repository syncing/deletion rules to match remaining default origins
- add a migration to purge existing `custom` registry repository records

## Testing
- pytest tests/unit/test_registry.py -k repository --maxfail=1 *(fails: ModuleNotFoundError: No module named 'tracecat_registry')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8c225a5883209ca8da708e85f658)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the legacy "custom" registry repository across the codebase and database. The registry now supports only default and local origins, simplifying sync, validation, and deletion rules.

- **Refactors**
  - Removed CUSTOM_REPOSITORY_ORIGIN and all related handling.
  - Stopped creating the custom repo in reload_registry.
  - Simplified origin validation and routing to default and local only.
  - Kept a guard to prevent deleting the default repository.

- **Migration**
  - Alembic migration deletes all "custom" repositories and their actions.
  - Downgrade adds back a stub "custom" repository entry.

<sup>Written for commit 5ef23fb5a0f416f1c65dd082c563b9b1a9dedf37. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

