### PR TITLE
fix(ui): Adjust dropdown menu styling for better overflow handling in action panel

### DIFF
--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -1290,7 +1290,8 @@ function ActionPanelContent({
                                       </DropdownMenuTrigger>
                                       <DropdownMenuContent
                                         align="start"
-                                        className="max-w-96"
+                                        collisionPadding={8}
+                                        className="max-h-[var(--radix-dropdown-menu-content-available-height)] max-w-96 overflow-y-auto"
                                       >
                                         {optionalFields.map(
                                           ([fieldName, fieldDefn]) => {


### PR DESCRIPTION
## Summary
- Add `collisionPadding` and overflow handling to the optional fields dropdown menu in the action panel
- Prevents dropdown content from being cut off when there are many optional fields

## Changes
- Added `collisionPadding={8}` for better viewport edge handling
- Added `max-height` constraint using Radix CSS variable for available height
- Added `overflow-y-auto` to enable scrolling when content exceeds available space

## Screens
### Before

<img width="499" height="396" alt="image" src="https://github.com/user-attachments/assets/698308e0-ba71-4cab-852e-ec0d583cfa1f" />

### After

<img width="1035" height="627" alt="Screenshot 2025-12-04 at 13 55 14" src="https://github.com/user-attachments/assets/21797c93-1131-4d1c-b556-d95628a4b9c9" />
