### PR TITLE
fix(ui): block input mid agent stream

### DIFF
--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -180,6 +180,8 @@ export function ChatSessionPane({
     onPendingMessageSent,
   ])
 
+  const isReady = status === "ready"
+
   const isWaitingForResponse = useMemo(() => {
     if (status === "submitted") return true
     if (status === "streaming") {
@@ -422,7 +424,7 @@ export function ChatSessionPane({
               }
               value={input}
               autoFocus={autoFocusInput && !isReadonly}
-              disabled={isReadonly}
+              disabled={isReadonly || !isReady}
             />
           </PromptInputBody>
           <PromptInputToolbar>
@@ -451,7 +453,7 @@ export function ChatSessionPane({
               </PromptInputTools>
             )}
             <PromptInputSubmit
-              disabled={isReadonly || !input || !!status}
+              disabled={isReadonly || (!input && isReady)}
               status={status}
               className="ml-auto text-muted-foreground/80"
             />

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -180,7 +180,8 @@ export function ChatSessionPane({
     onPendingMessageSent,
   ])
 
-  const isReady = status === "ready"
+  // Allow input when ready OR in error state (so user can retry after transient failures)
+  const canSubmit = status === "ready" || status === "error"
 
   const isWaitingForResponse = useMemo(() => {
     if (status === "submitted") return true
@@ -424,7 +425,7 @@ export function ChatSessionPane({
               }
               value={input}
               autoFocus={autoFocusInput && !isReadonly}
-              disabled={isReadonly || !isReady}
+              disabled={isReadonly || !canSubmit}
             />
           </PromptInputBody>
           <PromptInputToolbar>
@@ -453,7 +454,7 @@ export function ChatSessionPane({
               </PromptInputTools>
             )}
             <PromptInputSubmit
-              disabled={isReadonly || (!input && isReady)}
+              disabled={isReadonly || !canSubmit || !input}
               status={status}
               className="ml-auto text-muted-foreground/80"
             />

--- a/frontend/src/components/copilot/copilot-chat-pane.tsx
+++ b/frontend/src/components/copilot/copilot-chat-pane.tsx
@@ -97,6 +97,8 @@ export function CopilotChatPane({
       modelInfo,
     })
 
+  const isReady = status === "ready"
+
   const isWaitingForResponse = useMemo(() => {
     if (status === "submitted") return true
     if (status === "streaming") {
@@ -218,7 +220,7 @@ export function CopilotChatPane({
           }
           value={input}
           autoFocus={autoFocusInput && !isReadonly}
-          disabled={isReadonly}
+          disabled={isReadonly || !isReady}
         />
       </PromptInputBody>
       <PromptInputToolbar>
@@ -246,7 +248,7 @@ export function CopilotChatPane({
           </PromptInputTools>
         )}
         <PromptInputSubmit
-          disabled={isReadonly || (!input && !status)}
+          disabled={isReadonly || (!input && isReady)}
           status={status}
           className="ml-auto text-muted-foreground/80"
         />

--- a/frontend/src/components/copilot/copilot-chat-pane.tsx
+++ b/frontend/src/components/copilot/copilot-chat-pane.tsx
@@ -97,7 +97,8 @@ export function CopilotChatPane({
       modelInfo,
     })
 
-  const isReady = status === "ready"
+  // Allow input when ready OR in error state (so user can retry after transient failures)
+  const canSubmit = status === "ready" || status === "error"
 
   const isWaitingForResponse = useMemo(() => {
     if (status === "submitted") return true
@@ -220,7 +221,7 @@ export function CopilotChatPane({
           }
           value={input}
           autoFocus={autoFocusInput && !isReadonly}
-          disabled={isReadonly || !isReady}
+          disabled={isReadonly || !canSubmit}
         />
       </PromptInputBody>
       <PromptInputToolbar>
@@ -248,7 +249,7 @@ export function CopilotChatPane({
           </PromptInputTools>
         )}
         <PromptInputSubmit
-          disabled={isReadonly || (!input && isReady)}
+          disabled={isReadonly || !canSubmit || !input}
           status={status}
           className="ml-auto text-muted-foreground/80"
         />

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -63,7 +63,7 @@ describe("ChatSessionPane", () => {
       sendMessage,
       regenerate: jest.fn(),
       messages: [],
-      status: undefined,
+      status: "ready",
       lastError: null,
       clearError: jest.fn(),
       // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Block typing while the agent is streaming or processing to prevent mid-response edits. Applies to both chat and Copilot panes.

- **Bug Fixes**
  - Disable input unless status is "ready" or "error" (allows retry after failures).
  - Centralize submit gating with canSubmit and sync submit button with input state.

<sup>Written for commit 78d3cbc2bf42478d9d9c94119e52b9c6db9613b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

