### PR TITLE
feat(core): Add base64 encoding option for HTTP request action

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/http.py
+++ b/packages/tracecat-registry/tracecat_registry/core/http.py
@@ -213,13 +213,22 @@ class TemporaryClientCertificate:
                 )
 
 
-def httpx_to_response(response: httpx.Response) -> HTTPResponse:
+def httpx_to_response(
+    response: httpx.Response, *, base64_encode_data: bool = False
+) -> HTTPResponse:
     # Handle 204 No Content responses
     if response.status_code == 204:
         return HTTPResponse(
             status_code=response.status_code,
             headers=dict(response.headers.items()),
             data=None,  # RFC 7231: 204 responses MUST NOT contain a body
+        )
+
+    if base64_encode_data:
+        return HTTPResponse(
+            status_code=response.status_code,
+            headers=dict(response.headers.items()),
+            data=base64.b64encode(response.content).decode(),
         )
 
     # Parse response based on content type
@@ -554,6 +563,12 @@ async def http_request(
             "If specified, these status codes will not be treated as errors. Defaults to None."
         ),
     ] = None,
+    base64_encode_data: Annotated[
+        bool,
+        Doc(
+            "Base64 encode the raw response body before returning. Use this for binary downloads to prevent corruption from text decoding."
+        ),
+    ] = False,
     verify_ssl: VerifySSL = True,
 ) -> HTTPResponse:
     """Perform a HTTP request to a given URL."""
@@ -612,7 +627,10 @@ async def http_request(
         except httpx.ReadTimeout as e:
             logger.error(f"HTTP request timed out after {timeout} seconds.")
             raise e
-        return httpx_to_response(response)
+        return httpx_to_response(
+            response,
+            base64_encode_data=base64_encode_data,
+        )
 
 
 class PredicateArgs(TypedDict):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a base64_encode_data option to the HTTP request action to return a base64 string of the raw response body. This enables safe binary downloads and prevents corruption from text decoding.

- **New Features**
  - http_request now accepts base64_encode_data (default false); httpx_to_response supports it.
  - When true, returns a base64-encoded string of the raw bytes (e.g., images, PDFs).

- **Bug Fixes**
  - Prevents binary payload corruption caused by coercing bytes to text before encoding.
  - Integration tests verify lossless round-trip on a PNG download.

<sup>Written for commit cb5dd52f57981acdc69edaa5927fd5973f3e27d4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

