### PR TITLE
Ensure run_if sees parent actions in scatter streams

### DIFF
--- a/tests/unit/test_run_if_scatter.py
+++ b/tests/unit/test_run_if_scatter.py
@@ -1,0 +1,66 @@
+import pytest
+
+from tests.shared import generate_test_exec_id
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs, RETRY_POLICIES
+from tracecat.dsl.schemas import ActionStatement, GatherArgs, ScatterArgs
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.identifiers.workflow import WorkflowUUID
+
+
+@pytest.mark.anyio
+async def test_run_if_in_scatter_can_read_parent_actions(
+    test_role, temporal_client, test_worker_factory
+) -> None:
+    dsl = DSLInput(
+        title="run_if inherits parent actions in scatter",
+        description="Ensure run_if can access ACTIONS from parent streams during scatter",
+        entrypoint=DSLEntrypoint(ref="a"),
+        actions=[
+            ActionStatement(
+                ref="a",
+                action="core.transform.reshape",
+                args={"value": "${{ 5 }}"},
+            ),
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                depends_on=["a"],
+                args=ScatterArgs(collection=[1, 2, 3]).model_dump(),
+            ),
+            ActionStatement(
+                ref="inner",
+                action="core.transform.reshape",
+                depends_on=["scatter"],
+                run_if="${{ ACTIONS.a.result == 5 }}",
+                args={
+                    "value": "${{ ACTIONS.scatter.result + ACTIONS.a.result }}",
+                },
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["inner"],
+                args=GatherArgs(items="${{ ACTIONS.inner.result }}").model_dump(),
+            ),
+        ],
+        returns="${{ ACTIONS.gather.result }}",
+    )
+
+    run_args = DSLRunArgs(
+        dsl=dsl,
+        role=test_role,
+        wf_id=WorkflowUUID.new("wf-00000000000000000000000000000007"),
+    )
+    wf_exec_id = generate_test_exec_id(test_run_if_in_scatter_can_read_parent_actions.__name__)
+
+    worker = test_worker_factory(temporal_client)
+    async with worker:
+        result = await worker.client.execute_workflow(
+            DSLWorkflow.run,
+            run_args,
+            id=wf_exec_id,
+            task_queue=worker.task_queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+        )
+
+    assert result == [6, 7, 8]

--- a/tests/unit/test_scheduler_context.py
+++ b/tests/unit/test_scheduler_context.py
@@ -1,0 +1,74 @@
+import asyncio
+
+import pytest
+
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, create_default_execution_context
+from tracecat.dsl.schemas import (
+    ROOT_STREAM,
+    ActionStatement,
+    StreamID,
+    TaskResult,
+)
+from tracecat.dsl.scheduler import DSLScheduler
+from tracecat.dsl.types import Task
+from tracecat.expressions.common import ExprContext
+
+
+@pytest.mark.asyncio
+async def test_run_if_inherits_parent_actions(monkeypatch: pytest.MonkeyPatch):
+    dsl = DSLInput(
+        title="run_if inherits actions",
+        description="Ensure run_if can access ancestor ACTIONS context",
+        entrypoint=DSLEntrypoint(ref="upstream"),
+        actions=[
+            ActionStatement(
+                ref="upstream",
+                action="core.transform.reshape",
+                args={"value": "parent"},
+            ),
+            ActionStatement(
+                ref="child",
+                action="core.transform.reshape",
+                depends_on=["upstream"],
+                run_if="${{ ACTIONS.upstream.result == 'parent' }}",
+                args={"value": "child"},
+            ),
+        ],
+    )
+
+    async def fake_executor(_: ActionStatement) -> None:  # pragma: no cover - not invoked
+        return None
+
+    scheduler = DSLScheduler(
+        executor=fake_executor,
+        dsl=dsl,
+        context=create_default_execution_context(),
+    )
+
+    scheduler.streams[ROOT_STREAM][ExprContext.ACTIONS]["upstream"] = TaskResult(
+        result="parent", result_typename="str"
+    )
+
+    scatter_stream = StreamID.new("scatter", 0, base_stream_id=ROOT_STREAM)
+    scheduler.stream_hierarchy[scatter_stream] = ROOT_STREAM
+    scheduler.streams[scatter_stream] = {
+        ExprContext.ACTIONS: {
+            "scatter": TaskResult(result="item", result_typename="str")
+        }
+    }
+
+    captured: dict[str, object] = {}
+
+    async def fake_resolve(expr: str, context):
+        captured["context"] = context
+        return context[ExprContext.ACTIONS]["upstream"]["result"] == "parent"
+
+    monkeypatch.setattr(scheduler, "resolve_expression", fake_resolve)
+
+    task = Task(ref="child", stream_id=scatter_stream)
+    should_skip = await scheduler._task_should_skip(task, scheduler.tasks["child"])
+
+    assert should_skip is False
+    inherited_actions = captured["context"][ExprContext.ACTIONS]
+    assert inherited_actions["upstream"]["result"] == "parent"
+    assert inherited_actions["scatter"]["result"] == "item"


### PR DESCRIPTION
## Summary
- resolve `run_if` expressions with stream-aware ACTIONS lookups so scatter branches can see parent action results
- add a workflow test to confirm scatter branch `run_if` conditions evaluate parent ACTIONS values

## Testing
- uv run pytest tests/unit/test_run_if_scatter.py *(fails: unable to download `rignore` dependency)*
- uv run ruff *(fails: unable to download `cramjam` dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920aeee2f248320939db0b64abfd27e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes run_if so scatter branches can read parent ACTIONS and evaluate conditions correctly. Prevents tasks from being wrongly skipped when run_if depends on upstream results.

- **Bug Fixes**
  - Make run_if evaluation stream-aware by merging parent and local ACTIONS (get_context(inherit=True) with _get_inherited_context).
  - Resolve only referenced ACTIONS using extract_expressions and stream-aware lookups to ensure correct scope.
  - Add tests for scheduler context inheritance and a scatter/gather workflow that validates run_if sees ACTIONS.a (expects [6, 7, 8]).

<sup>Written for commit 6bf3e3a866bbe68ecf179f17d5c5382f4b8ddf0d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

