### PR TITLE
fix(ui): Drop extra toast blcoking full error message for registry sync

### DIFF
--- a/frontend/src/components/registry/dialogs/repository-sync-dialog.tsx
+++ b/frontend/src/components/registry/dialogs/repository-sync-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { AlertTriangleIcon, RefreshCcw } from "lucide-react"
+import { RefreshCcw } from "lucide-react"
 import type {
   RegistryRepositoriesSyncRegistryRepositoryData,
   RegistryRepositoryReadMinimal,
@@ -72,15 +72,6 @@ export function SyncRepositoryDialog({
       })
     } catch (error) {
       console.error("Error syncing repository", error)
-      toast({
-        title: "Error syncing repository",
-        description: (
-          <div className="flex items-start gap-2">
-            <AlertTriangleIcon className="size-4 fill-rose-600 text-white" />
-            <span>An error occurred while reloading the repository.</span>
-          </div>
-        ),
-      })
     } finally {
       setSelectedRepo(null)
     }


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a redundant error toast in the repository sync dialog that was hiding the real error message during registry sync. Users now see the full error from the sync request.

- **Bug Fixes**
  - Removed the generic error toast and the AlertTriangleIcon import.
  - Avoids duplicate toasts so the actual error can be displayed.

<sup>Written for commit 956c0f15f4eb5cb01797bce15a7ea069347f3aca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

