### PR TITLE
fix(db): add cascade delete to user FK constraints

### DIFF
--- a/alembic/versions/591905d1205e_add_cascade_delete_to_user_fk_.py
+++ b/alembic/versions/591905d1205e_add_cascade_delete_to_user_fk_.py
@@ -1,0 +1,47 @@
+"""add_cascade_delete_to_user_fk_constraints
+
+Revision ID: 591905d1205e
+Revises: 0fd1f09cd98b
+Create Date: 2025-12-09 22:53:04.405505
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "591905d1205e"
+down_revision: str | None = "0fd1f09cd98b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE access_token
+            DROP CONSTRAINT fk_access_token_user_id_user,
+            ADD CONSTRAINT fk_access_token_user_id_user
+                FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE
+    """)
+    op.execute("""
+        ALTER TABLE oauth_account
+            DROP CONSTRAINT fk_oauth_account_user_id_user,
+            ADD CONSTRAINT fk_oauth_account_user_id_user
+                FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        ALTER TABLE oauth_account
+            DROP CONSTRAINT fk_oauth_account_user_id_user,
+            ADD CONSTRAINT fk_oauth_account_user_id_user
+                FOREIGN KEY (user_id) REFERENCES "user"(id)
+    """)
+    op.execute("""
+        ALTER TABLE access_token
+            DROP CONSTRAINT fk_access_token_user_id_user,
+            ADD CONSTRAINT fk_access_token_user_id_user
+                FOREIGN KEY (user_id) REFERENCES "user"(id)
+    """)

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -203,9 +203,6 @@ def _to_dict(instance: RecordModel) -> dict[str, Any]:
 class OAuthAccount(SQLAlchemyBaseOAuthAccountTableUUID, Base):
     __tablename__ = "oauth_account"
 
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID, ForeignKey("user.id"), nullable=False
-    )
     user: Mapped[User] = relationship(back_populates="oauth_accounts")
 
 
@@ -381,9 +378,6 @@ class AccessToken(SQLAlchemyBaseAccessTokenTableUUID, Base):
     __tablename__ = "access_token"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID, unique=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID, ForeignKey("user.id"), nullable=False
-    )
     user: Mapped[User] = relationship(back_populates="access_tokens")
 
 


### PR DESCRIPTION
## Summary
- Add ON DELETE CASCADE to `access_token.user_id` and `oauth_account.user_id` foreign keys
- Aligns database constraints with fastapi-users model definitions which already specify cascade delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ON DELETE CASCADE to access_token.user_id and oauth_account.user_id and remove redundant user_id columns in models. Deleting a user now automatically removes related tokens and OAuth accounts, aligning with fastapi-users and preventing orphaned rows.

- **Migration**
  - Run Alembic upgrade to apply the new FK constraints.

- **Refactors**
  - Remove explicit user_id mapped columns in AccessToken and OAuthAccount; rely on fastapi-users base definitions.

<sup>Written for commit 116200270c2662804b8c3128bcbf73a9b4b3c03a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



