### PR TITLE
feat(integrations): SQL action

### DIFF
--- a/docs/cheatsheets/integrations.mdx
+++ b/docs/cheatsheets/integrations.mdx
@@ -13,6 +13,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | core           | http_request    | `ssl`   |
 | core           | require         | -       |
 | core           | send_email_smtp | `smtp`  |
+| core.sql       | execute_query   | `sql`   |
 | core.cases     | create_case     | -       |
 | core.cases     | create_comment  | -       |
 | core.cases     | get_case        | -       |
@@ -21,6 +22,7 @@ description: A cheatsheet of core actions, integrations, and credentials support
 | core.cases     | update_case     | -       |
 | core.cases     | update_comment  | -       |
 | core.cases     | search_cases    | -       |
+| core.script    | run_python      | -       |
 | core.table     | delete_row      | -       |
 | core.table     | insert_row      | -       |
 | core.table     | lookup          | -       |

--- a/packages/tracecat-registry/tracecat_registry/core/sql.py
+++ b/packages/tracecat-registry/tracecat_registry/core/sql.py
@@ -1,0 +1,188 @@
+"""Secure SQL actions via sqlalchemy using `core.sql.execute_query`."""
+
+import hmac
+from typing import Annotated, Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import URL, Engine, make_url
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.pool import NullPool
+from typing_extensions import Doc
+
+from tracecat import config
+from tracecat_registry import RegistrySecret, registry, secrets
+
+
+# Maximum number of rows to return from a query
+# This can be overridden via TRACECAT__MAX_ROWS_CLIENT_POSTGRES config
+DEFAULT_MAX_ROWS = config.TRACECAT__MAX_ROWS_CLIENT_POSTGRES
+
+# Registry secret for SQL connections
+sql_secret = RegistrySecret(
+    name="sql",
+    keys=["CONNECTION_URL"],
+)
+"""SQL connection secret.
+
+Required keys:
+- `CONNECTION_URL`: SQLAlchemy connection URL (e.g., 'postgresql+psycopg://user:pass@host:port/dbname')
+
+Common driver formats:
+- PostgreSQL: postgresql+psycopg://, postgresql+psycopg2://, postgresql+asyncpg://
+- MySQL: mysql+pymysql://, mysql+mysqlclient://, mysql+mysql-connector-python://
+- MSSQL: mssql+pyodbc://, mssql+pymssql://
+- Oracle: oracle+cx_oracle://
+- SQLite: sqlite+pysqlite://
+"""
+
+
+class SQLConnectionValidationError(Exception):
+    """Raised when SQL connection validation fails."""
+
+
+def _validate_connection_url(connection_url: URL) -> None:
+    """Validate that the connection URL does not point to Tracecat's internal database.
+
+    We only compare against the configured internal database endpoint/port and never
+    surface credentials from the internal URI to the user.
+
+    Args:
+        connection_url: SQLAlchemy URL object
+
+    Raises:
+        SQLConnectionValidationError: If connection attempts to access Tracecat's database
+    """
+    # Parse internal database URL
+    try:
+        internal_url = make_url(config.TRACECAT__DB_URI)
+    except Exception as exc:  # pragma: no cover - defensive fail-closed path
+        raise SQLConnectionValidationError(
+            "Internal database configuration error. Cannot validate connection safety."
+        ) from exc
+
+    # Resolve the internal endpoint from explicit config first, else fallback to the URI
+    internal_host = config.TRACECAT__DB_ENDPOINT or internal_url.host
+    if not internal_host:
+        raise SQLConnectionValidationError(
+            "Internal database endpoint is not configured. Cannot validate connection safety."
+        )
+
+    try:
+        internal_port = (
+            int(config.TRACECAT__DB_PORT)
+            if config.TRACECAT__DB_PORT is not None
+            else None
+        )
+    except ValueError as exc:
+        raise SQLConnectionValidationError(
+            "Internal database port configuration is invalid. Cannot validate connection safety."
+        ) from exc
+
+    internal_port = internal_port or internal_url.port or 5432
+
+    if connection_url.host:
+        user_host = connection_url.host.lower()
+        internal_host_lower = internal_host.lower()
+        if hmac.compare_digest(user_host, internal_host_lower):
+            user_port = connection_url.port or 5432
+            if user_port == internal_port:
+                raise SQLConnectionValidationError(
+                    "Cannot connect to Tracecat's internal database endpoint. Use an external database connection URL instead."
+                )
+
+
+def _create_engine_with_validation(connection_url: URL) -> Engine:
+    """Create a SQLAlchemy engine with security validation.
+
+    Args:
+        connection_url: SQLAlchemy URL object
+
+    Returns:
+        SQLAlchemy Engine
+
+    Raises:
+        SQLConnectionValidationError: If connection is unsafe
+    """
+    # Validate connection safety
+    _validate_connection_url(connection_url)
+
+    # Use NullPool to avoid double-pooling in Lambda-style executions and defer pooling
+    # to upstream services (e.g., RDS Proxy/pgBouncer).
+    engine = create_engine(
+        connection_url,
+        poolclass=NullPool,
+        pool_pre_ping=True,
+        hide_parameters=True,  # Hide parameters in logs for security
+    )
+    return engine
+
+
+@registry.register(
+    default_title="Execute SQL query",
+    description="Execute a parameterized SQL query on an external database with security controls.",
+    display_group="Database",
+    namespace="core.sql",
+    secrets=[sql_secret],
+)
+async def execute_query(
+    query: Annotated[
+        str,
+        Doc(
+            "SQL query to execute. Use :param_name syntax for bound parameters. "
+            "Do NOT use Tracecat expressions in the query string.",
+        ),
+    ],
+    bound_params: Annotated[
+        dict[str, Any] | None,
+        Doc(
+            "Bound query parameters as a dictionary (injected with :param_name syntax). "
+            "Supply dynamic values here, NOT within the query string. "
+            "This is required for safe, parameterized SQL queries."
+        ),
+    ] = None,
+    fetch_one: Annotated[
+        bool,
+        Doc(
+            "Return a single row instead of a list of rows. Defaults to False, which fetches all rows."
+        ),
+    ] = False,
+    max_rows: Annotated[
+        int,
+        Doc(
+            f"Maximum number of rows to return. Default {DEFAULT_MAX_ROWS}. "
+            "Prevents accidentally returning huge result sets."
+        ),
+    ] = DEFAULT_MAX_ROWS,
+) -> int | dict[str, Any] | list[dict[str, Any]] | None:
+    """Execute a parameterized SQL query on an external database."""
+    # Get connection URL from secrets and parse it
+    connection_url_str = secrets.get("CONNECTION_URL")
+    try:
+        connection_url = make_url(connection_url_str)
+    except Exception as e:
+        raise ValueError(f"Invalid CONNECTION_URL format: {e}") from e
+
+    engine = _create_engine_with_validation(connection_url)
+
+    try:
+        stmt = text(query)
+        parameters: dict[str, Any] = bound_params or {}
+
+        with engine.begin() as conn:
+            result = conn.execute(stmt, parameters)
+
+            if result.returns_rows:
+                mappings = result.mappings()
+                if fetch_one:
+                    row = mappings.fetchone()
+                    return dict(row) if row else None
+                else:
+                    row_mappings = result.mappings().fetchmany(size=max_rows)
+                    rows = [dict(row) for row in row_mappings]
+                    return rows
+
+            return result.rowcount
+    except SQLAlchemyError:
+        raise
+    finally:
+        engine.dispose()

