### PR TITLE
feat: add password reveal toggle

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,3 +1,4 @@
+import { Eye, EyeOff } from "lucide-react"
 import { cva, type VariantProps } from "class-variance-authority"
 import * as React from "react"
 
@@ -24,13 +25,62 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
     VariantProps<typeof inputVariants> {}
 
+const PasswordInput = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, variant, ...props }, forwardedRef) => {
+    const inputRef = React.useRef<HTMLInputElement | null>(null)
+    const [isRevealed, setIsRevealed] = React.useState(false)
+
+    React.useImperativeHandle(
+      forwardedRef,
+      () => inputRef.current as HTMLInputElement
+    )
+
+    return (
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type={isRevealed ? "text" : "password"}
+          className={cn(inputVariants({ variant }), "pr-10", className)}
+          {...props}
+        />
+        <button
+          type="button"
+          className="absolute inset-y-0 right-0 flex items-center rounded-md pr-3 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          onClick={() => setIsRevealed((prev) => !prev)}
+        >
+          <span className="sr-only">
+            {isRevealed ? "Hide password" : "Show password"}
+          </span>
+          {isRevealed ? (
+            <EyeOff aria-hidden="true" className="size-4" />
+          ) : (
+            <Eye aria-hidden="true" className="size-4" />
+          )}
+        </button>
+      </div>
+    )
+  }
+)
+PasswordInput.displayName = "PasswordInput"
+
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, variant, ...props }, ref) => {
+  ({ className, type = "text", variant, ...props }, forwardedRef) => {
+    if (type === "password") {
+      return (
+        <PasswordInput
+          {...props}
+          className={className}
+          variant={variant}
+          ref={forwardedRef}
+        />
+      )
+    }
+
     return (
       <input
+        ref={forwardedRef}
         type={type}
         className={cn(inputVariants({ variant }), className)}
-        ref={ref}
         {...props}
       />
     )

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,5 +1,5 @@
-import { Eye, EyeOff } from "lucide-react"
 import { cva, type VariantProps } from "class-variance-authority"
+import { Eye, EyeOff } from "lucide-react"
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -36,11 +36,11 @@ const PasswordInput = React.forwardRef<HTMLInputElement, InputProps>(
     )
 
     return (
-      <div className="relative">
+      <div className={cn("relative", className)}>
         <input
           ref={inputRef}
           type={isRevealed ? "text" : "password"}
-          className={cn(inputVariants({ variant }), "pr-10", className)}
+          className={cn(inputVariants({ variant }), "pr-10")}
           {...props}
         />
         <button


### PR DESCRIPTION
### Summary
Added a dedicated password input variant that handles reveal/hide with eye icons while preserving focus and accessibility.
Updated forms so any type="password" field automatically gains the toggle without extra wiring.

<img width="523" height="721" alt="image" src="https://github.com/user-attachments/assets/81d2d3f8-f02f-43c5-8114-94c345615b58" />








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a show/hide toggle to Input when type="password". All existing password fields now get an accessible reveal button by default.

- **New Features**
  - Introduced PasswordInput used automatically for type="password".
  - Toggle uses Eye/EyeOff icons, forwards refs, and includes screen-reader labels.
  - Added right padding and an inline button to prevent text overlap; className applies to the wrapper.

<sup>Written for commit 61800f26a85c4fb034a81f91cc039960202448ed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







