### PR TITLE
fix(executor): flatten secrets by key name in minimal_runner

### DIFF
--- a/tracecat/agent/mcp/executor.py
+++ b/tracecat/agent/mcp/executor.py
@@ -11,7 +11,6 @@ from typing import Any
 from uuid import uuid4
 
 from tracecat.agent.tokens import MCPTokenClaims
-from tracecat.auth.executor_tokens import mint_executor_token
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.dsl.schemas import (
@@ -21,23 +20,11 @@ from tracecat.dsl.schemas import (
     RunContext,
 )
 from tracecat.executor.backends.ephemeral import EphemeralBackend
-from tracecat.executor.schemas import (
-    ActionImplementation,
-    ExecutorResultFailure,
-    ResolvedContext,
-)
-from tracecat.executor.service import (
-    get_workspace_variables,
-)
-from tracecat.expressions.common import ExprContext
-from tracecat.expressions.eval import collect_expressions, eval_templated_object
+from tracecat.executor.service import dispatch_action
 from tracecat.identifiers import WorkflowUUID
 from tracecat.identifiers.workflow import generate_exec_id
 from tracecat.logger import logger
-from tracecat.registry.actions.schemas import RegistryActionImplValidator
-from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.registry.lock.types import RegistryLock
-from tracecat.secrets import secrets_manager
 
 
 class ActionNotAllowedError(Exception):
@@ -53,16 +40,14 @@ async def execute_action(
     args: dict[str, Any],
     claims: MCPTokenClaims,
     registry_lock: RegistryLock,
-    timeout_seconds: int = 300,
 ) -> Any:
-    """Execute an action using ActionRunner.
+    """Execute an action using dispatch_action.
 
     Args:
         action_name: The action to execute (e.g., "tools.slack.post_message")
         args: Arguments to pass to the action
         claims: Token claims containing role and allowed_actions
         registry_lock: Registry lock with origin→version mappings for action resolution
-        timeout_seconds: Maximum execution time
 
     Returns:
         The action result
@@ -95,109 +80,12 @@ async def execute_action(
         "Executing action via ActionRunner",
     )
 
-    # Resolve context
-    resolved_context = await _resolve_context(action_name, args, claims)
-
     # Build minimal RunActionInput
     run_input = _build_run_input(action_name, args, registry_lock)
 
     # Execute via ActionRunner with nsjail sandbox
     backend = EphemeralBackend()
-    execution = await backend.execute(
-        input=run_input,
-        role=role,
-        resolved_context=resolved_context,
-        timeout=float(timeout_seconds),
-    )
-
-    # Handle result
-    if isinstance(execution, ExecutorResultFailure):
-        raise ActionExecutionError(execution.error.message)
-    return execution.result
-
-
-async def _resolve_context(
-    action_name: str,
-    args: dict[str, Any],
-    claims: MCPTokenClaims,
-) -> ResolvedContext:
-    """Resolve secrets, variables, and action implementation.
-
-    Runs on the trusted side with DB access. The resulting ResolvedContext
-    is passed to ActionRunner for subprocess execution.
-    """
-    # Reconstruct Role from claims (same as in execute_action)
-    role = Role(
-        type="service",
-        service_id="tracecat-mcp",
-        workspace_id=claims.workspace_id,
-        user_id=claims.user_id,
-    )
-
-    # Get action implementation from DB
-    async with RegistryActionsService.with_session() as service:
-        reg_action = await service.get_action(action_name)
-        action_secrets = await service.fetch_all_action_secrets(reg_action)
-
-    # Build action implementation metadata
-    impl = RegistryActionImplValidator.validate_python(reg_action.implementation)
-    if impl.type == "template":
-        action_impl = ActionImplementation(
-            type="template",
-            action_name=action_name,
-            template_definition=impl.template_action.definition.model_dump(mode="json"),
-        )
-    elif impl.type == "udf":
-        action_impl = ActionImplementation(
-            type="udf",
-            action_name=action_name,
-            module=impl.module,
-            name=impl.name,
-        )
-    else:
-        raise ValueError(f"Unknown implementation type: {impl}")
-
-    # Collect expressions to know what secrets/variables are needed
-    collected = collect_expressions(args)
-
-    # Fetch secrets and variables
-    secrets = await secrets_manager.get_action_secrets(
-        secret_exprs=collected.secrets, action_secrets=action_secrets
-    )
-    workspace_variables = await get_workspace_variables(
-        variable_exprs=collected.variables,
-        role=role,
-    )
-
-    # Build execution context for expression evaluation
-    context = {
-        ExprContext.SECRETS: secrets,
-        ExprContext.VARS: workspace_variables,
-    }
-
-    # Evaluate templated args
-    evaluated_args = eval_templated_object(args, operand=context)
-
-    # Generate executor token for SDK authentication
-    if role.workspace_id is None:
-        raise ValueError("workspace_id is required for action execution")
-    executor_token = mint_executor_token(
-        workspace_id=role.workspace_id,
-        user_id=role.user_id,
-        wf_id="wf_agent",
-        wf_exec_id="wf_agent_exec",
-    )
-
-    return ResolvedContext(
-        secrets=secrets,
-        variables=workspace_variables,
-        action_impl=action_impl,
-        evaluated_args=dict(evaluated_args),
-        workspace_id=str(role.workspace_id),
-        workflow_id="wf_agent",
-        run_id="wf_agent_run",
-        executor_token=executor_token,
-    )
+    return await dispatch_action(backend, run_input)
 
 
 def _build_run_input(

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -298,9 +298,14 @@ def _flatten_secrets(secrets: dict[str, Any]) -> dict[str, str]:
         if isinstance(secret_value, dict):
             for k, v in secret_value.items():
                 if v is not None:
-                    result[f"{secret_name}__{k}".upper()] = str(v)
+                    if k in result:
+                        raise ValueError(
+                            f"Key {k!r} is duplicated in {secret_name!r}! "
+                            "Please ensure only one secret with a given name is set."
+                        )
+                    result[k] = str(v)
         elif secret_value is not None:
-            result[secret_name.upper()] = str(secret_value)
+            result[secret_name] = str(secret_value)
     return result
 
 

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -305,6 +305,11 @@ def _flatten_secrets(secrets: dict[str, Any]) -> dict[str, str]:
                         )
                     result[k] = str(v)
         elif secret_value is not None:
+            if secret_name in result:
+                raise ValueError(
+                    f"Key {secret_name!r} is duplicated! "
+                    "Please ensure only one secret with a given name is set."
+                )
             result[secret_name] = str(secret_value)
     return result
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Flatten secrets in minimal_runner using the original key names, removing the previous uppercase + secret-name prefix and adding a duplicate-key check to prevent collisions. Update the MCP executor to use dispatch_action for sandboxed runs and template support.

<sup>Written for commit 590fb779d3aaa0efe4034da10f3db17a8452fe23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

