### PR TITLE
feat(registry): add registry agent proxy layer

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/config.py
+++ b/packages/tracecat-registry/tracecat_registry/config.py
@@ -67,8 +67,6 @@ class _FeatureFlags:
         """Enable agent presets UDFs."""
         self.ai_ranking: bool = "ai-ranking" in _flags
         """Enable AI ranking UDFs."""
-        self.case_durations: bool = "case-durations" in _flags
-        """Enable case durations (enterprise feature)."""
 
 
 flags = _FeatureFlags()

--- a/packages/tracecat-registry/tracecat_registry/config.py
+++ b/packages/tracecat-registry/tracecat_registry/config.py
@@ -47,6 +47,15 @@ TRACECAT__DB_URI = os.environ.get(
 )
 TRACECAT__DB_ENDPOINT = os.environ.get("TRACECAT__DB_ENDPOINT")
 TRACECAT__DB_PORT = os.environ.get("TRACECAT__DB_PORT")
+TRACECAT__AGENT_MAX_RETRIES = int(os.environ.get("TRACECAT__AGENT_MAX_RETRIES", 20))
+
+TRACECAT__AGENT_MAX_TOOL_CALLS = int(
+    os.environ.get("TRACECAT__AGENT_MAX_TOOL_CALLS", 40)
+)
+"""The maximum number of tool calls that can be made per agent run."""
+
+TRACECAT__AGENT_MAX_REQUESTS = int(os.environ.get("TRACECAT__AGENT_MAX_REQUESTS", 120))
+"""The maximum number of requests that can be made per agent run."""
 
 
 class _FeatureFlags:

--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -3,10 +3,13 @@
 from typing import Annotated, Any
 from typing_extensions import Doc
 
