### PR TITLE
fix(agent): enable reasoning for anthropic models

### DIFF
--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -179,6 +179,17 @@ class TracecatCallbackHandler(CustomLogger):
             if response_format:
                 data["response_format"] = response_format
 
+        # Enable reasoning/thinking by default (disabled for structured outputs)
+        if output_type is None:
+            if provider == "anthropic":
+                # Anthropic uses native thinking parameter
+                if "thinking" not in data:
+                    data["thinking"] = {"type": "enabled", "budget_tokens": 1024}
+            elif provider == "openai":
+                # OpenAI models use reasoning_effort with summary for visibility
+                if "reasoning_effort" not in data:
+                    data["reasoning_effort"] = {"effort": "low", "summary": "auto"}
+
         logger.info(
             "Injected credentials for LLM call",
             workspace_id=workspace_id,

--- a/tracecat/agent/litellm_config.yaml
+++ b/tracecat/agent/litellm_config.yaml
@@ -5,19 +5,23 @@ model_list:
   # OpenAI models
   - model_name: gpt-4o-mini
     litellm_params:
-      model: openai/gpt-4o-mini
+      model: openai/responses/gpt-4o-mini
 
   - model_name: gpt-5-mini
     litellm_params:
-      model: openai/gpt-5-mini
+      model: openai/responses/gpt-5-mini
 
   - model_name: gpt-5-nano
     litellm_params:
-      model: openai/gpt-5-nano
+      model: openai/responses/gpt-5-nano
 
   - model_name: gpt-5
     litellm_params:
-      model: openai/gpt-5
+      model: openai/responses/gpt-5
+
+  - model_name: gpt-5.2
+    litellm_params:
+      model: openai/responses/gpt-5.2
 
   # Anthropic models
   - model_name: claude-sonnet-4-5-20250929
@@ -49,4 +53,3 @@ general_settings:
 litellm_settings:
   callbacks:
     - tracecat.agent.gateway.callback_handler
-  drop_params: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable default reasoning for Anthropic and OpenAI models in agent calls, improving answer quality while respecting structured output requests. LiteLLM config updated to use OpenAI Responses API and ensure reasoning params are passed through.

- **New Features**
  - Enables Anthropic thinking by default with 1024 budget tokens when output_type is None.
  - Sets OpenAI reasoning_effort to low with auto summary by default.
  - Skips reasoning when structured outputs are requested.

- **Dependencies**
  - Switched OpenAI models to openai/responses/*.
  - Added gpt-5.2.
  - Removed drop_params to avoid stripping provider-specific params.

<sup>Written for commit 90c34b600dcc11fb07647ef34217219aa287909f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

