### PR TITLE
feat(inbox): add inbox backend infrastructure

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -7851,6 +7851,7 @@ export const $InboxItemRead = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
       description: "Unique inbox item ID",
     },
@@ -7902,6 +7903,7 @@ export const $InboxItemRead = {
     },
     source_id: {
       type: "string",
+      format: "uuid",
       title: "Source Id",
       description: "ID of the source entity",
     },
@@ -17661,6 +17663,7 @@ export const $WorkflowSummary = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
       title: "Id",
       description: "Workflow ID",
     },

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5562,6 +5562,69 @@ export const $CursorPaginatedResponse_CaseReadMinimal_ = {
   title: "CursorPaginatedResponse[CaseReadMinimal]",
 } as const
 
+export const $CursorPaginatedResponse_InboxItemRead_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/InboxItemRead",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[InboxItemRead]",
+} as const
+
 export const $CursorPaginatedResponse_TableRowRead_ = {
   properties: {
     items: {
@@ -7782,6 +7845,114 @@ distinguish multiple files.`,
   type: "object",
   required: ["url", "media_type", "identifier"],
   title: "ImageUrl",
+} as const
+
+export const $InboxItemRead = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+      description: "Unique inbox item ID",
+    },
+    type: {
+      $ref: "#/components/schemas/InboxItemType",
+      description: "Type of inbox item",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+      description: "Display title",
+    },
+    preview: {
+      type: "string",
+      title: "Preview",
+      description: "Preview text",
+    },
+    status: {
+      $ref: "#/components/schemas/InboxItemStatus",
+      description: "Item status",
+    },
+    unread: {
+      type: "boolean",
+      title: "Unread",
+      description: "Whether the item is unread",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+      description: "Creation timestamp",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+      description: "Last update timestamp",
+    },
+    workflow: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/WorkflowSummary",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "Associated workflow",
+    },
+    source_id: {
+      type: "string",
+      title: "Source Id",
+      description: "ID of the source entity",
+    },
+    source_type: {
+      type: "string",
+      title: "Source Type",
+      description: "Type of source entity (e.g., agent_session)",
+    },
+    metadata: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Metadata",
+      description: "Type-specific metadata",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "type",
+    "title",
+    "preview",
+    "status",
+    "unread",
+    "created_at",
+    "updated_at",
+    "source_id",
+    "source_type",
+  ],
+  title: "InboxItemRead",
+  description: "Read model for inbox items.",
+} as const
+
+export const $InboxItemStatus = {
+  type: "string",
+  enum: ["pending", "completed", "failed"],
+  title: "InboxItemStatus",
+  description: "Status of inbox items.",
+} as const
+
+export const $InboxItemType = {
+  type: "string",
+  enum: ["approval"],
+  title: "InboxItemType",
+  description: "Types of inbox items.",
 } as const
 
 export const $InferredColumn = {
@@ -17484,6 +17655,37 @@ export const $WorkflowReadMinimal = {
   ],
   title: "WorkflowReadMinimal",
   description: "Minimal version of WorkflowRead model for list endpoints.",
+} as const
+
+export const $WorkflowSummary = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+      description: "Workflow ID",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+      description: "Workflow title",
+    },
+    alias: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Alias",
+      description: "Workflow alias",
+    },
+  },
+  type: "object",
+  required: ["id", "title"],
+  title: "WorkflowSummary",
+  description: "Summary of a workflow for inbox item context.",
 } as const
 
 export const $WorkflowSyncPullRequest = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -216,6 +216,10 @@ import type {
   GraphApplyGraphOperationsResponse,
   GraphGetGraphData,
   GraphGetGraphResponse,
+  InboxListItemsData,
+  InboxListItemsPaginatedData,
+  InboxListItemsPaginatedResponse,
+  InboxListItemsResponse,
   IntegrationsConnectProviderData,
   IntegrationsConnectProviderResponse,
   IntegrationsDeleteIntegrationData,
@@ -3825,6 +3829,72 @@ export const adminDemoteFromSuperuser = (
     url: "/admin/users/{user_id}/demote",
     path: {
       user_id: data.userId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Items
+ * List all inbox items for the workspace.
+ *
+ * Returns inbox items aggregated from all registered providers,
+ * sorted by status priority (pending first) then by creation time.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.limit
+ * @param data.offset
+ * @returns InboxItemRead Successful Response
+ * @throws ApiError
+ */
+export const inboxListItems = (
+  data: InboxListItemsData
+): CancelablePromise<InboxListItemsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/inbox",
+    query: {
+      limit: data.limit,
+      offset: data.offset,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Items Paginated
+ * List inbox items with cursor-based pagination.
+ *
+ * Supports sorting by created_at, updated_at, or status.
+ * Default sort is by created_at descending.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.limit
+ * @param data.cursor
+ * @param data.reverse
+ * @param data.orderBy Column name to order by (created_at, updated_at, status)
+ * @param data.sort Sort direction (asc or desc)
+ * @returns CursorPaginatedResponse_InboxItemRead_ Successful Response
+ * @throws ApiError
+ */
+export const inboxListItemsPaginated = (
+  data: InboxListItemsPaginatedData
+): CancelablePromise<InboxListItemsPaginatedResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/inbox/paginated",
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      reverse: data.reverse,
+      order_by: data.orderBy,
+      sort: data.sort,
+      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1689,6 +1689,30 @@ export type CursorPaginatedResponse_CaseReadMinimal_ = {
   total_estimate?: number | null
 }
 
+export type CursorPaginatedResponse_InboxItemRead_ = {
+  items: Array<InboxItemRead>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
 export type CursorPaginatedResponse_TableRowRead_ = {
   items: Array<TableRowRead>
   /**
@@ -2475,6 +2499,72 @@ export type ImageUrl = {
    */
   readonly identifier: string
 }
+
+/**
+ * Read model for inbox items.
+ */
+export type InboxItemRead = {
+  /**
+   * Unique inbox item ID
+   */
+  id: string
+  /**
+   * Type of inbox item
+   */
+  type: InboxItemType
+  /**
+   * Display title
+   */
+  title: string
+  /**
+   * Preview text
+   */
+  preview: string
+  /**
+   * Item status
+   */
+  status: InboxItemStatus
+  /**
+   * Whether the item is unread
+   */
+  unread: boolean
+  /**
+   * Creation timestamp
+   */
+  created_at: string
+  /**
+   * Last update timestamp
+   */
+  updated_at: string
+  /**
+   * Associated workflow
+   */
+  workflow?: WorkflowSummary | null
+  /**
+   * ID of the source entity
+   */
+  source_id: string
+  /**
+   * Type of source entity (e.g., agent_session)
+   */
+  source_type: string
+  /**
+   * Type-specific metadata
+   */
+  metadata?: {
+    [key: string]: unknown
+  } | null
+}
+
+/**
+ * Status of inbox items.
+ */
+export type InboxItemStatus = "pending" | "completed" | "failed"
+
+/**
+ * Types of inbox items.
+ */
+export type InboxItemType = "approval"
 
 /**
  * Inferred column mapping between CSV headers and table columns.
@@ -5553,6 +5643,24 @@ export type WorkflowReadMinimal = {
 }
 
 /**
+ * Summary of a workflow for inbox item context.
+ */
+export type WorkflowSummary = {
+  /**
+   * Workflow ID
+   */
+  id: string
+  /**
+   * Workflow title
+   */
+  title: string
+  /**
+   * Workflow alias
+   */
+  alias?: string | null
+}
+
+/**
  * Request model for pulling workflows from a Git repository.
  */
 export type WorkflowSyncPullRequest = {
@@ -6637,6 +6745,32 @@ export type AdminDemoteFromSuperuserData = {
 }
 
 export type AdminDemoteFromSuperuserResponse = AdminUserRead
+
+export type InboxListItemsData = {
+  limit?: number
+  offset?: number
+  workspaceId: string
+}
+
+export type InboxListItemsResponse = Array<InboxItemRead>
+
+export type InboxListItemsPaginatedData = {
+  cursor?: string | null
+  limit?: number
+  /**
+   * Column name to order by (created_at, updated_at, status)
+   */
+  orderBy?: string | null
+  reverse?: boolean
+  /**
+   * Sort direction (asc or desc)
+   */
+  sort?: "asc" | "desc" | null
+  workspaceId: string
+}
+
+export type InboxListItemsPaginatedResponse =
+  CursorPaginatedResponse_InboxItemRead_
 
 export type EditorListFunctionsData = {
   workspaceId: string
@@ -9452,6 +9586,36 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: AdminUserRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/inbox": {
+    get: {
+      req: InboxListItemsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<InboxItemRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/inbox/paginated": {
+    get: {
+      req: InboxListItemsPaginatedData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CursorPaginatedResponse_InboxItemRead_
         /**
          * Validation Error
          */

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -70,6 +70,7 @@ from tracecat.feature_flags import (
     is_feature_enabled,
 )
 from tracecat.feature_flags.router import router as feature_flags_router
+from tracecat.inbox.router import router as inbox_router
 from tracecat.integrations.router import (
     integrations_router,
     mcp_router,
@@ -289,6 +290,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(agent_session_router)
     app.include_router(approvals_router)
     app.include_router(admin_router)
+    app.include_router(inbox_router)
     app.include_router(editor_router)
     app.include_router(registry_repos_router)
     app.include_router(registry_actions_router)

--- a/tracecat/inbox/__init__.py
+++ b/tracecat/inbox/__init__.py
@@ -1,0 +1,1 @@
+"""Inbox module for unified notification aggregation."""

--- a/tracecat/inbox/dependencies.py
+++ b/tracecat/inbox/dependencies.py
@@ -1,0 +1,36 @@
+"""Inbox provider dependencies."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tracecat.logger import logger
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from tracecat.auth.types import Role
+    from tracecat.inbox.types import InboxProvider
+
+
+def get_inbox_providers(
+    session: AsyncSession,
+    role: Role,
+) -> list[InboxProvider]:
+    """Get list of inbox providers.
+
+    Providers are registered dynamically based on available features.
+    EE features (like approvals) are loaded if the tracecat_ee package is available.
+    """
+    providers: list[InboxProvider] = []
+
+    # EE: Add approvals provider if available
+    try:
+        from tracecat_ee.inbox.providers.approvals import ApprovalsInboxProvider
+
+        providers.append(ApprovalsInboxProvider(session, role))
+        logger.debug("Loaded ApprovalsInboxProvider")
+    except ImportError:
+        logger.debug("ApprovalsInboxProvider not available (EE feature)")
+
+    return providers

--- a/tracecat/inbox/router.py
+++ b/tracecat/inbox/router.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.types import Role
@@ -75,7 +75,6 @@ async def list_items_paginated(
         )
     except ValueError as e:
         logger.warning(f"Invalid request for list inbox items: {e}")
-        from fastapi import HTTPException, status
 
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/inbox/router.py
+++ b/tracecat/inbox/router.py
@@ -1,0 +1,83 @@
+"""Inbox API router."""
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Query
+
+from tracecat.auth.credentials import RoleACL
+from tracecat.auth.types import Role
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.inbox.dependencies import get_inbox_providers
+from tracecat.inbox.schemas import InboxItemRead
+from tracecat.inbox.service import InboxService
+from tracecat.logger import logger
+from tracecat.pagination import CursorPaginatedResponse
+
+router = APIRouter(prefix="/inbox", tags=["inbox"])
+
+WorkspaceUser = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="yes",
+    ),
+]
+
+
+@router.get("")
+async def list_items(
+    role: WorkspaceUser,
+    session: AsyncDBSession,
+    limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+) -> list[InboxItemRead]:
+    """List all inbox items for the workspace.
+
+    Returns inbox items aggregated from all registered providers,
+    sorted by status priority (pending first) then by creation time.
+    """
+    providers = get_inbox_providers(session, role)
+    service = InboxService(session, role, providers)
+    return await service.list_items(limit=limit, offset=offset)
+
+
+@router.get("/paginated")
+async def list_items_paginated(
+    role: WorkspaceUser,
+    session: AsyncDBSession,
+    limit: int = Query(default=20, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+    order_by: str | None = Query(
+        default=None,
+        description="Column name to order by (created_at, updated_at, status)",
+    ),
+    sort: Literal["asc", "desc"] | None = Query(
+        default=None, description="Sort direction (asc or desc)"
+    ),
+) -> CursorPaginatedResponse[InboxItemRead]:
+    """List inbox items with cursor-based pagination.
+
+    Supports sorting by created_at, updated_at, or status.
+    Default sort is by created_at descending.
+    """
+    providers = get_inbox_providers(session, role)
+    service = InboxService(session, role, providers)
+
+    try:
+        return await service.list_items_paginated(
+            limit=limit,
+            cursor=cursor,
+            reverse=reverse,
+            order_by=order_by,
+            sort=sort,
+        )
+    except ValueError as e:
+        logger.warning(f"Invalid request for list inbox items: {e}")
+        from fastapi import HTTPException, status
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e

--- a/tracecat/inbox/schemas.py
+++ b/tracecat/inbox/schemas.py
@@ -1,0 +1,41 @@
+"""Inbox API schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from tracecat.inbox.types import InboxItemStatus, InboxItemType
+
+
+class WorkflowSummary(BaseModel):
+    """Summary of a workflow for inbox item context."""
+
+    id: str = Field(..., description="Workflow ID")
+    title: str = Field(..., description="Workflow title")
+    alias: str | None = Field(default=None, description="Workflow alias")
+
+
+class InboxItemRead(BaseModel):
+    """Read model for inbox items."""
+
+    id: str = Field(..., description="Unique inbox item ID")
+    type: InboxItemType = Field(..., description="Type of inbox item")
+    title: str = Field(..., description="Display title")
+    preview: str = Field(..., description="Preview text")
+    status: InboxItemStatus = Field(..., description="Item status")
+    unread: bool = Field(..., description="Whether the item is unread")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+    workflow: WorkflowSummary | None = Field(
+        default=None, description="Associated workflow"
+    )
+    source_id: str = Field(..., description="ID of the source entity")
+    source_type: str = Field(
+        ..., description="Type of source entity (e.g., agent_session)"
+    )
+    metadata: dict[str, Any] | None = Field(
+        default=None, description="Type-specific metadata"
+    )

--- a/tracecat/inbox/schemas.py
+++ b/tracecat/inbox/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 from typing import Any
 
@@ -13,7 +14,7 @@ from tracecat.inbox.types import InboxItemStatus, InboxItemType
 class WorkflowSummary(BaseModel):
     """Summary of a workflow for inbox item context."""
 
-    id: str = Field(..., description="Workflow ID")
+    id: uuid.UUID = Field(..., description="Workflow ID")
     title: str = Field(..., description="Workflow title")
     alias: str | None = Field(default=None, description="Workflow alias")
 
@@ -21,7 +22,7 @@ class WorkflowSummary(BaseModel):
 class InboxItemRead(BaseModel):
     """Read model for inbox items."""
 
-    id: str = Field(..., description="Unique inbox item ID")
+    id: uuid.UUID = Field(..., description="Unique inbox item ID")
     type: InboxItemType = Field(..., description="Type of inbox item")
     title: str = Field(..., description="Display title")
     preview: str = Field(..., description="Preview text")
@@ -32,7 +33,7 @@ class InboxItemRead(BaseModel):
     workflow: WorkflowSummary | None = Field(
         default=None, description="Associated workflow"
     )
-    source_id: str = Field(..., description="ID of the source entity")
+    source_id: uuid.UUID = Field(..., description="ID of the source entity")
     source_type: str = Field(
         ..., description="Type of source entity (e.g., agent_session)"
     )

--- a/tracecat/inbox/service.py
+++ b/tracecat/inbox/service.py
@@ -122,12 +122,16 @@ class InboxService(BaseWorkspaceService, BaseCursorPaginator):
                 reverse=sort_desc,
             )
         elif order_by == "status":
-            # Status priority: pending first
+            # Status priority: pending first (asc) or completed first (desc)
+            # Secondary sort by created_at in the same direction
             all_items.sort(
                 key=lambda x: (
                     x.status != InboxItemStatus.PENDING,
-                    -x.created_at.timestamp(),
+                    x.created_at.timestamp()
+                    if sort_desc
+                    else -x.created_at.timestamp(),
                 ),
+                reverse=sort_desc,
             )
 
         # Find cursor position in merged results

--- a/tracecat/inbox/service.py
+++ b/tracecat/inbox/service.py
@@ -1,0 +1,181 @@
+"""Inbox service for aggregating notification items from multiple providers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from tracecat.inbox.schemas import InboxItemRead
+from tracecat.inbox.types import InboxItemStatus
+from tracecat.pagination import BaseCursorPaginator, CursorPaginatedResponse
+from tracecat.service import BaseWorkspaceService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from tracecat.auth.types import Role
+    from tracecat.inbox.types import InboxProvider
+
+
+class InboxService(BaseWorkspaceService, BaseCursorPaginator):
+    """Service for aggregating inbox items from multiple providers."""
+
+    service_name = "inbox"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        role: Role,
+        providers: list[InboxProvider] | None = None,
+    ):
+        BaseWorkspaceService.__init__(self, session, role)
+        BaseCursorPaginator.__init__(self, session)
+        self.providers = providers or []
+
+    async def list_items(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[InboxItemRead]:
+        """List all inbox items with simple pagination.
+
+        Aggregates items from all providers, sorts by status priority
+        (pending first) then by created_at descending.
+
+        Offset and limit are applied after merging all provider results
+        to ensure correct global pagination across providers.
+        """
+        items: list[InboxItemRead] = []
+
+        # Fetch enough items from each provider to cover offset + limit
+        fetch_limit = offset + limit
+        for provider in self.providers:
+            provider_items = await provider.list_items(limit=fetch_limit, offset=0)
+            items.extend(provider_items)
+
+        # Sort: pending first, then by created_at desc
+        items.sort(
+            key=lambda x: (
+                x.status != InboxItemStatus.PENDING,
+                -x.created_at.timestamp(),
+            )
+        )
+
+        # Apply offset and limit after merging and sorting
+        return items[offset : offset + limit]
+
+    async def list_items_paginated(
+        self,
+        *,
+        limit: int = 20,
+        cursor: str | None = None,
+        reverse: bool = False,
+        order_by: str | None = None,
+        sort: Literal["asc", "desc"] | None = None,
+    ) -> CursorPaginatedResponse[InboxItemRead]:
+        """List inbox items with cursor-based pagination.
+
+        For the initial implementation, this delegates pagination to providers
+        and merges results. Future optimization could use a materialized view
+        or unified table for more efficient cross-provider pagination.
+        """
+        # For now, use simple aggregation with in-memory pagination
+        # This works well for small-medium inbox sizes
+        # TODO: Optimize for large inboxes with cross-provider cursor pagination
+
+        all_items: list[InboxItemRead] = []
+
+        # Decode cursor to get target item ID if present
+        cursor_id: str | None = None
+        if cursor:
+            cursor_data = self.decode_cursor(cursor)
+            cursor_id = cursor_data.id
+
+        # Initial fetch - get enough items to likely include cursor position.
+        # For cross-provider aggregation, we fetch a larger window to increase
+        # the likelihood of including the cursor item. This is a known limitation
+        # of in-memory aggregation; very large inboxes may need a unified table.
+        # Fetch more when we have a cursor to search for.
+        initial_fetch_limit = limit * 10 if cursor_id else limit * 2
+
+        for provider in self.providers:
+            # Fetch items without cursor - handle pagination at aggregate level
+            provider_response = await provider.list_items_paginated(
+                limit=initial_fetch_limit,
+                cursor=None,
+                reverse=reverse,
+                order_by=order_by,
+                sort=sort,
+            )
+            all_items.extend(provider_response.items)
+
+        # Sort all items
+        sort_desc = sort != "asc"
+        if order_by == "created_at" or order_by is None:
+            all_items.sort(
+                key=lambda x: x.created_at.timestamp(),
+                reverse=sort_desc,
+            )
+        elif order_by == "updated_at":
+            all_items.sort(
+                key=lambda x: x.updated_at.timestamp(),
+                reverse=sort_desc,
+            )
+        elif order_by == "status":
+            # Status priority: pending first
+            all_items.sort(
+                key=lambda x: (
+                    x.status != InboxItemStatus.PENDING,
+                    -x.created_at.timestamp(),
+                ),
+            )
+
+        # Find cursor position in merged results
+        start_idx = 0
+        if cursor_id:
+            for i, item in enumerate(all_items):
+                if item.id == cursor_id:
+                    start_idx = i + 1 if not reverse else i
+                    break
+
+        # Slice items
+        if reverse:
+            end_idx = start_idx
+            start_idx = max(0, end_idx - limit)
+            items = all_items[start_idx:end_idx]
+            items.reverse()
+        else:
+            items = all_items[start_idx : start_idx + limit]
+
+        # Determine pagination state
+        has_more = start_idx + limit < len(all_items)
+        has_previous = start_idx > 0
+
+        # Generate cursors
+        next_cursor = None
+        prev_cursor = None
+
+        if items:
+            if has_more:
+                last_item = items[-1]
+                next_cursor = self.encode_cursor(
+                    id=last_item.id,
+                    sort_column=order_by or "created_at",
+                    sort_value=getattr(last_item, order_by or "created_at"),
+                )
+            if has_previous:
+                first_item = items[0]
+                prev_cursor = self.encode_cursor(
+                    id=first_item.id,
+                    sort_column=order_by or "created_at",
+                    sort_value=getattr(first_item, order_by or "created_at"),
+                )
+
+        return CursorPaginatedResponse(
+            items=items,
+            next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
+            has_more=has_more,
+            has_previous=has_previous,
+            total_estimate=len(all_items),
+        )

--- a/tracecat/inbox/types.py
+++ b/tracecat/inbox/types.py
@@ -1,0 +1,57 @@
+"""Inbox domain types and protocols."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING, Literal, Protocol
+
+if TYPE_CHECKING:
+    from tracecat.inbox.schemas import InboxItemRead
+    from tracecat.pagination import CursorPaginatedResponse
+
+
+class InboxItemType(StrEnum):
+    """Types of inbox items."""
+
+    APPROVAL = "approval"
+    # Future types:
+    # MENTION = "mention"
+    # ASSIGNMENT = "assignment"
+
+
+class InboxItemStatus(StrEnum):
+    """Status of inbox items."""
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class InboxProvider(Protocol):
+    """Protocol for inbox item providers.
+
+    Providers are responsible for fetching inbox items from their respective
+    domains (approvals, mentions, etc.) and transforming them into the unified
+    InboxItemRead format.
+    """
+
+    async def list_items(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[InboxItemRead]:
+        """List inbox items with simple offset pagination."""
+        ...
+
+    async def list_items_paginated(
+        self,
+        *,
+        limit: int = 20,
+        cursor: str | None = None,
+        reverse: bool = False,
+        order_by: str | None = None,
+        sort: Literal["asc", "desc"] | None = None,
+    ) -> CursorPaginatedResponse[InboxItemRead]:
+        """List inbox items with cursor-based pagination."""
+        ...


### PR DESCRIPTION
## Description

This PR adds backend infrastructure for a unified Inbox that aggregates notification items from multiple providers. The implementation includes:

- New `/inbox` and `/inbox/paginated` endpoints with workspace-scoped authentication
- Support for both simple pagination (limit/offset) and cursor-based pagination
- Sorting options by created_at, updated_at, and status with asc/desc direction
- Dynamic provider registration system that loads EE providers when available
- Core schemas and types for inbox items with workflow context
- Frontend client/type generation for the new APIs

The Inbox service aggregates items across providers with in-memory merge and sort, prioritizing pending items first, then by timestamp.

## Steps to QA

1. Run the backend with the new inbox module
2. Call the `/inbox` endpoint with a valid workspace ID
3. Verify the response format matches the expected schema
4. Test pagination with the `/inbox/paginated` endpoint
5. Verify sorting works with different order_by and sort parameters