### PR TITLE
perf(engine): Use local activities for template evaluation

### DIFF
--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -17,7 +17,7 @@ from tenacity import (
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_logger, ctx_run
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.dsl.schemas import ActionStatement, RunActionInput
+from tracecat.dsl.schemas import ActionStatement, ExecutionContext, RunActionInput
 from tracecat.dsl.types import ActionErrorInfo
 from tracecat.exceptions import (
     ExecutorClientError,
@@ -26,6 +26,7 @@ from tracecat.exceptions import (
     TracecatExpressionError,
 )
 from tracecat.executor.client import ExecutorClient
+from tracecat.executor.service import iter_for_each
 from tracecat.expressions.common import ExprContext
 from tracecat.expressions.core import TemplateExpression
 from tracecat.expressions.eval import eval_templated_object
@@ -230,3 +231,22 @@ class DSLActivities:
         """Evaluate templated objects using the expression engine."""
 
         return eval_templated_object(obj, operand=operand)
+
+    @staticmethod
+    @activity.defn
+    def iter_for_each_activity(
+        task: ActionStatement,
+        context: ExecutionContext,
+        assign_context: str = ExprContext.LOCAL_VARS,
+        patch: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Evaluate a ``for_each`` expression and render task args per iteration."""
+
+        return list(
+            iter_for_each(
+                task=task,
+                context=context,
+                assign_context=assign_context,
+                patch=patch,
+            )
+        )


### PR DESCRIPTION
## Summary
- Convert direct calls to `eval_templated_object` and `iter_for_each` to local activities
- Add `iter_for_each_activity` to `DSLActivities`
- Wrap template evaluation in local activity execution for better Temporal workflow determinism

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch template and for_each evaluation to Temporal local activities to improve workflow determinism and consistent retries. All expression evaluation now runs as local activities, covering task args, workflow alias, return values, and environment.

- **Refactors**
  - Added DSLActivities.iter_for_each_activity and started using ExecutionContext.
  - Introduced _evaluate_templated_object_activity and _iter_for_each_activity with fail-fast retry and 10s timeout.
  - Replaced direct eval/iter_for_each calls in retry_until, agent args, child workflow args/loop, returns, workflow alias, and environment.
  - Made _handle_return async and awaited in _run_workflow.

<sup>Written for commit 8d7273134303bdae1f6df2ffd6763dff3e5e183a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

