### PR TITLE
feat(tiers): add tier types, defaults, and schemas

### DIFF
--- a/tracecat/tiers/defaults.py
+++ b/tracecat/tiers/defaults.py
@@ -1,0 +1,23 @@
+"""Default tier configuration for self-hosted deployments - unlimited everything."""
+
+from __future__ import annotations
+
+from tracecat.tiers.schemas import EffectiveEntitlements, EffectiveLimits
+
+DEFAULT_TIER_DISPLAY_NAME = "Default"
+
+# Default limits for self-hosted deployments (None = unlimited)
+DEFAULT_LIMITS = EffectiveLimits(
+    api_rate_limit=None,
+    api_burst_capacity=None,
+    max_concurrent_workflows=None,
+    max_action_executions_per_workflow=None,
+    max_concurrent_actions=None,
+)
+
+# Default entitlements for self-hosted deployments (all enabled)
+DEFAULT_ENTITLEMENTS = EffectiveEntitlements(
+    custom_registry=True,
+    sso=True,
+    git_sync=True,
+)

--- a/tracecat/tiers/schemas.py
+++ b/tracecat/tiers/schemas.py
@@ -1,0 +1,134 @@
+"""Tier schemas for API request/response models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import Field
+
+from tracecat.core.schemas import Schema
+from tracecat.tiers.types import EntitlementsDict
+
+
+class EffectiveLimits(Schema):
+    """Effective resource limits for an organization.
+
+    Values are resolved from org overrides falling back to tier defaults.
+    None means unlimited.
+    """
+
+    api_rate_limit: int | None = Field(
+        None, description="API rate limit (requests per second). None = unlimited"
+    )
+    api_burst_capacity: int | None = Field(
+        None, description="API burst capacity. None = unlimited"
+    )
+    max_concurrent_workflows: int | None = Field(
+        None, description="Max concurrent running workflows. None = unlimited"
+    )
+    max_action_executions_per_workflow: int | None = Field(
+        None,
+        description="Max action executions per workflow run (runtime limit). None = unlimited",
+    )
+    max_concurrent_actions: int | None = Field(
+        None,
+        description="Max concurrent action executions across all workflows for an org. None = unlimited",
+    )
+
+
+class EffectiveEntitlements(Schema):
+    """Effective feature entitlements for an organization.
+
+    Values are resolved from org overrides falling back to tier defaults.
+    """
+
+    custom_registry: bool = Field(
+        False, description="Whether custom registry repositories are enabled"
+    )
+    sso: bool = Field(False, description="Whether SSO is enabled")
+    git_sync: bool = Field(False, description="Whether git sync is enabled")
+
+
+class TierRead(Schema):
+    """Tier response schema."""
+
+    id: uuid.UUID
+    display_name: str
+    max_concurrent_workflows: int | None
+    max_action_executions_per_workflow: int | None
+    max_concurrent_actions: int | None
+    api_rate_limit: int | None
+    api_burst_capacity: int | None
+    entitlements: EntitlementsDict
+    is_default: bool
+    sort_order: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class TierCreate(Schema):
+    """Create tier request."""
+
+    display_name: str = Field(..., min_length=1, max_length=255)
+    max_concurrent_workflows: int | None = None
+    max_action_executions_per_workflow: int | None = None
+    max_concurrent_actions: int | None = None
+    api_rate_limit: int | None = None
+    api_burst_capacity: int | None = None
+    entitlements: EntitlementsDict = Field(default={})
+    is_default: bool = False
+    sort_order: int = 0
+
+
+class TierUpdate(Schema):
+    """Update tier request."""
+
+    display_name: str | None = Field(None, min_length=1, max_length=255)
+    max_concurrent_workflows: int | None = None
+    max_action_executions_per_workflow: int | None = None
+    max_concurrent_actions: int | None = None
+    api_rate_limit: int | None = None
+    api_burst_capacity: int | None = None
+    entitlements: EntitlementsDict | None = None
+    is_default: bool | None = None
+    sort_order: int | None = None
+    is_active: bool | None = None
+
+
+class OrganizationTierRead(Schema):
+    """Organization tier assignment response."""
+
+    id: uuid.UUID
+    organization_id: uuid.UUID
+    tier_id: uuid.UUID
+    max_concurrent_workflows: int | None
+    max_action_executions_per_workflow: int | None
+    max_concurrent_actions: int | None
+    api_rate_limit: int | None
+    api_burst_capacity: int | None
+    entitlement_overrides: EntitlementsDict | None
+    stripe_customer_id: str | None
+    stripe_subscription_id: str | None
+    expires_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+    # Include resolved tier info
+    tier: TierRead | None = None
+
+
+class OrganizationTierUpdate(Schema):
+    """Update organization tier assignment request."""
+
+    tier_id: uuid.UUID | None = None
+    max_concurrent_workflows: int | None = None
+    max_action_executions_per_workflow: int | None = None
+    max_concurrent_actions: int | None = None
+    api_rate_limit: int | None = None
+    api_burst_capacity: int | None = None
+    entitlement_overrides: EntitlementsDict | None = None
+    stripe_customer_id: str | None = None
+    stripe_subscription_id: str | None = None
+    expires_at: datetime | None = None


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds core tier types and API schemas to manage limits and entitlements for organizations. Sets a self-hosted default tier with unlimited limits and all entitlements enabled.

- **New Features**
  - EffectiveLimits and EffectiveEntitlements models for resolved org settings (supports overrides; None = unlimited).
  - TierRead/Create/Update and OrganizationTierRead/Update schemas for CRUD and assignments, including Stripe fields and entitlement overrides.
  - Default tier display name plus default limits and entitlements for self-hosted deployments.
  - EntitlementsDict TypedDict for JSONB storage with partial overrides.

<sup>Written for commit 1504e454cdc8a5e8033dfe7ce3ad57f2a58932ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

