### PR TITLE
fix(api): add readiness healthcheck to ensure registry sync completes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,6 +82,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
 
   worker:
     build:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -92,6 +92,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
 
   worker:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
 
   worker:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.53.0}

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -238,6 +238,7 @@ import type {
   ProvidersListProvidersData,
   ProvidersListProvidersResponse,
   PublicCheckHealthResponse,
+  PublicCheckReadyResponse,
   PublicIncomingWebhookGetData,
   PublicIncomingWebhookGetResponse,
   PublicIncomingWebhookPostData,
@@ -6801,5 +6802,22 @@ export const publicCheckHealth =
     return __request(OpenAPI, {
       method: "GET",
       url: "/health",
+    })
+  }
+
+/**
+ * Check Ready
+ * Readiness check - returns 200 only after startup is complete.
+ *
+ * Use this endpoint for Docker healthchecks to ensure the API has finished
+ * initializing (including registry sync) before accepting traffic.
+ * @returns string Successful Response
+ * @throws ApiError
+ */
+export const publicCheckReady =
+  (): CancelablePromise<PublicCheckReadyResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/ready",
     })
   }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -7290,6 +7290,10 @@ export type PublicCheckHealthResponse = {
   [key: string]: string
 }
 
+export type PublicCheckReadyResponse = {
+  [key: string]: string
+}
+
 export type $OpenApiTs = {
   "/webhooks/{workflow_id}/{secret}": {
     post: {
@@ -10762,6 +10766,18 @@ export type $OpenApiTs = {
     }
   }
   "/health": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: {
+          [key: string]: string
+        }
+      }
+    }
+  }
+  "/ready": {
     get: {
       res: {
         /**

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -1,7 +1,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI, Request, status
+from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
@@ -88,9 +88,19 @@ from tracecat.workflow.tags.router import router as workflow_tags_router
 from tracecat.workspaces.router import router as workspaces_router
 from tracecat.workspaces.service import WorkspaceService
 
+# Global readiness state - set to True after lifespan startup completes
+_app_ready = False
+
+
+def is_app_ready() -> bool:
+    """Check if the API has completed startup."""
+    return _app_ready
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    global _app_ready
+
     # Temporal
     # Run in background to avoid blocking startup
     asyncio.create_task(add_temporal_search_attributes())
@@ -112,7 +122,15 @@ async def lifespan(app: FastAPI):
     logger.info(
         "Feature flags", feature_flags=[f.value for f in config.TRACECAT__FEATURE_FLAGS]
     )
+
+    # Mark app as ready after all startup tasks complete
+    _app_ready = True
+    logger.info("API startup complete, marking as ready")
+
     yield
+
+    # Mark app as not ready during shutdown
+    _app_ready = False
 
 
 async def setup_org_settings(session: AsyncSession, admin_role: Role):
@@ -387,3 +405,18 @@ async def info(session: AsyncDBSession) -> AppInfo:
 @app.get("/health", tags=["public"])
 def check_health() -> dict[str, str]:
     return {"message": "Hello world. I am the API. This is the health endpoint."}
+
+
+@app.get("/ready", tags=["public"])
+def check_ready() -> dict[str, str]:
+    """Readiness check - returns 200 only after startup is complete.
+
+    Use this endpoint for Docker healthchecks to ensure the API has finished
+    initializing (including registry sync) before accepting traffic.
+    """
+    if not is_app_ready():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="API is not ready yet",
+        )
+    return {"status": "ready"}


### PR DESCRIPTION
## Summary
- Add `/ready` endpoint that returns 503 until API startup completes, 200 when ready
- Add healthcheck to API service in all docker-compose files
- Fixes CI flakiness in `test-workflow-codec` where executor queries registry before API finishes syncing actions

## Notes
Follows the Kubernetes liveness/readiness convention:
- `/health` (liveness): "Is the process alive?" - always returns 200
- `/ready` (readiness): "Can it handle traffic?" - returns 200 only after startup tasks complete

## Test plan
- [ ] Verify `/ready` returns 503 during startup, 200 after
- [ ] Verify docker healthcheck waits for API readiness
- [ ] Run `test-workflow-codec` CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)