### PR TITLE
fix(executor): pass registry_lock from WorkflowDefinition to workflow executions

### DIFF
--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -250,6 +250,13 @@ class DSLWorkflow:
                 ) from e
             self.dispatch_type = "pull"
 
+        # Log registry lock for debugging
+        self.logger.debug(
+            "Workflow registry lock",
+            registry_lock=self.registry_lock,
+            dispatch_type=self.dispatch_type,
+        )
+
         # Note that we can't run the error handler above this
         # Run the workflow with error handling
         try:
@@ -1140,7 +1147,8 @@ class DSLWorkflow:
             runtime_config=runtime_config,
             execution_type=self.execution_type,
             time_anchor=child_time_anchor,
-            registry_lock=self.registry_lock,
+            # Use child's own registry_lock from its definition, not parent's
+            registry_lock=result.registry_lock,
         )
 
     async def _noop_gather_action(self, task: ActionStatement) -> Any:
@@ -1375,7 +1383,8 @@ class DSLWorkflow:
             ),
             runtime_config=runtime_config,
             execution_type=self.execution_type,
-            registry_lock=self.registry_lock,
+            # Use error handler's own registry_lock from its definition, not parent's
+            registry_lock=result.registry_lock,
         )
 
     async def _run_error_handler_workflow(

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -586,12 +586,14 @@ async def _get_registry_pythonpath(input: RunActionInput, role: Role) -> str | N
     tarball_uris: list[str] = []
     try:
         if input.registry_lock:
+            logger.debug(
+                "Resolving registry artifacts from lock",
+                registry_lock=input.registry_lock,
+            )
             artifacts = await get_registry_artifacts_for_lock(input.registry_lock)
         else:
             artifacts = await get_registry_artifacts_cached(role)
 
-        # Collect ALL tarball URIs, not just the first one
-        # This is important for multi-registry setups (e.g., builtin + custom)
         for artifact in artifacts:
             if artifact.tarball_uri:
                 tarball_uris.append(artifact.tarball_uri)

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -158,6 +158,7 @@ async def _incoming_webhook(
                 wf_id=workflow_id,
                 payload=p,
                 trigger_type=TriggerType.WEBHOOK,
+                registry_lock=defn.registry_lock,
             )
         # Currently just return the last response's wf_exec_id
         response = WorkflowExecutionCreateResponse(
@@ -174,6 +175,7 @@ async def _incoming_webhook(
             wf_id=workflow_id,
             payload=payload,
             trigger_type=TriggerType.WEBHOOK,
+            registry_lock=defn.registry_lock,
         )
 
     # Response handling
@@ -225,6 +227,7 @@ async def incoming_webhook_wait(
         wf_id=workflow_id,
         payload=payload,
         trigger_type=TriggerType.WEBHOOK,
+        registry_lock=defn.registry_lock,
     )
 
     return response["result"]

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -235,6 +235,7 @@ async def create_workflow_execution(
             wf_id=wf_id,
             payload=params.inputs,
             time_anchor=params.time_anchor,
+            registry_lock=defn.registry_lock,
         )
         return response
     except TracecatValidationError as e:

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -693,6 +693,7 @@ class WorkflowExecutionsService:
         payload: TriggerInputs | None = None,
         trigger_type: TriggerType = TriggerType.MANUAL,
         time_anchor: datetime.datetime | None = None,
+        registry_lock: dict[str, str] | None = None,
     ) -> WorkflowExecutionCreateResponse:
         """Create a new workflow execution.
 
@@ -706,6 +707,7 @@ class WorkflowExecutionsService:
             trigger_type=trigger_type,
             wf_exec_id=wf_exec_id,
             time_anchor=time_anchor,
+            registry_lock=registry_lock,
         )
         task = asyncio.ensure_future(coro)
         task.add_done_callback(self._handle_background_task_exception)
@@ -784,6 +786,7 @@ class WorkflowExecutionsService:
         trigger_type: TriggerType = TriggerType.MANUAL,
         wf_exec_id: WorkflowExecutionID | None = None,
         time_anchor: datetime.datetime | None = None,
+        registry_lock: dict[str, str] | None = None,
     ) -> WorkflowDispatchResponse:
         """Create a new workflow execution.
 
@@ -799,6 +802,7 @@ class WorkflowExecutionsService:
             trigger_inputs=payload,
             trigger_type=trigger_type,
             time_anchor=time_anchor,
+            registry_lock=registry_lock,
         )
 
     async def _dispatch_workflow(
@@ -810,6 +814,7 @@ class WorkflowExecutionsService:
         trigger_type: TriggerType = TriggerType.MANUAL,
         execution_type: ExecutionType = ExecutionType.PUBLISHED,
         time_anchor: datetime.datetime | None = None,
+        registry_lock: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> WorkflowDispatchResponse:
         if rpc_timeout := config.TEMPORAL__CLIENT_RPC_TIMEOUT:
@@ -841,6 +846,7 @@ class WorkflowExecutionsService:
             kwargs=kwargs,
             trigger_type=trigger_type,
             execution_type=execution_type,
+            registry_lock=registry_lock,
         )
 
         pairs = [trigger_type.to_temporal_search_attr_pair()]
@@ -867,6 +873,7 @@ class WorkflowExecutionsService:
                     trigger_inputs=trigger_inputs,
                     execution_type=execution_type,
                     time_anchor=time_anchor,
+                    registry_lock=registry_lock,
                 ),
                 id=wf_exec_id,
                 task_queue=config.TEMPORAL__CLUSTER_QUEUE,


### PR DESCRIPTION
## Summary
- Pass `registry_lock` from `WorkflowDefinition` through the workflow execution chain
- Child/subflows now use their own `registry_lock` from their definition (not inherited from parent)
- Add logging to trace registry version resolution

## Changes
- `workflow/executions/service.py`: Add `registry_lock` param to dispatch methods
- `workflow/executions/router.py`: Pass `defn.registry_lock` when creating executions
- `webhooks/router.py`: Pass `defn.registry_lock` for webhook-triggered executions  
- `dsl/workflow.py`: Use child's `result.registry_lock` instead of parent's
- `executor/service.py`, `executor/action_runner.py`: Add debug logging

## Test plan
- [ ] Trigger workflow via API and verify `registry_lock` flows through
- [ ] Trigger workflow via webhook and verify `registry_lock` flows through
- [ ] Execute child workflow and verify it uses its own `registry_lock`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures each workflow execution uses the correct registry versions by passing registry_lock from WorkflowDefinition throughout the execution chain. Subflows and error handlers use their own locks, with added logging to trace registry artifact resolution.

- **Bug Fixes**
  - Pass defn.registry_lock in execution and webhook routers.
  - Accept registry_lock in dispatch methods; propagate to DSLRunArgs.
  - Use child/error handler definition’s registry_lock in DSL.
  - Resolve tarballs per lock and build PYTHONPATH from all artifacts.
  - Add logs for lock resolution and dispatch type.

<sup>Written for commit b10317d07cff8c44e48203f3c1e9456328fcdabc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

