### PR TITLE
fix(agent): Disable parallel tool calls by default

### DIFF
--- a/tracecat/agent/factory.py
+++ b/tracecat/agent/factory.py
@@ -34,10 +34,11 @@ async def build_agent(config: AgentConfig) -> Agent[Any, Any]:
         agent_tools.extend(config.custom_tools)
         tool_prompt_tools.extend(config.custom_tools)
     _output_type = parse_output_type(config.output_type)
-    _model_settings = (
-        ModelSettings(**config.model_settings) if config.model_settings else None
-    )
-
+    # Disable parallel tool calls only if tools exist (OpenAI requires this)
+    model_settings_dict = {**(config.model_settings or {})}
+    if agent_tools or config.mcp_servers:
+        model_settings_dict["parallel_tool_calls"] = False
+    _model_settings = ModelSettings(**model_settings_dict)
     # Add verbosity prompt
     verbosity_prompt = VerbosityPrompt()
     instructions = f"{config.instructions}\n{verbosity_prompt.prompt}"

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -420,6 +420,10 @@ class AgentPresetService(BaseWorkspaceService):
 
     async def _preset_to_agent_config(self, preset: AgentPreset) -> AgentConfig:
         mcp_servers = await self._resolve_mcp_integrations(preset.mcp_integrations)
+        # Only disable parallel tool calls if tools will be present
+        model_settings = {}
+        if preset.actions or mcp_servers:
+            model_settings["parallel_tool_calls"] = False
         return AgentConfig(
             model_name=preset.model_name,
             model_provider=preset.model_provider,
@@ -431,4 +435,5 @@ class AgentPresetService(BaseWorkspaceService):
             tool_approvals=preset.tool_approvals,
             mcp_servers=mcp_servers,
             retries=preset.retries,
+            model_settings=model_settings,
         )


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable parallel tool calls only when tools or MCP servers are present to prevent race conditions, while keeping other model settings intact. Applied in agent build and preset-to-config paths.

- **Bug Fixes**
  - Agent factory sets model_settings.parallel_tool_calls = False only when tools/MCP are configured and merges with custom settings.
  - Preset-to-agent config conditionally adds {"parallel_tool_calls": False} when actions or MCP integrations exist.

<sup>Written for commit e716b2de66d869820ddbfdc81353c9bd1c9d4f59. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





