### PR TITLE
fix(expressions): return list from FN.range for JSON serialization

### DIFF
--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -446,9 +446,9 @@ def iter_product(*iterables: Sequence[Any]) -> list[tuple[Any, ...]]:
     return list(itertools.product(*iterables))
 
 
-def create_range(start: int, end: int, step: int = 1) -> range:
+def create_range(start: int, end: int, step: int = 1) -> list[int]:
     """Create a range of integers from start to end (exclusive), with a step size."""
-    return range(start, end, step)
+    return list(range(start, end, step))
 
 
 # Dictionary functions


### PR DESCRIPTION
## Summary
- Fix `FN.range()` to return a list instead of a Python `range` object
- Range objects are not JSON serializable, causing Temporal to convert them to strings like `"range(0, 100)"`
- This caused scatter operations to fail with "Collection is not iterable"

## Test plan
- [x] Existing `test_create_range` tests pass
- [ ] Verify scatter with `FN.range()` works in workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
FN.range() now returns a list of ints (not a range) so results are JSON-serializable and scatter steps can iterate over them. This prevents Temporal from turning ranges into strings like "range(0, 100)", which caused "Collection is not iterable" errors.

<sup>Written for commit e98bdd1ad831313ff0029c1e239ff1d32af1478a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

