### PR TITLE
feat(webhook): implement legacy format for webhook secret computation

### DIFF
--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -766,7 +766,9 @@ class Webhook(WorkspaceModel):
         secret = os.getenv("TRACECAT__SIGNING_SECRET")
         if not secret:
             raise ValueError("TRACECAT__SIGNING_SECRET is not set")
-        return hashlib.sha256(f"{self.id}{secret}".encode()).hexdigest()
+        # Using legacy format to prevent webhook url changes
+        id_part = f"wh-{self.id.hex}"
+        return hashlib.sha256(f"{id_part}{secret}".encode()).hexdigest()
 
     @property
     def url(self) -> str:


### PR DESCRIPTION
## Summary
- Added `secret_from_legacy_id` property to the Webhook model to compute secrets using the legacy prefixed ID format (`wh-{uuid.hex}`)
- Ensures backward compatibility with existing webhook URLs that were generated using the prefixed format
- Added unit tests to verify correct secret computation and prevent regression

## Test plan
- [x] Unit tests added for legacy secret computation
- [x] Tests verify the secret format matches expected legacy behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Webhook.secret to compute secrets using the legacy prefixed ID format (wh-{uuid.hex}) so existing webhook URLs remain valid. Add unit tests to confirm the legacy hash and prevent regression to raw UUID format.

<sup>Written for commit b299ef8aae14f0b644e6a7e0949beb38934474cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

