### PR TITLE
feat(audit): stream audit logs via webhook

### DIFF
--- a/frontend/src/app/organization/settings/audit/page.tsx
+++ b/frontend/src/app/organization/settings/audit/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { OrgSettingsAuditForm } from "@/components/organization/org-settings-audit"
+
+export default function AuditSettingsPage() {
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
+        <div className="flex w-full">
+          <div className="items-start space-y-3 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">
+              Audit logging
+            </h2>
+            <p className="text-md text-muted-foreground">
+              Configure audit log delivery to your webhook endpoint.
+            </p>
+          </div>
+        </div>
+
+        <OrgSettingsAuditForm />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2099,6 +2099,47 @@ distinguish multiple files.`,
   title: "AudioUrl",
 } as const
 
+export const $AuditSettingsRead = {
+  properties: {
+    audit_webhook_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Url",
+    },
+  },
+  type: "object",
+  required: ["audit_webhook_url"],
+  title: "AuditSettingsRead",
+  description: "Settings for audit logging.",
+} as const
+
+export const $AuditSettingsUpdate = {
+  properties: {
+    audit_webhook_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Url",
+      description:
+        "Webhook URL that receives streamed audit events. When unset, audit events are skipped.",
+    },
+  },
+  type: "object",
+  title: "AuditSettingsUpdate",
+  description: "Settings for audit logging.",
+} as const
+
 export const $AuthSettingsRead = {
   properties: {
     auth_basic_enabled: {
@@ -10671,6 +10712,18 @@ export const $Role = {
         },
       ],
       title: "Workspace Id",
+    },
+    organization_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Organization Id",
     },
     workspace_role: {
       anyOf: [

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10714,16 +10714,10 @@ export const $Role = {
       title: "Workspace Id",
     },
     organization_id: {
-      anyOf: [
-        {
-          type: "string",
-          format: "uuid",
-        },
-        {
-          type: "null",
-        },
-      ],
+      type: "string",
+      format: "uuid",
       title: "Organization Id",
+      default: "00000000-0000-0000-0000-000000000000",
     },
     workspace_role: {
       anyOf: [

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -295,6 +295,7 @@ import type {
   SecretsUpdateSecretByIdResponse,
   SettingsGetAgentSettingsResponse,
   SettingsGetAppSettingsResponse,
+  SettingsGetAuditSettingsResponse,
   SettingsGetAuthSettingsResponse,
   SettingsGetGitSettingsResponse,
   SettingsGetOauthSettingsResponse,
@@ -303,6 +304,8 @@ import type {
   SettingsUpdateAgentSettingsResponse,
   SettingsUpdateAppSettingsData,
   SettingsUpdateAppSettingsResponse,
+  SettingsUpdateAuditSettingsData,
+  SettingsUpdateAuditSettingsResponse,
   SettingsUpdateAuthSettingsData,
   SettingsUpdateAuthSettingsResponse,
   SettingsUpdateGitSettingsData,
@@ -3654,6 +3657,40 @@ export const settingsUpdateAppSettings = (
   return __request(OpenAPI, {
     method: "PATCH",
     url: "/settings/app",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Audit Settings
+ * @returns AuditSettingsRead Successful Response
+ * @throws ApiError
+ */
+export const settingsGetAuditSettings =
+  (): CancelablePromise<SettingsGetAuditSettingsResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/settings/audit",
+    })
+  }
+
+/**
+ * Update Audit Settings
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const settingsUpdateAuditSettings = (
+  data: SettingsUpdateAuditSettingsData
+): CancelablePromise<SettingsUpdateAuditSettingsResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/settings/audit",
     body: data.requestBody,
     mediaType: "application/json",
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -521,6 +521,23 @@ export type AudioUrl = {
   readonly identifier: string
 }
 
+/**
+ * Settings for audit logging.
+ */
+export type AuditSettingsRead = {
+  audit_webhook_url: string | null
+}
+
+/**
+ * Settings for audit logging.
+ */
+export type AuditSettingsUpdate = {
+  /**
+   * Webhook URL that receives streamed audit events. When unset, audit events are skipped.
+   */
+  audit_webhook_url?: string | null
+}
+
 export type AuthSettingsRead = {
   auth_basic_enabled: boolean
   auth_require_email_verification: boolean
@@ -3441,6 +3458,7 @@ export type RetryPromptPart = {
 export type Role = {
   type: "user" | "service"
   workspace_id?: string | null
+  organization_id?: string | null
   workspace_role?: WorkspaceRole | null
   user_id?: string | null
   access_level?: AccessLevel
@@ -6291,6 +6309,14 @@ export type SettingsUpdateAppSettingsData = {
 
 export type SettingsUpdateAppSettingsResponse = void
 
+export type SettingsGetAuditSettingsResponse = AuditSettingsRead
+
+export type SettingsUpdateAuditSettingsData = {
+  requestBody: AuditSettingsUpdate
+}
+
+export type SettingsUpdateAuditSettingsResponse = void
+
 export type SettingsGetAgentSettingsResponse = AgentSettingsRead
 
 export type SettingsUpdateAgentSettingsData = {
@@ -9002,6 +9028,29 @@ export type $OpenApiTs = {
     }
     patch: {
       req: SettingsUpdateAppSettingsData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/settings/audit": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AuditSettingsRead
+      }
+    }
+    patch: {
+      req: SettingsUpdateAuditSettingsData
       res: {
         /**
          * Successful Response

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3458,7 +3458,7 @@ export type RetryPromptPart = {
 export type Role = {
   type: "user" | "service"
   workspace_id?: string | null
-  organization_id?: string | null
+  organization_id?: string
   workspace_role?: WorkspaceRole | null
   user_id?: string | null
   access_level?: AccessLevel

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { useOrgAuditSettings } from "@/lib/hooks"
+
+const auditFormSchema = z.object({
+  audit_webhook_url: z
+    .string()
+    .trim()
+    .url({ message: "Enter a valid URL (https://...)" })
+    .max(2048)
+    .or(z.literal("")),
+})
+
+type AuditFormValues = z.infer<typeof auditFormSchema>
+
+export function OrgSettingsAuditForm() {
+  const {
+    auditSettings,
+    auditSettingsIsLoading,
+    auditSettingsError,
+    updateAuditSettings,
+    updateAuditSettingsIsPending,
+  } = useOrgAuditSettings()
+
+  const form = useForm<AuditFormValues>({
+    resolver: zodResolver(auditFormSchema),
+    values: {
+      audit_webhook_url: auditSettings?.audit_webhook_url ?? "",
+    },
+  })
+
+  const onSubmit = async (data: AuditFormValues) => {
+    const nextUrl = data.audit_webhook_url.trim()
+    try {
+      await updateAuditSettings({
+        requestBody: {
+          audit_webhook_url: nextUrl === "" ? null : nextUrl,
+        },
+      })
+    } catch {
+      console.error("Failed to update audit settings")
+    }
+  }
+
+  if (auditSettingsIsLoading) {
+    return <CenteredSpinner />
+  }
+  if (auditSettingsError || !auditSettings) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading audit settings: ${auditSettingsError?.message || "Unknown error"}`}
+      />
+    )
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <FormField
+          control={form.control}
+          name="audit_webhook_url"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <div className="space-y-2">
+                <FormLabel>Audit webhook URL</FormLabel>
+                <FormDescription>
+                  Provide an HTTPS endpoint to receive audit events. Leave blank
+                  to disable streaming.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Input
+                  type="url"
+                  placeholder="https://example.com/webhooks/audit"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" disabled={updateAuditSettingsIsPending}>
+          {updateAuditSettingsIsPending
+            ? "Updating..."
+            : "Update audit settings"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -74,6 +74,12 @@ export function OrganizationSidebar({
       isActive: pathname?.includes("/organization/settings/app"),
     },
     {
+      title: "Audit Logs",
+      url: "/organization/settings/audit",
+      icon: ShieldIcon,
+      isActive: pathname?.includes("/organization/settings/audit"),
+    },
+    {
       title: "Agent",
       url: "/organization/settings/agent",
       icon: BotIcon,

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -22,6 +22,7 @@ import {
   type AgentSettingsRead,
   type ApiError,
   type AppSettingsRead,
+  type AuditSettingsRead,
   type AuthSettingsRead,
   actionsDeleteAction,
   actionsGetAction,
@@ -163,6 +164,7 @@ import {
   type SessionRead,
   type SettingsUpdateAgentSettingsData,
   type SettingsUpdateAppSettingsData,
+  type SettingsUpdateAuditSettingsData,
   type SettingsUpdateAuthSettingsData,
   type SettingsUpdateGitSettingsData,
   type SettingsUpdateOauthSettingsData,
@@ -177,12 +179,14 @@ import {
   secretsUpdateSecretById,
   settingsGetAgentSettings,
   settingsGetAppSettings,
+  settingsGetAuditSettings,
   settingsGetAuthSettings,
   settingsGetGitSettings,
   settingsGetOauthSettings,
   settingsGetSamlSettings,
   settingsUpdateAgentSettings,
   settingsUpdateAppSettings,
+  settingsUpdateAuditSettings,
   settingsUpdateAuthSettings,
   settingsUpdateGitSettings,
   settingsUpdateOauthSettings,
@@ -2531,6 +2535,64 @@ export function useOrgAppSettings() {
     updateAppSettings,
     updateAppSettingsIsPending,
     updateAppSettingsError,
+  }
+}
+
+export function useOrgAuditSettings() {
+  const queryClient = useQueryClient()
+
+  // Get Audit settings
+  const {
+    data: auditSettings,
+    isLoading: auditSettingsIsLoading,
+    error: auditSettingsError,
+  } = useQuery<AuditSettingsRead>({
+    queryKey: ["org-audit-settings"],
+    queryFn: async () => await settingsGetAuditSettings(),
+  })
+
+  // Update Audit settings
+  const {
+    mutateAsync: updateAuditSettings,
+    isPending: updateAuditSettingsIsPending,
+    error: updateAuditSettingsError,
+  } = useMutation({
+    mutationFn: async (params: SettingsUpdateAuditSettingsData) =>
+      await settingsUpdateAuditSettings(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-audit-settings"] })
+      toast({
+        title: "Updated audit settings",
+        description: "Audit settings updated successfully.",
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      switch (error.status) {
+        case 403:
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+          break
+        default:
+          console.error("Failed to update audit settings", error)
+          toast({
+            title: "Failed to update audit settings",
+            description: `An error occurred while updating the audit settings: ${error.body.detail}`,
+          })
+      }
+    },
+  })
+
+  return {
+    // Get
+    auditSettings,
+    auditSettingsIsLoading,
+    auditSettingsError,
+    // Update
+    updateAuditSettings,
+    updateAuditSettingsIsPending,
+    updateAuditSettingsError,
   }
 }
 

--- a/tests/unit/api/test_api_workspaces.py
+++ b/tests/unit/api/test_api_workspaces.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 
 from tracecat.auth.types import Role
 from tracecat.authz.enums import WorkspaceRole
+from tracecat.authz.service import MembershipWithOrg
 from tracecat.db.models import Workspace
 from tracecat.logger import logger
 from tracecat.workspaces import router as workspaces_router
@@ -175,7 +176,9 @@ async def test_get_workspace_success(
         mock_membership.user_id = test_admin_role.user_id
         mock_membership.workspace_id = mock_workspace_data.id
         mock_membership.role = WorkspaceRole.ADMIN
-        mock_membership_svc.get_membership.return_value = mock_membership
+        mock_membership_svc.get_membership.return_value = MembershipWithOrg(
+            membership=mock_membership, org_id=mock_workspace_data.organization_id
+        )
         MockMembershipService.return_value = mock_membership_svc
 
         # Make request - use test_workspace which matches the test_admin_role's workspace

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import orjson
+import pytest
+import respx
+
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.service import AuditService
+from tracecat.auth.types import AccessLevel, Role
+
+
+@pytest.fixture
+def role() -> Role:
+    return Role(
+        type="user",
+        workspace_id=None,
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        access_level=AccessLevel.ADMIN,
+        workspace_role=None,
+    )
+
+
+@pytest.fixture
+def audit_service(role: Role) -> AuditService:
+    return AuditService(AsyncMock(), role=role)
+
+
+@pytest.mark.anyio
+async def test_create_event_skips_without_webhook(
+    monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
+) -> None:
+    monkeypatch.setattr(audit_service, "_get_webhook_url", AsyncMock(return_value=None))
+    post_mock = AsyncMock()
+    monkeypatch.setattr(audit_service, "_post_event", post_mock)
+
+    await audit_service.create_event(resource_type="workflow", action="create")
+
+    post_mock.assert_not_awaited()
+
+
+@respx.mock
+@pytest.mark.anyio
+async def test_create_event_streams_to_webhook(
+    monkeypatch: pytest.MonkeyPatch, audit_service: AuditService
+) -> None:
+    webhook_url = "https://example.com/audit"
+    monkeypatch.setattr(
+        audit_service, "_get_webhook_url", AsyncMock(return_value=webhook_url)
+    )
+    mock_user = MagicMock()
+    mock_user.email = "user@example.com"
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none = MagicMock(return_value=mock_user)
+    audit_service.session.execute = AsyncMock(return_value=result_mock)
+    route = respx.post(webhook_url).mock(return_value=httpx.Response(200))
+
+    await audit_service.create_event(
+        resource_type="workflow",
+        action="create",
+        resource_id=uuid.uuid4(),
+        status=AuditEventStatus.SUCCESS,
+    )
+
+    assert route.called
+    payload = orjson.loads(route.calls[0].request.content)
+    assert payload["resource_type"] == "workflow"
+    assert payload["action"] == "create"
+    assert payload["status"] == AuditEventStatus.SUCCESS.value
+    assert payload["actor_label"] == "user@example.com"

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -129,8 +129,11 @@ async def test_auth_cache_reduces_database_queries(mocker):
         "user_id": None,
     }
 
-    # Mock session
+    # Mock session with proper execute() and scalar_one_or_none() chain
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none = MagicMock(return_value=None)
     mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
 
     # First workspace check - should trigger database query
     await _role_dependency(
@@ -368,10 +371,16 @@ async def test_cache_user_id_validation():
             {UserRole.BASIC: AccessLevel.BASIC},
         ),
     ):
+        # Mock session with proper execute() and scalar_one_or_none() chain
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
         # Common parameters for _role_dependency
         common_params = {
             "request": request,
-            "session": AsyncMock(),
+            "session": mock_session,
             "workspace_id": workspace_id,
             "api_key": None,
             "allow_user": True,
@@ -443,10 +452,16 @@ async def test_cache_size_limit():
             {UserRole.BASIC: AccessLevel.BASIC},
         ),
     ):
+        # Mock session with proper execute() and scalar_one_or_none() chain
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
         # Check with excessive memberships
         role = await _role_dependency(
             request=request,
-            session=AsyncMock(),
+            session=mock_session,
             workspace_id=target_workspace_id,
             user=user,
             api_key=None,

--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -221,7 +221,7 @@ async def test_update_audit_settings(
     """Ensure audit webhook updates persist."""
     service = settings_service_with_defaults
     await service.update_audit_settings(
-        SettingUpdate(value="https://example.com/audit", value_type=ValueType.JSON)  # type: ignore[arg-type]
+        AuditSettingsUpdate(audit_webhook_url="https://example.com/audit")
     )
     settings = await service.list_org_settings(keys={"audit_webhook_url"})
     settings_dict = {setting.key: service.get_value(setting) for setting in settings}

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -13,6 +13,7 @@ from sqlalchemy import func, select
 
 from tracecat.agent.preset.schemas import AgentPresetCreate, AgentPresetUpdate
 from tracecat.agent.types import AgentConfig, MCPServerConfig, OutputType
+from tracecat.audit.logger import audit_log
 from tracecat.db.models import (
     AgentPreset,
     OAuthIntegration,
@@ -42,6 +43,7 @@ class AgentPresetService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalars().all()
 
+    @audit_log(resource_type="agent_preset", action="create")
     async def create_preset(self, params: AgentPresetCreate) -> AgentPreset:
         """Create a new agent preset scoped to the current workspace."""
 
@@ -90,6 +92,7 @@ class AgentPresetService(BaseWorkspaceService):
                 f"{len(missing_actions)} actions were not found in the registry: {sorted(missing_actions)}"
             )
 
+    @audit_log(resource_type="agent_preset", action="update")
     async def update_preset(
         self, preset: AgentPreset, params: AgentPresetUpdate
     ) -> AgentPreset:
@@ -130,6 +133,7 @@ class AgentPresetService(BaseWorkspaceService):
         await self.session.refresh(preset)
         return preset
 
+    @audit_log(resource_type="agent_preset", action="delete")
     async def delete_preset(self, preset: AgentPreset) -> None:
         """Delete a preset."""
         await self.session.delete(preset)

--- a/tracecat/audit/enums.py
+++ b/tracecat/audit/enums.py
@@ -1,0 +1,15 @@
+from enum import StrEnum
+
+
+class AuditEventActor(StrEnum):
+    """Valid actor types for audit logging."""
+
+    USER = "USER"
+
+
+class AuditEventStatus(StrEnum):
+    """Valid status values for audit events."""
+
+    ATTEMPT = "ATTEMPT"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -41,9 +41,15 @@ def audit_log(
                 return await func(self, *args, **kwargs)
 
             async with AuditService.with_session() as audit_service:
-                resource_id: uuid.UUID | None = _extract_resource_id(
-                    args, kwargs, None, resource_id_attr
-                )
+                try:
+                    resource_id: uuid.UUID | None = _extract_resource_id(
+                        args, kwargs, None, resource_id_attr
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Audit resource_id extraction failed", error=str(exc)
+                    )
+                    resource_id = None
 
                 # Log attempt
                 try:

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import functools
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any, Concatenate, ParamSpec, TypeVar
+
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.service import AuditService
+from tracecat.auth.types import Role
+from tracecat.contexts import ctx_role
+from tracecat.logger import logger
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def audit_log(
+    *,
+    resource_type: str,
+    action: str,
+    resource_id_attr: str = "id",
+) -> Callable[
+    [Callable[Concatenate[Any, P], Awaitable[R]]],
+    Callable[Concatenate[Any, P], Awaitable[R]],
+]:
+    """Decorator to emit audit attempt/success/failure around service methods.
+
+    If no user role or session is available, auditing is skipped without failing the call.
+    """
+
+    def decorator(
+        func: Callable[Concatenate[Any, P], Awaitable[R]],
+    ) -> Callable[Concatenate[Any, P], Awaitable[R]]:
+        @functools.wraps(func)
+        async def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> R:
+            role: Role | None = ctx_role.get()
+
+            # Skip audit if we don't have a user role
+            if role is None or role.user_id is None:
+                return await func(self, *args, **kwargs)
+
+            async with AuditService.with_session() as audit_service:
+                resource_id: uuid.UUID | None = _extract_resource_id(
+                    args, kwargs, None, resource_id_attr
+                )
+
+                # Log attempt
+                try:
+                    await audit_service.create_event(
+                        resource_type=resource_type,
+                        action=action,
+                        resource_id=resource_id,
+                        status=AuditEventStatus.ATTEMPT,
+                    )
+                except Exception as exc:
+                    logger.warning("Audit attempt log failed", error=str(exc))
+
+                try:
+                    # Execute the actual function
+                    result = await func(self, *args, **kwargs)
+
+                    # Log success
+                    try:
+                        resource_id = _extract_resource_id(
+                            args, kwargs, result, resource_id_attr
+                        )
+                        await audit_service.create_event(
+                            resource_type=resource_type,
+                            action=action,
+                            resource_id=resource_id,
+                            status=AuditEventStatus.SUCCESS,
+                        )
+                    except Exception as exc:
+                        logger.warning("Audit success log failed", error=str(exc))
+                    return result
+                except Exception:
+                    # Log failure
+                    try:
+                        await audit_service.create_event(
+                            resource_type=resource_type,
+                            action=action,
+                            resource_id=resource_id,
+                            status=AuditEventStatus.FAILURE,
+                        )
+                    except Exception as exc:
+                        logger.warning("Audit failure log failed", error=str(exc))
+                    raise
+
+        return wrapper
+
+    return decorator
+
+
+def _extract_resource_id(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    result: Any | None,
+    attr: str,
+) -> uuid.UUID | None:
+    """Heuristic to find a resource id.
+
+    Priority:
+    1) return value `attr` if present
+    2) first arg with `attr`
+    3) kwargs value for `attr`
+    """
+
+    raw: Any | None = None
+
+    if result is not None and hasattr(result, attr):
+        raw = getattr(result, attr)
+    else:
+        for arg in args:
+            if hasattr(arg, attr):
+                raw = getattr(arg, attr)
+                break
+        if raw is None and attr in kwargs:
+            raw = kwargs.get(attr)
+
+    if raw is None:
+        return None
+
+    return _coerce_uuid(raw, attr)
+
+
+def _coerce_uuid(value: Any, source: str) -> uuid.UUID | None:
+    """Convert UUID-like values to uuid.UUID or None, raising on invalid types."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, uuid.UUID):
+        return value
+
+    if isinstance(value, str):
+        try:
+            return uuid.UUID(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Resource ID {source!r} must be a UUID; got invalid string"
+            ) from exc
+
+    raise TypeError(
+        f"Resource ID {source!r} must be a UUID or stringified UUID, got {type(value).__name__}"
+    )

--- a/tracecat/audit/schemas.py
+++ b/tracecat/audit/schemas.py
@@ -13,6 +13,7 @@ class AuditEventRead(BaseModel):
     workspace_id: uuid.UUID | None = None
     actor_type: AuditEventActor
     actor_id: uuid.UUID
+    actor_label: str | None = None
     ip_address: str | None = None
     resource_type: str
     resource_id: uuid.UUID | None = None

--- a/tracecat/audit/schemas.py
+++ b/tracecat/audit/schemas.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field
+
+from tracecat.audit.enums import AuditEventActor, AuditEventStatus
+
+
+class AuditEventRead(BaseModel):
+    organization_id: uuid.UUID
+    workspace_id: uuid.UUID | None = None
+    actor_type: AuditEventActor
+    actor_id: uuid.UUID
+    ip_address: str | None = None
+    resource_type: str
+    resource_id: uuid.UUID | None = None
+    action: str
+    status: AuditEventStatus
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import httpx
+
+from tracecat.audit.enums import AuditEventActor, AuditEventStatus
+from tracecat.audit.schemas import AuditEventRead
+from tracecat.contexts import ctx_client_ip
+from tracecat.service import BaseService
+
+if TYPE_CHECKING:
+    from tracecat.settings.service import SettingsService
+
+
+class AuditService(BaseService):
+    """Stream user-driven events to an audit webhook if configured."""
+
+    service_name = "audit"
+
+    async def _get_webhook_url(self) -> str | None:
+        """Fetch the configured audit webhook URL.
+
+        Precedence:
+        1. `AUDIT_WEBHOOK_URL` env var
+        2. Organization setting `audit_webhook_url`
+        """
+
+        if env_url := os.environ.get("AUDIT_WEBHOOK_URL"):
+            return env_url
+
+        settings_service = SettingsService(self.session, role=self.role)
+        setting = await settings_service.get_org_setting("audit_webhook_url")
+        if setting is None:
+            return None
+
+        value = settings_service.get_value(setting)
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            self.logger.warning(
+                "audit_webhook_url must be a string",
+                value=value,
+                value_type=type(value),
+            )
+            return None
+
+        cleaned = value.strip()
+        return cleaned or None
+
+    async def _post_event(self, *, webhook_url: str, payload: AuditEventRead) -> None:
+        response: httpx.Response | None = None
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    webhook_url, json=payload.model_dump(mode="json")
+                )
+                response.raise_for_status()
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to deliver audit webhook",
+                error=str(exc),
+                webhook_url=webhook_url,
+                status_code=getattr(response, "status_code", None),
+            )
+
+    async def create_event(
+        self,
+        *,
+        resource_type: str,
+        action: str,
+        resource_id: uuid.UUID | None = None,
+        status: AuditEventStatus = AuditEventStatus.SUCCESS,
+    ) -> None:
+        role = self.role
+        if role is None or role.user_id is None or role.organization_id is None:
+            self.logger.debug("Skipping audit log", reason="non_user_role", role=role)
+            return
+
+        webhook_url = await self._get_webhook_url()
+        if not webhook_url:
+            self.logger.debug("Skipping audit log", reason="webhook_unconfigured")
+            return
+
+        payload = AuditEventRead(
+            organization_id=role.organization_id,
+            workspace_id=role.workspace_id,
+            actor_type=AuditEventActor.USER,
+            actor_id=role.user_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=action,
+            status=status,
+            ip_address=ctx_client_ip.get(),
+        )
+        await self._post_event(webhook_url=webhook_url, payload=payload)
+        self.logger.debug(
+            "Streamed audit event", resource_type=resource_type, action=action
+        )

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import uuid
-from typing import TYPE_CHECKING
 
 import httpx
 
@@ -10,9 +9,6 @@ from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 from tracecat.audit.schemas import AuditEventRead
 from tracecat.contexts import ctx_client_ip
 from tracecat.service import BaseService
-
-if TYPE_CHECKING:
-    from tracecat.settings.service import SettingsService
 
 
 class AuditService(BaseService):
@@ -30,6 +26,8 @@ class AuditService(BaseService):
 
         if env_url := os.environ.get("AUDIT_WEBHOOK_URL"):
             return env_url
+
+        from tracecat.settings.service import SettingsService  # noqa: PLC0415
 
         settings_service = SettingsService(self.session, role=self.role)
         setting = await settings_service.get_org_setting("audit_webhook_url")

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -22,17 +22,13 @@ class AuditService(BaseService):
 
         Precedence:
         1. `AUDIT_WEBHOOK_URL` env var
-        2. Organization setting `audit_webhook_url`
+        2. Organization setting `audit_webhook_url` (cached)
         """
+        from tracecat.settings.service import get_setting_cached  # noqa: PLC0415
 
-        from tracecat.settings.service import SettingsService  # noqa: PLC0415
-
-        settings_service = SettingsService(self.session, role=self.role)
-        setting = await settings_service.get_org_setting("audit_webhook_url")
-        if setting is None:
-            return None
-
-        value = settings_service.get_value(setting)
+        value = await get_setting_cached(
+            "audit_webhook_url", role=self.role, session=self.session
+        )
         if value is None:
             return None
         if not isinstance(value, str):

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -6,7 +6,7 @@ import httpx
 from sqlalchemy import select
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
-from tracecat.audit.types import AuditEvent
+from tracecat.audit.types import AuditAction, AuditEvent, AuditResourceType
 from tracecat.contexts import ctx_client_ip
 from tracecat.db.models import User
 from tracecat.service import BaseService
@@ -22,13 +22,11 @@ class AuditService(BaseService):
 
         Precedence:
         1. `AUDIT_WEBHOOK_URL` env var
-        2. Organization setting `audit_webhook_url` (cached)
+        2. Organization setting `audit_webhook_url`
         """
         from tracecat.settings.service import get_setting_cached  # noqa: PLC0415
 
-        value = await get_setting_cached(
-            "audit_webhook_url", role=self.role, session=self.session
-        )
+        value = await get_setting_cached("audit_webhook_url")
         if value is None:
             return None
         if not isinstance(value, str):
@@ -61,8 +59,8 @@ class AuditService(BaseService):
     async def create_event(
         self,
         *,
-        resource_type: str,
-        action: str,
+        resource_type: AuditResourceType,
+        action: AuditAction,
         resource_id: uuid.UUID | None = None,
         status: AuditEventStatus = AuditEventStatus.SUCCESS,
     ) -> None:

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 
 
-class AuditEventRead(BaseModel):
+class AuditEvent(BaseModel):
     organization_id: uuid.UUID
     workspace_id: uuid.UUID | None = None
     actor_type: AuditEventActor

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -2,10 +2,28 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
+
+AuditAction = Literal["create", "update", "delete"]
+AuditResourceType = Literal[
+    "workspace",
+    "workflow",
+    "workflow_execution",
+    "workspace_variable",
+    "tag",
+    "table",
+    "table_column",
+    "organization_setting",
+    "secret",
+    "organization_secret",
+    "chat",
+    "case",
+    "agent_preset",
+]
 
 
 class AuditEvent(BaseModel):
@@ -15,8 +33,8 @@ class AuditEvent(BaseModel):
     actor_id: uuid.UUID
     actor_label: str | None = None
     ip_address: str | None = None
-    resource_type: str
+    resource_type: AuditResourceType
     resource_id: uuid.UUID | None = None
-    action: str
+    action: AuditAction
     status: AuditEventStatus
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -19,7 +19,6 @@ from fastapi import (
 )
 from fastapi.security import APIKeyHeader, OAuth2PasswordBearer
 from pydantic import UUID4
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
@@ -27,10 +26,10 @@ from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import AccessLevel, Role
 from tracecat.auth.users import is_unprivileged, optional_current_active_user
 from tracecat.authz.enums import WorkspaceRole
-from tracecat.authz.service import MembershipService
+from tracecat.authz.service import MembershipService, MembershipWithOrg
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.db.models import Membership, User, Workspace
+from tracecat.db.models import User
 from tracecat.identifiers import InternalServiceID
 from tracecat.logger import logger
 
@@ -63,9 +62,9 @@ USER_ROLE_TO_ACCESS_LEVEL = {
 
 def get_role_from_user(
     user: User,
+    organization_id: UUID4,
     workspace_id: UUID4 | None = None,
     workspace_role: WorkspaceRole | None = None,
-    organization_id: UUID4 | None = None,
     service_id: InternalServiceID = "tracecat-api",
 ) -> Role:
     return Role(
@@ -152,7 +151,7 @@ async def _role_dependency(
             # Check if we have a cache available (from middleware)
             auth_cache = getattr(request.state, "auth_cache", None)
 
-            membership = None
+            membership_with_org: MembershipWithOrg | None = None
             if auth_cache:
                 # Try to get from cache first
                 cached_membership = auth_cache["memberships"].get(str(workspace_id))
@@ -161,7 +160,11 @@ async def _role_dependency(
                     cached_membership is not None
                     and cached_membership.user_id == user.id
                 ):
-                    membership = cached_membership
+                    # Convert cached Membership to MembershipWithOrg by fetching org_id
+                    svc = MembershipService(session)
+                    membership_with_org = await svc.get_membership(
+                        workspace_id=workspace_id, user_id=user.id
+                    )
                     logger.debug(
                         "Using cached membership",
                         user_id=user.id,
@@ -181,14 +184,9 @@ async def _role_dependency(
                             membership_count=len(all_memberships),
                             max_allowed=MAX_CACHED_MEMBERSHIPS,
                         )
-                        # Find membership without caching
-                        membership = next(
-                            (
-                                m
-                                for m in all_memberships
-                                if m.workspace_id == workspace_id
-                            ),
-                            None,
+                        # Find membership without caching - fetch with org_id
+                        membership_with_org = await svc.get_membership(
+                            workspace_id=workspace_id, user_id=user.id
                         )
                     else:
                         # Cache all memberships with user context
@@ -199,15 +197,17 @@ async def _role_dependency(
                         auth_cache["membership_checked"] = True
                         auth_cache["all_memberships"] = all_memberships
 
-                        # Get the specific membership
-                        membership = auth_cache["memberships"].get(str(workspace_id))
+                        # Get the specific membership with org_id
+                        membership_with_org = await svc.get_membership(
+                            workspace_id=workspace_id, user_id=user.id
+                        )
 
                         logger.debug(
                             "Loaded and cached all user memberships",
                             user_id=user.id,
                             workspace_count=len(all_memberships),
                             workspace_id=workspace_id,
-                            found=membership is not None,
+                            found=membership_with_org is not None,
                         )
                 elif auth_cache.get("user_id") != user.id:
                     # Cache belongs to different user - security fallback
@@ -217,13 +217,13 @@ async def _role_dependency(
                         request_user_id=user.id,
                     )
                     svc = MembershipService(session)
-                    membership = await svc.get_membership(
+                    membership_with_org = await svc.get_membership(
                         workspace_id=workspace_id, user_id=user.id
                     )
             else:
                 # No cache available (e.g., in tests), fall back to direct query
                 svc = MembershipService(session)
-                membership = await svc.get_membership(
+                membership_with_org = await svc.get_membership(
                     workspace_id=workspace_id, user_id=user.id
                 )
                 logger.debug(
@@ -232,7 +232,7 @@ async def _role_dependency(
                     workspace_id=workspace_id,
                 )
 
-            if membership is None:
+            if membership_with_org is None:
                 logger.debug(
                     "User is not a member of this workspace",
                     user=user,
@@ -246,7 +246,7 @@ async def _role_dependency(
                 require_workspace_roles = [require_workspace_roles]
             if (
                 require_workspace_roles
-                and membership.role not in require_workspace_roles
+                and membership_with_org.membership.role not in require_workspace_roles
             ):
                 logger.debug(
                     "User does not have the appropriate workspace role",
@@ -259,19 +259,13 @@ async def _role_dependency(
                     detail="You cannot perform this operation",
                 )
             # User has appropriate workspace role
-            workspace_role = membership.role
+            workspace_role = membership_with_org.membership.role
+            organization_id = membership_with_org.org_id
         else:
             # Privileged user doesn't need workspace role verification
             workspace_role = None
-
-        # Get organization_id from one of the user's workspace memberships (potentially no workspace id provided)
-        result = await session.execute(
-            select(Workspace.organization_id)
-            .join(Membership, Membership.workspace_id == Workspace.id)
-            .where(Membership.user_id == user.id)
-            .limit(1)
-        )
-        organization_id = result.scalar_one_or_none()
+            # For privileged users, get organization_id from default or user's first workspace
+            organization_id = config.TRACECAT__DEFAULT_ORG_ID
 
         role = get_role_from_user(
             user,

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -4,7 +4,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from tracecat.authz.enums import WorkspaceRole
-from tracecat.identifiers import InternalServiceID, UserID, WorkspaceID
+from tracecat.identifiers import InternalServiceID, OrganizationID, UserID, WorkspaceID
 
 
 class AccessLevel(IntEnum):
@@ -45,6 +45,7 @@ class Role(BaseModel):
 
     type: Literal["user", "service"] = Field(frozen=True)
     workspace_id: WorkspaceID | None = Field(default=None, frozen=True)
+    organization_id: OrganizationID | None = Field(default=None, frozen=True)
     workspace_role: WorkspaceRole | None = Field(default=None, frozen=True)
     user_id: UserID | None = Field(default=None, frozen=True)
     access_level: AccessLevel = Field(default=AccessLevel.BASIC, frozen=True)

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from tracecat import config
 from tracecat.authz.enums import WorkspaceRole
 from tracecat.identifiers import InternalServiceID, OrganizationID, UserID, WorkspaceID
 
@@ -45,7 +46,9 @@ class Role(BaseModel):
 
     type: Literal["user", "service"] = Field(frozen=True)
     workspace_id: WorkspaceID | None = Field(default=None, frozen=True)
-    organization_id: OrganizationID | None = Field(default=None, frozen=True)
+    organization_id: OrganizationID = Field(
+        default=config.TRACECAT__DEFAULT_ORG_ID, frozen=True
+    )
     workspace_role: WorkspaceRole | None = Field(default=None, frozen=True)
     user_id: UserID | None = Field(default=None, frozen=True)
     access_level: AccessLevel = Field(default=AccessLevel.BASIC, frozen=True)

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 from sqlalchemy.orm.attributes import flag_modified
 
+from tracecat.audit.logger import audit_log
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.types import Role
 from tracecat.cases.attachments import CaseAttachmentService
@@ -78,6 +79,7 @@ from tracecat.expressions.expectations import (
     create_expectation_model,
 )
 from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.logger import logger
 from tracecat.pagination import (
     BaseCursorPaginator,
     CursorPaginatedResponse,
@@ -630,7 +632,9 @@ class CasesService(BaseWorkspaceService):
 
         return case
 
+    @audit_log(resource_type="case", action="create")
     async def create_case(self, params: CaseCreate) -> Case:
+        logger.info("Creating case", session=self.session, role=self.role)
         try:
             now = datetime.now(UTC)
             # Create the base case first
@@ -671,6 +675,7 @@ class CasesService(BaseWorkspaceService):
             await self.session.rollback()
             raise
 
+    @audit_log(resource_type="case", action="update")
     async def update_case(self, case: Case, params: CaseUpdate) -> Case:
         """Update a case and optionally its custom fields.
 
@@ -796,6 +801,7 @@ class CasesService(BaseWorkspaceService):
             await self.session.rollback()
             raise
 
+    @audit_log(resource_type="case", action="delete")
     async def delete_case(self, case: Case) -> None:
         """Delete a case and optionally its associated field data.
 

--- a/tracecat/chat/service.py
+++ b/tracecat/chat/service.py
@@ -20,6 +20,7 @@ from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.types import AgentConfig, ModelMessageTA
+from tracecat.audit.logger import audit_log
 from tracecat.cases.prompts import CaseCopilotPrompts
 from tracecat.cases.service import CasesService
 from tracecat.chat.enums import ChatEntity, MessageKind
@@ -45,6 +46,7 @@ from tracecat.workspaces.prompts import WorkspaceCopilotPrompts
 class ChatService(BaseWorkspaceService):
     service_name = "chat"
 
+    @audit_log(resource_type="chat", action="create")
     async def create_chat(
         self,
         *,
@@ -388,6 +390,7 @@ class ChatService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalars().all()
 
+    @audit_log(resource_type="chat", action="update")
     async def update_chat(
         self,
         chat: Chat,

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -18,6 +18,7 @@ __all__ = [
     "ctx_interaction",
     "ctx_stream_id",
     "ctx_session",
+    "ctx_client_ip",
     "get_env",
 ]
 
@@ -27,6 +28,7 @@ ctx_logger: ContextVar[loguru.Logger] = ContextVar("logger", default=None)  # ty
 ctx_interaction: ContextVar[InteractionContext | None] = ContextVar(
     "interaction", default=None
 )
+ctx_client_ip: ContextVar[str | None] = ContextVar("client-ip", default=None)
 ctx_stream_id: ContextVar[StreamID] = ContextVar("stream-id", default=ROOT_STREAM)
 ctx_env: ContextVar[dict[str, str] | None] = ContextVar("env", default=None)
 ctx_session: ContextVar[AsyncSession | None] = ContextVar("session", default=None)

--- a/tracecat/middleware/request.py
+++ b/tracecat/middleware/request.py
@@ -1,26 +1,46 @@
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from tracecat.contexts import ctx_client_ip
+
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        # Extract request parameters
-        request_params = dict(request.query_params)
-        request_body = (
-            await request.json()
-            if request.headers.get("Content-Type") == "application/json"
-            else {}
-        )
+        # Capture client IP address
+        # Check X-Forwarded-For header first (for production behind proxies)
+        client_ip = None
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            # X-Forwarded-For format: "client, proxy1, proxy2"
+            # First IP is the original client
+            client_ip = forwarded_for.split(",")[0].strip()
+        # Fallback to direct connection IP
+        if not client_ip and request.client:
+            client_ip = request.client.host
 
-        # Log the incoming request with parameters
-        request.app.logger.debug(
-            "Incoming request",
-            method=request.method,
-            scheme=request.url.scheme,
-            hostname=request.url.hostname,
-            path=request.url.path,
-            params=request_params,
-            body=request_body,
-        )
+        token = ctx_client_ip.set(client_ip)
 
-        return await call_next(request)
+        try:
+            # Extract request parameters
+            request_params = dict(request.query_params)
+            request_body = (
+                await request.json()
+                if request.headers.get("Content-Type") == "application/json"
+                else {}
+            )
+
+            # Log the incoming request with parameters
+            request.app.logger.debug(
+                "Incoming request",
+                method=request.method,
+                scheme=request.url.scheme,
+                hostname=request.url.hostname,
+                path=request.url.path,
+                params=request_params,
+                body=request_body,
+                client_ip=client_ip,
+            )
+
+            return await call_next(request)
+        finally:
+            ctx_client_ip.reset(token)

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
+from tracecat.audit.logger import audit_log
 from tracecat.auth.types import Role
 from tracecat.db.models import BaseSecret, OrganizationSecret, Secret
 from tracecat.exceptions import (
@@ -176,6 +177,7 @@ class SecretsService(BaseService):
                 " Please double check that the name was correctly input."
             ) from e
 
+    @audit_log(resource_type="secret", action="create")
     async def create_secret(self, params: SecretCreate) -> None:
         """Create a workspace secret."""
         workspace_id = self.role.workspace_id
@@ -195,11 +197,13 @@ class SecretsService(BaseService):
         self.session.add(secret)
         await self.session.commit()
 
+    @audit_log(resource_type="secret", action="update", resource_id_attr="secret")
     async def update_secret(self, secret: Secret, params: SecretUpdate) -> None:
         """Update a workspace secret."""
 
         await self._update_secret(secret=secret, params=params)
 
+    @audit_log(resource_type="secret", action="delete", resource_id_attr="secret")
     async def delete_secret(self, secret: Secret) -> None:
         """Delete a workspace secret."""
 
@@ -280,6 +284,7 @@ class SecretsService(BaseService):
                 " Please double check that the name was correctly input."
             ) from e
 
+    @audit_log(resource_type="organization_secret", action="create")
     async def create_org_secret(self, params: SecretCreate) -> None:
         """Create a new organization secret."""
         secret = OrganizationSecret(
@@ -294,11 +299,19 @@ class SecretsService(BaseService):
         self.session.add(secret)
         await self.session.commit()
 
+    @audit_log(
+        resource_type="organization_secret", action="update", resource_id_attr="secret"
+    )
     async def update_org_secret(
         self, secret: OrganizationSecret, params: SecretUpdate
     ) -> None:
         await self._update_secret(secret=secret, params=params)
 
+    @audit_log(
+        resource_type="organization_secret",
+        action="delete",
+        resource_id_attr="org_secret",
+    )
     async def delete_org_secret(self, org_secret: OrganizationSecret) -> None:
         await self._delete_secret(org_secret)
 

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -197,13 +197,13 @@ class SecretsService(BaseService):
         self.session.add(secret)
         await self.session.commit()
 
-    @audit_log(resource_type="secret", action="update", resource_id_attr="secret")
+    @audit_log(resource_type="secret", action="update")
     async def update_secret(self, secret: Secret, params: SecretUpdate) -> None:
         """Update a workspace secret."""
 
         await self._update_secret(secret=secret, params=params)
 
-    @audit_log(resource_type="secret", action="delete", resource_id_attr="secret")
+    @audit_log(resource_type="secret", action="delete")
     async def delete_secret(self, secret: Secret) -> None:
         """Delete a workspace secret."""
 
@@ -299,9 +299,7 @@ class SecretsService(BaseService):
         self.session.add(secret)
         await self.session.commit()
 
-    @audit_log(
-        resource_type="organization_secret", action="update", resource_id_attr="secret"
-    )
+    @audit_log(resource_type="organization_secret", action="update")
     async def update_org_secret(
         self, secret: OrganizationSecret, params: SecretUpdate
     ) -> None:
@@ -310,7 +308,6 @@ class SecretsService(BaseService):
     @audit_log(
         resource_type="organization_secret",
         action="delete",
-        resource_id_attr="org_secret",
     )
     async def delete_org_secret(self, org_secret: OrganizationSecret) -> None:
         await self._delete_secret(org_secret)

--- a/tracecat/settings/constants.py
+++ b/tracecat/settings/constants.py
@@ -4,7 +4,7 @@ PUBLIC_SETTINGS_KEYS = {"auth_allowed_types"}
 """Settings that are allowed to be read by unauthenticated users.
 Currently this is used in /info to serve config to the frontend."""
 
-SENSITIVE_SETTINGS_KEYS = {"saml_idp_metadata_url"}
+SENSITIVE_SETTINGS_KEYS = {"saml_idp_metadata_url", "audit_webhook_url"}
 """Settings that are encrypted at rest."""
 
 AUTH_TYPE_TO_SETTING_KEY = {

--- a/tracecat/settings/router.py
+++ b/tracecat/settings/router.py
@@ -14,6 +14,8 @@ from tracecat.settings.schemas import (
     AgentSettingsUpdate,
     AppSettingsRead,
     AppSettingsUpdate,
+    AuditSettingsRead,
+    AuditSettingsUpdate,
     AuthSettingsRead,
     AuthSettingsUpdate,
     GitSettingsRead,
@@ -197,6 +199,30 @@ async def update_app_settings(
 ) -> None:
     service = SettingsService(session, role)
     await service.update_app_settings(params)
+
+
+@router.get("/audit", response_model=AuditSettingsRead)
+async def get_audit_settings(
+    *,
+    role: OrgAdminUserRole,
+    session: AsyncDBSession,
+) -> AuditSettingsRead:
+    service = SettingsService(session, role)
+    keys = AuditSettingsRead.keys()
+    settings = await service.list_org_settings(keys=keys)
+    settings_dict = {setting.key: service.get_value(setting) for setting in settings}
+    return AuditSettingsRead(**settings_dict)
+
+
+@router.patch("/audit", status_code=status.HTTP_204_NO_CONTENT)
+async def update_audit_settings(
+    *,
+    role: OrgAdminUserRole,
+    session: AsyncDBSession,
+    params: AuditSettingsUpdate,
+) -> None:
+    service = SettingsService(session, role)
+    await service.update_audit_settings(params)
 
 
 @router.get("/agent", response_model=AgentSettingsRead)

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -161,6 +161,21 @@ class AppSettingsUpdate(BaseSettingsGroup):
     )
 
 
+class AuditSettingsRead(BaseSettingsGroup):
+    """Settings for audit logging."""
+
+    audit_webhook_url: str | None
+
+
+class AuditSettingsUpdate(BaseSettingsGroup):
+    """Settings for audit logging."""
+
+    audit_webhook_url: str | None = Field(
+        default=None,
+        description="Webhook URL that receives streamed audit events. When unset, audit events are skipped.",
+    )
+
+
 class AgentSettingsRead(BaseSettingsGroup):
     agent_default_model: str | None
     agent_fixed_args: str | None

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -24,6 +24,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from tracecat.audit.logger import audit_log
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_workspace_role
 from tracecat.authz.enums import WorkspaceRole
@@ -252,6 +253,7 @@ class BaseTablesService(BaseWorkspaceService):
             raise TracecatNotFoundError(f"Table '{table_name}' not found")
         return table
 
+    @audit_log(resource_type="table", action="create")
     @require_workspace_role(WorkspaceRole.ADMIN, WorkspaceRole.EDITOR)
     async def create_table(self, params: TableCreate) -> Table:
         """Create a new lookup table.
@@ -317,6 +319,7 @@ class BaseTablesService(BaseWorkspaceService):
 
         return table
 
+    @audit_log(resource_type="table", action="update")
     @require_workspace_role(WorkspaceRole.ADMIN, WorkspaceRole.EDITOR)
     async def update_table(self, table: Table, params: TableUpdate) -> Table:
         """Update a lookup table."""
@@ -348,6 +351,7 @@ class BaseTablesService(BaseWorkspaceService):
         await self.session.flush()
         return table
 
+    @audit_log(resource_type="table", action="delete")
     @require_workspace_role(WorkspaceRole.ADMIN, WorkspaceRole.EDITOR)
     async def delete_table(self, table: Table) -> None:
         """Delete a lookup table."""
@@ -376,6 +380,7 @@ class BaseTablesService(BaseWorkspaceService):
             raise TracecatNotFoundError("Column not found")
         return column
 
+    @audit_log(resource_type="table_column", action="create")
     @require_workspace_role(WorkspaceRole.ADMIN, WorkspaceRole.EDITOR)
     async def create_column(
         self, table: Table, params: TableColumnCreate
@@ -447,6 +452,7 @@ class BaseTablesService(BaseWorkspaceService):
         await self.session.flush()
         return column
 
+    @audit_log(resource_type="table_column", action="update")
     @require_workspace_role(WorkspaceRole.ADMIN, WorkspaceRole.EDITOR)
     async def update_column(
         self,
@@ -616,6 +622,7 @@ class BaseTablesService(BaseWorkspaceService):
         # Commit the transaction
         await self.session.flush()
 
+    @audit_log(resource_type="table_column", action="delete")
     @require_workspace_role(WorkspaceRole.ADMIN, WorkspaceRole.EDITOR)
     async def delete_column(self, column: TableColumn) -> None:
         """Remove a column from an existing table."""

--- a/tracecat/tags/service.py
+++ b/tracecat/tags/service.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from slugify import slugify
 from sqlalchemy import select
 
+from tracecat.audit.logger import audit_log
 from tracecat.db.models import Tag
 from tracecat.identifiers import TagID
 from tracecat.service import BaseService
@@ -58,6 +59,7 @@ class TagsService(BaseService):
             # Not a UUID, try ref
             return await self.get_tag_by_ref(tag_identifier)
 
+    @audit_log(resource_type="tag", action="create")
     async def create_tag(self, tag: TagCreate) -> Tag:
         workspace_id = self.role.workspace_id
         if workspace_id is None:
@@ -78,6 +80,7 @@ class TagsService(BaseService):
         await self.session.commit()
         return db_tag
 
+    @audit_log(resource_type="tag", action="update")
     async def update_tag(self, tag: Tag, tag_update: TagUpdate) -> Tag:
         """Update tag and regenerate ref if name changed."""
         if tag_update.name and tag_update.name != tag.name:
@@ -89,6 +92,7 @@ class TagsService(BaseService):
         await self.session.refresh(tag)
         return tag
 
+    @audit_log(resource_type="tag", action="delete")
     async def delete_tag(self, tag: Tag) -> None:
         await self.session.delete(tag)
         await self.session.commit()

--- a/tracecat/variables/service.py
+++ b/tracecat/variables/service.py
@@ -6,6 +6,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
+from tracecat.audit.logger import audit_log
 from tracecat.contexts import ctx_role, ctx_run
 from tracecat.db.models import WorkspaceVariable
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
@@ -145,6 +146,7 @@ class VariablesService(BaseWorkspaceService):
                 " Please double check that the name was correctly input."
             ) from exc
 
+    @audit_log(resource_type="workspace_variable", action="create")
     async def create_variable(self, params: VariableCreate) -> WorkspaceVariable:
         if self.workspace_id is None:
             raise TracecatAuthorizationError(
@@ -163,6 +165,7 @@ class VariablesService(BaseWorkspaceService):
         await self.session.refresh(variable)
         return variable
 
+    @audit_log(resource_type="workspace_variable", action="update")
     async def update_variable(
         self, variable: WorkspaceVariable, params: VariableUpdate
     ) -> WorkspaceVariable:
@@ -176,6 +179,7 @@ class VariablesService(BaseWorkspaceService):
         await self.session.refresh(variable)
         return variable
 
+    @audit_log(resource_type="workspace_variable", action="delete")
     async def delete_variable(self, variable: WorkspaceVariable) -> None:
         await self.session.delete(variable)
         await self.session.commit()

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -22,6 +22,7 @@ from temporalio.exceptions import TerminatedError
 from temporalio.service import RPCError
 
 from tracecat import config
+from tracecat.audit.logger import audit_log
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.db.models import Interaction
@@ -694,6 +695,9 @@ class WorkflowExecutionsService:
             wf_exec_id=wf_exec_id,
         )
 
+    @audit_log(
+        resource_type="workflow_execution", action="create", resource_id_attr="wf_id"
+    )
     async def create_workflow_execution(
         self,
         dsl: DSLInput,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -695,9 +695,7 @@ class WorkflowExecutionsService:
             wf_exec_id=wf_exec_id,
         )
 
-    @audit_log(
-        resource_type="workflow_execution", action="create", resource_id_attr="wf_id"
-    )
+    @audit_log(resource_type="workflow_execution", action="create")
     async def create_workflow_execution(
         self,
         dsl: DSLInput,

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -12,6 +12,7 @@ from sqlalchemy import and_, cast, select
 from sqlalchemy.orm import selectinload
 from temporalio import activity
 
+from tracecat.audit.logger import audit_log
 from tracecat.db.models import (
     Action,
     Tag,
@@ -362,6 +363,7 @@ class WorkflowsManagementService(BaseService):
         await self.session.refresh(workflow)
         return workflow
 
+    @audit_log(resource_type="workflow", action="delete")
     async def delete_workflow(self, workflow_id: WorkflowID) -> None:
         """Delete a workflow and clean up associated resources.
 
@@ -401,6 +403,7 @@ class WorkflowsManagementService(BaseService):
         await self.session.delete(workflow)
         await self.session.commit()
 
+    @audit_log(resource_type="workflow", action="create")
     async def create_workflow(self, params: WorkflowCreate) -> Workflow:
         """Create a new workflow."""
 

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -363,7 +363,9 @@ class WorkflowsManagementService(BaseService):
         await self.session.refresh(workflow)
         return workflow
 
-    @audit_log(resource_type="workflow", action="delete")
+    @audit_log(
+        resource_type="workflow", action="delete", resource_id_attr="workflow_id"
+    )
     async def delete_workflow(self, workflow_id: WorkflowID) -> None:
         """Delete a workflow and clean up associated resources.
 

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -363,9 +363,7 @@ class WorkflowsManagementService(BaseService):
         await self.session.refresh(workflow)
         return workflow
 
-    @audit_log(
-        resource_type="workflow", action="delete", resource_id_attr="workflow_id"
-    )
+    @audit_log(resource_type="workflow", action="delete")
     async def delete_workflow(self, workflow_id: WorkflowID) -> None:
         """Delete a workflow and clean up associated resources.
 

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -292,14 +292,14 @@ async def update_workspace_membership(
 ) -> None:
     """Update a workspace membership for a user."""
     service = MembershipService(session, role=role)
-    membership = await service.get_membership(workspace_id, user_id=user_id)
-    if not membership:
+    membership_with_org = await service.get_membership(workspace_id, user_id=user_id)
+    if not membership_with_org:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Membership not found",
         )
     try:
-        await service.update_membership(membership, params=params)
+        await service.update_membership(membership_with_org.membership, params=params)
     except TracecatAuthorizationError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -323,12 +323,13 @@ async def get_workspace_membership(
 ) -> WorkspaceMembershipRead:
     """Get a workspace membership for a user."""
     service = MembershipService(session, role=role)
-    membership = await service.get_membership(workspace_id, user_id=user_id)
-    if not membership:
+    membership_with_org = await service.get_membership(workspace_id, user_id=user_id)
+    if not membership_with_org:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Membership not found",
         )
+    membership = membership_with_org.membership
     return WorkspaceMembershipRead(
         user_id=membership.user_id,
         workspace_id=membership.workspace_id,

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import load_only, noload
 
 from tracecat import config
+from tracecat.audit.logger import audit_log
 from tracecat.auth.types import AccessLevel, Role
 from tracecat.authz.controls import require_access_level
 from tracecat.authz.enums import OwnerType, WorkspaceRole
@@ -63,6 +64,7 @@ class WorkspaceService(BaseService):
         result = await self.session.execute(statement)
         return result.scalars().all()
 
+    @audit_log(resource_type="workspace", action="create")
     @require_access_level(AccessLevel.ADMIN)
     async def create_workspace(
         self,
@@ -118,6 +120,7 @@ class WorkspaceService(BaseService):
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
+    @audit_log(resource_type="workspace", action="update")
     @require_access_level(AccessLevel.ADMIN)
     async def update_workspace(
         self, workspace: Workspace, params: WorkspaceUpdate
@@ -132,6 +135,7 @@ class WorkspaceService(BaseService):
         await self.session.refresh(workspace)
         return workspace
 
+    @audit_log(resource_type="workspace", action="delete")
     @require_access_level(AccessLevel.ADMIN)
     async def delete_workspace(self, workspace_id: WorkspaceID) -> None:
         """Delete a workspace."""


### PR DESCRIPTION
## Summary
- Added AuditEventStatus enum (ATTEMPT, SUCCESS, FAILURE) to track action outcomes throughout the system
- Created AuditLogger context manager that automatically logs attempt/success/failure for user actions with mutable context support for setting resource IDs dynamically
- Changed resource_id field from string to uuid.UUID for type safety and consistency with database models
- Integrated audit logging across all user-driven endpoints: authentication flows, organization/workspace management, cases, workflows, secrets, variables, tables, tags, integrations (OAuth/MCP), and agent credentials/presets


















































<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a lightweight audit logging system that streams user events to a configurable webhook. Captures client IP and org/workspace context, and logs ATTEMPT/SUCCESS/FAILURE without slowing requests.

- **New Features**
  - AuditService posts JSON payloads (includes actor_label from user email) to a webhook configured via Organization Settings.
  - @audit_log decorator wraps service methods to emit attempt/success/failure and auto-detect resource_id.
  - Request middleware records client IP from X-Forwarded-For or connection.
  - Added API and UI for managing audit settings (/settings/audit and Organization Settings → Audit Logs).
  - Role now includes organization_id to scope events.
  - Instrumented core services: agents (presets), cases, chats, tables/columns, tags, variables, workflows, workspaces, secrets, and organization settings.

- **Migration**
  - Configure the webhook via Organization Settings → Audit Logs.
  - If behind a proxy, ensure X-Forwarded-For is forwarded.

<sup>Written for commit 16fba43da52949ed048429787aae02df46a0d434. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



















































