### PR TITLE
fix(agents): suppress stream errors to ensure agent execution continues

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -18,7 +18,7 @@ from pydantic_ai.tools import (
     DeferredToolResults,
 )
 from temporalio import activity, workflow
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ApplicationError, CancelledError
 
 with workflow.unsafe.imports_passed_through():
     from tracecat.agent.parsers import parse_output_type, try_parse_json
@@ -297,6 +297,9 @@ class DurableAgentWorkflow:
                     ),
                     start_to_close_timeout=timedelta(seconds=60),
                 )
+            except CancelledError:
+                # Re-raise cancellation to allow workflow to terminate properly
+                raise
             except Exception as e:
                 # Streaming is non-critical - log the error but continue processing
                 # This ensures agent execution completes even if streaming fails


### PR DESCRIPTION
## Summary
- Wrap event streaming activity in try/except to handle failures gracefully
- Log warnings for streaming errors instead of failing the workflow
- Ensure agent execution completes even if streaming is unavailable

Streaming is non-critical functionality - agent execution should not fail due to streaming issues.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress event stream errors so agent execution continues. Wrap the streaming activity in try/except, re-raise CancelledError to preserve cancellation, and log warnings instead of failing the workflow.

<sup>Written for commit d5f5c6a98233d84bd84673ec89dba0b3e821db3c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



