### PR TITLE
fix(agent): OpenAI Any parsing and Bedrock ARN support

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
@@ -85,6 +85,7 @@ async def get_session() -> aioboto3.Session:
     aws_access_key_id = secrets.get_or_default("AWS_ACCESS_KEY_ID")
     aws_secret_access_key = secrets.get_or_default("AWS_SECRET_ACCESS_KEY")
     aws_session_token = secrets.get_or_default("AWS_SESSION_TOKEN")
+    aws_bearer_token_bedrock = secrets.get_or_default("AWS_BEARER_TOKEN_BEDROCK")
 
     if aws_role_arn:
         aws_role_session_name = secrets.get_or_default("AWS_ROLE_SESSION_NAME")
@@ -113,6 +114,8 @@ async def get_session() -> aioboto3.Session:
             aws_secret_access_key=aws_secret_access_key,
             region_name=aws_region,
         )
+    elif aws_bearer_token_bedrock:
+        session = aioboto3.Session(region_name=aws_region)
     else:
         # NOTE: This is critical. We must not allow Boto3's default behavior of
         # using the AWS credentials from the environment.
@@ -128,6 +131,7 @@ def get_sync_session() -> boto3.Session:
     aws_access_key_id = secrets.get_or_default("AWS_ACCESS_KEY_ID")
     aws_secret_access_key = secrets.get_or_default("AWS_SECRET_ACCESS_KEY")
     aws_session_token = secrets.get_or_default("AWS_SESSION_TOKEN")
+    aws_bearer_token_bedrock = secrets.get_or_default("AWS_BEARER_TOKEN_BEDROCK")
 
     if aws_role_arn:
         aws_role_session_name = secrets.get_or_default("AWS_ROLE_SESSION_NAME")
@@ -156,6 +160,8 @@ def get_sync_session() -> boto3.Session:
             aws_secret_access_key=aws_secret_access_key,
             region_name=aws_region,
         )
+    elif aws_bearer_token_bedrock:
+        session = boto3.Session(region_name=aws_region)
     else:
         # NOTE: This is critical. We must not allow Boto3's default behavior of
         # using the AWS credentials from the environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "pyarrow==16.1.0",
     "pydantic-extra-types>=2.10.2,<3.0.0",
     "pydantic>=2.11.7,<3.0.0",
-    "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai]==1.22.0",
+    "pydantic-ai-slim[anthropic,bedrock,google,mcp,openai]==1.29.0",
     "pysaml2==7.5.0",
     "python-slugify==8.0.4",
     "ray[default]==2.52.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1860,9 +1860,9 @@ pydantic==2.12.5 \
     #   pydantic-settings
     #   ray
     #   tracecat
-pydantic-ai-slim==1.22.0 \
-    --hash=sha256:0c962bac44ea81bd731e787e07106ebc49dc1ea9c842b131a5adec0e869aad37 \
-    --hash=sha256:9c2b0504daf3cfd4c06c2454ebf3011b6e08cf05cb18460f2a97c258b8cead6a
+pydantic-ai-slim==1.29.0 \
+    --hash=sha256:3bc48b3024ae1a5ee4b1e8b3766b8222723a0b8efb6959a2cab0494b9ba64fc2 \
+    --hash=sha256:4c6f563af4c5297a9129809bbf9589dff1a99e9417ce5b8fa6ed837d38acd434
     # via tracecat
 pydantic-core==2.41.5 \
     --hash=sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90 \
@@ -1931,9 +1931,9 @@ pydantic-extra-types==2.10.6 \
     --hash=sha256:6106c448316d30abf721b5b9fecc65e983ef2614399a24142d689c7546cc246a \
     --hash=sha256:c63d70bf684366e6bbe1f4ee3957952ebe6973d41e7802aea0b770d06b116aeb
     # via tracecat
-pydantic-graph==1.22.0 \
-    --hash=sha256:388c2153fddd7a7f7befcca24ff520fe29b26ac01b5ebc49051a4dcd7198226b \
-    --hash=sha256:cc3d396e27f6a664211ed5ebacb205e6f1e2e42f1ca21846a587e3b52b438fe8
+pydantic-graph==1.29.0 \
+    --hash=sha256:5b2e12902423007508ecd216b4d47e7c95b544530868adc32b93756dcb6b1ba0 \
+    --hash=sha256:87cd673f7333c2db312595696beff597f4de4f6767c954d4e65964f54cb4b073
     # via pydantic-ai-slim
 pydantic-settings==2.12.0 \
     --hash=sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0 \

--- a/tracecat/agent/config.py
+++ b/tracecat/agent/config.py
@@ -55,24 +55,8 @@ MODEL_CONFIGS = {
             "required": ["anthropic"],
         },
     ),
