### PR TITLE
feat(api): Support Sentry env override

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -201,7 +201,11 @@ TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION = os.environ.get(
 ).lower() in ("true", "1")
 """Disable eager activity execution for Temporal workflows."""
 
-# Secrets manager config
+# === Sentry config === #
+SENTRY_ENVIRONMENT_OVERRIDE = os.environ.get("SENTRY_ENVIRONMENT_OVERRIDE")
+"""Override the Sentry environment. If not set, defaults to '{app_env}-{temporal_namespace}'."""
+
+# === Secrets manager config === #
 TRACECAT__UNSAFE_DISABLE_SM_MASKING = os.environ.get(
     "TRACECAT__UNSAFE_DISABLE_SM_MASKING",
     "0",  # Default to False

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -94,7 +94,9 @@ async def main() -> None:
         logger.info("Initializing Sentry interceptor")
         app_env = config.TRACECAT__APP_ENV
         temporal_namespace = config.TEMPORAL__CLUSTER_NAMESPACE
-        sentry_environment = f"{app_env}-{temporal_namespace}"
+        sentry_environment: str = (
+            config.SENTRY_ENVIRONMENT_OVERRIDE or f"{app_env}-{temporal_namespace}"
+        )
         sentry_sdk.init(
             dsn=sentry_dsn,
             environment=sentry_environment,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for overriding the Sentry environment to control how error events are tagged. Set SENTRY_ENVIRONMENT_OVERRIDE; otherwise it defaults to "{app_env}-{temporal_namespace}".

<sup>Written for commit fdd77c39afe75e701758617bde8d10c5cf025b52. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

