### PR TITLE
feat(api+integrations): Support array payloads and update payload UDF

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3121,6 +3121,10 @@ export const $CaseCreate = {
           type: "object",
         },
         {
+          items: {},
+          type: "array",
+        },
+        {
           type: "null",
         },
       ],
@@ -4034,6 +4038,10 @@ export const $CaseRead = {
           type: "object",
         },
         {
+          items: {},
+          type: "array",
+        },
+        {
           type: "null",
         },
       ],
@@ -4586,6 +4594,10 @@ export const $CaseUpdate = {
         {
           additionalProperties: true,
           type: "object",
+        },
+        {
+          items: {},
+          type: "array",
         },
         {
           type: "null",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -825,9 +825,12 @@ export type CaseCreate = {
     [key: string]: unknown
   } | null
   assignee_id?: string | null
-  payload?: {
-    [key: string]: unknown
-  } | null
+  payload?:
+    | {
+        [key: string]: unknown
+      }
+    | Array<unknown>
+    | null
 }
 
 /**
@@ -1153,9 +1156,12 @@ export type CaseRead = {
   description: string
   fields: Array<CaseFieldRead>
   assignee?: UserRead | null
-  payload: {
-    [key: string]: unknown
-  } | null
+  payload:
+    | {
+        [key: string]: unknown
+      }
+    | Array<unknown>
+    | null
   tags?: Array<CaseTagRead>
 }
 
@@ -1281,9 +1287,12 @@ export type CaseUpdate = {
     [key: string]: unknown
   } | null
   assignee_id?: string | null
-  payload?: {
-    [key: string]: unknown
-  } | null
+  payload?:
+    | {
+        [key: string]: unknown
+      }
+    | Array<unknown>
+    | null
 }
 
 /**

--- a/frontend/src/components/cases/case-payload-section.tsx
+++ b/frontend/src/components/cases/case-payload-section.tsx
@@ -2,12 +2,27 @@ import { Braces } from "lucide-react"
 import type { CaseRead } from "@/client"
 import { JsonViewWithControls } from "@/components/json-viewer"
 
+// Payload can be a dict or list (type will be updated after regenerating client types)
+type PayloadType = Record<string, unknown> | unknown[] | null
+
+function hasPayloadContent(payload: PayloadType): boolean {
+  if (payload === null || payload === undefined) {
+    return false
+  }
+  if (Array.isArray(payload)) {
+    return payload.length > 0
+  }
+  return Object.keys(payload).length > 0
+}
+
 export function CasePayloadSection({ caseData }: { caseData: CaseRead }) {
+  // Cast to PayloadType to handle both dict and list (forward-compatible with updated types)
+  const payload = caseData.payload as PayloadType
   return (
     <div className="space-y-4">
-      {caseData.payload && Object.keys(caseData.payload).length > 0 ? (
+      {hasPayloadContent(payload) ? (
         <JsonViewWithControls
-          src={caseData.payload}
+          src={payload}
           defaultTab="nested"
           defaultExpanded={true}
           showControls={true}

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -57,7 +57,7 @@ class CaseRead(Schema):
     description: str
     fields: list[CaseFieldRead]
     assignee: UserRead | None = None
-    payload: dict[str, Any] | None
+    payload: dict[str, Any] | list[Any] | None
     tags: list[CaseTagRead] = Field(default_factory=list)
 
 
@@ -69,7 +69,7 @@ class CaseCreate(Schema):
     severity: CaseSeverity
     fields: dict[str, Any] | None = None
     assignee_id: uuid.UUID | None = None
-    payload: dict[str, Any] | None = None
+    payload: dict[str, Any] | list[Any] | None = None
 
 
 class CaseUpdate(Schema):
@@ -80,7 +80,7 @@ class CaseUpdate(Schema):
     severity: CaseSeverity | None = None
     fields: dict[str, Any] | None = None
     assignee_id: uuid.UUID | None = None
-    payload: dict[str, Any] | None = None
+    payload: dict[str, Any] | list[Any] | None = None
 
 
 # Case Fields

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -1497,7 +1497,7 @@ class Case(WorkspaceModel):
         default=CaseStatus.NEW,
         nullable=False,
     )
-    payload: Mapped[dict[str, Any] | None] = mapped_column(
+    payload: Mapped[dict[str, Any] | list[Any] | None] = mapped_column(
         JSONB,
         nullable=True,
         doc="Additional data payload for the case",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable case payloads to be objects or arrays and add a UDF to append or replace payload data. This supports richer ingestion and safer incremental updates.

- **New Features**
  - Case payload now accepts object or array in API schemas, DB model (JSONB), and frontend viewer.
  - Added update_payload(case_id, payload, append=false): when append=true, dict+dict merges keys, list+list extends, and dict<->list converts and appends.

- **Migration**
  - Regenerate API/client types and update any code that assumed payload is always an object.
  - No backend data migration needed (JSONB unchanged); the UI already renders arrays and hides empty payloads.

<sup>Written for commit d33eaf077da75783f3feb3e332b476fc89a9b004. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

