### PR TITLE
fix(scheduler): ensure deterministic task queue ordering

### DIFF
--- a/tests/unit/test_dsl_scheduler_determinism.py
+++ b/tests/unit/test_dsl_scheduler_determinism.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tracecat.dsl.common import DSLEntrypoint, DSLInput
+from tracecat.dsl.enums import EdgeType
+from tracecat.dsl.scheduler import DSLScheduler
+from tracecat.dsl.schemas import ROOT_STREAM, ActionStatement
+from tracecat.dsl.types import Task
+from tracecat.expressions.common import ExprContext
+
+
+class _ControlledPutQueue:
+    def __init__(self) -> None:
+        self._events: dict[str, asyncio.Event] = {}
+        self.items: list[Task] = []
+
+    def _event(self, ref: str) -> asyncio.Event:
+        event = self._events.get(ref)
+        if event is None:
+            event = asyncio.Event()
+            self._events[ref] = event
+        return event
+
+    def release(self, ref: str) -> None:
+        self._event(ref).set()
+
+    async def put(self, item: Task) -> None:
+        await self._event(item.ref).wait()
+        self.items.append(item)
+
+    def qsize(self) -> int:
+        return len(self.items)
+
+
+@pytest.mark.anyio
+async def test_queue_tasks_is_deterministic() -> None:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    dsl = DSLInput(
+        title="test",
+        description="test",
+        entrypoint=DSLEntrypoint(ref="a"),
+        actions=[
+            ActionStatement(ref="a", action="core.noop"),
+            # Intentionally out of order; scheduler should queue in ref order.
+            ActionStatement(ref="c", action="core.noop", depends_on=["a"]),
+            ActionStatement(ref="b", action="core.noop", depends_on=["a"]),
+        ],
+    )
+    scheduler = DSLScheduler(
+        executor=executor,
+        dsl=dsl,
+        context={ExprContext.ACTIONS: {}},
+    )
+
+    assert scheduler.adj["a"] == (("b", EdgeType.SUCCESS), ("c", EdgeType.SUCCESS))
+
+    queue = _ControlledPutQueue()
+    scheduler.queue = queue  # type: ignore[assignment]
+
+    queue_task = asyncio.create_task(
+        scheduler._queue_tasks(Task(ref="a", stream_id=ROOT_STREAM))
+    )
+    await asyncio.sleep(0)
+    queue.release("c")
+    await asyncio.sleep(0)
+    queue.release("b")
+    await queue_task
+
+    assert [t.ref for t in queue.items] == ["b", "c"]


### PR DESCRIPTION
## Summary
- Sort adjacency list by ref and edge type for deterministic iteration order
- Process tasks sequentially instead of in parallel TaskGroup to guarantee reproducible execution order
- Add unit test to verify deterministic queueing behavior

## Test plan
- [x] Added `test_dsl_scheduler_determinism.py` to verify task ordering

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures deterministic task queue ordering in the DSL scheduler for reproducible execution across runs.

- **Bug Fixes**
  - Sort adjacency list by task ref and edge type for stable iteration.
  - Queue downstream tasks sequentially (no TaskGroup) to preserve order.
  - Add unit test verifying consistent successor ordering.

<sup>Written for commit c3a0915feb1d1ef74cf9b965df83c2ca6219bdd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

