### PR TITLE
chore: remove EXECUTOR_AUTH feature flag

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -7128,7 +7128,6 @@ export const $FeatureFlag = {
     "agent-presets",
     "case-durations",
     "case-tasks",
-    "executor-auth",
     "registry-client",
     "registry-sync-v2",
   ],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2210,7 +2210,6 @@ export type FeatureFlag =
   | "agent-presets"
   | "case-durations"
   | "case-tasks"
-  | "executor-auth"
   | "registry-client"
   | "registry-sync-v2"
 

--- a/tests/unit/test_executor_tokens.py
+++ b/tests/unit/test_executor_tokens.py
@@ -17,7 +17,6 @@ from tracecat.auth.executor_tokens import (
     verify_executor_token,
 )
 from tracecat.auth.types import AccessLevel
-from tracecat.feature_flags import FeatureFlag
 
 
 def _make_request(token: str | None) -> Request:
@@ -133,7 +132,6 @@ async def test_role_dependency_executor_token_derives_access_level_from_db(
     from tracecat.auth.schemas import UserRole
 
     monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
-    monkeypatch.setattr(config, "TRACECAT__FEATURE_FLAGS", {FeatureFlag.EXECUTOR_AUTH})
 
     workspace_id = uuid.uuid4()
     user_id = uuid.uuid4()
@@ -176,7 +174,6 @@ async def test_role_dependency_executor_token_defaults_to_basic_for_unknown_user
 ):
     """Verify that access_level defaults to BASIC when user is not found in DB."""
     monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
-    monkeypatch.setattr(config, "TRACECAT__FEATURE_FLAGS", {FeatureFlag.EXECUTOR_AUTH})
 
     workspace_id = uuid.uuid4()
     user_id = uuid.uuid4()
@@ -215,7 +212,6 @@ async def test_role_dependency_executor_token_defaults_to_basic_for_null_user(
 ):
     """Verify that access_level defaults to BASIC when user_id is null (system execution)."""
     monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
-    monkeypatch.setattr(config, "TRACECAT__FEATURE_FLAGS", {FeatureFlag.EXECUTOR_AUTH})
 
     workspace_id = uuid.uuid4()
 
@@ -258,7 +254,6 @@ async def test_role_dependency_executor_uses_jwt_workspace(
     workspace_id comes entirely from the JWT token.
     """
     monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
-    monkeypatch.setattr(config, "TRACECAT__FEATURE_FLAGS", {FeatureFlag.EXECUTOR_AUTH})
 
     jwt_workspace_id = uuid.uuid4()
 

--- a/tracecat/feature_flags/enums.py
+++ b/tracecat/feature_flags/enums.py
@@ -9,6 +9,5 @@ class FeatureFlag(StrEnum):
     AGENT_PRESETS = "agent-presets"
     CASE_DURATIONS = "case-durations"
     CASE_TASKS = "case-tasks"
-    EXECUTOR_AUTH = "executor-auth"
     REGISTRY_CLIENT = "registry-client"
     REGISTRY_SYNC_V2 = "registry-sync-v2"


### PR DESCRIPTION
## Summary
- Remove the `EXECUTOR_AUTH` feature flag from the codebase
- Update tests to remove feature flag monkeypatching
- Regenerate frontend client types

The executor auth feature is now the default behavior and no longer needs to be gated behind a feature flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the EXECUTOR_AUTH feature flag since executor auth is now always enabled. Cleaned up the enum and generated frontend types/schemas, and removed related test monkeypatching.

<sup>Written for commit 099bfae25d83a89adbb82f1eab8b5ddeca43804e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

