### PR TITLE
Add workflow relation metadata to directory items

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -14974,6 +14974,40 @@ export const $WorkflowDefinitionReadMinimal = {
   title: "WorkflowDefinitionReadMinimal",
 } as const
 
+export const $WorkflowRelationRead = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
+    title: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Title",
+    },
+    alias: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Alias",
+    },
+  },
+  type: "object",
+  required: ["id"],
+  title: "WorkflowRelationRead",
+} as const
+
 export const $WorkflowDirectoryItem = {
   properties: {
     id: {
@@ -15071,6 +15105,20 @@ export const $WorkflowDirectoryItem = {
         },
       ],
     },
+    parents: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/WorkflowRelationRead",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Parents",
+    },
     folder_id: {
       anyOf: [
         {
@@ -15082,6 +15130,20 @@ export const $WorkflowDirectoryItem = {
         },
       ],
       title: "Folder Id",
+    },
+    subflows: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/WorkflowRelationRead",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Subflows",
     },
     type: {
       type: "string",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4790,6 +4790,12 @@ export type WorkflowDefinitionReadMinimal = {
   created_at: string
 }
 
+export type WorkflowRelationRead = {
+  id: string
+  title?: string | null
+  alias?: string | null
+}
+
 export type WorkflowDirectoryItem = {
   id: string
   title: string
@@ -4804,6 +4810,8 @@ export type WorkflowDirectoryItem = {
   error_handler?: string | null
   latest_definition?: WorkflowDefinitionReadMinimal | null
   folder_id?: string | null
+  parents?: Array<WorkflowRelationRead> | null
+  subflows?: Array<WorkflowRelationRead> | null
   type: "workflow"
 }
 

--- a/frontend/src/components/dashboard/workflow-folders-table.tsx
+++ b/frontend/src/components/dashboard/workflow-folders-table.tsx
@@ -10,8 +10,11 @@ import type {
   ApiError,
   FolderDirectoryItem,
   TagRead,
+  WorkflowRelationRead,
+  WorkflowDirectoryItem,
   WorkflowReadMinimal,
 } from "@/client"
+import Link from "next/link"
 import { DeleteWorkflowAlertDialog } from "@/components/dashboard/delete-workflow-dialog"
 import { FolderDeleteAlertDialog } from "@/components/dashboard/folder-delete-dialog"
 import { FolderMoveDialog } from "@/components/dashboard/folder-move-dialog"
@@ -422,6 +425,71 @@ export function WorkflowsDashboardTable({
                 )
               },
               enableHiding: true,
+            },
+            {
+              id: "Relations",
+              accessorFn: (row: DirectoryItem) =>
+                row.type === "workflow" ? (row as WorkflowDirectoryItem) : undefined,
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Relations"
+                />
+              ),
+              cell: ({ row }) => {
+                if (row.original.type === "folder") {
+                  return (
+                    <span className="text-xs text-muted-foreground/70">
+                      {NO_DATA}
+                    </span>
+                  )
+                }
+
+                const { parents, subflows } = row.original as WorkflowDirectoryItem
+
+                if (!(parents?.length || subflows?.length)) {
+                  return (
+                    <span className="text-xs text-muted-foreground/70">
+                      No relations
+                    </span>
+                  )
+                }
+
+                const renderRelationBadge = (
+                  relation: WorkflowRelationRead,
+                  label: string
+                ) => (
+                  <Badge
+                    key={`${label}-${relation.id}`}
+                    asChild
+                    variant="secondary"
+                    className="gap-1 px-1.5 py-1 text-[0.65rem]"
+                  >
+                    <Link
+                      href={`/workspaces/${workspaceId}/workflows/${relation.id}`}
+                    >
+                      <span className="font-semibold uppercase text-muted-foreground">
+                        {label}
+                      </span>
+                      <span className="font-mono font-medium text-foreground/80">
+                        {relation.alias || relation.title || relation.id}
+                      </span>
+                    </Link>
+                  </Badge>
+                )
+
+                return (
+                  <div className="flex flex-wrap gap-1">
+                    {parents?.map((parent) =>
+                      renderRelationBadge(parent, "Parent")
+                    )}
+                    {subflows?.map((subflow) =>
+                      renderRelationBadge(subflow, "Subflow")
+                    )}
+                  </div>
+                )
+              },
             },
             {
               id: "actions",

--- a/tracecat/workflow/management/folders/schemas.py
+++ b/tracecat/workflow/management/folders/schemas.py
@@ -7,6 +7,12 @@ from pydantic import BaseModel, Field, TypeAdapter
 from tracecat.workflow.management.schemas import WorkflowReadMinimal
 
 
+class WorkflowRelationRead(BaseModel):
+    id: str
+    title: str | None = None
+    alias: str | None = None
+
+
 class WorkflowFolderRead(BaseModel):
     id: uuid.UUID
     name: str
@@ -40,6 +46,8 @@ class FolderDirectoryItem(WorkflowFolderRead):
 
 class WorkflowDirectoryItem(WorkflowReadMinimal):
     type: Literal["workflow"]
+    parents: list[WorkflowRelationRead] | None = None
+    subflows: list[WorkflowRelationRead] | None = None
 
 
 DirectoryItem = Annotated[


### PR DESCRIPTION
## Summary
- populate workflow directory items with parent/subflow relations derived from subflow execution actions
- expose relation fields through API/client schemas and render them in the workflows dashboard table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920edbb1e6c83208096bd88baa389de)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parent and subflow relations to workflow directory items and displays them in the dashboard with badges linking to related workflows. Improves visibility of workflow dependencies.

- **New Features**
  - Populate parents/subflows by parsing core.workflow.execute actions (via workflow_alias or workflow_id).
  - Add WorkflowRelationRead and parents/subflows to WorkflowDirectoryItem in API and generated client types.
  - Show a “Relations” column in the workflows table with Parent/Subflow badges that link to the target workflow (alias/title fallback to short ID).

<sup>Written for commit 218450a023c6e840a44516917f09bb1ecd34e99b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

