### PR TITLE
feat(app+ui): Handle null action results in workflow events panel

### DIFF
--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -212,15 +212,45 @@ export function SuccessEvent({
       )
     case "result":
       return (
-        <JsonViewWithControls
-          src={event.action_result}
+        <ActionResultViewer
+          result={event.action_result}
+          eventRef={eventRef}
           defaultExpanded={defaultExpanded}
           defaultTab={defaultTab}
-          copyPrefix={`ACTIONS.${eventRef}.result`}
         />
       )
   }
   return null
+}
+
+function ActionResultViewer({
+  result,
+  eventRef,
+  defaultExpanded = true,
+  defaultTab = "nested",
+}: {
+  result: unknown
+  eventRef: string
+  defaultExpanded?: boolean
+  defaultTab?: "nested" | "flat"
+}) {
+  if (result === null || result === undefined) {
+    return (
+      <div className="flex items-center justify-center gap-2 p-4 text-xs text-muted-foreground">
+        <CircleDot className="size-3 text-muted-foreground" />
+        <span>This action returned no result (null).</span>
+      </div>
+    )
+  }
+
+  return (
+    <JsonViewWithControls
+      src={result}
+      defaultExpanded={defaultExpanded}
+      defaultTab={defaultTab}
+      copyPrefix={`ACTIONS.${eventRef}.result`}
+    />
+  )
 }
 
 function StreamDetails({
@@ -340,11 +370,11 @@ function ActionEventContent({
               <ActionSessionStream session={session} />
             </TabsContent>
             <TabsContent value="result" className="mt-1">
-              <JsonViewWithControls
-                src={actionEvent.action_result}
+              <ActionResultViewer
+                result={actionEvent.action_result}
+                eventRef={eventRef}
                 defaultExpanded={true}
                 defaultTab="nested"
-                copyPrefix={`ACTIONS.${eventRef}.result`}
               />
             </TabsContent>
           </Tabs>

--- a/tracecat/dsl/compression.py
+++ b/tracecat/dsl/compression.py
@@ -134,6 +134,11 @@ class CompressionPayloadCodec(PayloadCodec):
                 result.append(payload)
                 continue
 
+            # Non-compression binary encodings (e.g. Temporal NullPayloadConverter)
+            if encoding == "binary/null":
+                result.append(payload)
+                continue
+
             try:
                 # Decompress based on encoding
                 if encoding == "binary/zstd":


### PR DESCRIPTION
## Summary
- display a descriptive message when an action result is null in the workflow events sidebar
- reuse the result viewer for both standard and session result tabs to avoid empty output
- handle binary and null payloads in the compression codec decode() path so they surface as None instead of empty panes

## Testing
- pnpm -C frontend lint

## Screens

https://github.com/user-attachments/assets/8eb51c0d-504a-4890-acc8-8842eb593a5d




------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920998857f4832083c156af8dad512a)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear message when a workflow action returns null and use a shared result viewer to keep the events sidebar consistent. Also interpret Temporal binary/null and empty payloads as None to remove empty panes in both Result and Session Result tabs.

- **Bug Fixes**
  - Display “This action returned no result (null).” when action_result is null or undefined across both result views.
  - Treat binary/null encodings and empty payloads as None in payload extraction and compression decoding.

<sup>Written for commit d0a1afef6df484dd4b2695dc31322c9f47204876. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



