### PR TITLE
fix(engine): Jsonpath filter list handling

### DIFF
--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1027,11 +1027,7 @@ def test_jsonpath_filter_returns_list():
                         {
                             "attributes": {
                                 "incident_role": {
-                                    "data": {
-                                        "attributes": {
-                                            "slug": "primary-role"
-                                        }
-                                    }
+                                    "data": {"attributes": {"slug": "primary-role"}}
                                 }
                             }
                         },
@@ -1048,10 +1044,7 @@ def test_jsonpath_filter_returns_list():
         }
     }
 
-    expr = (
-        "ACTIONS.parse_event.result.included[?(@.attributes.incident_role.data.attributes.slug"
-        " != \"primary-role\")].attributes.incident_role.data.attributes.slug"
-    )
+    expr = 'ACTIONS.parse_event.result.included[?(@.attributes.incident_role.data.attributes.slug != "primary-role")].attributes.incident_role.data.attributes.slug'
     parser = ExprParser()
     parse_tree = parser.parse(expr)
     assert parse_tree is not None
@@ -1059,10 +1052,7 @@ def test_jsonpath_filter_returns_list():
     actual = ev.transform(parse_tree)
     assert actual == ["secondary-role"]
 
-    expr = (
-        "ACTIONS.parse_event.result.included[?(@.attributes.incident_role.data.attributes.slug"  # noqa: E501
-        ").attributes.incident_role.data.attributes.slug"
-    )
+    expr = "ACTIONS.parse_event.result.included[?(@.attributes.incident_role.data.attributes.slug)].attributes.incident_role.data.attributes.slug"
     parse_tree = parser.parse(expr)
     assert parse_tree is not None
     actual = ev.transform(parse_tree)

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -1018,6 +1018,60 @@ def test_jsonpath_wildcard():
     assert actual == [1]
 
 
+def test_jsonpath_filter_returns_list():
+    context = {
+        ExprContext.ACTIONS: {
+            "parse_event": {
+                "result": {
+                    "included": [
+                        {
+                            "attributes": {
+                                "incident_role": {
+                                    "data": {
+                                        "attributes": {
+                                            "slug": "primary-role"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "attributes": {
+                                "incident_role": {
+                                    "data": {"attributes": {"slug": "secondary-role"}}
+                                }
+                            }
+                        },
+                    ]
+                }
+            }
+        }
+    }
+
+    expr = (
+        "ACTIONS.parse_event.result.included[?(@.attributes.incident_role.data.attributes.slug"
+        " != \"primary-role\")].attributes.incident_role.data.attributes.slug"
+    )
+    parser = ExprParser()
+    parse_tree = parser.parse(expr)
+    assert parse_tree is not None
+    ev = ExprEvaluator(operand=context)
+    actual = ev.transform(parse_tree)
+    assert actual == ["secondary-role"]
+
+    expr = (
+        "ACTIONS.parse_event.result.included[?(@.attributes.incident_role.data.attributes.slug"  # noqa: E501
+        ").attributes.incident_role.data.attributes.slug"
+    )
+    parse_tree = parser.parse(expr)
+    assert parse_tree is not None
+    actual = ev.transform(parse_tree)
+    assert actual == [
+        "primary-role",
+        "secondary-role",
+    ]
+
+
 def test_time_funcs():
     time_now_expr = "${{ FN.now() }}"
     dt = eval_templated_object(time_now_expr)

--- a/tracecat/expressions/common.py
+++ b/tracecat/expressions/common.py
@@ -7,6 +7,7 @@ from enum import StrEnum, auto
 from typing import Any, TypeVar
 
 import jsonpath_ng.ext
+import jsonpath_ng.jsonpath as jsonpath_nodes
 from jsonpath_ng.exceptions import JsonPathParserError
 
 from tracecat.exceptions import TracecatExpressionError
@@ -562,7 +563,41 @@ def eval_jsonpath(
         formatted_expr = _expr_with_context(expr, context_type)
         raise TracecatExpressionError(f"Invalid jsonpath {formatted_expr!r}") from e
     matches = [found.value for found in jsonpath_expr.find(operand)]
-    if len(matches) > 1 or "[*]" in expr:
+
+    def _contains_filter(path: jsonpath_nodes.JSONPath) -> bool:
+        stack: list[jsonpath_nodes.JSONPath] = [path]
+        while stack:
+            current = stack.pop()
+            if hasattr(current, "filter_expr"):
+                return True
+
+            for child in (
+                getattr(current, "left", None),
+                getattr(current, "right", None),
+                getattr(current, "child", None),
+                getattr(current, "expression", None),
+            ):
+                if isinstance(child, jsonpath_nodes.JSONPath):
+                    stack.append(child)
+
+            for children in (
+                getattr(current, "fields", None),
+                getattr(current, "fields_list", None),
+                getattr(current, "components", None),
+            ):
+                if isinstance(children, (list, tuple)):
+                    stack.extend(
+                        child
+                        for child in children
+                        if isinstance(child, jsonpath_nodes.JSONPath)
+                    )
+
+        return False
+
+    has_wildcard = "[*]" in expr
+    has_filter = "[?(" in expr or "[?@" in expr or _contains_filter(jsonpath_expr)
+
+    if len(matches) > 1 or has_wildcard or has_filter:
         # If there are multiple matches or array wildcard, return the list
         return matches
     elif len(matches) == 1:


### PR DESCRIPTION
## Summary
- ensure jsonpath filter expressions keep list semantics even with single matches
- anonymize jsonpath filter test data while preserving structure and coverage

## Testing
- uv run pytest tests/unit/test_expressions.py -k jsonpath *(fails: dependency download blocked by network proxy when fetching pydantic-ai-slim)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920da4e7a548320bc2ea5074809b284)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eval_jsonpath to always return a list for JSONPath filter and wildcard expressions, even when there’s a single match. Adds tests to lock in this behavior with anonymized data.

- **Bug Fixes**
  - Detect filters via AST traversal (and “[?…]” patterns) and treat them like wildcards, ensuring list output in all cases.
  - Added unit tests asserting list semantics; anonymized test payloads.

<sup>Written for commit 64251797485c88de343f849941870694bd175273. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



