### PR TITLE
fix(api): Remove decrypted parameter from get_provider_credentials

### DIFF
--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -168,8 +168,12 @@ class AgentManagementService(BaseService):
 
     async def check_provider_credentials(self, provider: str) -> bool:
         """Check if credentials exist for a provider at organization level."""
-        credentials = await self.get_provider_credentials(provider)
-        return credentials is not None
+        secret_name = self._get_credential_secret_name(provider)
+        try:
+            await self.secrets_service.get_org_secret_by_name(secret_name)
+            return True
+        except TracecatNotFoundError:
+            return False
 
     async def get_providers_status(self) -> dict[str, bool]:
         """Get credential status for all providers at organization level."""
@@ -181,8 +185,12 @@ class AgentManagementService(BaseService):
 
     async def check_workspace_provider_credentials(self, provider: str) -> bool:
         """Check if credentials exist for a provider at workspace level."""
-        credentials = await self.get_workspace_provider_credentials(provider)
-        return credentials is not None
+        secret_name = self._get_workspace_credential_secret_name(provider)
+        try:
+            await self.secrets_service.get_secret_by_name(secret_name)
+            return True
+        except TracecatNotFoundError:
+            return False
 
     async def get_workspace_providers_status(self) -> dict[str, bool]:
         """Get credential status for all providers at workspace level."""


### PR DESCRIPTION
## Summary
Always decrypt keys on get to fix breaking chat bug.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always decrypt workspace provider credentials on retrieval to fix chat failures caused by returning raw keys. Removed the decrypted parameter from get_workspace_provider_credentials, updated the preset call, and changed credential checks to use secret existence instead of fetching/decrypting.

<sup>Written for commit 0fc0664a8c33bc2b8b1b6811c9ae9482eef6673e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