-from tracecat.agent.factory import build_agent
-from tracecat.agent.runtime import run_agent_sync
-from tracecat.agent.types import AgentConfig, OutputType
-from tracecat.registry.fields import ActionType, AgentPreset, TextArea
+from tracecat_registry.fields import ActionType, AgentPreset, TextArea
+from tracecat_registry.sdk.agents import (
+    AgentConfig,
+    OutputType,
+    build_agent,
+    run_agent_sync,
+)
 from tracecat_registry import (
     ActionIsInterfaceError,
     RegistrySecret,

--- a/packages/tracecat-registry/tracecat_registry/core/ai.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ai.py
@@ -1,13 +1,13 @@
 """AI utilities. Actions that use LLMs to perform specific predefined tasks."""
 
-from typing import Annotated, Any, TypedDict, Literal
+from typing import Annotated, Any, Literal, TypedDict
 
 from typing_extensions import Doc
 
-from tracecat.ai.ranker import RankableItem, rank_items_pairwise, rank_items
-from tracecat_registry.core.transform import flatten_dict
 from tracecat_registry import registry
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.transform import flatten_dict
+from tracecat_registry.sdk.agents import RankableItem, rank_items, rank_items_pairwise
 
 
 MAX_KEYS: int = 100

--- a/packages/tracecat-registry/tracecat_registry/core/python.py
+++ b/packages/tracecat-registry/tracecat_registry/core/python.py
@@ -1,18 +1,10 @@
 import re
 from typing import Annotated, Any
 
-from tracecat.contexts import ctx_role
-from tracecat.logger import logger
-from tracecat.registry.fields import Code
-from tracecat.sandbox import (
-    PackageInstallError,
-    SandboxExecutionError,
-    SandboxService,
-    SandboxTimeoutError,
-    SandboxValidationError,
-)
-from tracecat_registry import registry
 from typing_extensions import Doc
+
+from tracecat_registry import RegistryActionError, config, registry
+from tracecat_registry.fields import Code
 
 
 class PythonScriptError(Exception):
@@ -136,6 +128,21 @@ async def run_python(
         PythonScriptTimeoutError: If script execution times out.
         PythonScriptExecutionError: If script execution fails.
     """
+    if config.flags.registry_client:
+        raise RegistryActionError(
+            "core.script.run_python cannot run in registry-client mode."
+        )
+
+    from tracecat.contexts import ctx_role
+    from tracecat.logger import logger
+    from tracecat.sandbox import (
+        PackageInstallError,
+        SandboxExecutionError,
+        SandboxService,
+        SandboxTimeoutError,
+        SandboxValidationError,
+    )
+
     # Validate script
     is_valid, error_message = _validate_script(script)
     if not is_valid:

--- a/packages/tracecat-registry/tracecat_registry/fields.py
+++ b/packages/tracecat-registry/tracecat_registry/fields.py
@@ -1,0 +1,35 @@
+"""Registry field types for UI rendering (registry-client compatible)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from tracecat_registry import config
+
+if not config.flags.registry_client or TYPE_CHECKING:
+    from tracecat.registry.fields import ActionType, AgentPreset, Code, TextArea
+else:
+
+    @dataclass(slots=True)
+    class TextArea:
+        component_id: Literal["text-area"] = "text-area"
+        rows: int = 4
+        placeholder: str = ""
+
+    @dataclass(slots=True)
+    class Code:
+        component_id: Literal["code"] = "code"
+        lang: Literal["yaml", "python"] = "python"
+
+    @dataclass(slots=True)
+    class AgentPreset:
+        component_id: Literal["agent-preset"] = "agent-preset"
+
+    @dataclass(slots=True)
+    class ActionType:
+        component_id: Literal["action-type"] = "action-type"
+        multiple: bool = False
+
+
+__all__ = ["ActionType", "AgentPreset", "Code", "TextArea"]

--- a/packages/tracecat-registry/tracecat_registry/integrations/agents/slack.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/agents/slack.py
@@ -15,11 +15,11 @@ from tracecat_registry.integrations.agents.prompts.slackbot import (
     SlackPrompts,
 )
 from tracecat_registry.integrations.slack_sdk import call_method, slack_secret
-from tracecat.agent.runtime import run_agent
+from tracecat_registry.sdk.agents import run_agent
 
 from tracecat_registry import registry
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
-from tracecat.registry.fields import ActionType, TextArea
+from tracecat_registry.fields import ActionType, TextArea
 from pydantic import BaseModel
 from typing_extensions import Doc
 from typing import Annotated, Any

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
@@ -1,9 +1,9 @@
-from tracecat.agent.runtime import run_agent
 from typing import Any, Annotated
 from typing_extensions import Doc
 
-from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
+from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.sdk.agents import run_agent
 
 
 github_mcp_oauth_secret = RegistryOAuthSecret(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
@@ -1,9 +1,9 @@
-from tracecat.agent.runtime import run_agent
 from typing import Any, Annotated
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.sdk.agents import run_agent
 
 
 linear_mcp_oauth_secret = RegistryOAuthSecret(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
@@ -1,9 +1,9 @@
-from tracecat.agent.runtime import run_agent
 from typing import Any, Annotated
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.sdk.agents import run_agent
 
 
 notion_mcp_oauth_secret = RegistryOAuthSecret(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
@@ -1,9 +1,9 @@
-from tracecat.agent.runtime import run_agent
 from typing import Any, Annotated
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.sdk.agents import run_agent
 
 
 runreveal_mcp_oauth_secret = RegistryOAuthSecret(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
@@ -1,9 +1,9 @@
-from tracecat.agent.runtime import run_agent
 from typing import Any, Annotated
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.sdk.agents import run_agent
 
 
 sentry_mcp_oauth_secret = RegistryOAuthSecret(

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -1,0 +1,254 @@
+"""Agent execution proxies for registry actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import uuid
+from typing import Literal, TypedDict, cast
+
+from pydantic import BaseModel
+
+from tracecat_registry import ActionIsInterfaceError, config
+
+
+type OutputType = (
+    Literal[
+        "bool",
+        "float",
+        "int",
+        "str",
+        "list[bool]",
+        "list[float]",
+        "list[int]",
+        "list[str]",
+    ]
+    | dict[str, object]
+)
+
+
+class MCPServerConfig(TypedDict):
+    """Configuration for an MCP server."""
+
+    url: str
+    headers: dict[str, str]
+
+
+class RankableItem(TypedDict):
+    id: str | int
+    text: str
+
+
+@dataclass(kw_only=True, slots=True)
+class AgentConfig:
+    """Configuration for an agent."""
+
+    # Model
+    model_name: str
+    model_provider: str
+    base_url: str | None = None
+    # Agent
+    instructions: str | None = None
+    output_type: OutputType | None = None
+    # Tools
+    actions: list[str] | None = None
+    namespaces: list[str] | None = None
+    tool_approvals: dict[str, bool] | None = None
+    # MCP
+    model_settings: dict[str, object] | None = None
+    mcp_servers: list[MCPServerConfig] | None = None
+    retries: int = config.TRACECAT__AGENT_MAX_RETRIES
+    deps_type: type[object] | None = None
+    custom_tools: list[object] | None = None
+
+
+class AgentOutput(BaseModel):
+    output: object
+    message_history: list[object] | None = None
+    duration: float
+    usage: object
+    session_id: uuid.UUID
+
+
+def _raise_registry_client() -> None:
+    if config.flags.registry_client:
+        raise ActionIsInterfaceError()
+
+
+async def build_agent(config: AgentConfig) -> object:
+    """The default factory for building an agent."""
+    _raise_registry_client()
+    from tracecat.agent.factory import build_agent as _build_agent
+    from tracecat.agent.types import AgentConfig as RuntimeAgentConfig
+
+    from tracecat.agent.types import CustomToolList
+
+    runtime_config = RuntimeAgentConfig(
+        model_name=config.model_name,
+        model_provider=config.model_provider,
+        base_url=config.base_url,
+        instructions=config.instructions,
+        output_type=config.output_type,
+        actions=config.actions,
+        namespaces=config.namespaces,
+        tool_approvals=config.tool_approvals,
+        model_settings=config.model_settings,
+        mcp_servers=config.mcp_servers,
+        retries=config.retries,
+        deps_type=config.deps_type,
+        custom_tools=cast(CustomToolList | None, config.custom_tools),
+    )
+    return await _build_agent(runtime_config)
+
+
+async def run_agent_sync(
+    agent: object,
+    user_prompt: str,
+    max_requests: int,
+    max_tools_calls: int | None = None,
+    *,
+    deferred_tool_results: object | None = None,
+) -> AgentOutput:
+    """Run an agent synchronously."""
+    _raise_registry_client()
+    from pydantic_ai import Agent as PydanticAgent
+    from pydantic_ai.tools import DeferredToolResults
+    from tracecat.agent.runtime import run_agent_sync as _run_agent_sync
+
+    result = await _run_agent_sync(
+        cast(PydanticAgent[object, object], agent),
+        user_prompt,
+        max_requests,
+        max_tools_calls,
+        deferred_tool_results=cast(DeferredToolResults | None, deferred_tool_results),
+    )
+    return AgentOutput.model_validate(result.model_dump())
+
+
+async def run_agent(
+    user_prompt: str,
+    model_name: str,
+    model_provider: str,
+    actions: list[str] | None = None,
+    namespaces: list[str] | None = None,
+    tool_approvals: dict[str, bool] | None = None,
+    mcp_server_url: str | None = None,
+    mcp_server_headers: dict[str, str] | None = None,
+    mcp_servers: list[MCPServerConfig] | None = None,
+    instructions: str | None = None,
+    output_type: OutputType | None = None,
+    model_settings: dict[str, object] | None = None,
+    max_tool_calls: int = config.TRACECAT__AGENT_MAX_TOOL_CALLS,
+    max_requests: int = config.TRACECAT__AGENT_MAX_REQUESTS,
+    retries: int = config.TRACECAT__AGENT_MAX_RETRIES,
+    base_url: str | None = None,
+    deferred_tool_results: object | None = None,
+) -> AgentOutput:
+    """Run an AI agent with specified configuration and actions."""
+    _raise_registry_client()
+    from pydantic_ai.tools import DeferredToolResults
+    from tracecat.agent.runtime import run_agent as _run_agent
+
+    result = await _run_agent(
+        user_prompt=user_prompt,
+        model_name=model_name,
+        model_provider=model_provider,
+        actions=actions,
+        namespaces=namespaces,
+        tool_approvals=tool_approvals,
+        mcp_server_url=mcp_server_url,
+        mcp_server_headers=mcp_server_headers,
+        mcp_servers=mcp_servers,
+        instructions=instructions,
+        output_type=output_type,
+        model_settings=model_settings,
+        max_tool_calls=max_tool_calls,
+        max_requests=max_requests,
+        retries=retries,
+        base_url=base_url,
+        deferred_tool_results=cast(DeferredToolResults | None, deferred_tool_results),
+    )
+    return AgentOutput.model_validate(result.model_dump())
+
+
+async def rank_items(
+    items: list[RankableItem],
+    criteria_prompt: str,
+    model_name: str,
+    model_provider: str,
+    model_settings: dict[str, object] | None = None,
+    max_requests: int = 5,
+    retries: int = 3,
+    base_url: str | None = None,
+    *,
+    min_items: int | None = None,
+    max_items: int | None = None,
+) -> list[str | int]:
+    """Rank items using an LLM based on natural language criteria."""
+    _raise_registry_client()
+    from tracecat.ai.ranker import rank_items as _rank_items
+
+    return await _rank_items(
+        items=items,
+        criteria_prompt=criteria_prompt,
+        model_name=model_name,
+        model_provider=model_provider,
+        model_settings=model_settings,
+        max_requests=max_requests,
+        retries=retries,
+        base_url=base_url,
+        min_items=min_items,
+        max_items=max_items,
+    )
+
+
+async def rank_items_pairwise(
+    items: list[RankableItem],
+    criteria_prompt: str,
+    model_name: str,
+    model_provider: str,
+    id_field: str = "id",
+    batch_size: int = 10,
+    num_passes: int = 10,
+    refinement_ratio: float = 0.5,
+    model_settings: dict[str, object] | None = None,
+    max_requests: int = 5,
+    retries: int = 3,
+    base_url: str | None = None,
+    *,
+    min_items: int | None = None,
+    max_items: int | None = None,
+) -> list[str | int]:
+    """Rank items using LLM pairwise comparisons."""
+    _raise_registry_client()
+    from tracecat.ai.ranker import rank_items_pairwise as _rank_items_pairwise
+
+    return await _rank_items_pairwise(
+        items=items,
+        criteria_prompt=criteria_prompt,
+        model_name=model_name,
+        model_provider=model_provider,
+        id_field=id_field,
+        batch_size=batch_size,
+        num_passes=num_passes,
+        refinement_ratio=refinement_ratio,
+        model_settings=model_settings,
+        max_requests=max_requests,
+        retries=retries,
+        base_url=base_url,
+        min_items=min_items,
+        max_items=max_items,
+    )
+
+
+__all__ = [
+    "AgentConfig",
+    "AgentOutput",
+    "MCPServerConfig",
+    "OutputType",
+    "RankableItem",
+    "build_agent",
+    "rank_items",
+    "rank_items_pairwise",
+    "run_agent",
+    "run_agent_sync",
+]


### PR DESCRIPTION
## Summary
- add agent proxy/stubs in tracecat_registry sdk to keep action boilerplate while gating registry-client execution
- restore AI/MCP/Slackbot action implementations to use the proxy layer
- add registry-client field stubs and mark the package as typed
- add agent limit config knobs for registry

## Testing
- uv run basedpyright packages/tracecat-registry/tracecat_registry/sdk/agents.py
- uv run ruff check .

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an agent proxy layer in the registry SDK to keep action interfaces while blocking runtime execution in registry-client mode. Updates AI/MCP/Slack actions to use the proxy, adds agent limit config knobs, and marks the package as typed.

- **New Features**
  - Agent proxy wrappers: build_agent, run_agent, run_agent_sync, rank_items, rank_items_pairwise (raise ActionIsInterfaceError in registry-client mode).
  - Lightweight field stubs for registry-client: TextArea, Code, AgentPreset, ActionType.
  - New env config: TRACECAT__AGENT_MAX_RETRIES, TRACECAT__AGENT_MAX_TOOL_CALLS, TRACECAT__AGENT_MAX_REQUESTS.
  - Added py.typed to mark the package as typed.

- **Refactors**
  - Switched core/agent, core/ai, and integrations to use tracecat_registry.sdk.agents and tracecat_registry.fields.
  - Gated core.python run_python under registry-client with a clear error; moved heavy imports inside the function.
  - Removed the case_durations feature flag.

<sup>Written for commit b9fc5535c0b6dbbc02225343149a6f444b9e84cc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