--- a/tests/registry/test_core_sql.py
+++ b/tests/registry/test_core_sql.py
@@ -1,0 +1,354 @@
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+from tracecat_registry.core.sql import (
+    SQLConnectionValidationError,
+    _validate_connection_url,
+    execute_query,
+)
+
+from tests.database import TEST_DB_CONFIG
+from tracecat import config
+from tracecat.secrets import secrets_manager
+
+
+def test_validate_connection_url_blocks_internal_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject user URLs that target the configured internal DB endpoint/port."""
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__DB_URI",
+        "postgresql+psycopg://tracecat:secret@internal-db:5432/tracecat",
+    )
+    monkeypatch.setattr(config, "TRACECAT__DB_ENDPOINT", "internal-db")
+    monkeypatch.setattr(config, "TRACECAT__DB_PORT", "5432")
+
+    connection_url = make_url(
+        "postgresql+psycopg://user:pass@internal-db:5432/external_db"
+    )
+
+    with pytest.raises(SQLConnectionValidationError) as excinfo:
+        _validate_connection_url(connection_url)
+
+    message = str(excinfo.value).lower()
+    assert "internal database endpoint" in message
+    assert "secret" not in message
+
+
+def test_validate_connection_url_allows_external_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allow user URLs that point to a different endpoint."""
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__DB_URI",
+        "postgresql+psycopg://tracecat:secret@internal-db:5432/tracecat",
+    )
+    monkeypatch.setattr(config, "TRACECAT__DB_ENDPOINT", "internal-db")
+    monkeypatch.setattr(config, "TRACECAT__DB_PORT", "5432")
+
+    connection_url = make_url(
+        "postgresql+psycopg://user:pass@external-db:5432/external_db"
+    )
+
+    _validate_connection_url(connection_url)  # Should not raise
+
+
+def test_validate_connection_url_uses_internal_uri_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fallback to TRACECAT__DB_URI when TRACECAT__DB_ENDPOINT is unset."""
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__DB_URI",
+        "postgresql+psycopg://tracecat:secret@postgres_db:6432/tracecat",
+    )
+    monkeypatch.setattr(config, "TRACECAT__DB_ENDPOINT", None)
+    monkeypatch.setattr(config, "TRACECAT__DB_PORT", None)
+
+    connection_url = make_url(
+        "postgresql+psycopg://user:pass@postgres_db:6432/external_db"
+    )
+
+    with pytest.raises(SQLConnectionValidationError):
+        _validate_connection_url(connection_url)
+
+
+# Integration tests using live Postgres database
+@pytest.fixture
+def setup_sql_test_table(db, monkeypatch: pytest.MonkeyPatch):
+    """Set up test table and mock config for SQL integration tests.
+
+    Mocks the internal database config to use a different endpoint
+    so the test database on localhost:5432 is allowed by validation.
+    """
+    # Mock internal database config to use a different endpoint
+    # This allows the test database on localhost:5432 to pass validation
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__DB_URI",
+        "postgresql+psycopg://tracecat:secret@internal-db:5432/tracecat",
+    )
+    monkeypatch.setattr(config, "TRACECAT__DB_ENDPOINT", "internal-db")
+    monkeypatch.setattr(config, "TRACECAT__DB_PORT", "5432")
+
+    # Create test table and insert sample data
+    engine = create_engine(TEST_DB_CONFIG.test_url_sync)
+    with engine.begin() as conn:
+        # Create test table
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS test_users (
+                    id SERIAL PRIMARY KEY,
+                    name VARCHAR(100) NOT NULL,
+                    email VARCHAR(100) UNIQUE NOT NULL,
+                    age INTEGER,
+                    active BOOLEAN DEFAULT TRUE
+                )
+                """
+            )
+        )
+        # Insert test data
+        conn.execute(
+            text(
+                """
+                INSERT INTO test_users (name, email, age, active)
+                VALUES
+                    ('Alice', 'alice@example.com', 30, TRUE),
+                    ('Bob', 'bob@example.com', 25, TRUE),
+                    ('Charlie', 'charlie@example.com', 35, FALSE),
+                    ('Diana', 'diana@example.com', 28, TRUE),
+                    ('Eve', 'eve@example.com', 32, TRUE)
+                ON CONFLICT DO NOTHING
+                """
+            )
+        )
+
+    yield
+
+    # Cleanup
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS test_users"))
+    engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_execute_query_select_all(setup_sql_test_table):
+    """Test SELECT query returning all rows."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "SELECT id, name, email, age, active FROM test_users ORDER BY id"
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 5
+        assert result[0]["name"] == "Alice"
+        assert result[0]["email"] == "alice@example.com"
+        assert result[0]["age"] == 30
+        assert result[0]["active"] is True
+
+
+@pytest.mark.anyio
+async def test_execute_query_select_with_where(setup_sql_test_table):
+    """Test SELECT query with WHERE clause."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "SELECT name, email FROM test_users WHERE active = :active",
+            bound_params={"active": True},
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 4  # 4 active users
+        assert all(row["name"] in ["Alice", "Bob", "Diana", "Eve"] for row in result)
+
+
+@pytest.mark.anyio
+async def test_execute_query_fetch_one(setup_sql_test_table):
+    """Test SELECT query with fetch_one=True."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "SELECT name, email FROM test_users WHERE age > :min_age ORDER BY age LIMIT 1",
+            bound_params={"min_age": 30},
+            fetch_one=True,
+        )
+
+        assert isinstance(result, dict)
+        # Users with age > 30: Charlie (35), Eve (32). Ordered by age, Eve comes first.
+        assert result["name"] == "Eve"
+        assert result["email"] == "eve@example.com"
+
+
+@pytest.mark.anyio
+async def test_execute_query_fetch_one_no_results(setup_sql_test_table):
+    """Test SELECT query with fetch_one=True when no results."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "SELECT name, email FROM test_users WHERE age > :min_age",
+            bound_params={"min_age": 100},
+            fetch_one=True,
+        )
+
+        assert result is None
+
+
+@pytest.mark.anyio
+async def test_execute_query_insert(setup_sql_test_table):
+    """Test INSERT query returning rowcount."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "INSERT INTO test_users (name, email, age, active) VALUES (:name, :email, :age, :active)",
+            bound_params={
+                "name": "Frank",
+                "email": "frank@example.com",
+                "age": 40,
+                "active": True,
+            },
+        )
+
+        assert isinstance(result, int)
+        assert result == 1
+
+        # Verify the insert
+        verify = await execute_query(
+            "SELECT name FROM test_users WHERE email = :email",
+            bound_params={"email": "frank@example.com"},
+            fetch_one=True,
+        )
+        assert verify is not None
+        assert isinstance(verify, dict)
+        assert verify["name"] == "Frank"
+
+
+@pytest.mark.anyio
+async def test_execute_query_update(setup_sql_test_table):
+    """Test UPDATE query returning rowcount."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "UPDATE test_users SET age = :new_age WHERE name = :name",
+            bound_params={"new_age": 31, "name": "Alice"},
+        )
+
+        assert isinstance(result, int)
+        assert result == 1
+
+        # Verify the update
+        verify = await execute_query(
+            "SELECT age FROM test_users WHERE name = :name",
+            bound_params={"name": "Alice"},
+            fetch_one=True,
+        )
+        assert verify is not None
+        assert isinstance(verify, dict)
+        assert verify["age"] == 31
+
+
+@pytest.mark.anyio
+async def test_execute_query_delete(setup_sql_test_table):
+    """Test DELETE query returning rowcount."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "DELETE FROM test_users WHERE name = :name", bound_params={"name": "Eve"}
+        )
+
+        assert isinstance(result, int)
+        assert result == 1
+
+        # Verify the delete
+        verify = await execute_query(
+            "SELECT name FROM test_users WHERE name = :name",
+            bound_params={"name": "Eve"},
+            fetch_one=True,
+        )
+        assert verify is None
+
+
+@pytest.mark.anyio
+async def test_execute_query_max_rows_limit(setup_sql_test_table):
+    """Test that max_rows limits the number of returned rows."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "SELECT id, name FROM test_users ORDER BY id", max_rows=2
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["name"] == "Alice"
+        assert result[1]["name"] == "Bob"
+
+
+@pytest.mark.anyio
+async def test_execute_query_parameterized_query(setup_sql_test_table):
+    """Test parameterized query with multiple parameters."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            """
+            SELECT name, email FROM test_users
+            WHERE age BETWEEN :min_age AND :max_age AND active = :active
+            ORDER BY name
+            """,
+            bound_params={"min_age": 25, "max_age": 30, "active": True},
+        )
+
+        assert isinstance(result, list)
+        # Should return Alice (30), Bob (25), Diana (28)
+        assert len(result) == 3
+        names = [row["name"] for row in result]
+        assert "Alice" in names
+        assert "Bob" in names
+        assert "Diana" in names
+
+
+@pytest.mark.anyio
+async def test_execute_query_invalid_sql(setup_sql_test_table):
+    """Test that invalid SQL raises an exception."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        with pytest.raises(SQLAlchemyError):
+            await execute_query("SELECT * FROM nonexistent_table")
+
+
+@pytest.mark.anyio
+async def test_execute_query_invalid_connection_url(monkeypatch: pytest.MonkeyPatch):
+    """Test that invalid connection URL raises an error."""
+    # Mock internal database config to avoid validation issues
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__DB_URI",
+        "postgresql+psycopg://tracecat:secret@internal-db:5432/tracecat",
+    )
+    monkeypatch.setattr(config, "TRACECAT__DB_ENDPOINT", "internal-db")
+    monkeypatch.setattr(config, "TRACECAT__DB_PORT", "5432")
+
+    # The error will be NoSuchModuleError from SQLAlchemy
+    from sqlalchemy.exc import NoSuchModuleError
+
+    with secrets_manager.env_sandbox({"CONNECTION_URL": "invalid://url"}):
+        with pytest.raises((ValueError, NoSuchModuleError)):
+            await execute_query("SELECT 1")
+
+
+@pytest.mark.anyio
+async def test_execute_query_no_bound_params(setup_sql_test_table):
+    """Test query without bound parameters."""
+    connection_url = TEST_DB_CONFIG.test_url_sync
+    with secrets_manager.env_sandbox({"CONNECTION_URL": connection_url}):
+        result = await execute_query(
+            "SELECT COUNT(*) as total FROM test_users WHERE active = TRUE"
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["total"] == 4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a secure SQL integration with core.sql.execute_query to run parameterized queries against external databases. Includes safety checks to block connections to Tracecat’s internal DB and limits large result sets.

- **New Features**
  - Added core.sql.execute_query action using SQLAlchemy with bound parameters, fetch_one, and max_rows; returns rows or rowcount.
  - Introduced sql secret (CONNECTION_URL) and validation to block internal DB endpoint/port; engine uses NullPool, pre_ping, and hides parameters.
  - Updated integrations cheatsheet to list core.sql.execute_query.

<sup>Written for commit 698f67e27fb46558e111058db053aaf83b8146af. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

