### PR TITLE
fix(worker): prevent loguru logging during workflow replay

### DIFF
--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -87,6 +87,11 @@ def get_activities() -> list[Callable]:
 
 
 async def main() -> None:
+    # Enable workflow replay log filtering for this process
+    from tracecat.logger import _logger
+
+    _logger._is_worker_process = True
+
     client = await get_temporal_client(plugins=[TracecatPydanticAIPlugin()])
 
     interceptors = []

--- a/tracecat/logger/_logger.py
+++ b/tracecat/logger/_logger.py
@@ -2,8 +2,36 @@
 
 import os
 import sys
+from typing import TYPE_CHECKING
 
 from loguru import logger as base_logger
+
+if TYPE_CHECKING:
+    from loguru import Record
+
+
+# Set to True by worker entrypoint to enable replay filtering
+_is_worker_process = False
+
+
+def _workflow_replay_filter(record: "Record") -> bool:
+    """Filter that prevents logging during Temporal workflow replay.
+
+    Only active when _is_worker_process is True (set by worker entrypoint).
+    """
+    if not _is_worker_process:
+        return True
+
+    try:
+        from temporalio import workflow
+
+        if workflow.unsafe.is_replaying():
+            return False
+    except Exception:
+        pass
+
+    return True
+
 
 try:
     base_logger.remove(0)
@@ -16,6 +44,7 @@ base_logger.add(
     format="<fg #808080>{time:YYYY-MM-DD HH:mm:ss.SSSSSS}Z [{process}] |</fg #808080>"
     " <level>{level: <8}  <fg #808080>{name}:{function}:{line} -</fg #808080> {message}"
     " <fg #808080>|</fg #808080> {extra}</level>",
+    filter=_workflow_replay_filter,
 )
 
 logger = base_logger


### PR DESCRIPTION
## Summary
- Add replay filter to loguru logger to skip log emission during Temporal workflow replay
- Skip `logger.bind()` in `DSLWorkflow.__init__` during replay to avoid lock acquisition

## Root Cause
Loguru uses internal thread locks for thread safety. During Temporal workflow replay, these blocking lock operations violate determinism requirements and can cause nondeterminism errors like:
```
Nondeterminism("Missing associated machine for LocalActivity(484)")
```

This matches a documented issue in the Ruby SDK where logging with internal locks during replay caused identical symptoms.

## Changes
- `tracecat/logger/_logger.py`: Add `_workflow_replay_filter` that checks `workflow.unsafe.is_replaying()` and skips logging during replay
- `tracecat/dsl/workflow.py`: Wrap `logger.bind()` call in replay check to avoid lock acquisition during replay

## Notes
- Local activities are unaffected because they don't re-execute during replay - the SDK returns cached results from history
- Regular activities run outside the workflow context, so the filter doesn't affect them

## Test plan
- [ ] Deploy to staging and verify workflows complete successfully
- [ ] Trigger a workflow with nested scatters to verify no nondeterminism errors during replay
- [ ] Verify logs are still emitted during normal (non-replay) execution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix: Temporal workflow replay logging**
> 
> - Add `_workflow_replay_filter` in `tracecat/logger/_logger.py` to drop logs when `workflow.unsafe.is_replaying()`; gated behind `_is_worker_process`
> - Enable the filter in `tracecat/dsl/worker.py` by setting `_logger._is_worker_process = True`
> 
> **Robustness: scatter handling**
> 
> - In `scheduler.py`, treat `None` as an empty `scatter` collection instead of erroring
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34f0e097939e2c6d941af7cd866904e32800d94d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Loguru from logging during Temporal workflow replay to avoid nondeterminism and deadlock errors. Also treat None scatter collections as empty to prevent iterable errors. Normal (non-replay) runs still log as before.

- **Bug Fixes**
  - Add replay filter to drop log records when workflow.unsafe.is_replaying(); enable it only in worker processes.
  - Skip logger.bind() in DSLWorkflow.__init__ during replay to avoid lock acquisition.
  - Treat None scatter collection as empty to avoid "Collection is not iterable" errors.
  - Local activities and external activities unaffected; logging remains enabled outside replay.

<sup>Written for commit 31769d23b8c18def2f686d63c4b9f43764cfd3e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

