### PR TITLE
feat(agents): confirmation dialog for resetting chat context

### DIFF
--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -700,6 +700,7 @@ function AgentPresetChatPane({
   workspaceId: string
 }) {
   const [createdChatId, setCreatedChatId] = useState<string | null>(null)
+  const [resetDialogOpen, setResetDialogOpen] = useState(false)
 
   const { providersStatus, isLoading: providersStatusLoading } =
     useModelProvidersStatus()
@@ -771,6 +772,7 @@ function AgentPresetChatPane({
   }
 
   const handleResetChat = async () => {
+    setResetDialogOpen(false)
     await handleStartChat(true)
   }
 
@@ -902,19 +904,37 @@ function AgentPresetChatPane({
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => void handleResetChat()}
-            disabled={createChatPending || !canStartChat}
-          >
-            {createChatPending ? (
-              <Loader2 className="mr-2 size-4 animate-spin" />
-            ) : (
-              <RotateCcw className="mr-2 size-4" />
-            )}
-            Reset chat
-          </Button>
+          <AlertDialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
+            <AlertDialogTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={createChatPending || !canStartChat}
+              >
+                {createChatPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <RotateCcw className="mr-2 size-4" />
+                )}
+                Reset chat
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Reset this chat?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will start a new conversation. Your current chat history
+                  will no longer be accessible.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => void handleResetChat()}>
+                  Reset chat
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
       <div className="flex-1 min-h-0">{renderBody()}</div>
@@ -1698,6 +1718,7 @@ function AgentPresetBuilderChatPane({
 }) {
   const presetId = preset?.id
   const [createdChatId, setCreatedChatId] = useState<string | null>(null)
+  const [resetDialogOpen, setResetDialogOpen] = useState(false)
 
   const {
     ready: chatReady,
@@ -1757,6 +1778,7 @@ function AgentPresetBuilderChatPane({
     if (!canStartChat) {
       return
     }
+    setResetDialogOpen(false)
     await handleStartChat(true)
   }
 
@@ -1885,19 +1907,39 @@ function AgentPresetBuilderChatPane({
           <h3 className="text-sm font-semibold">Builder assistant</h3>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => void handleResetChat()}
-            disabled={createChatPending || !canStartChat}
-          >
-            {createChatPending ? (
-              <Loader2 className="mr-2 size-4 animate-spin" />
-            ) : (
-              <RotateCcw className="mr-2 size-4" />
-            )}
-            Reset assistant
-          </Button>
+          <AlertDialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
+            <AlertDialogTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={createChatPending || !canStartChat}
+              >
+                {createChatPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <RotateCcw className="mr-2 size-4" />
+                )}
+                Reset assistant
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  Reset the builder assistant?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will start a new conversation. Your current chat history
+                  will no longer be accessible.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => void handleResetChat()}>
+                  Reset assistant
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
       <div className="flex-1 min-h-0">{renderBody()}</div>

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -19,6 +19,17 @@ import type {
 import { ChatSessionPane } from "@/components/chat/chat-session-pane"
 import { NoMessages } from "@/components/chat/messages"
 import { CenteredSpinner } from "@/components/loading/spinner"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -65,6 +76,7 @@ export function ChatInterface({
   const [selectedChatId, setSelectedChatId] = useState<string | undefined>(
     chatId
   )
+  const [newChatDialogOpen, setNewChatDialogOpen] = useState(false)
 
   const { chats, chatsLoading, chatsError } = useListChats({
     workspaceId: workspaceId,
@@ -132,6 +144,7 @@ export function ChatInterface({
   }, [chats, selectedChatId, onChatSelect])
 
   const handleCreateChat = async () => {
+    setNewChatDialogOpen(false)
     try {
       const newChat = await createChat({
         title: `Chat ${(chats?.length || 0) + 1}`,
@@ -327,22 +340,43 @@ export function ChatInterface({
               </DropdownMenu>
             )}
             {/* New chat icon button with tooltip */}
-            <TooltipProvider delayDuration={0}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="size-6 p-0"
-                    onClick={handleCreateChat}
-                    disabled={createChatPending}
-                  >
-                    <Plus className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">New chat</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <AlertDialog
+              open={newChatDialogOpen}
+              onOpenChange={setNewChatDialogOpen}
+            >
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <AlertDialogTrigger asChild>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="size-6 p-0"
+                        disabled={createChatPending}
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                  </AlertDialogTrigger>
+                  <TooltipContent side="bottom">New chat</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Start a new chat?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will create a new conversation. Your current chat will
+                    remain accessible from the conversations menu.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => void handleCreateChat()}>
+                    Start new chat
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Add confirmation dialogs to reset options in the agent preset builder 

<img width="980" height="530" alt="image" src="https://github.com/user-attachments/assets/31a99dc2-be02-45d9-b3c2-c7a468440921" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds confirmation dialogs before resetting the chat context and starting a new chat to prevent accidental conversation resets.

- **New Features**
  - Agent Presets Builder: Confirm before “Reset chat” and “Reset assistant,” with clear messaging about losing access to the current history.
  - Chat Interface: Confirm before starting a “New chat,” clarifying the current chat remains accessible from the conversations menu.

<sup>Written for commit a026f1257d68ea37a398de39f4cb938a4475d5ff. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

