### PR TITLE
fix(ui): Folder picker overflow + deduplicate scrollbars in folder/workflow move dialogs

### DIFF
--- a/frontend/src/components/dashboard/file-tree-command.tsx
+++ b/frontend/src/components/dashboard/file-tree-command.tsx
@@ -60,7 +60,7 @@ export function FileTreeCommand({ items, onSelect }: FileTreeCommandProps) {
               }
             }}
             className={cn(
-              "flex items-center gap-2 px-2",
+              "flex items-center gap-2 overflow-hidden px-2",
               { "pl-[calc(0.5rem+var(--indent))]": level > 0 },
               isSelected && "bg-accent"
             )}
@@ -92,7 +92,7 @@ export function FileTreeCommand({ items, onSelect }: FileTreeCommandProps) {
               ) : (
                 <Folder className="size-4 text-muted-foreground" />
               )}
-              <span>{item.name}</span>
+              <span className="truncate">{item.name}</span>
             </div>
           </CommandItem>
 

--- a/frontend/src/components/dashboard/file-tree-command.tsx
+++ b/frontend/src/components/dashboard/file-tree-command.tsx
@@ -59,19 +59,18 @@ export function FileTreeCommand({ items, onSelect }: FileTreeCommandProps) {
                 toggleFolder(item.path)
               }
             }}
-            className={cn(
-              "flex items-center gap-2 overflow-hidden px-2",
-              { "pl-[calc(0.5rem+var(--indent))]": level > 0 },
-              isSelected && "bg-accent"
-            )}
+            className={cn("px-2", {
+              "pl-[calc(0.5rem+var(--indent))]": level > 0,
+              "bg-accent": isSelected,
+            })}
             style={{ "--indent": `${level * 1.5}rem` } as React.CSSProperties}
           >
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               {hasChildren ? (
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="size-4 p-0"
+                  className="size-4 shrink-0 p-0"
                   onClick={(e) => {
                     e.stopPropagation()
                     toggleFolder(item.path)
@@ -92,7 +91,9 @@ export function FileTreeCommand({ items, onSelect }: FileTreeCommandProps) {
               ) : (
                 <Folder className="size-4 text-muted-foreground" />
               )}
-              <span className="truncate">{item.name}</span>
+              <span className="truncate" title={item.name}>
+                {item.name}
+              </span>
             </div>
           </CommandItem>
 

--- a/frontend/src/components/dashboard/folder-move-dialog.tsx
+++ b/frontend/src/components/dashboard/folder-move-dialog.tsx
@@ -173,7 +173,7 @@ export function FolderMoveDialog({
                 <ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="max-h-[300px] w-[--radix-popover-trigger-width] overflow-y-auto p-0">
+            <PopoverContent className="w-[--radix-popover-trigger-width] overflow-hidden p-0">
               <FileTreeCommand
                 items={fileTreeItems}
                 onSelect={handleSelectFolder}

--- a/frontend/src/components/dashboard/folder-move-dialog.tsx
+++ b/frontend/src/components/dashboard/folder-move-dialog.tsx
@@ -139,7 +139,7 @@ export function FolderMoveDialog({
             <span className="font-medium">{selectedFolder?.name}</span>.
             <div className="mt-2 text-xs">
               Current location:{" "}
-              <span className="font-medium">
+              <span className="font-medium break-words">
                 {currentParentPath === "/"
                   ? ROOT_FOLDER_NAME
                   : currentParentPath}
@@ -148,22 +148,31 @@ export function FolderMoveDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex items-center py-4">
+        <div className="flex w-full items-center py-4">
           <Popover open={openFolderSelect} onOpenChange={setOpenFolderSelect}>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
                 role="combobox"
                 aria-expanded={openFolderSelect}
-                className="w-full justify-between"
+                className="flex w-96 max-w-full min-w-0 justify-between overflow-hidden"
                 disabled={isMoving}
               >
                 {destinationPath ? (
-                  <div className="flex items-center gap-2">
-                    <FolderIcon className="size-4" />
-                    {destinationPath === "/"
-                      ? ROOT_FOLDER_NAME
-                      : destinationPath}
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <FolderIcon className="size-4 shrink-0" />
+                    <span
+                      className="truncate"
+                      title={
+                        destinationPath === "/"
+                          ? ROOT_FOLDER_NAME
+                          : destinationPath
+                      }
+                    >
+                      {destinationPath === "/"
+                        ? ROOT_FOLDER_NAME
+                        : destinationPath}
+                    </span>
                   </div>
                 ) : (
                   <div className="flex items-center gap-2">

--- a/frontend/src/components/dashboard/workflow-move-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-move-dialog.tsx
@@ -103,19 +103,30 @@ export function WorkflowMoveDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex items-center py-4">
+        <div className="w-full flex items-center py-4">
           <Popover open={openFolderSelect} onOpenChange={setOpenFolderSelect}>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
                 role="combobox"
                 aria-expanded={openFolderSelect}
-                className="w-full justify-between"
+                className="flex w-96 max-w-full min-w-0 justify-between overflow-hidden"
               >
                 {selectedFolder ? (
-                  <div className="flex items-center gap-2">
-                    <FolderIcon className="size-4" />
-                    {selectedFolder === "/" ? ROOT_FOLDER_NAME : selectedFolder}
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <FolderIcon className="size-4 shrink-0" />
+                    <span
+                      className="truncate"
+                      title={
+                        selectedFolder === "/"
+                          ? ROOT_FOLDER_NAME
+                          : selectedFolder
+                      }
+                    >
+                      {selectedFolder === "/"
+                        ? ROOT_FOLDER_NAME
+                        : selectedFolder}
+                    </span>
                   </div>
                 ) : (
                   <div className="flex items-center gap-2">

--- a/frontend/src/components/dashboard/workflow-move-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-move-dialog.tsx
@@ -125,7 +125,7 @@ export function WorkflowMoveDialog({
                 <ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="max-h-[300px] w-[--radix-popover-trigger-width] overflow-y-auto p-0">
+            <PopoverContent className="w-[--radix-popover-trigger-width] overflow-hidden p-0">
               <FileTreeCommand
                 items={fileTreeItems}
                 onSelect={handleSelectFolder}


### PR DESCRIPTION
## Summary
- adjust folder picker popovers in workflow and folder move dialogs to avoid double scrollbars
- truncate long folder names in the file tree list to keep the viewer within the dialog bounds

## Testing
- not run (not requested)

## Screens

https://github.com/user-attachments/assets/eaff4148-a2ec-4b4e-99b6-e932f28b6c93



------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920977272008320b739b40ced563cfb)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double scrollbars in folder pickers for workflow and folder move dialogs and truncates long folder names to keep the tree within dialog bounds.

- **Bug Fixes**
  - Set popover content to overflow-hidden and match trigger width to prevent nested scrolling.
  - Truncate folder names and selected paths, keep icons from shrinking, and wrap long “Current location” text to prevent overflow.

<sup>Written for commit ba8dd0ebc0356edc6760c15c235a8885763029e5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