-    "anthropic.claude-sonnet-4-5-20250929-v1:0": ModelConfig(
-        name="anthropic.claude-sonnet-4-5-20250929-v1:0",
-        provider="bedrock",
-        org_secret_name="agent-bedrock-credentials",
-        secrets={
-            "required": ["bedrock"],
-        },
-    ),
-    "anthropic.claude-haiku-4-5-20251001-v1:0": ModelConfig(
-        name="anthropic.claude-haiku-4-5-20251001-v1:0",
-        provider="bedrock",
-        org_secret_name="agent-bedrock-credentials",
-        secrets={
-            "required": ["bedrock"],
-        },
-    ),
-    "openai.gpt-oss-120b-1:0": ModelConfig(
-        name="openai.gpt-oss-120b-1:0",
+    "bedrock": ModelConfig(
+        name="bedrock",  # Placeholder; actual ARN from AWS_MODEL_ARN credential will be used at runtime
         provider="bedrock",
         org_secret_name="agent-bedrock-credentials",
         secrets={
@@ -122,13 +106,28 @@ PROVIDER_CREDENTIAL_CONFIGS = {
                 key="AWS_ACCESS_KEY_ID",
                 label="Access Key ID",
                 type="text",
-                description="Your AWS access key ID for Bedrock access.",
+                description="Your AWS access key ID for Bedrock access. Required if using IAM credentials.",
+                required=False,
             ),
             ProviderCredentialField(
                 key="AWS_SECRET_ACCESS_KEY",
                 label="Secret Access Key",
                 type="password",
-                description="Your AWS secret access key for Bedrock access.",
+                description="Your AWS secret access key for Bedrock access. Required if using IAM credentials.",
+                required=False,
+            ),
+            ProviderCredentialField(
+                key="AWS_BEARER_TOKEN_BEDROCK",
+                label="API Key",
+                type="password",
+                description="Your API Key for Bedrock access.",
+                required=False,
+            ),
+            ProviderCredentialField(
+                key="AWS_MODEL_ARN",
+                label="Model ARN",
+                type="text",
+                description="Your model ARN for Bedrock access.",
             ),
             ProviderCredentialField(
                 key="AWS_REGION",

--- a/tracecat/agent/providers.py
+++ b/tracecat/agent/providers.py
@@ -1,3 +1,5 @@
+import os
+
 import orjson
 from google.oauth2 import service_account
 from pydantic_ai.models import Model
@@ -93,6 +95,10 @@ def get_model(
                 provider=GoogleProvider(credentials=credentials),
             )
         case "bedrock":
+            bearer_token = secrets.get_or_default("AWS_BEARER_TOKEN_BEDROCK")
+            if bearer_token:
+                os.environ["AWS_BEARER_TOKEN_BEDROCK"] = bearer_token
+
             session = get_sync_session()
             client = session.client(service_name="bedrock-runtime")
             settings = None

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -255,6 +255,16 @@ class AgentManagementService(BaseService):
                 f"Please configure credentials for this provider first."
             )
 
+        # For Bedrock, the model name must be the ARN from credentials
+        if provider == "bedrock":
+            arn = credentials.get("AWS_MODEL_ARN")
+            if not arn:
+                raise TracecatNotFoundError(
+                    "AWS_MODEL_ARN not found in Bedrock credentials. "
+                    "Please configure the Model ARN in your Bedrock credentials."
+                )
+            model_config = model_config.model_copy(update={"name": arn})
+
         # Use the credentials directly in the environment sandbox
         with secrets_manager.env_sandbox(credentials):
             yield model_config

--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -3,8 +3,11 @@
 import inspect
 import keyword
 import textwrap
+import types
 from dataclasses import dataclass
-from typing import Any, Protocol
+from functools import reduce
+from operator import or_
+from typing import Any, Protocol, Union, get_args, get_origin
 
 import orjson
 from pydantic_ai import ModelRetry
@@ -33,6 +36,9 @@ from tracecat.logger import logger
 from tracecat.registry.actions.schemas import BoundRegistryAction, RegistryActionOptions
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets import secrets_manager
+
+# Define JsonValue type for tool parameters that accept any JSON-compatible value
+JsonValue = str | int | float | bool | None | list | dict
 
 
 def create_tool_call_message(
@@ -435,6 +441,39 @@ class FunctionSignature:
     param_mapping: dict[str, str]
 
 
+def _replace_any_with_jsonvalue(annotation: Any) -> Any:
+    """Replace Any type annotations with JsonValue for better tool schema generation.
+
+    Handles both direct Any types and Any within union types (e.g., str | Any).
+
+    Args:
+        annotation: The type annotation to check and potentially replace
+
+    Returns:
+        JsonValue if annotation is Any, or a union with Any replaced by JsonValue
+    """
+    # Check if the annotation is exactly Any
+    if annotation is Any:
+        return JsonValue
+
+    # Check if it's a Union type (handles both Union[X, Y] and X | Y syntax)
+    origin = get_origin(annotation)
+    if origin is Union or isinstance(annotation, types.UnionType):
+        # Get all the union members
+        args = get_args(annotation)
+        # Replace any Any members with JsonValue
+        new_args = tuple(JsonValue if arg is Any else arg for arg in args)
+
+        # If we made changes, reconstruct the union
+        if new_args != args:
+            # Use reduce with | operator to reconstruct union (Python 3.10+ syntax)
+            if len(new_args) == 1:
+                return new_args[0]
+            return reduce(or_, new_args)
+
+    return annotation
+
+
 def _create_function_signature(
     model_cls: type, fixed_args: set[str] | None = None
 ) -> FunctionSignature:
@@ -460,6 +499,8 @@ def _create_function_signature(
 
         # Use the Pydantic field's annotation directly
         annotation = field_info.annotation
+        # Replace Any with JsonValue for strictness (OpenAI specific) in tool schema generation
+        annotation = _replace_any_with_jsonvalue(annotation)
 
         # Handle defaults from Pydantic field
         if field_info.default is not PydanticUndefined:

--- a/uv.lock
+++ b/uv.lock
@@ -2940,7 +2940,7 @@ email = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.22.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -2951,9 +2951,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/4d/35875395f89a59fe7d0d8810457406db968ed9e9043012258a5c32624956/pydantic_ai_slim-1.22.0.tar.gz", hash = "sha256:0c962bac44ea81bd731e787e07106ebc49dc1ea9c842b131a5adec0e869aad37", size = 313768, upload-time = "2025-11-22T00:37:24.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/4e/cf6badd293814326308acd3ad17262d03a6f006dcc2c9ddac1b1f81ce7ce/pydantic_ai_slim-1.29.0.tar.gz", hash = "sha256:3bc48b3024ae1a5ee4b1e8b3766b8222723a0b8efb6959a2cab0494b9ba64fc2", size = 329307, upload-time = "2025-12-10T00:38:27.009Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/80/c2049fdf0caf9b4fcf19dc9c0f8b4f802a0f32cce5672d844de31eaa7ee9/pydantic_ai_slim-1.22.0-py3-none-any.whl", hash = "sha256:9c2b0504daf3cfd4c06c2454ebf3011b6e08cf05cb18460f2a97c258b8cead6a", size = 414554, upload-time = "2025-11-22T00:37:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ff/ca7bf7226c5d772d77be85e41721f2caa1d08fafac9e851405faa3def099/pydantic_ai_slim-1.29.0-py3-none-any.whl", hash = "sha256:4c6f563af4c5297a9129809bbf9589dff1a99e9417ce5b8fa6ed837d38acd434", size = 430893, upload-time = "2025-12-10T00:38:19.901Z" },
 ]
 
 [package.optional-dependencies]
@@ -3059,7 +3059,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.22.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3067,9 +3067,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/de/f4dcfa706de97fce1d3d9983be84d632752c7b7ac03878bb6cc46a381e67/pydantic_graph-1.22.0.tar.gz", hash = "sha256:cc3d396e27f6a664211ed5ebacb205e6f1e2e42f1ca21846a587e3b52b438fe8", size = 58366, upload-time = "2025-11-22T00:37:26.64Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/da/a27008203273e6adc8ebdfa1390ead7bc66d710229d9bd6955c98e07407a/pydantic_graph-1.29.0.tar.gz", hash = "sha256:87cd673f7333c2db312595696beff597f4de4f6767c954d4e65964f54cb4b073", size = 58454, upload-time = "2025-12-10T00:38:29.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/2e/b1cb0000768a39b00249c460f742f697a0f59785179862f1b33b8237b515/pydantic_graph-1.22.0-py3-none-any.whl", hash = "sha256:388c2153fddd7a7f7befcca24ff520fe29b26ac01b5ebc49051a4dcd7198226b", size = 72260, upload-time = "2025-11-22T00:37:16.294Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ff/52f4c1f6b65da79c4853dea925e46e7003be7391543550bebdf320e3a032/pydantic_graph-1.29.0-py3-none-any.whl", hash = "sha256:5b2e12902423007508ecd216b4d47e7c95b544530868adc32b93756dcb6b1ba0", size = 72330, upload-time = "2025-12-10T00:38:22.487Z" },
 ]
 
 [[package]]
@@ -4218,7 +4218,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = "==3.1.19" },
     { name = "pyarrow", specifier = "==16.1.0" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai"], specifier = "==1.22.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "google", "mcp", "openai"], specifier = "==1.29.0" },
     { name = "pydantic-extra-types", specifier = ">=2.10.2,<3.0.0" },
     { name = "pygithub", specifier = ">=2.7.0" },
     { name = "pysaml2", specifier = "==7.5.0" },


### PR DESCRIPTION
<img width="512" height="897" alt="image" src="https://github.com/user-attachments/assets/257e08ec-4a6e-41c5-b773-18e6dcce20dd" />






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tool parameter types JSON‑strict by replacing Any with JsonValue, improving tool call schema compatibility with OpenAI. Add Bedrock bearer token and model ARN support, and bump pydantic‑ai‑slim to 1.29.0.

- **New Features**
  - Bedrock: support API key (bearer) auth and model ARN; service sets the model name to the ARN and boto3 injects the Authorization header.

- **Refactors**
  - Replace Any with JsonValue in tool parameter annotations (including unions) to generate strict JSON‑compatible tool schemas; tests added.
  - Update pydantic‑ai‑slim and pydantic‑graph to 1.29.0.

<sup>Written for commit 35ffc99e3c711d1a2347ce897ead8be9b28ca1f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





