### PR TITLE
fix(ui): Align frontend slugify with python implementation

### DIFF
--- a/frontend/src/components/builder/canvas/action-node.tsx
+++ b/frontend/src/components/builder/canvas/action-node.tsx
@@ -73,7 +73,7 @@ import {
   useGetRegistryAction,
   useWorkflowManager,
 } from "@/lib/hooks"
-import { cn, slugify } from "@/lib/utils"
+import { cn, slugifyActionRef } from "@/lib/utils"
 import { CHILD_WORKFLOW_ACTION_TYPE } from "@/lib/workflow"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
@@ -123,8 +123,9 @@ export default React.memo(function ActionNode({
   )
   const actionValidationErrors = useMemo(() => {
     return (
-      validationErrors?.filter((e) => e.ref === slugify(action?.title ?? "")) ??
-      []
+      validationErrors?.filter(
+        (e) => e.ref === slugifyActionRef(action?.title ?? "")
+      ) ?? []
     )
   }, [validationErrors, action])
   const { registryAction } = useGetRegistryAction(action?.type)
@@ -629,7 +630,7 @@ function ActionNodeToolbar({
           <CommandGroup>
             <CommandItem
               onSelect={() => {
-                const value = `ACTIONS.${slugify(action.title)}.result`
+                const value = `ACTIONS.${slugifyActionRef(action.title)}.result`
                 navigator.clipboard.writeText(value)
                 toast({
                   title: "Copied action reference",
@@ -659,7 +660,7 @@ function ActionNodeToolbar({
               onSelect={() => {
                 sidebarRef.current?.setOpen(true)
                 sidebarRef.current?.setActiveTab("action-input")
-                setSelectedActionEventRef(slugify(action.title))
+                setSelectedActionEventRef(slugifyActionRef(action.title))
               }}
             >
               <LayoutListIcon className="mr-2 size-3" />
@@ -669,7 +670,7 @@ function ActionNodeToolbar({
               onSelect={() => {
                 sidebarRef.current?.setOpen(true)
                 sidebarRef.current?.setActiveTab("action-result")
-                setSelectedActionEventRef(slugify(action.title))
+                setSelectedActionEventRef(slugifyActionRef(action.title))
               }}
             >
               <CircleCheckBigIcon className="mr-2 size-3" />
@@ -680,7 +681,7 @@ function ActionNodeToolbar({
                 onSelect={() => {
                   sidebarRef.current?.setOpen(true)
                   sidebarRef.current?.setActiveTab("action-interaction")
-                  setSelectedActionEventRef(slugify(action.title))
+                  setSelectedActionEventRef(slugifyActionRef(action.title))
                 }}
               >
                 <MessagesSquare className="mr-2 size-3" />

--- a/frontend/src/components/builder/events/events-workflow.tsx
+++ b/frontend/src/components/builder/events/events-workflow.tsx
@@ -49,7 +49,7 @@ import {
   type WorkflowExecutionEventCompact,
   type WorkflowExecutionReadCompact,
 } from "@/lib/event-history"
-import { cn, slugify, undoSlugify } from "@/lib/utils"
+import { cn, slugifyActionRef, undoSlugify } from "@/lib/utils"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
@@ -233,7 +233,7 @@ export function WorkflowEvents({
   const centerNode = useCallback(
     (actionRef: string) => {
       const action = Object.values(workflow?.actions || {}).find(
-        (act) => slugify(act.title) === actionRef
+        (act) => slugifyActionRef(act.title) === actionRef
       )
       const id = action?.id
       if (id) {
@@ -263,7 +263,7 @@ export function WorkflowEvents({
   const isActionRefValid = useCallback(
     (actionRef: string) => {
       const action = Object.values(workflow?.actions || {}).find(
-        (act) => slugify(act.title) === actionRef
+        (act) => slugifyActionRef(act.title) === actionRef
       )
       return action !== undefined
     },
@@ -390,7 +390,7 @@ export function WorkflowEvents({
                                       "action-input"
                                     )
                                     setSelectedActionEventRef(
-                                      slugify(actionRef)
+                                      slugifyActionRef(actionRef)
                                     )
                                   }}
                                 >
@@ -409,7 +409,7 @@ export function WorkflowEvents({
                                       "action-result"
                                     )
                                     setSelectedActionEventRef(
-                                      slugify(actionRef)
+                                      slugifyActionRef(actionRef)
                                     )
                                   }}
                                 >

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -116,7 +116,7 @@ import type { RequestValidationError, TracecatApiError } from "@/lib/errors"
 import { useAction, useGetRegistryAction, useOrgAppSettings } from "@/lib/hooks"
 import { PERMITTED_INTERACTION_ACTIONS } from "@/lib/interactions"
 import { isTracecatJsonSchema, type TracecatJsonSchema } from "@/lib/schema"
-import { cn, slugify } from "@/lib/utils"
+import { cn, slugifyActionRef } from "@/lib/utils"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
@@ -659,7 +659,7 @@ function ActionPanelContent({
                 msg: String(error),
               },
             ],
-            ref: slugify(action?.title ?? ""),
+            ref: slugifyActionRef(action?.title ?? ""),
           },
         ])
       }
@@ -770,7 +770,7 @@ function ActionPanelContent({
   const finalValErrors = [
     ...(validationResults || []),
     ...(validationErrors || []),
-  ].filter((e) => e.ref === slugify(action.title))
+  ].filter((e) => e.ref === slugifyActionRef(action.title))
 
   return (
     <div

--- a/frontend/src/lib/event-history.ts
+++ b/frontend/src/lib/event-history.ts
@@ -7,7 +7,7 @@ import type {
   WorkflowExecutionEventCompact_Any__Union_AgentOutput__Any___Any_,
   WorkflowExecutionReadCompact_Any__Union_AgentOutput__Any___Any_,
 } from "@/client"
-import { undoSlugify } from "@/lib/utils"
+import { ACTION_REF_DELIMITER, undoSlugify } from "@/lib/utils"
 
 export type WorkflowExecutionEventCompact =
   WorkflowExecutionEventCompact_Any__Union_AgentOutput__Any___Any_
@@ -219,5 +219,5 @@ export function refToLabel(actionRef: string) {
   if (actionRef === WF_FAILURE_EVENT_REF) {
     return WF_FAILURE_EVENT_LABEL
   }
-  return undoSlugify(actionRef)
+  return undoSlugify(actionRef, ACTION_REF_DELIMITER)
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -67,6 +67,12 @@ export function slugify(value: string, delimiter: string = "-"): string {
     .replace(trimEdges, "") // Trim delimiters from ends
 }
 
+export const ACTION_REF_DELIMITER = "_"
+
+export function slugifyActionRef(value: string): string {
+  return slugify(value, ACTION_REF_DELIMITER)
+}
+
 export function undoSlugify(value: string, delimiter: string = "-"): string {
   return value
     .replace(new RegExp(delimiter, "g"), " ")

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -50,18 +50,24 @@ export const copyToClipboard = async ({
   }
 }
 
-export function slugify(value: string, delimiter: string = "_"): string {
-  return value
-    .normalize("NFD")
+export function slugify(value: string, delimiter: string = "-"): string {
+  const normalized = value
+    .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "") // Remove diacritics
+    .replace(/[^\x00-\x7F]/g, "") // Drop non-ASCII remnants
     .toLowerCase()
     .trim()
-    .replace(/['`]/g, "_") // Replace quotes and apostrophes with underscore
-    .replace(/[^a-z0-9_ ]/g, "") // Remove other special chars except underscore
-    .replace(/\s+/g, delimiter) // Replace spaces with delimiter
+
+  const escapedDelimiter = delimiter.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const trimEdges = new RegExp(`^${escapedDelimiter}|${escapedDelimiter}$`, "g")
+
+  return normalized
+    .replace(/[^\w\s-]/g, "") // Remove non-word, non-space, non-hyphen characters
+    .replace(/[-\s]+/g, delimiter) // Collapse whitespace and hyphens into the delimiter
+    .replace(trimEdges, "") // Trim delimiters from ends
 }
 
-export function undoSlugify(value: string, delimiter: string = "_"): string {
+export function undoSlugify(value: string, delimiter: string = "-"): string {
   return value
     .replace(new RegExp(delimiter, "g"), " ")
     .replace(/\b\w/g, (l) => l.toUpperCase())

--- a/frontend/tests/events-workflow.test.tsx
+++ b/frontend/tests/events-workflow.test.tsx
@@ -72,6 +72,7 @@ jest.mock("@/lib/utils", () => ({
   ),
   undoSlugify: jest.fn((str: string) => str),
   slugify: jest.fn((str: string) => str),
+  slugifyActionRef: jest.fn((str: string) => str),
 }))
 
 // Mock complex dependency chains that cause issues

--- a/frontend/tests/utils.test.ts
+++ b/frontend/tests/utils.test.ts
@@ -1,5 +1,10 @@
 import { compressActionsInString } from "@/lib/expressions"
-import { isServer, slugify, undoSlugify } from "@/lib/utils"
+import {
+  isServer,
+  slugify,
+  slugifyActionRef,
+  undoSlugify,
+} from "@/lib/utils"
 
 describe("slugify", () => {
   it("should convert a string to a slug", () => {
@@ -40,6 +45,13 @@ describe("slugify", () => {
     expected.forEach((pythonSlug, idx) => {
       expect(slugify(cases[idx], "_")).toBe(pythonSlug)
     })
+  })
+})
+
+describe("slugifyActionRef", () => {
+  it("uses underscore delimiter to align with backend action refs", () => {
+    expect(slugifyActionRef("Hello World")).toBe("hello_world")
+    expect(slugifyActionRef("foo--bar baz")).toBe("foo_bar_baz")
   })
 })
 

--- a/frontend/tests/utils.test.ts
+++ b/frontend/tests/utils.test.ts
@@ -1,10 +1,5 @@
 import { compressActionsInString } from "@/lib/expressions"
-import {
-  isServer,
-  slugify,
-  slugifyActionRef,
-  undoSlugify,
-} from "@/lib/utils"
+import { isServer, slugify, slugifyActionRef, undoSlugify } from "@/lib/utils"
 
 describe("slugify", () => {
   it("should convert a string to a slug", () => {

--- a/frontend/tests/utils.test.ts
+++ b/frontend/tests/utils.test.ts
@@ -4,13 +4,48 @@ import { isServer, slugify, undoSlugify } from "@/lib/utils"
 describe("slugify", () => {
   it("should convert a string to a slug", () => {
     const slug = slugify("Hello World")
-    expect(slug).toBe("hello_world")
+    expect(slug).toBe("hello-world")
+  })
+
+  it("matches the python implementation for key edge cases", () => {
+    const cases = [
+      "foo/bar:baz",
+      "  Café déjà-vu  ",
+      "foo__bar",
+      "foo--bar",
+      "Action: Name/Version",
+      "ACTIONS.test.result",
+      "ACTIONS test result",
+    ]
+
+    const expected = [
+      "foobarbaz",
+      "cafe-deja-vu",
+      "foo__bar",
+      "foo-bar",
+      "action-nameversion",
+      "actionstestresult",
+      "actions-test-result",
+    ]
+
+    expected.forEach((pythonSlug, idx) => {
+      expect(slugify(cases[idx])).toBe(pythonSlug)
+    })
+  })
+
+  it("supports alternative delimiters like python", () => {
+    const cases = ["Hello World", "foo--bar", "foo/bar:baz"]
+    const expected = ["hello_world", "foo_bar", "foobarbaz"]
+
+    expected.forEach((pythonSlug, idx) => {
+      expect(slugify(cases[idx], "_")).toBe(pythonSlug)
+    })
   })
 })
 
 describe("undoSlugify", () => {
   it("should convert a slug back to a string", () => {
-    const string = undoSlugify("hello_world")
+    const string = undoSlugify("hello-world")
     expect(string).toBe("Hello World")
   })
 })


### PR DESCRIPTION
## Summary
- adjust the frontend slugify helper to mirror python-style cleanup by removing non-word punctuation and collapsing whitespace
- add fixture expectations derived from python slugify behavior, including alternate delimiter support

## Testing
- pnpm -C frontend test -- utils.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692091cc46008320ba6a3a431d79e3b6)







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the frontend slugify to match Python output and default to "-" with ASCII-only cleanup. Adds slugifyActionRef for action references (uses "_") and updates UI and event labels to match the backend.

- **Refactors**
  - Normalize with NFKD; remove diacritics and non-ASCII; strip punctuation; collapse spaces/hyphens; trim edges.
  - Add ACTION_REF_DELIMITER and slugifyActionRef; replace action ref usages in builder and events.
  - Update refToLabel to use undoSlugify with the action ref delimiter; expand tests for Python parity and the new helper.

- **Migration**
  - Use slugifyActionRef for action references; replace slugify(action.title) calls.
  - If you rely on underscore slugs elsewhere, pass "_" to slugify/undoSlugify and update any routes, keys, or tests expecting underscores.

<sup>Written for commit dbdc2ce29a3515ff165286800b531f461f96dee7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







