### PR TITLE
feat: Add opus 4.5 to agent configs

### DIFF
--- a/tracecat/agent/config.py
+++ b/tracecat/agent/config.py
@@ -63,6 +63,14 @@ MODEL_CONFIGS = {
             "required": ["anthropic"],
         },
     ),
+    "claude-opus-4-5-20251101": ModelConfig(
+        name="claude-opus-4-5-20251101",
+        provider="anthropic",
+        org_secret_name="agent-anthropic-credentials",
+        secrets={
+            "required": ["anthropic"],
+        },
+    ),
     "bedrock": ModelConfig(
         name="bedrock",  # Placeholder; actual ARN from AWS_MODEL_ARN credential will be used at runtime
         provider="bedrock",

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -717,6 +717,7 @@ TRACECAT__MODEL_CONTEXT_LIMITS = {
     "gpt-5": 350_000,
     "claude-sonnet-4-5-20250929": 180_000,
     "claude-haiku-4-5-20251001": 180_000,
+    "claude-opus-4-5-20251101": 180_000,
     "anthropic.claude-sonnet-4-5-20250929-v1:0": 180_000,
     "anthropic.claude-haiku-4-5-20251001-v1:0": 180_000,
 }


### PR DESCRIPTION
### Motivation
- Expose the Anthropic "claude-opus-4-5-20251101" model so it can be selected and used by agents and ensure truncation logic has an appropriate context limit for the model.

### Description
- Add a `ModelConfig` entry for `claude-opus-4-5-20251101` in `tracecat/agent/config.py` with provider set to `anthropic` and the same org secret as other Anthropic models.
- Add a model-specific context limit entry for `claude-opus-4-5-20251101` in `tracecat/config.py` to support agent message history truncation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69704dc0c2b483208b0a210b8f4d8797)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Anthropic claude-opus-4-5-20251101 to the agent model list so agents can select and use it. Set its context limit to 180,000 tokens for message history truncation, using the existing agent-anthropic-credentials secret.

<sup>Written for commit ad54e2bb01e306ee631998d6d72af9d9925169bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

