### PR TITLE
fix(db): Clean orphan cases before adding workspace foreign key

### DIFF
--- a/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
+++ b/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
@@ -26,6 +26,7 @@ def upgrade() -> None:
         DELETE FROM cases
         WHERE owner_id IS NOT NULL
           AND owner_id NOT IN (SELECT id FROM workspace)
+          AND EXISTS (SELECT 1 FROM workspace)
         """
     )
 

--- a/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
+++ b/alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py
@@ -20,6 +20,15 @@ fk_cases_owner_id_workspace = "fk_cases_owner_id_workspace"
 
 
 def upgrade() -> None:
+    # Remove orphaned cases before enforcing the workspace foreign key.
+    op.execute(
+        """
+        DELETE FROM cases
+        WHERE owner_id IS NOT NULL
+          AND owner_id NOT IN (SELECT id FROM workspace)
+        """
+    )
+
     op.create_foreign_key(
         fk_cases_owner_id_workspace,
         "cases",


### PR DESCRIPTION
## QA
Ran manual QA that creates orphaned cases by deleting a Workspace, then running the alembic migration and verifying that only the orphaned cases were deleted.

## Summary
- delete orphaned cases before adding the workspace foreign key constraint on cases to avoid failing migrations when orphaned records exist

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dde3fdf6883209828ba1adc383dc1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Delete orphaned `cases` rows lacking a valid `workspace.id` before creating a `cases.owner_id -> workspace.id` foreign key with `ON DELETE CASCADE` (includes downgrade to drop constraint).
> 
> - **Migration (`alembic/versions/3d3c6f1f8c0a_add_workspace_fk_to_cases.py`)**:
>   - Pre-clean: delete orphaned `cases` where `owner_id` not in `workspace.id` (only if any `workspace` exists).
>   - Add FK: create `cases.owner_id -> workspace.id` with `ondelete="CASCADE"`.
>   - Downgrade: drop the `fk_cases_owner_id_workspace` constraint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0df0d59c721fc951a3fb4bf306d2a37724d25d6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete orphaned cases before adding the workspace foreign key to cases. This prevents migration failures and ensures referential integrity.

- **Migration**
  - Removes cases with owner_id set but no matching workspace.id, only if a workspace exists.
  - If any need to be kept, fix owner_id or create the missing workspace before running the migration.

<sup>Written for commit 0df0d59c721fc951a3fb4bf306d2a37724d25d6f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





