### PR TITLE
fix: Resolve type errors across codebase

### DIFF
--- a/alembic/versions/7694c8910510_migrate_entities_to_tables.py
+++ b/alembic/versions/7694c8910510_migrate_entities_to_tables.py
@@ -119,7 +119,7 @@ def upgrade() -> None:
                 "updated_at": entity.updated_at,
             },
         )
-        table_id = table_insert_result.fetchone().id
+        table_id = table_insert_result.one().id
 
         # 4. Get entity fields and create table columns
         fields_result = connection.execute(

--- a/tests/unit/test_integrations_service.py
+++ b/tests/unit/test_integrations_service.py
@@ -1152,10 +1152,21 @@ class TestIntegrationService:
     ) -> None:
         """Ensure request schema rejects insecure OAuth endpoints."""
         with pytest.raises(ValidationError):
-            IntegrationUpdate(
-                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
-                **{field: value},
-            )
+            # Explicitly construct kwargs to avoid type checker issues with **{field: value}
+            # when client_secret expects SecretStr | None
+            match field:
+                case "authorization_endpoint":
+                    IntegrationUpdate(
+                        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+                        authorization_endpoint=value,
+                    )
+                case "token_endpoint":
+                    IntegrationUpdate(
+                        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+                        token_endpoint=value,
+                    )
+                case _:
+                    raise ValueError(f"Unexpected field: {field}")
 
     async def test_store_provider_config_includes_default_endpoints(
         self,

--- a/tests/unit/test_tables_router.py
+++ b/tests/unit/test_tables_router.py
@@ -2,7 +2,8 @@ from io import BytesIO
 
 import pytest
 from fastapi import HTTPException, status
-from starlette.datastructures import Headers, UploadFile
+from fastapi.datastructures import UploadFile
+from starlette.datastructures import Headers
 
 from tracecat.tables.router import _read_csv_upload_with_limit
 

--- a/tracecat/expressions/expectations.py
+++ b/tracecat/expressions/expectations.py
@@ -128,7 +128,7 @@ class TypeTransformer(Transformer):
             seen_values.add(value_lower)
             literal_values.append(value)
 
-        literal_type = Literal.__getitem__(tuple(literal_values))
+        literal_type = Literal.__getitem__(tuple(literal_values))  # pyright: ignore[reportAttributeAccessIssue]
         logger.trace("Enum literal type:", field=self.field_name, values=literal_values)
         return literal_type
 

--- a/tracecat/tables/importer.py
+++ b/tracecat/tables/importer.py
@@ -223,7 +223,7 @@ class CSVSchemaInferer:
     def initialise(cls, headers: Sequence[str | None]) -> Self:
         return cls(headers)
 
-    def observe(self, row: dict[str, str | None]) -> None:
+    def observe(self, row: dict[str, str]) -> None:
         for stats in self._columns:
             stats.observe(row.get(stats.original_name))
 


### PR DESCRIPTION
## Summary
- Fix SQLAlchemy result method in migration (use `.one()` instead of `.fetchone()`)
- Refactor test to avoid type checker issues with dynamic kwargs
- Organize imports in tables router
- Add type ignore comment for Literal type construction
- Correct type hint in CSVSchemaInferer

## Test plan
- Existing tests pass
- Type checker validation passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes type errors across the codebase and corrects an Alembic migration to use Result.one() for safer row retrieval. This stabilizes the migration and makes type checking pass.

- **Bug Fixes**
  - Migration: use result.one().id instead of fetchone() when inserting tables.
  - Tests: replace dynamic kwargs with explicit args in IntegrationUpdate HTTPS validation.
  - Imports: tidy and correct UploadFile/Headers imports in tables router tests.
  - Typing: add pyright ignore for Literal.__getitem__ and fix CSV schema inferer observe() signature to dict[str, str].

<sup>Written for commit c650b80bf85577780f32f4a39e967c84698d2d21. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

