### PR TITLE
refactor(db): Add explicit constraint names to alembic migrations

### DIFF
--- a/alembic/versions/046d417c113f_add_org_secrets.py
+++ b/alembic/versions/046d417c113f_add_org_secrets.py
@@ -45,8 +45,10 @@ def upgrade() -> None:
         sa.Column("encrypted_keys", sa.LargeBinary(), nullable=False),
         sa.Column("environment", sa.String(), nullable=False),
         sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("name", "environment"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="organizationsecret_pkey"),
+        sa.UniqueConstraint(
+            "name", "environment", name="organizationsecret_name_environment_key"
+        ),
     )
     op.create_index(
         op.f("ix_organizationsecret_id"), "organizationsecret", ["id"], unique=True

--- a/alembic/versions/0fd54220f319_add_casecomment_schema.py
+++ b/alembic/versions/0fd54220f319_add_casecomment_schema.py
@@ -44,8 +44,13 @@ def upgrade() -> None:
         sa.Column("parent_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("last_edited_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("case_id", sa.UUID(), nullable=False),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="case_comments_case_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_comments_pkey"),
     )
     op.create_index(op.f("ix_case_comments_id"), "case_comments", ["id"], unique=True)
     # ### end Alembic commands ###

--- a/alembic/versions/14b4de0bbc0e_add_is_system_and_type_to_registry_repos.py
+++ b/alembic/versions/14b4de0bbc0e_add_is_system_and_type_to_registry_repos.py
@@ -74,7 +74,7 @@ def upgrade() -> None:
         ),
         sa.Column("expires_at", sa.DateTime(), nullable=True),
         sa.Column("actor", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="interaction_pkey"),
     )
     op.create_index(op.f("ix_interaction_id"), "interaction", ["id"], unique=True)
     op.create_index(

--- a/alembic/versions/1ccd61edfcaa_add_case_and_casefields_schemas.py
+++ b/alembic/versions/1ccd61edfcaa_add_case_and_casefields_schemas.py
@@ -116,7 +116,7 @@ def upgrade() -> None:
             ),
             nullable=False,
         ),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="cases_pkey"),
     )
     op.create_index(op.f("ix_cases_case_number"), "cases", ["case_number"], unique=True)
     op.create_index(op.f("ix_cases_id"), "cases", ["id"], unique=True)
@@ -136,9 +136,14 @@ def upgrade() -> None:
         ),
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("case_id", sa.UUID(), nullable=False),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("case_id"),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="case_fields_case_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="case_fields_pkey"),
+        sa.UniqueConstraint("case_id", name="case_fields_case_id_key"),
     )
     op.create_index(op.f("ix_case_fields_id"), "case_fields", ["id"], unique=True)
     # ### end Alembic commands ###

--- a/alembic/versions/2d6eadcf4976_add_workspace_variables.py
+++ b/alembic/versions/2d6eadcf4976_add_workspace_variables.py
@@ -44,9 +44,19 @@ def upgrade() -> None:
         sa.Column("environment", sa.String(), nullable=False),
         sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("owner_id", sa.UUID(), nullable=False),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("name", "environment", "owner_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="workspace_variable_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="workspace_variable_pkey"),
+        sa.UniqueConstraint(
+            "name",
+            "environment",
+            "owner_id",
+            name="workspace_variable_name_environment_owner_id_key",
+        ),
     )
     op.create_index(
         op.f("ix_workspace_variable_id"), "workspace_variable", ["id"], unique=True

--- a/alembic/versions/36f47d3628bf_remove_versioning_from_registry_tables.py
+++ b/alembic/versions/36f47d3628bf_remove_versioning_from_registry_tables.py
@@ -31,7 +31,9 @@ def upgrade() -> None:
     op.alter_column(
         "registryrepository", "origin", existing_type=sa.VARCHAR(), nullable=False
     )
-    op.create_unique_constraint(None, "registryrepository", ["origin"])
+    op.create_unique_constraint(
+        "registryrepository_origin_key", "registryrepository", ["origin"]
+    )
     op.drop_column("registryrepository", "version")
     # ### end Alembic commands ###
 
@@ -42,7 +44,9 @@ def downgrade() -> None:
         "registryrepository",
         sa.Column("version", sa.VARCHAR(), autoincrement=False, nullable=False),
     )
