### PR TITLE
fix: align UI password minimum length with backend

### DIFF
--- a/frontend/src/components/auth/sign-up.tsx
+++ b/frontend/src/components/auth/sign-up.tsx
@@ -97,7 +97,7 @@ const basicRegistrationSchema = z.object({
   email: z.string().email().min(3, { message: "Required" }),
   password: z
     .string()
-    .min(12, "Password needs to be at least 12 characters long"),
+    .min(16, "Password needs to be at least 16 characters long"),
 })
 type BasicLoginForm = z.infer<typeof basicRegistrationSchema>
 

--- a/frontend/src/components/auth/update-password-form.tsx
+++ b/frontend/src/components/auth/update-password-form.tsx
@@ -22,10 +22,10 @@ import { useUserManager } from "@/lib/hooks"
 
 const resetPasswordSchema = z
   .object({
-    password: z.string().min(8, "Password must be at least 8 characters"),
+    password: z.string().min(16, "Password must be at least 16 characters"),
     confirmPassword: z
       .string()
-      .min(8, "Password must be at least 8 characters"),
+      .min(16, "Password must be at least 16 characters"),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords do not match",

--- a/frontend/src/components/organization/org-settings-auth.tsx
+++ b/frontend/src/components/organization/org-settings-auth.tsx
@@ -56,7 +56,7 @@ export function OrgSettingsAuthForm() {
         })) ?? [],
       auth_require_email_verification:
         authSettings?.auth_require_email_verification ?? false,
-      auth_min_password_length: authSettings?.auth_min_password_length ?? 12,
+      auth_min_password_length: authSettings?.auth_min_password_length ?? 16,
       auth_session_expire_time_seconds:
         authSettings?.auth_session_expire_time_seconds ?? 3600,
     },


### PR DESCRIPTION
### Motivation
- Align frontend password validation with the backend's updated minimum password length of 16 characters to avoid client/backend mismatches during registration and password updates.

### Description
- Updated the sign-up password schema in `frontend/src/components/auth/sign-up.tsx` to require `.min(16)`, updated the update-password schema in `frontend/src/components/auth/update-password-form.tsx` to require 16 characters for both `password` and `confirmPassword`, and changed the default `auth_min_password_length` in `frontend/src/components/organization/org-settings-auth.tsx` to `16`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea20724bc8320b914b5f00d2f3469)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align frontend password validation to 16 characters to match the backend, preventing registration/reset failures from mismatched rules.

- **Bug Fixes**
  - Sign-up schema: password min length set to 16.
  - Update/reset password schema: password and confirmPassword min length set to 16.
  - Org auth settings: default auth_min_password_length set to 16.

<sup>Written for commit 0e78d0eb9ff6768fc3feb74fcb9812702c7f355b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

