### PR TITLE
feat(integrations): Include case tags in case and metrics UDFs

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -35,6 +35,7 @@ from tracecat.cases.schemas import (
 from tracecat.cases.service import CasesService, CaseCommentsService
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.auth.users import lookup_user_by_email
+from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.tags.schemas import TagRead, TagCreate
 from tracecat.tables.common import coerce_optional_to_utc_datetime
 from tracecat_registry import registry
@@ -363,6 +364,10 @@ async def get_case(
             )
         )
 
+    # Get tags for the case
+    tags = await service.tags.list_tags_for_case(case.id)
+    tag_reads = [CaseTagRead.model_validate(tag, from_attributes=True) for tag in tags]
+
     # Convert any UUID to string before serializing
     case_read = CaseRead(
         id=case.id,  # Use UUID directly
@@ -376,6 +381,7 @@ async def get_case(
         description=case.description,
         fields=final_fields,
         payload=case.payload,
+        tags=tag_reads,
     )
 
     # Use model_dump(mode="json") to ensure UUIDs are converted to strings

--- a/tracecat/cases/durations/schemas.py
+++ b/tracecat/cases/durations/schemas.py
@@ -187,6 +187,10 @@ class CaseDurationMetric(BaseModel):
     case_priority: str = Field(..., description="Case priority value")
     case_severity: str = Field(..., description="Case severity value")
     case_status: str = Field(..., description="Case status value")
+    case_tags: list[str] = Field(
+        default_factory=list,
+        description="List of tag refs associated with the case",
+    )
 
     # Case identifiers (high cardinality - for drill-down/lookups)
     case_id: str = Field(..., description="Case UUID for lookups")

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -434,6 +434,7 @@ class CaseDurationService(BaseWorkspaceService):
                         case_priority=case.priority.value,
                         case_severity=case.severity.value,
                         case_status=case.status.value,
+                        case_tags=[tag.ref for tag in case.tags],
                         # Case identifiers (high cardinality, for drill-down)
                         case_id=str(case.id),
                         case_short_id=case.short_id,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose case tags in case details and duration metrics to enable filtering and grouping by tag in UDFs and dashboards.

- **New Features**
  - get_case now returns tags on CaseRead.
  - Added case_tags (list of tag refs) to CaseDurationMetric.
  - Populated case_tags from case data in the duration metrics formatter.

<sup>Written for commit 85c46955f2bdaef82769e912ac1dd77717f6ec96. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

