### PR TITLE
fix(ui): Missing dropdown in conversations history and copilot presets

### DIFF
--- a/frontend/src/components/chat/agent-preset-menu.tsx
+++ b/frontend/src/components/chat/agent-preset-menu.tsx
@@ -1,0 +1,179 @@
+"use client"
+
+import { BoxIcon, Check, ChevronsUpDown, Loader2 } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import type { AgentPresetReadMinimal } from "@/client"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+interface AgentPresetMenuProps {
+  label: string
+  presets?: AgentPresetReadMinimal[]
+  presetsIsLoading: boolean
+  presetsError: unknown
+  selectedPresetId: string | null
+  onSelect: (presetId: string | null) => void | Promise<void>
+  disabled?: boolean
+  showSpinner?: boolean
+  noPresetDescription?: string
+}
+
+export function AgentPresetMenu({
+  label,
+  presets,
+  presetsIsLoading,
+  presetsError,
+  selectedPresetId,
+  onSelect,
+  disabled = false,
+  showSpinner = false,
+  noPresetDescription = "Use workspace default agent instructions.",
+}: AgentPresetMenuProps) {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (disabled) {
+      setOpen(false)
+    }
+  }, [disabled])
+
+  const presetList = presets ?? []
+  const hasPresetOptions = presetList.length > 0
+  const errorMessage = useMemo(() => {
+    if (typeof presetsError === "string") return presetsError
+    if (
+      presetsError &&
+      typeof presetsError === "object" &&
+      "body" in presetsError &&
+      typeof (presetsError as { body?: { detail?: unknown } }).body?.detail ===
+        "string"
+    ) {
+      return (presetsError as { body?: { detail?: string } }).body?.detail
+    }
+    if (
+      presetsError &&
+      typeof presetsError === "object" &&
+      "message" in presetsError &&
+      typeof (presetsError as { message?: unknown }).message === "string"
+    ) {
+      return (presetsError as { message: string }).message
+    }
+    return "Failed to load presets"
+  }, [presetsError])
+
+  const handleSelect = (presetId: string | null) => {
+    setOpen(false)
+    void onSelect(presetId)
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (disabled) return
+        setOpen(nextOpen)
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="px-2 justify-between"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+        >
+          <div className="flex items-center gap-1.5">
+            <BoxIcon className="size-3 text-muted-foreground" />
+            <span className="max-w-[11rem] truncate" title={label}>
+              {label}
+            </span>
+          </div>
+          {showSpinner ? (
+            <Loader2 className="ml-1 size-3 animate-spin text-muted-foreground" />
+          ) : (
+            <ChevronsUpDown className="ml-1 size-3 opacity-70" />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        {presetsIsLoading ? (
+          <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading presets…
+          </div>
+        ) : presetsError ? (
+          <div className="p-3 text-sm text-red-600">{errorMessage}</div>
+        ) : (
+          <Command>
+            <CommandInput placeholder="Search presets..." className="h-9" />
+            <CommandList className="max-h-64 overflow-y-auto">
+              <CommandEmpty>No presets found.</CommandEmpty>
+              <CommandGroup>
+                <CommandItem
+                  value="no preset"
+                  onSelect={() => handleSelect(null)}
+                  className="flex items-start justify-between gap-2 py-2"
+                >
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium">No preset</span>
+                    <span className="text-xs text-muted-foreground">
+                      {noPresetDescription}
+                    </span>
+                  </div>
+                  {selectedPresetId === null ? (
+                    <Check className="mt-1 size-4" />
+                  ) : null}
+                </CommandItem>
+                {hasPresetOptions ? (
+                  presetList.map((preset) => (
+                    <CommandItem
+                      key={preset.id}
+                      value={`${preset.name} ${preset.description ?? ""}`}
+                      onSelect={() => handleSelect(preset.id)}
+                      className="flex items-start justify-between gap-2 py-2"
+                    >
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate text-sm font-medium">
+                          {preset.name}
+                        </span>
+                        {preset.description ? (
+                          <span className="text-xs text-muted-foreground">
+                            {preset.description}
+                          </span>
+                        ) : null}
+                      </div>
+                      {selectedPresetId === preset.id ? (
+                        <Check className="mt-1 size-4" />
+                      ) : null}
+                    </CommandItem>
+                  ))
+                ) : (
+                  <CommandItem
+                    disabled
+                    value="no presets available"
+                    className="py-2 text-xs text-muted-foreground"
+                  >
+                    No presets available
+                  </CommandItem>
+                )}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/chat/chat-history-dropdown.tsx
+++ b/frontend/src/components/chat/chat-history-dropdown.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { formatDistanceToNow } from "date-fns"
+import { Check, ChevronDown, Loader2 } from "lucide-react"
+import { useState } from "react"
+
+import type { ChatRead } from "@/client"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+interface ChatHistoryDropdownProps {
+  chats: ChatRead[] | undefined
+  isLoading: boolean
+  error: unknown
+  selectedChatId: string | undefined
+  onSelectChat: (chatId: string) => void
+}
+
+export function ChatHistoryDropdown({
+  chats,
+  isLoading,
+  error,
+  selectedChatId,
+  onSelectChat,
+}: ChatHistoryDropdownProps) {
+  const [open, setOpen] = useState(false)
+
+  const handleSelect = (chatId: string) => {
+    onSelectChat(chatId)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="px-2"
+          role="combobox"
+          aria-expanded={open}
+        >
+          Conversations
+          <ChevronDown className="ml-1 size-3" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 p-0">
+        {isLoading ? (
+          <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading chats…
+          </div>
+        ) : error ? (
+          <div className="p-3 text-sm text-red-600">Failed to load chats</div>
+        ) : (
+          <Command>
+            <CommandInput placeholder="Search chats..." className="h-9" />
+            <CommandList className="max-h-64 overflow-y-auto">
+              <CommandEmpty>No chats found.</CommandEmpty>
+              <CommandGroup>
+                {chats?.map((chat) => (
+                  <CommandItem
+                    key={chat.id}
+                    value={chat.title}
+                    onSelect={() => handleSelect(chat.id)}
+                    className="flex items-start justify-between gap-2 py-2"
+                  >
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate text-sm font-medium">
+                        {chat.title}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {formatDistanceToNow(new Date(chat.created_at), {
+                          addSuffix: true,
+                        })}
+                      </span>
+                    </div>
+                    {selectedChatId === chat.id ? (
+                      <Check className="mt-1 size-4 shrink-0" />
+                    ) : null}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/hooks/use-chat-preset-manager.ts
+++ b/frontend/src/hooks/use-chat-preset-manager.ts
@@ -1,0 +1,82 @@
+import type { ChatReadVercel } from "@/client"
+import { toast } from "@/components/ui/use-toast"
+import { useAgentPreset, useAgentPresets } from "@/hooks/use-agent-presets"
+import { parseChatError, type useUpdateChat } from "@/hooks/use-chat"
+
+interface UseChatPresetManagerProps {
+  workspaceId: string
+  chat: ChatReadVercel | undefined
+  updateChat: ReturnType<typeof useUpdateChat>["updateChat"]
+  isUpdatingChat: boolean
+  chatLoading: boolean
+  selectedChatId: string | undefined
+  enabled?: boolean
+}
+
+export function useChatPresetManager({
+  workspaceId,
+  chat,
+  updateChat,
+  isUpdatingChat,
+  chatLoading,
+  selectedChatId,
+  enabled = true,
+}: UseChatPresetManagerProps) {
+  const { presets, presetsIsLoading, presetsError } = useAgentPresets(
+    workspaceId,
+    { enabled }
+  )
+
+  const presetOptions = enabled ? (presets ?? []) : []
+  const effectivePresetId = chat?.agent_preset_id ?? null
+
+  const { preset: selectedPreset, presetIsLoading: selectedPresetLoading } =
+    useAgentPreset(workspaceId, effectivePresetId, {
+      enabled: enabled && Boolean(effectivePresetId),
+    })
+
+  const handlePresetChange = async (nextPresetId: string | null) => {
+    if (!selectedChatId) {
+      return
+    }
+    const currentPresetId = chat?.agent_preset_id ?? null
+    if (nextPresetId === currentPresetId) {
+      return
+    }
+
+    try {
+      await updateChat({
+        chatId: selectedChatId,
+        update: {
+          agent_preset_id: nextPresetId,
+        },
+      })
+    } catch (error) {
+      console.error("Failed to update chat preset:", error)
+      toast({
+        title: "Failed to update preset",
+        description: parseChatError(error),
+        variant: "destructive",
+      })
+    }
+  }
+
+  const presetMenuLabel = selectedPreset?.name ?? "No preset"
+  const presetMenuDisabled =
+    !enabled || !selectedChatId || chatLoading || isUpdatingChat
+  const showPresetSpinner =
+    presetsIsLoading || isUpdatingChat || chatLoading || selectedPresetLoading
+
+  return {
+    presets: presetOptions,
+    presetsIsLoading,
+    presetsError,
+    selectedPreset,
+    selectedPresetId: effectivePresetId,
+    selectedPresetLoading,
+    handlePresetChange,
+    presetMenuLabel,
+    presetMenuDisabled,
+    showPresetSpinner,
+  }
+}


### PR DESCRIPTION
<img width="563" height="590" alt="Screenshot 2025-12-09 at 4 38 25 PM" src="https://github.com/user-attachments/assets/58ddea5a-1384-4c24-8fcd-7543dd1b7166" />
<img width="563" height="590" alt="Screenshot 2025-12-09 at 4 38 20 PM" src="https://github.com/user-attachments/assets/b9f08e6d-34c2-4d61-8b38-49bba9b84091" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the missing Conversations and Agent Preset dropdowns in Chat and Copilot, using shared components with search, loading states, and error handling for a consistent UX.

- **Bug Fixes**
  - Reintroduced Conversations dropdown with search and current selection.
  - Reintroduced Agent Preset selector with “No preset,” search, spinner, and error messages.

- **Refactors**
  - Added AgentPresetMenu and ChatHistoryDropdown components and integrated them into ChatInterface and CopilotChatInterface.
  - Created useChatPresetManager to centralize preset fetching, selection, and updateChat handling, removing duplicated logic.

<sup>Written for commit 3b303eebfc3bfe49c3fe1dd2a762f3346f131d58. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

