### PR TITLE
feat(tiers): add tier and organization tier system

### DIFF
--- a/alembic/versions/a1b2c3d4e5f7_add_tier_and_organization_tier_tables.py
+++ b/alembic/versions/a1b2c3d4e5f7_add_tier_and_organization_tier_tables.py
@@ -1,0 +1,150 @@
+"""Add tier and organization_tier tables
+
+Revision ID: a1b2c3d4e5f7
+Revises: f4f5b93cbb16
+Create Date: 2025-01-23 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f7"
+down_revision: str | None = "f4f5b93cbb16"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Create tier table
+    op.create_table(
+        "tier",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("max_concurrent_workflows", sa.Integer(), nullable=True),
+        sa.Column("max_action_executions_per_workflow", sa.Integer(), nullable=True),
+        sa.Column("max_concurrent_actions", sa.Integer(), nullable=True),
+        sa.Column("api_rate_limit", sa.Integer(), nullable=True),
+        sa.Column("api_burst_capacity", sa.Integer(), nullable=True),
+        sa.Column(
+            "entitlements",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_tier"),
+    )
+
+    # Seed the default tier (unlimited everything for self-hosted)
+    op.execute(
+        """
+        INSERT INTO tier (id, display_name, max_concurrent_workflows, max_action_executions_per_workflow,
+                          max_concurrent_actions, api_rate_limit, api_burst_capacity, entitlements,
+                          is_default, sort_order, is_active)
+        VALUES (
+            'default',
+            'Default',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            '{"custom_registry": true, "sso": true, "git_sync": true}'::jsonb,
+            true,
+            0,
+            true
+        )
+        """
+    )
+
+    # Create organization_tier table
+    op.create_table(
+        "organization_tier",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tier_id", sa.String(), nullable=False, server_default="default"),
+        sa.Column("max_concurrent_workflows", sa.Integer(), nullable=True),
+        sa.Column("max_action_executions_per_workflow", sa.Integer(), nullable=True),
+        sa.Column("max_concurrent_actions", sa.Integer(), nullable=True),
+        sa.Column("api_rate_limit", sa.Integer(), nullable=True),
+        sa.Column("api_burst_capacity", sa.Integer(), nullable=True),
+        sa.Column(
+            "entitlement_overrides",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("stripe_customer_id", sa.String(), nullable=True),
+        sa.Column("stripe_subscription_id", sa.String(), nullable=True),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_organization_tier"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name="fk_organization_tier_organization_id_organization",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tier_id"],
+            ["tier.id"],
+            name="fk_organization_tier_tier_id_tier",
+        ),
+        sa.UniqueConstraint(
+            "organization_id", name="uq_organization_tier_organization_id"
+        ),
+    )
+    op.create_index(
+        "ix_organization_tier_organization_id",
+        "organization_tier",
+        ["organization_id"],
+        unique=True,
+    )
+
+    # Backfill: Create organization_tier records for all existing organizations
+    op.execute(
+        """
+        INSERT INTO organization_tier (id, organization_id, tier_id)
+        SELECT gen_random_uuid(), id, 'default'
+        FROM organization
+        WHERE id NOT IN (SELECT organization_id FROM organization_tier)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_organization_tier_organization_id", table_name="organization_tier"
+    )
+    op.drop_table("organization_tier")
+    op.drop_table("tier")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6672,6 +6672,28 @@ export const $EditorParamRead = {
   title: "EditorParamRead",
 } as const
 
