### PR TITLE
fix: increase agent activity timeouts to 5 minutes

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/durable.py
@@ -119,7 +119,7 @@ class DurableModel(Model):
         result = await workflow.execute_activity_method(
             AgentActivities.model_request,
             args=(args, agent_ctx),
-            start_to_close_timeout=timedelta(seconds=120),
+            start_to_close_timeout=timedelta(seconds=300),
         )
         resp = ModelResponseTA.validate_python(result.model_response)
         logger.debug(f"DurableModel response: {to_json(resp, indent=2).decode()}")

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -155,7 +155,7 @@ class DurableAgentWorkflow:
                 base_url=cfg.base_url,
             ),
             activity_config=workflow.ActivityConfig(
-                start_to_close_timeout=timedelta(seconds=60),
+                start_to_close_timeout=timedelta(seconds=300),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             ),
             deps_type=PersistableStreamingAgentDepsSpec,


### PR DESCRIPTION
## Summary
- Increase `start_to_close_timeout` for model request activities from 120s to 300s (5 min)
- Increase `start_to_close_timeout` for streaming request activities from 60s to 300s (5 min)

This prevents premature timeouts for longer AI model responses, especially streaming requests which can take longer due to token-by-token generation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase agent activity timeouts to 5 minutes to prevent premature timeouts on long model and streaming responses. Model requests from 120s to 300s; streaming requests from 60s to 300s.

<sup>Written for commit 75ebb0e4ba8303930f94e0f80b18821a4bda8ea0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

