### PR TITLE
feat(ui): Equal width for workspace secret inputs

### DIFF
--- a/frontend/src/components/workspaces/add-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/add-workspace-secret.tsx
@@ -185,7 +185,7 @@ export function NewCredentialsDialog({
                             key={`${field.id}.${index}`}
                             className="flex w-full items-center gap-2"
                           >
-                            <FormControl>
+                            <FormControl className="flex-1">
                               <Input
                                 id={`key-${index}`}
                                 className="text-sm"
@@ -198,7 +198,7 @@ export function NewCredentialsDialog({
                                 placeholder="Key"
                               />
                             </FormControl>
-                            <FormControl>
+                            <FormControl className="flex-1">
                               <Input
                                 id={`value-${index}`}
                                 className="text-sm"


### PR DESCRIPTION
## Summary
Fixed the key and value input fields in the workspace secret creation dialog to have equal width (50/50) instead of allowing one to be larger than the other.

<img width="617" height="670" alt="image" src="https://github.com/user-attachments/assets/7a75e669-b9b6-48c9-a5c7-499fe9026f2a" />

## Description
- Added flex-1 class to both FormControl components wrapping the key and value inputs
- Ensures both input fields take equal space within the flex container
- Improves visual consistency and prevents one field from dominating the layout



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Key and Value inputs in the workspace secret dialog equal width for a cleaner, balanced layout. Applied flex-1 to both FormControl wrappers so the fields split space 50/50 and neither dominates.

<sup>Written for commit 8438edcca5ce7f7237c1e5550073791b91b8037b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



