### PR TITLE
feat(integrations): Servicenow issues and tables API

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/add_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/add_comment.yml
@@ -9,88 +9,88 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  incident_id:
-    type: str
-    description: Incident number (e.g., INC0010001) or sys_id.
-  comment:
-    type: str
-    description: Text to add to the incident.
-  is_work_note:
-    type: bool
-    description: Set true to add as work note instead of customer-facing comment.
-    default: false
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    incident_id:
+      type: str
+      description: Incident number (e.g., INC0010001) or sys_id.
+    comment:
+      type: str
+      description: Text to add to the incident.
+    is_work_note:
+      type: bool
+      description: Set true to add as work note instead of customer-facing comment.
+      default: false
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: lookup_incident
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params:
-        sysparm_query: number=${{ FN.url_encode(inputs.incident_id) }}^ORsys_id=${{ FN.url_encode(inputs.incident_id) }}
-        sysparm_limit: 1
-        sysparm_display_value: true
-  - ref: resolve_incident
-    action: core.script.run_python
-    args:
-      inputs:
-        lookup: ${{ steps.lookup_incident.result.data.result }}
-        incident_id: ${{ inputs.incident_id }}
-      script: |
-        def main(lookup, incident_id):
-            sys_id = incident_id
-            if isinstance(lookup, list) and lookup:
-                sys_id = lookup[0].get("sys_id", incident_id)
-            elif isinstance(lookup, dict) and lookup:
-                sys_id = lookup.get("sys_id", incident_id)
-            return {"sys_id": sys_id}
-  - ref: build_payload
-    action: core.script.run_python
-    args:
-      inputs:
-        comment: ${{ inputs.comment }}
-        is_work_note: ${{ inputs.is_work_note }}
-      script: |
-        def main(comment, is_work_note=False):
-            if is_work_note:
-                return {"work_notes": comment}
-            return {"comments": comment}
-  - ref: add_comment
-    action: core.http_request
-    args:
-      method: PUT
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident/${{ FN.url_encode(steps.resolve_incident.result.sys_id) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      payload: ${{ steps.build_payload.result }}
-returns: ${{ steps.add_comment.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: lookup_incident
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params:
+          sysparm_query: number=${{ FN.url_encode(inputs.incident_id) }}^ORsys_id=${{ FN.url_encode(inputs.incident_id) }}
+          sysparm_limit: 1
+          sysparm_display_value: true
+    - ref: resolve_incident
+      action: core.script.run_python
+      args:
+        inputs:
+          lookup: ${{ steps.lookup_incident.result.data.result }}
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def main(lookup, incident_id):
+              sys_id = incident_id
+              if isinstance(lookup, list) and lookup:
+                  sys_id = lookup[0].get("sys_id", incident_id)
+              elif isinstance(lookup, dict) and lookup:
+                  sys_id = lookup.get("sys_id", incident_id)
+              return {"sys_id": sys_id}
+    - ref: build_payload
+      action: core.script.run_python
+      args:
+        inputs:
+          comment: ${{ inputs.comment }}
+          is_work_note: ${{ inputs.is_work_note }}
+        script: |
+          def main(comment, is_work_note=False):
+              if is_work_note:
+                  return {"work_notes": comment}
+              return {"comments": comment}
+    - ref: add_comment
+      action: core.http_request
+      args:
+        method: PUT
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident/${{ FN.url_encode(steps.resolve_incident.result.sys_id) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        payload: ${{ steps.build_payload.result }}
+  returns: ${{ steps.add_comment.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/create_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/create_incident.yml
@@ -9,113 +9,113 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  short_description:
-    type: str
-    description: Short description of the incident.
-  description:
-    type: str | None
-    description: Detailed description of the incident.
-    default: null
-  caller_id:
-    type: str | None
-    description: User who reported the incident (sys_id or user name).
-    default: null
-  category:
-    type: str | None
-    description: Category of the incident.
-    default: null
-  subcategory:
-    type: str | None
-    description: Subcategory of the incident.
-    default: null
-  priority:
-    type: str | None
-    description: Priority of the incident.
-    default: null
-  impact:
-    type: str | None
-    description: Impact of the incident.
-    default: null
-  urgency:
-    type: str | None
-    description: Urgency of the incident.
-    default: null
-  assigned_to:
-    type: str | None
-    description: User assigned to the incident.
-    default: null
-  assignment_group:
-    type: str | None
-    description: Group assigned to the incident.
-    default: null
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    short_description:
+      type: str
+      description: Short description of the incident.
+    description:
+      type: str | None
+      description: Detailed description of the incident.
+      default: null
+    caller_id:
+      type: str | None
+      description: User who reported the incident (sys_id or user name).
+      default: null
+    category:
+      type: str | None
+      description: Category of the incident.
+      default: null
+    subcategory:
+      type: str | None
+      description: Subcategory of the incident.
+      default: null
+    priority:
+      type: str | None
+      description: Priority of the incident.
+      default: null
+    impact:
+      type: str | None
+      description: Impact of the incident.
+      default: null
+    urgency:
+      type: str | None
+      description: Urgency of the incident.
+      default: null
+    assigned_to:
+      type: str | None
+      description: User assigned to the incident.
+      default: null
+    assignment_group:
+      type: str | None
+      description: Group assigned to the incident.
+      default: null
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: build_payload
-    action: core.script.run_python
-    args:
-      inputs:
-        short_description: ${{ inputs.short_description }}
-        description: ${{ inputs.description }}
-        caller_id: ${{ inputs.caller_id }}
-        category: ${{ inputs.category }}
-        subcategory: ${{ inputs.subcategory }}
-        priority: ${{ inputs.priority }}
-        impact: ${{ inputs.impact }}
-        urgency: ${{ inputs.urgency }}
-        assigned_to: ${{ inputs.assigned_to }}
-        assignment_group: ${{ inputs.assignment_group }}
-      script: |
-        def main(short_description, description=None, caller_id=None, category=None, subcategory=None,
-                 priority=None, impact=None, urgency=None, assigned_to=None, assignment_group=None):
-            payload = {"short_description": short_description}
-            optional = {
-                "description": description,
-                "caller_id": caller_id,
-                "category": category,
-                "subcategory": subcategory,
-                "priority": priority,
-                "impact": impact,
-                "urgency": urgency,
-                "assigned_to": assigned_to,
-                "assignment_group": assignment_group,
-            }
-            for key, value in optional.items():
-                if value is not None:
-                    payload[key] = value
-            return payload
-  - ref: create_incident
-    action: core.http_request
-    args:
-      method: POST
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      payload: ${{ steps.build_payload.result }}
-returns: ${{ steps.create_incident.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: build_payload
+      action: core.script.run_python
+      args:
+        inputs:
+          short_description: ${{ inputs.short_description }}
+          description: ${{ inputs.description }}
+          caller_id: ${{ inputs.caller_id }}
+          category: ${{ inputs.category }}
+          subcategory: ${{ inputs.subcategory }}
+          priority: ${{ inputs.priority }}
+          impact: ${{ inputs.impact }}
+          urgency: ${{ inputs.urgency }}
+          assigned_to: ${{ inputs.assigned_to }}
+          assignment_group: ${{ inputs.assignment_group }}
+        script: |
+          def main(short_description, description=None, caller_id=None, category=None, subcategory=None,
+                   priority=None, impact=None, urgency=None, assigned_to=None, assignment_group=None):
+              payload = {"short_description": short_description}
+              optional = {
+                  "description": description,
+                  "caller_id": caller_id,
+                  "category": category,
+                  "subcategory": subcategory,
+                  "priority": priority,
+                  "impact": impact,
+                  "urgency": urgency,
+                  "assigned_to": assigned_to,
+                  "assignment_group": assignment_group,
+              }
+              for key, value in optional.items():
+                  if value is not None:
+                      payload[key] = value
+              return payload
+    - ref: create_incident
+      action: core.http_request
+      args:
+        method: POST
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        payload: ${{ steps.build_payload.result }}
+  returns: ${{ steps.create_incident.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/get_incident_by_number.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/get_incident_by_number.yml
@@ -9,45 +9,45 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  incident_number:
-    type: str
-    description: Incident number (e.g., INC0010001).
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    incident_number:
+      type: str
+      description: Incident number (e.g., INC0010001).
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: get_incident
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params:
-        sysparm_query: number=${{ FN.url_encode(inputs.incident_number) }}
-        sysparm_limit: 1
-        sysparm_display_value: true
-        sysparm_exclude_reference_link: true
-returns: ${{ steps.get_incident.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: get_incident
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params:
+          sysparm_query: number=${{ FN.url_encode(inputs.incident_number) }}
+          sysparm_limit: 1
+          sysparm_display_value: true
+          sysparm_exclude_reference_link: true
+  returns: ${{ steps.get_incident.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/list_incidents.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/list_incidents.yml
@@ -9,100 +9,100 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  limit:
-    type: int
-    description: Maximum number of incidents to return.
-    default: 10
-  offset:
-    type: int
-    description: Pagination offset.
-    default: 0
-  state:
-    type: str | None
-    description: Filter by state.
-    default: null
-  assigned_to:
-    type: str | None
-    description: Filter by assigned user.
-    default: null
-  category:
-    type: str | None
-    description: Filter by category.
-    default: null
-  query:
-    type: str | None
-    description: Additional query string to search short_description or description.
-    default: null
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    limit:
+      type: int
+      description: Maximum number of incidents to return.
+      default: 10
+    offset:
+      type: int
+      description: Pagination offset.
+      default: 0
+    state:
+      type: str | None
+      description: Filter by state.
+      default: null
+    assigned_to:
+      type: str | None
+      description: Filter by assigned user.
+      default: null
+    category:
+      type: str | None
+      description: Filter by category.
+      default: null
+    query:
+      type: str | None
+      description: Additional query string to search short_description or description.
+      default: null
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: build_params
-    action: core.script.run_python
-    args:
-      inputs:
-        limit: ${{ inputs.limit }}
-        offset: ${{ inputs.offset }}
-        state: ${{ inputs.state }}
-        assigned_to: ${{ inputs.assigned_to }}
-        category: ${{ inputs.category }}
-        query: ${{ inputs.query }}
-      script: |
-        from urllib.parse import quote_plus
+              return {"base_url": base_url.rstrip("/")}
+    - ref: build_params
+      action: core.script.run_python
+      args:
+        inputs:
+          limit: ${{ inputs.limit }}
+          offset: ${{ inputs.offset }}
+          state: ${{ inputs.state }}
+          assigned_to: ${{ inputs.assigned_to }}
+          category: ${{ inputs.category }}
+          query: ${{ inputs.query }}
+        script: |
+          from urllib.parse import quote_plus
 
 
-        def main(limit, offset, state=None, assigned_to=None, category=None, query=None):
-            params = {
-                "sysparm_limit": limit,
-                "sysparm_offset": offset,
-                "sysparm_display_value": "true",
-                "sysparm_exclude_reference_link": "true",
-            }
-            base_filters = []
-            if state:
-                base_filters.append(f"state={quote_plus(state, safe='')}")
-            if assigned_to:
-                base_filters.append(f"assigned_to={quote_plus(assigned_to, safe='')}")
-            if category:
-                base_filters.append(f"category={quote_plus(category, safe='')}")
-            if query:
-                safe_query = quote_plus(query, safe="")
-                branches = [
-                    "^".join(base_filters + [f"short_descriptionLIKE{safe_query}"]),
-                    "^".join(base_filters + [f"descriptionLIKE{safe_query}"]),
-                ]
-                params["sysparm_query"] = "^NQ".join(branches)
-            elif base_filters:
-                params["sysparm_query"] = "^".join(base_filters)
-            return params
-  - ref: list_incidents
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params: ${{ steps.build_params.result }}
-returns: ${{ steps.list_incidents.result.data }}
+          def main(limit, offset, state=None, assigned_to=None, category=None, query=None):
+              params = {
+                  "sysparm_limit": limit,
+                  "sysparm_offset": offset,
+                  "sysparm_display_value": "true",
+                  "sysparm_exclude_reference_link": "true",
+              }
+              base_filters = []
+              if state:
+                  base_filters.append(f"state={quote_plus(state, safe='')}")
+              if assigned_to:
+                  base_filters.append(f"assigned_to={quote_plus(assigned_to, safe='')}")
+              if category:
+                  base_filters.append(f"category={quote_plus(category, safe='')}")
+              if query:
+                  safe_query = quote_plus(query, safe="")
+                  branches = [
+                      "^".join(base_filters + [f"short_descriptionLIKE{safe_query}"]),
+                      "^".join(base_filters + [f"descriptionLIKE{safe_query}"]),
+                  ]
+                  params["sysparm_query"] = "^NQ".join(branches)
+              elif base_filters:
+                  params["sysparm_query"] = "^".join(base_filters)
+              return params
+    - ref: list_incidents
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params: ${{ steps.build_params.result }}
+  returns: ${{ steps.list_incidents.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/resolve_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/resolve_incident.yml
@@ -9,90 +9,90 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  incident_id:
-    type: str
-    description: Incident number (e.g., INC0010001) or sys_id.
-  resolution_code:
-    type: str
-    description: Resolution code to record.
-  resolution_notes:
-    type: str
-    description: Resolution notes to record.
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    incident_id:
+      type: str
+      description: Incident number (e.g., INC0010001) or sys_id.
+    resolution_code:
+      type: str
+      description: Resolution code to record.
+    resolution_notes:
+      type: str
+      description: Resolution notes to record.
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: lookup_incident
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params:
-        sysparm_query: number=${{ FN.url_encode(inputs.incident_id) }}^ORsys_id=${{ FN.url_encode(inputs.incident_id) }}
-        sysparm_limit: 1
-        sysparm_display_value: true
-  - ref: resolve_incident_id
-    action: core.script.run_python
-    args:
-      inputs:
-        lookup: ${{ steps.lookup_incident.result.data.result }}
-        incident_id: ${{ inputs.incident_id }}
-      script: |
-        def main(lookup, incident_id):
-            sys_id = incident_id
-            if isinstance(lookup, list) and lookup:
-                sys_id = lookup[0].get("sys_id", incident_id)
-            elif isinstance(lookup, dict) and lookup:
-                sys_id = lookup.get("sys_id", incident_id)
-            return {"sys_id": sys_id}
-  - ref: build_payload
-    action: core.script.run_python
-    args:
-      inputs:
-        resolution_code: ${{ inputs.resolution_code }}
-        resolution_notes: ${{ inputs.resolution_notes }}
-      script: |
-        def main(resolution_code, resolution_notes):
-            return {
-                "state": "6",
-                "close_code": resolution_code,
-                "close_notes": resolution_notes,
-                "resolved_at": "now",
-            }
-  - ref: resolve_incident
-    action: core.http_request
-    args:
-      method: PATCH
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident/${{ FN.url_encode(steps.resolve_incident_id.result.sys_id) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      payload: ${{ steps.build_payload.result }}
-returns: ${{ steps.resolve_incident.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: lookup_incident
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params:
+          sysparm_query: number=${{ FN.url_encode(inputs.incident_id) }}^ORsys_id=${{ FN.url_encode(inputs.incident_id) }}
+          sysparm_limit: 1
+          sysparm_display_value: true
+    - ref: resolve_incident_id
+      action: core.script.run_python
+      args:
+        inputs:
+          lookup: ${{ steps.lookup_incident.result.data.result }}
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def main(lookup, incident_id):
+              sys_id = incident_id
+              if isinstance(lookup, list) and lookup:
+                  sys_id = lookup[0].get("sys_id", incident_id)
+              elif isinstance(lookup, dict) and lookup:
+                  sys_id = lookup.get("sys_id", incident_id)
+              return {"sys_id": sys_id}
+    - ref: build_payload
+      action: core.script.run_python
+      args:
+        inputs:
+          resolution_code: ${{ inputs.resolution_code }}
+          resolution_notes: ${{ inputs.resolution_notes }}
+        script: |
+          def main(resolution_code, resolution_notes):
+              return {
+                  "state": "6",
+                  "close_code": resolution_code,
+                  "close_notes": resolution_notes,
+                  "resolved_at": "now",
+              }
+    - ref: resolve_incident
+      action: core.http_request
+      args:
+        method: PATCH
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident/${{ FN.url_encode(steps.resolve_incident_id.result.sys_id) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        payload: ${{ steps.build_payload.result }}
+  returns: ${{ steps.resolve_incident.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/update_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/incidents/update_incident.yml
@@ -9,163 +9,163 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  incident_id:
-    type: str
-    description: Incident number (e.g., INC0010001) or sys_id.
-  short_description:
-    type: str | None
-    description: Updated short description.
-    default: null
-  description:
-    type: str | None
-    description: Detailed description.
-    default: null
-  state:
-    type: str | None
-    description: Incident state code.
-    default: null
-  category:
-    type: str | None
-    description: Category value.
-    default: null
-  subcategory:
-    type: str | None
-    description: Subcategory value.
-    default: null
-  priority:
-    type: str | None
-    description: Priority value.
-    default: null
-  impact:
-    type: str | None
-    description: Impact value.
-    default: null
-  urgency:
-    type: str | None
-    description: Urgency value.
-    default: null
-  assigned_to:
-    type: str | None
-    description: User assigned to the incident.
-    default: null
-  assignment_group:
-    type: str | None
-    description: Group assigned to the incident.
-    default: null
-  work_notes:
-    type: str | None
-    description: Work notes to append.
-    default: null
-  close_notes:
-    type: str | None
-    description: Closure notes.
-    default: null
-  close_code:
-    type: str | None
-    description: Closure code.
-    default: null
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    incident_id:
+      type: str
+      description: Incident number (e.g., INC0010001) or sys_id.
+    short_description:
+      type: str | None
+      description: Updated short description.
+      default: null
+    description:
+      type: str | None
+      description: Detailed description.
+      default: null
+    state:
+      type: str | None
+      description: Incident state code.
+      default: null
+    category:
+      type: str | None
+      description: Category value.
+      default: null
+    subcategory:
+      type: str | None
+      description: Subcategory value.
+      default: null
+    priority:
+      type: str | None
+      description: Priority value.
+      default: null
+    impact:
+      type: str | None
+      description: Impact value.
+      default: null
+    urgency:
+      type: str | None
+      description: Urgency value.
+      default: null
+    assigned_to:
+      type: str | None
+      description: User assigned to the incident.
+      default: null
+    assignment_group:
+      type: str | None
+      description: Group assigned to the incident.
+      default: null
+    work_notes:
+      type: str | None
+      description: Work notes to append.
+      default: null
+    close_notes:
+      type: str | None
+      description: Closure notes.
+      default: null
+    close_code:
+      type: str | None
+      description: Closure code.
+      default: null
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: lookup_incident
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params:
-        sysparm_query: number=${{ FN.url_encode(inputs.incident_id) }}^ORsys_id=${{ FN.url_encode(inputs.incident_id) }}
-        sysparm_limit: 1
-        sysparm_display_value: true
-  - ref: resolve_incident
-    action: core.script.run_python
-    args:
-      inputs:
-        lookup: ${{ steps.lookup_incident.result.data.result }}
-        incident_id: ${{ inputs.incident_id }}
-      script: |
-        def main(lookup, incident_id):
-            sys_id = incident_id
-            if isinstance(lookup, list) and lookup:
-                sys_id = lookup[0].get("sys_id", incident_id)
-            elif isinstance(lookup, dict) and lookup:
-                sys_id = lookup.get("sys_id", incident_id)
-            return {"sys_id": sys_id}
-  - ref: build_payload
-    action: core.script.run_python
-    args:
-      inputs:
-        short_description: ${{ inputs.short_description }}
-        description: ${{ inputs.description }}
-        state: ${{ inputs.state }}
-        category: ${{ inputs.category }}
-        subcategory: ${{ inputs.subcategory }}
-        priority: ${{ inputs.priority }}
-        impact: ${{ inputs.impact }}
-        urgency: ${{ inputs.urgency }}
-        assigned_to: ${{ inputs.assigned_to }}
-        assignment_group: ${{ inputs.assignment_group }}
-        work_notes: ${{ inputs.work_notes }}
-        close_notes: ${{ inputs.close_notes }}
-        close_code: ${{ inputs.close_code }}
-      script: |
-        def main(short_description=None, description=None, state=None, category=None, subcategory=None,
-                 priority=None, impact=None, urgency=None, assigned_to=None, assignment_group=None,
-                 work_notes=None, close_notes=None, close_code=None):
-            payload = {}
-            optional = {
-                "short_description": short_description,
-                "description": description,
-                "state": state,
-                "category": category,
-                "subcategory": subcategory,
-                "priority": priority,
-                "impact": impact,
-                "urgency": urgency,
-                "assigned_to": assigned_to,
-                "assignment_group": assignment_group,
-                "work_notes": work_notes,
-                "close_notes": close_notes,
-                "close_code": close_code,
-            }
-            for key, value in optional.items():
-                if value is not None:
-                    payload[key] = value
-            return payload
-  - ref: update_incident
-    action: core.http_request
-    args:
-      method: PUT
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident/${{ FN.url_encode(steps.resolve_incident.result.sys_id) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      payload: ${{ steps.build_payload.result }}
-returns: ${{ steps.update_incident.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: lookup_incident
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params:
+          sysparm_query: number=${{ FN.url_encode(inputs.incident_id) }}^ORsys_id=${{ FN.url_encode(inputs.incident_id) }}
+          sysparm_limit: 1
+          sysparm_display_value: true
+    - ref: resolve_incident
+      action: core.script.run_python
+      args:
+        inputs:
+          lookup: ${{ steps.lookup_incident.result.data.result }}
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def main(lookup, incident_id):
+              sys_id = incident_id
+              if isinstance(lookup, list) and lookup:
+                  sys_id = lookup[0].get("sys_id", incident_id)
+              elif isinstance(lookup, dict) and lookup:
+                  sys_id = lookup.get("sys_id", incident_id)
+              return {"sys_id": sys_id}
+    - ref: build_payload
+      action: core.script.run_python
+      args:
+        inputs:
+          short_description: ${{ inputs.short_description }}
+          description: ${{ inputs.description }}
+          state: ${{ inputs.state }}
+          category: ${{ inputs.category }}
+          subcategory: ${{ inputs.subcategory }}
+          priority: ${{ inputs.priority }}
+          impact: ${{ inputs.impact }}
+          urgency: ${{ inputs.urgency }}
+          assigned_to: ${{ inputs.assigned_to }}
+          assignment_group: ${{ inputs.assignment_group }}
+          work_notes: ${{ inputs.work_notes }}
+          close_notes: ${{ inputs.close_notes }}
+          close_code: ${{ inputs.close_code }}
+        script: |
+          def main(short_description=None, description=None, state=None, category=None, subcategory=None,
+                   priority=None, impact=None, urgency=None, assigned_to=None, assignment_group=None,
+                   work_notes=None, close_notes=None, close_code=None):
+              payload = {}
+              optional = {
+                  "short_description": short_description,
+                  "description": description,
+                  "state": state,
+                  "category": category,
+                  "subcategory": subcategory,
+                  "priority": priority,
+                  "impact": impact,
+                  "urgency": urgency,
+                  "assigned_to": assigned_to,
+                  "assignment_group": assignment_group,
+                  "work_notes": work_notes,
+                  "close_notes": close_notes,
+                  "close_code": close_code,
+              }
+              for key, value in optional.items():
+                  if value is not None:
+                      payload[key] = value
+              return payload
+    - ref: update_incident
+      action: core.http_request
+      args:
+        method: PUT
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/incident/${{ FN.url_encode(steps.resolve_incident.result.sys_id) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        payload: ${{ steps.build_payload.result }}
+  returns: ${{ steps.update_incident.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/create_table_record.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/create_table_record.yml
@@ -9,47 +9,47 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  table:
-    type: str
-    description: Target table name (e.g., incident, cmdb_ci_service).
-  fields:
-    type: dict[str, Any]
-    description: Field values to set on the new record.
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    table:
+      type: str
+      description: Target table name (e.g., incident, cmdb_ci_service).
+    fields:
+      type: dict[str, Any]
+      description: Field values to set on the new record.
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: create_record
-    action: core.http_request
-    args:
-      method: POST
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      payload: ${{ inputs.fields }}
-returns: ${{ steps.create_record.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: create_record
+      action: core.http_request
+      args:
+        method: POST
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        payload: ${{ inputs.fields }}
+  returns: ${{ steps.create_record.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/delete_table_record.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/delete_table_record.yml
@@ -9,45 +9,45 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  table:
-    type: str
-    description: Target table name (e.g., incident, cmdb_ci_service).
-  record_id:
-    type: str
-    description: Record sys_id.
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    table:
+      type: str
+      description: Target table name (e.g., incident, cmdb_ci_service).
+    record_id:
+      type: str
+      description: Record sys_id.
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: delete_record
-    action: core.http_request
-    args:
-      method: DELETE
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}/${{ FN.url_encode(inputs.record_id) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      headers:
-        Accept: application/json
-returns: ${{ steps.delete_record.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: delete_record
+      action: core.http_request
+      args:
+        method: DELETE
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}/${{ FN.url_encode(inputs.record_id) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        headers:
+          Accept: application/json
+  returns: ${{ steps.delete_record.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/get_table_record.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/get_table_record.yml
@@ -9,49 +9,49 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  table:
-    type: str
-    description: Target table name (e.g., incident, cmdb_ci_service).
-  record_id:
-    type: str
-    description: Record sys_id.
-  display_value:
-    type: bool
-    description: Return display values when true.
-    default: true
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    table:
+      type: str
+      description: Target table name (e.g., incident, cmdb_ci_service).
+    record_id:
+      type: str
+      description: Record sys_id.
+    display_value:
+      type: bool
+      description: Return display values when true.
+      default: true
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: get_record
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}/${{ FN.url_encode(inputs.record_id) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params:
-        sysparm_display_value: ${{ inputs.display_value and 'true' or 'false' }}
-returns: ${{ steps.get_record.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: get_record
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}/${{ FN.url_encode(inputs.record_id) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params:
+          sysparm_display_value: ${{ inputs.display_value and 'true' or 'false' }}
+  returns: ${{ steps.get_record.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/list_table_fields.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/list_table_fields.yml
@@ -9,81 +9,81 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  table:
-    type: str
-    description: Target table name (e.g., incident).
-  element:
-    type: str | None
-    description: Optional field name filter.
-    default: null
-  include_choices:
-    type: bool
-    description: Include sys_choice options for fields that use choices.
-    default: true
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    table:
+      type: str
+      description: Target table name (e.g., incident).
+    element:
+      type: str | None
+      description: Optional field name filter.
+      default: null
+    include_choices:
+      type: bool
+      description: Include sys_choice options for fields that use choices.
+      default: true
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: list_fields
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/sys_dictionary
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params:
-        sysparm_query: ${{ "name=" + FN.url_encode(inputs.table) + ("^element=" + FN.url_encode(inputs.element) if inputs.element else "") }}
-        sysparm_display_value: true
-  - ref: list_choices
-    action: core.http_request
-    when: ${{ inputs.include_choices }}
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/sys_choice
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params:
-        sysparm_query: ${{ "name=" + FN.url_encode(inputs.table) + ("^element=" + FN.url_encode(inputs.element) if inputs.element else "") }}
-        sysparm_display_value: true
-  - ref: combine
-    action: core.script.run_python
-    args:
-      inputs:
-        fields: ${{ steps.list_fields.result.data.result }}
-        choices: ${{ steps.list_choices.result.data.result if inputs.include_choices else [] }}
-      script: |
-        from collections import defaultdict
+              return {"base_url": base_url.rstrip("/")}
+    - ref: list_fields
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/sys_dictionary
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params:
+          sysparm_query: ${{ "name=" + FN.url_encode(inputs.table) + ("^element=" + FN.url_encode(inputs.element) if inputs.element else "") }}
+          sysparm_display_value: true
+    - ref: list_choices
+      action: core.http_request
+      when: ${{ inputs.include_choices }}
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/sys_choice
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params:
+          sysparm_query: ${{ "name=" + FN.url_encode(inputs.table) + ("^element=" + FN.url_encode(inputs.element) if inputs.element else "") }}
+          sysparm_display_value: true
+    - ref: combine
+      action: core.script.run_python
+      args:
+        inputs:
+          fields: ${{ steps.list_fields.result.data.result }}
+          choices: ${{ steps.list_choices.result.data.result if inputs.include_choices else [] }}
+        script: |
+          from collections import defaultdict
 
-        def main(fields, choices):
-            choice_map = defaultdict(list)
-            for c in choices or []:
-                element = c.get("element")
-                choice_map[element].append(c)
-            for f in fields or []:
-                elem = f.get("element")
-                f["choices"] = choice_map.get(elem, [])
-            return {"fields": fields, "choice_count": sum(len(v) for v in choice_map.values())}
-returns: ${{ steps.combine.result }}
+          def main(fields, choices):
+              choice_map = defaultdict(list)
+              for c in choices or []:
+                  element = c.get("element")
+                  choice_map[element].append(c)
+              for f in fields or []:
+                  elem = f.get("element")
+                  f["choices"] = choice_map.get(elem, [])
+              return {"fields": fields, "choice_count": sum(len(v) for v in choice_map.values())}
+  returns: ${{ steps.combine.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/list_table_records.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/list_table_records.yml
@@ -9,82 +9,82 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  table:
-    type: str
-    description: Target table name (e.g., incident, cmdb_ci_service).
-  query:
-    type: str | None
-    description: sysparm_query filter string.
-    default: null
-  fields:
-    type: list[str] | None
-    description: Specific fields to return (defaults to all).
-    default: null
-  limit:
-    type: int
-    description: Maximum records to return.
-    default: 10
-  offset:
-    type: int
-    description: Pagination offset.
-    default: 0
-  display_value:
-    type: bool
-    description: Return display values when true.
-    default: true
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    table:
+      type: str
+      description: Target table name (e.g., incident, cmdb_ci_service).
+    query:
+      type: str | None
+      description: sysparm_query filter string.
+      default: null
+    fields:
+      type: list[str] | None
+      description: Specific fields to return (defaults to all).
+      default: null
+    limit:
+      type: int
+      description: Maximum records to return.
+      default: 10
+    offset:
+      type: int
+      description: Pagination offset.
+      default: 0
+    display_value:
+      type: bool
+      description: Return display values when true.
+      default: true
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: build_params
-    action: core.script.run_python
-    args:
-      inputs:
-        query: ${{ inputs.query }}
-        fields: ${{ inputs.fields }}
-        limit: ${{ inputs.limit }}
-        offset: ${{ inputs.offset }}
-        display_value: ${{ inputs.display_value }}
-      script: |
-        def main(query=None, fields=None, limit=10, offset=0, display_value=True):
-            params = {
-                "sysparm_limit": limit,
-                "sysparm_offset": offset,
-                "sysparm_display_value": "true" if display_value else "false",
-            }
-            if query:
-                params["sysparm_query"] = query
-            if fields:
-                params["sysparm_fields"] = ",".join(fields)
-            return params
-  - ref: list_records
-    action: core.http_request
-    args:
-      method: GET
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      params: ${{ steps.build_params.result }}
-returns: ${{ steps.list_records.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: build_params
+      action: core.script.run_python
+      args:
+        inputs:
+          query: ${{ inputs.query }}
+          fields: ${{ inputs.fields }}
+          limit: ${{ inputs.limit }}
+          offset: ${{ inputs.offset }}
+          display_value: ${{ inputs.display_value }}
+        script: |
+          def main(query=None, fields=None, limit=10, offset=0, display_value=True):
+              params = {
+                  "sysparm_limit": limit,
+                  "sysparm_offset": offset,
+                  "sysparm_display_value": "true" if display_value else "false",
+              }
+              if query:
+                  params["sysparm_query"] = query
+              if fields:
+                  params["sysparm_fields"] = ",".join(fields)
+              return params
+    - ref: list_records
+      action: core.http_request
+      args:
+        method: GET
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        params: ${{ steps.build_params.result }}
+  returns: ${{ steps.list_records.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/update_table_record.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/servicenow/tables/update_table_record.yml
@@ -9,50 +9,50 @@ definition:
   secrets:
     - name: servicenow
       keys: ["SERVICENOW_USERNAME", "SERVICENOW_PASSWORD"]
-expects:
-  base_url:
-    type: str | None
-    description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
-    default: null
-  table:
-    type: str
-    description: Target table name (e.g., incident, cmdb_ci_service).
-  record_id:
-    type: str
-    description: Record sys_id.
-  fields:
-    type: dict[str, Any]
-    description: Field values to update.
-steps:
-  - ref: resolve_base_url
-    action: core.script.run_python
-    args:
-      inputs:
-        base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
-      script: |
-        from urllib.parse import urlparse
+  expects:
+    base_url:
+      type: str | None
+      description: ServiceNow base URL (e.g., https://your-instance.service-now.com)
+      default: null
+    table:
+      type: str
+      description: Target table name (e.g., incident, cmdb_ci_service).
+    record_id:
+      type: str
+      description: Record sys_id.
+    fields:
+      type: dict[str, Any]
+      description: Field values to update.
+  steps:
+    - ref: resolve_base_url
+      action: core.script.run_python
+      args:
+        inputs:
+          base_url: ${{ inputs.base_url or VARS.servicenow.base_url }}
+        script: |
+          from urllib.parse import urlparse
 
-        def main(base_url=None):
-            if not base_url:
-                raise ValueError("ServiceNow base_url is required")
+          def main(base_url=None):
+              if not base_url:
+                  raise ValueError("ServiceNow base_url is required")
 
-            parsed = urlparse(base_url)
-            if parsed.scheme != "https":
-                raise ValueError("ServiceNow base_url must use https")
-            if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
-                raise ValueError("ServiceNow base_url must be a service-now.com host")
+              parsed = urlparse(base_url)
+              if parsed.scheme != "https":
+                  raise ValueError("ServiceNow base_url must use https")
+              if not parsed.hostname or not parsed.hostname.endswith("service-now.com"):
+                  raise ValueError("ServiceNow base_url must be a service-now.com host")
 
-            return {"base_url": base_url.rstrip("/")}
-  - ref: update_record
-    action: core.http_request
-    args:
-      method: PATCH
-      url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}/${{ FN.url_encode(inputs.record_id) }}
-      auth:
-        username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
-        password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      payload: ${{ inputs.fields }}
-returns: ${{ steps.update_record.result.data }}
+              return {"base_url": base_url.rstrip("/")}
+    - ref: update_record
+      action: core.http_request
+      args:
+        method: PATCH
+        url: ${{ steps.resolve_base_url.result.base_url }}/api/now/table/${{ FN.url_encode(inputs.table) }}/${{ FN.url_encode(inputs.record_id) }}
+        auth:
+          username: ${{ SECRETS.servicenow.SERVICENOW_USERNAME }}
+          password: ${{ SECRETS.servicenow.SERVICENOW_PASSWORD }}
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        payload: ${{ inputs.fields }}
+  returns: ${{ steps.update_record.result.data }}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds ServiceNow incident and table actions, and removes deprecated user/group templates. Lets you create, update, list, resolve incidents and manage table records with validated base_url and request encoding via the ServiceNow Table API.

- **New Features**
  - Incidents: create, get/list, update, resolve, add_comment (by number or sys_id).
  - Tables: create/get/update/delete records; list records with filters; list table fields with choices.

- **Migration**
  - Configure secrets: SERVICENOW_USERNAME and SERVICENOW_PASSWORD under “servicenow”.
  - Set VARS.servicenow.base_url or pass base_url per action (must be https and a service-now.com host).

<sup>Written for commit 8aec68649ff5d7645daa0a5187723a6c28401da5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





