### PR TITLE
fix(registry): Isolate registry sync in fresh venv

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -111,7 +111,7 @@ jobs:
           COMPOSE_BAKE: "true"
           TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
           TRACECAT__EXECUTOR_BACKEND: "direct"
-          TRACECAT__FEATURE_FLAGS: "registry-sync-v2"
+          TRACECAT__FEATURE_FLAGS: "registry-sync-v2,registry-client"
           # Disable sandboxed registry sync to use local subprocess instead of Temporal workflow
           # This avoids the need for Docker executor to handle RegistrySyncWorkflow
           TRACECAT__REGISTRY_SYNC_SANDBOX_ENABLED: "false"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Isolated registry sync from the parent venv and installed custom registry packages to a separate target directory with uv pip to avoid dependency conflicts and use the correct interpreter. Added import isolation so custom registries can only use their declared dependencies via the tarball’s site-packages.

- **Bug Fixes**
  - Use uv pip with --python and --target, add the target via site.addsitedir before import, switch remote installs from uv add to uv pip install, and clear VIRTUAL_ENV/UV_PROJECT_ENVIRONMENT in the subprocess.
  - Pass TRACECAT_ISOLATED_SITE_PACKAGES from the tarball build and rebuild sys.path to stdlib + isolated site-packages + custom target before importing repositories.

<sup>Written for commit e4e998b3232844a5c2dca129d566a289bba656a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

