### PR TITLE
fix(agent): Use surrogate_id for deterministic message ordering

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
 
-- Tracecat version (e.g. `0.53.11`)
+- Tracecat version (e.g. `0.53.12`)
 - OS (e.g. Ubuntu 20.03 on WSL2)
 - Where did you deploy Tracecat? (VM, AWS EC2, etc.)
 - CPU architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ If you have an idea or feature request, please [open an issue](https://github.co
 If you encounter an invalid Action Template, Python integration, or inline function, please [open an issue](https://github.com/TracecatHQ/tracecat/issues).
 Make sure to provide the following information:
 
-- Tracecat version (e.g. `0.53.11`)
+- Tracecat version (e.g. `0.53.12`)
 
 ## Frontend / Backend Contributions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
 
   api:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.53.11}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.53.12}
     container_name: api
     restart: unless-stopped
     networks:
@@ -86,7 +86,7 @@ services:
         condition: service_healthy
 
   worker:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.53.11}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.53.12}
     restart: unless-stopped
     networks:
       - core
@@ -128,7 +128,7 @@ services:
         condition: service_healthy
 
   executor:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.53.11}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-0.53.12}
     restart: unless-stopped
     networks:
       - core-db
@@ -187,7 +187,7 @@ services:
         condition: service_healthy
 
   ui:
-    image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-0.53.11}
+    image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-0.53.12}
     container_name: ui
     restart: unless-stopped
     networks:

--- a/docs/quickstart/install.mdx
+++ b/docs/quickstart/install.mdx
@@ -28,15 +28,15 @@ Deploy a local Tracecat stack using Docker Compose. View step-by-step instructio
 
 ```bash
 # 1. Setup .env configs and secrets (you'll be prompted for superadmin email)
-curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/env.sh
-curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/.env.example
+curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/env.sh
+curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/.env.example
 chmod +x env.sh && ./env.sh
 
 # 2. Download Caddyfile
-curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/Caddyfile
+curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/Caddyfile
 
 # 3. Download Docker Compose file
-curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/docker-compose.yml
 
 # Run Tracecat
 docker compose up -d
@@ -45,7 +45,7 @@ docker compose up -d
 <PublicUrlNote />
 
 Check out the generated `.env` file to better understand Tracecat's configurations.
-You can also view the template `.env.example` file [here](https://github.com/TracecatHQ/tracecat/blob/0.53.11/.env.example).
+You can also view the template `.env.example` file [here](https://github.com/TracecatHQ/tracecat/blob/0.53.12/.env.example).
 
 ### AWS Fargate
 

--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -41,10 +41,10 @@ Use the commands listed below to download the required configuration files
 
 ```bash
 # 1. Download the env.sh installation script
-curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/env.sh
+curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/env.sh
 
 # 2. Download the .env.example template file (env.sh needs this to generate your .env file)
-curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/.env.example
+curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/.env.example
 
 # 3. Make the env.sh script executable and run it
 chmod +x env.sh && ./env.sh
@@ -85,13 +85,13 @@ Tracecat uses Caddy as a reverse proxy.
 You'll need to download the following `Caddyfile` to configure this service.
 
 ```bash
-curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/Caddyfile
+curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/Caddyfile
 ```
 
 ## Download Docker Compose File
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/docker-compose.yml
 ```
 
 ## Start Tracecat
@@ -179,4 +179,4 @@ Please check the following:
 
 - Log into Tracecat and build your first playbook. [View quickstart](/quickstart).
 - Tracecat comes with basic (email + password) authentication. Find out how to configure other authentication methods. [View docs](/self-hosting/authentication/overview).
-- Read inline comments in the generated `.env` file to better understand Tracecat's configurations. [View `.env.example` file](https://github.com/TracecatHQ/tracecat/blob/0.53.11/.env.example).
+- Read inline comments in the generated `.env` file to better understand Tracecat's configurations. [View `.env.example` file](https://github.com/TracecatHQ/tracecat/blob/0.53.12/.env.example).

--- a/docs/self-hosting/updating.mdx
+++ b/docs/self-hosting/updating.mdx
@@ -23,8 +23,8 @@ description: Learn how to safely update versions and run data migrations.
     version.
 
     ```
-    curl -o env-migration.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/env-migration.sh
-    curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/.env.example
+    curl -o env-migration.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/env-migration.sh
+    curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/.env.example
     ```
 
   </Step>
@@ -41,14 +41,14 @@ description: Learn how to safely update versions and run data migrations.
     Download the latest Docker Compose file.
 
     ```
-    curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/docker-compose.yml
+    curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/docker-compose.yml
     ```
   </Step>
   <Step title="Update Caddyfile">
     Download the latest Caddyfile.
 
     ```
-    curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.11/Caddyfile
+    curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/0.53.12/Caddyfile
     ```
   </Step>
   <Step title="Restart Tracecat">

--- a/tracecat/__init__.py
+++ b/tracecat/__init__.py
@@ -1,3 +1,3 @@
 """Tracecat is open source AI automation platform for mission critical workflows."""
 
-__version__ = "0.53.11"
+__version__ = "0.53.12"

--- a/tracecat/chat/service.py
+++ b/tracecat/chat/service.py
@@ -499,7 +499,7 @@ class ChatService(BaseWorkspaceService):
                 DBChatMessage.chat_id == chat_id,
                 DBChatMessage.workspace_id == self.workspace_id,
             )
-            .order_by(DBChatMessage.created_at.asc())
+            .order_by(DBChatMessage.surrogate_id)
         )
 
         if kinds:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use surrogate_id to order chat messages for a deterministic sequence. Fixes cases where created_at led to misordered threads and inconsistent pagination.

- **Bug Fixes**
  - Order messages by surrogate_id instead of created_at to guarantee stable, monotonic results across async inserts and clock skew.

- **Dependencies**
  - Bump Tracecat version to 0.53.12 and update Docker image tags and docs to match.

<sup>Written for commit 23d4b4afbaa6611ee9b26205851acb703e55fd59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

