### PR TITLE
fix: correct table_columns metadata type for INTEGER columns

### DIFF
--- a/alembic/versions/a81bc08c39a1_fix_bigint_metadata_to_integer.py
+++ b/alembic/versions/a81bc08c39a1_fix_bigint_metadata_to_integer.py
@@ -5,7 +5,7 @@ The physical PostgreSQL columns should remain BIGINT, but the metadata should us
 (the Tracecat SqlType enum value).
 
 Revision ID: a81bc08c39a1
-Revises: b873c83b8e0a
+Revises: 3d3c6f1f8c0a
 Create Date: 2025-11-27 10:14:17.606168
 
 """
@@ -18,7 +18,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "a81bc08c39a1"
-down_revision: str | None = "b873c83b8e0a"
+down_revision: str | None = "3d3c6f1f8c0a"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary
Created a new migration to fix migration c23dbe59fec6 that incorrectly updated table_columns metadata from 'INTEGER' to 'BIGINT', causing ValueError: 'BIGINT' is not a valid SqlType when users tried to insert rows into tables with integer columns.
 
## Description
  - Added new migration a81bc08c39a1 to repair affected deployments by converting 'BIGINT' back to
  'INTEGER' in table_columns metadata
  - Physical database columns correctly use BIGINT for integer support, but Tracecat's metadata must
   use 'INTEGER' to match the SqlType enum







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect 'BIGINT' metadata in table_columns that caused "ValueError: 'BIGINT' is not a valid SqlType". Metadata now stays 'INTEGER' while PostgreSQL columns remain BIGINT.

- **Bug Fixes**
  - Added migration a81bc08c39a1 to repair affected deployments by converting metadata from 'BIGINT' back to 'INTEGER'.

- **Migration**
  - Run alembic upgrade to apply a81bc08c39a1.
  - No manual steps required.

<sup>Written for commit 2eece452c35cea59790619560866e11c165d38f0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