-    op.drop_constraint(None, "registryrepository", type_="unique")  # type: ignore
+    op.drop_constraint(
+        "registryrepository_origin_key", "registryrepository", type_="unique"
+    )
     op.alter_column(
         "registryrepository", "origin", existing_type=sa.VARCHAR(), nullable=True
     )

--- a/alembic/versions/3bc0a0970817_add_tags_and_workflow_tags_tables.py
+++ b/alembic/versions/3bc0a0970817_add_tags_and_workflow_tags_tables.py
@@ -41,9 +41,14 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.UUID(), nullable=True),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("color", sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("name", "owner_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="tag_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="tag_pkey"),
+        sa.UniqueConstraint("name", "owner_id", name="tag_name_owner_id_key"),
     )
     op.create_index(op.f("ix_tag_id"), "tag", ["id"], unique=True)
     op.create_index(op.f("ix_tag_name"), "tag", ["name"], unique=False)
@@ -54,12 +59,14 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["tag_id"],
             ["tag.id"],
+            name="workflowtag_tag_id_fkey",
         ),
         sa.ForeignKeyConstraint(
             ["workflow_id"],
             ["workflow.id"],
+            name="workflowtag_workflow_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("tag_id", "workflow_id"),
+        sa.PrimaryKeyConstraint("tag_id", "workflow_id", name="workflowtag_pkey"),
     )
     # ### end Alembic commands ###
 

--- a/alembic/versions/3c55aa60ca2c_rename_summary_to_instructions_add_.py
+++ b/alembic/versions/3c55aa60ca2c_rename_summary_to_instructions_add_.py
@@ -27,9 +27,19 @@ def upgrade() -> None:
         "runbookcaselink",
         sa.Column("runbook_id", sa.UUID(), nullable=False),
         sa.Column("case_id", sa.UUID(), nullable=False),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["runbook_id"], ["runbook.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("runbook_id", "case_id"),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="runbookcaselink_case_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["runbook_id"],
+            ["runbook.id"],
+            ondelete="CASCADE",
+            name="runbookcaselink_runbook_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("runbook_id", "case_id", name="runbookcaselink_pkey"),
     )
 
     # Add version column with default value

--- a/alembic/versions/4410b3fd2e7e_add_prompt_table.py
+++ b/alembic/versions/4410b3fd2e7e_add_prompt_table.py
@@ -45,8 +45,13 @@ def upgrade() -> None:
         sa.Column("tools", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("summary", sa.String(), nullable=True),
         sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.ForeignKeyConstraint(["chat_id"], ["chat.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["chat_id"],
+            ["chat.id"],
+            ondelete="CASCADE",
+            name="prompt_chat_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="prompt_pkey"),
     )
     op.create_index(op.f("ix_prompt_id"), "prompt", ["id"], unique=True)
     # ### end Alembic commands ###

--- a/alembic/versions/496c162975d7_add_organization_settings_table.py
+++ b/alembic/versions/496c162975d7_add_organization_settings_table.py
@@ -43,7 +43,7 @@ def upgrade() -> None:
         sa.Column("value", sa.LargeBinary(), nullable=False),
         sa.Column("value_type", sa.String(), nullable=False),
         sa.Column("is_encrypted", sa.Boolean(), nullable=False),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="organization_settings_pkey"),
     )
     op.create_index(
         op.f("ix_organization_settings_id"),

--- a/alembic/versions/4aade4315ef9_add_tables_table.py
+++ b/alembic/versions/4aade4315ef9_add_tables_table.py
@@ -40,8 +40,8 @@ def upgrade() -> None:
         sa.Column("owner_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("name", "owner_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="tables_pkey"),
+        sa.UniqueConstraint("name", "owner_id", name="tables_name_owner_id_key"),
     )
     op.create_index(op.f("ix_tables_id"), "tables", ["id"], unique=True)
     op.create_index(op.f("ix_tables_name"), "tables", ["name"], unique=False)
