### PR TITLE
refactor(db): Migrate prefixed IDs to native PostgreSQL UUIDs

### DIFF
--- a/alembic/versions/0fd1f09cd98b_make_workspace_id_non_nullable_for_.py
+++ b/alembic/versions/0fd1f09cd98b_make_workspace_id_non_nullable_for_.py
@@ -1,7 +1,7 @@
 """make workspace_id non-nullable for workspace-scoped models
 
 Revision ID: 0fd1f09cd98b
-Revises: a1b2c3d4e5f6
+Revises: b23b877ee161
 Create Date: 2025-12-04 14:14:05.910579
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0fd1f09cd98b"
-down_revision: str | None = "a1b2c3d4e5f6"
+down_revision: str | None = "b23b877ee161"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/b23b877ee161_migrate_prefixed_ids_to_uuid.py
+++ b/alembic/versions/b23b877ee161_migrate_prefixed_ids_to_uuid.py
@@ -1,0 +1,476 @@
+"""Migrate prefixed IDs to UUID
+
+Revision ID: b23b877ee161
+Revises: a1b2c3d4e5f6
+Create Date: 2025-12-03
+
+Migrates the following tables from prefixed string IDs to native PostgreSQL UUIDs:
+- secret (prefix: secret-)
+- organization_secret (prefix: secret-)
+- workflow_definition (prefix: wf-defn-)
+- webhook (prefix: wh-) - has FK from webhook_api_key
+- schedule (prefix: sch-)
+- action (prefix: act-) - has JSON refs in workflow.object
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.logger import logger
+
+# revision identifiers, used by Alembic.
+revision: str = "b23b877ee161"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Tables and their prefixes (prefix length includes the trailing dash)
+SIMPLE_TABLES = {
+    "secret": 7,  # "secret-" = 7 chars
+    "organization_secret": 7,  # "secret-" = 7 chars
+    "workflow_definition": 8,  # "wf-defn-" = 8 chars
+    "schedule": 4,  # "sch-" = 4 chars
+}
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    # =========================================================================
+    # 1. Migrate simple tables (no FK references): secret, organization_secret,
+    #    workflow_definition, schedule
+    # =========================================================================
+    for table, prefix_len in SIMPLE_TABLES.items():
+        logger.info(f"Migrating {table}.id from prefixed string to UUID")
+
+        # Add new UUID column
+        op.add_column(table, sa.Column("id_new", sa.UUID(), nullable=True))
+
+        # Populate new column by extracting UUID from prefixed ID
+        connection.execute(
+            sa.text(f"""
+            UPDATE {table}
+            SET id_new = CAST(substring(id from {prefix_len + 1}) AS uuid)
+        """)
+        )
+
+        # Make the new column NOT NULL
+        op.alter_column(table, "id_new", nullable=False)
+
+        # Drop the unique index on id (all tables use ix_<table>_id pattern)
+        op.drop_index(f"ix_{table}_id", table_name=table)
+
+        # Drop old column and rename new column
+        op.drop_column(table, "id")
+        op.alter_column(table, "id_new", new_column_name="id")
+
+        # Recreate unique index
+        op.create_index(f"ix_{table}_id", table, ["id"], unique=True)
+
+    # =========================================================================
+    # 2. Migrate webhook table (has FK from webhook_api_key)
+    # =========================================================================
+    logger.info("Migrating webhook.id from prefixed string to UUID")
+
+    # Drop the FK constraint from webhook_api_key first
+    op.drop_constraint(
+        "fk_webhook_api_key_webhook_id_webhook", "webhook_api_key", type_="foreignkey"
+    )
+
+    # Drop the unique constraint on webhook_api_key.webhook_id
+    op.drop_constraint(
+        "uq_webhook_api_key_webhook_id", "webhook_api_key", type_="unique"
+    )
+
+    # Add new UUID columns to both tables
+    op.add_column("webhook", sa.Column("id_new", sa.UUID(), nullable=True))
+    op.add_column(
+        "webhook_api_key", sa.Column("webhook_id_new", sa.UUID(), nullable=True)
+    )
+
+    # Populate webhook.id_new (wh- = 3 chars)
+    connection.execute(
+        sa.text("""
+        UPDATE webhook
+        SET id_new = CAST(substring(id from 4) AS uuid)
+    """)
+    )
+
+    # Populate webhook_api_key.webhook_id_new by joining with webhook
+    connection.execute(
+        sa.text("""
+        UPDATE webhook_api_key wak
+        SET webhook_id_new = w.id_new
+        FROM webhook w
+        WHERE wak.webhook_id = w.id
+    """)
+    )
+
+    # Make webhook.id_new NOT NULL
+    op.alter_column("webhook", "id_new", nullable=False)
+
+    # Drop unique index on webhook.id
+    op.drop_index("ix_webhook_id", table_name="webhook")
+
+    # Drop old columns and rename new columns
+    op.drop_column("webhook", "id")
+    op.alter_column("webhook", "id_new", new_column_name="id")
+
+    op.drop_column("webhook_api_key", "webhook_id")
+    op.alter_column("webhook_api_key", "webhook_id_new", new_column_name="webhook_id")
+
+    # Recreate unique index on webhook.id
+    op.create_index("ix_webhook_id", "webhook", ["id"], unique=True)
+
+    # Recreate unique constraint on webhook_api_key.webhook_id
+    op.create_unique_constraint(
+        "uq_webhook_api_key_webhook_id", "webhook_api_key", ["webhook_id"]
+    )
+
+    # Recreate FK constraint
+    op.create_foreign_key(
+        "fk_webhook_api_key_webhook_id_webhook",
+        "webhook_api_key",
+        "webhook",
+        ["webhook_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # =========================================================================
+    # 3. Migrate action table (has JSON refs in workflow.object)
+    # =========================================================================
+    logger.info("Migrating action.id from prefixed string to UUID")
+
+    # Add new UUID column to action
+    op.add_column("action", sa.Column("id_new", sa.UUID(), nullable=True))
+
+    # Populate action.id_new (act- = 4 chars)
+    connection.execute(
+        sa.text("""
+        UPDATE action
+        SET id_new = CAST(substring(id from 5) AS uuid)
+    """)
+    )
+
+    # Update workflow.object JSON - replace action IDs in nodes[].id
+    logger.info("Updating workflow.object JSON with new action UUIDs")
+    connection.execute(
+        sa.text("""
+        WITH action_mapping AS (
+            SELECT id AS old_id, id_new AS new_id FROM action
+        )
+        UPDATE workflow w
+        SET object = jsonb_set(
+            w.object,
+            '{nodes}',
+            (
+                SELECT COALESCE(
+                    jsonb_agg(
+                        CASE
+                            WHEN m.new_id IS NOT NULL
+                            THEN jsonb_set(node, '{id}', to_jsonb(m.new_id::text))
+                            ELSE node
+                        END
+                        ORDER BY ordinality
+                    ),
+                    '[]'::jsonb
+                )
+                FROM jsonb_array_elements(w.object->'nodes') WITH ORDINALITY AS t(node, ordinality)
+                LEFT JOIN action_mapping m ON node->>'id' = m.old_id
+            )
+        )
+        WHERE w.object IS NOT NULL
+          AND w.object->'nodes' IS NOT NULL
+          AND jsonb_array_length(w.object->'nodes') > 0
+    """)
+    )
+
+    # Update workflow.object JSON - replace action IDs in edges[].source and edges[].target
+    logger.info("Updating workflow.object edges with new action UUIDs")
+    connection.execute(
+        sa.text("""
+        WITH action_mapping AS (
+            SELECT id AS old_id, id_new AS new_id FROM action
+        )
+        UPDATE workflow w
+        SET object = jsonb_set(
+            w.object,
+            '{edges}',
+            (
+                SELECT COALESCE(
+                    jsonb_agg(
+                        (
+                            SELECT
+                                CASE
+                                    WHEN m_tgt.new_id IS NOT NULL
+                                    THEN jsonb_set(edge_with_source, '{target}', to_jsonb(m_tgt.new_id::text))
+                                    ELSE edge_with_source
+                                END
+                            FROM (
+                                SELECT
+                                    CASE
+                                        WHEN m_src.new_id IS NOT NULL
+                                        THEN jsonb_set(edge, '{source}', to_jsonb(m_src.new_id::text))
+                                        ELSE edge
+                                    END AS edge_with_source
+                                FROM action_mapping m_src
+                                WHERE edge->>'source' = m_src.old_id
+                                UNION ALL
+                                SELECT edge AS edge_with_source
+                                WHERE NOT EXISTS (
+                                    SELECT 1 FROM action_mapping m_src
+                                    WHERE edge->>'source' = m_src.old_id
+                                )
+                            ) source_sub
+                            LEFT JOIN action_mapping m_tgt ON edge->>'target' = m_tgt.old_id
+                            LIMIT 1
+                        )
+                        ORDER BY ordinality
+                    ),
+                    '[]'::jsonb
+                )
+                FROM jsonb_array_elements(w.object->'edges') WITH ORDINALITY AS t(edge, ordinality)
+            )
+        )
+        WHERE w.object IS NOT NULL
+          AND w.object->'edges' IS NOT NULL
+          AND jsonb_array_length(w.object->'edges') > 0
+    """)
+    )
+
+    # Update workflow.entrypoint - convert prefixed action ID to UUID
+    logger.info("Updating workflow.entrypoint with new action UUIDs")
+    connection.execute(
+        sa.text("""
+        UPDATE workflow w
+        SET entrypoint = a.id_new::text
+        FROM action a
+        WHERE w.entrypoint = a.id
+          AND w.entrypoint IS NOT NULL
+    """)
+    )
+
+    # Make action.id_new NOT NULL
+    op.alter_column("action", "id_new", nullable=False)
+
+    # Drop unique index on action.id
+    op.drop_index("ix_action_id", table_name="action")
+
+    # Drop old column and rename new column
+    op.drop_column("action", "id")
+    op.alter_column("action", "id_new", new_column_name="id")
+
+    # Recreate unique index
+    op.create_index("ix_action_id", "action", ["id"], unique=True)
+
+    logger.info("Migration complete: all prefixed IDs converted to UUIDs")
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    # =========================================================================
+    # 1. Downgrade action table
+    # =========================================================================
+    logger.info("Downgrading action.id from UUID to prefixed string")
+
+    # Add old column
+    op.add_column("action", sa.Column("id_old", sa.String(64), nullable=True))
+
+    # Populate old column
+    connection.execute(
+        sa.text("""
+        UPDATE action
+        SET id_old = 'act-' || replace(id::text, '-', '')
+    """)
+    )
+
+    # Update workflow.object JSON - restore prefixed IDs in nodes
+    # Use string comparison (id::text) to avoid casting non-UUID strings like "trigger-xxx"
+    connection.execute(
+        sa.text("""
+        WITH action_mapping AS (
+            SELECT id::text AS new_id, id_old AS old_id FROM action
+        )
+        UPDATE workflow w
+        SET object = jsonb_set(
+            w.object,
+            '{nodes}',
+            (
+                SELECT COALESCE(
+                    jsonb_agg(
+                        CASE
+                            WHEN m.old_id IS NOT NULL
+                            THEN jsonb_set(node, '{id}', to_jsonb(m.old_id))
+                            ELSE node
+                        END
+                        ORDER BY ordinality
+                    ),
+                    '[]'::jsonb
+                )
+                FROM jsonb_array_elements(w.object->'nodes') WITH ORDINALITY AS t(node, ordinality)
+                LEFT JOIN action_mapping m ON node->>'id' = m.new_id
+            )
+        )
+        WHERE w.object IS NOT NULL
+          AND w.object->'nodes' IS NOT NULL
+          AND jsonb_array_length(w.object->'nodes') > 0
+    """)
+    )
+
+    # Update workflow.object edges - restore prefixed IDs
+    # Use string comparison to avoid casting non-UUID strings
+    connection.execute(
+        sa.text("""
+        WITH action_mapping AS (
+            SELECT id::text AS new_id, id_old AS old_id FROM action
+        )
+        UPDATE workflow w
+        SET object = jsonb_set(
+            w.object,
+            '{edges}',
+            (
+                SELECT COALESCE(
+                    jsonb_agg(
+                        (
+                            SELECT
+                                CASE
+                                    WHEN m_tgt.old_id IS NOT NULL
+                                    THEN jsonb_set(edge_with_source, '{target}', to_jsonb(m_tgt.old_id))
+                                    ELSE edge_with_source
+                                END
+                            FROM (
+                                SELECT
+                                    CASE
+                                        WHEN m_src.old_id IS NOT NULL
+                                        THEN jsonb_set(edge, '{source}', to_jsonb(m_src.old_id))
+                                        ELSE edge
+                                    END AS edge_with_source
+                                FROM action_mapping m_src
+                                WHERE edge->>'source' = m_src.new_id
+                                UNION ALL
+                                SELECT edge AS edge_with_source
+                                WHERE NOT EXISTS (
+                                    SELECT 1 FROM action_mapping m_src
+                                    WHERE edge->>'source' = m_src.new_id
+                                )
+                            ) source_sub
+                            LEFT JOIN action_mapping m_tgt ON edge->>'target' = m_tgt.new_id
+                            LIMIT 1
+                        )
+                        ORDER BY ordinality
+                    ),
+                    '[]'::jsonb
+                )
+                FROM jsonb_array_elements(w.object->'edges') WITH ORDINALITY AS t(edge, ordinality)
+            )
+        )
+        WHERE w.object IS NOT NULL
+          AND w.object->'edges' IS NOT NULL
+          AND jsonb_array_length(w.object->'edges') > 0
+    """)
+    )
+
+    # Restore workflow.entrypoint to prefixed action ID
+    connection.execute(
+        sa.text("""
+        UPDATE workflow w
+        SET entrypoint = a.id_old
+        FROM action a
+        WHERE w.entrypoint = a.id::text
+          AND w.entrypoint IS NOT NULL
+    """)
+    )
+
+    op.alter_column("action", "id_old", nullable=False)
+    op.drop_index("ix_action_id", table_name="action")
+    op.drop_column("action", "id")
+    op.alter_column("action", "id_old", new_column_name="id")
+    op.create_index("ix_action_id", "action", ["id"], unique=True)
+
+    # =========================================================================
+    # 2. Downgrade webhook table
+    # =========================================================================
+    logger.info("Downgrading webhook.id from UUID to prefixed string")
+
+    op.drop_constraint(
+        "fk_webhook_api_key_webhook_id_webhook", "webhook_api_key", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "uq_webhook_api_key_webhook_id", "webhook_api_key", type_="unique"
+    )
+
+    op.add_column("webhook", sa.Column("id_old", sa.String(64), nullable=True))
+    op.add_column(
+        "webhook_api_key", sa.Column("webhook_id_old", sa.String(64), nullable=True)
+    )
+
+    connection.execute(
+        sa.text("""
+        UPDATE webhook
+        SET id_old = 'wh-' || replace(id::text, '-', '')
+    """)
+    )
+
+    connection.execute(
+        sa.text("""
+        UPDATE webhook_api_key wak
+        SET webhook_id_old = w.id_old
+        FROM webhook w
+        WHERE wak.webhook_id = w.id
+    """)
+    )
+
+    op.alter_column("webhook", "id_old", nullable=False)
+    op.drop_index("ix_webhook_id", table_name="webhook")
+    op.drop_column("webhook", "id")
+    op.alter_column("webhook", "id_old", new_column_name="id")
+
+    op.drop_column("webhook_api_key", "webhook_id")
+    op.alter_column("webhook_api_key", "webhook_id_old", new_column_name="webhook_id")
+
+    op.create_index("ix_webhook_id", "webhook", ["id"], unique=True)
+    op.create_unique_constraint(
+        "uq_webhook_api_key_webhook_id", "webhook_api_key", ["webhook_id"]
+    )
+    op.create_foreign_key(
+        "fk_webhook_api_key_webhook_id_webhook",
+        "webhook_api_key",
+        "webhook",
+        ["webhook_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # =========================================================================
+    # 3. Downgrade simple tables
+    # =========================================================================
+    prefixes = {
+        "secret": "secret-",
+        "organization_secret": "secret-",
+        "workflow_definition": "wf-defn-",
+        "schedule": "sch-",
+    }
+
+    for table, prefix in prefixes.items():
+        logger.info(f"Downgrading {table}.id from UUID to prefixed string")
+
+        op.add_column(table, sa.Column("id_old", sa.String(255), nullable=True))
+
+        connection.execute(
+            sa.text(f"""
+            UPDATE {table}
+            SET id_old = '{prefix}' || replace(id::text, '-', '')
+        """)
+        )
+
+        op.alter_column(table, "id_old", nullable=False)
+        op.drop_index(f"ix_{table}_id", table_name=table)
+        op.drop_column(table, "id")
+        op.alter_column(table, "id_old", new_column_name="id")
+        op.create_index(f"ix_{table}_id", table, ["id"], unique=True)
+
+    logger.info("Downgrade complete: all UUIDs converted back to prefixed IDs")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -176,7 +176,7 @@ export const $ActionRead = {
   properties: {
     id: {
       type: "string",
-      pattern: "act-[0-9a-f]{32}",
+      format: "uuid",
       title: "Id",
     },
     type: {
@@ -256,7 +256,7 @@ export const $ActionReadMinimal = {
   properties: {
     id: {
       type: "string",
-      pattern: "act-[0-9a-f]{32}",
+      format: "uuid",
       title: "Id",
     },
     workflow_id: {
@@ -5549,14 +5549,14 @@ export const $DSLRunArgs = {
       anyOf: [
         {
           type: "string",
-          pattern: "sch-[0-9a-f]{32}",
         },
         {
           type: "null",
         },
       ],
       title: "Schedule Id",
-      description: "The schedule ID that triggered this workflow, if any.",
+      description:
+        "The schedule ID that triggered this workflow, if any. Auto-converts from legacy 'sch-<hex>' format.",
     },
   },
   type: "object",
@@ -6206,7 +6206,7 @@ export const $EventGroup_TypeVar_ = {
         {
           type: "string",
           pattern:
-            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
         },
         {
           type: "string",
@@ -7659,7 +7659,7 @@ export const $InteractionContext = {
     execution_id: {
       type: "string",
       pattern:
-        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
       title: "Execution Id",
     },
     action_ref: {
@@ -7683,7 +7683,7 @@ export const $InteractionInput = {
     execution_id: {
       type: "string",
       pattern:
-        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
       title: "Execution Id",
     },
     action_ref: {
@@ -7765,7 +7765,7 @@ export const $InteractionRead = {
     wf_exec_id: {
       type: "string",
       pattern:
-        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
       title: "Wf Exec Id",
     },
     actor: {
@@ -8540,6 +8540,7 @@ export const $OrganizationSecretRead = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
     },
     type: {
@@ -10812,7 +10813,7 @@ export const $RunContext = {
     wf_exec_id: {
       type: "string",
       pattern:
-        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
       title: "Wf Exec Id",
     },
     wf_run_id: {
@@ -11078,7 +11079,6 @@ export const $ScheduleRead = {
   properties: {
     id: {
       type: "string",
-      pattern: "sch-[0-9a-f]{32}",
       title: "Id",
     },
     workspace_id: {
@@ -11446,6 +11446,7 @@ export const $SecretRead = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
     },
     type: {
@@ -11524,6 +11525,7 @@ export const $SecretReadMinimal = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
     },
     type: {
@@ -15318,6 +15320,7 @@ export const $WebhookRead = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
     },
     secret: {
@@ -15508,6 +15511,7 @@ export const $WorkflowDefinitionRead = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
     },
     workflow_id: {
@@ -15570,6 +15574,7 @@ export const $WorkflowDefinitionReadMinimal = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
     },
     version: {
@@ -15850,7 +15855,7 @@ export const $WorkflowExecutionCreateResponse = {
     wf_exec_id: {
       type: "string",
       pattern:
-        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+        "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
       title: "Wf Exec Id",
     },
     payload: {
@@ -15926,7 +15931,7 @@ export const $WorkflowExecutionEvent = {
         {
           type: "string",
           pattern:
-            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
         },
         {
           type: "null",
@@ -16036,7 +16041,7 @@ export const $WorkflowExecutionEventCompact_Any__Union_AgentOutput__Any___Any_ =
           {
             type: "string",
             pattern:
-              "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+              "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
           },
           {
             type: "null",
@@ -16183,7 +16188,7 @@ export const $WorkflowExecutionRead = {
         {
           type: "string",
           pattern:
-            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
         },
         {
           type: "null",
@@ -16301,7 +16306,7 @@ export const $WorkflowExecutionReadCompact_Any__Union_AgentOutput__Any___Any_ =
           {
             type: "string",
             pattern:
-              "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+              "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
           },
           {
             type: "null",
@@ -16418,7 +16423,7 @@ export const $WorkflowExecutionReadMinimal = {
         {
           type: "string",
           pattern:
-            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|sch-[0-9a-f]{32}-.*))",
+            "(?P<workflow_id>wf-[0-9a-f]{32}|wf_[0-9a-zA-Z]+)[:/](?P<execution_id>(exec_[0-9a-zA-Z]+|exec-[\\w-]+|(?:sch-[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-.*))",
         },
         {
           type: "null",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1718,7 +1718,7 @@ export type DSLRunArgs = {
    */
   timeout?: string
   /**
-   * The schedule ID that triggered this workflow, if any.
+   * The schedule ID that triggered this workflow, if any. Auto-converts from legacy 'sch-<hex>' format.
    */
   schedule_id?: string | null
 }

--- a/tests/unit/api/test_api_secrets.py
+++ b/tests/unit/api/test_api_secrets.py
@@ -22,7 +22,7 @@ from tracecat.secrets.schemas import SecretKeyValue
 def mock_secret(test_workspace: Workspace) -> Secret:
     """Create a mock secret DB object."""
     secret = Secret(
-        id="secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        id=uuid.UUID("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"),
         workspace_id=test_workspace.id,
         name="test_secret",
         type=SecretType.CUSTOM,
@@ -272,7 +272,7 @@ async def test_update_secret_by_id_not_found(
         MockService.return_value = mock_svc
 
         # Make request
-        fake_id = "secret-00000000000000000000000000000000"
+        fake_id = "00000000-0000-4000-8000-000000000000"
         response = client.post(
             f"/secrets/{fake_id}",
             params={"workspace_id": str(test_admin_role.workspace_id)},
@@ -319,7 +319,7 @@ async def test_delete_secret_by_id_not_found(
         MockService.return_value = mock_svc
 
         # Make request
-        fake_id = "secret-00000000000000000000000000000000"
+        fake_id = "00000000-0000-4000-8000-000000000000"
         response = client.delete(
             f"/secrets/{fake_id}",
             params={"workspace_id": str(test_admin_role.workspace_id)},
@@ -336,7 +336,7 @@ async def test_delete_secret_by_id_not_found(
 def mock_org_secret(mock_org_id: uuid.UUID) -> OrganizationSecret:
     """Create a mock organization secret DB object."""
     secret = OrganizationSecret(
-        id="secret-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        id=uuid.UUID("bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"),
         organization_id=mock_org_id,
         name="org_secret",
         type=SecretType.CUSTOM,

--- a/tests/unit/api/test_api_workflow_actions.py
+++ b/tests/unit/api/test_api_workflow_actions.py
@@ -42,7 +42,7 @@ def mock_workflow(test_workspace: Workspace) -> Workflow:
 def mock_action(test_workspace: Workspace, mock_workflow: Workflow) -> Action:
     """Create a mock action DB object."""
     action = Action(
-        id="act-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        id=uuid.UUID("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaab"),
         workspace_id=test_workspace.id,
         workflow_id=mock_workflow.id,
         type="core.http_request",
@@ -167,7 +167,7 @@ async def test_get_action_not_found(
         mock_get.return_value = None
 
         workflow_id = str(mock_workflow.id)
-        fake_action_id = "act-00000000000000000000000000000000"
+        fake_action_id = "00000000-0000-4000-8000-000000000000"
 
         response = client.get(
             f"/actions/{fake_action_id}",
@@ -193,7 +193,7 @@ async def test_update_action_not_found(
         mock_get.return_value = None
 
         workflow_id = str(mock_workflow.id)
-        fake_action_id = "act-00000000000000000000000000000000"
+        fake_action_id = "00000000-0000-4000-8000-000000000000"
 
         response = client.post(
             f"/actions/{fake_action_id}",

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -46,7 +46,7 @@ def mock_workflow(test_workspace: Workspace) -> Workflow:
 def mock_webhook(test_workspace: Workspace, mock_workflow: Workflow) -> Webhook:
     """Create a mock webhook DB object."""
     return Webhook(
-        id="wh-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        id=uuid.UUID("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaac"),
         workspace_id=test_workspace.id,
         workflow_id=mock_workflow.id,
         status="online",
@@ -504,7 +504,7 @@ async def test_get_workflow_with_relationships(
             updated_at=datetime(2024, 1, 1, tzinfo=UTC),
         )
         mock_action = Action(
-            id="act-12345678901234567890123456789012",
+            id=uuid.UUID("12345678-1234-4123-8123-123456789012"),
             type="webhook",
             title="Test Action",
             description="Test action description",
@@ -518,7 +518,7 @@ async def test_get_workflow_with_relationships(
             updated_at=datetime(2024, 1, 1, tzinfo=UTC),
         )
         mock_schedule = Schedule(
-            id="sch-12345678901234567890123456789012",
+            id=uuid.UUID("12345678-1234-4123-8123-123456789013"),
             status="online",
             workspace_id=test_workspace.id,
             workflow_id=mock_workflow.id,
@@ -553,9 +553,9 @@ async def test_get_workflow_with_relationships(
 
         # Verify relationships are properly serialized
         assert "actions" in data
-        assert "act-12345678901234567890123456789012" in data["actions"]
+        assert "12345678-1234-4123-8123-123456789012" in data["actions"]
         assert (
-            data["actions"]["act-12345678901234567890123456789012"]["title"]
+            data["actions"]["12345678-1234-4123-8123-123456789012"]["title"]
             == "Test Action"
         )
 

--- a/tests/unit/test_expressions.py
+++ b/tests/unit/test_expressions.py
@@ -445,7 +445,7 @@ def test_evaluate_templated_secret(test_role: Role):
         # Mock workflow getter from API side
         for secret_name, secret_keys in TEST_SECRETS.items():
             secret = Secret(
-                id=f"secret_{uuid.uuid4().hex}",
+                id=uuid.uuid4(),
                 name=secret_name,
                 workspace_id=uuid.uuid4(),
                 # Explicitly set the concrete secret type so enums can be resolved during serialization.

--- a/tests/unit/test_schedule_update_cron_clearing.py
+++ b/tests/unit/test_schedule_update_cron_clearing.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import temporalio.client
 
-from tracecat.identifiers.resource import ResourcePrefix
+from tracecat.identifiers import ScheduleUUID
 from tracecat.workflow.schedules import bridge
 from tracecat.workflow.schedules.schemas import ScheduleUpdate
 
@@ -15,7 +15,7 @@ from tracecat.workflow.schedules.schemas import ScheduleUpdate
 async def test_update_schedule_from_cron_to_interval_clears_cron():
     """Test that updating a schedule from cron to interval clears existing cron expressions."""
 
-    schedule_id = ResourcePrefix.SCHEDULE.factory()()
+    schedule_id = ScheduleUUID.new_uuid4()
 
     # Mock the Temporal handle
     mock_handle = MagicMock()
@@ -82,7 +82,7 @@ async def test_update_schedule_from_cron_to_interval_clears_cron():
 async def test_update_schedule_with_explicit_cron_clears_interval():
     """Test that updating a schedule with explicit cron clears intervals."""
 
-    schedule_id = ResourcePrefix.SCHEDULE.factory()()
+    schedule_id = ScheduleUUID.new_uuid4()
 
     # Mock the Temporal handle
     mock_handle = MagicMock()
@@ -147,7 +147,7 @@ async def test_update_schedule_with_explicit_cron_clears_interval():
 async def test_update_schedule_preserves_existing_when_neither_provided():
     """Test that not providing cron or interval preserves existing schedule type."""
 
-    schedule_id = ResourcePrefix.SCHEDULE.factory()()
+    schedule_id = ScheduleUUID.new_uuid4()
 
     # Mock the Temporal handle
     mock_handle = MagicMock()

--- a/tests/unit/test_workflow_schedule_cleanup.py
+++ b/tests/unit/test_workflow_schedule_cleanup.py
@@ -9,7 +9,6 @@ import pytest
 from tracecat.auth.types import Role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import Schedule, Workflow
-from tracecat.identifiers.resource import ResourcePrefix
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.management.management import WorkflowsManagementService
 
@@ -37,7 +36,7 @@ async def test_delete_workflow_cleans_up_schedules(test_role: Role):
 
         # Create test schedules in the database
         schedule1 = Schedule(
-            id=ResourcePrefix.SCHEDULE.factory()(),
+            id=uuid.uuid4(),
             workflow_id=workflow.id,
             workspace_id=test_role.workspace_id
             if test_role.workspace_id
@@ -49,7 +48,7 @@ async def test_delete_workflow_cleans_up_schedules(test_role: Role):
             timeout=None,
         )
         schedule2 = Schedule(
-            id=ResourcePrefix.SCHEDULE.factory()(),
+            id=uuid.uuid4(),
             workflow_id=workflow.id,
             workspace_id=test_role.workspace_id
             if test_role.workspace_id
@@ -104,7 +103,7 @@ async def test_delete_workflow_handles_temporal_errors_gracefully(test_role: Rol
 
         # Create a test schedule
         schedule = Schedule(
-            id=ResourcePrefix.SCHEDULE.factory()(),
+            id=uuid.uuid4(),
             workflow_id=workflow.id,
             workspace_id=test_role.workspace_id
             if test_role.workspace_id

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -175,7 +175,7 @@ class ExecuteToolCallResult(BaseModel):
 
 
 class ModelRequestArgs(BaseModel):
-    model_config: ConfigDict = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     role: Role
     messages: list[ModelMessage]
     model_settings: ModelSettings | None

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -60,7 +60,6 @@ from tracecat.identifiers import (
     OwnerID,
     WorkspaceID,
     action,
-    id_factory,
 )
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
@@ -417,12 +416,12 @@ class BaseSecret(Base):
 
     __abstract__ = True
 
-    id: Mapped[str] = mapped_column(
-        String(255),
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
         nullable=False,
         unique=True,
         index=True,
-        default=id_factory("secret"),
     )
     type: Mapped[str] = mapped_column(String(255), nullable=False, default="custom")
     name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
@@ -501,9 +500,9 @@ class WorkflowDefinition(WorkspaceModel):
 
     __tablename__ = "workflow_definition"
 
-    id: Mapped[str] = mapped_column(
-        String(64),
-        default=id_factory("wf-defn"),
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
         nullable=False,
         unique=True,
         index=True,
@@ -701,8 +700,8 @@ class WebhookApiKey(WorkspaceModel):
         unique=True,
         index=True,
     )
-    webhook_id: Mapped[str | None] = mapped_column(
-        String,
+    webhook_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
         ForeignKey("webhook.id", ondelete="CASCADE"),
         nullable=True,
         unique=True,
@@ -724,9 +723,9 @@ class WebhookApiKey(WorkspaceModel):
 class Webhook(WorkspaceModel):
     __tablename__ = "webhook"
 
-    id: Mapped[str] = mapped_column(
-        String(64),
-        default=id_factory("wh"),
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
         nullable=False,
         unique=True,
         index=True,
@@ -800,9 +799,9 @@ class Webhook(WorkspaceModel):
 class Schedule(WorkspaceModel):
     __tablename__ = "schedule"
 
-    id: Mapped[str] = mapped_column(
-        String(64),
-        default=id_factory("sch"),
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
         nullable=False,
         unique=True,
         index=True,
@@ -847,9 +846,9 @@ class Action(WorkspaceModel):
 
     __tablename__ = "action"
 
-    id: Mapped[str] = mapped_column(
-        String(64),
-        default=id_factory("act"),
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
         nullable=False,
         unique=True,
         index=True,

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -64,7 +64,7 @@ from tracecat.exceptions import (
 from tracecat.expressions.common import ExprContext
 from tracecat.expressions.core import extract_expressions
 from tracecat.expressions.expectations import ExpectedField
-from tracecat.identifiers import ScheduleID
+from tracecat.identifiers.schedules import ScheduleUUID
 from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID
 from tracecat.interactions.schemas import ActionInteractionValidator
 from tracecat.logger import logger
@@ -452,9 +452,9 @@ class DSLRunArgs(BaseModel):
         description="Platform activity start-to-close timeout.",
     )
     """Platform activity start-to-close timeout."""
-    schedule_id: ScheduleID | None = Field(
+    schedule_id: ScheduleUUID | None = Field(
         default=None,
-        description="The schedule ID that triggered this workflow, if any.",
+        description="The schedule ID that triggered this workflow, if any. Auto-converts from legacy 'sch-<hex>' format.",
     )
 
     @field_validator("wf_id", mode="before")
@@ -608,7 +608,8 @@ def build_action_statements(
     graph: RFGraph, actions: list[Action]
 ) -> list[ActionStatement]:
     """Convert DB Actions into ActionStatements using the graph."""
-    id2action = {action.id: action for action in actions}
+    # Use string keys since graph node IDs are strings (UUID format)
+    id2action = {str(action.id): action for action in actions}
 
     statements = []
     for node in graph.action_nodes():

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -102,7 +102,7 @@ class DSLInput(BaseModel):
     """
 
     # Using this for backwards compatibility of existing workflow definitions
-    model_config: ConfigDict = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore")
     title: str
     description: str
     entrypoint: DSLEntrypoint

--- a/tracecat/dsl/schemas.py
+++ b/tracecat/dsl/schemas.py
@@ -59,7 +59,7 @@ class ActionRetryPolicy(BaseModel):
 
 
 class ActionStatement(BaseModel):
-    id: str | None = Field(
+    id: uuid.UUID | None = Field(
         default=None,
         exclude=True,
         description=(

--- a/tracecat/dsl/validation.py
+++ b/tracecat/dsl/validation.py
@@ -79,7 +79,7 @@ def normalize_trigger_inputs(
 
 
 class ValidateTriggerInputsActivityInputs(BaseModel):
-    model_config: ConfigDict = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     dsl: DSLInput
     trigger_inputs: TriggerInputs
 
@@ -95,7 +95,7 @@ async def validate_trigger_inputs_activity(
 
 
 class NormalizeTriggerInputsActivityInputs(BaseModel):
-    model_config: ConfigDict = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     input_schema: dict[str, ExpectedField]
     trigger_inputs: TriggerInputs
 

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -38,7 +38,7 @@ class TSObject(BaseModel):
     - You must serialize with `by_alias=True` to get the camelCase keys.
     """
 
-    model_config: ConfigDict = ConfigDict(
+    model_config = ConfigDict(
         extra="allow",
         alias_generator=to_camel,
         populate_by_name=True,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -991,7 +991,7 @@ class DSLWorkflow:
         return validation_result
 
     async def _get_schedule_trigger_inputs(
-        self, schedule_id: identifiers.ScheduleID, worflow_id: identifiers.WorkflowID
+        self, schedule_id: identifiers.ScheduleUUID, worflow_id: identifiers.WorkflowID
     ) -> dict[str, Any] | None:
         """Get the trigger inputs for a schedule.
 

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -39,14 +39,15 @@ e.g. wf-77932a0b140a4465a1a25a5c95edcfb8:run-b140a425a577932a0c95edcfb8465a1a
 """
 
 import uuid
-from typing import Annotated, Literal
-
-from pydantic import StringConstraints
+from typing import Literal
 
 from tracecat.identifiers import action, resource, schedules, workflow
 from tracecat.identifiers.action import ActionID, ActionKey, ActionRef
 from tracecat.identifiers.resource import id_factory
-from tracecat.identifiers.schedules import ScheduleID
+from tracecat.identifiers.schedules import (
+    ScheduleUUID,
+    schedule_id_to_temporal,
+)
 from tracecat.identifiers.workflow import (
     WorkflowExecutionID,
     WorkflowExecutionSuffixID,
@@ -63,7 +64,15 @@ OrganizationID = uuid.UUID
 OwnerID = uuid.UUID
 """Generic owner identifier for Ownership model. Can be UserID, WorkspaceID, or OrganizationID."""
 
-SecretID = Annotated[str, StringConstraints(pattern=r"secret-[0-9a-f]{32}")]
+SecretID = uuid.UUID
+"""A unique ID for a secret. Now uses native UUID format."""
+
+WebhookID = uuid.UUID
+"""A unique ID for a webhook. Now uses native UUID format."""
+
+WorkflowDefinitionID = uuid.UUID
+"""A unique ID for a workflow definition. Now uses native UUID format."""
+
 VariableID = uuid.UUID
 SessionID = uuid.UUID
 WorkflowTagID = uuid.UUID
@@ -93,7 +102,11 @@ __all__ = [
     "WorkflowExecutionID",
     "WorkflowExecutionSuffixID",
     "WorkflowRunID",
-    "ScheduleID",
+    "ScheduleUUID",
+    "schedule_id_to_temporal",
+    "SecretID",
+    "WebhookID",
+    "WorkflowDefinitionID",
     "UserID",
     "WorkspaceID",
     "OrganizationID",

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -41,13 +41,14 @@ e.g. wf-77932a0b140a4465a1a25a5c95edcfb8:run-b140a425a577932a0c95edcfb8465a1a
 import uuid
 from typing import Literal
 
-from tracecat.identifiers import action, resource, schedules, workflow
-from tracecat.identifiers.action import ActionID, ActionKey, ActionRef
+from tracecat.identifiers import action, resource, schedules, secret, workflow
+from tracecat.identifiers.action import ActionID, ActionKey, ActionRef, ActionUUID
 from tracecat.identifiers.resource import id_factory
 from tracecat.identifiers.schedules import (
     ScheduleUUID,
     schedule_id_to_temporal,
 )
+from tracecat.identifiers.secret import SecretID, SecretUUID
 from tracecat.identifiers.workflow import (
     WorkflowExecutionID,
     WorkflowExecutionSuffixID,
@@ -64,11 +65,10 @@ OrganizationID = uuid.UUID
 OwnerID = uuid.UUID
 """Generic owner identifier for Ownership model. Can be UserID, WorkspaceID, or OrganizationID."""
 
-SecretID = uuid.UUID
-"""A unique ID for a secret. Now uses native UUID format."""
+# SecretID is now imported from tracecat/identifiers/secret.py
 
 WebhookID = uuid.UUID
-"""A unique ID for a webhook. Now uses native UUID format."""
+"""A unique ID for a webhook. Uses native UUID format."""
 
 WorkflowDefinitionID = uuid.UUID
 """A unique ID for a workflow definition. Now uses native UUID format."""
@@ -97,6 +97,7 @@ __all__ = [
     "ActionID",
     "ActionKey",
     "ActionRef",
+    "ActionUUID",
     "WorkflowID",
     "WorkflowUUID",
     "WorkflowExecutionID",
@@ -105,6 +106,7 @@ __all__ = [
     "ScheduleUUID",
     "schedule_id_to_temporal",
     "SecretID",
+    "SecretUUID",
     "WebhookID",
     "WorkflowDefinitionID",
     "UserID",
@@ -120,5 +122,6 @@ __all__ = [
     "action",
     "workflow",
     "schedules",
+    "secret",
     "resource",
 ]

--- a/tracecat/identifiers/action.py
+++ b/tracecat/identifiers/action.py
@@ -1,5 +1,6 @@
 """Action identifiers."""
 
+import uuid
 from typing import Annotated
 
 from pydantic import StringConstraints
@@ -7,8 +8,8 @@ from slugify import slugify
 
 from tracecat.identifiers.resource import ResourcePrefix
 
-ActionID = Annotated[str, StringConstraints(pattern=r"act-[0-9a-f]{32}")]
-"""A unique ID for an action. e.g. 'act-77932a0b140a4465a1a25a5c95edcfb8'"""
+ActionID = uuid.UUID
+"""A unique ID for an action. Now uses native UUID format."""
 
 ActionKey = Annotated[str, StringConstraints(pattern=r"act:wf-[0-9a-f]{32}:[a-z0-9_]+")]
 """A unique key for an action, using the workflow ID and action ref. e.g. 'act:wf-77932a0b140a4465a1a25a5c95edcfb8:reshape_findings_into_smac'"""

--- a/tracecat/identifiers/action.py
+++ b/tracecat/identifiers/action.py
@@ -1,13 +1,45 @@
 """Action identifiers."""
 
+from __future__ import annotations
+
 import uuid
 from typing import Annotated
 
 from pydantic import StringConstraints
 from slugify import slugify
 
+from tracecat.identifiers.common import TracecatUUID
 from tracecat.identifiers.resource import ResourcePrefix
 
+# Prefixes
+ACT_ID_PREFIX = "act_"
+LEGACY_ACTION_ID_PREFIX = "act-"
+
+# Patterns for validation
+_ACT_ID_SHORT_PATTERN = rf"{ACT_ID_PREFIX}[0-9a-zA-Z]+"
+_LEGACY_ACTION_ID_PATTERN = r"act-[0-9a-f]{32}"
+
+# Short ID type (used as TracecatUUID type parameter)
+ActionIDShort = Annotated[str, StringConstraints(pattern=_ACT_ID_SHORT_PATTERN)]
+LegacyActionID = Annotated[str, StringConstraints(pattern=_LEGACY_ACTION_ID_PATTERN)]
+
+
+class ActionUUID(TracecatUUID[ActionIDShort]):
+    """UUID for action resources.
+
+    Supports:
+    - Native UUID format (database storage)
+    - Short ID format: `act_xxx`
+    - Legacy format: `act-<32hex>`
+    """
+
+    prefix = ACT_ID_PREFIX
+    legacy_prefix = LEGACY_ACTION_ID_PREFIX
+
+
+AnyActionID = ActionUUID | ActionIDShort | LegacyActionID | uuid.UUID
+
+# Keep ActionID as alias for backward compatibility in type hints
 ActionID = uuid.UUID
 """A unique ID for an action. Now uses native UUID format."""
 

--- a/tracecat/identifiers/common.py
+++ b/tracecat/identifiers/common.py
@@ -157,7 +157,7 @@ class TracecatUUID[ShortID: str](UUID):
         if cls.legacy_prefix is None:
             raise ValueError(f"Legacy IDs are not supported for {cls.__name__}")
         prefix_len = len(cls.legacy_prefix)
-        hex_str = id[prefix_len - 1 :]
+        hex_str = id[prefix_len:]
         return cls.from_uuid(UUID(hex_str))
 
     def to_legacy(self) -> str:

--- a/tracecat/identifiers/schedules.py
+++ b/tracecat/identifiers/schedules.py
@@ -1,25 +1,55 @@
 """Schedule identifiers."""
 
+from __future__ import annotations
+
 from typing import Annotated
+from uuid import UUID
 
 from pydantic import StringConstraints
 
-# Patterns
-SCHEDULE_ID_PATTERN = r"sch-[0-9a-f]{32}"
-SCHEDULE_EXEC_ID_PATTERN = rf"{SCHEDULE_ID_PATTERN}-.*"
+from tracecat.identifiers.common import TracecatUUID
 
-# Annotations
-ScheduleID = Annotated[str, StringConstraints(pattern=SCHEDULE_ID_PATTERN)]
-"""A unique ID for a schedule.
+# Prefixes
+SCH_ID_PREFIX = "sch_"
+LEGACY_SCHEDULE_ID_PREFIX = "sch-"
 
-This is the equivalent of a Schedule ID in Temporal.
+# Patterns for validation
+_SCH_ID_SHORT_PATTERN = rf"{SCH_ID_PREFIX}[0-9a-zA-Z]+"
+_LEGACY_SCHEDULE_ID_PATTERN = r"sch-[0-9a-f]{32}"
+_UUID_PATTERN = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
-Exapmles
---------
-- `sch-77932a0b140a4465a1a25a5c95edcfb8`
-"""
+# Used by workflow.py for execution ID matching
+TEMPORAL_SCHEDULE_ID_PATTERN = rf"(?:{_LEGACY_SCHEDULE_ID_PATTERN}|{_UUID_PATTERN})"
+SCHEDULE_EXEC_ID_PATTERN = rf"{TEMPORAL_SCHEDULE_ID_PATTERN}-.*"
 
-ScheduleExecutionID = Annotated[
-    str, StringConstraints(pattern=SCHEDULE_EXEC_ID_PATTERN)
+# Short ID type (used as TracecatUUID type parameter)
+ScheduleIDShort = Annotated[str, StringConstraints(pattern=_SCH_ID_SHORT_PATTERN)]
+LegacyScheduleID = Annotated[
+    str, StringConstraints(pattern=_LEGACY_SCHEDULE_ID_PATTERN)
 ]
-"""The full unique ID for a scheduled workflow execution."""
+
+
+class ScheduleUUID(TracecatUUID[ScheduleIDShort]):
+    """UUID for schedule resources.
+
+    Supports:
+    - Native UUID format (database storage)
+    - Short ID format: `sch_xxx`
+    - Legacy format: `sch-<32hex>` (Temporal compatibility)
+    """
+
+    prefix = SCH_ID_PREFIX
+    legacy_prefix = LEGACY_SCHEDULE_ID_PREFIX
+
+
+AnyScheduleID = ScheduleUUID | ScheduleIDShort | LegacyScheduleID | UUID
+
+TemporalScheduleID = str
+"""Schedule ID format used in Temporal APIs (legacy 'sch-<hex>' format)."""
+
+
+def schedule_id_to_temporal(schedule_id: ScheduleUUID | str) -> TemporalScheduleID:
+    """Convert a ScheduleID to legacy format for Temporal APIs."""
+    if isinstance(schedule_id, ScheduleUUID):
+        return schedule_id.to_legacy()
+    return ScheduleUUID.new(schedule_id).to_legacy()

--- a/tracecat/identifiers/secret.py
+++ b/tracecat/identifiers/secret.py
@@ -1,0 +1,42 @@
+"""Secret identifiers."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+from tracecat.identifiers.common import TracecatUUID
+
+# Prefixes
+SECRET_ID_PREFIX = "secret_"
+LEGACY_SECRET_ID_PREFIX = "secret-"
+
+# Patterns for validation
+_SECRET_ID_SHORT_PATTERN = rf"{SECRET_ID_PREFIX}[0-9a-zA-Z]+"
+_LEGACY_SECRET_ID_PATTERN = r"secret-[0-9a-f]{32}"
+
+# Short ID type (used as TracecatUUID type parameter)
+SecretIDShort = Annotated[str, StringConstraints(pattern=_SECRET_ID_SHORT_PATTERN)]
+LegacySecretID = Annotated[str, StringConstraints(pattern=_LEGACY_SECRET_ID_PATTERN)]
+
+
+class SecretUUID(TracecatUUID[SecretIDShort]):
+    """UUID for secret resources.
+
+    Supports:
+    - Native UUID format (database storage)
+    - Short ID format: `secret_xxx`
+    - Legacy format: `secret-<32hex>`
+    """
+
+    prefix = SECRET_ID_PREFIX
+    legacy_prefix = LEGACY_SECRET_ID_PREFIX
+
+
+AnySecretID = SecretUUID | SecretIDShort | LegacySecretID | uuid.UUID
+
+# Keep SecretID as alias for backward compatibility in type hints
+SecretID = uuid.UUID
+"""A unique ID for a secret. Now uses native UUID format."""

--- a/tracecat/secrets/dependencies.py
+++ b/tracecat/secrets/dependencies.py
@@ -1,0 +1,16 @@
+"""Dependencies for secret routes."""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from tracecat.identifiers.secret import SecretUUID
+
+
+def secret_id_path_dependency(secret_id: str) -> SecretUUID:
+    """Convert any secret ID format (UUID, short, legacy) to SecretUUID."""
+    return SecretUUID.new(secret_id)
+
+
+AnySecretIDPath = Annotated[SecretUUID, Depends(secret_id_path_dependency)]
+"""A secret ID that can be a UUID, short ID (secret_xxx), or legacy format (secret-<hex>)."""

--- a/tracecat/secrets/router.py
+++ b/tracecat/secrets/router.py
@@ -10,6 +10,7 @@ from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.identifiers import SecretID
 from tracecat.logger import logger
+from tracecat.secrets.dependencies import AnySecretIDPath
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import (
     OrganizationSecretRead,
@@ -155,7 +156,7 @@ async def update_secret_by_id(
     *,
     role: WorkspaceAdminUser,
     session: AsyncDBSession,
-    secret_id: SecretID,
+    secret_id: AnySecretIDPath,
     params: SecretUpdate,
 ) -> None:
     """Update a secret by ID."""
@@ -180,7 +181,7 @@ async def delete_secret_by_id(
     *,
     role: WorkspaceAdminUser,
     session: AsyncDBSession,
-    secret_id: SecretID,
+    secret_id: AnySecretIDPath,
 ) -> None:
     """Delete a secret by ID."""
     service = SecretsService(session, role=role)
@@ -266,7 +267,7 @@ async def update_org_secret_by_id(
     *,
     role: OrgAdminUser,
     session: AsyncDBSession,
-    secret_id: SecretID,
+    secret_id: AnySecretIDPath,
     params: SecretUpdate,
 ) -> None:
     """Update an organization secret by ID."""
@@ -296,7 +297,7 @@ async def delete_org_secret_by_id(
     *,
     role: OrgAdminUser,
     session: AsyncDBSession,
-    secret_id: SecretID,
+    secret_id: AnySecretIDPath,
 ) -> None:
     """Delete an organization secret by ID."""
     service = SecretsService(session, role=role)

--- a/tracecat/secrets/schemas.py
+++ b/tracecat/secrets/schemas.py
@@ -128,7 +128,7 @@ class SecretSearch(BaseModel):
 
 
 class SecretReadMinimal(BaseModel):
-    id: str
+    id: UUID
     type: SecretType
     name: str
     description: str | None = None
@@ -139,7 +139,7 @@ class SecretReadMinimal(BaseModel):
 class SecretReadBase(BaseModel):
     """Base read schema for secrets."""
 
-    id: str
+    id: UUID
     type: SecretType
     name: str
     description: str | None = None

--- a/tracecat/webhooks/schemas.py
+++ b/tracecat/webhooks/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 from ipaddress import ip_address, ip_network
 from typing import Any, Literal, Self
@@ -21,7 +22,7 @@ NDJSON_CONTENT_TYPES = (
 
 
 class WebhookRead(Schema):
-    id: str
+    id: uuid.UUID
     secret: str
     status: WebhookStatus
     entrypoint_ref: str | None = None

--- a/tracecat/workflow/actions/dependencies.py
+++ b/tracecat/workflow/actions/dependencies.py
@@ -1,0 +1,16 @@
+"""Dependencies for workflow action routes."""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from tracecat.identifiers.action import ActionUUID
+
+
+def action_id_path_dependency(action_id: str) -> ActionUUID:
+    """Convert any action ID format (UUID, short, legacy) to ActionUUID."""
+    return ActionUUID.new(action_id)
+
+
+AnyActionIDPath = Annotated[ActionUUID, Depends(action_id_path_dependency)]
+"""An action ID that can be a UUID, short ID (act_xxx), or legacy format (act-<hex>)."""

--- a/tracecat/workflow/actions/router.py
+++ b/tracecat/workflow/actions/router.py
@@ -4,10 +4,10 @@ from pydantic_core import PydanticUndefined
 from tracecat.auth.dependencies import WorkspaceUserRole
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import RegistryError, TracecatValidationError
-from tracecat.identifiers.action import ActionID
 from tracecat.identifiers.workflow import AnyWorkflowIDPath, WorkflowUUID
 from tracecat.interactions.schemas import ActionInteractionValidator
 from tracecat.registry.actions.service import RegistryActionsService
+from tracecat.workflow.actions.dependencies import AnyActionIDPath
 from tracecat.workflow.actions.schemas import (
     ActionControlFlow,
     ActionCreate,
@@ -77,7 +77,7 @@ async def create_action(
 @router.get("/{action_id}")
 async def get_action(
     role: WorkspaceUserRole,
-    action_id: ActionID,
+    action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
 ) -> ActionRead:
@@ -128,7 +128,7 @@ async def get_action(
 @router.post("/{action_id}")
 async def update_action(
     role: WorkspaceUserRole,
-    action_id: ActionID,
+    action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     params: ActionUpdate,
     session: AsyncDBSession,
@@ -148,7 +148,7 @@ async def update_action(
 @router.delete("/{action_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_action(
     role: WorkspaceUserRole,
-    action_id: ActionID,
+    action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
 ) -> None:

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -209,7 +209,7 @@ class EventGroup[T: EventInput](BaseModel):
             udf_namespace=namespace,
             udf_name=task_name,
             udf_key=task.action,
-            action_id=task.id,
+            action_id=str(task.id) if task.id else None,
             action_ref=task.ref,
             action_title=task.title,
             action_description=task.description,

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -641,7 +641,7 @@ class WorkflowsManagementService(BaseService):
         # Delete actions that don't exist in the action_nodes
         orphaned_action_ids = ids_in_db - ids_in_graph
         for action in actions:
-            if action.id not in orphaned_action_ids:
+            if str(action.id) not in orphaned_action_ids:
                 continue
             await self.session.delete(action)
             self.logger.info(f"Deleted orphaned action: {action.title}")

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -619,7 +619,7 @@ class WorkflowsManagementService(BaseService):
         self.logger.info("Creating graph for workflow", graph=base_graph)
 
         # Add DSL contents to the Workflow
-        ref2id = {act.ref: act.id for act in actions}
+        ref2id = {act.ref: str(act.id) for act in actions}
         updated_graph = dsl.to_graph(trigger_node=base_graph.trigger, ref2id=ref2id)
         workflow.object = updated_graph.model_dump(by_alias=True, mode="json")
 
@@ -637,7 +637,7 @@ class WorkflowsManagementService(BaseService):
 
         # Set difference of action IDs
         ids_in_graph = {node.id for node in action_nodes}
-        ids_in_db = {action.id for action in actions}
+        ids_in_db = {str(action.id) for action in actions}
         # Delete actions that don't exist in the action_nodes
         orphaned_action_ids = ids_in_db - ids_in_graph
         for action in actions:

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -278,7 +278,7 @@ async def get_workflow(
 
     actions = workflow.actions or []
     actions_responses = {
-        action.id: ActionRead.model_validate(action, from_attributes=True)
+        str(action.id): ActionRead.model_validate(action, from_attributes=True)
         for action in actions
     }
     # Add webhook/schedules

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -43,7 +43,7 @@ class WorkflowRead(Schema):
 
 
 class WorkflowDefinitionReadMinimal(Schema):
-    id: str
+    id: uuid.UUID
     version: int
     created_at: datetime
 
@@ -51,7 +51,7 @@ class WorkflowDefinitionReadMinimal(Schema):
 class WorkflowDefinitionRead(Schema):
     """API response model for persisted workflow definitions."""
 
-    id: str
+    id: uuid.UUID
     workflow_id: WorkflowUUID | None
     workspace_id: WorkspaceID
     version: int

--- a/tracecat/workflow/schedules/dependencies.py
+++ b/tracecat/workflow/schedules/dependencies.py
@@ -1,0 +1,13 @@
+from typing import Annotated
+
+from fastapi import Depends
+
+from tracecat.identifiers import ScheduleUUID
+
+
+def schedule_id_path_dependency(schedule_id: str) -> ScheduleUUID:
+    return ScheduleUUID.new(schedule_id)
+
+
+AnyScheduleIDPath = Annotated[ScheduleUUID, Depends(schedule_id_path_dependency)]
+"""A schedule ID that can be either a UUID or a short ID in the format sch_XXXXX."""

--- a/tracecat/workflow/schedules/router.py
+++ b/tracecat/workflow/schedules/router.py
@@ -5,10 +5,10 @@ from tracecat.auth.dependencies import WorkspaceUserRole
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Schedule
 from tracecat.exceptions import TracecatNotFoundError, TracecatServiceError
-from tracecat.identifiers import ScheduleID
 from tracecat.identifiers.workflow import OptionalAnyWorkflowIDQuery, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.workflow.management.management import WorkflowsManagementService
+from tracecat.workflow.schedules.dependencies import AnyScheduleIDPath
 from tracecat.workflow.schedules.schemas import (
     ScheduleCreate,
     ScheduleRead,
@@ -64,7 +64,9 @@ async def create_schedule(
 
 @router.get("/{schedule_id}", response_model=ScheduleRead)
 async def get_schedule(
-    role: WorkspaceUserRole, session: AsyncDBSession, schedule_id: ScheduleID
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    schedule_id: AnyScheduleIDPath,
 ) -> ScheduleRead:
     """Get a schedule from a workflow."""
     service = WorkflowSchedulesService(session, role=role)
@@ -83,7 +85,7 @@ async def get_schedule(
 async def update_schedule(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
-    schedule_id: ScheduleID,
+    schedule_id: AnyScheduleIDPath,
     params: ScheduleUpdate,
 ) -> ScheduleRead:
     """Update a schedule from a workflow. You cannot update the Workflow Definition, but you can update other fields."""
@@ -106,7 +108,7 @@ async def update_schedule(
 
 @router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_schedule(
-    role: WorkspaceUserRole, session: AsyncDBSession, schedule_id: ScheduleID
+    role: WorkspaceUserRole, session: AsyncDBSession, schedule_id: AnyScheduleIDPath
 ) -> None:
     """Delete a schedule from a workflow."""
     service = WorkflowSchedulesService(session, role=role)

--- a/tracecat/workflow/schedules/schemas.py
+++ b/tracecat/workflow/schedules/schemas.py
@@ -6,12 +6,12 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from tracecat.auth.types import Role
 from tracecat.core.schemas import Schema
-from tracecat.identifiers import ScheduleID, WorkflowID, WorkspaceID
+from tracecat.identifiers import ScheduleUUID, WorkflowID, WorkspaceID
 from tracecat.identifiers.workflow import AnyWorkflowID
 
 
 class ScheduleRead(Schema):
-    id: ScheduleID
+    id: ScheduleUUID
     workspace_id: WorkspaceID
     created_at: datetime
     updated_at: datetime
@@ -98,6 +98,14 @@ class ScheduleSearch(BaseModel):
 
 
 class GetScheduleActivityInputs(BaseModel):
+    """Activity input for fetching schedule data.
+
+    ScheduleUUID (ScheduleUUID) auto-validates from any format:
+    - Native UUID
+    - Short ID: sch_xxx
+    - Legacy format: sch-<32hex>
+    """
+
     role: Role
-    schedule_id: ScheduleID
+    schedule_id: ScheduleUUID
     workflow_id: WorkflowID

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -320,7 +320,7 @@ class WorkflowImportService(BaseWorkspaceService):
 
         # 5. Regenerate the React Flow graph
         base_graph = RFGraph.with_defaults(existing_workflow)
-        ref2id = {act.ref: act.id for act in actions}
+        ref2id = {act.ref: str(act.id) for act in actions}
         updated_graph = dsl.to_graph(trigger_node=base_graph.trigger, ref2id=ref2id)
         existing_workflow.object = updated_graph.model_dump(by_alias=True, mode="json")
 


### PR DESCRIPTION
## Summary
- Migrate database models (Schedule, Action, Webhook, Secret, WorkflowDefinition) from prefixed string IDs to native PostgreSQL UUIDs
- Add alembic migration with data migration logic for existing records
- Update identifier utilities to support both legacy prefixed format and new UUID format for backward compatibility
- Reparent alembic migration to maintain linear history

## Test plan
- [ ] Run alembic migration on test database
- [ ] Verify existing schedules and workflows continue to function
- [ ] Test schedule creation with new UUID format

🤖 Generated with [Claude Code](https://claude.com/claude-code)









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated prefixed string IDs to native PostgreSQL UUIDs for Schedule, Action, Webhook, Secret, and WorkflowDefinition with a safe data migration and backward compatibility. Temporal schedules still use legacy string IDs, but we auto-convert to/from UUIDs.

- **Migration**
  - Added Alembic migration that converts IDs and updates indexes, FKs, and constraints.
  - Rewrites workflow.object JSON (nodes, edges, entrypoint) from old action IDs to UUIDs.
  - Reparented the previous migration to keep linear history.

- **Refactors**
  - Switched DB models to UUID columns and updated Pydantic/response schemas accordingly.
  - Added ActionUUID and SecretUUID alongside ScheduleUUID to accept UUID, short IDs, and legacy prefixed formats; auto-convert for Temporal where needed.
  - Updated action/secret/schedule routers with path dependencies to parse any ID format; frontend schemas now use uuid format and broadened execution_id patterns for schedule UUIDs.
  - Adjusted graph and management code to handle UUIDs (string keys) and updated tests.
  - Fixed legacy ID parsing in TracecatUUID.from_legacy to correctly slice without including the hyphen.

<sup>Written for commit b1fcca31d8c83ae3ac8d7c6b2a6ed1537d9b746a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









