### PR TITLE
Adjust scatter interval test timing threshold

### DIFF
--- a/tests/unit/test_scatter_interval.py
+++ b/tests/unit/test_scatter_interval.py
@@ -163,8 +163,8 @@ async def test_scatter_without_interval(
     # Verify results
     assert result["ACTIONS"]["gather"]["result"] == [2, 3, 4, 5]
 
-    # Without interval, execution should be relatively fast (< 2 seconds for simple ops)
-    assert elapsed < 2.0, (
+    # Without interval, execution should be relatively fast (< 4 seconds for simple ops)
+    assert elapsed < 4.0, (
         f"Execution without interval should be fast, but took {elapsed:.2f}s"
     )
 


### PR DESCRIPTION
## Summary
- increase the allowable execution time in `test_scatter_without_interval` to reduce flakiness

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a99414548320b32cd684df22da3e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the allowable execution time in test_scatter_without_interval from 2s to 4s to reduce flakiness on slower CI runners. Test-only change that preserves the “fast without interval” intent while allowing for environment variance.

<sup>Written for commit cd810acd79c4ccb8a4cba6273dba41b1d0527354. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

