### PR TITLE
feat(integrations): Terraform Cloud

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/apply_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/apply_run.yml
@@ -1,0 +1,36 @@
+type: action
+definition:
+  title: Apply run
+  description: Apply a run that is waiting for confirmation.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#apply-a-run
+  namespace: tools.terraform_cloud
+  name: apply_run
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    run_id:
+      type: str
+      description: Run ID to apply.
+    comment:
+      type: str | None
+      description: Optional apply comment.
+      default: null
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: apply_run
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/runs/${{ inputs.run_id }}/actions/apply
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          comment: ${{ inputs.comment }}
+  returns: ${{ steps.apply_run.result.status_code }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/cancel_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/cancel_run.yml
@@ -1,0 +1,36 @@
+type: action
+definition:
+  title: Cancel run
+  description: Cancel a run that is in progress or pending.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#cancel-a-run
+  namespace: tools.terraform_cloud
+  name: cancel_run
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    run_id:
+      type: str
+      description: Run ID to cancel.
+    comment:
+      type: str
+      description: Optional cancel comment.
+      default: ""
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: cancel_run
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/runs/${{ inputs.run_id }}/actions/cancel
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          comment: ${{ inputs.comment }}
+  returns: ${{ steps.cancel_run.result.status_code }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/create_project_variable.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/create_project_variable.yml
@@ -1,0 +1,62 @@
+type: action
+definition:
+  title: Create project variable
+  description: Create a Terraform variable on a project.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#project-variables
+  namespace: tools.terraform_cloud
+  name: create_project_variable
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    project_id:
+      type: str
+      description: Project ID.
+    key:
+      type: str
+      description: Variable key.
+    value:
+      type: str
+      description: Variable value.
+    category:
+      type: str
+      description: Variable category (terraform or env).
+      enum: ["terraform", "env"]
+    hcl:
+      type: bool
+      description: Interpret value as HCL.
+      default: false
+    sensitive:
+      type: bool
+      description: Whether the value is sensitive.
+      default: false
+    description:
+      type: str
+      description: Variable description.
+      default: ""
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: create_project_variable
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/projects/${{ inputs.project_id }}/vars
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          data:
+            type: vars
+            attributes:
+              key: ${{ inputs.key }}
+              value: ${{ inputs.value }}
+              category: ${{ inputs.category }}
+              hcl: ${{ inputs.hcl }}
+              sensitive: ${{ inputs.sensitive }}
+              description: ${{ inputs.description }}
+  returns: ${{ steps.create_project_variable.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/create_workspace_variable.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/create_workspace_variable.yml
@@ -1,0 +1,62 @@
+type: action
+definition:
+  title: Create workspace variable
+  description: Create a Terraform variable on a workspace.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#workspace-variables
+  namespace: tools.terraform_cloud
+  name: create_workspace_variable
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    workspace_id:
+      type: str
+      description: Workspace ID.
+    key:
+      type: str
+      description: Variable key.
+    value:
+      type: str
+      description: Variable value.
+    category:
+      type: str
+      description: Variable category (terraform or env).
+      enum: ["terraform", "env"]
+    hcl:
+      type: bool
+      description: Interpret value as HCL.
+      default: false
+    sensitive:
+      type: bool
+      description: Whether the value is sensitive.
+      default: false
+    description:
+      type: str
+      description: Variable description.
+      default: ""
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: create_workspace_variable
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/workspaces/${{ inputs.workspace_id }}/vars
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          data:
+            type: vars
+            attributes:
+              key: ${{ inputs.key }}
+              value: ${{ inputs.value }}
+              category: ${{ inputs.category }}
+              hcl: ${{ inputs.hcl }}
+              sensitive: ${{ inputs.sensitive }}
+              description: ${{ inputs.description }}
+  returns: ${{ steps.create_workspace_variable.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/discard_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/discard_run.yml
@@ -1,0 +1,36 @@
+type: action
+definition:
+  title: Discard run
+  description: Discard a run waiting for confirmation or queued.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#discard-a-run
+  namespace: tools.terraform_cloud
+  name: discard_run
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    run_id:
+      type: str
+      description: Run ID to discard.
+    comment:
+      type: str
+      description: Optional discard comment.
+      default: ""
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: discard_run
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/runs/${{ inputs.run_id }}/actions/discard
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          comment: ${{ inputs.comment }}
+  returns: ${{ steps.discard_run.result.status_code }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/get_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/get_run.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Get run
+  description: Retrieve details for a Terraform run.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#get-run-details
+  namespace: tools.terraform_cloud
+  name: get_run
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    run_id:
+      type: str
+      description: Run ID.
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: get_run
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/runs/${{ inputs.run_id }}
+        method: GET
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Accept: application/vnd.api+json
+  returns: ${{ steps.get_run.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/get_workspace_outputs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/get_workspace_outputs.yml
@@ -1,0 +1,29 @@
+type: action
+definition:
+  title: Get workspace outputs
+  description: Fetch outputs from the current state version of a workspace.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces
+  namespace: tools.terraform_cloud
+  name: get_workspace_outputs
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    workspace_id:
+      type: str
+      description: Workspace ID.
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: get_outputs
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/workspaces/${{ inputs.workspace_id }}/current-state-version-outputs
+        method: GET
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Accept: application/vnd.api+json
+  returns: ${{ steps.get_outputs.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_projects.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_projects.yml
@@ -1,0 +1,56 @@
+type: action
+definition:
+  title: List projects
+  description: List projects in an organization.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/projects#list-projects
+  namespace: tools.terraform_cloud
+  name: list_projects
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    organization_name:
+      type: str
+      description: Terraform organization name.
+    query:
+      type: str | None
+      description: Case-insensitive project name search string (q parameter).
+      default: null
+    names:
+      type: str | None
+      description: Comma-separated project names to match exactly.
+      default: null
+    page_number:
+      type: int | None
+      description: Page number for pagination.
+      default: null
+    page_size:
+      type: int | None
+      description: Page size (maximum 100).
+      default: null
+    sort:
+      type: str | None
+      description: Sort projects by name; prefix with - for descending.
+      default: null
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: list_projects
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/organizations/${{ FN.url_encode(inputs.organization_name) }}/projects
+        method: GET
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        params:
+          q: ${{ inputs.query }}
+          filter[names]: ${{ inputs.names }}
+          page[number]: ${{ inputs.page_number }}
+          page[size]: ${{ inputs.page_size }}
+          sort: ${{ inputs.sort }}
+  returns: ${{ steps.list_projects.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_runs.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_runs.yml
@@ -1,0 +1,51 @@
+type: action
+definition:
+  title: List runs
+  description: List runs for a workspace.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#list-runs-in-a-workspace
+  namespace: tools.terraform_cloud
+  name: list_runs
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    workspace_id:
+      type: str
+      description: Workspace ID to list runs for.
+    page_number:
+      type: int | None
+      description: Page number for pagination.
+      default: null
+    page_size:
+      type: int | None
+      description: Page size (maximum 100).
+      default: null
+    operation:
+      type: str | None
+      description: Filter by operation (e.g. plan, apply, refresh). Comma-separated to include multiple.
+      default: null
+    status:
+      type: str | None
+      description: Filter by run status (e.g. planned, applied, errored). Comma-separated to include multiple.
+      default: null
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: list_runs
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/workspaces/${{ inputs.workspace_id }}/runs
+        method: GET
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        params:
+          page[number]: ${{ inputs.page_number }}
+          page[size]: ${{ inputs.page_size }}
+          filter[operation]: ${{ inputs.operation }}
+          filter[status]: ${{ inputs.status }}
+  returns: ${{ steps.list_runs.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_workspaces.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/list_workspaces.yml
@@ -1,0 +1,66 @@
+type: action
+definition:
+  title: List workspaces
+  description: List workspaces in an organization.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#list-workspaces
+  namespace: tools.terraform_cloud
+  name: list_workspaces
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    organization_name:
+      type: str
+      description: Terraform organization name.
+    page_number:
+      type: int | None
+      description: Page number for pagination.
+      default: null
+    page_size:
+      type: int | None
+      description: Page size (maximum 100).
+      default: null
+    search_name:
+      type: str | None
+      description: Fuzzy search string for workspace names.
+      default: null
+    search_tags:
+      type: str | None
+      description: Comma-separated tags the workspace must include.
+      default: null
+    exclude_tags:
+      type: str | None
+      description: Comma-separated tags to exclude from results.
+      default: null
+    project_id:
+      type: str | None
+      description: Filter workspaces by project ID.
+      default: null
+    sort:
+      type: str | None
+      description: Sort by name, current-run.created-at, or latest-change-at. Prefix with - to reverse.
+      default: null
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: list_workspaces
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/organizations/${{ FN.url_encode(inputs.organization_name) }}/workspaces
+        method: GET
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        params:
+          page[number]: ${{ inputs.page_number }}
+          page[size]: ${{ inputs.page_size }}
+          search[name]: ${{ inputs.search_name }}
+          search[tags]: ${{ inputs.search_tags }}
+          search[exclude-tags]: ${{ inputs.exclude_tags }}
+          filter[project][id]: ${{ inputs.project_id }}
+          sort: ${{ inputs.sort }}
+  returns: ${{ steps.list_workspaces.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/lock_workspace.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/lock_workspace.yml
@@ -1,0 +1,36 @@
+type: action
+definition:
+  title: Lock workspace
+  description: Lock a workspace to prevent new runs.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#lock-a-workspace
+  namespace: tools.terraform_cloud
+  name: lock_workspace
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    workspace_id:
+      type: str
+      description: Workspace ID to lock.
+    reason:
+      type: str
+      description: Reason for locking the workspace.
+      default: ""
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: lock_workspace
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/workspaces/${{ inputs.workspace_id }}/actions/lock
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          reason: ${{ inputs.reason }}
+  returns: ${{ steps.lock_workspace.result.status_code }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/queue_apply_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/queue_apply_run.yml
@@ -1,0 +1,79 @@
+type: action
+definition:
+  title: Queue apply run
+  description: Queue a run with auto-apply enabled.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#create-a-run
+  namespace: tools.terraform_cloud
+  name: queue_apply_run
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    workspace_id:
+      type: str
+      description: Workspace ID to run against.
+    message:
+      type: str
+      description: Run message.
+      default: Run queued by Tracecat
+    auto_apply:
+      type: bool
+      description: Apply automatically after plan succeeds.
+      default: true
+    plan_only:
+      type: bool
+      description: Whether to run plan-only. Set false to allow apply.
+      default: false
+    is_destroy:
+      type: bool
+      description: Create a destroy plan.
+      default: false
+    refresh:
+      type: bool
+      description: Refresh state before planning.
+      default: true
+    refresh_only:
+      type: bool
+      description: Create a refresh-only plan.
+      default: false
+    target_addrs:
+      type: list[str]
+      description: List of resource addresses to target.
+      default: []
+    replace_addrs:
+      type: list[str]
+      description: Resources to replace during the run.
+      default: []
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: queue_apply_run
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/runs
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          data:
+            type: runs
+            attributes:
+              message: ${{ inputs.message }}
+              auto-apply: ${{ inputs.auto_apply }}
+              plan-only: ${{ inputs.plan_only }}
+              is-destroy: ${{ inputs.is_destroy }}
+              refresh: ${{ inputs.refresh }}
+              refresh-only: ${{ inputs.refresh_only }}
+              target-addrs: ${{ inputs.target_addrs }}
+              replace-addrs: ${{ inputs.replace_addrs }}
+            relationships:
+              workspace:
+                data:
+                  type: workspaces
+                  id: ${{ inputs.workspace_id }}
+  returns: ${{ steps.queue_apply_run.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/queue_plan_run.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/queue_plan_run.yml
@@ -1,0 +1,75 @@
+type: action
+definition:
+  title: Queue plan run
+  description: Start a plan-only Terraform run for a workspace.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#create-a-run
+  namespace: tools.terraform_cloud
+  name: queue_plan_run
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    workspace_id:
+      type: str
+      description: Workspace ID to run against.
+    message:
+      type: str
+      description: Run message.
+      default: Plan queued by Tracecat
+    plan_only:
+      type: bool
+      description: Execute a plan-only run (no apply).
+      default: true
+    is_destroy:
+      type: bool
+      description: Create a destroy plan.
+      default: false
+    refresh:
+      type: bool
+      description: Refresh state before planning.
+      default: true
+    refresh_only:
+      type: bool
+      description: Create a refresh-only plan.
+      default: false
+    target_addrs:
+      type: list[str]
+      description: List of resource addresses to target.
+      default: []
+    replace_addrs:
+      type: list[str]
+      description: Resources to replace during the plan.
+      default: []
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: queue_plan_run
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/runs
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          data:
+            type: runs
+            attributes:
+              message: ${{ inputs.message }}
+              auto-apply: false
+              plan-only: ${{ inputs.plan_only }}
+              is-destroy: ${{ inputs.is_destroy }}
+              refresh: ${{ inputs.refresh }}
+              refresh-only: ${{ inputs.refresh_only }}
+              target-addrs: ${{ inputs.target_addrs }}
+              replace-addrs: ${{ inputs.replace_addrs }}
+            relationships:
+              workspace:
+                data:
+                  type: workspaces
+                  id: ${{ inputs.workspace_id }}
+  returns: ${{ steps.queue_plan_run.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/unlock_workspace.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/terraform_cloud/unlock_workspace.yml
@@ -1,0 +1,36 @@
+type: action
+definition:
+  title: Unlock workspace
+  description: Unlock a workspace that was previously locked.
+  display_group: Terraform Cloud
+  doc_url: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#unlock-a-workspace
+  namespace: tools.terraform_cloud
+  name: unlock_workspace
+  secrets:
+    - name: terraform_cloud
+      keys: ["TERRAFORM_CLOUD_TOKEN"]
+  expects:
+    workspace_id:
+      type: str
+      description: Workspace ID to unlock.
+    comment:
+      type: str
+      description: Optional unlock comment.
+      default: ""
+    base_url:
+      type: str
+      description: Terraform Cloud/Enterprise API base URL.
+      default: https://app.terraform.io/api/v2
+  steps:
+    - ref: unlock_workspace
+      action: core.http_request
+      args:
+        url: ${{ inputs.base_url }}/workspaces/${{ inputs.workspace_id }}/actions/unlock
+        method: POST
+        headers:
+          Authorization: Bearer ${{ SECRETS.terraform_cloud.TERRAFORM_CLOUD_TOKEN }}
+          Content-Type: application/vnd.api+json
+          Accept: application/vnd.api+json
+        payload:
+          comment: ${{ inputs.comment }}
+  returns: ${{ steps.unlock_workspace.result.status_code }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Terraform Cloud integration actions to automate runs, workspace management, and variable creation. Playbooks can now trigger plans/applies, lock/unlock workspaces, read outputs, and list projects/workspaces.

- **New Features**
  - Runs: queue plan/apply, apply/cancel/discard, list, get.
  - Workspaces: list, lock/unlock, read current-state outputs.
  - Variables: create project and workspace variables.
  - Projects: list organization projects with filters and pagination.

- **Migration**
  - Add the terraform_cloud secret with TERRAFORM_CLOUD_TOKEN.
  - Optional: override base_url for Terraform Enterprise (defaults to https://app.terraform.io/api/v2).

<sup>Written for commit b188a3e7b1a9d8756e55da42d87bd3cf824382cf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