+export const $EntitlementsDict = {
+  properties: {
+    custom_registry: {
+      type: "boolean",
+      title: "Custom Registry",
+    },
+    sso: {
+      type: "boolean",
+      title: "Sso",
+    },
+    git_sync: {
+      type: "boolean",
+      title: "Git Sync",
+    },
+  },
+  type: "object",
+  title: "EntitlementsDict",
+  description: `TypedDict for tier entitlements stored in JSONB.
+
+All keys are optional (total=False) to support partial overrides.`,
+} as const
+
 export const $ErrorDetails = {
   properties: {
     type: {
@@ -9594,6 +9616,281 @@ export const $OrganizationSecretRead = {
   ],
   title: "OrganizationSecretRead",
   description: "Read schema for organization-scoped secrets.",
+} as const
+
+export const $OrganizationTierRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    organization_id: {
+      type: "string",
+      format: "uuid",
+      title: "Organization Id",
+    },
+    tier_id: {
+      type: "string",
+      title: "Tier Id",
+    },
+    max_concurrent_workflows: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Workflows",
+    },
+    max_action_executions_per_workflow: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Action Executions Per Workflow",
+    },
+    max_concurrent_actions: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Actions",
+    },
+    api_rate_limit: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Rate Limit",
+    },
+    api_burst_capacity: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Burst Capacity",
+    },
+    entitlement_overrides: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/EntitlementsDict",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    stripe_customer_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stripe Customer Id",
+    },
+    stripe_subscription_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stripe Subscription Id",
+    },
+    expires_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Expires At",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+    tier: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/TierRead",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "organization_id",
+    "tier_id",
+    "max_concurrent_workflows",
+    "max_action_executions_per_workflow",
+    "max_concurrent_actions",
+    "api_rate_limit",
+    "api_burst_capacity",
+    "entitlement_overrides",
+    "stripe_customer_id",
+    "stripe_subscription_id",
+    "expires_at",
+    "created_at",
+    "updated_at",
+  ],
+  title: "OrganizationTierRead",
+  description: "Organization tier assignment response.",
+} as const
+
+export const $OrganizationTierUpdate = {
+  properties: {
+    tier_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Tier Id",
+    },
+    max_concurrent_workflows: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Workflows",
+    },
+    max_action_executions_per_workflow: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Action Executions Per Workflow",
+    },
+    max_concurrent_actions: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Actions",
+    },
+    api_rate_limit: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Rate Limit",
+    },
+    api_burst_capacity: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Burst Capacity",
+    },
+    entitlement_overrides: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/EntitlementsDict",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    stripe_customer_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stripe Customer Id",
+    },
+    stripe_subscription_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stripe Subscription Id",
+    },
+    expires_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Expires At",
+    },
+  },
+  type: "object",
+  title: "OrganizationTierUpdate",
+  description: "Update organization tier assignment request.",
 } as const
 
 export const $OutputType = {
@@ -14873,6 +15170,327 @@ export const $ThinkingBlock = {
   type: "object",
   required: ["thinking", "signature"],
   title: "ThinkingBlock",
+} as const
+
+export const $TierCreate = {
+  properties: {
+    id: {
+      type: "string",
+      maxLength: 63,
+      minLength: 1,
+      pattern: "^[a-z0-9_-]+$",
+      title: "Id",
+    },
+    display_name: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Display Name",
+    },
+    max_concurrent_workflows: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Workflows",
+    },
+    max_action_executions_per_workflow: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Action Executions Per Workflow",
+    },
+    max_concurrent_actions: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Actions",
+    },
+    api_rate_limit: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Rate Limit",
+    },
+    api_burst_capacity: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Burst Capacity",
+    },
+    entitlements: {
+      $ref: "#/components/schemas/EntitlementsDict",
+      default: {},
+    },
+    is_default: {
+      type: "boolean",
+      title: "Is Default",
+      default: false,
+    },
+    sort_order: {
+      type: "integer",
+      title: "Sort Order",
+      default: 0,
+    },
+  },
+  type: "object",
+  required: ["id", "display_name"],
+  title: "TierCreate",
+  description: "Create tier request.",
+} as const
+
+export const $TierRead = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
+    max_concurrent_workflows: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Workflows",
+    },
+    max_action_executions_per_workflow: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Action Executions Per Workflow",
+    },
+    max_concurrent_actions: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Actions",
+    },
+    api_rate_limit: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Rate Limit",
+    },
+    api_burst_capacity: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Burst Capacity",
+    },
+    entitlements: {
+      $ref: "#/components/schemas/EntitlementsDict",
+    },
+    is_default: {
+      type: "boolean",
+      title: "Is Default",
+    },
+    sort_order: {
+      type: "integer",
+      title: "Sort Order",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "display_name",
+    "max_concurrent_workflows",
+    "max_action_executions_per_workflow",
+    "max_concurrent_actions",
+    "api_rate_limit",
+    "api_burst_capacity",
+    "entitlements",
+    "is_default",
+    "sort_order",
+    "is_active",
+    "created_at",
+    "updated_at",
+  ],
+  title: "TierRead",
+  description: "Tier response schema.",
+} as const
+
+export const $TierUpdate = {
+  properties: {
+    display_name: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 255,
+          minLength: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Display Name",
+    },
+    max_concurrent_workflows: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Workflows",
+    },
+    max_action_executions_per_workflow: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Action Executions Per Workflow",
+    },
+    max_concurrent_actions: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Concurrent Actions",
+    },
+    api_rate_limit: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Rate Limit",
+    },
+    api_burst_capacity: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Api Burst Capacity",
+    },
+    entitlements: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/EntitlementsDict",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    is_default: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Is Default",
+    },
+    sort_order: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Sort Order",
+    },
+    is_active: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Is Active",
+    },
+  },
+  type: "object",
+  title: "TierUpdate",
+  description: "Update tier request.",
 } as const
 
 export const $Toggle = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -18,14 +18,22 @@ import type {
   ActionsUpdateActionResponse,
   AdminCreateOrganizationData,
   AdminCreateOrganizationResponse,
+  AdminCreateTierData,
+  AdminCreateTierResponse,
   AdminDeleteOrganizationData,
   AdminDeleteOrganizationResponse,
+  AdminDeleteTierData,
+  AdminDeleteTierResponse,
   AdminDemoteFromSuperuserData,
   AdminDemoteFromSuperuserResponse,
   AdminGetOrganizationData,
   AdminGetOrganizationResponse,
+  AdminGetOrgTierData,
+  AdminGetOrgTierResponse,
   AdminGetRegistrySettingsResponse,
   AdminGetRegistryStatusResponse,
+  AdminGetTierData,
+  AdminGetTierResponse,
   AdminGetUserData,
   AdminGetUserResponse,
   AdminListOrganizationsResponse,
@@ -35,6 +43,8 @@ import type {
   AdminListOrgRepositoryVersionsResponse,
   AdminListRegistryVersionsData,
   AdminListRegistryVersionsResponse,
+  AdminListTiersData,
+  AdminListTiersResponse,
   AdminListUsersResponse,
   AdminPromoteOrgRepositoryVersionData,
   AdminPromoteOrgRepositoryVersionResponse,
@@ -50,8 +60,12 @@ import type {
   AdminSyncRepositoryResponse,
   AdminUpdateOrganizationData,
   AdminUpdateOrganizationResponse,
+  AdminUpdateOrgTierData,
+  AdminUpdateOrgTierResponse,
   AdminUpdateRegistrySettingsData,
   AdminUpdateRegistrySettingsResponse,
+  AdminUpdateTierData,
+  AdminUpdateTierResponse,
   AgentCreateProviderCredentialsData,
   AgentCreateProviderCredentialsResponse,
   AgentDeleteProviderCredentialsData,
@@ -3941,6 +3955,172 @@ export const adminUpdateRegistrySettings = (
   return __request(OpenAPI, {
     method: "PATCH",
     url: "/admin/settings/registry",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Tiers
+ * List all tiers.
+ * @param data The data for the request.
+ * @param data.includeInactive Include inactive tiers in results
+ * @returns TierRead Successful Response
+ * @throws ApiError
+ */
+export const adminListTiers = (
+  data: AdminListTiersData = {}
+): CancelablePromise<AdminListTiersResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/admin/tiers",
+    query: {
+      include_inactive: data.includeInactive,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Tier
+ * Create a new tier.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns TierRead Successful Response
+ * @throws ApiError
+ */
+export const adminCreateTier = (
+  data: AdminCreateTierData
+): CancelablePromise<AdminCreateTierResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/admin/tiers",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Tier
+ * Get tier by ID.
+ * @param data The data for the request.
+ * @param data.tierId
+ * @returns TierRead Successful Response
+ * @throws ApiError
+ */
+export const adminGetTier = (
+  data: AdminGetTierData
+): CancelablePromise<AdminGetTierResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/admin/tiers/{tier_id}",
+    path: {
+      tier_id: data.tierId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Tier
+ * Update a tier.
+ * @param data The data for the request.
+ * @param data.tierId
+ * @param data.requestBody
+ * @returns TierRead Successful Response
+ * @throws ApiError
+ */
+export const adminUpdateTier = (
+  data: AdminUpdateTierData
+): CancelablePromise<AdminUpdateTierResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/admin/tiers/{tier_id}",
+    path: {
+      tier_id: data.tierId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Tier
+ * Delete a tier (only if no orgs are assigned to it).
+ * @param data The data for the request.
+ * @param data.tierId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const adminDeleteTier = (
+  data: AdminDeleteTierData
+): CancelablePromise<AdminDeleteTierResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/admin/tiers/{tier_id}",
+    path: {
+      tier_id: data.tierId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Org Tier
+ * Get tier assignment for an organization.
+ * @param data The data for the request.
+ * @param data.orgId
+ * @returns OrganizationTierRead Successful Response
+ * @throws ApiError
+ */
+export const adminGetOrgTier = (
+  data: AdminGetOrgTierData
+): CancelablePromise<AdminGetOrgTierResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/admin/tiers/organizations/{org_id}",
+    path: {
+      org_id: data.orgId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Org Tier
+ * Update organization's tier assignment and overrides.
+ * @param data The data for the request.
+ * @param data.orgId
+ * @param data.requestBody
+ * @returns OrganizationTierRead Successful Response
+ * @throws ApiError
+ */
+export const adminUpdateOrgTier = (
+  data: AdminUpdateOrgTierData
+): CancelablePromise<AdminUpdateOrgTierResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/admin/tiers/organizations/{org_id}",
+    path: {
+      org_id: data.orgId,
+    },
     body: data.requestBody,
     mediaType: "application/json",
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2075,6 +2075,17 @@ export type EditorParamRead = {
   optional: boolean
 }
 
+/**
+ * TypedDict for tier entitlements stored in JSONB.
+ *
+ * All keys are optional (total=False) to support partial overrides.
+ */
+export type EntitlementsDict = {
+  custom_registry?: boolean
+  sso?: boolean
+  git_sync?: boolean
+}
+
 export type ErrorDetails = {
   type: string
   loc: Array<number | string>
@@ -3108,6 +3119,43 @@ export type OrganizationSecretRead = {
   created_at: string
   updated_at: string
   organization_id: string
+}
+
+/**
+ * Organization tier assignment response.
+ */
+export type OrganizationTierRead = {
+  id: string
+  organization_id: string
+  tier_id: string
+  max_concurrent_workflows: number | null
+  max_action_executions_per_workflow: number | null
+  max_concurrent_actions: number | null
+  api_rate_limit: number | null
+  api_burst_capacity: number | null
+  entitlement_overrides: EntitlementsDict | null
+  stripe_customer_id: string | null
+  stripe_subscription_id: string | null
+  expires_at: string | null
+  created_at: string
+  updated_at: string
+  tier?: TierRead | null
+}
+
+/**
+ * Update organization tier assignment request.
+ */
+export type OrganizationTierUpdate = {
+  tier_id?: string | null
+  max_concurrent_workflows?: number | null
+  max_action_executions_per_workflow?: number | null
+  max_concurrent_actions?: number | null
+  api_rate_limit?: number | null
+  api_burst_capacity?: number | null
+  entitlement_overrides?: EntitlementsDict | null
+  stripe_customer_id?: string | null
+  stripe_subscription_id?: string | null
+  expires_at?: string | null
 }
 
 export type OutputType =
@@ -4893,6 +4941,57 @@ export type TextUIPart = {
 export type ThinkingBlock = {
   thinking: string
   signature: string
+}
+
+/**
+ * Create tier request.
+ */
+export type TierCreate = {
+  id: string
+  display_name: string
+  max_concurrent_workflows?: number | null
+  max_action_executions_per_workflow?: number | null
+  max_concurrent_actions?: number | null
+  api_rate_limit?: number | null
+  api_burst_capacity?: number | null
+  entitlements?: EntitlementsDict
+  is_default?: boolean
+  sort_order?: number
+}
+
+/**
+ * Tier response schema.
+ */
+export type TierRead = {
+  id: string
+  display_name: string
+  max_concurrent_workflows: number | null
+  max_action_executions_per_workflow: number | null
+  max_concurrent_actions: number | null
+  api_rate_limit: number | null
+  api_burst_capacity: number | null
+  entitlements: EntitlementsDict
+  is_default: boolean
+  sort_order: number
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Update tier request.
+ */
+export type TierUpdate = {
+  display_name?: string | null
+  max_concurrent_workflows?: number | null
+  max_action_executions_per_workflow?: number | null
+  max_concurrent_actions?: number | null
+  api_rate_limit?: number | null
+  api_burst_capacity?: number | null
+  entitlements?: EntitlementsDict | null
+  is_default?: boolean | null
+  sort_order?: number | null
+  is_active?: boolean | null
 }
 
 export type Toggle = {
@@ -6920,6 +7019,53 @@ export type AdminUpdateRegistrySettingsData = {
 }
 
 export type AdminUpdateRegistrySettingsResponse = PlatformRegistrySettingsRead
+
+export type AdminListTiersData = {
+  /**
+   * Include inactive tiers in results
+   */
+  includeInactive?: boolean
+}
+
+export type AdminListTiersResponse = Array<TierRead>
+
+export type AdminCreateTierData = {
+  requestBody: TierCreate
+}
+
+export type AdminCreateTierResponse = TierRead
+
+export type AdminGetTierData = {
+  tierId: string
+}
+
+export type AdminGetTierResponse = TierRead
+
+export type AdminUpdateTierData = {
+  requestBody: TierUpdate
+  tierId: string
+}
+
+export type AdminUpdateTierResponse = TierRead
+
+export type AdminDeleteTierData = {
+  tierId: string
+}
+
+export type AdminDeleteTierResponse = void
+
+export type AdminGetOrgTierData = {
+  orgId: string
+}
+
+export type AdminGetOrgTierResponse = OrganizationTierRead
+
+export type AdminUpdateOrgTierData = {
+  orgId: string
+  requestBody: OrganizationTierUpdate
+}
+
+export type AdminUpdateOrgTierResponse = OrganizationTierRead
 
 export type AdminListUsersResponse = Array<AdminUserRead>
 
@@ -9829,6 +9975,103 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: PlatformRegistrySettingsRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/tiers": {
+    get: {
+      req: AdminListTiersData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<TierRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AdminCreateTierData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: TierRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/tiers/{tier_id}": {
+    get: {
+      req: AdminGetTierData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: TierRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: AdminUpdateTierData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: TierRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AdminDeleteTierData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/tiers/organizations/{org_id}": {
+    get: {
+      req: AdminGetOrgTierData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: OrganizationTierRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: AdminUpdateOrgTierData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: OrganizationTierRead
         /**
          * Validation Error
          */

--- a/packages/tracecat-ee/tracecat_ee/admin/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/router.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter
 from tracecat_ee.admin.organizations.router import router as organizations_router
 from tracecat_ee.admin.registry.router import router as registry_router
 from tracecat_ee.admin.settings.router import router as settings_router
+from tracecat_ee.admin.tiers.router import router as tiers_router
 from tracecat_ee.admin.users.router import router as users_router
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -12,4 +13,5 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 router.include_router(organizations_router)
 router.include_router(registry_router)
 router.include_router(settings_router)
+router.include_router(tiers_router)
 router.include_router(users_router)

--- a/packages/tracecat-ee/tracecat_ee/admin/tiers/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/tiers/__init__.py
@@ -1,0 +1,6 @@
+"""Admin tier management module."""
+
+from tracecat_ee.admin.tiers.router import router
+from tracecat_ee.admin.tiers.service import AdminTierService
+
+__all__ = ["router", "AdminTierService"]

--- a/packages/tracecat-ee/tracecat_ee/admin/tiers/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/tiers/router.py
@@ -1,0 +1,137 @@
+"""Admin tier management endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from tracecat.auth.credentials import SuperuserRole
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat_ee.admin.tiers.schemas import (
+    OrganizationTierRead,
+    OrganizationTierUpdate,
+    TierCreate,
+    TierRead,
+    TierUpdate,
+)
+from tracecat_ee.admin.tiers.service import AdminTierService
+
+router = APIRouter(prefix="/tiers", tags=["admin:tiers"])
+
+
+# Tier CRUD endpoints
+
+
+@router.get("", response_model=list[TierRead])
+async def list_tiers(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    include_inactive: bool = Query(
+        False, description="Include inactive tiers in results"
+    ),
+) -> list[TierRead]:
+    """List all tiers."""
+    service = AdminTierService(session, role=role)
+    return list(await service.list_tiers(include_inactive=include_inactive))
+
+
+@router.post("", response_model=TierRead, status_code=status.HTTP_201_CREATED)
+async def create_tier(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    params: TierCreate,
+) -> TierRead:
+    """Create a new tier."""
+    service = AdminTierService(session, role=role)
+    try:
+        return await service.create_tier(params)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
+@router.get("/{tier_id}", response_model=TierRead)
+async def get_tier(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    tier_id: str,
+) -> TierRead:
+    """Get tier by ID."""
+    service = AdminTierService(session, role=role)
+    try:
+        return await service.get_tier(tier_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.patch("/{tier_id}", response_model=TierRead)
+async def update_tier(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    tier_id: str,
+    params: TierUpdate,
+) -> TierRead:
+    """Update a tier."""
+    service = AdminTierService(session, role=role)
+    try:
+        return await service.update_tier(tier_id, params)
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+            ) from e
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
+@router.delete("/{tier_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_tier(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    tier_id: str,
+) -> None:
+    """Delete a tier (only if no orgs are assigned to it)."""
+    service = AdminTierService(session, role=role)
+    try:
+        await service.delete_tier(tier_id)
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+            ) from e
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+
+# Organization tier endpoints
+
+
+@router.get("/organizations/{org_id}", response_model=OrganizationTierRead)
+async def get_org_tier(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    org_id: uuid.UUID,
+) -> OrganizationTierRead:
+    """Get tier assignment for an organization."""
+    service = AdminTierService(session, role=role)
+    try:
+        return await service.get_org_tier(org_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.patch("/organizations/{org_id}", response_model=OrganizationTierRead)
+async def update_org_tier(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    org_id: uuid.UUID,
+    params: OrganizationTierUpdate,
+) -> OrganizationTierRead:
+    """Update organization's tier assignment and overrides."""
+    service = AdminTierService(session, role=role)
+    try:
+        return await service.update_org_tier(org_id, params)
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+            ) from e
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e

--- a/packages/tracecat-ee/tracecat_ee/admin/tiers/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/tiers/schemas.py
@@ -1,0 +1,24 @@
+"""Admin tier management schemas."""
+
+from __future__ import annotations
+
+# Re-export schemas from core tiers module for admin API
+from tracecat.tiers.schemas import (
+    EffectiveEntitlements,
+    EffectiveLimits,
+    OrganizationTierRead,
+    OrganizationTierUpdate,
+    TierCreate,
+    TierRead,
+    TierUpdate,
+)
+
+__all__ = [
+    "EffectiveEntitlements",
+    "EffectiveLimits",
+    "OrganizationTierRead",
+    "OrganizationTierUpdate",
+    "TierCreate",
+    "TierRead",
+    "TierUpdate",
+]

--- a/packages/tracecat-ee/tracecat_ee/admin/tiers/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/tiers/service.py
@@ -1,0 +1,230 @@
+"""Admin tier management service."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+
+from tracecat.db.models import Organization, OrganizationTier, Tier
+from tracecat.service import BaseService
+from tracecat.tiers.schemas import (
+    OrganizationTierRead,
+    OrganizationTierUpdate,
+    TierCreate,
+    TierRead,
+    TierUpdate,
+)
+
+
+class AdminTierService(BaseService):
+    """Platform-level tier management."""
+
+    service_name = "admin_tier"
+
+    # Tier CRUD operations
+
+    async def list_tiers(self, include_inactive: bool = False) -> Sequence[TierRead]:
+        """List all tiers."""
+        stmt = select(Tier).order_by(Tier.sort_order, Tier.id)
+        if not include_inactive:
+            stmt = stmt.where(Tier.is_active.is_(True))
+        result = await self.session.execute(stmt)
+        return TierRead.list_adapter().validate_python(result.scalars().all())
+
+    async def get_tier(self, tier_id: str) -> TierRead:
+        """Get tier by ID."""
+        stmt = select(Tier).where(Tier.id == tier_id)
+        result = await self.session.execute(stmt)
+        tier = result.scalar_one_or_none()
+        if not tier:
+            raise ValueError(f"Tier {tier_id} not found")
+        return TierRead.model_validate(tier)
+
+    async def create_tier(self, params: TierCreate) -> TierRead:
+        """Create a new tier."""
+        # If this tier is set as default, unset other defaults
+        if params.is_default:
+            await self._unset_other_defaults(None)
+
+        tier = Tier(
+            id=params.id,
+            display_name=params.display_name,
+            max_concurrent_workflows=params.max_concurrent_workflows,
+            max_action_executions_per_workflow=params.max_action_executions_per_workflow,
+            max_concurrent_actions=params.max_concurrent_actions,
+            api_rate_limit=params.api_rate_limit,
+            api_burst_capacity=params.api_burst_capacity,
+            entitlements=params.entitlements,
+            is_default=params.is_default,
+            sort_order=params.sort_order,
+        )
+        self.session.add(tier)
+        try:
+            await self.session.commit()
+        except IntegrityError as e:
+            await self.session.rollback()
+            raise ValueError(f"Tier with ID '{params.id}' already exists") from e
+        await self.session.refresh(tier)
+        return TierRead.model_validate(tier)
+
+    async def update_tier(self, tier_id: str, params: TierUpdate) -> TierRead:
+        """Update a tier."""
+        stmt = select(Tier).where(Tier.id == tier_id)
+        result = await self.session.execute(stmt)
+        tier = result.scalar_one_or_none()
+        if not tier:
+            raise ValueError(f"Tier {tier_id} not found")
+
+        # If setting this tier as default, unset other defaults
+        if params.is_default is True:
+            await self._unset_other_defaults(tier_id)
+
+        update_data = params.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(tier, field, value)
+
+        await self.session.commit()
+        await self.session.refresh(tier)
+        return TierRead.model_validate(tier)
+
+    async def delete_tier(self, tier_id: str) -> None:
+        """Delete a tier (only if no orgs are assigned to it)."""
+        # Check if tier exists
+        stmt = select(Tier).where(Tier.id == tier_id)
+        result = await self.session.execute(stmt)
+        tier = result.scalar_one_or_none()
+        if not tier:
+            raise ValueError(f"Tier {tier_id} not found")
+
+        # Prevent deleting the default tier
+        if tier.is_default:
+            raise ValueError("Cannot delete the default tier")
+
+        # Check if any orgs are using this tier
+        org_stmt = select(OrganizationTier).where(OrganizationTier.tier_id == tier_id)
+        org_result = await self.session.execute(org_stmt)
+        if org_result.first():
+            raise ValueError(
+                f"Cannot delete tier {tier_id}: organizations are still assigned to it"
+            )
+
+        await self.session.delete(tier)
+        await self.session.commit()
+
+    async def _unset_other_defaults(self, exclude_tier_id: str | None) -> None:
+        """Unset is_default on all tiers except the specified one."""
+        stmt = select(Tier).where(Tier.is_default.is_(True))
+        if exclude_tier_id:
+            stmt = stmt.where(Tier.id != exclude_tier_id)
+        result = await self.session.execute(stmt)
+        for tier in result.scalars().all():
+            tier.is_default = False
+
+    # Organization tier operations
+
+    async def get_org_tier(self, org_id: uuid.UUID) -> OrganizationTierRead:
+        """Get tier assignment for an organization."""
+        # Verify org exists
+        await self._verify_org_exists(org_id)
+
+        stmt = (
+            select(OrganizationTier)
+            .options(selectinload(OrganizationTier.tier))
+            .where(OrganizationTier.organization_id == org_id)
+        )
+        result = await self.session.execute(stmt)
+        org_tier = result.scalar_one_or_none()
+
+        if not org_tier:
+            raise ValueError(f"No tier assignment found for organization {org_id}")
+
+        tier_read = TierRead.model_validate(org_tier.tier) if org_tier.tier else None
+        return OrganizationTierRead(
+            id=org_tier.id,
+            organization_id=org_tier.organization_id,
+            tier_id=org_tier.tier_id,
+            max_concurrent_workflows=org_tier.max_concurrent_workflows,
+            max_action_executions_per_workflow=org_tier.max_action_executions_per_workflow,
+            max_concurrent_actions=org_tier.max_concurrent_actions,
+            api_rate_limit=org_tier.api_rate_limit,
+            api_burst_capacity=org_tier.api_burst_capacity,
+            entitlement_overrides=org_tier.entitlement_overrides,
+            stripe_customer_id=org_tier.stripe_customer_id,
+            stripe_subscription_id=org_tier.stripe_subscription_id,
+            expires_at=org_tier.expires_at,
+            created_at=org_tier.created_at,
+            updated_at=org_tier.updated_at,
+            tier=tier_read,
+        )
+
+    async def update_org_tier(
+        self, org_id: uuid.UUID, params: OrganizationTierUpdate
+    ) -> OrganizationTierRead:
+        """Update organization's tier assignment and overrides."""
+        # Verify org exists
+        await self._verify_org_exists(org_id)
+
+        stmt = (
+            select(OrganizationTier)
+            .options(selectinload(OrganizationTier.tier))
+            .where(OrganizationTier.organization_id == org_id)
+        )
+        result = await self.session.execute(stmt)
+        org_tier = result.scalar_one_or_none()
+
+        if not org_tier:
+            # Create new org tier
+            org_tier = OrganizationTier(organization_id=org_id, tier_id="default")
+            self.session.add(org_tier)
+
+        # If changing tier_id, verify the new tier exists
+        if params.tier_id is not None:
+            tier_stmt = select(Tier).where(Tier.id == params.tier_id)
+            tier_result = await self.session.execute(tier_stmt)
+            if not tier_result.scalar_one_or_none():
+                raise ValueError(f"Tier {params.tier_id} not found")
+
+        update_data = params.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(org_tier, field, value)
+
+        await self.session.commit()
+
+        # Refresh with tier loaded
+        stmt = (
+            select(OrganizationTier)
+            .options(selectinload(OrganizationTier.tier))
+            .where(OrganizationTier.id == org_tier.id)
+        )
+        result = await self.session.execute(stmt)
+        org_tier = result.scalar_one()
+
+        tier_read = TierRead.model_validate(org_tier.tier) if org_tier.tier else None
+        return OrganizationTierRead(
+            id=org_tier.id,
+            organization_id=org_tier.organization_id,
+            tier_id=org_tier.tier_id,
+            max_concurrent_workflows=org_tier.max_concurrent_workflows,
+            max_action_executions_per_workflow=org_tier.max_action_executions_per_workflow,
+            max_concurrent_actions=org_tier.max_concurrent_actions,
+            api_rate_limit=org_tier.api_rate_limit,
+            api_burst_capacity=org_tier.api_burst_capacity,
+            entitlement_overrides=org_tier.entitlement_overrides,
+            stripe_customer_id=org_tier.stripe_customer_id,
+            stripe_subscription_id=org_tier.stripe_subscription_id,
+            expires_at=org_tier.expires_at,
+            created_at=org_tier.created_at,
+            updated_at=org_tier.updated_at,
+            tier=tier_read,
+        )
+
+    async def _verify_org_exists(self, org_id: uuid.UUID) -> None:
+        """Verify organization exists."""
+        stmt = select(Organization).where(Organization.id == org_id)
+        result = await self.session.execute(stmt)
+        if not result.scalar_one_or_none():
+            raise ValueError(f"Organization {org_id} not found")

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -66,6 +66,7 @@ from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGra
 from tracecat.interactions.enums import InteractionStatus, InteractionType
 from tracecat.invitations.enums import InvitationStatus
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+from tracecat.tiers.types import EntitlementsDict
 from tracecat.workspaces.schemas import WorkspaceSettings
 
 _UNSET = object()
@@ -206,6 +207,11 @@ class Organization(Base, TimestampMixin):
         secondary="organization_membership",
         back_populates="organizations",
         lazy="select",
+    )
+    organization_tier: Mapped[OrganizationTier | None] = relationship(
+        "OrganizationTier",
+        back_populates="organization",
+        uselist=False,
     )
 
 
@@ -2845,3 +2851,75 @@ class Invitation(InvitationMixin, TimestampMixin, Base):
     # Relationships
     workspace: Mapped[Workspace] = relationship("Workspace")
     inviter: Mapped[User | None] = relationship("User")
+
+
+class Tier(Base, TimestampMixin):
+    """Platform-configurable tier definition.
+
+    Tiers define resource limits and feature entitlements that apply to organizations.
+    The default tier provides unlimited access for self-hosted deployments.
+    """
+
+    __tablename__ = "tier"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True
+    )  # "default", "free", "pro", etc.
+    display_name: Mapped[str] = mapped_column(String)
+
+    # Limits (None = unlimited)
+    max_concurrent_workflows: Mapped[int | None] = mapped_column(Integer)
+    max_action_executions_per_workflow: Mapped[int | None] = mapped_column(Integer)
+    max_concurrent_actions: Mapped[int | None] = mapped_column(Integer)
+    api_rate_limit: Mapped[int | None] = mapped_column(Integer)
+    api_burst_capacity: Mapped[int | None] = mapped_column(Integer)
+
+    # Entitlements (JSONB for flexibility)
+    entitlements: Mapped[EntitlementsDict] = mapped_column(JSONB, default=dict)
+
+    # Metadata
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+
+class OrganizationTier(Base, TimestampMixin):
+    """Organization's assigned tier with optional overrides.
+
+    Each organization can have a tier assigned with per-org overrides for limits
+    and entitlements. None values mean "use tier default".
+    """
+
+    __tablename__ = "organization_tier"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        unique=True,
+        index=True,
+    )
+    tier_id: Mapped[str] = mapped_column(
+        String, ForeignKey("tier.id"), default="default"
+    )
+
+    # Per-org limit overrides (None = use tier default)
+    max_concurrent_workflows: Mapped[int | None] = mapped_column(Integer)
+    max_action_executions_per_workflow: Mapped[int | None] = mapped_column(Integer)
+    max_concurrent_actions: Mapped[int | None] = mapped_column(Integer)
+    api_rate_limit: Mapped[int | None] = mapped_column(Integer)
+    api_burst_capacity: Mapped[int | None] = mapped_column(Integer)
+
+    # Per-org entitlement overrides
+    entitlement_overrides: Mapped[EntitlementsDict | None] = mapped_column(JSONB)
+
+    # Billing (future)
+    stripe_customer_id: Mapped[str | None] = mapped_column(String)
+    stripe_subscription_id: Mapped[str | None] = mapped_column(String)
+    expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+    # Relationships
+    organization: Mapped[Organization] = relationship(
+        "Organization", back_populates="organization_tier"
+    )
+    tier: Mapped[Tier] = relationship("Tier")

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -191,4 +191,16 @@ class RateLimitExceeded(ExecutorClientError):
 
 
 class PayloadSizeExceeded(TracecatException):
-    """ERror raised when a payload exceeds a size limit."""
+    """Error raised when a payload exceeds a size limit."""
+
+
+class EntitlementRequired(TracecatException):
+    """Exception raised when a feature requires a higher subscription tier.
+
+    Raised when an organization attempts to use a feature they are not entitled to.
+    """
+
+    def __init__(self, entitlement: str):
+        self.entitlement = entitlement
+        message = f"Feature '{entitlement}' requires a higher subscription tier"
+        super().__init__(message, detail={"entitlement": entitlement})

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -36,6 +36,7 @@ from tracecat.registry.repositories.schemas import (
 from tracecat.registry.repositories.service import RegistryReposService
 from tracecat.settings.service import get_setting
 from tracecat.ssh import ssh_context
+from tracecat.tiers import Entitlement, check_entitlement
 
 router = APIRouter(prefix=REGISTRY_REPOS_PATH, tags=["registry-repositories"])
 
@@ -433,6 +434,10 @@ async def create_registry_repository(
     params: RegistryRepositoryCreate,
 ) -> RegistryRepositoryRead:
     """Create a new registry repository."""
+    # Check entitlement for custom registry (non-system repositories)
+    if params.origin != DEFAULT_REGISTRY_ORIGIN:
+        await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
+
     service = RegistryReposService(session, role=role)
     try:
         created_repository = await service.create_repository(params)

--- a/tracecat/tiers/__init__.py
+++ b/tracecat/tiers/__init__.py
@@ -1,0 +1,49 @@
+"""Tier management for organizations.
+
+Imports are deferred to avoid circular imports with db.models.
+Use explicit imports from submodules when needed at module load time.
+"""
+
+from tracecat.tiers.types import EntitlementsDict
+
+# Lazy exports - import from submodules directly to avoid circular imports
+__all__ = [
+    "EntitlementsDict",
+]
+
+
+def __getattr__(name: str):
+    """Lazy import to avoid circular imports."""
+    if name == "DEFAULT_ENTITLEMENTS":
+        from tracecat.tiers.defaults import DEFAULT_ENTITLEMENTS
+
+        return DEFAULT_ENTITLEMENTS
+    if name == "DEFAULT_LIMITS":
+        from tracecat.tiers.defaults import DEFAULT_LIMITS
+
+        return DEFAULT_LIMITS
+    if name == "DEFAULT_TIER_DISPLAY_NAME":
+        from tracecat.tiers.defaults import DEFAULT_TIER_DISPLAY_NAME
+
+        return DEFAULT_TIER_DISPLAY_NAME
+    if name == "DEFAULT_TIER_ID":
+        from tracecat.tiers.defaults import DEFAULT_TIER_ID
+
+        return DEFAULT_TIER_ID
+    if name == "Entitlement":
+        from tracecat.tiers.entitlements import Entitlement
+
+        return Entitlement
+    if name == "EntitlementService":
+        from tracecat.tiers.entitlements import EntitlementService
+
+        return EntitlementService
+    if name == "check_entitlement":
+        from tracecat.tiers.entitlements import check_entitlement
+
+        return check_entitlement
+    if name == "TierService":
+        from tracecat.tiers.service import TierService
+
+        return TierService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tracecat/tiers/defaults.py
+++ b/tracecat/tiers/defaults.py
@@ -1,0 +1,25 @@
+"""Default tier configuration for self-hosted deployments - unlimited everything."""
+
+from __future__ import annotations
+
+from tracecat.tiers.schemas import EffectiveEntitlements, EffectiveLimits
+
+# Default tier ID used in database seeding and fallbacks
+DEFAULT_TIER_ID = "default"
+DEFAULT_TIER_DISPLAY_NAME = "Default"
+
+# Default limits for self-hosted deployments (None = unlimited)
+DEFAULT_LIMITS = EffectiveLimits(
+    api_rate_limit=None,
+    api_burst_capacity=None,
+    max_concurrent_workflows=None,
+    max_action_executions_per_workflow=None,
+    max_concurrent_actions=None,
+)
+
+# Default entitlements for self-hosted deployments (all enabled)
+DEFAULT_ENTITLEMENTS = EffectiveEntitlements(
+    custom_registry=True,
+    sso=True,
+    git_sync=True,
+)

--- a/tracecat/tiers/entitlements.py
+++ b/tracecat/tiers/entitlements.py
@@ -1,0 +1,86 @@
+"""Entitlement checks for feature gating by tier."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from tracecat.exceptions import EntitlementRequired
+from tracecat.tiers.service import TierService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from tracecat.auth.types import Role
+    from tracecat.identifiers import OrganizationID
+
+
+class Entitlement(StrEnum):
+    """Available feature entitlements."""
+
+    CUSTOM_REGISTRY = "custom_registry"
+    SSO = "sso"
+    GIT_SYNC = "git_sync"
+
+
+class EntitlementService:
+    """Checks feature entitlements for organizations.
+
+    Usage:
+        async with TierService.with_session(role=role) as tier_svc:
+            entitlement_svc = EntitlementService(tier_svc)
+            await entitlement_svc.check_entitlement(org_id, Entitlement.CUSTOM_REGISTRY)
+    """
+
+    def __init__(self, tier_service: TierService):
+        self.tier_service = tier_service
+
+    async def is_entitled(
+        self, org_id: OrganizationID, entitlement: Entitlement
+    ) -> bool:
+        """Check if an organization has a specific entitlement.
+
+        Args:
+            org_id: The organization ID to check
+            entitlement: The entitlement to check for
+
+        Returns:
+            True if the organization is entitled to the feature, False otherwise
+        """
+        effective = await self.tier_service.get_effective_entitlements(org_id)
+        return getattr(effective, entitlement.value, False)
+
+    async def check_entitlement(
+        self, org_id: OrganizationID, entitlement: Entitlement
+    ) -> None:
+        """Check if an organization has an entitlement, raising if not.
+
+        Args:
+            org_id: The organization ID to check
+            entitlement: The entitlement to require
+
+        Raises:
+            EntitlementRequired: If the organization is not entitled to the feature
+        """
+        if not await self.is_entitled(org_id, entitlement):
+            raise EntitlementRequired(entitlement.value)
+
+
+async def check_entitlement(
+    session: AsyncSession,
+    role: Role,
+    entitlement: Entitlement,
+) -> None:
+    """Convenience function to check entitlement in a single call.
+
+    Args:
+        session: Database session
+        role: The current role (must have organization_id)
+        entitlement: The entitlement to require
+
+    Raises:
+        EntitlementRequired: If the organization is not entitled to the feature
+    """
+    tier_svc = TierService(session, role=role)
+    entitlement_svc = EntitlementService(tier_svc)
+    await entitlement_svc.check_entitlement(role.organization_id, entitlement)

--- a/tracecat/tiers/schemas.py
+++ b/tracecat/tiers/schemas.py
@@ -1,0 +1,135 @@
+"""Tier schemas for API request/response models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import Field
+
+from tracecat.core.schemas import Schema
+from tracecat.tiers.types import EntitlementsDict
+
+
+class EffectiveLimits(Schema):
+    """Effective resource limits for an organization.
+
+    Values are resolved from org overrides falling back to tier defaults.
+    None means unlimited.
+    """
+
+    api_rate_limit: int | None = Field(
+        None, description="API rate limit (requests per second). None = unlimited"
+    )
+    api_burst_capacity: int | None = Field(
+        None, description="API burst capacity. None = unlimited"
+    )
+    max_concurrent_workflows: int | None = Field(
+        None, description="Max concurrent running workflows. None = unlimited"
+    )
+    max_action_executions_per_workflow: int | None = Field(
+        None,
+        description="Max action executions per workflow run (runtime limit). None = unlimited",
+    )
+    max_concurrent_actions: int | None = Field(
+        None,
+        description="Max concurrent action executions across all workflows for an org. None = unlimited",
+    )
+
+
+class EffectiveEntitlements(Schema):
+    """Effective feature entitlements for an organization.
+
+    Values are resolved from org overrides falling back to tier defaults.
+    """
+
+    custom_registry: bool = Field(
+        False, description="Whether custom registry repositories are enabled"
+    )
+    sso: bool = Field(False, description="Whether SSO is enabled")
+    git_sync: bool = Field(False, description="Whether git sync is enabled")
+
+
+class TierRead(Schema):
+    """Tier response schema."""
+
+    id: str
+    display_name: str
+    max_concurrent_workflows: int | None
+    max_action_executions_per_workflow: int | None
+    max_concurrent_actions: int | None
+    api_rate_limit: int | None
+    api_burst_capacity: int | None
+    entitlements: EntitlementsDict
+    is_default: bool
+    sort_order: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class TierCreate(Schema):
+    """Create tier request."""
+
+    id: str = Field(..., min_length=1, max_length=63, pattern=r"^[a-z0-9_-]+$")
+    display_name: str = Field(..., min_length=1, max_length=255)
+    max_concurrent_workflows: int | None = None
+    max_action_executions_per_workflow: int | None = None
+    max_concurrent_actions: int | None = None
+    api_rate_limit: int | None = None
+    api_burst_capacity: int | None = None
+    entitlements: EntitlementsDict = Field(default={})
+    is_default: bool = False
+    sort_order: int = 0
+
+
+class TierUpdate(Schema):
+    """Update tier request."""
+
+    display_name: str | None = Field(None, min_length=1, max_length=255)
+    max_concurrent_workflows: int | None = None
+    max_action_executions_per_workflow: int | None = None
+    max_concurrent_actions: int | None = None
+    api_rate_limit: int | None = None
+    api_burst_capacity: int | None = None
+    entitlements: EntitlementsDict | None = None
+    is_default: bool | None = None
+    sort_order: int | None = None
+    is_active: bool | None = None
+
+
+class OrganizationTierRead(Schema):
+    """Organization tier assignment response."""
+
+    id: uuid.UUID
+    organization_id: uuid.UUID
+    tier_id: str
+    max_concurrent_workflows: int | None
+    max_action_executions_per_workflow: int | None
+    max_concurrent_actions: int | None
+    api_rate_limit: int | None
+    api_burst_capacity: int | None
+    entitlement_overrides: EntitlementsDict | None
+    stripe_customer_id: str | None
+    stripe_subscription_id: str | None
+    expires_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+    # Include resolved tier info
+    tier: TierRead | None = None
+
+
+class OrganizationTierUpdate(Schema):
+    """Update organization tier assignment request."""
+
+    tier_id: str | None = None
+    max_concurrent_workflows: int | None = None
+    max_action_executions_per_workflow: int | None = None
+    max_concurrent_actions: int | None = None
+    api_rate_limit: int | None = None
+    api_burst_capacity: int | None = None
+    entitlement_overrides: EntitlementsDict | None = None
+    stripe_customer_id: str | None = None
+    stripe_subscription_id: str | None = None
+    expires_at: datetime | None = None

--- a/tracecat/tiers/service.py
+++ b/tracecat/tiers/service.py
@@ -1,0 +1,148 @@
+"""Tier management service."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from tracecat.db.models import Organization, OrganizationTier, Tier
+from tracecat.service import BaseService
+from tracecat.tiers.defaults import DEFAULT_ENTITLEMENTS, DEFAULT_LIMITS
+from tracecat.tiers.schemas import EffectiveEntitlements, EffectiveLimits
+
+if TYPE_CHECKING:
+    from tracecat.identifiers import OrganizationID
+
+
+class TierService(BaseService):
+    """Manages organization tiers."""
+
+    service_name = "tier"
+
+    async def get_tier(self, tier_id: str) -> Tier | None:
+        """Get tier by ID."""
+        stmt = select(Tier).where(Tier.id == tier_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_default_tier(self) -> Tier | None:
+        """Get the default tier for new organizations.
+
+        Returns None if no default tier exists (migration hasn't run yet).
+        """
+        stmt = select(Tier).where(Tier.is_default.is_(True), Tier.is_active.is_(True))
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_org_tier(self, org_id: OrganizationID) -> OrganizationTier | None:
+        """Get tier assignment for an organization."""
+        stmt = (
+            select(OrganizationTier)
+            .options(selectinload(OrganizationTier.tier))
+            .where(OrganizationTier.organization_id == org_id)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_or_create_org_tier(self, org_id: OrganizationID) -> OrganizationTier:
+        """Get existing org tier or create with default tier.
+
+        If no OrganizationTier exists for the org, creates one with the default tier.
+        """
+        org_tier = await self.get_org_tier(org_id)
+        if org_tier is not None:
+            return org_tier
+
+        # Create new org tier with default
+        default_tier = await self.get_default_tier()
+        tier_id = default_tier.id if default_tier else "default"
+
+        # Verify org exists
+        org_stmt = select(Organization).where(Organization.id == org_id)
+        result = await self.session.execute(org_stmt)
+        org = result.scalar_one_or_none()
+        if org is None:
+            raise ValueError(f"Organization {org_id} not found")
+
+        org_tier = OrganizationTier(organization_id=org_id, tier_id=tier_id)
+        self.session.add(org_tier)
+        await self.session.commit()
+        await self.session.refresh(org_tier)
+
+        # Load the tier relationship
+        stmt = (
+            select(OrganizationTier)
+            .options(selectinload(OrganizationTier.tier))
+            .where(OrganizationTier.id == org_tier.id)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one()
+
+    async def get_effective_limits(self, org_id: OrganizationID) -> EffectiveLimits:
+        """Get effective limits (org override or tier default).
+
+        Falls back to DEFAULT_LIMITS if no tier is configured.
+        """
+        org_tier = await self.get_org_tier(org_id)
+
+        if org_tier is None:
+            # No org tier - use default limits from config
+            return DEFAULT_LIMITS
+
+        tier = org_tier.tier
+
+        def resolve(org_value: int | None, tier_value: int | None) -> int | None:
+            """Resolve value: org override takes precedence, then tier default."""
+            return org_value if org_value is not None else tier_value
+
+        return EffectiveLimits(
+            api_rate_limit=resolve(
+                org_tier.api_rate_limit, tier.api_rate_limit if tier else None
+            ),
+            api_burst_capacity=resolve(
+                org_tier.api_burst_capacity, tier.api_burst_capacity if tier else None
+            ),
+            max_concurrent_workflows=resolve(
+                org_tier.max_concurrent_workflows,
+                tier.max_concurrent_workflows if tier else None,
+            ),
+            max_action_executions_per_workflow=resolve(
+                org_tier.max_action_executions_per_workflow,
+                tier.max_action_executions_per_workflow if tier else None,
+            ),
+            max_concurrent_actions=resolve(
+                org_tier.max_concurrent_actions,
+                tier.max_concurrent_actions if tier else None,
+            ),
+        )
+
+    async def get_effective_entitlements(
+        self, org_id: OrganizationID
+    ) -> EffectiveEntitlements:
+        """Get effective entitlements (org override or tier default).
+
+        Falls back to DEFAULT_ENTITLEMENTS if no tier is configured.
+        """
+        org_tier = await self.get_org_tier(org_id)
+
+        if org_tier is None:
+            # No org tier - use default entitlements from config
+            return DEFAULT_ENTITLEMENTS
+
+        tier = org_tier.tier
+        tier_entitlements = tier.entitlements if tier else {}
+        overrides = org_tier.entitlement_overrides or {}
+
+        def resolve_entitlement(key: str, default: bool = False) -> bool:
+            """Resolve entitlement: org override takes precedence, then tier default."""
+            if key in overrides:
+                return overrides[key]
+            return tier_entitlements.get(key, default)
+
+        return EffectiveEntitlements(
+            custom_registry=resolve_entitlement("custom_registry"),
+            sso=resolve_entitlement("sso"),
+            git_sync=resolve_entitlement("git_sync"),
+        )

--- a/tracecat/tiers/types.py
+++ b/tracecat/tiers/types.py
@@ -1,0 +1,16 @@
+"""Type definitions for the tiers module."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class EntitlementsDict(TypedDict, total=False):
+    """TypedDict for tier entitlements stored in JSONB.
+
+    All keys are optional (total=False) to support partial overrides.
+    """
+
+    custom_registry: bool
+    sso: bool
+    git_sync: bool


### PR DESCRIPTION
## Summary
- Adds tier-based resource limits and feature entitlements for multi-tenant deployments
- Limits: `max_concurrent_workflows`, `max_action_executions_per_workflow`, `max_concurrent_actions`, `api_rate_limit`, `api_burst_capacity`
- Entitlements: `custom_registry`, `sso`, `git_sync`
- Admin API endpoints (EE) for tier CRUD and org tier assignments
- Alembic migration with default tier seeding + org backfill

## Test plan
- [ ] Run migration against test database
- [ ] Verify default tier is created
- [ ] Verify org tier records are backfilled for existing orgs
- [ ] Test admin tier CRUD endpoints
- [ ] Test entitlement check on custom registry endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tier system with org-level limits and feature entitlements, plus admin APIs to manage tiers and assignments. Enforces custom registry access via entitlements and seeds a default, unlimited tier for self-hosted setups.

- **New Features**
  - Tier and OrganizationTier models with limits and entitlements.
  - TierService resolves effective limits/entitlements; EntitlementService + check_entitlement().
  - Admin EE API: CRUD for /admin/tiers and GET/PATCH /admin/tiers/organizations/{org_id}.
  - Frontend client schemas/types/services updated for tiers and org assignments.
  - EntitlementRequired exception with 403 handler; gated custom registry creation.
  - Default tier: unlimited limits and all entitlements.

- **Migration**
  - Alembic migration creates tier and organization_tier tables.
  - Seeds the default tier and backfills organization_tier for existing orgs.

<sup>Written for commit 3e2ef975bbbd0ab6000465e4d4bcd2d193fdd4f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

