### PR TITLE
feat: Add workspace foreign key to cases

### DIFF
--- a/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
+++ b/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "3d3c6f1f8c0a"
-down_revision: str | None = "7694c8910510"
+down_revision: str | None = "3f1bacf5a8a9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
+++ b/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
@@ -1,0 +1,34 @@
+"""add workspace foreign key to cases
+
+Revision ID: 3d3c6f1f8c0a
+Revises: 7694c8910510
+Create Date: 2025-11-22 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3d3c6f1f8c0a"
+down_revision: str | None = "7694c8910510"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+fk_cases_owner_id_workspace = "fk_cases_owner_id_workspace"
+
+
+def upgrade() -> None:
+    op.create_foreign_key(
+        fk_cases_owner_id_workspace,
+        "cases",
+        "workspace",
+        ["owner_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(fk_cases_owner_id_workspace, "cases", type_="foreignkey")

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -239,6 +239,11 @@ class Workspace(RecordModel):
         back_populates="owner",
         cascade="all, delete",
     )
+    cases: Mapped[list[Case]] = relationship(
+        "Case",
+        back_populates="owner",
+        cascade="all, delete",
+    )
     secrets: Mapped[list[Secret]] = relationship(
         "Secret",
         back_populates="owner",
@@ -1308,6 +1313,11 @@ class Case(RecordModel):
         nullable=True,
         doc="Additional data payload for the case",
     )
+    owner_id: Mapped[OwnerID] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID,
         ForeignKey("user.id", ondelete="SET NULL"),
@@ -1340,6 +1350,7 @@ class Case(RecordModel):
         back_populates="assigned_cases",
         lazy="selectin",
     )
+    owner: Mapped[Workspace] = relationship("Workspace", back_populates="cases")
     tags: Mapped[list[CaseTag]] = relationship(
         "CaseTag",
         secondary=CaseTagLink.__table__,


### PR DESCRIPTION
## Summary
- add a workspace-to-case relationship so case ownership is linked to workspaces
- add a migration enforcing a cascading foreign key from cases to workspaces

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927ab9b8f6c8320bd01f4c6e78a655f)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a required workspace relationship to cases and a cascading foreign key so deleting a workspace automatically deletes its cases. This ties case ownership to workspaces and prevents orphaned data.

- **Migration**
  - Run Alembic migration to create FK cases.owner_id → workspace.id (ON DELETE CASCADE).
  - Backfill owner_id for existing cases; ensure no NULLs before deploy.
  - Verify workspace deletion cascades to related cases.

<sup>Written for commit 6a61c73cf42e1c4bb8a13ff8104f358b22d4ad1d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



