### PR TITLE
feat(workflow): add deterministic logical_time for FN.now() and variants

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5731,6 +5731,20 @@ export const $DSLRunArgs = {
         "Execution type (draft or published). Draft executions use draft aliases for child workflows.",
       default: "published",
     },
+    time_anchor: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Time Anchor",
+      description:
+        "The workflow's logical time anchor for FN.now() and related functions. If not provided, computed from TemporalScheduledStartTime (for schedules) or workflow start_time (for other triggers). Stored as UTC.",
+    },
   },
   type: "object",
   required: ["role", "wf_id"],
@@ -16145,6 +16159,20 @@ export const $WorkflowExecutionCreate = {
         },
       ],
       title: "Inputs",
+    },
+    time_anchor: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Time Anchor",
+      description:
+        "Override the workflow's time anchor for FN.now() and related functions. If not provided, computed from TemporalScheduledStartTime (for schedules) or workflow start_time (for other triggers).",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1781,6 +1781,10 @@ export type DSLRunArgs = {
    * Execution type (draft or published). Draft executions use draft aliases for child workflows.
    */
   execution_type?: ExecutionType
+  /**
+   * The workflow's logical time anchor for FN.now() and related functions. If not provided, computed from TemporalScheduledStartTime (for schedules) or workflow start_time (for other triggers). Stored as UTC.
+   */
+  time_anchor?: string | null
 }
 
 /**
@@ -5109,6 +5113,10 @@ export type WorkflowEventType =
 export type WorkflowExecutionCreate = {
   workflow_id: string
   inputs?: unknown | null
+  /**
+   * Override the workflow's time anchor for FN.now() and related functions. If not provided, computed from TemporalScheduledStartTime (for schedules) or workflow start_time (for other triggers).
+   */
+  time_anchor?: string | null
 }
 
 export type WorkflowExecutionCreateResponse = {

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,10 +1,11 @@
 from collections import Counter
-from datetime import UTC, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Any, Literal
 
 import orjson
 import pytest
 
+from tracecat.contexts import ctx_time_anchor
 from tracecat.expressions.functions import (
     _bool,
     add,
@@ -77,6 +78,7 @@ from tracecat.expressions.functions import (
     not_equal,
     not_in,
     not_null,
+    now,
     or_,
     parse_datetime,
     parse_time,
@@ -101,11 +103,14 @@ from tracecat.expressions.functions import (
     to_datetime,
     to_time,
     to_timestamp,
+    today,
     union,
     unset_timezone,
     uppercase,
     url_decode,
     url_encode,
+    utcnow,
+    wall_clock,
     weeks_between,
     zip_iterables,
 )
@@ -1588,3 +1593,179 @@ def test_hash_sha512() -> None:
         hash_sha512(b"test")
         == "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff"
     )
+
+
+# ============================================================================
+# Time Anchor Tests (FN.now(), FN.utcnow(), FN.today(), FN.wall_clock())
+# ============================================================================
+
+
+class TestTimeAnchorFunctions:
+    """Tests for time anchor functionality in FN.now(), FN.utcnow(), FN.today(), and FN.wall_clock()."""
+
+    def test_now_with_time_anchor(self) -> None:
+        """Test that now() uses ctx_time_anchor when set."""
+        # Set a specific time anchor (UTC-aware datetime)
+        time_anchor = datetime(2024, 6, 15, 10, 30, 0, tzinfo=UTC)
+        token = ctx_time_anchor.set(time_anchor)
+        try:
+            result = now()
+            # Type narrowing: when called without as_isoformat, now() returns datetime
+            assert isinstance(result, datetime)
+            # Result should be naive (no tzinfo) - the time_anchor converted to local
+            assert result.tzinfo is None
+            # The result should be the time_anchor converted to local timezone
+            # The actual local time depends on the system timezone
+            expected_local = time_anchor.astimezone().replace(tzinfo=None)
+            assert result == expected_local
+        finally:
+            ctx_time_anchor.reset(token)
+
+    def test_now_without_time_anchor(self) -> None:
+        """Test that now() falls back to wall clock when ctx_time_anchor is not set."""
+        # Ensure ctx_time_anchor is not set (default is None)
+        assert ctx_time_anchor.get() is None
+
+        before = datetime.now()
+        result = now()
+        after = datetime.now()
+
+        # Type narrowing: when called without as_isoformat, now() returns datetime
+        assert isinstance(result, datetime)
+        # Result should be a naive datetime close to wall clock time
+        assert result.tzinfo is None
+        assert before <= result <= after
+
+    def test_now_with_isoformat(self) -> None:
+        """Test now() with as_isoformat=True."""
+        time_anchor = datetime(2024, 6, 15, 10, 30, 45, tzinfo=UTC)
+        token = ctx_time_anchor.set(time_anchor)
+        try:
+            result = now(as_isoformat=True)
+            assert isinstance(result, str)
+            # Should be ISO 8601 format
+            parsed = datetime.fromisoformat(result)
+            expected_local = time_anchor.astimezone().replace(tzinfo=None)
+            assert parsed == expected_local
+        finally:
+            ctx_time_anchor.reset(token)
+
+    def test_utcnow_with_time_anchor(self) -> None:
+        """Test that utcnow() uses ctx_time_anchor when set."""
+        time_anchor = datetime(2024, 6, 15, 10, 30, 0, tzinfo=UTC)
+        token = ctx_time_anchor.set(time_anchor)
+        try:
+            result = utcnow()
+            # Type narrowing: when called without as_isoformat, utcnow() returns datetime
+            assert isinstance(result, datetime)
+            # Result should be UTC-aware
+            assert result.tzinfo == UTC
+            assert result == time_anchor
+        finally:
+            ctx_time_anchor.reset(token)
+
+    def test_utcnow_without_time_anchor(self) -> None:
+        """Test that utcnow() falls back to wall clock when ctx_time_anchor is not set."""
+        assert ctx_time_anchor.get() is None
+
+        before = datetime.now(UTC)
+        result = utcnow()
+        after = datetime.now(UTC)
+
+        # Type narrowing: when called without as_isoformat, utcnow() returns datetime
+        assert isinstance(result, datetime)
+        # Result should be UTC-aware
+        assert result.tzinfo == UTC
+        assert before <= result <= after
+
+    def test_utcnow_with_naive_time_anchor(self) -> None:
+        """Test that utcnow() handles naive time_anchor by treating it as UTC."""
+        # Naive datetime (no timezone info)
+        time_anchor = datetime(2024, 6, 15, 10, 30, 0)
+        token = ctx_time_anchor.set(time_anchor)
+        try:
+            result = utcnow()
+            # Type narrowing: when called without as_isoformat, utcnow() returns datetime
+            assert isinstance(result, datetime)
+            # Should add UTC timezone to naive datetime
+            assert result.tzinfo == UTC
+            assert result == datetime(2024, 6, 15, 10, 30, 0, tzinfo=UTC)
+        finally:
+            ctx_time_anchor.reset(token)
+
+    def test_utcnow_with_isoformat(self) -> None:
+        """Test utcnow() with as_isoformat=True."""
+        time_anchor = datetime(2024, 6, 15, 10, 30, 45, tzinfo=UTC)
+        token = ctx_time_anchor.set(time_anchor)
+        try:
+            result = utcnow(as_isoformat=True)
+            assert isinstance(result, str)
+            # Should contain timezone info
+            assert "+" in result or "Z" in result or result.endswith("+00:00")
+        finally:
+            ctx_time_anchor.reset(token)
+
+    def test_today_with_time_anchor(self) -> None:
+        """Test that today() uses ctx_time_anchor when set."""
+        time_anchor = datetime(2024, 6, 15, 10, 30, 0, tzinfo=UTC)
+        token = ctx_time_anchor.set(time_anchor)
+        try:
+            result = today()
+            # Result should be a date object
+            assert isinstance(result, date)
+            # The date should be the local date of the time_anchor
+            expected_date = time_anchor.astimezone().date()
+            assert result == expected_date
+        finally:
+            ctx_time_anchor.reset(token)
+
+    def test_today_without_time_anchor(self) -> None:
+        """Test that today() falls back to wall clock when ctx_time_anchor is not set."""
+        assert ctx_time_anchor.get() is None
+
+        result = today()
+        expected = date.today()
+
+        assert isinstance(result, date)
+        assert result == expected
+
+    def test_wall_clock_always_returns_current_time(self) -> None:
+        """Test that wall_clock() ignores ctx_time_anchor and returns actual time."""
+        # Set a time anchor to a specific past time
+        time_anchor = datetime(2000, 1, 1, 0, 0, 0, tzinfo=UTC)
+        token = ctx_time_anchor.set(time_anchor)
+        try:
+            before = datetime.now()
+            result = wall_clock()
+            after = datetime.now()
+
+            # Type narrowing: when called without as_isoformat, wall_clock() returns datetime
+            assert isinstance(result, datetime)
+            # wall_clock should return current wall time, not time_anchor
+            assert result.tzinfo is None
+            assert before <= result <= after
+            # Definitely not the year 2000
+            assert result.year >= 2024
+        finally:
+            ctx_time_anchor.reset(token)
+
+    def test_wall_clock_with_isoformat(self) -> None:
+        """Test wall_clock() with as_isoformat=True."""
+        result = wall_clock(as_isoformat=True)
+        assert isinstance(result, str)
+        # Should be parseable as ISO 8601
+        parsed = datetime.fromisoformat(result)
+        assert parsed.year >= 2024
+
+    def test_wall_clock_without_time_anchor(self) -> None:
+        """Test wall_clock() when ctx_time_anchor is not set."""
+        assert ctx_time_anchor.get() is None
+
+        before = datetime.now()
+        result = wall_clock()
+        after = datetime.now()
+
+        # Type narrowing: when called without as_isoformat, wall_clock() returns datetime
+        assert isinstance(result, datetime)
+        assert result.tzinfo is None
+        assert before <= result <= after

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -5466,42 +5466,71 @@ async def test_workflow_trigger_validation_error_details(
 async def test_workflow_time_anchor_deterministic_time_functions(
     test_role: Role,
     temporal_client: Client,
-    test_worker_factory: Callable[..., AsyncGenerator[Worker, None]],
+    test_worker_factory: Callable[..., Worker],
 ):
-    """Test that FN.now(), FN.utcnow(), and FN.today() use time_anchor for deterministic results.
+    """Test that FN.now()/utcnow()/today() return logical time = time_anchor + elapsed.
 
     This test verifies:
-    1. When time_anchor is provided, FN.now()/utcnow()/today() return values based on it
-    2. FN.wall_clock() ignores time_anchor and returns actual current time
-    3. Multiple calls to these functions within the same workflow return consistent values
+    1. Time functions return values based on time_anchor (not wall clock)
+    2. Time advances between sequential actions (logical time = time_anchor + elapsed)
+    3. FN.wall_clock() ignores time_anchor and returns actual current time
     """
     # Use a specific time_anchor that's clearly in the past
     time_anchor = datetime(2024, 6, 15, 14, 30, 45, tzinfo=UTC)
 
+    # Create a workflow with sequential actions to verify time advances
     dsl = DSLInput(
         **{
             "title": "Time Anchor Test",
             "description": "Test deterministic time functions with time_anchor",
-            "entrypoint": {"expects": {}, "ref": "get_times"},
+            "entrypoint": {"expects": {}, "ref": "action_1"},
             "actions": [
                 {
-                    "ref": "get_times",
+                    "ref": "action_1",
                     "action": "core.transform.reshape",
                     "args": {
                         "value": {
-                            # FN.now() returns local naive datetime from time_anchor
-                            "now_iso": "${{ FN.to_isoformat(FN.now()) }}",
-                            # FN.utcnow() returns UTC-aware datetime from time_anchor
                             "utcnow_iso": "${{ FN.to_isoformat(FN.utcnow()) }}",
-                            # FN.today() returns date from time_anchor
+                            "now_iso": "${{ FN.to_isoformat(FN.now()) }}",
                             "today_str": "${{ str(FN.today()) }}",
-                            # FN.wall_clock() should return actual time, not time_anchor
                             "wall_clock_iso": "${{ FN.to_isoformat(FN.wall_clock()) }}",
                         }
                     },
                 },
+                {
+                    "ref": "action_2",
+                    "action": "core.transform.reshape",
+                    "args": {
+                        "value": {
+                            "utcnow_iso": "${{ FN.to_isoformat(FN.utcnow()) }}",
+                        }
+                    },
+                    "depends_on": ["action_1"],
+                },
+                {
+                    "ref": "action_3",
+                    "action": "core.transform.reshape",
+                    "args": {
+                        "value": {
+                            "utcnow_iso": "${{ FN.to_isoformat(FN.utcnow()) }}",
+                        }
+                    },
+                    "depends_on": ["action_2"],
+                },
+                {
+                    "ref": "combine",
+                    "action": "core.transform.reshape",
+                    "args": {
+                        "value": {
+                            "action_1": "${{ ACTIONS.action_1.result }}",
+                            "action_2": "${{ ACTIONS.action_2.result }}",
+                            "action_3": "${{ ACTIONS.action_3.result }}",
+                        }
+                    },
+                    "depends_on": ["action_3"],
+                },
             ],
-            "returns": "${{ ACTIONS.get_times.result }}",
+            "returns": "${{ ACTIONS.combine.result }}",
         }
     )
 
@@ -5523,44 +5552,57 @@ async def test_workflow_time_anchor_deterministic_time_functions(
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
 
-    # With `returns` set, the result is directly the evaluated value
-    times = result
+    # Extract times from each action
+    action_1 = result["action_1"]
+    action_2 = result["action_2"]
+    action_3 = result["action_3"]
 
-    # Verify FN.utcnow() used the time_anchor (should be 2024-06-15T14:30:45+00:00)
-    assert "2024-06-15" in times["utcnow_iso"]
-    assert "14:30:45" in times["utcnow_iso"]
+    time_1 = datetime.fromisoformat(action_1["utcnow_iso"])
+    time_2 = datetime.fromisoformat(action_2["utcnow_iso"])
+    time_3 = datetime.fromisoformat(action_3["utcnow_iso"])
 
-    # Verify FN.today() used the time_anchor (date portion in local timezone)
-    # The exact date depends on local timezone, but it should be 2024-06-15 or close
-    assert times["today_str"].startswith(
+    # Verify all times are based on time_anchor (same date, starting from 14:30:45)
+    assert "2024-06-15" in action_1["utcnow_iso"]
+    assert "14:30:45" in action_1["utcnow_iso"]
+    assert "2024-06-15" in action_2["utcnow_iso"]
+    assert "2024-06-15" in action_3["utcnow_iso"]
+
+    # Verify time advances between sequential actions
+    # (logical time = time_anchor + elapsed workflow time)
+    assert time_2 >= time_1, (
+        f"action_2 time {time_2} should be >= action_1 time {time_1}"
+    )
+    assert time_3 >= time_2, (
+        f"action_3 time {time_3} should be >= action_2 time {time_2}"
+    )
+
+    # Verify FN.today() used the time_anchor date
+    assert action_1["today_str"].startswith(
         "2024-06-1"
     )  # Could be 14 or 15 depending on TZ
 
     # Verify FN.now() used the time_anchor (converted to local timezone)
-    # Should contain 2024-06-15 (possibly different hour due to TZ conversion)
-    assert "2024-06-1" in times["now_iso"]
+    assert "2024-06-1" in action_1["now_iso"]
 
-    # Verify FN.wall_clock() did NOT use time_anchor (should be current year 2024+)
-    wall_clock_year = int(times["wall_clock_iso"][:4])
-    assert wall_clock_year >= 2024  # Should be current time, not 2024-06-15
-
-    # The wall_clock should definitely not be 2024-06-15 14:30:45
-    # It should be the actual current time when the test ran
-    assert "2024-06-15T14:30:45" not in times["wall_clock_iso"]
+    # Verify FN.wall_clock() did NOT use time_anchor
+    wall_clock_year = int(action_1["wall_clock_iso"][:4])
+    assert wall_clock_year >= 2024
+    assert "2024-06-15T14:30:45" not in action_1["wall_clock_iso"]
 
 
 @pytest.mark.anyio
 async def test_workflow_time_anchor_inherited_by_child_workflow(
     test_role: Role,
     temporal_client: Client,
-    test_worker_factory: Callable[..., AsyncGenerator[Worker, None]],
+    test_worker_factory: Callable[..., Worker],
 ):
-    """Test that child workflows inherit the time_anchor from their parent.
+    """Test that child workflows continue logical time from parent's current position.
 
     This test verifies:
-    1. When a parent workflow has a time_anchor, child workflows receive it
-    2. FN.utcnow() in the child workflow returns the same anchored time as the parent
-    3. The time_anchor propagates correctly through core.workflow.execute
+    1. Child workflows receive parent's current logical time (not raw time_anchor)
+    2. Child's FN.utcnow() returns time >= parent's, since child starts after parent
+    3. Both parent and child times are based on the same original time_anchor
+    4. Time progresses continuously across parent -> child workflow boundary
     """
     # Use a specific time_anchor that's clearly in the past
     time_anchor = datetime(2024, 6, 15, 14, 30, 45, tzinfo=UTC)
@@ -5569,18 +5611,18 @@ async def test_workflow_time_anchor_inherited_by_child_workflow(
     child_dsl = DSLInput(
         title="Time Anchor Child",
         description="Child workflow that returns anchored time",
-        entrypoint={"expects": {}, "ref": "get_time"},
+        entrypoint=DSLEntrypoint(expects={}, ref="get_time"),
         actions=[
-            {
-                "ref": "get_time",
-                "action": "core.transform.reshape",
-                "args": {
+            ActionStatement(
+                ref="get_time",
+                action="core.transform.reshape",
+                args={
                     "value": {
                         "utcnow_iso": "${{ FN.to_isoformat(FN.utcnow()) }}",
                         "today_str": "${{ str(FN.today()) }}",
                     }
                 },
-            },
+            ),
         ],
         returns="${{ ACTIONS.get_time.result }}",
     )
@@ -5591,38 +5633,38 @@ async def test_workflow_time_anchor_inherited_by_child_workflow(
     parent_dsl = DSLInput(
         title="Time Anchor Parent",
         description="Parent workflow that calls child and compares times",
-        entrypoint={"ref": "parent_time"},
+        entrypoint=DSLEntrypoint(ref="parent_time"),
         actions=[
-            {
-                "ref": "parent_time",
-                "action": "core.transform.reshape",
-                "args": {
+            ActionStatement(
+                ref="parent_time",
+                action="core.transform.reshape",
+                args={
                     "value": {
                         "utcnow_iso": "${{ FN.to_isoformat(FN.utcnow()) }}",
                     }
                 },
-            },
-            {
-                "ref": "call_child",
-                "action": "core.workflow.execute",
-                "args": {
+            ),
+            ActionStatement(
+                ref="call_child",
+                action="core.workflow.execute",
+                args={
                     "workflow_id": child_workflow.id,
                     "trigger_inputs": {},
                 },
-                "depends_on": ["parent_time"],
-            },
-            {
-                "ref": "combine_results",
-                "action": "core.transform.reshape",
-                "args": {
+                depends_on=["parent_time"],
+            ),
+            ActionStatement(
+                ref="combine_results",
+                action="core.transform.reshape",
+                args={
                     "value": {
                         "parent_utcnow": "${{ ACTIONS.parent_time.result.utcnow_iso }}",
                         "child_utcnow": "${{ ACTIONS.call_child.result.utcnow_iso }}",
                         "child_today": "${{ ACTIONS.call_child.result.today_str }}",
                     }
                 },
-                "depends_on": ["call_child"],
-            },
+                depends_on=["call_child"],
+            ),
         ],
         returns="${{ ACTIONS.combine_results.result }}",
     )
@@ -5630,7 +5672,8 @@ async def test_workflow_time_anchor_inherited_by_child_workflow(
     test_name = "test_workflow_time_anchor_inherited_by_child"
     wf_exec_id = generate_test_exec_id(test_name)
 
-    async with test_worker_factory(temporal_client):
+    worker = test_worker_factory(temporal_client)
+    async with worker:
         result = await temporal_client.execute_workflow(
             DSLWorkflow.run,
             DSLRunArgs(
@@ -5645,15 +5688,20 @@ async def test_workflow_time_anchor_inherited_by_child_workflow(
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
 
-    # Both parent and child should have the same anchored time
+    # Both parent and child times should be based on the same time_anchor
     assert "2024-06-15" in result["parent_utcnow"]
     assert "14:30:45" in result["parent_utcnow"]
 
     assert "2024-06-15" in result["child_utcnow"]
     assert "14:30:45" in result["child_utcnow"]
 
-    # The parent and child utcnow should be identical since they use the same anchor
-    assert result["parent_utcnow"] == result["child_utcnow"]
+    # Child time should be >= parent time since child continues from parent's position
+    # (child starts after some workflow time has elapsed from when parent evaluated its time)
+    parent_time = datetime.fromisoformat(result["parent_utcnow"])
+    child_time = datetime.fromisoformat(result["child_utcnow"])
+    assert child_time >= parent_time, (
+        f"Child time {child_time} should be >= parent time {parent_time}"
+    )
 
     # Child's today should also be based on the time_anchor
     assert result["child_today"].startswith("2024-06-1")

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -5523,8 +5523,8 @@ async def test_workflow_time_anchor_deterministic_time_functions(
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
 
-    # Extract the times from the result
-    times = result[ExprContext.ACTIONS]["get_times"]["result"]
+    # With `returns` set, the result is directly the evaluated value
+    times = result
 
     # Verify FN.utcnow() used the time_anchor (should be 2024-06-15T14:30:45+00:00)
     assert "2024-06-15" in times["utcnow_iso"]

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
+from datetime import datetime
 
 import loguru
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,6 +20,7 @@ __all__ = [
     "ctx_stream_id",
     "ctx_session",
     "ctx_client_ip",
+    "ctx_time_anchor",
     "get_env",
 ]
 
@@ -34,6 +36,9 @@ ctx_env: ContextVar[dict[str, str] | None] = ContextVar("env", default=None)
 ctx_session: ContextVar[AsyncSession | None] = ContextVar("session", default=None)
 ctx_session_id: ContextVar[uuid.UUID | None] = ContextVar("session-id", default=None)
 """ID for a streamable session, if any."""
+
+ctx_time_anchor: ContextVar[datetime | None] = ContextVar("time-anchor", default=None)
+"""Workflow time anchor for deterministic FN.now() during replay/reset."""
 
 
 @asynccontextmanager

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -20,7 +20,7 @@ __all__ = [
     "ctx_stream_id",
     "ctx_session",
     "ctx_client_ip",
-    "ctx_time_anchor",
+    "ctx_logical_time",
     "get_env",
 ]
 
@@ -37,8 +37,8 @@ ctx_session: ContextVar[AsyncSession | None] = ContextVar("session", default=Non
 ctx_session_id: ContextVar[uuid.UUID | None] = ContextVar("session-id", default=None)
 """ID for a streamable session, if any."""
 
-ctx_time_anchor: ContextVar[datetime | None] = ContextVar("time-anchor", default=None)
-"""Workflow time anchor for deterministic FN.now() during replay/reset."""
+ctx_logical_time: ContextVar[datetime | None] = ContextVar("logical-time", default=None)
+"""Current logical time = time_anchor + elapsed workflow time. Used by FN.now()."""
 
 
 @asynccontextmanager

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -15,7 +15,7 @@ from tenacity import (
 )
 
 from tracecat.auth.types import Role
-from tracecat.contexts import ctx_logger, ctx_run
+from tracecat.contexts import ctx_logger, ctx_run, ctx_time_anchor
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.dsl.schemas import ActionStatement, RunActionInput
 from tracecat.dsl.types import ActionErrorInfo
@@ -115,6 +115,12 @@ class DSLActivities:
             environment=environment,
         )
         ctx_logger.set(log)
+
+        # Set time anchor context for deterministic FN.now() etc.
+        env_context = input.exec_context.get(ExprContext.ENV) or {}
+        workflow_context = env_context.get("workflow") or {}
+        if time_anchor := workflow_context.get("time_anchor"):
+            ctx_time_anchor.set(time_anchor)
 
         act_info = activity.info()
         act_attempt = act_info.attempt

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -119,13 +119,15 @@ class DSLActivities:
 
         # Set logical_time for deterministic FN.now() etc.
         # logical_time = time_anchor + elapsed workflow time
+        # Always set unconditionally to avoid stale context leakage
         env_context = input.exec_context.get(ExprContext.ENV) or {}
         workflow_context = env_context.get("workflow") or {}
-        if logical_time := workflow_context.get("logical_time"):
+        logical_time = workflow_context.get("logical_time")
+        if logical_time is not None:
             # logical_time may be serialized as ISO string through Temporal
             if isinstance(logical_time, str):
                 logical_time = datetime.fromisoformat(logical_time)
-            ctx_logical_time.set(logical_time)
+        ctx_logical_time.set(logical_time)
 
         act_info = activity.info()
         act_attempt = act_info.attempt

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime
 from typing import Any
 
 import dateparser
@@ -120,6 +121,9 @@ class DSLActivities:
         env_context = input.exec_context.get(ExprContext.ENV) or {}
         workflow_context = env_context.get("workflow") or {}
         if time_anchor := workflow_context.get("time_anchor"):
+            # time_anchor may be serialized as ISO string through Temporal
+            if isinstance(time_anchor, str):
+                time_anchor = datetime.fromisoformat(time_anchor)
             ctx_time_anchor.set(time_anchor)
 
         act_info = activity.info()

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import deque
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from tempfile import SpooledTemporaryFile
 from typing import Any, Literal, NotRequired, Self, TypedDict, cast
@@ -492,6 +492,14 @@ class DSLRunArgs(BaseModel):
         default=ExecutionType.PUBLISHED,
         description="Execution type (draft or published). Draft executions use draft aliases for child workflows.",
     )
+    time_anchor: datetime | None = Field(
+        default=None,
+        description=(
+            "The workflow's logical time anchor for FN.now() and related functions. "
+            "If not provided, computed from TemporalScheduledStartTime (for schedules) "
+            "or workflow start_time (for other triggers). Stored as UTC."
+        ),
+    )
 
     @field_validator("wf_id", mode="before")
     @classmethod
@@ -511,6 +519,10 @@ class ExecuteChildWorkflowArgs(BaseModel):
     fail_strategy: FailStrategy = FailStrategy.ISOLATED
     timeout: float | None = None
     wait_strategy: WaitStrategy = WaitStrategy.WAIT
+    time_anchor: datetime | None = Field(
+        default=None,
+        description="Override time anchor for child workflow. If None, inherits from parent.",
+    )
 
     @model_validator(mode="after")
     def validate_workflow_id_or_alias(self) -> Self:

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -30,6 +30,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.plugins import TracecatPydanticAIPlugin
     from tracecat.dsl.validation import (
         normalize_trigger_inputs_activity,
+        resolve_time_anchor_activity,
         validate_trigger_inputs_activity,
     )
     from tracecat.dsl.workflow import DSLWorkflow
@@ -75,6 +76,7 @@ def get_activities() -> list[Callable]:
         *WorkflowSchedulesService.get_activities(),
         validate_trigger_inputs_activity,
         normalize_trigger_inputs_activity,
+        resolve_time_anchor_activity,
         *WorkflowsManagementService.get_activities(),
         *InteractionService.get_activities(),
     ]

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -381,13 +381,15 @@ async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
 
     # Set logical_time for deterministic FN.now() etc.
     # logical_time = time_anchor + elapsed workflow time
+    # Always set unconditionally to avoid stale context leakage
     env_context = context.get(ExprContext.ENV) or {}
     workflow_context = env_context.get("workflow") or {}
-    if logical_time := workflow_context.get("logical_time"):
+    logical_time = workflow_context.get("logical_time")
+    if logical_time is not None:
         # logical_time may be serialized as ISO string through Temporal
         if isinstance(logical_time, str):
             logical_time = datetime.fromisoformat(logical_time)
-        ctx_logical_time.set(logical_time)
+    ctx_logical_time.set(logical_time)
 
     flattened_secrets = secrets_manager.flatten_secrets(secrets)
 

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -6,6 +6,7 @@ import time
 import traceback
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -382,6 +383,9 @@ async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
     env_context = context.get(ExprContext.ENV) or {}
     workflow_context = env_context.get("workflow") or {}
     if time_anchor := workflow_context.get("time_anchor"):
+        # time_anchor may be serialized as ISO string through Temporal
+        if isinstance(time_anchor, str):
+            time_anchor = datetime.fromisoformat(time_anchor)
         ctx_time_anchor.set(time_anchor)
 
     flattened_secrets = secrets_manager.flatten_secrets(secrets)

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -25,6 +25,7 @@ from tracecat.contexts import (
     ctx_role,
     ctx_run,
     ctx_session_id,
+    ctx_time_anchor,
     with_session,
 )
 from tracecat.db.engine import get_async_engine, get_async_session_context_manager
@@ -376,6 +377,12 @@ async def run_action_from_input(input: RunActionInput, role: Role) -> Any:
     context = input.exec_context.copy()
     context[ExprContext.SECRETS] = secrets
     context[ExprContext.VARS] = workspace_variables
+
+    # Set time anchor context for deterministic FN.now() etc.
+    env_context = context.get(ExprContext.ENV) or {}
+    workflow_context = env_context.get("workflow") or {}
+    if time_anchor := workflow_context.get("time_anchor"):
+        ctx_time_anchor.set(time_anchor)
 
     flattened_secrets = secrets_manager.flatten_secrets(secrets)
 

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -884,8 +884,11 @@ def utcnow(as_isoformat: bool = False, timespec: str = "auto") -> datetime | str
 
     time_anchor = ctx_time_anchor.get()
     if time_anchor is not None:
-        # Ensure time_anchor is UTC-aware
-        dt = time_anchor if time_anchor.tzinfo else time_anchor.replace(tzinfo=UTC)
+        # Ensure time_anchor is UTC-aware; convert if it has a different timezone
+        if time_anchor.tzinfo is None:
+            dt = time_anchor.replace(tzinfo=UTC)
+        else:
+            dt = time_anchor.astimezone(UTC)
     else:
         dt = datetime.now(UTC)
 

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -228,7 +228,10 @@ async def create_workflow_execution(
     dsl_input = DSLInput(**defn.content)
     try:
         response = service.create_workflow_execution_nowait(
-            dsl=dsl_input, wf_id=wf_id, payload=params.inputs
+            dsl=dsl_input,
+            wf_id=wf_id,
+            payload=params.inputs,
+            time_anchor=params.time_anchor,
         )
         return response
     except TracecatValidationError as e:
@@ -288,7 +291,10 @@ async def create_draft_workflow_execution(
 
     try:
         response = service.create_draft_workflow_execution_nowait(
-            dsl=dsl_input, wf_id=wf_id, payload=params.inputs
+            dsl=dsl_input,
+            wf_id=wf_id,
+            payload=params.inputs,
+            time_anchor=params.time_anchor,
         )
         return response
     except TracecatValidationError as e:

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -566,6 +566,14 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
 class WorkflowExecutionCreate(BaseModel):
     workflow_id: AnyWorkflowID
     inputs: TriggerInputs | None = None
+    time_anchor: datetime | None = Field(
+        default=None,
+        description=(
+            "Override the workflow's time anchor for FN.now() and related functions. "
+            "If not provided, computed from TemporalScheduledStartTime (for schedules) "
+            "or workflow start_time (for other triggers)."
+        ),
+    )
 
 
 class WorkflowExecutionCreateResponse(TypedDict):


### PR DESCRIPTION
## Summary
- Add `time_anchor` field to workflow inputs for deterministic `FN.now()`, `FN.utcnow()`, and `FN.today()` that survives workflow resets
- Webhook/manual triggers: minted at service layer, baked into workflow input
- Scheduled triggers: resolved via local activity using `TemporalScheduledStartTime`
- Child workflows inherit parent's `time_anchor` with optional override
- Add `FN.wall_clock()` for actual current time when needed

## Test plan
- [x] Unit tests for `now()`, `utcnow()`, `today()`, `wall_clock()` with/without time_anchor
- [ ] Manual test: webhook trigger workflow with `FN.now()` and verify reset preserves time
- [ ] Manual test: scheduled workflow uses `TemporalScheduledStartTime`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make workflow time deterministic by anchoring FN.now(), FN.utcnow(), and FN.today() to a logical time (time_anchor + elapsed). Scheduled runs use TemporalScheduledStartTime, webhook/manual runs mint the anchor at dispatch, child workflows inherit the current logical time, and FN.wall_clock() returns real time.

- **New Features**
  - Added time_anchor to execution inputs and workflow ENV; per-action logical_time is injected; overridable via API.
  - Resolved time_anchor via local activity: TemporalScheduledStartTime for schedules, otherwise workflow start_time.
  - Propagated current logical_time to child workflows with optional override.
  - Updated FN.now()/FN.utcnow()/FN.today() to use logical_time; added FN.wall_clock() for actual current time.
  - Wired service and worker: mint anchor for webhook/manual triggers; set ctx_logical_time in executor/action runner; updated client schemas/types; added unit and integration tests.

- **Migration**
  - If you relied on FN.now()/FN.utcnow()/FN.today() returning wall-clock time, switch to FN.wall_clock().
  - Optionally pass time_anchor in WorkflowExecutionCreate to simulate or backfill time.
  - No data migration required; defaults maintain existing behavior.

<sup>Written for commit eee192d34b93228a51c0c8b973cb6facc3f3856a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

