### PR TITLE
feat(integrations): add Google Drive UDFs for file and permission management

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/google_drive.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/google_drive.py
@@ -285,9 +285,9 @@ async def permanently_delete_file(
             headers={"Authorization": f"Bearer {access_token}"},
         )
         response.raise_for_status()
-        # Return empty dict if no content (DELETE typically returns 204)
+        # Return status info if no content (DELETE typically returns 204)
         if response.status_code == 204 or not response.content:
-            return {}
+            return {"status_code": response.status_code}
         return response.json()
 
 
@@ -434,7 +434,7 @@ async def revoke_permission(
             headers={"Authorization": f"Bearer {access_token}"},
         )
         response.raise_for_status()
-        # Return empty dict if no content (DELETE typically returns 204)
+        # Return status info if no content (DELETE typically returns 204)
         if response.status_code == 204 or not response.content:
-            return {}
+            return {"status_code": response.status_code}
         return response.json()


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds 10 Google Drive UDFs for file management and permission control in security automation workflows.

### Functions Added

**File Operations (4):**
1. `list_files` - Search and list files with Drive query syntax
2. `get_file` - Get file metadata and webViewLink
3. `upload_file` - Upload files to Drive
4. `create_folder` - Create folders for organizing investigations

**Deletion (2):**
5. `delete_file` - Move to trash (recoverable)
6. `permanently_delete_file` - Permanent deletion (unrecoverable)

**Permission Management (4):**
7. `get_file_permissions` - Audit who has access to files
8. `add_permission` - Grant access (reader/writer/commenter/owner roles)
9. `update_permission` - Modify existing permissions
10. `revoke_permission` - Remove access

All functions use the `tools.google_drive` namespace and integrate with Tracecat's OAuth system via the `google_drive` provider.

## Related Issues

N/A - New feature addition

Depends on companion PR for Google Drive OAuth provider (#XXXX).

## Screenshots / Recordings

N/A - Backend functions only

## Steps to QA

### Prerequisites
1. Merge companion OAuth provider PR first
2. Configure Google Drive OAuth in Tracecat UI
3. Connect your Google Drive account

### Test Workflow

Create a workflow with these actions:

# Test 1: List files
- id: list_files
  type: tools.google_drive.list_files
  args:
    query: "mimeType='application/vnd.google-apps.folder'"
    max_results: 5

# Test 2: Create folder
- id: create_folder
  type: tools.google_drive.create_folder
  args:
    folder_name: "Tracecat Test Folder"

# Test 3: Get permissions
- id: get_permissions
  type: tools.google_drive.get_file_permissions
  args:
    file_id: ${{ ACTIONS.create_folder.result.id }}

# Test 4: Add permission
- id: add_permission
  type: tools.google_drive.add_permission
  args:
    file_id: ${{ ACTIONS.create_folder.result.id }}
    email: "test@example.com"
    role: "reader"

# Test 5: Cleanup
- id: delete_folder
  type: tools.google_drive.delete_file
  args:
    file_id: ${{ ACTIONS.create_folder.result.id }}**Verify:**
- ✅ Files are listed correctly
- ✅ Folder is created in your Drive
- ✅ Permissions are retrieved
- ✅ Permission is added successfully
- ✅ Folder moves to trash

### Run Tests

uv run pytest tests/registry/
uv run ruff check packages/tracecat-registry/## Testing Completed

✅ **All 10 functions tested with real Google Drive account:**
- Listed files with various query filters
- Retrieved file metadata and webViewLinks
- Created test folders
- Uploaded test files
- Managed permissions (get, add, update, revoke)
- Tested both soft delete and permanent delete
- Verified 36+ permissions on shared spreadsheet

✅ **Security:**
- Uses Tracecat's OAuth system (secure token storage)
- Proper error handling with `raise_for_status()`
- Default role is "reader" (principle of least privilege)
- Permission changes clearly documented
- Permanent delete includes warning in docstring

✅ **Code Quality:**
- No linter errors
- Type hints on all functions
- Complete docstrings with examples
- Follows registry guidelines

## Use Cases

### Data Loss Prevention
- Find files shared with "anyone"
- Check permissions and identify external shares
- Revoke unauthorized access automatically

### Incident Response
- Create investigation folders
- Add security team with appropriate permissions
- Upload and organize evidence
- Audit all access throughout investigation

### Compliance Automation
- Regular permission audits on sensitive files
- Identify permissions older than 90 days
- Generate compliance reports
- Auto-revoke or downgrade stale permissions

## Files Changed

- `packages/tracecat-registry/tracecat_registry/integrations/google_drive.py` (NEW - 366 lines)

## Breaking Changes

None - New integration with no impact on existing functionality.

## Notes for Reviewers

- Namespace is `tools.google_drive` (consistent with other integrations)
- Display group is "Google Drive"
- All functions are async and use `httpx` for API calls
- Uses `RegistryOAuthSecret` with `provider_id="google_drive"`
- Error handling delegates to Drive API responses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 10 Google Drive UDFs for file and permission management to power security workflows. Responses include the full Drive API payload with a configurable fields filter, and upload_file now uses proper multipart upload to prevent empty files.

- **New Features**
  - File ops: list_files, get_file, upload_file, create_folder
  - Deletion: delete_file (trash), permanently_delete_file
  - Permissions: get_file_permissions, add_permission, update_permission, revoke_permission
  - Namespace: tools.google_drive; async over httpx
  - Response control: fields parameter to limit returned data

- **Migration**
  - Merge and configure the Google Drive OAuth provider, then connect an account in Tracecat
  - No breaking changes

<sup>Written for commit 24ac34cd036efe47b6ef28117e33f44060b70a1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

