### PR TITLE
feat(agents): Disable flaky history processing for agent runs

### DIFF
--- a/tracecat/agent/factory.py
+++ b/tracecat/agent/factory.py
@@ -8,10 +8,6 @@ from pydantic_ai.agent import AbstractAgent
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.tools import DeferredToolRequests
 
-from tracecat.agent.context import (
-    trim_history_processor,
-    truncate_tool_returns_processor,
-)
 from tracecat.agent.parsers import parse_output_type
 from tracecat.agent.prompts import ToolCallPrompt, VerbosityPrompt
 from tracecat.agent.providers import get_model
@@ -81,6 +77,5 @@ async def build_agent(config: AgentConfig) -> Agent[Any, Any]:
         tools=agent_tools,
         toolsets=toolsets,
         deps_type=config.deps_type or type(None),
-        history_processors=[truncate_tool_returns_processor, trim_history_processor],
     )
     return agent


### PR DESCRIPTION
## Summary
Disable flaky history processing for agent runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled history processors in agent runs to avoid flaky behavior and inconsistent history trimming. Removed trim_history_processor and truncate_tool_returns_processor from agent factory so runs no longer mutate or truncate history.

<sup>Written for commit fa2634ac7f60a7ddf145d80e2740231cd85c7c02. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

