### PR TITLE
ci: Nightly release

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -5,13 +5,9 @@ on:
     branches: ["staging", "preview"]
     tags:
       - "*.*.*"
-  pull_request:
-    branches: ["staging"]
-  workflow_dispatch:
-    inputs:
-      git-ref:
-        description: "Git Ref (Optional)"
-        required: true
+      - "nightly-*"
+  schedule:
+    - cron: "0 0 * * *"  # Nightly at midnight UTC
 
 env:
   REGISTRY: ghcr.io
@@ -56,9 +52,10 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
+            type=match,pattern=nightly-(.*),group=0
 
       - name: Set up Docker builder
         uses: useblacksmith/setup-docker-builder@78f41686563c732ccc097f7baac2f092f67538f0 # v1
@@ -116,9 +113,10 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
+            type=match,pattern=nightly-(.*),group=0
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
@@ -126,7 +124,7 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/tracecathq/tracecat@sha256:%s ' *) \
-            ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && '-t ghcr.io/tracecathq/tracecat:latest' || '' }}
+            ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/nightly-') && '-t ghcr.io/tracecathq/tracecat:latest' || '' }}
 
       - name: Inspect image
         run: |
@@ -166,9 +164,10 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
+            type=match,pattern=nightly-(.*),group=0
 
       - name: Set up Docker builder
         uses: useblacksmith/setup-docker-builder@78f41686563c732ccc097f7baac2f092f67538f0 # v1
@@ -238,9 +237,10 @@ jobs:
           tags: |
             type=sha
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
+            type=match,pattern=nightly-(.*),group=0
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
@@ -248,7 +248,7 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/tracecathq/tracecat-ui@sha256:%s ' *) \
-            ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && '-t ghcr.io/tracecathq/tracecat-ui:latest' || '' }}
+            ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/nightly-') && '-t ghcr.io/tracecathq/tracecat-ui:latest' || '' }}
 
       - name: Inspect image
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a nightly release to the Docker image workflow and fix latest tagging. Nightly images run daily, get nightly-YYYYMMDD-SHA tags, and never update :latest; semver tags now publish :latest.

- **New Features**
  - Nightly schedule at 00:00 UTC.
  - Support nightly-* tag pushes and add nightly-YYYYMMDD-SHA metadata tags.
  - Remove pull_request and workflow_dispatch triggers.

- **Bug Fixes**
  - Publish :latest only on non-nightly tag pushes; semver tags (*.*.*) now correctly update :latest.

<sup>Written for commit 6a7f955c235f4c5dd75c066712d07c0a078cce2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

