### PR TITLE
feat(ui): Handle dynamic child workflow aliases in action nodes

### DIFF
--- a/frontend/src/components/builder/canvas/action-node.tsx
+++ b/frontend/src/components/builder/canvas/action-node.tsx
@@ -69,12 +69,12 @@ import {
 } from "@/components/ui/tooltip"
 import { toast, useToast } from "@/components/ui/use-toast"
 import { useActionNodeZoomBreakpoint } from "@/hooks/canvas"
+import { isExpression } from "@/lib/expressions"
 import {
   useAction,
   useGetRegistryAction,
   useWorkflowManager,
 } from "@/lib/hooks"
-import { isExpression } from "@/lib/expressions"
 import { cn, slugify } from "@/lib/utils"
 import { CHILD_WORKFLOW_ACTION_TYPE } from "@/lib/workflow"
 import { useWorkflowBuilder } from "@/providers/builder"
@@ -98,6 +98,7 @@ type ChildWorkflowInfo = {
   childWorkflowId?: string
   childWorkflowAlias?: string
   childIdFromAlias?: string
+  isDynamicChildWorkflowAlias: boolean
 }
 
 export default React.memo(function ActionNode({
@@ -356,6 +357,7 @@ export default React.memo(function ActionNode({
     childIdFromAlias,
     childWorkflowAlias,
     childWorkflowId,
+    isDynamicChildWorkflowAlias,
   }
 
   return (
@@ -743,8 +745,12 @@ function ChildWorkflowLink({
   workspaceId: string
   childWorkflowInfo: ChildWorkflowInfo
 }) {
-  const { childWorkflowId, childWorkflowAlias, childIdFromAlias } =
-    childWorkflowInfo
+  const {
+    childWorkflowId,
+    childWorkflowAlias,
+    childIdFromAlias,
+    isDynamicChildWorkflowAlias,
+  } = childWorkflowInfo
   const { setSelectedNodeId } = useWorkflowBuilder()
 
   const handleClearSelection = () => {
@@ -781,16 +787,17 @@ function ChildWorkflowLink({
       return (
         <Tooltip>
           <TooltipTrigger>
-            <div className="rounded-sm border bg-muted-foreground/10 p-0.5">
-              <BracesIcon className="size-3 text-foreground/70" />
+            <div className="rounded-sm border bg-blue-200/30 p-0.5">
+              <BracesIcon className="size-3 text-blue-600/80" />
             </div>
           </TooltipTrigger>
-          <TooltipContent sideOffset={20}>
+          <TooltipContent
+            sideOffset={20}
+            className="max-w-[300px] whitespace-normal break-words"
+          >
             <span>
               This subflow is resolved dynamically at runtime using the{" "}
-              <TooltipCode value="workflow_alias" />
-              {" "}
-              expression
+              <TooltipCode value="workflow_alias" /> expression
             </span>
           </TooltipContent>
         </Tooltip>
@@ -851,7 +858,7 @@ function ChildWorkflowLink({
 
 function TooltipCode({ value }: { value: string }) {
   return (
-    <span className="m-0.5 rounded-sm border border-muted-foreground/40 bg-muted-foreground/70 p-0.5 font-mono tracking-tighter">
+    <span className="m-0.5 rounded-sm border border-muted-foreground/40 bg-muted-foreground/70 px-0.5 py-0.25 font-mono tracking-tighter">
       {value}
     </span>
   )


### PR DESCRIPTION
## Summary
- Detect expression-based child workflow aliases and avoid static workflow resolution errors
- Show a dynamic subflow indicator when workflow_alias uses an expression

## Testing
- Not run (not requested)

## Screens

<img width="1728" height="959" alt="Screenshot 2025-11-21 at 12 17 10" src="https://github.com/user-attachments/assets/313844d3-b204-441b-8050-878523462369" />


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692091493c5083208ef8956e5bf0ec9d)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for dynamic child workflow aliases in action nodes. Expression-based workflow_alias values no longer trigger resolution errors and now show a runtime subflow indicator.

- **New Features**
  - Detect expression-based workflow_alias and skip static ID lookup.
  - Show braces icon with a tooltip to indicate the subflow is resolved at runtime.

<sup>Written for commit 39f8287c3fd856a227a89fe06f557d45c28bf5b8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



