### PR TITLE
fix(dsl): await _queue_tasks sequentially in scatter for determinism

### DIFF
--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -768,8 +768,7 @@ class DSLScheduler:
                 task=new_scoped_task,
             )
             # This will queue the task for execution stream
-            coro = self._queue_tasks(new_scoped_task)
-            _ = asyncio.create_task(coro)
+            await self._queue_tasks(new_scoped_task)
 
         self.open_streams[task] = len(streams)
         # Get the next tasks to queue


### PR DESCRIPTION
## Summary
- Replace `asyncio.create_task()` with direct `await` when queuing tasks in the scheduler's loop stream handling
- Ensures deterministic task ordering by processing tasks sequentially rather than spawning concurrent tasks

## Test plan
- [ ] Verify scheduler behavior with loop streams
- [ ] Confirm task execution order is deterministic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure deterministic task ordering by awaiting _queue_tasks in scatter handling, processing tasks sequentially instead of concurrently. This removes race conditions and order jitter in loop stream execution.

<sup>Written for commit 2f91555f21f23cb2c9adcaa55e5d88b76ed1bfd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

