### PR TITLE
fix(tests): stabilize async DB engine lifecycle in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,11 @@ from tests.database import TEST_DB_CONFIG
 from tracecat import config
 from tracecat.auth.types import AccessLevel, Role, system_role
 from tracecat.contexts import ctx_role
-from tracecat.db.engine import get_async_engine, get_async_session_context_manager
+from tracecat.db.engine import (
+    get_async_engine,
+    get_async_session_context_manager,
+    reset_async_engine,
+)
 from tracecat.db.models import Base, Workspace
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.plugins import TracecatPydanticAIPlugin
@@ -170,16 +174,23 @@ def monkeysession(request: pytest.FixtureRequest):
 
 @pytest.fixture(autouse=True, scope="function")
 async def test_db_engine():
-    """Create a new engine for each integration test."""
+    """Ensure a fresh async engine for each test.
+
+    This fixture creates a new engine for each test function and disposes it
+    after the test completes. This ensures connections are properly cleaned up
+    and don't hold references to closed event loops when using pytest-xdist.
+    """
     engine = get_async_engine()
     try:
         yield engine
     finally:
-        # Ensure the engine is disposed even if the test fails
         try:
             await engine.dispose()
         except Exception as e:
-            logger.error(f"Error disposing engine in test_db_engine: {e}")
+            logger.warning(f"Error disposing engine: {e}")
+        finally:
+            # Reset the global so next test gets a fresh engine
+            reset_async_engine()
 
 
 @pytest.fixture(scope="session")

--- a/tracecat/db/engine.py
+++ b/tracecat/db/engine.py
@@ -164,6 +164,15 @@ def get_async_engine() -> AsyncEngine:
     return _async_engine
 
 
+def reset_async_engine() -> None:
+    """Reset the global async engine.
+
+    This should only be used in tests to ensure clean state between tests.
+    """
+    global _async_engine
+    _async_engine = None
+
+
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
     """Get an async SQLAlchemy database session."""
     async with AsyncSession(get_async_engine(), expire_on_commit=False) as session:


### PR DESCRIPTION
## Summary

Fixes "Event loop is closed" errors in CI by properly managing the async database engine lifecycle during tests.

**Problem**: The async engine connection pool holds references to the event loop where connections were created. With pytest-xdist parallel testing and pytest-anyio, different tests may run on different event loops. When SQLAlchemy tries to terminate connections created on a closed loop, it fails.

**Solution**:
- Add `reset_async_engine()` function to clear the global engine singleton
- Make `test_db_engine` fixture async and dispose + reset the engine after each test
- This ensures each test gets a fresh engine with connections on the current event loop

## Changes

- `tracecat/db/engine.py`: Add `reset_async_engine()` to reset the global `_async_engine`
- `tests/conftest.py`: Update `test_db_engine` fixture to properly dispose and reset engine per test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "Event loop is closed" errors in CI by isolating the async DB engine per test. Each test now gets a fresh engine and cleans up connections.

- **Bug Fixes**
  - Added reset_async_engine() to clear the global engine in tests.
  - Updated test_db_engine fixture to dispose the engine and reset it after each test.

<sup>Written for commit d71906c30edf43ec357620225c88661588669b01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

