### PR TITLE
feat(auth): extract workspace_id from JWT for executor auth

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -163,12 +163,6 @@ class TracecatClient:
         if headers:
             request_headers.update(headers)
 
-        # Add workspace_id to query params if set
-        if self._workspace_id:
-            params = params or {}
-            if "workspace_id" not in params:
-                params["workspace_id"] = self._workspace_id
-
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             response = await client.request(
                 method,


### PR DESCRIPTION
## Summary
- Remove redundant `workspace_id` query param from `/internal` endpoints
- Extract `workspace_id` entirely from JWT token for executor auth
- Add `ExecutorTokenClaims` dataclass with `role`, `run_id`, `workflow_id`
- Remove `workspace_id` injection from SDK client

## Test plan
- [ ] Verify internal API routes work without `workspace_id` query param
- [ ] Verify SDK can call internal endpoints with executor token
- [ ] Run unit tests for executor tokens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Executor auth now reads workspace_id from the JWT, removing the workspace_id query param from /internal routes and simplifying the SDK. verify_executor_token now returns structured claims (role, run_id, workflow_id).

- **Refactors**
  - Executor-only auth: RoleACL pulls workspace_id from JWT; no query param validation.
  - Added ExecutorTokenClaims and updated verify_executor_token to return claims.
  - Removed workspace_id injection from the SDK client.
  - Updated unit tests for claims and JWT-derived workspace_id.
  - Aligned SSO ACS request body to snake_case: saml_response, relay_state.

- **Migration**
  - Omit workspace_id from internal endpoint requests; it’s taken from the token.
  - Use claims.role from verify_executor_token; run_id and workflow_id are optional.
  - For RoleACL with executor-only + require_workspace, do not pass workspace_id.
  - Frontend/clients should send saml_response and relay_state for SSO ACS.

<sup>Written for commit 582ec132b27a8501b1f600272d5dcf20ec1cf4c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

