### PR TITLE
feat(agent): session and workflow changes for inbox flow

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1540,7 +1540,14 @@ export const $AgentSessionCreate = {
 
 export const $AgentSessionEntity = {
   type: "string",
-  enum: ["case", "agent_preset", "agent_preset_builder", "copilot", "workflow"],
+  enum: [
+    "case",
+    "agent_preset",
+    "agent_preset_builder",
+    "copilot",
+    "workflow",
+    "approval",
+  ],
   title: "AgentSessionEntity",
   description: `The type of entity associated with an agent session.
 
@@ -1549,7 +1556,28 @@ Determines the context and behavior of the session:
 - AGENT_PRESET: Live chat testing a preset configuration
 - AGENT_PRESET_BUILDER: Builder chat for editing/configuring a preset
 - COPILOT: Workspace-level copilot assistant
-- WORKFLOW: Workflow-initiated agent run (from action)`,
+- WORKFLOW: Workflow-initiated agent run (from action)
+- APPROVAL: Inbox approval continuation (hidden from main chat list)`,
+} as const
+
+export const $AgentSessionForkRequest = {
+  properties: {
+    entity_type: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/AgentSessionEntity",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description:
+        "Override entity type for the forked session. Use 'approval' for inbox forks to hide from main chat list.",
+    },
+  },
+  type: "object",
+  title: "AgentSessionForkRequest",
+  description: "Request schema for forking an agent session.",
 } as const
 
 export const $AgentSessionRead = {
@@ -1636,6 +1664,18 @@ export const $AgentSessionRead = {
         },
       ],
       title: "Last Stream Id",
+    },
+    parent_session_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Parent Session Id",
     },
     created_at: {
       type: "string",
@@ -1750,6 +1790,18 @@ export const $AgentSessionReadVercel = {
         },
       ],
       title: "Last Stream Id",
+    },
+    parent_session_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Parent Session Id",
     },
     created_at: {
       type: "string",
@@ -1872,6 +1924,18 @@ export const $AgentSessionReadWithMessages = {
         },
       ],
       title: "Last Stream Id",
+    },
+    parent_session_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Parent Session Id",
     },
     created_at: {
       type: "string",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -70,6 +70,8 @@ import type {
   AgentSessionsCreateSessionResponse,
   AgentSessionsDeleteSessionData,
   AgentSessionsDeleteSessionResponse,
+  AgentSessionsForkSessionData,
+  AgentSessionsForkSessionResponse,
   AgentSessionsGetSessionData,
   AgentSessionsGetSessionResponse,
   AgentSessionsGetSessionVercelData,
@@ -3283,6 +3285,8 @@ export const agentSessionsCreateSession = (
  * @param data.workspaceId
  * @param data.entityType Filter by entity type
  * @param data.entityId Filter by entity ID
+ * @param data.excludeEntityTypes Entity types to exclude from results
+ * @param data.parentSessionId Filter by parent session ID (for finding forked sessions)
  * @param data.limit Maximum number of sessions to return
  * @returns unknown Successful Response
  * @throws ApiError
@@ -3296,6 +3300,8 @@ export const agentSessionsListSessions = (
     query: {
       entity_type: data.entityType,
       entity_id: data.entityId,
+      exclude_entity_types: data.excludeEntityTypes,
+      parent_session_id: data.parentSessionId,
       limit: data.limit,
       workspace_id: data.workspaceId,
     },
@@ -3483,6 +3489,41 @@ export const agentSessionsStreamSessionEvents = (
       format: data.format,
       workspace_id: data.workspaceId,
     },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Fork Session
+ * Fork an existing session to continue conversation post-decision.
+ *
+ * Creates a new session linked to the parent session, allowing users
+ * to ask the agent for context after making approval decisions.
+ *
+ * Set entity_type to 'approval' for inbox forks to hide from main chat list.
+ * @param data The data for the request.
+ * @param data.sessionId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentSessionRead Successful Response
+ * @throws ApiError
+ */
+export const agentSessionsForkSession = (
+  data: AgentSessionsForkSessionData
+): CancelablePromise<AgentSessionsForkSessionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/agent/sessions/{session_id}/fork",
+    path: {
+      session_id: data.sessionId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -356,6 +356,7 @@ export type AgentSessionCreate = {
  * - AGENT_PRESET_BUILDER: Builder chat for editing/configuring a preset
  * - COPILOT: Workspace-level copilot assistant
  * - WORKFLOW: Workflow-initiated agent run (from action)
+ * - APPROVAL: Inbox approval continuation (hidden from main chat list)
  */
 export type AgentSessionEntity =
   | "case"
@@ -363,6 +364,17 @@ export type AgentSessionEntity =
   | "agent_preset_builder"
   | "copilot"
   | "workflow"
+  | "approval"
+
+/**
+ * Request schema for forking an agent session.
+ */
+export type AgentSessionForkRequest = {
+  /**
+   * Override entity type for the forked session. Use 'approval' for inbox forks to hide from main chat list.
+   */
+  entity_type?: AgentSessionEntity | null
+}
 
 /**
  * Response schema for agent session.
@@ -378,6 +390,7 @@ export type AgentSessionRead = {
   agent_preset_id: string | null
   harness_type: string | null
   last_stream_id?: string | null
+  parent_session_id?: string | null
   created_at: string
   updated_at: string
 }
@@ -396,6 +409,7 @@ export type AgentSessionReadVercel = {
   agent_preset_id: string | null
   harness_type: string | null
   last_stream_id?: string | null
+  parent_session_id?: string | null
   created_at: string
   updated_at: string
   /**
@@ -418,6 +432,7 @@ export type AgentSessionReadWithMessages = {
   agent_preset_id: string | null
   harness_type: string | null
   last_stream_id?: string | null
+  parent_session_id?: string | null
   created_at: string
   updated_at: string
   /**
@@ -6604,9 +6619,17 @@ export type AgentSessionsListSessionsData = {
    */
   entityType?: AgentSessionEntity | null
   /**
+   * Entity types to exclude from results
+   */
+  excludeEntityTypes?: Array<AgentSessionEntity> | null
+  /**
    * Maximum number of sessions to return
    */
   limit?: number
+  /**
+   * Filter by parent session ID (for finding forked sessions)
+   */
+  parentSessionId?: string | null
   workspaceId: string
 }
 
@@ -6665,6 +6688,14 @@ export type AgentSessionsStreamSessionEventsData = {
 }
 
 export type AgentSessionsStreamSessionEventsResponse = unknown
+
+export type AgentSessionsForkSessionData = {
+  requestBody?: AgentSessionForkRequest | null
+  sessionId: string
+  workspaceId: string
+}
+
+export type AgentSessionsForkSessionResponse = AgentSessionRead
 
 export type ApprovalsSubmitApprovalsData = {
   requestBody: ApprovalSubmission
@@ -9379,6 +9410,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: unknown
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/agent/sessions/{session_id}/fork": {
+    post: {
+      req: AgentSessionsForkSessionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentSessionRead
         /**
          * Validation Error
          */

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -100,6 +100,23 @@ export interface ChatSessionPaneProps {
   toolsEnabled?: boolean
   /** Autofocus the prompt input when the pane mounts. */
   autoFocusInput?: boolean
+  /**
+   * Called before sending a message. If provided, receives the message text
+   * and should handle sending it (e.g., to a forked session). Returns the
+   * new session ID to switch to, or null to cancel.
+   * Used for inbox fork-on-send behavior.
+   */
+  onBeforeSend?: (messageText: string) => Promise<string | null>
+  /**
+   * Message to send immediately on mount. Used after forking a session
+   * to send the user's message to the newly forked session.
+   */
+  pendingMessage?: string
+  /**
+   * Callback when the pending message has been sent.
+   * Used to clear the pending message state in the parent.
+   */
+  onPendingMessageSent?: () => void
 }
 
 export function ChatSessionPane({
@@ -113,6 +130,9 @@ export function ChatSessionPane({
   modelInfo,
   toolsEnabled = true,
   autoFocusInput = false,
+  onBeforeSend,
+  pendingMessage,
+  onPendingMessageSent,
 }: ChatSessionPaneProps) {
   const queryClient = useQueryClient()
   const processedMessageRef = useRef<
@@ -140,6 +160,25 @@ export function ChatSessionPane({
       messages: uiMessages,
       modelInfo,
     })
+
+  // Track whether we've sent the pending message to avoid double-sends
+  const pendingMessageSentRef = useRef(false)
+
+  // Send pending message on mount (used after forking)
+  useEffect(() => {
+    if (pendingMessage && !pendingMessageSentRef.current && !isReadonly) {
+      pendingMessageSentRef.current = true
+      clearError()
+      sendMessage({ text: pendingMessage })
+      onPendingMessageSent?.()
+    }
+  }, [
+    pendingMessage,
+    isReadonly,
+    clearError,
+    sendMessage,
+    onPendingMessageSent,
+  ])
 
   const isWaitingForResponse = useMemo(() => {
     if (status === "submitted") return true
@@ -240,23 +279,37 @@ export function ChatSessionPane({
     }
   }, [messages, invalidateEntityQueries])
 
-  const handleSubmit = (message: PromptInputMessage) => {
+  const handleSubmit = async (message: PromptInputMessage) => {
     const hasText = Boolean(message.text?.trim())
 
     if (!hasText) {
       return
     }
 
+    const messageText = message.text || ""
+
+    if (onBeforeSend) {
+      const result = await onBeforeSend(messageText)
+      // Only clear input if onBeforeSend succeeded (non-null)
+      // If null, the action was cancelled and user keeps their draft
+      if (result !== null) {
+        setInput("")
+      }
+      // Parent will handle switching sessions and sending via pendingMessage
+      return
+    }
+
+    // Clear input for normal message sending
+    setInput("")
+
     try {
       clearError()
       sendMessage({
-        text: message.text || "Sent with attachments",
+        text: messageText,
         ...(message.files?.length ? { files: message.files } : {}),
       })
     } catch (error) {
       console.error("Failed to send message:", error)
-    } finally {
-      setInput("")
     }
   }
 

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -166,6 +166,12 @@ export const ENTITY_TO_INVALIDATION: Record<
       // No invalidation logic for workflow entity
     },
   },
+  approval: {
+    predicate: () => false,
+    handler: (_queryClient, _workspaceId, _entityId) => {
+      // No invalidation logic for approval entity
+    },
+  },
 }
 
 export type ModelInfo = {

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -44,9 +44,7 @@ class RuntimeInitPayload:
     sdk_session_id: str | None = None
     sdk_session_data: str | None = None  # JSONL content for resume
     is_approval_continuation: bool = False  # True when resuming after approval decision
-    is_fork: bool = (
-        False  # True when forking from parent session (use fork_session=True)
-    )
+    is_fork: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RuntimeInitPayload:

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -44,6 +44,9 @@ class RuntimeInitPayload:
     sdk_session_id: str | None = None
     sdk_session_data: str | None = None  # JSONL content for resume
     is_approval_continuation: bool = False  # True when resuming after approval decision
+    is_fork: bool = (
+        False  # True when forking from parent session (use fork_session=True)
+    )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RuntimeInitPayload:
@@ -75,6 +78,7 @@ class RuntimeInitPayload:
             sdk_session_id=data.get("sdk_session_id"),
             sdk_session_data=data.get("sdk_session_data"),
             is_approval_continuation=data.get("is_approval_continuation", False),
+            is_fork=data.get("is_fork", False),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -87,6 +91,7 @@ class RuntimeInitPayload:
             "user_prompt": self.user_prompt,
             "litellm_auth_token": self.litellm_auth_token,
             "is_approval_continuation": self.is_approval_continuation,
+            "is_fork": self.is_fork,
         }
         if self.allowed_actions is not None:
             result["allowed_actions"] = {

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -85,6 +85,8 @@ class AgentExecutorInput(BaseModel):
     sdk_session_data: str | None = None
     # True when resuming after approval decision (continuation prompt should be internal)
     is_approval_continuation: bool = False
+    # True when forking from parent session (SDK should use fork_session=True)
+    is_fork: bool = False
 
 
 class AgentExecutorResult(BaseModel):
@@ -150,6 +152,7 @@ class SandboxedAgentExecutor:
                 sdk_session_id=self.input.sdk_session_id,
                 sdk_session_data=self.input.sdk_session_data,
                 is_approval_continuation=self.input.is_approval_continuation,
+                is_fork=self.input.is_fork,
             )
             handler = LoopbackHandler(input=loopback_input)
 

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -87,6 +87,7 @@ class LoopbackInput:
     sdk_session_id: str | None = None
     sdk_session_data: str | None = None
     is_approval_continuation: bool = False
+    is_fork: bool = False  # True when forking from parent session
 
 
 @dataclass(kw_only=True, slots=True)
@@ -199,6 +200,7 @@ class LoopbackHandler:
             sdk_session_id=self.input.sdk_session_id,
             sdk_session_data=self.input.sdk_session_data,
             is_approval_continuation=self.input.is_approval_continuation,
+            is_fork=self.input.is_fork,
         )
 
         payload_bytes = orjson.dumps(payload.to_dict())

--- a/tracecat/agent/session/schemas.py
+++ b/tracecat/agent/session/schemas.py
@@ -103,6 +103,8 @@ class AgentSessionRead(BaseModel):
     harness_type: str | None
     # Stream tracking
     last_stream_id: str | None = None
+    # Fork tracking
+    parent_session_id: uuid.UUID | None = None
     # Timestamps
     created_at: datetime
     updated_at: datetime
@@ -123,4 +125,14 @@ class AgentSessionReadVercel(AgentSessionRead):
 
     messages: list[UIMessage] = Field(
         default_factory=list, description="Session messages in Vercel UI format"
+    )
+
+
+class AgentSessionForkRequest(BaseModel):
+    """Request schema for forking an agent session."""
+
+    entity_type: AgentSessionEntity | None = Field(
+        default=None,
+        description="Override entity type for the forked session. "
+        "Use 'approval' for inbox forks to hide from main chat list.",
     )

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -66,6 +66,7 @@ class SessionHistoryData:
 
     sdk_session_id: str
     sdk_session_data: str
+    is_fork: bool = False  # If True, SDK should use fork_session=True
 
 
 class AgentSessionService(BaseWorkspaceService):
@@ -190,6 +191,8 @@ class AgentSessionService(BaseWorkspaceService):
         created_by: UserID | None = None,
         entity_type: AgentSessionEntity | None = None,
         entity_id: uuid.UUID | None = None,
+        exclude_entity_types: list[AgentSessionEntity] | None = None,
+        parent_session_id: uuid.UUID | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[AgentSessionRead | ChatReadMinimal]:
@@ -202,6 +205,8 @@ class AgentSessionService(BaseWorkspaceService):
             created_by: Filter by user who created the session.
             entity_type: Filter by entity type.
             entity_id: Filter by entity ID.
+            exclude_entity_types: Entity types to exclude from results.
+            parent_session_id: Filter by parent session ID (for finding forked sessions).
             limit: Maximum number of results.
             offset: Number of results to skip.
 
@@ -218,13 +223,26 @@ class AgentSessionService(BaseWorkspaceService):
             session_stmt = session_stmt.where(
                 AgentSession.entity_type == entity_type.value
             )
+        if exclude_entity_types:
+            session_stmt = session_stmt.where(
+                AgentSession.entity_type.notin_(
+                    [et.value for et in exclude_entity_types]
+                )
+            )
         if entity_id is not None:
             session_stmt = session_stmt.where(AgentSession.entity_id == entity_id)
+        if parent_session_id is not None:
+            session_stmt = session_stmt.where(
+                AgentSession.parent_session_id == parent_session_id
+            )
 
         session_result = await self.session.execute(session_stmt)
         sessions = list(session_result.scalars().all())
 
         # Query legacy Chat table
+        # Note: exclude_entity_types is not applied here because legacy Chat records
+        # predate entity types like WORKFLOW and APPROVAL that are typically excluded.
+        # Legacy chats only have entity types like "case" or "agent_preset".
         chat_stmt = select(Chat).where(Chat.workspace_id == self.workspace_id)
         if created_by is not None:
             chat_stmt = chat_stmt.where(Chat.user_id == created_by)
@@ -333,6 +351,9 @@ class AgentSessionService(BaseWorkspaceService):
         Reconstructs the SDK session JSONL from stored history entries.
         Returns None if no history exists or no sdk_session_id is set.
 
+        For forked sessions (with parent_session_id), loads the parent's history
+        and sets is_fork=True so the runtime uses fork_session=True with the SDK.
+
         The sdk_session_id is stored on the AgentSession model (not in the
         JSONL content) to keep the history entries pristine for SDK resume.
 
@@ -343,24 +364,43 @@ class AgentSessionService(BaseWorkspaceService):
             SessionHistoryData with sdk_session_id and reconstructed JSONL,
             or None if no history found or sdk_session_id not set.
         """
-        # First get the AgentSession to retrieve sdk_session_id
+        # First get the AgentSession to check for fork and retrieve sdk_session_id
         agent_session = await self.get_session(session_id)
         if agent_session is None:
             return None
 
-        sdk_session_id = agent_session.sdk_session_id
+        # For forked sessions, load parent's history instead
+        is_fork = agent_session.parent_session_id is not None
+        if is_fork:
+            parent_session = await self.get_session(agent_session.parent_session_id)  # type: ignore
+            if parent_session is None:
+                logger.warning(
+                    "Forked session references non-existent parent",
+                    session_id=session_id,
+                    parent_session_id=agent_session.parent_session_id,
+                )
+                return None
+            # Use parent's sdk_session_id and history
+            source_session = parent_session
+            source_session_id = agent_session.parent_session_id
+        else:
+            source_session = agent_session
+            source_session_id = session_id
+
+        sdk_session_id = source_session.sdk_session_id
         if not sdk_session_id:
             logger.debug(
                 "No sdk_session_id on session (new session or legacy)",
-                session_id=session_id,
+                session_id=source_session_id,
+                is_fork=is_fork,
             )
             return None
 
-        # Load history entries
+        # Load history entries from source session
         stmt = (
             select(AgentSessionHistory)
             .where(
-                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.session_id == source_session_id,
             )
             .order_by(AgentSessionHistory.surrogate_id)
         )
@@ -370,8 +410,9 @@ class AgentSessionService(BaseWorkspaceService):
         if not history_entries:
             logger.warning(
                 "sdk_session_id set but no history entries",
-                session_id=session_id,
+                session_id=source_session_id,
                 sdk_session_id=sdk_session_id,
+                is_fork=is_fork,
             )
             return None
 
@@ -386,6 +427,7 @@ class AgentSessionService(BaseWorkspaceService):
         return SessionHistoryData(
             sdk_session_id=sdk_session_id,
             sdk_session_data=sdk_session_data,
+            is_fork=is_fork,
         )
 
     async def get_session_history(
@@ -732,6 +774,71 @@ class AgentSessionService(BaseWorkspaceService):
                         model_provider=model_config.provider,
                         actions=agent_session.tools,
                     )
+        elif session_entity in (
+            AgentSessionEntity.WORKFLOW,
+            AgentSessionEntity.APPROVAL,
+        ):
+            # Check if this is a forked session (has parent_session_id)
+            is_forked = agent_session.parent_session_id is not None
+
+            if is_forked:
+                # Forked sessions use the parent's preset but with no tools.
+                # Prepend context - agent should not mention this is a forked session.
+                fork_context = (
+                    "You do not have access to any tools in this conversation. "
+                    "If the user asks you to perform actions, politely decline and "
+                    "suggest they start a new workflow if they need to take action.\n\n"
+                )
+                # Get parent session to check for preset
+                parent_session = await self.get_session(
+                    agent_session.parent_session_id  # type: ignore[arg-type]
+                )
+                if parent_session and parent_session.agent_preset_id:
+                    # Use parent's preset with forked context prepended
+                    async with agent_svc.with_preset_config(
+                        preset_id=parent_session.agent_preset_id,
+                        use_workspace_credentials=True,
+                    ) as preset_config:
+                        combined_instructions = (
+                            f"{fork_context}{preset_config.instructions}"
+                            if preset_config.instructions
+                            else fork_context.strip()
+                        )
+                        yield AgentConfig(
+                            instructions=combined_instructions,
+                            model_name=preset_config.model_name,
+                            model_provider=preset_config.model_provider,
+                            actions=[],  # No tools for forked sessions
+                        )
+                else:
+                    # No preset - use workspace model with fork context
+                    async with agent_svc.with_model_config(
+                        use_workspace_credentials=True
+                    ) as model_config:
+                        yield AgentConfig(
+                            instructions=fork_context.strip(),
+                            model_name=model_config.name,
+                            model_provider=model_config.provider,
+                            actions=[],  # No tools for forked sessions
+                        )
+            elif agent_session.agent_preset_id:
+                # Workflow sessions with preset use the preset config
+                async with agent_svc.with_preset_config(
+                    preset_id=agent_session.agent_preset_id,
+                    use_workspace_credentials=True,
+                ) as preset_config:
+                    yield preset_config
+            else:
+                # Workflow without preset uses workspace credentials
+                async with agent_svc.with_model_config(
+                    use_workspace_credentials=True
+                ) as model_config:
+                    yield AgentConfig(
+                        instructions="",
+                        model_name=model_config.name,
+                        model_provider=model_config.provider,
+                        actions=agent_session.tools,
+                    )
         else:
             raise ValueError(
                 f"Unsupported session entity type: {agent_session.entity_type}. "
@@ -777,6 +884,7 @@ class AgentSessionService(BaseWorkspaceService):
     ) -> list[ChatMessage]:
         """Retrieve session messages, optionally filtered by message kind.
 
+        For forked sessions, includes parent session messages first.
         Checks the new AgentSessionHistory table first, then falls back to
         the legacy ChatMessage table for backward compatibility.
 
@@ -785,25 +893,31 @@ class AgentSessionService(BaseWorkspaceService):
             kinds: Optional list of message kinds to filter by.
 
         Returns:
-            List of ChatMessage objects.
+            List of ChatMessage objects (parent messages + current if forked).
         """
+        agent_session = await self.get_session(session_id)
+
+        # If no history in new table, fall back to legacy ChatMessage table
+        if not agent_session:
+            chat_service = ChatService(self.session, self.role)
+            return await chat_service.list_legacy_messages(session_id, kinds=kinds)
+
+        session_ids = [session_id]
+        if agent_session and agent_session.parent_session_id:
+            session_ids.insert(0, agent_session.parent_session_id)
+
         # Fetch all history entries (both chat-message and internal)
         # Internal entries are needed for tool result enrichment in the adapter
         all_history_stmt = (
             select(AgentSessionHistory)
-            .where(AgentSessionHistory.session_id == session_id)
+            .where(AgentSessionHistory.session_id.in_(session_ids))
             .order_by(AgentSessionHistory.surrogate_id)
         )
         all_history_result = await self.session.execute(all_history_stmt)
         all_entries = list(all_history_result.scalars().all())
 
-        # If no history in new table, fall back to legacy ChatMessage table
-        if not all_entries:
-            chat_service = ChatService(self.session, self.role)
-            return await chat_service.list_legacy_messages(session_id, kinds=kinds)
-
-        # Fetch all approvals for this session
-        approval_stmt = select(Approval).where(Approval.session_id == session_id)
+        # Fetch approvals for this session and parent session (for forked sessions)
+        approval_stmt = select(Approval).where(Approval.session_id.in_(session_ids))
         approval_result = await self.session.execute(approval_stmt)
         approvals = approval_result.scalars().all()
         approval_by_tool_id: dict[str, Approval] = {
@@ -1085,3 +1199,63 @@ class AgentSessionService(BaseWorkspaceService):
             return orjson.dumps(result).decode("utf-8")
         except (TypeError, ValueError):
             return str(result)
+
+    # =========================================================================
+    # Session Forking (for post-decision agent interactions)
+    # =========================================================================
+
+    async def fork_session(
+        self,
+        parent_session_id: uuid.UUID,
+        *,
+        entity_type: AgentSessionEntity | None = None,
+    ) -> AgentSession:
+        """Create a forked session from a parent session.
+
+        Forked sessions allow users to continue interacting with an agent
+        after making approval decisions, to ask for context or clarification.
+
+        Args:
+            parent_session_id: The ID of the session to fork.
+            entity_type: Override entity type for the forked session. If None,
+                inherits from parent. Use APPROVAL for inbox forks to hide
+                from main chat list.
+
+        Returns:
+            The newly created forked AgentSession.
+
+        Raises:
+            TracecatNotFoundError: If the parent session is not found.
+        """
+        parent = await self.get_session(parent_session_id)
+        if parent is None:
+            raise TracecatNotFoundError(
+                f"Parent session with ID {parent_session_id} not found"
+            )
+
+        # Forked sessions are read-only "reviewer" sessions.
+        forked_session = AgentSession(
+            workspace_id=self.workspace_id,
+            # Metadata - inherit from parent, except entity_type if overridden
+            title=f"{parent.title} (continued)",
+            created_by=self.role.user_id,
+            entity_type=entity_type.value if entity_type else parent.entity_type,
+            entity_id=parent.entity_id,
+            tools=[],
+            agent_preset_id=None,
+            # Harness - inherit from parent
+            harness_type=parent.harness_type,
+            # Fork reference
+            parent_session_id=parent_session_id,
+        )
+        self.session.add(forked_session)
+        await self.session.commit()
+        await self.session.refresh(forked_session)
+
+        logger.info(
+            "Created forked session",
+            forked_session_id=forked_session.id,
+            parent_session_id=parent_session_id,
+        )
+
+        return forked_session

--- a/tracecat/agent/session/types.py
+++ b/tracecat/agent/session/types.py
@@ -12,6 +12,7 @@ class AgentSessionEntity(StrEnum):
     - AGENT_PRESET_BUILDER: Builder chat for editing/configuring a preset
     - COPILOT: Workspace-level copilot assistant
     - WORKFLOW: Workflow-initiated agent run (from action)
+    - APPROVAL: Inbox approval continuation (hidden from main chat list)
     """
 
     CASE = "case"
@@ -19,3 +20,4 @@ class AgentSessionEntity(StrEnum):
     AGENT_PRESET_BUILDER = "agent_preset_builder"
     COPILOT = "copilot"
     WORKFLOW = "workflow"
+    APPROVAL = "approval"

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -766,6 +766,7 @@ class DSLWorkflow:
                             max_tool_calls=action_args.max_tool_calls,
                             use_workspace_credentials=action_args.use_workspace_credentials,
                         ),
+                        title=self.dsl.title,
                         entity_type=AgentSessionEntity.WORKFLOW,
                         entity_id=self.run_context.wf_id,
                     )
@@ -826,6 +827,7 @@ class DSLWorkflow:
                             max_tool_calls=preset_action_args.max_tool_calls,
                             use_workspace_credentials=preset_action_args.use_workspace_credentials,
                         ),
+                        title=self.dsl.title,
                         entity_type=AgentSessionEntity.WORKFLOW,
                         entity_id=self.run_context.wf_id,
                     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds session forking for the inbox flow so users can continue a conversation after making an approval decision, without polluting main chats. Introduces an approval session type, parent-child session links, and runtime support to fork SDK sessions from parent history.

- **New Features**
  - New POST /agent/sessions/{session_id}/fork to create a child session; optional entity_type override (use approval to hide from main chat).
  - New session entity approval and parent_session_id on sessions; returned in reads.
  - List sessions supports exclude_entity_types and parent_session_id filters.
  - Forked runs load parent history (also shown in forked chats) and mark is_fork so the runtime starts a new SDK session from the parent.
  - Forked sessions run with no tools and prepend brief “no tools” instructions; presets are inherited from the parent when present.
  - Frontend chat pane supports fork-on-send via onBeforeSend and pendingMessage; approval entity is excluded from cache invalidation.
  - send_message SSE start cursor uses last_stream_id when set; otherwise "$" to stream only new events.
  - Workflow-created sessions set title and curr_run_id for approval lookups.

- **Migration**
  - Use POST /agent/sessions/{id}/fork and set entity_type=approval for inbox follow-ups.
  - When listing sessions, exclude approval or filter by parent_session_id as needed.

<sup>Written for commit 8f144ef49138a6e3784d00e63bab06df081e7081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