@@ -65,9 +65,14 @@ def upgrade() -> None:
         sa.Column("type", sa.String(), nullable=False),
         sa.Column("nullable", sa.Boolean(), nullable=False),
         sa.Column("default", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.ForeignKeyConstraint(["table_id"], ["tables.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("table_id", "name"),
+        sa.ForeignKeyConstraint(
+            ["table_id"],
+            ["tables.id"],
+            ondelete="CASCADE",
+            name="table_columns_table_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="table_columns_pkey"),
+        sa.UniqueConstraint("table_id", "name", name="table_columns_table_id_name_key"),
     )
     op.create_index(op.f("ix_table_columns_id"), "table_columns", ["id"], unique=True)
     op.create_index(

--- a/alembic/versions/50e22ca490f9_initial_migration.py
+++ b/alembic/versions/50e22ca490f9_initial_migration.py
@@ -51,7 +51,7 @@ def upgrade() -> None:
         sa.Column("action", sa.String(), nullable=True),
         sa.Column("context", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_pkey"),
     )
     op.create_index(op.f("ix_case_id"), "case", ["id"], unique=True)
     op.create_table(
@@ -76,7 +76,7 @@ def upgrade() -> None:
         sa.Column("case_id", sa.String(), nullable=False),
         sa.Column("initiator_role", sa.String(), nullable=False),
         sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="caseevent_pkey"),
     )
     op.create_index(op.f("ix_caseevent_id"), "caseevent", ["id"], unique=True)
     op.create_table(
@@ -85,7 +85,7 @@ def upgrade() -> None:
         sa.Column("resource_type", sa.String(), nullable=False),
         sa.Column("owner_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("owner_type", sa.String(), nullable=False),
-        sa.PrimaryKeyConstraint("resource_id"),
+        sa.PrimaryKeyConstraint("resource_id", name="ownership_pkey"),
     )
     op.create_table(
         "udfspec",
@@ -112,7 +112,7 @@ def upgrade() -> None:
             "json_schema", postgresql.JSONB(astext_type=sa.Text()), nullable=True
         ),
         sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="udfspec_pkey"),
     )
     op.create_index(op.f("ix_udfspec_id"), "udfspec", ["id"], unique=True)
     op.create_table(
@@ -131,7 +131,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("settings", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name="user_pkey"),
     )
     op.create_index(op.f("ix_user_email"), "user", ["email"], unique=True)
     op.create_table(
@@ -153,8 +153,8 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("settings", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="workspace_pkey"),
+        sa.UniqueConstraint("id", name="workspace_id_key"),
     )
     op.create_index(op.f("ix_workspace_name"), "workspace", ["name"], unique=True)
     op.create_table(
@@ -169,8 +169,9 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["user_id"],
             ["user.id"],
+            name="accesstoken_user_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("token"),
+        sa.PrimaryKeyConstraint("token", name="accesstoken_pkey"),
     )
     op.create_index(
         op.f("ix_accesstoken_created_at"), "accesstoken", ["created_at"], unique=False
@@ -198,8 +199,9 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["user_id"],
             ["user.id"],
+            name="caseaction_user_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="caseaction_pkey"),
     )
     op.create_index(op.f("ix_caseaction_id"), "caseaction", ["id"], unique=True)
     op.create_table(
@@ -225,8 +227,9 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["user_id"],
             ["user.id"],
+            name="casecontext_user_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="casecontext_pkey"),
     )
     op.create_index(op.f("ix_casecontext_id"), "casecontext", ["id"], unique=True)
     op.create_table(
@@ -236,12 +239,14 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["user_id"],
             ["user.id"],
+            name="membership_user_id_fkey",
         ),
         sa.ForeignKeyConstraint(
             ["workspace_id"],
             ["workspace.id"],
+            name="membership_workspace_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("user_id", "workspace_id"),
+        sa.PrimaryKeyConstraint("user_id", "workspace_id", name="membership_pkey"),
     )
     op.create_table(
         "oauthaccount",
@@ -256,8 +261,9 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["user_id"],
             ["user.id"],
+            name="oauthaccount_user_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name="oauthaccount_pkey"),
     )
     op.create_index(
         op.f("ix_oauthaccount_account_id"), "oauthaccount", ["account_id"], unique=False
@@ -287,8 +293,13 @@ def upgrade() -> None:
         sa.Column("encrypted_keys", sa.LargeBinary(), nullable=False),
         sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("owner_id", sa.UUID(), nullable=True),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="secret_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="secret_pkey"),
     )
     op.create_index(op.f("ix_secret_id"), "secret", ["id"], unique=True)
     op.create_index(op.f("ix_secret_name"), "secret", ["name"], unique=False)
@@ -321,8 +332,13 @@ def upgrade() -> None:
         sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("icon_url", sa.String(), nullable=True),
         sa.Column("owner_id", sa.UUID(), nullable=True),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="workflow_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="workflow_pkey"),
     )
     op.create_index(op.f("ix_workflow_id"), "workflow", ["id"], unique=True)
     op.create_table(
@@ -351,8 +367,13 @@ def upgrade() -> None:
             "control_flow", postgresql.JSONB(astext_type=sa.Text()), nullable=True
         ),
         sa.Column("workflow_id", sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(["workflow_id"], ["workflow.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["workflow.id"],
+            ondelete="CASCADE",
+            name="action_workflow_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="action_pkey"),
     )
     op.create_index(op.f("ix_action_id"), "action", ["id"], unique=True)
     op.create_table(
@@ -380,8 +401,13 @@ def upgrade() -> None:
         sa.Column("start_at", sa.DateTime(), nullable=True),
         sa.Column("end_at", sa.DateTime(), nullable=True),
         sa.Column("workflow_id", sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(["workflow_id"], ["workflow.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["workflow.id"],
+            ondelete="CASCADE",
+            name="schedule_workflow_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="schedule_pkey"),
     )
     op.create_index(op.f("ix_schedule_id"), "schedule", ["id"], unique=True)
     op.create_table(
@@ -405,8 +431,13 @@ def upgrade() -> None:
         sa.Column("method", sa.String(), nullable=False),
         sa.Column("filters", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("workflow_id", sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(["workflow_id"], ["workflow.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["workflow.id"],
+            ondelete="CASCADE",
+            name="webhook_workflow_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="webhook_pkey"),
     )
     op.create_index(op.f("ix_webhook_id"), "webhook", ["id"], unique=True)
     op.create_table(
@@ -429,8 +460,13 @@ def upgrade() -> None:
         sa.Column("version", sa.Integer(), nullable=False),
         sa.Column("workflow_id", sa.String(), nullable=True),
         sa.Column("content", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.ForeignKeyConstraint(["workflow_id"], ["workflow.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["workflow.id"],
+            ondelete="CASCADE",
+            name="workflowdefinition_workflow_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="workflowdefinition_pkey"),
     )
     op.create_index(
         op.f("ix_workflowdefinition_id"), "workflowdefinition", ["id"], unique=True

--- a/alembic/versions/5273ec029b1b_add_registry_repository_and_action_.py
+++ b/alembic/versions/5273ec029b1b_add_registry_repository_and_action_.py
@@ -41,8 +41,8 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("version", sa.String(), nullable=False),
         sa.Column("origin", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="registryrepository_pkey"),
+        sa.UniqueConstraint("id", name="registryrepository_id_key"),
     )
     op.create_table(
         "registryaction",
@@ -77,10 +77,13 @@ def upgrade() -> None:
         sa.Column("options", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("repository_id", sa.UUID(), nullable=False),
         sa.ForeignKeyConstraint(
-            ["repository_id"], ["registryrepository.id"], ondelete="CASCADE"
+            ["repository_id"],
+            ["registryrepository.id"],
+            ondelete="CASCADE",
+            name="registryaction_repository_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="registryaction_pkey"),
+        sa.UniqueConstraint("id", name="registryaction_id_key"),
         sa.UniqueConstraint(
             "namespace",
             "name",

--- a/alembic/versions/53678b07d2d1_add_case_records.py
+++ b/alembic/versions/53678b07d2d1_add_case_records.py
@@ -41,8 +41,13 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("entity_id", sa.UUID(), nullable=False),
         sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["entity_id"],
+            ["entity.id"],
+            ondelete="CASCADE",
+            name="entity_record_entity_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="entity_record_pkey"),
         sa.UniqueConstraint("id", name="uq_entity_record_id"),
     )
     op.create_index("idx_record_entity", "entity_record", ["entity_id"], unique=False)
@@ -74,12 +79,25 @@ def upgrade() -> None:
         sa.Column("case_id", sa.UUID(), nullable=False),
         sa.Column("entity_id", sa.UUID(), nullable=False),
         sa.Column("record_id", sa.UUID(), nullable=False),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(
-            ["record_id"], ["entity_record.id"], ondelete="CASCADE"
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="case_record_case_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["entity_id"],
+            ["entity.id"],
+            ondelete="CASCADE",
+            name="case_record_entity_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["record_id"],
+            ["entity_record.id"],
+            ondelete="CASCADE",
+            name="case_record_record_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_record_pkey"),
         sa.UniqueConstraint("case_id", "record_id", name="uq_case_record_link"),
     )
     op.create_index("idx_case_record_case", "case_record", ["case_id"], unique=False)

--- a/alembic/versions/584c872028d2_add_entities_and_entity_fields.py
+++ b/alembic/versions/584c872028d2_add_entities_and_entity_fields.py
@@ -56,9 +56,14 @@ def upgrade() -> None:
         sa.Column("description", sa.String(), nullable=True),
         sa.Column("icon", sa.String(), nullable=True),
         sa.Column("is_active", sa.Boolean(), nullable=False),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="entity_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="entity_pkey"),
+        sa.UniqueConstraint("id", name="entity_id_key"),
         sa.UniqueConstraint("owner_id", "key", name="uq_entity_owner_key"),
     )
     op.create_table(
@@ -103,11 +108,21 @@ def upgrade() -> None:
         sa.Column(
             "default_value", postgresql.JSONB(astext_type=sa.Text()), nullable=True
         ),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["entity_id"],
+            ["entity.id"],
+            ondelete="CASCADE",
+            name="entity_field_entity_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="entity_field_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="entity_field_pkey"),
         sa.UniqueConstraint("entity_id", "key", name="uq_entity_field_key"),
-        sa.UniqueConstraint("id"),
+        sa.UniqueConstraint("id", name="entity_field_id_key"),
     )
     op.create_table(
         "entity_field_option",
@@ -128,8 +143,13 @@ def upgrade() -> None:
         sa.Column("key", sa.String(), nullable=False),
         sa.Column("label", sa.String(), nullable=False),
         sa.Column("description", sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(["field_id"], ["entity_field.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["field_id"],
+            ["entity_field.id"],
+            ondelete="CASCADE",
+            name="entity_field_option_field_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="entity_field_option_pkey"),
         sa.UniqueConstraint("field_id", "key", name="uq_field_option_key"),
     )
     # ### end Alembic commands ###

--- a/alembic/versions/61f47f34caa9_add_workflowfolder.py
+++ b/alembic/versions/61f47f34caa9_add_workflowfolder.py
@@ -44,8 +44,13 @@ def upgrade() -> None:
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("path", sa.String(), nullable=False),
         sa.Column("owner_id", sa.UUID(), nullable=True),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="workflow_folder_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="workflow_folder_pkey"),
         sa.UniqueConstraint("path", "owner_id", name="uq_workflow_folder_path_owner"),
     )
     op.create_index(

--- a/alembic/versions/62bd5a3dccde_add_webhook_api_key.py
+++ b/alembic/versions/62bd5a3dccde_add_webhook_api_key.py
@@ -46,9 +46,14 @@ def upgrade() -> None:
         sa.Column("last_used_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("revoked_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("revoked_by", sa.UUID(), nullable=True),
-        sa.ForeignKeyConstraint(["webhook_id"], ["webhook.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
-        sa.UniqueConstraint("webhook_id"),
+        sa.ForeignKeyConstraint(
+            ["webhook_id"],
+            ["webhook.id"],
+            ondelete="CASCADE",
+            name="webhook_api_key_webhook_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="webhook_api_key_pkey"),
+        sa.UniqueConstraint("webhook_id", name="webhook_api_key_webhook_id_key"),
     )
     op.create_index(
         op.f("ix_webhook_api_key_id"), "webhook_api_key", ["id"], unique=True

--- a/alembic/versions/70144f614d3d_add_workspace_oauth_providers.py
+++ b/alembic/versions/70144f614d3d_add_workspace_oauth_providers.py
@@ -59,8 +59,13 @@ def upgrade() -> None:
             server_default=sa.text("'[]'::jsonb"),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="oauth_provider_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="oauth_provider_pkey"),
         sa.UniqueConstraint(
             "owner_id",
             "provider_id",

--- a/alembic/versions/71c8649f752f_add_saml_request_data_table_for_.py
+++ b/alembic/versions/71c8649f752f_add_saml_request_data_table_for_.py
@@ -32,7 +32,7 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name="saml_request_data_pkey"),
     )
     # ### end Alembic commands ###
 

--- a/alembic/versions/89a8d57c3608_add_oauth_state_table.py
+++ b/alembic/versions/89a8d57c3608_add_oauth_state_table.py
@@ -41,9 +41,19 @@ def upgrade() -> None:
         sa.Column("user_id", sa.UUID(), nullable=False),
         sa.Column("provider_id", sa.String(), nullable=False),
         sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["workspace_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("state"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+            name="oauth_state_user_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="oauth_state_workspace_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("state", name="oauth_state_pkey"),
     )
     op.create_index(
         "ix_oauth_state_expires_at", "oauth_state", ["expires_at"], unique=False

--- a/alembic/versions/93f034d69301_add_chat_message_table.py
+++ b/alembic/versions/93f034d69301_add_chat_message_table.py
@@ -42,8 +42,13 @@ def upgrade() -> None:
         sa.Column("chat_id", sa.UUID(), nullable=False),
         sa.Column("kind", sa.String(), nullable=False),
         sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.ForeignKeyConstraint(["chat_id"], ["chat.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["chat_id"],
+            ["chat.id"],
+            ondelete="CASCADE",
+            name="chat_message_chat_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="chat_message_pkey"),
     )
     op.create_index(op.f("ix_chat_message_id"), "chat_message", ["id"], unique=True)
     op.drop_constraint("uq_runbook_alias_owner_id", "runbook", type_="unique")

--- a/alembic/versions/9a001807d27b_add_case_attachments.py
+++ b/alembic/versions/9a001807d27b_add_case_attachments.py
@@ -53,7 +53,7 @@ def upgrade() -> None:
         sa.Column("size", sa.Integer(), nullable=False),
         sa.Column("creator_id", sa.UUID(), nullable=True),
         sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="file_pkey"),
     )
     op.create_index(op.f("ix_file_id"), "file", ["id"], unique=True)
     op.create_index(op.f("ix_file_sha256"), "file", ["sha256"], unique=False)
@@ -74,9 +74,19 @@ def upgrade() -> None:
         sa.Column("id", sa.UUID(), nullable=False),
         sa.Column("case_id", sa.UUID(), nullable=False),
         sa.Column("file_id", sa.UUID(), nullable=False),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["file_id"], ["file.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="case_attachment_case_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["file_id"],
+            ["file.id"],
+            ondelete="CASCADE",
+            name="case_attachment_file_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="case_attachment_pkey"),
         sa.UniqueConstraint("case_id", "file_id", name="uq_case_attachment_case_file"),
     )
     op.create_index(

--- a/alembic/versions/b376e6d16619_create_approval_table.py
+++ b/alembic/versions/b376e6d16619_create_approval_table.py
@@ -66,8 +66,9 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["approved_by"],
             ["user.id"],
+            name="approval_approved_by_fkey",
         ),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.PrimaryKeyConstraint("surrogate_id", name="approval_pkey"),
         sa.UniqueConstraint(
             "owner_id",
             "session_id",

--- a/alembic/versions/b6c80a9bb5ce_tasks_added_to_cases.py
+++ b/alembic/versions/b6c80a9bb5ce_tasks_added_to_cases.py
@@ -74,10 +74,25 @@ def upgrade() -> None:
         ),
         sa.Column("assignee_id", sa.UUID(), nullable=True),
         sa.Column("workflow_id", sa.UUID(), nullable=True),
-        sa.ForeignKeyConstraint(["assignee_id"], ["user.id"], ondelete="SET NULL"),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["workflow_id"], ["workflow.id"], ondelete="SET NULL"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["assignee_id"],
+            ["user.id"],
+            ondelete="SET NULL",
+            name="case_tasks_assignee_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="case_tasks_case_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workflow_id"],
+            ["workflow.id"],
+            ondelete="SET NULL",
+            name="case_tasks_workflow_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_tasks_pkey"),
     )
     op.create_index(op.f("ix_case_tasks_id"), "case_tasks", ["id"], unique=True)
     op.sync_enum_values(  # type: ignore[attr-defined]

--- a/alembic/versions/c2a4f8a5cf72_separate_case_and_workflow_tags.py
+++ b/alembic/versions/c2a4f8a5cf72_separate_case_and_workflow_tags.py
@@ -47,8 +47,13 @@ def upgrade() -> None:
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("ref", sa.String(), nullable=False),
         sa.Column("color", sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="case_tag_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_tag_pkey"),
         sa.UniqueConstraint("name", "owner_id", name="uq_case_tag_name_owner"),
         sa.UniqueConstraint("ref", "owner_id", name="uq_case_tag_ref_owner"),
     )

--- a/alembic/versions/d110a55643ba_add_agent_presets.py
+++ b/alembic/versions/d110a55643ba_add_agent_presets.py
@@ -62,8 +62,13 @@ def upgrade() -> None:
             "model_settings", postgresql.JSONB(astext_type=sa.Text()), nullable=True
         ),
         sa.Column("retries", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="agent_preset_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="agent_preset_pkey"),
         sa.UniqueConstraint("owner_id", "slug", name="uq_agent_preset_owner_slug"),
     )
     op.create_index(op.f("ix_agent_preset_id"), "agent_preset", ["id"], unique=True)

--- a/alembic/versions/d1693ed72940_add_oauthintegration.py
+++ b/alembic/versions/d1693ed72940_add_oauthintegration.py
@@ -51,9 +51,19 @@ def upgrade() -> None:
         sa.Column(
             "provider_config", postgresql.JSONB(astext_type=sa.Text()), nullable=True
         ),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="oauth_integration_owner_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+            name="oauth_integration_user_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="oauth_integration_pkey"),
         sa.UniqueConstraint(
             "owner_id", "provider_id", name="uq_oauth_integration_owner_provider"
         ),

--- a/alembic/versions/d4fd132ccb50_add_case_duration_table.py
+++ b/alembic/versions/d4fd132ccb50_add_case_duration_table.py
@@ -46,18 +46,37 @@ def upgrade() -> None:
         sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("ended_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("duration", sa.Interval(), nullable=True),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(
-            ["definition_id"], ["case_duration_definition.id"], ondelete="CASCADE"
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="case_duration_case_id_fkey",
         ),
         sa.ForeignKeyConstraint(
-            ["end_event_id"], ["case_event.id"], ondelete="SET NULL"
+            ["definition_id"],
+            ["case_duration_definition.id"],
+            ondelete="CASCADE",
+            name="case_duration_definition_id_fkey",
         ),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(
-            ["start_event_id"], ["case_event.id"], ondelete="SET NULL"
+            ["end_event_id"],
+            ["case_event.id"],
+            ondelete="SET NULL",
+            name="case_duration_end_event_id_fkey",
         ),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="case_duration_owner_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["start_event_id"],
+            ["case_event.id"],
+            ondelete="SET NULL",
+            name="case_duration_start_event_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_duration_pkey"),
         sa.UniqueConstraint(
             "case_id", "definition_id", name="uq_case_duration_case_definition"
         ),

--- a/alembic/versions/db946949e584_remove_caseaction_and_casecontext_and_.py
+++ b/alembic/versions/db946949e584_remove_caseaction_and_casecontext_and_.py
@@ -28,7 +28,12 @@ def upgrade() -> None:
     op.drop_table("casecontext")
     op.alter_column("caseevent", "case_id", existing_type=sa.VARCHAR(), nullable=True)
     op.create_foreign_key(
-        None, "caseevent", "case", ["case_id"], ["id"], ondelete="CASCADE"
+        "caseevent_case_id_fkey",
+        "caseevent",
+        "case",
+        ["case_id"],
+        ["id"],
+        ondelete="CASCADE",
     )
     op.drop_column("caseevent", "workflow_id")
     # ### end Alembic commands ###
@@ -40,7 +45,7 @@ def downgrade() -> None:
         "caseevent",
         sa.Column("workflow_id", sa.VARCHAR(), autoincrement=False, nullable=False),
     )
-    op.drop_constraint(None, "caseevent", type_="foreignkey")  # type: ignore
+    op.drop_constraint("caseevent_case_id_fkey", "caseevent", type_="foreignkey")
     op.alter_column("caseevent", "case_id", existing_type=sa.VARCHAR(), nullable=False)
     op.create_table(
         "casecontext",

--- a/alembic/versions/e147aaff7068_add_chat_table.py
+++ b/alembic/versions/e147aaff7068_add_chat_table.py
@@ -44,8 +44,13 @@ def upgrade() -> None:
         sa.Column("entity_type", sa.String(), nullable=False),
         sa.Column("entity_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("tools", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+            name="chat_user_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="chat_pkey"),
     )
     op.create_index(op.f("ix_chat_id"), "chat", ["id"], unique=True)
     # ### end Alembic commands ###

--- a/alembic/versions/f04f005837c9_create_case_duration_definitions.py
+++ b/alembic/versions/f04f005837c9_create_case_duration_definitions.py
@@ -106,8 +106,13 @@ def upgrade() -> None:
             ),
             nullable=False,
         ),
-        sa.ForeignKeyConstraint(["owner_id"], ["workspace.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["owner_id"],
+            ["workspace.id"],
+            ondelete="CASCADE",
+            name="case_duration_definition_owner_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_duration_definition_pkey"),
         sa.UniqueConstraint(
             "owner_id", "name", name="uq_case_duration_definition_owner_name"
         ),

--- a/alembic/versions/fbc309cb247f_add_tag_ref_and_case_tags.py
+++ b/alembic/versions/fbc309cb247f_add_tag_ref_and_case_tags.py
@@ -28,9 +28,19 @@ def upgrade() -> None:
         "casetag",
         sa.Column("case_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("tag_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["tag_id"], ["tag.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("case_id", "tag_id"),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="casetag_case_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"],
+            ["tag.id"],
+            ondelete="CASCADE",
+            name="casetag_tag_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("case_id", "tag_id", name="casetag_pkey"),
     )
 
     # Add ref column to tag table

--- a/alembic/versions/fc82d8b66c20_add_case_events.py
+++ b/alembic/versions/fc82d8b66c20_add_case_events.py
@@ -71,8 +71,13 @@ def upgrade() -> None:
         sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
         sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("case_id", sa.UUID(), nullable=False),
-        sa.ForeignKeyConstraint(["case_id"], ["cases.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("surrogate_id"),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["cases.id"],
+            ondelete="CASCADE",
+            name="case_event_case_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name="case_event_pkey"),
     )
     op.create_index(op.f("ix_case_event_id"), "case_event", ["id"], unique=True)
     # ### end Alembic commands ###


### PR DESCRIPTION
## Summary
- Add explicit PostgreSQL constraint names to all alembic migrations
- Covers primary keys, foreign keys, and unique constraints
- Follows PostgreSQL naming conventions (e.g., `tablename_pkey`, `tablename_column_fkey`)

## Verification
Verified that constraint names match exactly between this branch and main:

1. Applied all migrations on fresh database (this branch)
2. Queried all constraints (PRIMARY KEY, FOREIGN KEY, UNIQUE)
3. Switched to main, applied migrations on fresh database
4. Compared constraint names - **all 118 constraints match exactly**

```
- FOREIGN KEY: 44 constraints
- PRIMARY KEY: 40 constraints
- UNIQUE: 34 constraints
```

## Test plan
- [x] Verify migrations apply cleanly on fresh database
- [x] Verify constraint names match between branch and main
- [ ] Verify downgrade migrations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized PostgreSQL constraint names across Alembic migrations to make schema management and downgrades more reliable. No schema changes; only explicit naming for consistency.

- **Refactors**
  - Added explicit names for all primary key, foreign key, and unique constraints following PostgreSQL conventions (e.g., tablename_pkey, tablename_column_fkey, tablename_columns_key).
  - Replaced anonymous constraints and None usage with named constraints; updated drop_constraint calls to target the correct names.
  - Aligned compound unique constraints and many-to-many primary keys to deterministic names across tables (e.g., registryrepository_origin_key, workflowtag_pkey, casetag_pkey).

<sup>Written for commit aeccac9fd44c7ad093170b155914adcaa536a18b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->