### PR TITLE
fix(api): Include assignee/tags in list and search cases

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -41,6 +41,7 @@ if not config.flags.registry_client or TYPE_CHECKING:
         CaseReadMinimal,
         CaseUpdate,
     )
+    from tracecat.cases.tags.schemas import CaseTagRead
     from tracecat.cases.service import CaseCommentsService, CasesService
     from tracecat.db.engine import get_async_session_context_manager
     from tracecat.exceptions import TracecatNotFoundError as InternalNotFoundError
@@ -492,6 +493,13 @@ async def list_cases(
                 status=case.status,
                 priority=case.priority,
                 severity=case.severity,
+                assignee=UserRead.model_validate(case.assignee, from_attributes=True)
+                if case.assignee
+                else None,
+                tags=[
+                    CaseTagRead.model_validate(tag, from_attributes=True)
+                    for tag in case.tags
+                ],
             ).model_dump(mode="json")
             for case in cases
         ],
@@ -628,6 +636,13 @@ async def search_cases(
                 status=case.status,
                 priority=case.priority,
                 severity=case.severity,
+                assignee=UserRead.model_validate(case.assignee, from_attributes=True)
+                if case.assignee
+                else None,
+                tags=[
+                    CaseTagRead.model_validate(tag, from_attributes=True)
+                    for tag in case.tags
+                ],
             ).model_dump(mode="json")
             for case in cases
         ],

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -53,6 +53,7 @@ def mock_case():
     case.short_id = "CASE-1234"
     case.payload = {"alert_type": "security", "severity": "high"}
     case.tags = []  # Empty list of tags by default
+    case.assignee = None
 
     # Set up model_dump to return a dict representation
     case.model_dump.return_value = {

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -35,6 +35,7 @@ def mock_case(test_workspace: Workspace) -> Case:
     case.id = uuid.UUID("cccccccc-cccc-4ccc-cccc-cccccccccccc")
     case.case_number = 1
     case.tags = []
+    case.assignee = None
     return case
 
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -161,7 +161,12 @@ class CasesService(BaseWorkspaceService):
         | None = None,
         sort: Literal["asc", "desc"] | None = None,
     ) -> Sequence[Case]:
-        statement = select(Case).where(Case.workspace_id == self.workspace_id)
+        statement = (
+            select(Case)
+            .where(Case.workspace_id == self.workspace_id)
+            .options(selectinload(Case.tags))
+            .options(selectinload(Case.assignee))
+        )
         if limit is not None:
             statement = statement.limit(limit)
         if order_by is not None:
@@ -514,6 +519,7 @@ class CasesService(BaseWorkspaceService):
             select(Case)
             .where(Case.workspace_id == self.workspace_id)
             .options(selectinload(Case.tags))
+            .options(selectinload(Case.assignee))
         )
 
         # Apply search term filter (search in summary and description)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added assignee and tags to case list and search responses to fix missing data and provide complete case metadata. Also eager-loads these relations to avoid extra queries.

- **Bug Fixes**
  - Include assignee (UserRead) and tags (CaseTagRead) in list_cases and search_cases serialization.
  - Eager-load assignee and tags in CasesService using selectinload to prevent N+1 queries.
  - Update tests to set assignee to None by default.

<sup>Written for commit 872035193625f3eeabb504b22603aaaf1567b973. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

