### PR TITLE
feat(tiers): add entitlement system for feature gating

### DIFF
--- a/tracecat/tiers/entitlements.py
+++ b/tracecat/tiers/entitlements.py
@@ -1,0 +1,86 @@
+"""Entitlement checks for feature gating by tier."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from tracecat.exceptions import EntitlementRequired
+from tracecat.tiers.service import TierService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from tracecat.auth.types import Role
+    from tracecat.identifiers import OrganizationID
+
+
+class Entitlement(StrEnum):
+    """Available feature entitlements."""
+
+    CUSTOM_REGISTRY = "custom_registry"
+    SSO = "sso"
+    GIT_SYNC = "git_sync"
+
+
+class EntitlementService:
+    """Checks feature entitlements for organizations.
+
+    Usage:
+        async with TierService.with_session(role=role) as tier_svc:
+            entitlement_svc = EntitlementService(tier_svc)
+            await entitlement_svc.check_entitlement(org_id, Entitlement.CUSTOM_REGISTRY)
+    """
+
+    def __init__(self, tier_service: TierService):
+        self.tier_service = tier_service
+
+    async def is_entitled(
+        self, org_id: OrganizationID, entitlement: Entitlement
+    ) -> bool:
+        """Check if an organization has a specific entitlement.
+
+        Args:
+            org_id: The organization ID to check
+            entitlement: The entitlement to check for
+
+        Returns:
+            True if the organization is entitled to the feature, False otherwise
+        """
+        effective = await self.tier_service.get_effective_entitlements(org_id)
+        return getattr(effective, entitlement.value, False)
+
+    async def check_entitlement(
+        self, org_id: OrganizationID, entitlement: Entitlement
+    ) -> None:
+        """Check if an organization has an entitlement, raising if not.
+
+        Args:
+            org_id: The organization ID to check
+            entitlement: The entitlement to require
+
+        Raises:
+            EntitlementRequired: If the organization is not entitled to the feature
+        """
+        if not await self.is_entitled(org_id, entitlement):
+            raise EntitlementRequired(entitlement.value)
+
+
+async def check_entitlement(
+    session: AsyncSession,
+    role: Role,
+    entitlement: Entitlement,
+) -> None:
+    """Convenience function to check entitlement in a single call.
+
+    Args:
+        session: Database session
+        role: The current role (must have organization_id)
+        entitlement: The entitlement to require
+
+    Raises:
+        EntitlementRequired: If the organization is not entitled to the feature
+    """
+    tier_svc = TierService(session, role=role)
+    entitlement_svc = EntitlementService(tier_svc)
+    await entitlement_svc.check_entitlement(role.organization_id, entitlement)


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tier-based entitlement system to gate features by organization. Provides a simple API to check and enforce access across services and endpoints.

- **New Features**
  - Entitlement enum: CUSTOM_REGISTRY, SSO, GIT_SYNC.
  - EntitlementService with is_entitled and check_entitlement (raises EntitlementRequired).
  - Convenience check_entitlement(session, role, entitlement) function for inline checks.

<sup>Written for commit 466e1e448f5ffa1a73d0174a2a34f08c6e52c69a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

