### PR TITLE
fix(registry): move type stubs to dev dependencies

### DIFF
--- a/packages/tracecat-registry/pyproject.toml
+++ b/packages/tracecat-registry/pyproject.toml
@@ -37,13 +37,15 @@ dependencies = [
     "slack-sdk==3.28.0",
     "tavily-python==0.7.6",
     "tenacity==8.3.0",
-    "types-aioboto3[sts,s3]>=15.0.0",
-    "types-boto3[sts,s3]>=1.39.0,<2.0.0",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 cli = ["typer>=0.15.1", "rich>=13.7.0"]
+dev = [
+    "types-aioboto3[sts,s3]>=15.0.0",
+    "types-boto3[sts,s3]>=1.39.0,<2.0.0",
+]
 
 [project.urls]
 Homepage = "https://tracecat.com"

--- a/packages/tracecat-registry/tracecat_registry/integrations/amazon_s3.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/amazon_s3.py
@@ -1,17 +1,22 @@
 """S3 integration to download files and return contents as a string."""
 
-import re
-from typing import Annotated, Any
-from typing_extensions import Doc
+import asyncio
 import base64
 import binascii
-import asyncio
+import re
+from typing import TYPE_CHECKING, Annotated, Any
 
 from tenacity import retry, stop_after_attempt, wait_exponential
-from types_aiobotocore_s3.type_defs import (
-    ListObjectsV2OutputTypeDef,
-    DeleteObjectOutputTypeDef,
-)
+from typing_extensions import Doc
+
+if TYPE_CHECKING:
+    from types_aiobotocore_s3.type_defs import (
+        DeleteObjectOutputTypeDef,
+        ListObjectsV2OutputTypeDef,
+    )
+else:
+    ListObjectsV2OutputTypeDef = dict[str, Any]
+    DeleteObjectOutputTypeDef = dict[str, Any]
 
 from tracecat_registry import RegistrySecret, registry
 import tracecat_registry.integrations.aws_boto3 as aws_boto3

--- a/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
@@ -4,15 +4,20 @@ Provides a interface to Boto3's Client and Paginator APIs.
 Supports role-based authentication and session management.
 """
 
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 from typing_extensions import Doc
 
 import boto3
 import aioboto3
-from types_aiobotocore_sts.type_defs import (
-    CredentialsTypeDef as AsyncCredentialsTypeDef,
-)
-from types_boto3_sts.type_defs import CredentialsTypeDef
+
+if TYPE_CHECKING:
+    from types_aiobotocore_sts.type_defs import (
+        CredentialsTypeDef as AsyncCredentialsTypeDef,
+    )
+    from types_boto3_sts.type_defs import CredentialsTypeDef
+else:
+    AsyncCredentialsTypeDef = dict[str, Any]
+    CredentialsTypeDef = dict[str, Any]
 
 from tracecat_registry import (
     RegistrySecret,

--- a/requirements.txt
+++ b/requirements.txt
@@ -274,12 +274,6 @@ botocore==1.40.61 \
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.41.6 \
-    --hash=sha256:2b53574c4ea4f8d5887e516ef2208b996fd988fc2a613f676ea9144597f20cd2 \
-    --hash=sha256:859e4147b5b14dc5eb64fc84fa02424839354368a0fea41da52c7a1d06427e37
-    # via
-    #   types-aioboto3
-    #   types-boto3
 cachetools==5.5.2 \
     --hash=sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4 \
     --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
@@ -2603,38 +2597,6 @@ typer==0.20.0 \
     #   fastapi-cli
     #   fastapi-cloud-cli
     #   modal
-types-aioboto3==15.5.0 \
-    --hash=sha256:5769a1c3df7ca1abedf3656ddf0b970c9b0436d0f88cf4686040b55cd2a02925 \
-    --hash=sha256:8aed7c9b6fe9b59e6ce74f7a6db7b8a9912a34c8f80ed639fac1fa59d6b20aa1
-    # via tracecat-registry
-types-aiobotocore==2.26.0.post1 \
-    --hash=sha256:a0aadb9dfd10ecb2bca4b2eac59c71a7536b50145f3027aebf80084589252ed4 \
-    --hash=sha256:de72760a09029ef74c92cf07e8081f5286d1d0f78a509e86b491d9aecb6a4f38
-    # via types-aioboto3
-types-aiobotocore-s3==2.25.2 \
-    --hash=sha256:151301e84bb2f1cbf30f0d1ef791bb75c141cfbfe47b93fd317b7f1ba3eb35e4 \
-    --hash=sha256:678aa425491af19bd6d011d59ecdbbb7ae7e95800efddcf4fd559ab72c94e194
-    # via types-aioboto3
-types-aiobotocore-sts==2.25.2 \
-    --hash=sha256:1342271243d03fd8d4a1eab566d9137f70ec723bb6ad613669c74152ac3a0427 \
-    --hash=sha256:487da184371dc9761fd3ed663d519f4a19f690d7dcc1fe8f551b6dd805f08549
-    # via types-aioboto3
-types-awscrt==0.29.1 \
-    --hash=sha256:545f100e17d7633aa1791f92a8a4716f8ee1fc7cc9ee98dd31676d6c5e07e733 \
-    --hash=sha256:f583bef3d42a307b3f3c02ef8d5d49fbec04e02bf3aacd3ada3953213c9150a7
-    # via botocore-stubs
-types-boto3==1.41.5 \
-    --hash=sha256:c0e129bfd62b2ae58c53285c7a4895127f1bdfe7921d558d3c8525cf387d6d0c \
-    --hash=sha256:d37e3615f2319404407efc8dbdf10111c74c9e47296d3e0d691d2b95742254bd
-    # via tracecat-registry
-types-boto3-s3==1.41.1 \
-    --hash=sha256:2a991334affac08e348085da391892730d383ebb8174f809e24273fee0c7b30a \
-    --hash=sha256:6ee17eadb7608a75d5a572a35f2efd334c7de80f95e9c8e36f0d0481a230e380
-    # via types-boto3
-types-boto3-sts==1.41.0 \
-    --hash=sha256:ac002224e6d72e728e660cbaf9d095e918af7330698d0be89690d081378a4b4c \
-    --hash=sha256:bc7c7bf7ae844f9d8c31cf3c25b7a42d2ad849546dd8064bbd0b63da5892e4cb
-    # via types-boto3
 types-certifi==2021.10.8.3 \
     --hash=sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f \
     --hash=sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a
@@ -2643,12 +2605,6 @@ types-protobuf==6.32.1.20251105 \
     --hash=sha256:641002611ff87dd9fedc38a39a29cacb9907ae5ce61489b53e99ca2074bef764 \
     --hash=sha256:a15109d38f7cfefd2539ef86d3f93a6a41c7cad53924f8aa1a51eaddbb72a660
     # via temporalio
-types-s3transfer==0.15.0 \
-    --hash=sha256:1e617b14a9d3ce5be565f4b187fafa1d96075546b52072121f8fda8e0a444aed \
-    --hash=sha256:43a523e0c43a88e447dfda5f4f6b63bf3da85316fdd2625f650817f2b170b5f7
-    # via
-    #   types-aioboto3
-    #   types-boto3
 types-toml==0.10.8.20240310 \
     --hash=sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331 \
     --hash=sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d

--- a/uv.lock
+++ b/uv.lock
@@ -4283,14 +4283,16 @@ dependencies = [
     { name = "slack-sdk" },
     { name = "tavily-python" },
     { name = "tenacity" },
-    { name = "types-aioboto3", extra = ["s3", "sts"] },
-    { name = "types-boto3", extra = ["s3", "sts"] },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "rich" },
     { name = "typer" },
+]
+dev = [
+    { name = "types-aioboto3", extra = ["s3", "sts"] },
+    { name = "types-boto3", extra = ["s3", "sts"] },
 ]
 
 [package.metadata]
@@ -4313,10 +4315,10 @@ requires-dist = [
     { name = "tavily-python", specifier = "==0.7.6" },
     { name = "tenacity", specifier = "==8.3.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.15.1" },
-    { name = "types-aioboto3", extras = ["s3", "sts"], specifier = ">=15.0.0" },
-    { name = "types-boto3", extras = ["s3", "sts"], specifier = ">=1.39.0,<2.0.0" },
+    { name = "types-aioboto3", extras = ["s3", "sts"], marker = "extra == 'dev'", specifier = ">=15.0.0" },
+    { name = "types-boto3", extras = ["s3", "sts"], marker = "extra == 'dev'", specifier = ">=1.39.0,<2.0.0" },
 ]
-provides-extras = ["cli"]
+provides-extras = ["cli", "dev"]
 
 [[package]]
 name = "trove-classifiers"


### PR DESCRIPTION
## Summary
- Move `types-aioboto3` and `types-boto3` from runtime dependencies to optional dev dependencies
- These type stubs are only needed at type-checking time, not runtime
- Use `TYPE_CHECKING` guard in `aws_boto3.py` with lazy annotation evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move AWS type stubs to dev-only and guard imports across S3/STS to reduce runtime dependencies and avoid import errors.

- **Dependencies**
  - Moved types-aioboto3/types-boto3 to an optional dev extra; removed them from runtime deps (requirements and lock updated).
  - Use TYPE_CHECKING with dict fallbacks for S3 and STS type defs in amazon_s3.py and aws_boto3.py to remove runtime stub requirements.

<sup>Written for commit d856f8872f21f60b052500f21fc77ae18b693abf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





