### PR TITLE
fix: Surface specific GitHub App errors to users

### DIFF
--- a/tracecat/vcs/github/app.py
+++ b/tracecat/vcs/github/app.py
@@ -11,6 +11,7 @@ from pydantic import SecretStr
 
 from tracecat.auth.types import AccessLevel
 from tracecat.authz.controls import require_access_level
+from tracecat.exceptions import TracecatException
 from tracecat.git.types import GitUrl
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import SecretCreate, SecretKeyValue, SecretUpdate
@@ -22,7 +23,7 @@ from tracecat.vcs.github.schemas import (
 )
 
 
-class GitHubAppError(Exception):
+class GitHubAppError(TracecatException):
     """GitHub App operation error."""
 
 


### PR DESCRIPTION
## Summary
Fixes issue where GitHub App errors (e.g., "App is not installed") were being shown as generic "An unexpected error occurred" messages to users.

## Changes
- Changed `GitHubAppError` to extend `TracecatException` instead of base `Exception`
- This ensures GitHub App errors use the TracecatException handler which properly exposes error details

## Impact
**Before**: Users see generic "Failed to publish workflow" with no context
**After**: Users see specific error like "Failed to publish workflow: App is not installed on org/repo"

## Technical Details
- `GitHubAppError` now automatically benefits from the `tracecat_exception_handler` which returns structured errors with `type`, `message`, and `detail` fields
- Frontend already handles these fields properly in toast notifications
- All endpoints throwing `GitHubAppError` now surface errors correctly without needing explicit catch blocks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced specific GitHub App errors to users by making GitHubAppError extend TracecatException. The UI now shows clear messages (e.g., "App is not installed on org/repo") instead of a generic failure.

<sup>Written for commit ac1d7107ca199de3c820521535759a6a96f90f82. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

