### PR TITLE
fix(integrations)!: Hardcode subtree and attributes in LDAP

### DIFF
--- a/tests/registry/test_ldap.py
+++ b/tests/registry/test_ldap.py
@@ -142,48 +142,29 @@ def configure_ldap_secrets(live_ldap_server: dict[str, Any]):
 
 def _run_search(
     ldap_data: dict[str, str],
-    *,
-    attributes: str,
 ) -> list[dict[str, Any]]:
     return search_entries(
         search_base=ldap_data["base_dn"],
         search_filter=ldap_data["filter"],
-        attributes=attributes,
     )
 
 
 def test_live_search_all_attributes(
     ldap_test_data: dict[str, str], configure_ldap_secrets
 ) -> None:
-    results = _run_search(ldap_test_data, attributes="ALL_ATTRIBUTES")
+    results = _run_search(ldap_test_data)
     assert results and results[0]["attributes"]["uid"] == ["tracecat.test"]
 
 
-def test_live_search_single_attribute(
+def test_live_search_returns_all_attributes(
     ldap_test_data: dict[str, str], configure_ldap_secrets
 ) -> None:
-    results = _run_search(ldap_test_data, attributes="uid")
+    results = _run_search(ldap_test_data)
     assert results
     attrs = results[0]["attributes"]
-    assert set(attrs) == {"uid"}
+    # Verify that all expected attributes are present
+    assert "uid" in attrs
+    assert "mail" in attrs
+    assert "cn" in attrs
     assert attrs["uid"] == ["tracecat.test"]
-
-
-def test_live_search_multiple_attribute_string(
-    ldap_test_data: dict[str, str], configure_ldap_secrets
-) -> None:
-    results = _run_search(ldap_test_data, attributes="uid, mail\n cn ")
-    assert results
-    attrs = results[0]["attributes"]
-    assert set(attrs) == {"uid", "mail", "cn"}
     assert attrs["mail"] == ["tracecat@example.com"]
-
-
-def test_live_search_blank_string_defaults_to_all_attributes(
-    ldap_test_data: dict[str, str], configure_ldap_secrets
-) -> None:
-    results = _run_search(ldap_test_data, attributes="   ")
-    assert results
-    attrs = results[0]["attributes"]
-    assert "mail" in attrs and "cn" in attrs
-    assert attrs["uid"] == ["tracecat.test"]


### PR DESCRIPTION
To align with last working implementation: https://github.com/TracecatHQ/tracecat/pull/293

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcoded LDAP search to always use SUBTREE scope and return ALL_ATTRIBUTES, simplifying the API and making results consistent. Also standardized the return shape and added clear error handling.

- **Refactors**
  - Removed search_scope and attributes from search_entries; the client now uses SUBTREE and ALL_ATTRIBUTES by default.
  - Returned entries now include only dn and attributes.
  - Raise RuntimeError on failed search instead of returning an empty list.
  - Updated tests to reflect the new defaults and return shape.

- **Migration**
  - Stop passing search_scope and attributes to search_entries.
  - Update code that expects specific attributes; all attributes are always returned.
  - Handle RuntimeError for search failures.

<sup>Written for commit 626f29ccf2147da57edc71818f5098700f6a3b06. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

