### PR TITLE
feat(service): add organization_id property to BaseService

### DIFF
--- a/alembic/versions/045d54f6247c_scope_org_unique_constraints.py
+++ b/alembic/versions/045d54f6247c_scope_org_unique_constraints.py
@@ -1,0 +1,110 @@
+"""Scope org-unique constraints by organization.
+
+Revision ID: 045d54f6247c
+Revises: 4a298374b126
+Create Date: 2026-01-16 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "045d54f6247c"
+down_revision: str | None = "4a298374b126"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # organization_secret: (organization_id, name, environment)
+    op.drop_constraint(
+        op.f("uq_organization_secret_name_environment"),
+        "organization_secret",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq_organization_secret_organization_id_name_environment"),
+        "organization_secret",
+        ["organization_id", "name", "environment"],
+    )
+
+    # organization_settings: unique key -> (organization_id, key)
+    op.drop_index(op.f("ix_organization_settings_key"), table_name="organization_settings")
+    op.create_unique_constraint(
+        op.f("uq_organization_settings_organization_id_key"),
+        "organization_settings",
+        ["organization_id", "key"],
+    )
+
+    # registry_repository: unique origin -> (organization_id, origin)
+    op.drop_constraint(
+        op.f("uq_registry_repository_origin"),
+        "registry_repository",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq_registry_repository_organization_id_origin"),
+        "registry_repository",
+        ["organization_id", "origin"],
+    )
+
+    # registry_action: unique namespace+name -> (organization_id, namespace, name)
+    op.drop_constraint(
+        "uq_registry_action_namespace_name",
+        "registry_action",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq_registry_action_organization_id_namespace_name"),
+        "registry_action",
+        ["organization_id", "namespace", "name"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("uq_registry_action_organization_id_namespace_name"),
+        "registry_action",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_registry_action_namespace_name",
+        "registry_action",
+        ["namespace", "name"],
+    )
+
+    op.drop_constraint(
+        op.f("uq_registry_repository_organization_id_origin"),
+        "registry_repository",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq_registry_repository_origin"),
+        "registry_repository",
+        ["origin"],
+    )
+
+    op.drop_constraint(
+        op.f("uq_organization_settings_organization_id_key"),
+        "organization_settings",
+        type_="unique",
+    )
+    op.create_index(
+        op.f("ix_organization_settings_key"),
+        "organization_settings",
+        ["key"],
+        unique=True,
+    )
+
+    op.drop_constraint(
+        op.f("uq_organization_secret_organization_id_name_environment"),
+        "organization_secret",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        op.f("uq_organization_secret_name_environment"),
+        "organization_secret",
+        ["name", "environment"],
+    )

--- a/alembic/versions/045d54f6247c_scope_org_unique_constraints.py
+++ b/alembic/versions/045d54f6247c_scope_org_unique_constraints.py
@@ -31,7 +31,9 @@ def upgrade() -> None:
     )
 
     # organization_settings: unique key -> (organization_id, key)
-    op.drop_index(op.f("ix_organization_settings_key"), table_name="organization_settings")
+    op.drop_index(
+        op.f("ix_organization_settings_key"), table_name="organization_settings"
+    )
     op.create_unique_constraint(
         op.f("uq_organization_settings_organization_id_key"),
         "organization_settings",

--- a/alembic/versions/4a298374b126_seed_default_org_and_workspace_fk.py
+++ b/alembic/versions/4a298374b126_seed_default_org_and_workspace_fk.py
@@ -1,0 +1,100 @@
+"""Seed default organization and enforce workspace org FK.
+
+Revision ID: 4a298374b126
+Revises: 7aab03def5b6, c2a4f8a5cf72
+Create Date: 2026-01-16 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4a298374b126"
+down_revision: tuple[str, str] | None = ("7aab03def5b6", "c2a4f8a5cf72")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensure a default organization row exists for the sentinel UUID.
+    op.execute(
+        """
+        INSERT INTO organization (id, name, slug, is_active, created_at, updated_at)
+        VALUES (
+            '00000000-0000-0000-0000-000000000000',
+            'Default Organization',
+            'default',
+            true,
+            now(),
+            now()
+        )
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+
+    # Backfill organization rows for any pre-existing workspaces with non-default orgs.
+    op.execute(
+        """
+        INSERT INTO organization (id, name, slug, is_active, created_at, updated_at)
+        SELECT
+            w.organization_id,
+            'Organization ' || w.organization_id::text,
+            'org-' || replace(w.organization_id::text, '-', ''),
+            true,
+            now(),
+            now()
+        FROM workspace AS w
+        LEFT JOIN organization AS o ON o.id = w.organization_id
+        WHERE o.id IS NULL
+        """
+    )
+
+    op.create_index(
+        op.f("ix_workspace_organization_id"),
+        "workspace",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        op.f("fk_workspace_organization_id_organization"),
+        "workspace",
+        "organization",
+        ["organization_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION prevent_workspace_org_change()
+        RETURNS trigger AS $$
+        BEGIN
+            IF NEW.organization_id IS DISTINCT FROM OLD.organization_id THEN
+                RAISE EXCEPTION 'workspace.organization_id is immutable';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER workspace_organization_id_immutable
+        BEFORE UPDATE OF organization_id ON workspace
+        FOR EACH ROW
+        EXECUTE FUNCTION prevent_workspace_org_change();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS workspace_organization_id_immutable ON workspace")
+    op.execute("DROP FUNCTION IF EXISTS prevent_workspace_org_change")
+    op.drop_constraint(
+        op.f("fk_workspace_organization_id_organization"),
+        "workspace",
+        type_="foreignkey",
+    )
+    op.drop_index(op.f("ix_workspace_organization_id"), table_name="workspace")

--- a/alembic/versions/4a298374b126_seed_default_org_and_workspace_fk.py
+++ b/alembic/versions/4a298374b126_seed_default_org_and_workspace_fk.py
@@ -90,7 +90,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute("DROP TRIGGER IF EXISTS workspace_organization_id_immutable ON workspace")
+    op.execute(
+        "DROP TRIGGER IF EXISTS workspace_organization_id_immutable ON workspace"
+    )
     op.execute("DROP FUNCTION IF EXISTS prevent_workspace_org_change")
     op.drop_constraint(
         op.f("fk_workspace_organization_id_organization"),

--- a/alembic/versions/4a298374b126_seed_default_org_and_workspace_fk.py
+++ b/alembic/versions/4a298374b126_seed_default_org_and_workspace_fk.py
@@ -38,7 +38,7 @@ def upgrade() -> None:
     op.execute(
         """
         INSERT INTO organization (id, name, slug, is_active, created_at, updated_at)
-        SELECT
+        SELECT DISTINCT
             w.organization_id,
             'Organization ' || w.organization_id::text,
             'org-' || replace(w.organization_id::text, '-', ''),
@@ -48,6 +48,7 @@ def upgrade() -> None:
         FROM workspace AS w
         LEFT JOIN organization AS o ON o.id = w.organization_id
         WHERE o.id IS NULL
+        ON CONFLICT (id) DO NOTHING
         """
     )
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -17537,10 +17537,16 @@ export const $WorkspaceCreate = {
       ],
     },
     organization_id: {
-      type: "string",
-      format: "uuid",
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Organization Id",
-      default: "00000000-0000-0000-0000-000000000000",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5567,7 +5567,7 @@ export type WorkflowUpdate = {
 export type WorkspaceCreate = {
   name: string
   settings?: WorkspaceSettingsUpdate | null
-  organization_id?: string
+  organization_id?: string | null
 }
 
 export type WorkspaceMember = {

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -199,6 +199,7 @@ Commands:
   ps            Show running containers
   logs [svc]    Show logs (optionally for specific service)
   attach <svc>  Attach to a running service container (e.g., attach api)
+  db            Open lazysql to the cluster's PostgreSQL database
   ports         Show port mappings for the cluster
   list          List all running Tracecat clusters
 
@@ -209,6 +210,7 @@ Examples:
   ./cluster 2 up -d              Start cluster 2 explicitly
   ./cluster 2 -p local up -d     Start cluster 2 with local profile
   ./cluster attach api           Attach shell to api service
+  ./cluster db                   Open lazysql to the database
   ./cluster list                 List all clusters
 
 Current worktree: ${WORKTREE_ID}
@@ -375,6 +377,12 @@ COMPOSE_FILE=$(get_compose_file "$PROFILE")
 if [[ "$COMMAND" == "ports" ]]; then
     show_ports "$CLUSTER_NUM"
     exit 0
+fi
+
+# Handle 'db' command - open lazysql to postgres
+if [[ "$COMMAND" == "db" ]]; then
+    calculate_ports "$CLUSTER_NUM"
+    exec lazysql "postgres://postgres:postgres@localhost:${PG_PORT}/postgres"
 fi
 
 # Handle 'attach' command

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,7 +221,27 @@ def registry_version_with_manifest(db: None, env_sandbox: None) -> Iterator[None
         sync_db_uri = sync_db_uri.replace("+asyncpg", "+psycopg")
         sync_engine = create_engine(sync_db_uri)
 
+        # Ensure schema exists for service sessions that target the default DB.
+        Base.metadata.create_all(sync_engine)
+
         with Session(sync_engine) as session:
+            session.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, slug, is_active, created_at, updated_at)
+                    VALUES (
+                        '00000000-0000-0000-0000-000000000000',
+                        'Default Organization',
+                        'default',
+                        true,
+                        now(),
+                        now()
+                    )
+                    ON CONFLICT (id) DO NOTHING
+                    """
+                )
+            )
+            session.commit()
             # Create a registry repository for core actions
             origin = "tracecat_registry"
             repo = session.scalar(

--- a/tests/integration/test_syncv2_execv2_e2e.py
+++ b/tests/integration/test_syncv2_execv2_e2e.py
@@ -761,7 +761,9 @@ class TestFailureScenarios:
         # Try to resolve non-existent version
         registry_lock = {"tracecat_registry": "nonexistent-version-12345"}
 
-        artifacts = await get_registry_artifacts_for_lock(registry_lock)
+        artifacts = await get_registry_artifacts_for_lock(
+            registry_lock, organization_id=test_role.organization_id
+        )
 
         # Should return empty list (version not found)
         assert len(artifacts) == 0

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -646,10 +646,10 @@ class TestMCPIntegrationWorkspaceIsolation:
         )
         mcp1 = await service1.create_mcp_integration(params=params1)
 
