### PR TITLE
feat(agent): Add flag for remote agent executor

### DIFF
--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -514,9 +514,13 @@ for _flag in os.environ.get("TRACECAT__FEATURE_FLAGS", "").split(","):
 
 
 # === Agent config === #
+ENABLE_REMOTE_AGENT_EXECUTOR = os.environ.get(
+    "ENABLE_REMOTE_AGENT_EXECUTOR", "false"
+).lower() in ("true", "1")
+"""Whether to enable the remote agent executor."""
+
 TRACECAT__AGENT_MAX_TOOLS = int(os.environ.get("TRACECAT__AGENT_MAX_TOOLS", 30))
 """The maximum number of tools that can be used in an agent."""
-
 
 TRACECAT__AGENT_MAX_TOOL_CALLS = int(
     os.environ.get("TRACECAT__AGENT_MAX_TOOL_CALLS", 40)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add ENABLE_REMOTE_AGENT_EXECUTOR config flag to toggle the remote agent executor. Disabled by default; enable by setting ENABLE_REMOTE_AGENT_EXECUTOR=true or 1.

<sup>Written for commit 75dd45a2872c90cf8f6db234665bd3f4560070c6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