-        # Create workspace 2
+        # Create workspace 2 (using the same organization as workspace 1)
         workspace2 = Workspace(
             name="test-workspace-2",
-            organization_id=svc_role.user_id,
+            organization_id=svc_workspace.organization_id,
         )
         session.add(workspace2)
         await session.flush()
@@ -698,10 +698,10 @@ class TestMCPIntegrationWorkspaceIsolation:
             expires_in=3600,
         )
 
-        # Create workspace 2
+        # Create workspace 2 (using the same organization as workspace 1)
         workspace2 = Workspace(
             name="test-workspace-2",
-            organization_id=svc_role.user_id,
+            organization_id=svc_workspace.organization_id,
         )
         session.add(workspace2)
         await session.flush()

--- a/tests/unit/test_org_scoped_uniques.py
+++ b/tests/unit/test_org_scoped_uniques.py
@@ -1,0 +1,183 @@
+"""Tests for organization-scoped uniqueness constraints."""
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.db.models import (
+    Organization,
+    OrganizationSecret,
+    OrganizationSetting,
+    RegistryAction,
+    RegistryRepository,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.mark.anyio
+async def test_org_scoped_uniques_for_settings_and_secrets(
+    session: AsyncSession,
+) -> None:
+    org_a_id = uuid.uuid4()
+    org_b_id = uuid.uuid4()
+    org_a = Organization(
+        id=org_a_id,
+        name="Org A",
+        slug=f"org-a-{org_a_id.hex[:8]}",
+        is_active=True,
+    )
+    org_b = Organization(
+        id=org_b_id,
+        name="Org B",
+        slug=f"org-b-{org_b_id.hex[:8]}",
+        is_active=True,
+    )
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    secret_name = "shared-secret"
+    secret_env = "prod"
+    session.add_all(
+        [
+            OrganizationSecret(
+                organization_id=org_a_id,
+                name=secret_name,
+                environment=secret_env,
+                type="custom",
+                encrypted_keys=b"secret-a",
+            ),
+            OrganizationSecret(
+                organization_id=org_b_id,
+                name=secret_name,
+                environment=secret_env,
+                type="custom",
+                encrypted_keys=b"secret-b",
+            ),
+        ]
+    )
+    await session.commit()
+
+    session.add(
+        OrganizationSecret(
+            organization_id=org_a_id,
+            name=secret_name,
+            environment=secret_env,
+            type="custom",
+            encrypted_keys=b"secret-dup",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await session.commit()
+    await session.rollback()
+
+    setting_key = "sync.enabled"
+    session.add_all(
+        [
+            OrganizationSetting(
+                organization_id=org_a_id,
+                key=setting_key,
+                value=b"true",
+                value_type="bool",
+                is_encrypted=False,
+            ),
+            OrganizationSetting(
+                organization_id=org_b_id,
+                key=setting_key,
+                value=b"false",
+                value_type="bool",
+                is_encrypted=False,
+            ),
+        ]
+    )
+    await session.commit()
+
+    session.add(
+        OrganizationSetting(
+            organization_id=org_a_id,
+            key=setting_key,
+            value=b"false",
+            value_type="bool",
+            is_encrypted=False,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await session.commit()
+    await session.rollback()
+
+
+@pytest.mark.anyio
+async def test_org_scoped_uniques_for_registry(session: AsyncSession) -> None:
+    org_a_id = uuid.uuid4()
+    org_b_id = uuid.uuid4()
+    org_a = Organization(
+        id=org_a_id,
+        name="Org A",
+        slug=f"org-a-{org_a_id.hex[:8]}",
+        is_active=True,
+    )
+    org_b = Organization(
+        id=org_b_id,
+        name="Org B",
+        slug=f"org-b-{org_b_id.hex[:8]}",
+        is_active=True,
+    )
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    origin = "git://example.com/registry.git"
+    session.add_all(
+        [
+            RegistryRepository(organization_id=org_a_id, origin=origin),
+            RegistryRepository(organization_id=org_b_id, origin=origin),
+        ]
+    )
+    await session.commit()
+
+    session.add(RegistryRepository(organization_id=org_a_id, origin=origin))
+    with pytest.raises(IntegrityError):
+        await session.commit()
+    await session.rollback()
+
+    action_namespace = "tools.core"
+    action_name = "do_thing"
+    session.add_all(
+        [
+            RegistryAction(
+                organization_id=org_a_id,
+                name=action_name,
+                description="Does a thing",
+                namespace=action_namespace,
+                origin=origin,
+                type="action",
+                interface={},
+            ),
+            RegistryAction(
+                organization_id=org_b_id,
+                name=action_name,
+                description="Does a thing",
+                namespace=action_namespace,
+                origin=origin,
+                type="action",
+                interface={},
+            ),
+        ]
+    )
+    await session.commit()
+
+    session.add(
+        RegistryAction(
+            organization_id=org_a_id,
+            name=action_name,
+            description="Does a thing",
+            namespace=action_namespace,
+            origin=origin,
+            type="action",
+            interface={},
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await session.commit()
+    await session.rollback()

--- a/tests/unit/test_registry_resolver.py
+++ b/tests/unit/test_registry_resolver.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tracecat import config
 from tracecat.exceptions import RegistryError
 from tracecat.executor import registry_resolver
 from tracecat.registry.lock.types import RegistryLock
@@ -132,7 +133,9 @@ class TestResolveAction:
             return_value=(manifest, impl_index),
         ):
             action_impl = await registry_resolver.resolve_action(
-                "core.transform.reshape", lock
+                "core.transform.reshape",
+                lock,
+                organization_id=config.TRACECAT__DEFAULT_ORG_ID,
             )
 
         assert action_impl.type == "udf"
@@ -148,7 +151,11 @@ class TestResolveAction:
         )
 
         with pytest.raises(RegistryError) as exc_info:
-            await registry_resolver.resolve_action("core.transform.reshape", lock)
+            await registry_resolver.resolve_action(
+                "core.transform.reshape",
+                lock,
+                organization_id=config.TRACECAT__DEFAULT_ORG_ID,
+            )
 
         assert "not bound in registry_lock" in str(exc_info.value)
 
@@ -185,7 +192,11 @@ class TestResolveAction:
             side_effect=RegistryError("Registry version not found"),
         ):
             with pytest.raises(RegistryError) as exc_info:
-                await registry_resolver.resolve_action("core.transform.reshape", lock)
+                await registry_resolver.resolve_action(
+                    "core.transform.reshape",
+                    lock,
+                    organization_id=config.TRACECAT__DEFAULT_ORG_ID,
+                )
 
             assert "Registry version not found" in str(exc_info.value)
 
@@ -228,7 +239,9 @@ class TestCollectActionSecretsFromManifest:
             return_value=(manifest, impl_index),
         ):
             secrets = await registry_resolver.collect_action_secrets_from_manifest(
-                "tools.api.call", lock
+                "tools.api.call",
+                lock,
+                organization_id=config.TRACECAT__DEFAULT_ORG_ID,
             )
 
         assert len(secrets) == 1
@@ -245,7 +258,9 @@ class TestCollectActionSecretsFromManifest:
 
         with pytest.raises(RegistryError) as exc_info:
             await registry_resolver.collect_action_secrets_from_manifest(
-                "tools.api.call", lock
+                "tools.api.call",
+                lock,
+                organization_id=config.TRACECAT__DEFAULT_ORG_ID,
             )
 
         assert "not bound in registry_lock" in str(exc_info.value)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -583,7 +583,9 @@ async def execute_approved_tools_activity(
     )
 
     # Prefetch registry manifests into agent worker's cache for O(1) action resolution
-    await registry_resolver.prefetch_lock(input.registry_lock)
+    await registry_resolver.prefetch_lock(
+        input.registry_lock, input.role.organization_id
+    )
 
     # Initialize stream for emitting tool results to frontend
     stream = await AgentStream.new(

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -87,6 +87,21 @@ class MembershipService(BaseService):
         result = await self.session.execute(statement)
         return result.scalars().all()
 
+    async def list_user_memberships_with_org(
+        self, user_id: UserID
+    ) -> Sequence[MembershipWithOrg]:
+        """List all workspace memberships for a user with organization IDs."""
+        statement = (
+            select(Membership, Workspace.organization_id)
+            .join(Workspace, Membership.workspace_id == Workspace.id)
+            .where(Membership.user_id == user_id)
+        )
+        result = await self.session.execute(statement)
+        return [
+            MembershipWithOrg(membership=membership, org_id=org_id)
+            for membership, org_id in result.all()
+        ]
+
     @require_workspace_role(WorkspaceRole.ADMIN)
     async def create_membership(
         self,

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -46,6 +46,7 @@ TRACECAT__SERVICE_ROLES_WHITELIST = [
 ]
 TRACECAT__DEFAULT_USER_ID = uuid.UUID(int=0)
 TRACECAT__DEFAULT_ORG_ID = uuid.UUID(int=0)
+"""Deprecated: This config is being remove in favor of platform-scoped models."""
 
 # === DB Config === #
 TRACECAT__DB_URI = os.environ.get(

--- a/tracecat/executor/backends/direct.py
+++ b/tracecat/executor/backends/direct.py
@@ -120,7 +120,7 @@ class DirectBackend(ExecutorBackend):
         )
 
         # Download and extract tarballs for custom registries
-        tarball_paths = await self._ensure_registry_tarballs(input)
+        tarball_paths = await self._ensure_registry_tarballs(input, role)
 
         if tarball_paths:
             logger.debug(
@@ -269,7 +269,9 @@ class DirectBackend(ExecutorBackend):
             )
             return service.get_bound(reg_action, mode="execution")
 
-    async def _ensure_registry_tarballs(self, input: RunActionInput) -> list[str]:
+    async def _ensure_registry_tarballs(
+        self, input: RunActionInput, role: Role
+    ) -> list[str]:
         """Download and extract registry tarballs, returning paths to add to sys.path.
 
         This ensures custom registry modules are available for in-process execution.
@@ -285,7 +287,7 @@ class DirectBackend(ExecutorBackend):
             return []
 
         # Get tarball URIs for all origins in the registry lock
-        tarball_uris = await self._get_tarball_uris(input)
+        tarball_uris = await self._get_tarball_uris(input, role)
         if not tarball_uris:
             logger.debug("No tarball URIs found, using empty paths")
             return []
@@ -312,7 +314,9 @@ class DirectBackend(ExecutorBackend):
         )
         return extracted_paths
 
-    async def _get_tarball_uris(self, input: RunActionInput) -> list[str]:
+    async def _get_tarball_uris(
+        self, input: RunActionInput, role: Role
+    ) -> list[str]:
         """Get tarball URIs for registry environment (deterministic ordering).
 
         Args:
@@ -324,7 +328,7 @@ class DirectBackend(ExecutorBackend):
         """
         try:
             artifacts = await get_registry_artifacts_for_lock(
-                input.registry_lock.origins
+                input.registry_lock.origins, role.organization_id
             )
             return self._sort_tarball_uris(artifacts)
         except Exception as e:

--- a/tracecat/executor/backends/direct.py
+++ b/tracecat/executor/backends/direct.py
@@ -314,9 +314,7 @@ class DirectBackend(ExecutorBackend):
         )
         return extracted_paths
 
-    async def _get_tarball_uris(
-        self, input: RunActionInput, role: Role
-    ) -> list[str]:
+    async def _get_tarball_uris(self, input: RunActionInput, role: Role) -> list[str]:
         """Get tarball URIs for registry environment (deterministic ordering).
 
         Args:

--- a/tracecat/executor/backends/ephemeral.py
+++ b/tracecat/executor/backends/ephemeral.py
@@ -75,7 +75,7 @@ class EphemeralBackend(ExecutorBackend):
         )
 
         # Get ALL tarball URIs for registry environment (deterministic ordering)
-        tarball_uris = await self._get_tarball_uris(input)
+        tarball_uris = await self._get_tarball_uris(input, role)
 
         # Error out early if no tarballs resolved (unless local repository is enabled)
         if not tarball_uris and not config.TRACECAT__LOCAL_REPOSITORY_ENABLED:
@@ -119,6 +119,7 @@ class EphemeralBackend(ExecutorBackend):
     async def _get_tarball_uris(
         self,
         input: RunActionInput,
+        role: Role,
     ) -> list[str]:
         """Get tarball URIs for registry environment (deterministic ordering).
 
@@ -134,7 +135,7 @@ class EphemeralBackend(ExecutorBackend):
 
         try:
             artifacts = await get_registry_artifacts_for_lock(
-                input.registry_lock.origins
+                input.registry_lock.origins, role.organization_id
             )
             return self._sort_tarball_uris(artifacts)
         except Exception as e:

--- a/tracecat/registry/actions/service.py
+++ b/tracecat/registry/actions/service.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, TypedDict
 from typing import cast as typing_cast
 
-from pydantic import UUID4, ValidationError
+from pydantic import ValidationError
 from pydantic_core import ErrorDetails, to_jsonable_python
 from sqlalchemy import Boolean, cast, func, or_, select
 from tracecat_registry import (
@@ -235,7 +235,6 @@ class RegistryActionsService(BaseService):
     async def create_action(
         self,
         params: RegistryActionCreate,
-        organization_id: UUID4 | None = None,
         *,
         commit: bool = True,
     ) -> RegistryAction:
@@ -256,7 +255,7 @@ class RegistryActionsService(BaseService):
             interface = params.interface
 
         action = RegistryAction(
-            organization_id=organization_id or self.organization_id,
+            organization_id=self.organization_id,
             interface=to_jsonable_python(interface),
             **params.model_dump(exclude={"interface"}),
         )

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -6,7 +6,6 @@ from collections import deque
 
 from sqlalchemy import select
 
-from tracecat import config
 from tracecat.db.models import RegistryRepository, RegistryVersion
 from tracecat.dsl.enums import PlatformAction
 from tracecat.exceptions import RegistryError
@@ -60,8 +59,8 @@ class RegistryLockService(BaseService):
                 RegistryVersion.repository_id == RegistryRepository.id,
             )
             .where(
-                RegistryRepository.organization_id == config.TRACECAT__DEFAULT_ORG_ID,
-                RegistryVersion.organization_id == config.TRACECAT__DEFAULT_ORG_ID,
+                RegistryRepository.organization_id == self.organization_id,
+                RegistryVersion.organization_id == self.organization_id,
             )
             .distinct(RegistryVersion.repository_id)
             .order_by(

--- a/tracecat/registry/sync/base_service.py
+++ b/tracecat/registry/sync/base_service.py
@@ -274,7 +274,7 @@ class BaseRegistrySyncService[
         )
 
     def _get_storage_namespace(self) -> str:
-        return self._storage_namespace() or str(config.TRACECAT__DEFAULT_ORG_ID)
+        return self._storage_namespace() or str(self.organization_id)
 
     async def _build_and_upload_artifacts(
         self,

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -8,7 +8,6 @@ from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tracecat import config
 from tracecat.audit.logger import audit_log
 from tracecat.auth.types import Role
 from tracecat.db.models import BaseSecret, OrganizationSecret, Secret
@@ -283,7 +282,7 @@ class SecretsService(BaseService):
         """List all organization secrets."""
 
         stmt = select(OrganizationSecret).where(
-            OrganizationSecret.organization_id == config.TRACECAT__DEFAULT_ORG_ID
+            OrganizationSecret.organization_id == self.organization_id
         )
         if types:
             stmt = stmt.where(OrganizationSecret.type.in_(types))
@@ -294,7 +293,7 @@ class SecretsService(BaseService):
         """Get an organization secret by ID."""
 
         statement = select(OrganizationSecret).where(
-            OrganizationSecret.organization_id == config.TRACECAT__DEFAULT_ORG_ID,
+            OrganizationSecret.organization_id == self.organization_id,
             OrganizationSecret.id == secret_id,
         )
         result = await self.session.execute(statement)
@@ -308,7 +307,7 @@ class SecretsService(BaseService):
         """Retrieve an organization-wide secret by its name."""
         environment = environment or DEFAULT_SECRETS_ENVIRONMENT
         statement = select(OrganizationSecret).where(
-            OrganizationSecret.organization_id == config.TRACECAT__DEFAULT_ORG_ID,
+            OrganizationSecret.organization_id == self.organization_id,
             OrganizationSecret.name == secret_name,
             OrganizationSecret.environment == environment,
         )
@@ -336,7 +335,7 @@ class SecretsService(BaseService):
         elif params.type == SecretType.CA_CERT:
             validate_ca_cert_values(params.keys)
         secret = OrganizationSecret(
-            organization_id=config.TRACECAT__DEFAULT_ORG_ID,
+            organization_id=self.organization_id,
             name=params.name,
             type=params.type,
             description=params.description,

--- a/tracecat/service.py
+++ b/tracecat/service.py
@@ -4,10 +4,12 @@ from typing import Any, ClassVar, Self
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.exceptions import TracecatAuthorizationError
+from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 
 
@@ -20,6 +22,12 @@ class BaseService:
         self.session = session
         self.role = role or ctx_role.get()
         self.logger = logger.bind(service=self.service_name)
+
+    @property
+    def organization_id(self) -> OrganizationID:
+        if self.role is None:
+            return config.TRACECAT__DEFAULT_ORG_ID
+        return self.role.organization_id
 
     @classmethod
     @asynccontextmanager

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -116,9 +116,7 @@ async def create_workspace(
     """
     service = WorkspaceService(session, role=role)
     try:
-        workspace = await service.create_workspace(
-            params.name, organization_id=params.organization_id
-        )
+        workspace = await service.create_workspace(params.name)
     except TracecatAuthorizationError as e:
         logger.warning(
             "User does not have the appropriate access level",

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -93,7 +93,7 @@ class WorkspaceSettingsUpdate(Schema):
 class WorkspaceCreate(Schema):
     name: str = Field(..., min_length=1, max_length=100)
     settings: WorkspaceSettingsUpdate | None = None
-    organization_id: OrganizationID = Field(default=config.TRACECAT__DEFAULT_ORG_ID)
+    organization_id: OrganizationID | None = None
 
 
 class WorkspaceUpdate(Schema):

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -30,12 +30,16 @@ class WorkspaceService(BaseService):
         self, limit: int | None = None
     ) -> Sequence[Workspace]:
         """List all workspaces in the organization."""
-        statement = select(Workspace).options(
-            load_only(
-                *(getattr(Workspace, f) for f in self._load_only)
-            ),  # only what the route returns
-            noload("*"),  # disable all relationship loaders
-        ).where(Workspace.organization_id == self.organization_id)
+        statement = (
+            select(Workspace)
+            .options(
+                load_only(
+                    *(getattr(Workspace, f) for f in self._load_only)
+                ),  # only what the route returns
+                noload("*"),  # disable all relationship loaders
+            )
+            .where(Workspace.organization_id == self.organization_id)
+        )
         if limit is not None:
             if limit <= 0:
                 raise TracecatException("List workspace limit must be greater than 0")

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -13,7 +13,7 @@ from tracecat.authz.enums import OwnerType, WorkspaceRole
 from tracecat.cases.service import CaseFieldsService
 from tracecat.db.models import Membership, Ownership, User, Workspace
 from tracecat.exceptions import TracecatException, TracecatManagementError
-from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
+from tracecat.identifiers import UserID, WorkspaceID
 from tracecat.service import BaseService
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
 from tracecat.workspaces.schemas import WorkspaceSearch, WorkspaceUpdate
@@ -74,15 +74,13 @@ class WorkspaceService(BaseService):
         self,
         name: str,
         *,
-        organization_id: OrganizationID | None = None,
         override_id: UUID4 | None = None,
         users: list[User] | None = None,
     ) -> Workspace:
         """Create a new workspace."""
-        organization_id = organization_id or self.organization_id
         kwargs = {
             "name": name,
-            "organization_id": organization_id,
+            "organization_id": self.organization_id,
             # Workspace model defines the relationship as "members"
             "members": users or [],
         }
@@ -96,7 +94,7 @@ class WorkspaceService(BaseService):
         ownership = Ownership(
             resource_id=str(workspace.id),
             resource_type="workspace",
-            owner_id=organization_id,
+            owner_id=self.organization_id,
             owner_type=OwnerType.USER.value,
         )
         self.session.add(ownership)


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds `organization_id` to `BaseService` and refactors all services and executors to use org context for queries, caching, and registry resolution. It also scopes uniqueness and enforces workspace→organization FK to solidify multi-tenant isolation.

### Why Two Migrations?

The changes require two separate migrations that must run in sequence:

1. **`4a298374b126` - Seed default org and workspace FK**
   - Seeds the default organization (`00000000-0000-0000-0000-000000000000`)
   - Backfills organization rows for any existing workspaces with non-default org IDs
   - Adds FK constraint `workspace.organization_id → organization.id`
   - Creates a trigger to make `workspace.organization_id` immutable

2. **`045d54f6247c` - Scope org-unique constraints**
   - Updates unique constraints on `organization_secret`, `organization_settings`, `registry_repository`, and `registry_action` to include `organization_id`
   - This allows different organizations to have resources with the same names (e.g., two orgs can each have a secret named "API_KEY")

**Why they cannot be combined:** The second migration modifies unique constraints that reference `organization_id`. For these constraints to be valid, all existing `organization_id` values must already reference existing organizations. The first migration ensures this by:
1. Seeding the default organization
2. Backfilling organization rows for any orphaned workspace org IDs
3. Only then establishing the FK constraint

Once the FK is in place and data integrity is guaranteed, the second migration can safely scope the unique constraints by `organization_id`.

## Related Issues

<!-- Fixes # -->

## Screenshots / Recordings

N/A - Backend changes only

## Steps to QA

1. Run migrations: `alembic upgrade head`
2. Verify FK constraint exists: `\d workspace` should show `fk_workspace_organization_id_organization`
3. Verify unique constraints are org-scoped in `organization_secret`, `organization_settings`, `registry_repository`, `registry_action`
4. Run tests: `uv run pytest tests/unit tests/registry -x`
