### PR TITLE
feat(tiers): enforce workflow concurrency limits

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8571,7 +8571,7 @@ export const $ExternalObject = {
 
 export const $FeatureFlag = {
   type: "string",
-  enum: ["ai-ranking"],
+  enum: ["ai-ranking", "workflow-concurrency-limits"],
   title: "FeatureFlag",
   description: "Feature flag enum reserved for engineering rollouts.",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2611,7 +2611,7 @@ export type ExternalObject = {
 /**
  * Feature flag enum reserved for engineering rollouts.
  */
-export type FeatureFlag = "ai-ranking"
+export type FeatureFlag = "ai-ranking" | "workflow-concurrency-limits"
 
 /**
  * Response model for feature flags.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,18 +282,49 @@ def default_org(db: None, env_sandbox: None) -> Iterator[None]:
         Base.metadata.create_all(sync_engine)
 
         with Session(sync_engine) as session:
-            org_slug = f"test-org-{TEST_ORG_ID.hex[:8]}"
-            existing_slug_owner = session.execute(
-                text("SELECT id FROM organization WHERE slug = :slug"),
-                {"slug": org_slug},
-            ).scalar_one_or_none()
+            base_org_slug = f"test-org-{TEST_ORG_ID.hex[:8]}"
+            org_slug = base_org_slug
+
+            insert_org_stmt = text(
+                """
+                INSERT INTO organization (id, name, slug, is_active, created_at, updated_at)
+                VALUES (
+                    :org_id,
+                    'Test Organization',
+                    :org_slug,
+                    true,
+                    now(),
+                    now()
+                )
+                ON CONFLICT (id) DO NOTHING
+                """
+            )
+
+            def _slug_owner(slug: str) -> str | None:
+                owner = session.execute(
+                    text("SELECT id FROM organization WHERE slug = :slug"),
+                    {"slug": slug},
+                ).scalar_one_or_none()
+                return str(owner) if owner is not None else None
+
+            def _insert_org(slug: str) -> None:
+                session.execute(
+                    insert_org_stmt,
+                    {
+                        "org_id": str(TEST_ORG_ID),
+                        "org_slug": slug,
+                    },
+                )
+                session.commit()
+
+            existing_slug_owner = _slug_owner(base_org_slug)
 
             # Handle stale/shared DB state where the canonical slug already exists
             # with a different org ID (for example from previous CI runs).
             if existing_slug_owner is not None and str(existing_slug_owner) != str(
                 TEST_ORG_ID
             ):
-                fallback_slug = f"{org_slug}-{TEST_DB_CONFIG.test_db_name[:8]}"
+                fallback_slug = f"{base_org_slug}-{TEST_DB_CONFIG.test_db_name[:8]}"
                 logger.warning(
                     "Default test org slug is already in use by another org; "
                     "using fallback slug",
@@ -303,27 +334,34 @@ def default_org(db: None, env_sandbox: None) -> Iterator[None]:
                 )
                 org_slug = fallback_slug
 
-            session.execute(
-                text(
-                    """
-                    INSERT INTO organization (id, name, slug, is_active, created_at, updated_at)
-                    VALUES (
-                        :org_id,
-                        'Test Organization',
-                        :org_slug,
-                        true,
-                        now(),
-                        now()
+            try:
+                _insert_org(org_slug)
+            except IntegrityError:
+                # Handle select->insert races where another session claims the canonical
+                # slug after our pre-check and before our insert/commit.
+                session.rollback()
+                existing_slug_owner = _slug_owner(base_org_slug)
+                if existing_slug_owner is not None and existing_slug_owner != str(
+                    TEST_ORG_ID
+                ):
+                    fallback_slug = f"{base_org_slug}-{TEST_DB_CONFIG.test_db_name[:8]}"
+                    logger.warning(
+                        "Default test org slug became occupied during insert; "
+                        "retrying with fallback slug",
+                        org_id=str(TEST_ORG_ID),
+                        existing_slug_owner=existing_slug_owner,
+                        fallback_slug=fallback_slug,
                     )
-                    ON CONFLICT (id) DO NOTHING
-                    """
-                ),
-                {
-                    "org_id": str(TEST_ORG_ID),
-                    "org_slug": org_slug,
-                },
-            )
-            session.commit()
+                    _insert_org(fallback_slug)
+                else:
+                    # If the canonical org now exists (likely inserted concurrently),
+                    # this fixture's intent is satisfied; re-raise otherwise.
+                    org_exists = session.execute(
+                        text("SELECT 1 FROM organization WHERE id = :org_id"),
+                        {"org_id": str(TEST_ORG_ID)},
+                    ).scalar_one_or_none()
+                    if org_exists is None:
+                        raise
 
         sync_engine.dispose()
 

--- a/tests/temporal/test_workflow_concurrency_limits.py
+++ b/tests/temporal/test_workflow_concurrency_limits.py
@@ -91,7 +91,7 @@ async def concurrency_limits_enabled(
 
 def _workflow_semaphore_key(org_id: uuid.UUID) -> str:
     """Build the Redis key used for workflow permit tracking for an org."""
-    return f"tier:org:{org_id}:semaphore"
+    return f"tier:org:{org_id}:workflow-semaphore"
 
 
 def _action_semaphore_key(org_id: uuid.UUID) -> str:

--- a/tests/temporal/test_workflow_concurrency_limits.py
+++ b/tests/temporal/test_workflow_concurrency_limits.py
@@ -1,0 +1,788 @@
+"""Temporal e2e tests for workflow concurrency tier limits.
+
+These tests exercise the real tier-limit activities and Redis semaphore behavior
+through running workflows, while mocking action execution for deterministic
+coordination.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from collections.abc import AsyncGenerator, Callable
+from datetime import timedelta
+
+import pytest
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from temporalio import activity
+from temporalio.client import WorkflowFailureError, WorkflowHandle
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from tests.shared import TEST_WF_ID, generate_test_exec_id
+from tracecat import config
+from tracecat.auth.types import Role
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import Organization, OrganizationTier, Tier
+from tracecat.dsl._converter import get_data_converter
+from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.schemas import (
+    ActionRetryPolicy,
+    ActionStatement,
+    GatherArgs,
+    RunActionInput,
+    ScatterArgs,
+)
+from tracecat.dsl.worker import get_activities
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.executor.activities import ExecutorActivities
+from tracecat.feature_flags.enums import FeatureFlag
+from tracecat.redis import client as redis_client_module
+from tracecat.redis.client import get_redis_client
+from tracecat.storage.object import InlineObject, StoredObject
+
+pytestmark = [
+    pytest.mark.temporal,
+    pytest.mark.usefixtures("registry_version_with_manifest"),
+]
+
+
+@pytest.fixture
+async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=get_data_converter(compression_enabled=False)
+    ) as workflow_env:
+        yield workflow_env
+
+
+@pytest.fixture
+async def concurrency_limits_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncGenerator[None, None]:
+    """Enable tier-limit enforcement and isolate Redis for this test session.
+
+    This fixture enables the workflow concurrency feature flags and sets timing
+    constants to short values so backoff and permit wait behavior can be exercised
+    quickly in tests. It also points Redis client configuration at the test
+    environment before each test and tears down the shared connection before and
+    after execution.
+    """
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__FEATURE_FLAGS",
+        {FeatureFlag.WORKFLOW_CONCURRENCY_LIMITS},
+    )
+    monkeypatch.setattr(config, "TRACECAT__WORKFLOW_PERMIT_BACKOFF_BASE_SECONDS", 0.02)
+    monkeypatch.setattr(config, "TRACECAT__WORKFLOW_PERMIT_BACKOFF_MAX_SECONDS", 0.1)
+    monkeypatch.setattr(config, "TRACECAT__WORKFLOW_PERMIT_MAX_WAIT_SECONDS", 30)
+    monkeypatch.setattr(config, "TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS", 30)
+    monkeypatch.setattr(config, "TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS", 10.0)
+    monkeypatch.setattr(redis_client_module, "REDIS_URL", os.environ["REDIS_URL"])
+
+    redis_wrapper = await get_redis_client()
+    await redis_wrapper.close()
+    yield
+    await redis_wrapper.close()
+
+
+def _workflow_semaphore_key(org_id: uuid.UUID) -> str:
+    """Build the Redis key used for workflow permit tracking for an org."""
+    return f"tier:org:{org_id}:semaphore"
+
+
+def _action_semaphore_key(org_id: uuid.UUID) -> str:
+    """Build the Redis key used for action permit tracking for an org."""
+    return f"tier:org:{org_id}:action-semaphore"
+
+
+def _build_single_action_dsl(
+    *,
+    title: str,
+    ref: str,
+    start_delay_seconds: float = 0.0,
+    retry_until: str | None = None,
+) -> DSLInput:
+    """Build a single-action DSL used by concurrency tests.
+
+    The returned DSL keeps the action name and reference stable, while allowing the
+    caller to vary optional retry timing and start delay behavior per test.
+    """
+    retry_policy = (
+        ActionRetryPolicy(retry_until=retry_until)
+        if retry_until is not None
+        else ActionRetryPolicy()
+    )
+    return DSLInput(
+        title=title,
+        description=title,
+        entrypoint=DSLEntrypoint(ref=ref),
+        actions=[
+            ActionStatement(
+                ref=ref,
+                action="core.transform.reshape",
+                args={"ref": ref},
+                start_delay=start_delay_seconds,
+                retry_policy=retry_policy,
+            )
+        ],
+    )
+
+
+async def _configure_org_limits(
+    org_id: uuid.UUID,
+    *,
+    max_concurrent_workflows: int | None = None,
+    max_concurrent_actions: int | None = None,
+    max_action_executions_per_workflow: int | None = None,
+) -> None:
+    """Upsert an organization tier configuration with deterministic e2e limits."""
+    tier_id = uuid.uuid5(org_id, "temporal-tier")
+    tier_values = {
+        "display_name": f"Temporal Tier {org_id.hex[:8]}",
+        "max_concurrent_workflows": max_concurrent_workflows,
+        "max_action_executions_per_workflow": max_action_executions_per_workflow,
+        "max_concurrent_actions": max_concurrent_actions,
+        "api_rate_limit": None,
+        "api_burst_capacity": None,
+        "entitlements": {},
+        "is_default": False,
+        "sort_order": 0,
+        "is_active": True,
+    }
+
+    async with get_async_session_context_manager() as session:
+        await session.execute(
+            pg_insert(Organization)
+            .values(
+                id=org_id,
+                name=f"Temporal Org {org_id.hex[:8]}",
+                slug=f"temporal-org-{org_id.hex}",
+                is_active=True,
+            )
+            .on_conflict_do_nothing(index_elements=["id"])
+        )
+        await session.execute(
+            pg_insert(Tier)
+            .values(id=tier_id, **tier_values)
+            .on_conflict_do_update(index_elements=["id"], set_=tier_values)
+        )
+        await session.execute(
+            pg_insert(OrganizationTier)
+            .values(
+                organization_id=org_id,
+                tier_id=tier_id,
+                max_concurrent_workflows=None,
+                max_action_executions_per_workflow=None,
+                max_concurrent_actions=None,
+                api_rate_limit=None,
+                api_burst_capacity=None,
+                entitlement_overrides=None,
+            )
+            .on_conflict_do_update(
+                index_elements=["organization_id"],
+                set_={"tier_id": tier_id},
+            )
+        )
+        await session.commit()
+
+
+async def _start_batch(
+    *,
+    env: WorkflowEnvironment,
+    role: Role,
+    dsl: DSLInput,
+    workflow_name_prefix: str,
+    size: int,
+) -> list[WorkflowHandle]:
+    """Start a batch of identical workflows using the same role and DSL.
+
+    Returns:
+        A list of workflow handles, one per started workflow, so callers can await
+        completion and assert post-run semaphore state.
+    """
+    handles: list[WorkflowHandle] = []
+    for i in range(size):
+        handle = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id(f"{workflow_name_prefix}_{i}_{uuid.uuid4().hex[:6]}"),
+            task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+        )
+        handles.append(handle)
+    return handles
+
+
+def _role_for_org(base_role: Role, org_id: uuid.UUID) -> Role:
+    """Return a role copy scoped to the requested organization."""
+    return base_role.model_copy(update={"organization_id": org_id})
+
+
+@pytest.mark.anyio
+async def test_workflow_concurrency_batch_never_exceeds_cap(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    test_worker_factory: Callable[..., Worker],
+    concurrency_limits_enabled: None,
+) -> None:
+    """Verify workflow permit acquisition caps concurrent active workflows.
+
+    The test starts more workflows than the configured permit cap, mocks action
+    execution to park each workflow on permit hold, then checks that active
+    workflow permits never grow beyond the configured limit. It also observes the
+    Redis semaphore directly to verify it reflects the same limit and is cleaned up
+    after all workflows complete.
+    """
+    cap = 3
+    batch_size = 8
+    org_id = test_role.organization_id
+    assert org_id is not None
+    await _configure_org_limits(org_id, max_concurrent_workflows=cap)
+
+    redis_wrapper = await get_redis_client()
+    redis_client = await redis_wrapper._get_client()
+    semaphore_key = _workflow_semaphore_key(org_id)
+    await redis_client.delete(semaphore_key)
+
+    in_flight_actions = 0
+    max_in_flight_actions = 0
+    max_workflow_permits = 0
+    lock = asyncio.Lock()
+    reached_cap = asyncio.Event()
+    release_actions = asyncio.Event()
+    stop_monitor = asyncio.Event()
+
+    async def monitor_workflow_permits() -> None:
+        nonlocal max_workflow_permits
+        while not stop_monitor.is_set():
+            count = int(await redis_client.zcard(semaphore_key))
+            max_workflow_permits = max(max_workflow_permits, count)
+            await asyncio.sleep(0.01)
+
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
+    async def execute_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> StoredObject:
+        del input, role
+        nonlocal in_flight_actions, max_in_flight_actions
+        async with lock:
+            in_flight_actions += 1
+            max_in_flight_actions = max(max_in_flight_actions, in_flight_actions)
+            if in_flight_actions >= cap:
+                reached_cap.set()
+        try:
+            await release_actions.wait()
+            return InlineObject(data={"ok": True})
+        finally:
+            async with lock:
+                in_flight_actions -= 1
+
+    dsl = _build_single_action_dsl(title="workflow-cap-batch", ref="task")
+    activities = get_activities()
+    activities.append(execute_action_activity_mock)
+
+    monitor_task = asyncio.create_task(monitor_workflow_permits())
+
+    async with (
+        test_worker_factory(env.client, activities=activities),
+        test_worker_factory(
+            env.client,
+            activities=[execute_action_activity_mock],
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        ),
+    ):
+        handles = await _start_batch(
+            env=env,
+            role=test_role,
+            dsl=dsl,
+            workflow_name_prefix="workflow_cap_batch",
+            size=batch_size,
+        )
+
+        await asyncio.wait_for(reached_cap.wait(), timeout=10)
+        assert in_flight_actions == cap
+        assert int(await redis_client.zcard(semaphore_key)) == cap
+
+        release_actions.set()
+        for handle in handles:
+            await handle.result()
+
+    stop_monitor.set()
+    await asyncio.gather(monitor_task, return_exceptions=True)
+
+    assert max_in_flight_actions <= cap
+    assert max_workflow_permits <= cap
+    assert int(await redis_client.zcard(semaphore_key)) == 0
+
+
+@pytest.mark.anyio
+async def test_action_concurrency_never_exceeds_cap(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    test_worker_factory: Callable[..., Worker],
+    concurrency_limits_enabled: None,
+) -> None:
+    """Verify action permit cap is enforced for a workflow batch.
+
+    We configure an organization-level action concurrency limit, launch more workflows
+    than that cap, and hold mocked action executions open. The test asserts that
+    only the capped number of actions can hold permits simultaneously, while
+    remaining workflows wait.
+    """
+    cap = 2
+    batch_size = 7
+    org_id = test_role.organization_id
+    assert org_id is not None
+    await _configure_org_limits(org_id, max_concurrent_actions=cap)
+
+    redis_wrapper = await get_redis_client()
+    redis_client = await redis_wrapper._get_client()
+    semaphore_key = _action_semaphore_key(org_id)
+    await redis_client.delete(semaphore_key)
+
+    in_flight_actions = 0
+    max_in_flight_actions = 0
+    max_action_permits = 0
+    lock = asyncio.Lock()
+    reached_cap = asyncio.Event()
+    release_actions = asyncio.Event()
+    stop_monitor = asyncio.Event()
+
+    async def monitor_action_permits() -> None:
+        nonlocal max_action_permits
+        while not stop_monitor.is_set():
+            count = int(await redis_client.zcard(semaphore_key))
+            max_action_permits = max(max_action_permits, count)
+            await asyncio.sleep(0.01)
+
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
+    async def execute_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> StoredObject:
+        del input, role
+        nonlocal in_flight_actions, max_in_flight_actions
+        async with lock:
+            in_flight_actions += 1
+            max_in_flight_actions = max(max_in_flight_actions, in_flight_actions)
+            if in_flight_actions >= cap:
+                reached_cap.set()
+        try:
+            await release_actions.wait()
+            return InlineObject(data={"ok": True})
+        finally:
+            async with lock:
+                in_flight_actions -= 1
+
+    dsl = _build_single_action_dsl(title="action-cap-batch", ref="task")
+    activities = get_activities()
+    activities.append(execute_action_activity_mock)
+
+    monitor_task = asyncio.create_task(monitor_action_permits())
+
+    async with (
+        test_worker_factory(env.client, activities=activities),
+        test_worker_factory(
+            env.client,
+            activities=[execute_action_activity_mock],
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        ),
+    ):
+        handles = await _start_batch(
+            env=env,
+            role=test_role,
+            dsl=dsl,
+            workflow_name_prefix="action_cap_batch",
+            size=batch_size,
+        )
+
+        await asyncio.wait_for(reached_cap.wait(), timeout=10)
+        assert in_flight_actions == cap
+        assert int(await redis_client.zcard(semaphore_key)) == cap
+
+        release_actions.set()
+        for handle in handles:
+            await handle.result()
+
+    stop_monitor.set()
+    await asyncio.gather(monitor_task, return_exceptions=True)
+
+    assert max_in_flight_actions <= cap
+    assert max_action_permits <= cap
+    assert int(await redis_client.zcard(semaphore_key)) == 0
+
+
+@pytest.mark.anyio
+async def test_scatter_gather_respects_action_concurrency_cap(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    test_worker_factory: Callable[..., Worker],
+    concurrency_limits_enabled: None,
+) -> None:
+    """Ensure scatter branch actions obey org action concurrency cap.
+
+    We execute a single workflow with a scatter fan-out larger than the cap and
+    verify that only `cap` branch actions run concurrently while gather completes
+    after release.
+    """
+    cap = 2
+    scatter_width = 6
+    org_id = test_role.organization_id
+    assert org_id is not None
+    await _configure_org_limits(org_id, max_concurrent_actions=cap)
+
+    redis_wrapper = await get_redis_client()
+    redis_client = await redis_wrapper._get_client()
+    semaphore_key = _action_semaphore_key(org_id)
+    await redis_client.delete(semaphore_key)
+
+    in_flight_actions = 0
+    max_in_flight_actions = 0
+    max_action_permits = 0
+    lock = asyncio.Lock()
+    reached_cap = asyncio.Event()
+    release_actions = asyncio.Event()
+    stop_monitor = asyncio.Event()
+
+    async def monitor_action_permits() -> None:
+        nonlocal max_action_permits
+        while not stop_monitor.is_set():
+            count = int(await redis_client.zcard(semaphore_key))
+            max_action_permits = max(max_action_permits, count)
+            await asyncio.sleep(0.01)
+
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
+    async def execute_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> StoredObject:
+        del role
+        nonlocal in_flight_actions, max_in_flight_actions
+        if input.task.ref != "work":
+            return InlineObject(data={"ok": True})
+        async with lock:
+            in_flight_actions += 1
+            max_in_flight_actions = max(max_in_flight_actions, in_flight_actions)
+            if in_flight_actions >= cap:
+                reached_cap.set()
+        try:
+            await release_actions.wait()
+            return InlineObject(data=input.task.args["value"])
+        finally:
+            async with lock:
+                in_flight_actions -= 1
+
+    dsl = DSLInput(
+        title="scatter-gather-cap",
+        description="scatter/gather action cap",
+        entrypoint=DSLEntrypoint(ref="scatter"),
+        actions=[
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(collection=list(range(scatter_width))).model_dump(),
+            ),
+            ActionStatement(
+                ref="work",
+                action="core.transform.reshape",
+                depends_on=["scatter"],
+                args={"value": "${{ ACTIONS.scatter.result }}"},
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                depends_on=["work"],
+                args=GatherArgs(items="${{ ACTIONS.work.result }}").model_dump(),
+            ),
+        ],
+    )
+    activities = get_activities()
+    activities.append(execute_action_activity_mock)
+
+    monitor_task = asyncio.create_task(monitor_action_permits())
+
+    async with (
+        test_worker_factory(env.client, activities=activities),
+        test_worker_factory(
+            env.client,
+            activities=[execute_action_activity_mock],
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        ),
+    ):
+        handle: WorkflowHandle = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id(f"scatter_gather_cap_{uuid.uuid4().hex[:6]}"),
+            task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+        )
+
+        await asyncio.wait_for(reached_cap.wait(), timeout=10)
+        assert in_flight_actions == cap
+        assert int(await redis_client.zcard(semaphore_key)) == cap
+
+        release_actions.set()
+        await handle.result()
+
+    stop_monitor.set()
+    await asyncio.gather(monitor_task, return_exceptions=True)
+
+    assert max_in_flight_actions <= cap
+    assert max_action_permits <= cap
+    assert int(await redis_client.zcard(semaphore_key)) == 0
+
+
+@pytest.mark.anyio
+async def test_start_delay_does_not_consume_action_permit(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    test_worker_factory: Callable[..., Worker],
+    concurrency_limits_enabled: None,
+) -> None:
+    """Show delayed actions do not consume action permits prematurely.
+
+    A workflow with a long delayed action is started alongside an immediate action.
+    The immediate workflow should acquire and hold the only available permit first;
+    the delayed workflow should remain unstarted until its start delay passes and the
+    permit is released.
+    """
+    org_id = test_role.organization_id
+    assert org_id is not None
+    await _configure_org_limits(org_id, max_concurrent_actions=1)
+
+    redis_wrapper = await get_redis_client()
+    redis_client = await redis_wrapper._get_client()
+    semaphore_key = _action_semaphore_key(org_id)
+    await redis_client.delete(semaphore_key)
+
+    immediate_started = asyncio.Event()
+    delayed_started = asyncio.Event()
+    release_immediate = asyncio.Event()
+
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
+    async def execute_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> StoredObject:
+        del role
+        if input.task.ref == "immediate_action":
+            immediate_started.set()
+            await release_immediate.wait()
+        else:
+            delayed_started.set()
+        return InlineObject(data={"ref": input.task.ref})
+
+    delayed_dsl = _build_single_action_dsl(
+        title="delayed-action",
+        ref="delayed_action",
+        start_delay_seconds=3600,
+    )
+    immediate_dsl = _build_single_action_dsl(
+        title="immediate-action",
+        ref="immediate_action",
+    )
+    activities = get_activities()
+    activities.append(execute_action_activity_mock)
+
+    async with (
+        test_worker_factory(env.client, activities=activities),
+        test_worker_factory(
+            env.client,
+            activities=[execute_action_activity_mock],
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        ),
+    ):
+        delayed_handle = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=delayed_dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id(f"delayed_{uuid.uuid4().hex[:6]}"),
+            task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+        )
+        immediate_handle = await env.client.start_workflow(
+            DSLWorkflow.run,
+            DSLRunArgs(dsl=immediate_dsl, role=test_role, wf_id=TEST_WF_ID),
+            id=generate_test_exec_id(f"immediate_{uuid.uuid4().hex[:6]}"),
+            task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+        )
+
+        await asyncio.wait_for(immediate_started.wait(), timeout=10)
+        assert delayed_started.is_set() is False
+        assert int(await redis_client.zcard(semaphore_key)) == 1
+
+        release_immediate.set()
+        await immediate_handle.result()
+
+        await env.sleep(timedelta(hours=2))
+        await delayed_handle.result()
+        assert delayed_started.is_set()
+
+    assert int(await redis_client.zcard(semaphore_key)) == 0
+
+
+@pytest.mark.anyio
+async def test_retry_until_iterations_count_toward_action_execution_limit_e2e(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    test_worker_factory: Callable[..., Worker],
+    concurrency_limits_enabled: None,
+) -> None:
+    """Confirm retry loops consume the action execution budget and fail at the cap.
+
+    The mocked action returns a non-terminal status repeatedly while the DSL's
+    retry policy evaluates a success condition. The test asserts the workflow fails
+    with the expected limit error and that the action was executed exactly at the
+    configured maximum attempts.
+    """
+    org_id = test_role.organization_id
+    assert org_id is not None
+    await _configure_org_limits(org_id, max_action_executions_per_workflow=2)
+
+    num_activity_executions = 0
+
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
+    async def execute_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> StoredObject:
+        del input, role
+        nonlocal num_activity_executions
+        num_activity_executions += 1
+        return InlineObject(data={"status": "loading"})
+
+    dsl = _build_single_action_dsl(
+        title="retry-until-limit",
+        ref="retry_action",
+        retry_until="${{ ACTIONS.retry_action.result.status == 'success' }}",
+    )
+    activities = get_activities()
+    activities.append(execute_action_activity_mock)
+
+    async with (
+        test_worker_factory(env.client, activities=activities),
+        test_worker_factory(
+            env.client,
+            activities=[execute_action_activity_mock],
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        ),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                DSLWorkflow.run,
+                DSLRunArgs(dsl=dsl, role=test_role, wf_id=TEST_WF_ID),
+                id=generate_test_exec_id(f"retry_limit_{uuid.uuid4().hex[:6]}"),
+                task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+            )
+        assert isinstance(exc_info.value.cause, ApplicationError)
+        assert "Action execution limit exceeded" in str(exc_info.value.cause)
+
+    assert num_activity_executions == 2
+
+
+@pytest.mark.anyio
+async def test_concurrency_caps_are_isolated_per_organization(
+    env: WorkflowEnvironment,
+    test_role: Role,
+    test_worker_factory: Callable[..., Worker],
+    concurrency_limits_enabled: None,
+) -> None:
+    """Validate semaphore namespaces are isolated by organization.
+
+    Two org identifiers are configured with different action limits (1 vs 2) so we
+    can verify each org's semaphore enforces its own cap independently. We launch
+    enough workflows per org to saturate each cap, confirm the per-org permit counts
+    match their respective limits, and verify both semaphores are drained after
+    execution finishes.
+    """
+    cap_a = 1
+    cap_b = 2
+    batch_size_a = 3
+    batch_size_b = 5
+    org_a = test_role.organization_id
+    assert org_a is not None
+    org_b = uuid.uuid5(org_a, "temporal-concurrency-org-b")
+    role_b = _role_for_org(test_role, org_b)
+
+    await _configure_org_limits(org_a, max_concurrent_actions=cap_a)
+    await _configure_org_limits(org_b, max_concurrent_actions=cap_b)
+
+    redis_wrapper = await get_redis_client()
+    redis_client = await redis_wrapper._get_client()
+    key_a = _action_semaphore_key(org_a)
+    key_b = _action_semaphore_key(org_b)
+    await redis_client.delete(key_a)
+    await redis_client.delete(key_b)
+
+    in_flight_a = 0
+    in_flight_b = 0
+    max_in_flight_a = 0
+    max_in_flight_b = 0
+    lock = asyncio.Lock()
+    a_reached_cap = asyncio.Event()
+    b_reached_cap = asyncio.Event()
+    release_actions = asyncio.Event()
+
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
+    async def execute_action_activity_mock(
+        input: RunActionInput, role: Role
+    ) -> StoredObject:
+        del input
+        nonlocal in_flight_a, in_flight_b, max_in_flight_a, max_in_flight_b
+        is_org_a = role.organization_id == org_a
+        async with lock:
+            if is_org_a:
+                in_flight_a += 1
+                max_in_flight_a = max(max_in_flight_a, in_flight_a)
+                if in_flight_a >= cap_a:
+                    a_reached_cap.set()
+            else:
+                in_flight_b += 1
+                max_in_flight_b = max(max_in_flight_b, in_flight_b)
+                if in_flight_b >= cap_b:
+                    b_reached_cap.set()
+        try:
+            await release_actions.wait()
+            return InlineObject(data={"ok": True})
+        finally:
+            async with lock:
+                if is_org_a:
+                    in_flight_a -= 1
+                else:
+                    in_flight_b -= 1
+
+    dsl = _build_single_action_dsl(title="cross-org", ref="task")
+    activities = get_activities()
+    activities.append(execute_action_activity_mock)
+
+    async with (
+        test_worker_factory(env.client, activities=activities),
+        test_worker_factory(
+            env.client,
+            activities=[execute_action_activity_mock],
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        ),
+    ):
+        handles_a = await _start_batch(
+            env=env,
+            role=test_role,
+            dsl=dsl,
+            workflow_name_prefix="cross_org_a",
+            size=batch_size_a,
+        )
+        handles_b = await _start_batch(
+            env=env,
+            role=role_b,
+            dsl=dsl,
+            workflow_name_prefix="cross_org_b",
+            size=batch_size_b,
+        )
+
+        await asyncio.wait_for(a_reached_cap.wait(), timeout=10)
+        await asyncio.wait_for(b_reached_cap.wait(), timeout=10)
+        assert int(await redis_client.zcard(key_a)) == cap_a
+        assert int(await redis_client.zcard(key_b)) == cap_b
+
+        release_actions.set()
+        for handle in handles_a + handles_b:
+            await handle.result()
+
+    assert max_in_flight_a <= cap_a
+    assert max_in_flight_b <= cap_b
+    assert int(await redis_client.zcard(key_a)) == 0
+    assert int(await redis_client.zcard(key_b)) == 0

--- a/tests/temporal/test_workflow_concurrency_limits.py
+++ b/tests/temporal/test_workflow_concurrency_limits.py
@@ -208,7 +208,9 @@ async def _start_batch(
         handle = await env.client.start_workflow(
             DSLWorkflow.run,
             DSLRunArgs(dsl=dsl, role=role, wf_id=TEST_WF_ID),
-            id=generate_test_exec_id(f"{workflow_name_prefix}_{i}_{uuid.uuid4().hex[:6]}"),
+            id=generate_test_exec_id(
+                f"{workflow_name_prefix}_{i}_{uuid.uuid4().hex[:6]}"
+            ),
             task_queue=config.TEMPORAL__CLUSTER_QUEUE,
         )
         handles.append(handle)

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -947,6 +947,7 @@ async def test_child_workflow_context_passing(
                     "action": "core.workflow.execute",
                     "args": {
                         "workflow_id": child_workflow.id,
+                        "wait_strategy": WaitStrategy.WAIT.value,
                         "trigger_inputs": {
                             "data_from_parent": "Parent sent child ${{ ACTIONS.parent_first_action.result.reshaped_data }}",  # This is the parent's trigger data
                         },
@@ -1237,6 +1238,7 @@ async def test_single_child_workflow_alias(
                 action="core.workflow.execute",
                 args={
                     "workflow_alias": "the_child",
+                    "wait_strategy": WaitStrategy.WAIT.value,
                     "trigger_inputs": {
                         "data": "Test",
                         "index": 0,
@@ -1468,6 +1470,7 @@ async def test_child_workflow_with_expression_alias(
                 action="core.workflow.execute",
                 args={
                     "workflow_alias": "${{ ACTIONS.get_alias.result }}",  # Use expression
+                    "wait_strategy": WaitStrategy.WAIT.value,
                     "trigger_inputs": {
                         "data": "Test data",
                         "index": 42,
@@ -1545,6 +1548,7 @@ async def test_single_child_workflow_override_environment_correct(
                     "action": "core.workflow.execute",
                     "args": {
                         "workflow_id": child_workflow.id,
+                        "wait_strategy": WaitStrategy.WAIT.value,
                         "trigger_inputs": {},
                         "environment": "__TEST_ENVIRONMENT__",
                     },
@@ -1709,6 +1713,7 @@ async def test_single_child_workflow_environment_has_correct_default(
                     "action": "core.workflow.execute",
                     "args": {
                         "workflow_id": child_workflow.id,
+                        "wait_strategy": WaitStrategy.WAIT.value,
                         "trigger_inputs": {},
                         # No environment set, should default to the child DSL default
                     },
@@ -6355,6 +6360,7 @@ async def test_workflow_time_anchor_inherited_by_child_workflow(
                 action="core.workflow.execute",
                 args={
                     "workflow_id": child_workflow.id,
+                    "wait_strategy": WaitStrategy.WAIT.value,
                     "trigger_inputs": {},
                 },
                 depends_on=["parent_time"],

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -1146,6 +1146,74 @@ async def test_child_workflow_loop(
     await assert_context_equal(result, expected)
 
 
+@pytest.mark.anyio
+async def test_child_workflow_parallel_loop_respects_in_flight_cap(
+    test_role: Role,
+    temporal_client: Client,
+    monkeypatch: pytest.MonkeyPatch,
+    test_worker_factory: Callable[[Client], Worker],
+    test_executor_worker_factory: Callable[[Client], Worker],
+) -> None:
+    test_name = test_child_workflow_parallel_loop_respects_in_flight_cap.__name__
+    wf_exec_id = generate_test_exec_id(test_name)
+    monkeypatch.setattr(config, "TRACECAT__CHILD_WORKFLOW_MAX_IN_FLIGHT", 2)
+
+    child_dsl = DSLInput(
+        entrypoint=DSLEntrypoint(expects={}, ref="reshape"),
+        actions=[
+            ActionStatement(
+                ref="reshape",
+                action="core.transform.reshape",
+                args={
+                    "value": {
+                        "index": "${{ TRIGGER.index }}",
+                    },
+                },
+                start_delay=1,
+            )
+        ],
+        description="Testing bounded child workflow fanout",
+        returns="${{ ACTIONS.reshape.result }}",
+        title="Child",
+        triggers=[],
+    )
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
+
+    parent_dsl = DSLInput(
+        title="Parent",
+        description="Test bounded child fanout",
+        entrypoint=DSLEntrypoint(ref="run_child", expects={}),
+        actions=[
+            ActionStatement(
+                ref="run_child",
+                action="core.workflow.execute",
+                args={
+                    "workflow_id": child_workflow.id,
+                    "trigger_inputs": {"index": "${{ var.x }}"},
+                    "loop_strategy": LoopStrategy.PARALLEL.value,
+                },
+                for_each="${{ for var.x in FN.range(0, 6) }}",
+            ),
+        ],
+        returns="${{ ACTIONS.run_child.result }}",
+        triggers=[],
+    )
+
+    run_args = DSLRunArgs(
+        dsl=parent_dsl,
+        role=test_role,
+        wf_id=WorkflowUUID.new("wf-00000000000000000000000000000002"),
+    )
+    worker = test_worker_factory(temporal_client)
+    executor_worker = test_executor_worker_factory(temporal_client)
+    started_at = datetime.now(UTC)
+    result = await _run_workflow(wf_exec_id, run_args, worker, executor_worker)
+    duration_seconds = (datetime.now(UTC) - started_at).total_seconds()
+
+    assert duration_seconds >= 2.0
+    assert await to_data(result) == [{"index": i} for i in range(6)]
+
+
 # Test workflow alias
 @pytest.mark.anyio
 async def test_single_child_workflow_alias(

--- a/tests/unit/test_admin_tier_service_cache_invalidation.py
+++ b/tests/unit/test_admin_tier_service_cache_invalidation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import uuid
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.admin.tiers.service import AdminTierService
+
+from tracecat.auth.types import PlatformRole, Role
+from tracecat.db.models import Organization, OrganizationTier, Tier
+from tracecat.tiers.schemas import OrganizationTierUpdate, TierUpdate
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+def _tier(*, is_default: bool) -> Tier:
+    return Tier(
+        display_name=f"Tier {uuid.uuid4().hex[:8]}",
+        max_concurrent_workflows=None,
+        max_action_executions_per_workflow=None,
+        max_concurrent_actions=None,
+        api_rate_limit=None,
+        api_burst_capacity=None,
+        entitlements={},
+        is_default=is_default,
+        sort_order=0,
+        is_active=True,
+    )
+
+
+@pytest.mark.anyio
+async def test_update_org_tier_invalidates_effective_limits_cache(
+    session: AsyncSession,
+    test_admin_role: Role,
+) -> None:
+    org_id = test_admin_role.organization_id
+    assert org_id is not None
+    org = Organization(
+        id=org_id,
+        name=f"Org {uuid.uuid4().hex[:8]}",
+        slug=f"org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    default_tier = _tier(is_default=True)
+    session.add_all([org, default_tier])
+    await session.commit()
+
+    service = AdminTierService(session, cast(PlatformRole, test_admin_role))
+
+    with patch(
+        "tracecat_ee.admin.tiers.service.invalidate_effective_limits_cache",
+        new=AsyncMock(),
+    ) as invalidate_mock:
+        result = await service.update_org_tier(
+            org_id,
+            OrganizationTierUpdate(max_concurrent_actions=4),
+        )
+
+    assert result.max_concurrent_actions == 4
+    invalidate_mock.assert_awaited_once_with(org_id)
+
+
+@pytest.mark.anyio
+async def test_update_tier_invalidates_assigned_organization_caches(
+    session: AsyncSession,
+    test_admin_role: Role,
+) -> None:
+    org_a_id = test_admin_role.organization_id
+    assert org_a_id is not None
+    org_a = Organization(
+        id=org_a_id,
+        name=f"Org {uuid.uuid4().hex[:8]}",
+        slug=f"org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    shared_tier = _tier(is_default=False)
+    org_b = Organization(
+        id=uuid.uuid4(),
+        name=f"Org {uuid.uuid4().hex[:8]}",
+        slug=f"org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add_all([org_a, shared_tier, org_b])
+    await session.flush()
+    session.add_all(
+        [
+            OrganizationTier(
+                organization_id=org_a_id,
+                tier_id=shared_tier.id,
+            ),
+            OrganizationTier(
+                organization_id=org_b.id,
+                tier_id=shared_tier.id,
+            ),
+        ]
+    )
+    await session.commit()
+
+    service = AdminTierService(session, cast(PlatformRole, test_admin_role))
+
+    with patch(
+        "tracecat_ee.admin.tiers.service.invalidate_effective_limits_cache_many",
+        new=AsyncMock(),
+    ) as invalidate_many_mock:
+        await service.update_tier(
+            shared_tier.id,
+            TierUpdate(
+                display_name=shared_tier.display_name,
+                max_concurrent_actions=7,
+            ),
+        )
+
+    invalidate_many_mock.assert_awaited_once()
+    assert invalidate_many_mock.await_args is not None
+    invalidated_org_ids = set(invalidate_many_mock.await_args.args[0])
+    assert invalidated_org_ids == {org_a_id, org_b.id}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from tracecat.config import bound_env
+
+
+def test_bound_env_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TEST_BOUND_ENV", raising=False)
+
+    result = bound_env("TEST_BOUND_ENV", 16, lower=8)
+
+    assert result == 16
+
+
+def test_bound_env_clamps_below_lower(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_BOUND_ENV", "4")
+
+    result = bound_env("TEST_BOUND_ENV", 16, lower=8)
+
+    assert result == 8
+
+
+def test_bound_env_clamps_above_upper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_BOUND_ENV", "99")
+
+    result = bound_env("TEST_BOUND_ENV", 16, upper=32)
+
+    assert result == 32
+
+
+def test_bound_env_parses_float(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_BOUND_ENV", "1.5")
+
+    result = bound_env("TEST_BOUND_ENV", 0.5, lower=0.0, upper=2.0)
+
+    assert result == 1.5
+
+
+def test_bound_env_uses_default_for_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_BOUND_ENV", "")
+
+    result = bound_env("TEST_BOUND_ENV", 10, lower=8)
+
+    assert result == 10
+
+
+def test_bound_env_rejects_invalid_numeric_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_BOUND_ENV", "not-a-number")
+
+    with pytest.raises(ValueError, match="TEST_BOUND_ENV must be an integer"):
+        bound_env("TEST_BOUND_ENV", 16, lower=8)
+
+
+def test_bound_env_rejects_invalid_bounds() -> None:
+    with pytest.raises(
+        ValueError, match="lower \\(10\\) cannot be greater than upper \\(8\\)"
+    ):
+        bound_env("TEST_BOUND_ENV", 16, lower=10, upper=8)

--- a/tests/unit/test_dsl_scheduler_concurrency.py
+++ b/tests/unit/test_dsl_scheduler_concurrency.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.dsl.common import DSLEntrypoint, DSLInput
+from tracecat.dsl.scheduler import DSLScheduler
+from tracecat.dsl.schemas import ActionStatement, ExecutionContext, RunContext
+from tracecat.identifiers.workflow import WorkflowUUID
+
+
+@pytest.mark.anyio
+async def test_scheduler_respects_max_pending_tasks_cap() -> None:
+    max_pending_tasks = 3
+    total_tasks = 10
+    active_tasks = 0
+    started_tasks = 0
+    max_active_tasks = 0
+    cap_reached = asyncio.Event()
+    release_tasks = asyncio.Event()
+
+    async def executor(_: ActionStatement) -> None:
+        nonlocal active_tasks, max_active_tasks, started_tasks
+        started_tasks += 1
+        active_tasks += 1
+        max_active_tasks = max(max_active_tasks, active_tasks)
+        if max_active_tasks == max_pending_tasks:
+            cap_reached.set()
+        await release_tasks.wait()
+        active_tasks -= 1
+
+    dsl = DSLInput(
+        title="test",
+        description="test",
+        entrypoint=DSLEntrypoint(ref="task_0"),
+        actions=[
+            ActionStatement(ref=f"task_{index}", action="core.noop")
+            for index in range(total_tasks)
+        ],
+    )
+    wf_id = WorkflowUUID.new_uuid4()
+    test_role = Role(
+        type="service",
+        service_id="tracecat-runner",
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+    test_run_context = RunContext(
+        wf_id=wf_id,
+        wf_exec_id=f"{wf_id.short()}/exec_test",
+        wf_run_id=uuid.uuid4(),
+        environment="test",
+        logical_time=datetime.now(UTC),
+    )
+    scheduler = DSLScheduler(
+        executor=executor,
+        dsl=dsl,
+        max_pending_tasks=max_pending_tasks,
+        context=ExecutionContext(ACTIONS={}, TRIGGER=None),
+        role=test_role,
+        run_context=test_run_context,
+    )
+
+    scheduler_task = asyncio.create_task(scheduler.start())
+    await asyncio.wait_for(cap_reached.wait(), timeout=2)
+    await asyncio.sleep(0)
+
+    assert max_active_tasks == max_pending_tasks
+    assert active_tasks == max_pending_tasks
+
+    release_tasks.set()
+    result = await asyncio.wait_for(scheduler_task, timeout=2)
+
+    assert result is None
+    assert started_tasks == total_tasks
+    assert max_active_tasks == max_pending_tasks

--- a/tests/unit/test_dsl_scheduler_determinism.py
+++ b/tests/unit/test_dsl_scheduler_determinism.py
@@ -78,6 +78,7 @@ async def test_queue_tasks_is_deterministic() -> None:
     scheduler = DSLScheduler(
         executor=executor,
         dsl=dsl,
+        max_pending_tasks=16,
         context=ExecutionContext(ACTIONS={}, TRIGGER=None),
         role=test_role,
         run_context=test_run_context,

--- a/tests/unit/test_dsl_validation.py
+++ b/tests/unit/test_dsl_validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tracecat import config
-from tracecat.dsl.validation import (
+from tracecat.dsl.init_activities import (
     resolve_workflow_concurrency_limits_enabled_activity,
 )
 from tracecat.feature_flags import FeatureFlag

--- a/tests/unit/test_dsl_validation.py
+++ b/tests/unit/test_dsl_validation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from tracecat import config
+from tracecat.dsl.validation import (
+    resolve_workflow_concurrency_limits_enabled_activity,
+)
+from tracecat.feature_flags import FeatureFlag
+
+
+def test_resolve_workflow_concurrency_limits_enabled_activity_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__FEATURE_FLAGS",
+        {FeatureFlag.WORKFLOW_CONCURRENCY_LIMITS},
+    )
+
+    assert resolve_workflow_concurrency_limits_enabled_activity() is True
+
+
+def test_resolve_workflow_concurrency_limits_enabled_activity_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__FEATURE_FLAGS", set())
+
+    assert resolve_workflow_concurrency_limits_enabled_activity() is False

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -18,7 +18,7 @@ from tracecat.dsl.schemas import (
     TaskResult,
 )
 from tracecat.dsl.workflow import DSLWorkflow
-from tracecat.logger import logger
+from tracecat.dsl.workflow_logging import get_workflow_logger
 from tracecat.storage.object import InlineObject
 from tracecat.tiers.schemas import EffectiveLimits
 
@@ -45,7 +45,7 @@ def _build_workflow(*, limits: EffectiveLimits | None = None) -> DSLWorkflow:
         workspace_id=uuid.uuid4(),
         organization_id=uuid.uuid4(),
     )
-    workflow.logger = logger
+    workflow.logger = get_workflow_logger()
     workflow.runtime_config = DSLConfig()
     workflow._tier_limits = limits
     workflow._workflow_permit_acquired = False

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from tracecat.auth.types import Role
+from tracecat.dsl.schemas import (
+    ROOT_STREAM,
+    ActionRetryPolicy,
+    ActionStatement,
+    DSLConfig,
+    ExecutionContext,
+    TaskResult,
+)
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.logger import logger
+from tracecat.storage.object import InlineObject
+from tracecat.tiers.schemas import EffectiveLimits
+
+
+def _effective_limits(
+    *,
+    max_action_executions_per_workflow: int | None = None,
+    max_concurrent_actions: int | None = None,
+) -> EffectiveLimits:
+    return EffectiveLimits(
+        api_rate_limit=None,
+        api_burst_capacity=None,
+        max_concurrent_workflows=None,
+        max_action_executions_per_workflow=max_action_executions_per_workflow,
+        max_concurrent_actions=max_concurrent_actions,
+    )
+
+
+def _build_workflow(*, limits: EffectiveLimits | None = None) -> DSLWorkflow:
+    workflow = object.__new__(DSLWorkflow)
+    workflow.role = Role(
+        type="service",
+        service_id="tracecat-runner",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+    workflow.logger = logger
+    workflow.runtime_config = DSLConfig()
+    workflow._tier_limits = limits
+    workflow._workflow_permit_acquired = False
+    workflow._workflow_permit_heartbeat_task = None
+    workflow._action_execution_count = 0
+    context = ExecutionContext(ACTIONS={}, TRIGGER=None)
+    workflow.context = context
+    workflow.scheduler = cast(Any, SimpleNamespace(streams={ROOT_STREAM: context}))
+    return workflow
+
+
+@pytest.mark.anyio
+async def test_retry_until_counts_action_execution_limit_per_iteration() -> None:
+    workflow = _build_workflow(limits=_effective_limits(max_action_executions_per_workflow=3))
+    task = ActionStatement(
+        ref="retry_action",
+        action="core.transform.reshape",
+        retry_policy=ActionRetryPolicy(
+            retry_until="${{ ACTIONS.retry_action.result.status == 'success' }}"
+        ),
+    )
+    attempts = [
+        TaskResult.from_result({"status": "loading"}),
+        TaskResult.from_result({"status": "loading"}),
+        TaskResult.from_result({"status": "success"}),
+    ]
+
+    with (
+        patch.object(workflow, "_execute_task", new=AsyncMock(side_effect=attempts)),
+        patch.object(workflow, "_set_logical_time_context", return_value=None),
+        patch(
+            "tracecat.dsl.workflow.workflow.execute_activity",
+            new=AsyncMock(side_effect=[False, False, True]),
+        ),
+    ):
+        result = await workflow.execute_task(task)
+
+    assert result.get_data() == {"status": "success"}
+    assert workflow._action_execution_count == 3
+
+
+@pytest.mark.anyio
+async def test_retry_until_enforces_action_execution_limit() -> None:
+    workflow = _build_workflow(limits=_effective_limits(max_action_executions_per_workflow=2))
+    task = ActionStatement(
+        ref="retry_action",
+        action="core.transform.reshape",
+        retry_policy=ActionRetryPolicy(
+            retry_until="${{ ACTIONS.retry_action.result.status == 'success' }}"
+        ),
+    )
+
+    execute_task_mock = AsyncMock(
+        side_effect=[
+            TaskResult.from_result({"status": "loading"}),
+            TaskResult.from_result({"status": "loading"}),
+            TaskResult.from_result({"status": "success"}),
+        ]
+    )
+
+    with (
+        patch.object(workflow, "_execute_task", new=execute_task_mock),
+        patch.object(workflow, "_set_logical_time_context", return_value=None),
+        patch(
+            "tracecat.dsl.workflow.workflow.execute_activity",
+            new=AsyncMock(side_effect=[False, False, True]),
+        ),
+    ):
+        with pytest.raises(
+            ApplicationError,
+            match="Action execution limit exceeded",
+        ):
+            await workflow.execute_task(task)
+
+    assert execute_task_mock.await_count == 2
+    assert workflow._action_execution_count == 3
+
+
+@pytest.mark.anyio
+async def test_execute_task_handles_timers_before_action_permit_acquisition() -> None:
+    workflow = _build_workflow(limits=_effective_limits(max_concurrent_actions=1))
+    task = ActionStatement(
+        ref="delayed_action",
+        action="core.transform.reshape",
+        start_delay=30,
+    )
+    events: list[str] = []
+    acquire_mock = AsyncMock(side_effect=lambda **_: events.append("acquire"))
+
+    with (
+        patch.object(
+            workflow,
+            "_handle_timers",
+            new=AsyncMock(side_effect=lambda _: events.append("timers")),
+        ),
+        patch.object(workflow, "_action_permit_id", return_value="permit-id"),
+        patch.object(workflow, "_acquire_action_permit", new=acquire_mock),
+        patch.object(
+            workflow, "_action_permit_heartbeat_loop", new=AsyncMock(return_value=None)
+        ),
+        patch.object(
+            workflow,
+            "_run_action",
+            new=AsyncMock(return_value=InlineObject(data={"ok": True})),
+        ),
+        patch.object(workflow, "_release_action_permit", new=AsyncMock(return_value=None)),
+    ):
+        result = await workflow._execute_task(task)
+
+    assert events[:2] == ["timers", "acquire"]
+    assert acquire_mock.await_count == 1
+    assert result.get_data() == {"ok": True}

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -59,7 +59,9 @@ def _build_workflow(*, limits: EffectiveLimits | None = None) -> DSLWorkflow:
 
 @pytest.mark.anyio
 async def test_retry_until_counts_action_execution_limit_per_iteration() -> None:
-    workflow = _build_workflow(limits=_effective_limits(max_action_executions_per_workflow=3))
+    workflow = _build_workflow(
+        limits=_effective_limits(max_action_executions_per_workflow=3)
+    )
     task = ActionStatement(
         ref="retry_action",
         action="core.transform.reshape",
@@ -89,7 +91,9 @@ async def test_retry_until_counts_action_execution_limit_per_iteration() -> None
 
 @pytest.mark.anyio
 async def test_retry_until_enforces_action_execution_limit() -> None:
-    workflow = _build_workflow(limits=_effective_limits(max_action_executions_per_workflow=2))
+    workflow = _build_workflow(
+        limits=_effective_limits(max_action_executions_per_workflow=2)
+    )
     task = ActionStatement(
         ref="retry_action",
         action="core.transform.reshape",
@@ -151,7 +155,9 @@ async def test_execute_task_handles_timers_before_action_permit_acquisition() ->
             "_run_action",
             new=AsyncMock(return_value=InlineObject(data={"ok": True})),
         ),
-        patch.object(workflow, "_release_action_permit", new=AsyncMock(return_value=None)),
+        patch.object(
+            workflow, "_release_action_permit", new=AsyncMock(return_value=None)
+        ),
     ):
         result = await workflow._execute_task(task)
 

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -53,6 +53,8 @@ def _build_workflow(*, limits: EffectiveLimits | None = None) -> DSLWorkflow:
         workspace_id=uuid.uuid4(),
         organization_id=uuid.uuid4(),
     )
+    assert workflow.role.organization_id is not None
+    workflow.organization_id = workflow.role.organization_id
     workflow.logger = get_workflow_logger()
     workflow.runtime_config = DSLConfig()
     workflow._tier_limits = limits

--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -184,6 +184,59 @@ async def test_execute_task_handles_timers_before_action_permit_acquisition() ->
     assert result.get_data() == {"ok": True}
 
 
+@pytest.mark.anyio
+async def test_execute_task_releases_action_permit_when_cancelled_during_heartbeat_stop() -> (
+    None
+):
+    workflow = _build_workflow(limits=_effective_limits(max_concurrent_actions=1))
+    task = ActionStatement(ref="limited_action", action="core.transform.reshape")
+    gather_started = asyncio.Event()
+    unblock_gather = asyncio.Event()
+    release_mock = AsyncMock(return_value=None)
+    original_gather = asyncio.gather
+
+    async def heartbeat_loop(*, action_id: str) -> None:
+        del action_id
+        await asyncio.sleep(3600)
+
+    async def delayed_gather(*args: Any, **kwargs: Any) -> list[Any]:
+        gather_started.set()
+        await unblock_gather.wait()
+        return cast(list[Any], await original_gather(*args, **kwargs))
+
+    with (
+        patch.object(workflow, "_handle_timers", new=AsyncMock(return_value=None)),
+        patch.object(workflow, "_action_permit_id", return_value="permit-id"),
+        patch.object(
+            workflow, "_acquire_action_permit", new=AsyncMock(return_value=None)
+        ),
+        patch.object(
+            workflow,
+            "_action_permit_heartbeat_loop",
+            new=heartbeat_loop,
+        ),
+        patch.object(
+            workflow,
+            "_run_action",
+            new=AsyncMock(return_value=InlineObject(data={"ok": True})),
+        ),
+        patch.object(workflow, "_release_action_permit", new=release_mock),
+        patch("tracecat.dsl.workflow.asyncio.gather", new=delayed_gather),
+    ):
+
+        async def run_execute_task() -> TaskResult:
+            return await workflow._execute_task(task)
+
+        execute_task = asyncio.create_task(run_execute_task())
+        await gather_started.wait()
+        execute_task.cancel()
+        unblock_gather.set()
+        result = await execute_task
+
+    assert result.get_data() == {"ok": True}
+    release_mock.assert_awaited_once_with(action_id="permit-id")
+
+
 def test_resolve_child_loop_batch_plan_applies_dispatch_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_rate_limits.py
+++ b/tests/unit/test_rate_limits.py
@@ -41,8 +41,12 @@ def client(app: FastAPI) -> TestClient:
 class TestRateLimitIntegration:
     """Integration tests for the rate limiting middleware."""
 
-    def test_rate_limit_single_endpoint(self, client: TestClient):
+    def test_rate_limit_single_endpoint(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test that requests to a single endpoint are rate limited."""
+        monkeypatch.setattr("time.time", lambda: 0.0)
+
         # First 3 requests should succeed (capacity = 3)
         for _ in range(3):
             response = client.get("/test")
@@ -54,8 +58,12 @@ class TestRateLimitIntegration:
         assert response.status_code == HTTP_429_TOO_MANY_REQUESTS
         assert response.text == "Rate limit exceeded. Please try again later."
 
-    def test_rate_limit_different_endpoints(self, client: TestClient):
+    def test_rate_limit_different_endpoints(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test that rate limiting works across different endpoints when by_endpoint=True."""
+        monkeypatch.setattr("time.time", lambda: 0.0)
+
         # First 2 requests to /test should succeed
         for _ in range(2):
             response = client.get("/test")
@@ -113,8 +121,10 @@ class TestRateLimitIntegration:
         response = client.get("/test")
         assert response.status_code == HTTP_429_TOO_MANY_REQUESTS
 
-    def test_rate_limit_by_ip(self):
+    def test_rate_limit_by_ip(self, monkeypatch: pytest.MonkeyPatch):
         """Test that rate limiting works by IP address."""
+        monkeypatch.setattr("time.time", lambda: 0.0)
+
         # Create a new app with rate limiting by IP only
         app = FastAPI()
 

--- a/tests/unit/test_tier_activities.py
+++ b/tests/unit/test_tier_activities.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -15,129 +13,66 @@ from tracecat.tiers.activities import (
     acquire_action_permit_activity,
     acquire_workflow_permit_activity,
 )
-from tracecat.tiers.schemas import EffectiveLimits
+from tracecat.tiers.exceptions import InvalidOrganizationConcurrencyCapError
+from tracecat.tiers.permits import PermitAcquireOutcome
 from tracecat.tiers.semaphore import AcquireResult
 
 ORG_ID = uuid.UUID("00000000-0000-4000-8000-000000000111")
 
 
-def _limits(
-    *,
-    max_concurrent_workflows: int | None = None,
-    max_concurrent_actions: int | None = None,
-) -> EffectiveLimits:
-    return EffectiveLimits(
-        api_rate_limit=None,
-        api_burst_capacity=None,
-        max_concurrent_workflows=max_concurrent_workflows,
-        max_action_executions_per_workflow=None,
-        max_concurrent_actions=max_concurrent_actions,
-    )
-
-
 @pytest.mark.anyio
-async def test_acquire_action_permit_activity_uses_cached_effective_limit() -> None:
-    semaphore = SimpleNamespace(
-        acquire_action=AsyncMock(
-            return_value=AcquireResult(acquired=True, current_count=1)
+async def test_acquire_action_permit_activity_uses_permit_service() -> None:
+    permit_svc = SimpleNamespace(
+        acquire_action_permit=AsyncMock(
+            return_value=PermitAcquireOutcome(
+                result=AcquireResult(acquired=True, current_count=1),
+                effective_limit=2,
+                cap_source="cache",
+            )
         )
     )
-    redis_wrapper = SimpleNamespace(_get_client=AsyncMock(return_value=object()))
 
-    @asynccontextmanager
-    async def _unexpected_session_context() -> AsyncIterator[object]:
-        raise AssertionError("DB lookup should not run when cache has limits")
-        yield
-
-    with (
-        patch(
-            "tracecat.tiers.activities.get_effective_limits_cached",
-            new=AsyncMock(return_value=_limits(max_concurrent_actions=2)),
-        ),
-        patch(
-            "tracecat.tiers.activities.set_effective_limits_cached",
-            new=AsyncMock(),
-        ),
-        patch(
-            "tracecat.tiers.activities.get_async_session_context_manager",
-            new=_unexpected_session_context,
-        ),
-        patch("tracecat.tiers.activities.RedisSemaphore", return_value=semaphore),
-        patch(
-            "tracecat.tiers.activities.get_redis_client",
-            new=AsyncMock(return_value=redis_wrapper),
-        ),
+    with patch(
+        "tracecat.tiers.activities.TierPermitService.create",
+        new=AsyncMock(return_value=permit_svc),
     ):
         result = await acquire_action_permit_activity(
             AcquireActionPermitInput(org_id=ORG_ID, action_id="wf:root:task", limit=99)
         )
 
     assert result.acquired is True
-    semaphore.acquire_action.assert_awaited_once()
-    assert semaphore.acquire_action.await_args.kwargs["limit"] == 2
+    permit_svc.acquire_action_permit.assert_awaited_once_with(
+        org_id=ORG_ID,
+        action_id="wf:root:task",
+    )
 
 
 @pytest.mark.anyio
-async def test_acquire_workflow_permit_activity_populates_cache_on_miss() -> None:
-    expected_limits = _limits(max_concurrent_workflows=3)
-    semaphore = SimpleNamespace(
-        acquire_workflow=AsyncMock(
-            return_value=AcquireResult(acquired=True, current_count=1)
+async def test_acquire_workflow_permit_activity_maps_invalid_cap_error() -> None:
+    permit_svc = SimpleNamespace(
+        acquire_workflow_permit=AsyncMock(
+            side_effect=InvalidOrganizationConcurrencyCapError(
+                scope="workflow",
+                org_id=ORG_ID,
+                limit=0,
+            )
         )
     )
-    redis_wrapper = SimpleNamespace(_get_client=AsyncMock(return_value=object()))
-    tier_service = SimpleNamespace(
-        get_effective_limits=AsyncMock(return_value=expected_limits)
-    )
 
-    @asynccontextmanager
-    async def _session_context() -> AsyncIterator[object]:
-        yield object()
-
-    with (
-        patch(
-            "tracecat.tiers.activities.get_effective_limits_cached",
-            new=AsyncMock(return_value=None),
-        ),
-        patch(
-            "tracecat.tiers.activities.set_effective_limits_cached",
-            new=AsyncMock(),
-        ) as set_cache_mock,
-        patch(
-            "tracecat.tiers.activities.get_async_session_context_manager",
-            new=_session_context,
-        ),
-        patch("tracecat.tiers.activities.TierService", return_value=tier_service),
-        patch("tracecat.tiers.activities.RedisSemaphore", return_value=semaphore),
-        patch(
-            "tracecat.tiers.activities.get_redis_client",
-            new=AsyncMock(return_value=redis_wrapper),
-        ),
-    ):
-        result = await acquire_workflow_permit_activity(
-            AcquireWorkflowPermitInput(org_id=ORG_ID, workflow_id="wf-exec", limit=99)
-        )
-
-    assert result.acquired is True
-    tier_service.get_effective_limits.assert_awaited_once_with(ORG_ID)
-    set_cache_mock.assert_awaited_once_with(ORG_ID, expected_limits)
-    semaphore.acquire_workflow.assert_awaited_once()
-    assert semaphore.acquire_workflow.await_args.kwargs["limit"] == 3
-
-
-@pytest.mark.anyio
-async def test_acquire_action_permit_activity_rejects_non_positive_cap() -> None:
     with patch(
-        "tracecat.tiers.activities.get_effective_limits_cached",
-        new=AsyncMock(return_value=_limits(max_concurrent_actions=0)),
+        "tracecat.tiers.activities.TierPermitService.create",
+        new=AsyncMock(return_value=permit_svc),
     ):
         with pytest.raises(
-            ApplicationError, match="Invalid organization concurrency cap"
-        ):
-            await acquire_action_permit_activity(
-                AcquireActionPermitInput(
+            ApplicationError,
+            match="Invalid organization concurrency cap",
+        ) as exc_info:
+            await acquire_workflow_permit_activity(
+                AcquireWorkflowPermitInput(
                     org_id=ORG_ID,
-                    action_id="wf:root:task",
-                    limit=1,
+                    workflow_id="wf-exec",
+                    limit=99,
                 )
             )
+
+    assert exc_info.value.type == "InvalidOrganizationConcurrencyCap"

--- a/tests/unit/test_tier_activities.py
+++ b/tests/unit/test_tier_activities.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from tracecat.tiers.activities import (
+    AcquireActionPermitInput,
+    AcquireWorkflowPermitInput,
+    acquire_action_permit_activity,
+    acquire_workflow_permit_activity,
+)
+from tracecat.tiers.schemas import EffectiveLimits
+from tracecat.tiers.semaphore import AcquireResult
+
+ORG_ID = uuid.UUID("00000000-0000-4000-8000-000000000111")
+
+
+def _limits(
+    *,
+    max_concurrent_workflows: int | None = None,
+    max_concurrent_actions: int | None = None,
+) -> EffectiveLimits:
+    return EffectiveLimits(
+        api_rate_limit=None,
+        api_burst_capacity=None,
+        max_concurrent_workflows=max_concurrent_workflows,
+        max_action_executions_per_workflow=None,
+        max_concurrent_actions=max_concurrent_actions,
+    )
+
+
+@pytest.mark.anyio
+async def test_acquire_action_permit_activity_uses_cached_effective_limit() -> None:
+    semaphore = SimpleNamespace(
+        acquire_action=AsyncMock(
+            return_value=AcquireResult(acquired=True, current_count=1)
+        )
+    )
+    redis_wrapper = SimpleNamespace(_get_client=AsyncMock(return_value=object()))
+
+    @asynccontextmanager
+    async def _unexpected_session_context() -> AsyncIterator[object]:
+        raise AssertionError("DB lookup should not run when cache has limits")
+        yield
+
+    with (
+        patch(
+            "tracecat.tiers.activities.get_effective_limits_cached",
+            new=AsyncMock(return_value=_limits(max_concurrent_actions=2)),
+        ),
+        patch(
+            "tracecat.tiers.activities.set_effective_limits_cached",
+            new=AsyncMock(),
+        ),
+        patch(
+            "tracecat.tiers.activities.get_async_session_context_manager",
+            new=_unexpected_session_context,
+        ),
+        patch("tracecat.tiers.activities.RedisSemaphore", return_value=semaphore),
+        patch(
+            "tracecat.tiers.activities.get_redis_client",
+            new=AsyncMock(return_value=redis_wrapper),
+        ),
+    ):
+        result = await acquire_action_permit_activity(
+            AcquireActionPermitInput(org_id=ORG_ID, action_id="wf:root:task", limit=99)
+        )
+
+    assert result.acquired is True
+    semaphore.acquire_action.assert_awaited_once()
+    assert semaphore.acquire_action.await_args.kwargs["limit"] == 2
+
+
+@pytest.mark.anyio
+async def test_acquire_workflow_permit_activity_populates_cache_on_miss() -> None:
+    expected_limits = _limits(max_concurrent_workflows=3)
+    semaphore = SimpleNamespace(
+        acquire_workflow=AsyncMock(
+            return_value=AcquireResult(acquired=True, current_count=1)
+        )
+    )
+    redis_wrapper = SimpleNamespace(_get_client=AsyncMock(return_value=object()))
+    tier_service = SimpleNamespace(
+        get_effective_limits=AsyncMock(return_value=expected_limits)
+    )
+
+    @asynccontextmanager
+    async def _session_context() -> AsyncIterator[object]:
+        yield object()
+
+    with (
+        patch(
+            "tracecat.tiers.activities.get_effective_limits_cached",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "tracecat.tiers.activities.set_effective_limits_cached",
+            new=AsyncMock(),
+        ) as set_cache_mock,
+        patch(
+            "tracecat.tiers.activities.get_async_session_context_manager",
+            new=_session_context,
+        ),
+        patch("tracecat.tiers.activities.TierService", return_value=tier_service),
+        patch("tracecat.tiers.activities.RedisSemaphore", return_value=semaphore),
+        patch(
+            "tracecat.tiers.activities.get_redis_client",
+            new=AsyncMock(return_value=redis_wrapper),
+        ),
+    ):
+        result = await acquire_workflow_permit_activity(
+            AcquireWorkflowPermitInput(org_id=ORG_ID, workflow_id="wf-exec", limit=99)
+        )
+
+    assert result.acquired is True
+    tier_service.get_effective_limits.assert_awaited_once_with(ORG_ID)
+    set_cache_mock.assert_awaited_once_with(ORG_ID, expected_limits)
+    semaphore.acquire_workflow.assert_awaited_once()
+    assert semaphore.acquire_workflow.await_args.kwargs["limit"] == 3
+
+
+@pytest.mark.anyio
+async def test_acquire_action_permit_activity_rejects_non_positive_cap() -> None:
+    with patch(
+        "tracecat.tiers.activities.get_effective_limits_cached",
+        new=AsyncMock(return_value=_limits(max_concurrent_actions=0)),
+    ):
+        with pytest.raises(
+            ApplicationError, match="Invalid organization concurrency cap"
+        ):
+            await acquire_action_permit_activity(
+                AcquireActionPermitInput(
+                    org_id=ORG_ID,
+                    action_id="wf:root:task",
+                    limit=1,
+                )
+            )

--- a/tests/unit/test_tier_limits_cache.py
+++ b/tests/unit/test_tier_limits_cache.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tracecat import config
+from tracecat.tiers.limits_cache import (
+    effective_limits_cache_key,
+    get_effective_limits_cached,
+    invalidate_effective_limits_cache_many,
+    set_effective_limits_cached,
+)
+from tracecat.tiers.schemas import EffectiveLimits
+
+
+class _FakeRedisClient:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.deleted_keys: list[str] = []
+
+    async def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            if key in self.values:
+                removed += 1
+                del self.values[key]
+            self.deleted_keys.append(key)
+        return removed
+
+
+class _FakeRedisWrapper:
+    def __init__(self, client: _FakeRedisClient) -> None:
+        self._client = client
+        self.set_calls: list[tuple[str, str, int | None]] = []
+
+    async def _get_client(self) -> _FakeRedisClient:
+        return self._client
+
+    async def set(
+        self, key: str, value: str, *, expire_seconds: int | None = None
+    ) -> bool:
+        self._client.values[key] = value
+        self.set_calls.append((key, value, expire_seconds))
+        return True
+
+
+def _limits(
+    *, workflows: int | None = None, actions: int | None = None
+) -> EffectiveLimits:
+    return EffectiveLimits(
+        api_rate_limit=None,
+        api_burst_capacity=None,
+        max_concurrent_workflows=workflows,
+        max_action_executions_per_workflow=None,
+        max_concurrent_actions=actions,
+    )
+
+
+@pytest.mark.anyio
+async def test_effective_limits_cache_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    client = _FakeRedisClient()
+    wrapper = _FakeRedisWrapper(client)
+    monkeypatch.setattr(config, "TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS", 30)
+    monkeypatch.setattr(
+        "tracecat.tiers.limits_cache.get_redis_client",
+        AsyncMock(return_value=wrapper),
+    )
+
+    limits = _limits(workflows=3, actions=2)
+    await set_effective_limits_cached(org_id, limits)
+    cached = await get_effective_limits_cached(org_id)
+
+    assert cached == limits
+    assert wrapper.set_calls[0][0] == effective_limits_cache_key(org_id)
+    assert wrapper.set_calls[0][2] == 30
+
+    await invalidate_effective_limits_cache_many([org_id])
+    assert await get_effective_limits_cached(org_id) is None
+
+
+@pytest.mark.anyio
+async def test_effective_limits_cache_drops_invalid_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    client = _FakeRedisClient()
+    wrapper = _FakeRedisWrapper(client)
+    key = effective_limits_cache_key(org_id)
+    client.values[key] = "{invalid-json"
+    monkeypatch.setattr(config, "TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS", 30)
+    monkeypatch.setattr(
+        "tracecat.tiers.limits_cache.get_redis_client",
+        AsyncMock(return_value=wrapper),
+    )
+
+    cached = await get_effective_limits_cached(org_id)
+
+    assert cached is None
+    assert key in client.deleted_keys
+
+
+@pytest.mark.anyio
+async def test_effective_limits_cache_respects_disabled_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    client = _FakeRedisClient()
+    wrapper = _FakeRedisWrapper(client)
+    monkeypatch.setattr(config, "TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS", 0)
+    monkeypatch.setattr(
+        "tracecat.tiers.limits_cache.get_redis_client",
+        AsyncMock(return_value=wrapper),
+    )
+
+    await set_effective_limits_cached(org_id, _limits(actions=5))
+
+    assert wrapper.set_calls == []
+    assert await get_effective_limits_cached(org_id) is None

--- a/tests/unit/test_tier_permits.py
+++ b/tests/unit/test_tier_permits.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tracecat.tiers.exceptions import InvalidOrganizationConcurrencyCapError
+from tracecat.tiers.permits import TierPermitService
+from tracecat.tiers.schemas import EffectiveLimits
+from tracecat.tiers.semaphore import AcquireResult, RedisSemaphore
+
+ORG_ID = uuid.UUID("00000000-0000-4000-8000-000000000111")
+
+
+def _limits(
+    *,
+    max_concurrent_workflows: int | None = None,
+    max_concurrent_actions: int | None = None,
+) -> EffectiveLimits:
+    return EffectiveLimits(
+        api_rate_limit=None,
+        api_burst_capacity=None,
+        max_concurrent_workflows=max_concurrent_workflows,
+        max_action_executions_per_workflow=None,
+        max_concurrent_actions=max_concurrent_actions,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_effective_limits_for_org_uses_cache() -> None:
+    permit_svc = TierPermitService(cast(RedisSemaphore, SimpleNamespace()))
+    expected_limits = _limits(max_concurrent_actions=2)
+
+    @asynccontextmanager
+    async def _unexpected_session_context() -> AsyncIterator[object]:
+        raise AssertionError("DB lookup should not run when cache has limits")
+        yield
+
+    with (
+        patch(
+            "tracecat.tiers.permits.get_effective_limits_cached",
+            new=AsyncMock(return_value=expected_limits),
+        ),
+        patch(
+            "tracecat.tiers.permits.set_effective_limits_cached",
+            new=AsyncMock(),
+        ),
+        patch(
+            "tracecat.tiers.permits.get_async_session_context_manager",
+            new=_unexpected_session_context,
+        ),
+    ):
+        limits, source = await permit_svc.get_effective_limits_for_org(ORG_ID)
+
+    assert limits == expected_limits
+    assert source == "cache"
+
+
+@pytest.mark.anyio
+async def test_get_effective_limits_for_org_populates_cache_on_miss() -> None:
+    permit_svc = TierPermitService(cast(RedisSemaphore, SimpleNamespace()))
+    expected_limits = _limits(max_concurrent_workflows=3)
+    tier_service = SimpleNamespace(
+        get_effective_limits=AsyncMock(return_value=expected_limits)
+    )
+
+    @asynccontextmanager
+    async def _session_context() -> AsyncIterator[object]:
+        yield object()
+
+    with (
+        patch(
+            "tracecat.tiers.permits.get_effective_limits_cached",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "tracecat.tiers.permits.set_effective_limits_cached",
+            new=AsyncMock(),
+        ) as set_cache_mock,
+        patch(
+            "tracecat.tiers.permits.get_async_session_context_manager",
+            new=_session_context,
+        ),
+        patch("tracecat.tiers.permits.TierService", return_value=tier_service),
+    ):
+        limits, source = await permit_svc.get_effective_limits_for_org(ORG_ID)
+
+    assert limits == expected_limits
+    assert source == "db"
+    tier_service.get_effective_limits.assert_awaited_once_with(ORG_ID)
+    set_cache_mock.assert_awaited_once_with(ORG_ID, expected_limits)
+
+
+@pytest.mark.anyio
+async def test_acquire_action_permit_uses_effective_limit() -> None:
+    semaphore = SimpleNamespace(
+        acquire_action=AsyncMock(
+            return_value=AcquireResult(acquired=True, current_count=1)
+        )
+    )
+    permit_svc = TierPermitService(cast(RedisSemaphore, semaphore))
+
+    @asynccontextmanager
+    async def _unexpected_session_context() -> AsyncIterator[object]:
+        raise AssertionError("DB lookup should not run when cache has limits")
+        yield
+
+    with (
+        patch(
+            "tracecat.tiers.permits.get_effective_limits_cached",
+            new=AsyncMock(return_value=_limits(max_concurrent_actions=2)),
+        ),
+        patch(
+            "tracecat.tiers.permits.set_effective_limits_cached",
+            new=AsyncMock(),
+        ),
+        patch(
+            "tracecat.tiers.permits.get_async_session_context_manager",
+            new=_unexpected_session_context,
+        ),
+    ):
+        outcome = await permit_svc.acquire_action_permit(
+            org_id=ORG_ID,
+            action_id="wf:root:task",
+        )
+
+    assert outcome.result.acquired is True
+    assert outcome.effective_limit == 2
+    assert outcome.cap_source == "cache"
+    semaphore.acquire_action.assert_awaited_once_with(
+        org_id=ORG_ID,
+        action_id="wf:root:task",
+        limit=2,
+    )
+
+
+def test_normalize_concurrency_limit_rejects_non_positive_cap() -> None:
+    with pytest.raises(InvalidOrganizationConcurrencyCapError):
+        TierPermitService.normalize_concurrency_limit(
+            limit=0,
+            org_id=ORG_ID,
+            scope="workflow",
+        )

--- a/tests/unit/test_tiers_semaphore.py
+++ b/tests/unit/test_tiers_semaphore.py
@@ -79,7 +79,10 @@ async def test_semaphore_uses_distinct_scope_keys_for_release_and_heartbeat() ->
         action_id="wf-123:root:step",
     )
 
-    assert client.zrem.await_args_list[0].args == ("tier:org:org-123:semaphore", "wf-123")
+    assert client.zrem.await_args_list[0].args == (
+        "tier:org:org-123:semaphore",
+        "wf-123",
+    )
     assert client.zrem.await_args_list[1].args == (
         "tier:org:org-123:action-semaphore",
         "wf-123:root:step",

--- a/tests/unit/test_tiers_semaphore.py
+++ b/tests/unit/test_tiers_semaphore.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tracecat.tiers.activities import (
+    TierActivities,
+    acquire_action_permit_activity,
+    heartbeat_action_permit_activity,
+    release_action_permit_activity,
+)
+from tracecat.tiers.semaphore import RedisSemaphore
+
+
+class _ScriptRecorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], list[object]]] = []
+
+    async def __call__(self, *, keys: list[str], args: list[object]) -> list[int]:
+        self.calls.append((keys, args))
+        return [1, 1]
+
+
+class _FakeRedisClient:
+    def __init__(self, script: _ScriptRecorder) -> None:
+        self._script = script
+        self.zrem = AsyncMock(return_value=1)
+        self.zadd = AsyncMock(return_value=1)
+        self.zremrangebyscore = AsyncMock(return_value=0)
+        self.zcard = AsyncMock(return_value=0)
+
+    def register_script(self, _: str) -> Callable[..., object]:
+        return self._script
+
+
+@pytest.mark.anyio
+async def test_semaphore_uses_distinct_scope_keys_for_acquire() -> None:
+    script = _ScriptRecorder()
+    client = _FakeRedisClient(script)
+    semaphore = RedisSemaphore(client)  # type: ignore[arg-type]
+
+    await semaphore.acquire_workflow(
+        org_id="org-123",  # type: ignore[arg-type]
+        workflow_id="wf-123",
+        limit=3,
+    )
+    await semaphore.acquire_action(
+        org_id="org-123",  # type: ignore[arg-type]
+        action_id="wf-123:root:step",
+        limit=5,
+    )
+
+    assert script.calls[0][0] == ["tier:org:org-123:semaphore"]
+    assert script.calls[1][0] == ["tier:org:org-123:action-semaphore"]
+
+
+@pytest.mark.anyio
+async def test_semaphore_uses_distinct_scope_keys_for_release_and_heartbeat() -> None:
+    script = _ScriptRecorder()
+    client = _FakeRedisClient(script)
+    semaphore = RedisSemaphore(client)  # type: ignore[arg-type]
+
+    await semaphore.release_workflow(
+        org_id="org-123",  # type: ignore[arg-type]
+        workflow_id="wf-123",
+    )
+    await semaphore.release_action(
+        org_id="org-123",  # type: ignore[arg-type]
+        action_id="wf-123:root:step",
+    )
+    await semaphore.heartbeat_workflow(
+        org_id="org-123",  # type: ignore[arg-type]
+        workflow_id="wf-123",
+    )
+    await semaphore.heartbeat_action(
+        org_id="org-123",  # type: ignore[arg-type]
+        action_id="wf-123:root:step",
+    )
+
+    assert client.zrem.await_args_list[0].args == ("tier:org:org-123:semaphore", "wf-123")
+    assert client.zrem.await_args_list[1].args == (
+        "tier:org:org-123:action-semaphore",
+        "wf-123:root:step",
+    )
+    assert client.zadd.await_args_list[0].args[0] == "tier:org:org-123:semaphore"
+    assert client.zadd.await_args_list[1].args[0] == "tier:org:org-123:action-semaphore"
+
+
+def test_tier_activities_include_action_permit_activities() -> None:
+    activities = TierActivities.get_activities()
+    assert acquire_action_permit_activity in activities
+    assert release_action_permit_activity in activities
+    assert heartbeat_action_permit_activity in activities

--- a/tests/unit/test_tiers_semaphore.py
+++ b/tests/unit/test_tiers_semaphore.py
@@ -49,9 +49,7 @@ class _FakeRedisClient:
         self.acquire_calls.append((keys, args))
         return self._acquire_result
 
-    async def _heartbeat_script(
-        self, *, keys: list[str], args: list[str | int]
-    ) -> int:
+    async def _heartbeat_script(self, *, keys: list[str], args: list[str | int]) -> int:
         self.heartbeat_calls.append((keys, args))
         return self._heartbeat_result
 

--- a/tests/unit/test_tiers_semaphore.py
+++ b/tests/unit/test_tiers_semaphore.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
+import redis.asyncio as redis
 
 from tracecat.tiers.activities import (
     TierActivities,
@@ -13,82 +16,118 @@ from tracecat.tiers.activities import (
 )
 from tracecat.tiers.semaphore import RedisSemaphore
 
+ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000123")
 
-class _ScriptRecorder:
-    def __init__(self) -> None:
-        self.calls: list[tuple[list[str], list[object]]] = []
-
-    async def __call__(self, *, keys: list[str], args: list[object]) -> list[int]:
-        self.calls.append((keys, args))
-        return [1, 1]
+# Callable returned by register_script: takes keys= and args=, returns awaitable.
+_ScriptCallable = Callable[..., Awaitable[list[int] | int]]
 
 
 class _FakeRedisClient:
-    def __init__(self, script: _ScriptRecorder) -> None:
-        self._script = script
+    def __init__(
+        self,
+        *,
+        acquire_result: list[int] | None = None,
+        heartbeat_result: int = 1,
+    ) -> None:
+        self._acquire_result = acquire_result or [1, 1]
+        self._heartbeat_result = heartbeat_result
+        self.acquire_calls: list[tuple[list[str], list[str | int]]] = []
+        self.heartbeat_calls: list[tuple[list[str], list[str | int]]] = []
         self.zrem = AsyncMock(return_value=1)
-        self.zadd = AsyncMock(return_value=1)
         self.zremrangebyscore = AsyncMock(return_value=0)
         self.zcard = AsyncMock(return_value=0)
 
-    def register_script(self, _: str) -> Callable[..., object]:
-        return self._script
+    def register_script(self, script: str) -> _ScriptCallable:
+        """Return a callable that mimics AsyncScript for acquire or heartbeat."""
+        if "ZREMRANGEBYSCORE" in script:
+            return self._acquire_script
+        return self._heartbeat_script
+
+    async def _acquire_script(
+        self, *, keys: list[str], args: list[str | int]
+    ) -> list[int]:
+        self.acquire_calls.append((keys, args))
+        return self._acquire_result
+
+    async def _heartbeat_script(
+        self, *, keys: list[str], args: list[str | int]
+    ) -> int:
+        self.heartbeat_calls.append((keys, args))
+        return self._heartbeat_result
 
 
 @pytest.mark.anyio
 async def test_semaphore_uses_distinct_scope_keys_for_acquire() -> None:
-    script = _ScriptRecorder()
-    client = _FakeRedisClient(script)
-    semaphore = RedisSemaphore(client)  # type: ignore[arg-type]
+    client = _FakeRedisClient()
+    semaphore = RedisSemaphore(cast(redis.Redis, client))
 
     await semaphore.acquire_workflow(
-        org_id="org-123",  # type: ignore[arg-type]
+        org_id=ORG_ID,
         workflow_id="wf-123",
         limit=3,
     )
     await semaphore.acquire_action(
-        org_id="org-123",  # type: ignore[arg-type]
+        org_id=ORG_ID,
         action_id="wf-123:root:step",
         limit=5,
     )
 
-    assert script.calls[0][0] == ["tier:org:org-123:semaphore"]
-    assert script.calls[1][0] == ["tier:org:org-123:action-semaphore"]
+    assert client.acquire_calls[0][0] == [f"tier:org:{ORG_ID}:semaphore"]
+    assert client.acquire_calls[1][0] == [f"tier:org:{ORG_ID}:action-semaphore"]
 
 
 @pytest.mark.anyio
 async def test_semaphore_uses_distinct_scope_keys_for_release_and_heartbeat() -> None:
-    script = _ScriptRecorder()
-    client = _FakeRedisClient(script)
-    semaphore = RedisSemaphore(client)  # type: ignore[arg-type]
+    client = _FakeRedisClient()
+    semaphore = RedisSemaphore(cast(redis.Redis, client))
 
     await semaphore.release_workflow(
-        org_id="org-123",  # type: ignore[arg-type]
+        org_id=ORG_ID,
         workflow_id="wf-123",
     )
     await semaphore.release_action(
-        org_id="org-123",  # type: ignore[arg-type]
+        org_id=ORG_ID,
         action_id="wf-123:root:step",
     )
     await semaphore.heartbeat_workflow(
-        org_id="org-123",  # type: ignore[arg-type]
+        org_id=ORG_ID,
         workflow_id="wf-123",
     )
     await semaphore.heartbeat_action(
-        org_id="org-123",  # type: ignore[arg-type]
+        org_id=ORG_ID,
         action_id="wf-123:root:step",
     )
 
     assert client.zrem.await_args_list[0].args == (
-        "tier:org:org-123:semaphore",
+        f"tier:org:{ORG_ID}:semaphore",
         "wf-123",
     )
     assert client.zrem.await_args_list[1].args == (
-        "tier:org:org-123:action-semaphore",
+        f"tier:org:{ORG_ID}:action-semaphore",
         "wf-123:root:step",
     )
-    assert client.zadd.await_args_list[0].args[0] == "tier:org:org-123:semaphore"
-    assert client.zadd.await_args_list[1].args[0] == "tier:org:org-123:action-semaphore"
+    assert client.heartbeat_calls[0][0] == [f"tier:org:{ORG_ID}:semaphore"]
+    assert client.heartbeat_calls[1][0] == [f"tier:org:{ORG_ID}:action-semaphore"]
+
+
+@pytest.mark.anyio
+async def test_heartbeat_returns_true_when_permit_exists() -> None:
+    client = _FakeRedisClient(heartbeat_result=1)
+    semaphore = RedisSemaphore(cast(redis.Redis, client))
+
+    refreshed = await semaphore.heartbeat_workflow(org_id=ORG_ID, workflow_id="wf-123")
+
+    assert refreshed is True
+
+
+@pytest.mark.anyio
+async def test_heartbeat_returns_false_when_permit_missing() -> None:
+    client = _FakeRedisClient(heartbeat_result=0)
+    semaphore = RedisSemaphore(cast(redis.Redis, client))
+
+    refreshed = await semaphore.heartbeat_workflow(org_id=ORG_ID, workflow_id="wf-123")
+
+    assert refreshed is False
 
 
 def test_tier_activities_include_action_permit_activities() -> None:

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -58,6 +58,9 @@ TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS = float(
 )
 """Interval in seconds between workflow permit heartbeat refreshes."""
 
+TRACECAT__PERMIT_TTL_SECONDS = int(os.environ.get("TRACECAT__PERMIT_TTL_SECONDS", 300))
+"""TTL in seconds for workflow/action concurrency permits before stale pruning."""
+
 TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS = int(
     os.environ.get("TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS", 120)
 )

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -29,7 +29,7 @@ TRACECAT__LOOP_MAX_BATCH_SIZE = int(
 """Maximum number of parallel requests to the worker service."""
 
 TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS = int(
-    os.environ.get("TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS") or 16
+    os.environ.get("TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS") or 128
 )
 """Maximum number of scheduler task coroutines allowed in-flight."""
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -44,17 +44,17 @@ TRACECAT__WORKFLOW_PERMIT_MAX_WAIT_SECONDS = int(
 """Maximum seconds to wait for a workflow concurrency permit before failing."""
 
 TRACECAT__WORKFLOW_PERMIT_BACKOFF_BASE_SECONDS = float(
-    os.environ.get("TRACECAT__WORKFLOW_PERMIT_BACKOFF_BASE_SECONDS", 1)
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_BACKOFF_BASE_SECONDS") or 1
 )
 """Base backoff in seconds when retrying workflow permit acquisition."""
 
 TRACECAT__WORKFLOW_PERMIT_BACKOFF_MAX_SECONDS = float(
-    os.environ.get("TRACECAT__WORKFLOW_PERMIT_BACKOFF_MAX_SECONDS", 30)
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_BACKOFF_MAX_SECONDS") or 30
 )
 """Maximum backoff in seconds when retrying workflow permit acquisition."""
 
 TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS = float(
-    os.environ.get("TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS", 60)
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS") or 60
 )
 """Interval in seconds between workflow permit heartbeat refreshes."""
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -63,6 +63,11 @@ TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS = int(
 )
 """Maximum seconds to wait for an action concurrency permit before failing."""
 
+TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS = int(
+    os.environ.get("TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS", 30)
+)
+"""TTL in seconds for cached per-organization effective tier limits."""
+
 TRACECAT__EXECUTOR_QUEUE = os.environ.get(
     "TRACECAT__EXECUTOR_QUEUE", "shared-action-queue"
 )

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -29,7 +29,7 @@ TRACECAT__LOOP_MAX_BATCH_SIZE = int(
 """Maximum number of parallel requests to the worker service."""
 
 TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS = int(
-    os.environ.get("TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS") or 128
+    os.environ.get("TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS") or 64
 )
 """Maximum number of scheduler task coroutines allowed in-flight."""
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -28,6 +28,41 @@ TRACECAT__LOOP_MAX_BATCH_SIZE = int(
 )
 """Maximum number of parallel requests to the worker service."""
 
+TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS = int(
+    os.environ.get("TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS", 16)
+)
+"""Maximum number of scheduler task coroutines allowed in-flight."""
+
+TRACECAT__CHILD_WORKFLOW_MAX_IN_FLIGHT = int(
+    os.environ.get("TRACECAT__CHILD_WORKFLOW_MAX_IN_FLIGHT", 8)
+)
+"""Hard cap on concurrent child workflows for looped subflow execution."""
+
+TRACECAT__WORKFLOW_PERMIT_MAX_WAIT_SECONDS = int(
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_MAX_WAIT_SECONDS", 300)
+)
+"""Maximum seconds to wait for a workflow concurrency permit before failing."""
+
+TRACECAT__WORKFLOW_PERMIT_BACKOFF_BASE_SECONDS = float(
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_BACKOFF_BASE_SECONDS", 1)
+)
+"""Base backoff in seconds when retrying workflow permit acquisition."""
+
+TRACECAT__WORKFLOW_PERMIT_BACKOFF_MAX_SECONDS = float(
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_BACKOFF_MAX_SECONDS", 30)
+)
+"""Maximum backoff in seconds when retrying workflow permit acquisition."""
+
+TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS = float(
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS", 60)
+)
+"""Interval in seconds between workflow permit heartbeat refreshes."""
+
+TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS = int(
+    os.environ.get("TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS", 120)
+)
+"""Maximum seconds to wait for an action concurrency permit before failing."""
+
 TRACECAT__EXECUTOR_QUEUE = os.environ.get(
     "TRACECAT__EXECUTOR_QUEUE", "shared-action-queue"
 )

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -29,17 +29,17 @@ TRACECAT__LOOP_MAX_BATCH_SIZE = int(
 """Maximum number of parallel requests to the worker service."""
 
 TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS = int(
-    os.environ.get("TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS", 16)
+    os.environ.get("TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS") or 16
 )
 """Maximum number of scheduler task coroutines allowed in-flight."""
 
 TRACECAT__CHILD_WORKFLOW_MAX_IN_FLIGHT = int(
-    os.environ.get("TRACECAT__CHILD_WORKFLOW_MAX_IN_FLIGHT", 8)
+    os.environ.get("TRACECAT__CHILD_WORKFLOW_MAX_IN_FLIGHT") or 8
 )
 """Hard cap on concurrent child workflows for looped subflow execution."""
 
 TRACECAT__WORKFLOW_PERMIT_MAX_WAIT_SECONDS = int(
-    os.environ.get("TRACECAT__WORKFLOW_PERMIT_MAX_WAIT_SECONDS", 300)
+    os.environ.get("TRACECAT__WORKFLOW_PERMIT_MAX_WAIT_SECONDS") or 300
 )
 """Maximum seconds to wait for a workflow concurrency permit before failing."""
 
@@ -58,16 +58,18 @@ TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS = float(
 )
 """Interval in seconds between workflow permit heartbeat refreshes."""
 
-TRACECAT__PERMIT_TTL_SECONDS = int(os.environ.get("TRACECAT__PERMIT_TTL_SECONDS", 300))
+TRACECAT__PERMIT_TTL_SECONDS = int(
+    os.environ.get("TRACECAT__PERMIT_TTL_SECONDS") or 300
+)
 """TTL in seconds for workflow/action concurrency permits before stale pruning."""
 
 TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS = int(
-    os.environ.get("TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS", 120)
+    os.environ.get("TRACECAT__ACTION_PERMIT_MAX_WAIT_SECONDS") or 120
 )
 """Maximum seconds to wait for an action concurrency permit before failing."""
 
 TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS = int(
-    os.environ.get("TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS", 30)
+    os.environ.get("TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS") or 30
 )
 """TTL in seconds for cached per-organization effective tier limits."""
 

--- a/tracecat/dsl/init_activities.py
+++ b/tracecat/dsl/init_activities.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+from temporalio import activity
+
+from tracecat.feature_flags import FeatureFlag, is_feature_enabled
+from tracecat.workflow.executions.enums import TriggerType
+
+
+class ResolveTimeAnchorActivityInputs(BaseModel):
+    """Inputs for resolving the workflow time anchor."""
+
+    trigger_type: TriggerType
+    start_time: datetime
+    scheduled_start_time: datetime | None = None
+
+
+@activity.defn
+def resolve_time_anchor_activity(
+    inputs: ResolveTimeAnchorActivityInputs,
+) -> datetime:
+    """Resolve the time anchor based on trigger type.
+
+    This activity is recorded in workflow history and replayed on reset,
+    ensuring the same time anchor is used across workflow resets.
+
+    For scheduled workflows, uses TemporalScheduledStartTime (the intended schedule time).
+    For other triggers (webhook, manual, case), uses the workflow start time.
+    """
+    if inputs.trigger_type == TriggerType.SCHEDULED and inputs.scheduled_start_time:
+        return inputs.scheduled_start_time
+    return inputs.start_time
+
+
+@activity.defn
+def resolve_workflow_concurrency_limits_enabled_activity() -> bool:
+    """Resolve and freeze concurrency-limit flag state in workflow history."""
+    return is_feature_enabled(FeatureFlag.WORKFLOW_CONCURRENCY_LIMITS)

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -743,8 +743,7 @@ class DSLScheduler:
             pending_tasks.difference_update(done_tasks)
 
             while (
-                not self.queue.empty()
-                and len(pending_tasks) < self.max_pending_tasks
+                not self.queue.empty() and len(pending_tasks) < self.max_pending_tasks
             ):
                 task_instance = await self.queue.get()
                 self.logger.debug("Scheduling task", task=task_instance)
@@ -757,9 +756,7 @@ class DSLScheduler:
                     max_pending_tasks=self.max_pending_tasks,
                     queue_size=self.queue.qsize(),
                 )
-                await workflow.wait(
-                    pending_tasks, return_when=asyncio.FIRST_COMPLETED
-                )
+                await workflow.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)
             elif pending_tasks:
                 # Wait for at least one pending task to complete
                 await workflow.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -121,6 +121,7 @@ class DSLScheduler:
         *,
         executor: Callable[[ActionStatement], Awaitable[Any]],
         dsl: DSLInput,
+        max_pending_tasks: int,
         skip_strategy: SkipStrategy = SkipStrategy.PROPAGATE,
         context: ExecutionContext,
         role: Role,
@@ -130,6 +131,9 @@ class DSLScheduler:
         # Static
         self.dsl = dsl
         self.executor = executor
+        if max_pending_tasks < 1:
+            raise ValueError("max_pending_tasks must be greater than 0")
+        self.max_pending_tasks = max_pending_tasks
         self.skip_strategy = skip_strategy
         self.role = role
         self.run_context = run_context
@@ -202,6 +206,7 @@ class DSLScheduler:
             adj=self.adj,
             indegrees=self.indegrees,
             task_count=len(self.tasks),
+            max_pending_tasks=self.max_pending_tasks,
         )
 
     @staticmethod
@@ -737,11 +742,24 @@ class DSLScheduler:
             done_tasks = {t for t in pending_tasks if t.done()}
             pending_tasks.difference_update(done_tasks)
 
-            if not self.queue.empty():
+            while (
+                not self.queue.empty()
+                and len(pending_tasks) < self.max_pending_tasks
+            ):
                 task_instance = await self.queue.get()
                 self.logger.debug("Scheduling task", task=task_instance)
                 task = asyncio.create_task(self._schedule_task(task_instance))
                 pending_tasks.add(task)
+            if not self.queue.empty() and len(pending_tasks) >= self.max_pending_tasks:
+                self.logger.debug(
+                    "Scheduler throttled by max pending task cap",
+                    pending_tasks=len(pending_tasks),
+                    max_pending_tasks=self.max_pending_tasks,
+                    queue_size=self.queue.qsize(),
+                )
+                await workflow.wait(
+                    pending_tasks, return_when=asyncio.FIRST_COMPLETED
+                )
             elif pending_tasks:
                 # Wait for at least one pending task to complete
                 await workflow.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)

--- a/tracecat/dsl/validation.py
+++ b/tracecat/dsl/validation.py
@@ -11,6 +11,7 @@ from tracecat.expressions.expectations import (
     ExpectedField,
     create_expectation_model,
 )
+from tracecat.feature_flags import FeatureFlag, is_feature_enabled
 from tracecat.validation.schemas import ValidationDetail
 from tracecat.workflow.executions.enums import TriggerType
 
@@ -88,3 +89,9 @@ def resolve_time_anchor_activity(
     if inputs.trigger_type == TriggerType.SCHEDULED and inputs.scheduled_start_time:
         return inputs.scheduled_start_time
     return inputs.start_time
+
+
+@activity.defn
+def resolve_workflow_concurrency_limits_enabled_activity() -> bool:
+    """Resolve and freeze concurrency-limit flag state in workflow history."""
+    return is_feature_enabled(FeatureFlag.WORKFLOW_CONCURRENCY_LIMITS)

--- a/tracecat/dsl/validation.py
+++ b/tracecat/dsl/validation.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from datetime import datetime
-
-from pydantic import BaseModel
-from temporalio import activity
 
 from tracecat.dsl.schemas import TriggerInputs
 from tracecat.expressions.expectations import (
     ExpectedField,
     create_expectation_model,
 )
-from tracecat.feature_flags import FeatureFlag, is_feature_enabled
 from tracecat.validation.schemas import ValidationDetail
-from tracecat.workflow.executions.enums import TriggerType
 
 
 def normalize_trigger_inputs(
@@ -64,34 +58,3 @@ PYDANTIC_ERR_TYPE_HANDLER: dict[str, Callable[[Sequence[int | str]], str]] = {
         f"Invalid type at '{'.'.join(str(s) for s in loc)}'."
     ),
 }
-
-
-class ResolveTimeAnchorActivityInputs(BaseModel):
-    """Inputs for resolving the workflow time anchor."""
-
-    trigger_type: TriggerType
-    start_time: datetime
-    scheduled_start_time: datetime | None = None
-
-
-@activity.defn
-def resolve_time_anchor_activity(
-    inputs: ResolveTimeAnchorActivityInputs,
-) -> datetime:
-    """Resolve the time anchor based on trigger type.
-
-    This activity is recorded in workflow history and replayed on reset,
-    ensuring the same time anchor is used across workflow resets.
-
-    For scheduled workflows, uses TemporalScheduledStartTime (the intended schedule time).
-    For other triggers (webhook, manual, case), uses the workflow start time.
-    """
-    if inputs.trigger_type == TriggerType.SCHEDULED and inputs.scheduled_start_time:
-        return inputs.scheduled_start_time
-    return inputs.start_time
-
-
-@activity.defn
-def resolve_workflow_concurrency_limits_enabled_activity() -> bool:
-    """Resolve and freeze concurrency-limit flag state in workflow history."""
-    return is_feature_enabled(FeatureFlag.WORKFLOW_CONCURRENCY_LIMITS)

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -21,12 +21,12 @@ with workflow.unsafe.imports_passed_through():
     from tracecat import config
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
-    from tracecat.dsl.interceptor import SentryInterceptor
-    from tracecat.dsl.plugins import TracecatPydanticAIPlugin
-    from tracecat.dsl.validation import (
+    from tracecat.dsl.init_activities import (
         resolve_time_anchor_activity,
         resolve_workflow_concurrency_limits_enabled_activity,
     )
+    from tracecat.dsl.interceptor import SentryInterceptor
+    from tracecat.dsl.plugins import TracecatPydanticAIPlugin
     from tracecat.dsl.workflow import DSLWorkflow
     from tracecat.ee.interactions.service import InteractionService
     from tracecat.logger import logger

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -28,6 +28,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.ee.interactions.service import InteractionService
     from tracecat.logger import logger
     from tracecat.storage.collection import CollectionActivities
+    from tracecat.tiers.activities import TierActivities
     from tracecat.workflow.management.definitions import (
         get_workflow_definition_activity,
         resolve_registry_lock_activity,
@@ -90,6 +91,7 @@ def get_activities() -> list[Callable]:
         resolve_time_anchor_activity,
         *WorkflowsManagementService.get_activities(),
         *InteractionService.get_activities(),
+        *TierActivities.get_activities(),
     ]
     return activities
 

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -23,7 +23,10 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.interceptor import SentryInterceptor
     from tracecat.dsl.plugins import TracecatPydanticAIPlugin
-    from tracecat.dsl.validation import resolve_time_anchor_activity
+    from tracecat.dsl.validation import (
+        resolve_time_anchor_activity,
+        resolve_workflow_concurrency_limits_enabled_activity,
+    )
     from tracecat.dsl.workflow import DSLWorkflow
     from tracecat.ee.interactions.service import InteractionService
     from tracecat.logger import logger
@@ -89,6 +92,7 @@ def get_activities() -> list[Callable]:
         get_workspace_organization_id_activity,
         *WorkflowSchedulesService.get_activities(),
         resolve_time_anchor_activity,
+        resolve_workflow_concurrency_limits_enabled_activity,
         *WorkflowsManagementService.get_activities(),
         *InteractionService.get_activities(),
         *TierActivities.get_activities(),

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -374,6 +374,15 @@ class DSLWorkflow:
             dispatch_type=self.dispatch_type,
         )
 
+        # Snapshot flag value in workflow history for deterministic replay behavior.
+        self.workflow_concurrency_limits_enabled = (
+            await workflow.execute_local_activity(
+                resolve_workflow_concurrency_limits_enabled_activity,
+                start_to_close_timeout=timedelta(seconds=5),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+        )
+
         # Fetch tier limits for this organization
         if (
             self.workflow_concurrency_limits_enabled
@@ -599,15 +608,6 @@ class DSLWorkflow:
                 start_to_close_timeout=timedelta(seconds=5),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
-
-        # Snapshot flag value in workflow history for deterministic replay behavior.
-        self.workflow_concurrency_limits_enabled = (
-            await workflow.execute_local_activity(
-                resolve_workflow_concurrency_limits_enabled_activity,
-                start_to_close_timeout=timedelta(seconds=5),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
-            )
-        )
 
         # Prepare user facing context
         # trigger_inputs is already a StoredObject from args or normalize_trigger_inputs_activity

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -835,7 +835,9 @@ class DSLWorkflow:
                 else None
             )
             if max_concurrent_actions is not None and self._is_executable_action(task):
-                action_permit_id = self._action_permit_id(task=task, stream_id=stream_id)
+                action_permit_id = self._action_permit_id(
+                    task=task, stream_id=stream_id
+                )
                 await self._acquire_action_permit(
                     action_id=action_permit_id,
                     limit=max_concurrent_actions,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -101,7 +101,6 @@ with workflow.unsafe.imports_passed_through():
         TracecatNotFoundError,
     )
     from tracecat.expressions.eval import is_template_only
-    from tracecat.identifiers import WorkspaceID
     from tracecat.identifiers.workflow import (
         WorkflowExecutionID,
         WorkflowID,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -78,6 +78,11 @@ with workflow.unsafe.imports_passed_through():
         PlatformAction,
         WaitStrategy,
     )
+    from tracecat.dsl.init_activities import (
+        ResolveTimeAnchorActivityInputs,
+        resolve_time_anchor_activity,
+        resolve_workflow_concurrency_limits_enabled_activity,
+    )
     from tracecat.dsl.scheduler import DSLScheduler
     from tracecat.dsl.schemas import (
         ROOT_STREAM,
@@ -91,12 +96,7 @@ with workflow.unsafe.imports_passed_through():
         TaskResult,
     )
     from tracecat.dsl.types import ActionErrorInfo, ActionErrorInfoAdapter
-    from tracecat.dsl.validation import (
-        ResolveTimeAnchorActivityInputs,
-        format_input_schema_validation_error,
-        resolve_time_anchor_activity,
-        resolve_workflow_concurrency_limits_enabled_activity,
-    )
+    from tracecat.dsl.validation import format_input_schema_validation_error
     from tracecat.dsl.workflow_logging import get_workflow_logger
     from tracecat.ee.interactions.decorators import maybe_interactive
     from tracecat.ee.interactions.schemas import InteractionInput, InteractionResult

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -208,6 +208,7 @@ class DSLWorkflow:
     time_anchor: datetime
     context: ExecutionContext
     run_context: RunContext
+    organization_id: identifiers.OrganizationID
     dep_list: dict[str, list[str]]
     scheduler: DSLScheduler
 
@@ -376,13 +377,10 @@ class DSLWorkflow:
         )
 
         # Fetch tier limits for this organization
-        if (
-            self.workflow_concurrency_limits_enabled
-            and self.role.organization_id is not None
-        ):
+        if self.workflow_concurrency_limits_enabled:
             self._tier_limits = await workflow.execute_activity(
                 get_tier_limits_activity,
-                arg=GetTierLimitsInput(org_id=self.role.organization_id),
+                arg=GetTierLimitsInput(org_id=self.organization_id),
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
@@ -1956,15 +1954,13 @@ class DSLWorkflow:
             await asyncio.shield(cleanup_task)
 
     async def _workflow_permit_heartbeat_loop(self) -> None:
-        if self.role.organization_id is None:
-            return
         heartbeat_interval = config.TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS
         if heartbeat_interval <= 0:
             self.logger.info("Workflow permit heartbeat disabled")
             return
 
         wf_id = workflow.info().workflow_id
-        org_id = self.role.organization_id
+        org_id = self.organization_id
         while self._workflow_permit_acquired:
             await asyncio.sleep(
                 self._next_permit_heartbeat_sleep_seconds(
@@ -1993,12 +1989,10 @@ class DSLWorkflow:
                 self.logger.warning("Workflow permit heartbeat failed", error=e)
 
     async def _action_permit_heartbeat_loop(self, *, action_id: str) -> None:
-        if self.role.organization_id is None:
-            return
         heartbeat_interval = config.TRACECAT__WORKFLOW_PERMIT_HEARTBEAT_SECONDS
         if heartbeat_interval <= 0:
             return
-        org_id = self.role.organization_id
+        org_id = self.organization_id
         while True:
             await asyncio.sleep(
                 self._next_permit_heartbeat_sleep_seconds(
@@ -2050,10 +2044,8 @@ class DSLWorkflow:
 
         Retries until a permit is acquired or max wait time is exceeded.
         """
-        if self.role.organization_id is None:
-            raise ValueError("Organization ID is required to acquire workflow permit")
         wf_id = workflow.info().workflow_id
-        org_id = self.role.organization_id
+        org_id = self.organization_id
         attempt = 0
         started_at = workflow.now()
 
@@ -2111,9 +2103,7 @@ class DSLWorkflow:
 
     async def _acquire_action_permit(self, *, action_id: str, limit: int) -> None:
         """Acquire an action execution permit or wait with exponential backoff."""
-        if self.role.organization_id is None:
-            raise ValueError("Organization ID is required to acquire action permit")
-        org_id = self.role.organization_id
+        org_id = self.organization_id
         attempt = 0
         started_at = workflow.now()
 
@@ -2170,11 +2160,9 @@ class DSLWorkflow:
         """Release the workflow execution permit."""
         if not self._workflow_permit_acquired:
             return
-        if self.role.organization_id is None:
-            return
 
         wf_id = workflow.info().workflow_id
-        org_id = self.role.organization_id
+        org_id = self.organization_id
 
         try:
             await workflow.execute_activity(
@@ -2197,10 +2185,7 @@ class DSLWorkflow:
 
     async def _release_action_permit(self, *, action_id: str) -> None:
         """Release an action execution permit."""
-        if self.role.organization_id is None:
-            return
-
-        org_id = self.role.organization_id
+        org_id = self.organization_id
         try:
             await workflow.execute_activity(
                 release_action_permit_activity,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -1194,13 +1194,10 @@ class DSLWorkflow:
             task_result = task_result.with_error(msg, err_type)
             raise ApplicationError(msg, non_retryable=True, type=err_type) from e
         finally:
-            if (
-                action_permit_heartbeat_task is not None
-                and not action_permit_heartbeat_task.done()
-            ):
-                action_permit_heartbeat_task.cancel()
-                await asyncio.gather(
-                    action_permit_heartbeat_task, return_exceptions=True
+            if action_permit_heartbeat_task is not None:
+                await self._run_cancellation_safe_cleanup(
+                    self._stop_action_permit_heartbeat(action_permit_heartbeat_task),
+                    operation="stop_action_permit_heartbeat",
                 )
             if action_permit_id is not None:
                 await self._run_cancellation_safe_cleanup(
@@ -2029,6 +2026,11 @@ class DSLWorkflow:
         self._workflow_permit_heartbeat_task = asyncio.create_task(
             self._workflow_permit_heartbeat_loop()
         )
+
+    async def _stop_action_permit_heartbeat(self, task: asyncio.Task[None]) -> None:
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
 
     async def _stop_workflow_permit_heartbeat(self) -> None:
         task = self._workflow_permit_heartbeat_task

--- a/tracecat/feature_flags/enums.py
+++ b/tracecat/feature_flags/enums.py
@@ -5,5 +5,4 @@ class FeatureFlag(StrEnum):
     """Feature flag enum reserved for engineering rollouts."""
 
     AI_RANKING = "ai-ranking"
-    RBAC = "rbac"
     WORKFLOW_CONCURRENCY_LIMITS = "workflow-concurrency-limits"

--- a/tracecat/feature_flags/enums.py
+++ b/tracecat/feature_flags/enums.py
@@ -5,3 +5,5 @@ class FeatureFlag(StrEnum):
     """Feature flag enum reserved for engineering rollouts."""
 
     AI_RANKING = "ai-ranking"
+    RBAC = "rbac"
+    WORKFLOW_CONCURRENCY_LIMITS = "workflow-concurrency-limits"

--- a/tracecat/tiers/activities.py
+++ b/tracecat/tiers/activities.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from temporalio import activity
 
 from tracecat.db.engine import get_async_session_context_manager
+from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 from tracecat.redis.client import get_redis_client
 from tracecat.tiers.schemas import EffectiveLimits
@@ -16,8 +17,8 @@ from tracecat.tiers.service import TierService
 class AcquireWorkflowPermitInput(BaseModel):
     """Input for acquiring a workflow execution permit."""
 
-    org_id: str
-    """Organization ID (as string for serialization)."""
+    org_id: OrganizationID
+    """Organization ID."""
     workflow_id: str
     """Workflow execution ID."""
     limit: int
@@ -27,8 +28,8 @@ class AcquireWorkflowPermitInput(BaseModel):
 class ReleaseWorkflowPermitInput(BaseModel):
     """Input for releasing a workflow execution permit."""
 
-    org_id: str
-    """Organization ID (as string for serialization)."""
+    org_id: OrganizationID
+    """Organization ID."""
     workflow_id: str
     """Workflow execution ID."""
 
@@ -36,8 +37,8 @@ class ReleaseWorkflowPermitInput(BaseModel):
 class HeartbeatWorkflowPermitInput(BaseModel):
     """Input for refreshing a workflow permit TTL."""
 
-    org_id: str
-    """Organization ID (as string for serialization)."""
+    org_id: OrganizationID
+    """Organization ID."""
     workflow_id: str
     """Workflow execution ID."""
 
@@ -45,15 +46,15 @@ class HeartbeatWorkflowPermitInput(BaseModel):
 class GetTierLimitsInput(BaseModel):
     """Input for getting tier limits."""
 
-    org_id: str
-    """Organization ID (as string for serialization)."""
+    org_id: OrganizationID
+    """Organization ID."""
 
 
 class AcquireActionPermitInput(BaseModel):
     """Input for acquiring an action execution permit."""
 
-    org_id: str
-    """Organization ID (as string for serialization)."""
+    org_id: OrganizationID
+    """Organization ID."""
     action_id: str
     """Action execution ID."""
     limit: int
@@ -63,8 +64,8 @@ class AcquireActionPermitInput(BaseModel):
 class ReleaseActionPermitInput(BaseModel):
     """Input for releasing an action execution permit."""
 
-    org_id: str
-    """Organization ID (as string for serialization)."""
+    org_id: OrganizationID
+    """Organization ID."""
     action_id: str
     """Action execution ID."""
 
@@ -72,8 +73,8 @@ class ReleaseActionPermitInput(BaseModel):
 class HeartbeatActionPermitInput(BaseModel):
     """Input for refreshing an action execution permit TTL."""
 
-    org_id: str
-    """Organization ID (as string for serialization)."""
+    org_id: OrganizationID
+    """Organization ID."""
     action_id: str
     """Action execution ID."""
 
@@ -95,7 +96,7 @@ async def acquire_workflow_permit_activity(
     semaphore = RedisSemaphore(client)
 
     result = await semaphore.acquire_workflow(
-        org_id=input.org_id,  # type: ignore[arg-type]
+        org_id=input.org_id,
         workflow_id=input.workflow_id,
         limit=input.limit,
     )
@@ -126,7 +127,7 @@ async def release_workflow_permit_activity(
     semaphore = RedisSemaphore(client)
 
     await semaphore.release_workflow(
-        org_id=input.org_id,  # type: ignore[arg-type]
+        org_id=input.org_id,
         workflow_id=input.workflow_id,
     )
 
@@ -154,7 +155,7 @@ async def heartbeat_workflow_permit_activity(
     semaphore = RedisSemaphore(client)
 
     return await semaphore.heartbeat_workflow(
-        org_id=input.org_id,  # type: ignore[arg-type]
+        org_id=input.org_id,
         workflow_id=input.workflow_id,
     )
 
@@ -169,7 +170,7 @@ async def acquire_action_permit_activity(
     semaphore = RedisSemaphore(client)
 
     result = await semaphore.acquire_action(
-        org_id=input.org_id,  # type: ignore[arg-type]
+        org_id=input.org_id,
         action_id=input.action_id,
         limit=input.limit,
     )
@@ -195,7 +196,7 @@ async def release_action_permit_activity(
     semaphore = RedisSemaphore(client)
 
     await semaphore.release_action(
-        org_id=input.org_id,  # type: ignore[arg-type]
+        org_id=input.org_id,
         action_id=input.action_id,
     )
 
@@ -216,7 +217,7 @@ async def heartbeat_action_permit_activity(
     semaphore = RedisSemaphore(client)
 
     return await semaphore.heartbeat_action(
-        org_id=input.org_id,  # type: ignore[arg-type]
+        org_id=input.org_id,
         action_id=input.action_id,
     )
 
@@ -235,7 +236,7 @@ async def get_tier_limits_activity(
     """
     async with get_async_session_context_manager() as session:
         service = TierService(session)
-        limits = await service.get_effective_limits(input.org_id)  # type: ignore[arg-type]
+        limits = await service.get_effective_limits(input.org_id)
 
     logger.debug(
         "Fetched tier limits",

--- a/tracecat/tiers/activities.py
+++ b/tracecat/tiers/activities.py
@@ -1,0 +1,169 @@
+"""Temporal activities for tier enforcement."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+from temporalio import activity
+
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.logger import logger
+from tracecat.redis.client import get_redis_client
+from tracecat.tiers.schemas import EffectiveLimits
+from tracecat.tiers.semaphore import AcquireResult, RedisSemaphore
+from tracecat.tiers.service import TierService
+
+
+class AcquireWorkflowPermitInput(BaseModel):
+    """Input for acquiring a workflow execution permit."""
+
+    org_id: str
+    """Organization ID (as string for serialization)."""
+    workflow_id: str
+    """Workflow execution ID."""
+    limit: int
+    """Maximum concurrent workflows allowed."""
+
+
+class ReleaseWorkflowPermitInput(BaseModel):
+    """Input for releasing a workflow execution permit."""
+
+    org_id: str
+    """Organization ID (as string for serialization)."""
+    workflow_id: str
+    """Workflow execution ID."""
+
+
+class HeartbeatWorkflowPermitInput(BaseModel):
+    """Input for refreshing a workflow permit TTL."""
+
+    org_id: str
+    """Organization ID (as string for serialization)."""
+    workflow_id: str
+    """Workflow execution ID."""
+
+
+class GetTierLimitsInput(BaseModel):
+    """Input for getting tier limits."""
+
+    org_id: str
+    """Organization ID (as string for serialization)."""
+
+
+@activity.defn
+async def acquire_workflow_permit_activity(
+    input: AcquireWorkflowPermitInput,
+) -> AcquireResult:
+    """Try to acquire a workflow execution permit.
+
+    Uses Redis semaphore to enforce per-organization concurrent workflow limits.
+
+    Returns:
+        AcquireResult with acquired status and current count.
+    """
+    redis_client = await get_redis_client()
+    # Get the underlying redis.Redis client for the semaphore
+    client = await redis_client._get_client()
+    semaphore = RedisSemaphore(client)
+
+    result = await semaphore.acquire(
+        org_id=input.org_id,  # type: ignore[arg-type]
+        workflow_id=input.workflow_id,
+        limit=input.limit,
+    )
+
+    logger.info(
+        "Workflow permit acquire attempt",
+        org_id=input.org_id,
+        workflow_id=input.workflow_id,
+        limit=input.limit,
+        acquired=result.acquired,
+        current_count=result.current_count,
+    )
+
+    return result
+
+
+@activity.defn
+async def release_workflow_permit_activity(
+    input: ReleaseWorkflowPermitInput,
+) -> None:
+    """Release a workflow execution permit.
+
+    Args:
+        input: Contains org_id and workflow_id.
+    """
+    redis_client = await get_redis_client()
+    client = await redis_client._get_client()
+    semaphore = RedisSemaphore(client)
+
+    await semaphore.release(
+        org_id=input.org_id,  # type: ignore[arg-type]
+        workflow_id=input.workflow_id,
+    )
+
+    logger.info(
+        "Workflow permit released",
+        org_id=input.org_id,
+        workflow_id=input.workflow_id,
+    )
+
+
+@activity.defn
+async def heartbeat_workflow_permit_activity(
+    input: HeartbeatWorkflowPermitInput,
+) -> bool:
+    """Refresh TTL for a long-running workflow's permit.
+
+    Args:
+        input: Contains org_id and workflow_id.
+
+    Returns:
+        True if the permit was found and updated, False otherwise.
+    """
+    redis_client = await get_redis_client()
+    client = await redis_client._get_client()
+    semaphore = RedisSemaphore(client)
+
+    return await semaphore.heartbeat(
+        org_id=input.org_id,  # type: ignore[arg-type]
+        workflow_id=input.workflow_id,
+    )
+
+
+@activity.defn
+async def get_tier_limits_activity(
+    input: GetTierLimitsInput,
+) -> EffectiveLimits:
+    """Fetch tier limits for an organization.
+
+    Args:
+        input: Contains org_id.
+
+    Returns:
+        EffectiveLimits with the organization's effective limits.
+    """
+    async with get_async_session_context_manager() as session:
+        service = TierService(session)
+        limits = await service.get_effective_limits(input.org_id)  # type: ignore[arg-type]
+
+    logger.debug(
+        "Fetched tier limits",
+        org_id=input.org_id,
+        limits=limits.model_dump(),
+    )
+
+    return limits
+
+
+class TierActivities:
+    """Container for tier-related activities."""
+
+    @staticmethod
+    def get_activities() -> list:
+        """Get all tier-related activities for worker registration."""
+        return [
+            acquire_workflow_permit_activity,
+            release_workflow_permit_activity,
+            heartbeat_workflow_permit_activity,
+            get_tier_limits_activity,
+        ]

--- a/tracecat/tiers/exceptions.py
+++ b/tracecat/tiers/exceptions.py
@@ -49,3 +49,27 @@ class TierInUseError(TierError):
             f"Cannot delete tier '{tier_id}': organizations are still assigned to it"
         )
         self.tier_id = tier_id
+
+
+class TierLimitExceeded(TierError):
+    """Base exception for tier limit violations."""
+
+    def __init__(self, limit_name: str, current: int, limit: int):
+        super().__init__(f"Tier limit '{limit_name}' exceeded: {current}/{limit}")
+        self.limit_name = limit_name
+        self.current = current
+        self.limit = limit
+
+
+class ConcurrentWorkflowLimitExceeded(TierLimitExceeded):
+    """Raised when max_concurrent_workflows limit is exceeded."""
+
+    def __init__(self, current: int, limit: int):
+        super().__init__("max_concurrent_workflows", current, limit)
+
+
+class ActionExecutionLimitExceeded(TierLimitExceeded):
+    """Raised when max_action_executions_per_workflow limit is exceeded."""
+
+    def __init__(self, current: int, limit: int):
+        super().__init__("max_action_executions_per_workflow", current, limit)

--- a/tracecat/tiers/exceptions.py
+++ b/tracecat/tiers/exceptions.py
@@ -61,6 +61,19 @@ class TierLimitExceeded(TierError):
         self.limit = limit
 
 
+class InvalidOrganizationConcurrencyCapError(TierError):
+    """Raised when an effective concurrency cap is configured as non-positive."""
+
+    def __init__(self, *, scope: str, org_id: OrganizationID, limit: int):
+        super().__init__(
+            "Invalid organization concurrency cap: "
+            f"scope={scope} org_id={org_id} limit={limit}"
+        )
+        self.scope = scope
+        self.org_id = org_id
+        self.limit = limit
+
+
 class ConcurrentWorkflowLimitExceeded(TierLimitExceeded):
     """Raised when max_concurrent_workflows limit is exceeded."""
 

--- a/tracecat/tiers/limits_cache.py
+++ b/tracecat/tiers/limits_cache.py
@@ -1,0 +1,79 @@
+"""Redis cache for organization effective tier limits."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from tracecat import config
+from tracecat.logger import logger
+from tracecat.redis.client import get_redis_client
+from tracecat.tiers.schemas import EffectiveLimits
+
+if TYPE_CHECKING:
+    from tracecat.identifiers import OrganizationID
+
+
+def effective_limits_cache_key(org_id: OrganizationID) -> str:
+    """Build the Redis key for an organization's effective limits cache."""
+    return f"tier:org:{org_id}:effective-limits:v1"
+
+
+async def get_effective_limits_cached(org_id: OrganizationID) -> EffectiveLimits | None:
+    """Read effective limits from Redis cache."""
+    ttl_seconds = config.TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS
+    if ttl_seconds <= 0:
+        return None
+
+    redis_client = await get_redis_client()
+    client = await redis_client._get_client()
+    key = effective_limits_cache_key(org_id)
+    payload = await client.get(key)
+    if payload is None:
+        return None
+
+    try:
+        return EffectiveLimits.model_validate_json(payload)
+    except Exception:
+        logger.warning(
+            "Invalid effective limits cache payload, dropping key",
+            org_id=org_id,
+            key=key,
+        )
+        await client.delete(key)
+        return None
+
+
+async def set_effective_limits_cached(
+    org_id: OrganizationID, limits: EffectiveLimits
+) -> None:
+    """Write effective limits to Redis cache."""
+    ttl_seconds = config.TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS
+    if ttl_seconds <= 0:
+        return
+
+    redis_client = await get_redis_client()
+    await redis_client.set(
+        effective_limits_cache_key(org_id),
+        limits.model_dump_json(),
+        expire_seconds=ttl_seconds,
+    )
+
+
+async def invalidate_effective_limits_cache(org_id: OrganizationID) -> None:
+    """Delete an organization's effective limits cache entry."""
+    redis_client = await get_redis_client()
+    await redis_client.delete(effective_limits_cache_key(org_id))
+
+
+async def invalidate_effective_limits_cache_many(
+    org_ids: Sequence[OrganizationID],
+) -> None:
+    """Delete cache entries for multiple organizations."""
+    if not org_ids:
+        return
+
+    redis_client = await get_redis_client()
+    client = await redis_client._get_client()
+    keys = [effective_limits_cache_key(org_id) for org_id in org_ids]
+    await client.delete(*keys)

--- a/tracecat/tiers/permits.py
+++ b/tracecat/tiers/permits.py
@@ -1,0 +1,194 @@
+"""Reusable permit orchestration for tier-based concurrency controls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Self
+
+from tracecat import config
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.identifiers import OrganizationID
+from tracecat.logger import logger
+from tracecat.redis.client import get_redis_client
+from tracecat.tiers.exceptions import InvalidOrganizationConcurrencyCapError
+from tracecat.tiers.limits_cache import (
+    get_effective_limits_cached,
+    set_effective_limits_cached,
+)
+from tracecat.tiers.schemas import EffectiveLimits
+from tracecat.tiers.semaphore import AcquireResult, RedisSemaphore
+from tracecat.tiers.service import TierService
+
+PermitScope = Literal["workflow", "action"]
+_UNBOUNDED_CONCURRENCY_LIMIT = 2_147_483_647
+
+
+@dataclass(frozen=True)
+class PermitAcquireOutcome:
+    """Metadata returned for permit acquisition attempts."""
+
+    result: AcquireResult
+    effective_limit: int
+    cap_source: str
+
+
+class TierPermitService:
+    """Reusable service for tier permit acquire/release/heartbeat operations."""
+
+    def __init__(self, semaphore: RedisSemaphore) -> None:
+        self._semaphore = semaphore
+
+    @classmethod
+    async def create(cls) -> Self:
+        """Create a service using the process Redis client and configured permit TTL."""
+        redis_client = await get_redis_client()
+        client = await redis_client._get_client()
+        semaphore = RedisSemaphore(
+            client, ttl_seconds=config.TRACECAT__PERMIT_TTL_SECONDS
+        )
+        return cls(semaphore)
+
+    async def acquire_workflow_permit(
+        self,
+        *,
+        org_id: OrganizationID,
+        workflow_id: str,
+    ) -> PermitAcquireOutcome:
+        """Acquire or reject a workflow permit based on effective limits."""
+        limits, cap_source = await self.get_effective_limits_for_org(org_id)
+        effective_limit = self.normalize_concurrency_limit(
+            limit=limits.max_concurrent_workflows,
+            org_id=org_id,
+            scope="workflow",
+        )
+        result = await self._semaphore.acquire_workflow(
+            org_id=org_id,
+            workflow_id=workflow_id,
+            limit=effective_limit,
+        )
+        return PermitAcquireOutcome(
+            result=result,
+            effective_limit=effective_limit,
+            cap_source=cap_source,
+        )
+
+    async def release_workflow_permit(
+        self,
+        *,
+        org_id: OrganizationID,
+        workflow_id: str,
+    ) -> None:
+        """Release a workflow permit."""
+        await self._semaphore.release_workflow(
+            org_id=org_id,
+            workflow_id=workflow_id,
+        )
+
+    async def heartbeat_workflow_permit(
+        self,
+        *,
+        org_id: OrganizationID,
+        workflow_id: str,
+    ) -> bool:
+        """Heartbeat a workflow permit lease."""
+        return await self._semaphore.heartbeat_workflow(
+            org_id=org_id,
+            workflow_id=workflow_id,
+        )
+
+    async def acquire_action_permit(
+        self,
+        *,
+        org_id: OrganizationID,
+        action_id: str,
+    ) -> PermitAcquireOutcome:
+        """Acquire or reject an action permit based on effective limits."""
+        limits, cap_source = await self.get_effective_limits_for_org(org_id)
+        effective_limit = self.normalize_concurrency_limit(
+            limit=limits.max_concurrent_actions,
+            org_id=org_id,
+            scope="action",
+        )
+        result = await self._semaphore.acquire_action(
+            org_id=org_id,
+            action_id=action_id,
+            limit=effective_limit,
+        )
+        return PermitAcquireOutcome(
+            result=result,
+            effective_limit=effective_limit,
+            cap_source=cap_source,
+        )
+
+    async def release_action_permit(
+        self,
+        *,
+        org_id: OrganizationID,
+        action_id: str,
+    ) -> None:
+        """Release an action permit."""
+        await self._semaphore.release_action(
+            org_id=org_id,
+            action_id=action_id,
+        )
+
+    async def heartbeat_action_permit(
+        self,
+        *,
+        org_id: OrganizationID,
+        action_id: str,
+    ) -> bool:
+        """Heartbeat an action permit lease."""
+        return await self._semaphore.heartbeat_action(
+            org_id=org_id,
+            action_id=action_id,
+        )
+
+    async def get_effective_limits_for_org(
+        self,
+        org_id: OrganizationID,
+    ) -> tuple[EffectiveLimits, str]:
+        """Resolve effective limits via cache first, then DB fallback."""
+        try:
+            limits = await get_effective_limits_cached(org_id)
+        except Exception as e:
+            logger.warning(
+                "Failed to read effective limits cache",
+                org_id=org_id,
+                error=e,
+            )
+            limits = None
+        if limits is not None:
+            return limits, "cache"
+
+        async with get_async_session_context_manager() as session:
+            service = TierService(session)
+            limits = await service.get_effective_limits(org_id)
+
+        try:
+            await set_effective_limits_cached(org_id, limits)
+        except Exception as e:
+            logger.warning(
+                "Failed to update effective limits cache",
+                org_id=org_id,
+                error=e,
+            )
+        return limits, "db"
+
+    @staticmethod
+    def normalize_concurrency_limit(
+        *,
+        limit: int | None,
+        org_id: OrganizationID,
+        scope: PermitScope,
+    ) -> int:
+        """Normalize nullable concurrency limits to usable semaphore limits."""
+        if limit is None:
+            return _UNBOUNDED_CONCURRENCY_LIMIT
+        if limit <= 0:
+            raise InvalidOrganizationConcurrencyCapError(
+                scope=scope,
+                org_id=org_id,
+                limit=limit,
+            )
+        return limit

--- a/tracecat/tiers/semaphore.py
+++ b/tracecat/tiers/semaphore.py
@@ -247,7 +247,9 @@ class RedisSemaphore:
             scope=PermitScope.WORKFLOW,
         )
 
-    async def heartbeat_workflow(self, org_id: OrganizationID, workflow_id: str) -> bool:
+    async def heartbeat_workflow(
+        self, org_id: OrganizationID, workflow_id: str
+    ) -> bool:
         """Heartbeat a workflow permit."""
         return await self._heartbeat(
             org_id=org_id,

--- a/tracecat/tiers/semaphore.py
+++ b/tracecat/tiers/semaphore.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import redis.asyncio as redis
@@ -25,6 +26,11 @@ class AcquireResult:
     """Whether the permit was acquired."""
     current_count: int
     """Current number of workflows holding permits."""
+
+
+class PermitScope(StrEnum):
+    WORKFLOW = "workflow"
+    ACTION = "action"
 
 
 # Lua script for atomic acquire operation
@@ -76,9 +82,12 @@ class RedisSemaphore:
         self._ttl_seconds = ttl_seconds
         self._acquire_script: Any = None
 
-    def _semaphore_key(self, org_id: OrganizationID) -> str:
+    def _semaphore_key(self, org_id: OrganizationID, scope: PermitScope) -> str:
         """Get the Redis key for an organization's semaphore."""
-        return f"tier:org:{org_id}:semaphore"
+        if scope == PermitScope.WORKFLOW:
+            # Keep workflow key stable for backward compatibility.
+            return f"tier:org:{org_id}:semaphore"
+        return f"tier:org:{org_id}:action-semaphore"
 
     async def _get_acquire_script(self) -> Any:
         """Get or create the acquire Lua script."""
@@ -86,35 +95,38 @@ class RedisSemaphore:
             self._acquire_script = self._client.register_script(_ACQUIRE_SCRIPT)
         return self._acquire_script
 
-    async def acquire(
+    async def _acquire(
         self,
         org_id: OrganizationID,
-        workflow_id: str,
+        permit_id: str,
         limit: int,
+        *,
+        scope: PermitScope,
     ) -> AcquireResult:
-        """Try to acquire a permit for a workflow.
+        """Try to acquire a permit.
 
         Atomically:
         1. Prunes stale entries (older than TTL)
-        2. Checks if workflow already holds a permit (idempotent)
+        2. Checks if permit holder already holds a permit (idempotent)
         3. Checks current count against limit
-        4. Adds workflow_id if under limit
+        4. Adds permit_id if under limit
 
         Args:
             org_id: Organization ID.
-            workflow_id: Workflow execution ID.
-            limit: Maximum concurrent workflows allowed.
+            permit_id: Permit holder ID.
+            limit: Maximum concurrent entries allowed.
+            scope: Permit scope namespace.
 
         Returns:
             AcquireResult with acquired status and current count.
         """
-        key = self._semaphore_key(org_id)
+        key = self._semaphore_key(org_id, scope)
         now = int(time.time())
 
         script = await self._get_acquire_script()
         result = await script(
             keys=[key],
-            args=[workflow_id, limit, now, self._ttl_seconds],
+            args=[permit_id, limit, now, self._ttl_seconds],
         )
 
         acquired = bool(result[0])
@@ -123,7 +135,8 @@ class RedisSemaphore:
         logger.debug(
             "Semaphore acquire attempt",
             org_id=str(org_id),
-            workflow_id=workflow_id,
+            permit_id=permit_id,
+            scope=scope,
             limit=limit,
             acquired=acquired,
             current_count=current_count,
@@ -131,66 +144,143 @@ class RedisSemaphore:
 
         return AcquireResult(acquired=acquired, current_count=current_count)
 
-    async def release(self, org_id: OrganizationID, workflow_id: str) -> None:
-        """Release a permit for a workflow.
+    async def _release(
+        self,
+        org_id: OrganizationID,
+        permit_id: str,
+        *,
+        scope: PermitScope,
+    ) -> None:
+        """Release a permit.
 
         Args:
             org_id: Organization ID.
-            workflow_id: Workflow execution ID.
+            permit_id: Permit holder ID.
+            scope: Permit scope namespace.
         """
-        key = self._semaphore_key(org_id)
-        removed = await self._client.zrem(key, workflow_id)
+        key = self._semaphore_key(org_id, scope)
+        removed = await self._client.zrem(key, permit_id)
 
         logger.debug(
             "Semaphore release",
             org_id=str(org_id),
-            workflow_id=workflow_id,
+            permit_id=permit_id,
+            scope=scope,
             removed=bool(removed),
         )
 
-    async def heartbeat(self, org_id: OrganizationID, workflow_id: str) -> bool:
-        """Refresh TTL for a long-running workflow.
+    async def _heartbeat(
+        self,
+        org_id: OrganizationID,
+        permit_id: str,
+        *,
+        scope: PermitScope,
+    ) -> bool:
+        """Refresh TTL for a long-running permit holder.
 
-        Updates the timestamp for the workflow's entry, preventing it from
+        Updates the timestamp for the permit's entry, preventing it from
         being pruned as stale.
 
         Args:
             org_id: Organization ID.
-            workflow_id: Workflow execution ID.
+            permit_id: Permit holder ID.
+            scope: Permit scope namespace.
 
         Returns:
-            True if the workflow was found and updated, False otherwise.
+            True if the permit was found and updated, False otherwise.
         """
-        key = self._semaphore_key(org_id)
+        key = self._semaphore_key(org_id, scope)
         now = int(time.time())
 
         # Only update if the entry exists (XX flag)
-        result = await self._client.zadd(key, {workflow_id: now}, xx=True)
+        result = await self._client.zadd(key, {permit_id: now}, xx=True)
 
         logger.debug(
             "Semaphore heartbeat",
             org_id=str(org_id),
-            workflow_id=workflow_id,
+            permit_id=permit_id,
+            scope=scope,
             updated=bool(result),
         )
 
         return bool(result)
 
-    async def get_count(self, org_id: OrganizationID) -> int:
-        """Get the current count of workflows holding permits.
+    async def get_count(self, org_id: OrganizationID, scope: PermitScope) -> int:
+        """Get the current count of permit holders.
 
         Note: This performs TTL pruning before counting.
 
         Args:
             org_id: Organization ID.
+            scope: Permit scope namespace.
 
         Returns:
             Current count of active workflows.
         """
-        key = self._semaphore_key(org_id)
+        key = self._semaphore_key(org_id, scope)
         now = int(time.time())
 
         # Prune stale entries first
         await self._client.zremrangebyscore(key, "-inf", now - self._ttl_seconds)
 
         return await self._client.zcard(key)
+
+    async def acquire_workflow(
+        self,
+        org_id: OrganizationID,
+        workflow_id: str,
+        limit: int,
+    ) -> AcquireResult:
+        """Acquire a workflow permit."""
+        return await self._acquire(
+            org_id=org_id,
+            permit_id=workflow_id,
+            limit=limit,
+            scope=PermitScope.WORKFLOW,
+        )
+
+    async def release_workflow(self, org_id: OrganizationID, workflow_id: str) -> None:
+        """Release a workflow permit."""
+        await self._release(
+            org_id=org_id,
+            permit_id=workflow_id,
+            scope=PermitScope.WORKFLOW,
+        )
+
+    async def heartbeat_workflow(self, org_id: OrganizationID, workflow_id: str) -> bool:
+        """Heartbeat a workflow permit."""
+        return await self._heartbeat(
+            org_id=org_id,
+            permit_id=workflow_id,
+            scope=PermitScope.WORKFLOW,
+        )
+
+    async def acquire_action(
+        self,
+        org_id: OrganizationID,
+        action_id: str,
+        limit: int,
+    ) -> AcquireResult:
+        """Acquire an action permit."""
+        return await self._acquire(
+            org_id=org_id,
+            permit_id=action_id,
+            limit=limit,
+            scope=PermitScope.ACTION,
+        )
+
+    async def release_action(self, org_id: OrganizationID, action_id: str) -> None:
+        """Release an action permit."""
+        await self._release(
+            org_id=org_id,
+            permit_id=action_id,
+            scope=PermitScope.ACTION,
+        )
+
+    async def heartbeat_action(self, org_id: OrganizationID, action_id: str) -> bool:
+        """Heartbeat an action permit."""
+        return await self._heartbeat(
+            org_id=org_id,
+            permit_id=action_id,
+            scope=PermitScope.ACTION,
+        )

--- a/tracecat/tiers/semaphore.py
+++ b/tracecat/tiers/semaphore.py
@@ -1,0 +1,196 @@
+"""Redis-based semaphore for per-organization workflow concurrency control."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import redis.asyncio as redis
+
+from tracecat.logger import logger
+
+if TYPE_CHECKING:
+    from tracecat.identifiers import OrganizationID
+
+# Default TTL for semaphore entries (1 hour)
+DEFAULT_TTL_SECONDS = 3600
+
+
+@dataclass(frozen=True)
+class AcquireResult:
+    """Result of attempting to acquire a workflow permit."""
+
+    acquired: bool
+    """Whether the permit was acquired."""
+    current_count: int
+    """Current number of workflows holding permits."""
+
+
+# Lua script for atomic acquire operation
+# KEYS[1] = semaphore key
+# ARGV[1] = workflow_id, ARGV[2] = limit, ARGV[3] = now (unix timestamp), ARGV[4] = ttl
+_ACQUIRE_SCRIPT = """
+local key = KEYS[1]
+local wf_id = ARGV[1]
+local limit = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+
+-- Prune stale entries (older than TTL)
+redis.call('ZREMRANGEBYSCORE', key, '-inf', now - ttl)
+
+-- Check if already holding (idempotent acquire)
+if redis.call('ZSCORE', key, wf_id) then
+    redis.call('ZADD', key, now, wf_id)  -- refresh timestamp
+    return {1, redis.call('ZCARD', key)}  -- acquired=true
+end
+
+-- Check count
+local count = redis.call('ZCARD', key)
+if count >= limit then
+    return {0, count}  -- acquired=false
+end
+
+-- Add and return
+redis.call('ZADD', key, now, wf_id)
+return {1, count + 1}  -- acquired=true
+"""
+
+
+class RedisSemaphore:
+    """Per-organization workflow semaphore using Redis sorted sets.
+
+    Uses sorted sets with Unix timestamps as scores for TTL-based pruning.
+    Members are workflow execution IDs.
+    """
+
+    def __init__(self, client: redis.Redis, ttl_seconds: int = DEFAULT_TTL_SECONDS):
+        """Initialize the semaphore.
+
+        Args:
+            client: Redis client instance.
+            ttl_seconds: TTL for semaphore entries in seconds.
+        """
+        self._client = client
+        self._ttl_seconds = ttl_seconds
+        self._acquire_script: Any = None
+
+    def _semaphore_key(self, org_id: OrganizationID) -> str:
+        """Get the Redis key for an organization's semaphore."""
+        return f"tier:org:{org_id}:semaphore"
+
+    async def _get_acquire_script(self) -> Any:
+        """Get or create the acquire Lua script."""
+        if self._acquire_script is None:
+            self._acquire_script = self._client.register_script(_ACQUIRE_SCRIPT)
+        return self._acquire_script
+
+    async def acquire(
+        self,
+        org_id: OrganizationID,
+        workflow_id: str,
+        limit: int,
+    ) -> AcquireResult:
+        """Try to acquire a permit for a workflow.
+
+        Atomically:
+        1. Prunes stale entries (older than TTL)
+        2. Checks if workflow already holds a permit (idempotent)
+        3. Checks current count against limit
+        4. Adds workflow_id if under limit
+
+        Args:
+            org_id: Organization ID.
+            workflow_id: Workflow execution ID.
+            limit: Maximum concurrent workflows allowed.
+
+        Returns:
+            AcquireResult with acquired status and current count.
+        """
+        key = self._semaphore_key(org_id)
+        now = int(time.time())
+
+        script = await self._get_acquire_script()
+        result = await script(
+            keys=[key],
+            args=[workflow_id, limit, now, self._ttl_seconds],
+        )
+
+        acquired = bool(result[0])
+        current_count = int(result[1])
+
+        logger.debug(
+            "Semaphore acquire attempt",
+            org_id=str(org_id),
+            workflow_id=workflow_id,
+            limit=limit,
+            acquired=acquired,
+            current_count=current_count,
+        )
+
+        return AcquireResult(acquired=acquired, current_count=current_count)
+
+    async def release(self, org_id: OrganizationID, workflow_id: str) -> None:
+        """Release a permit for a workflow.
+
+        Args:
+            org_id: Organization ID.
+            workflow_id: Workflow execution ID.
+        """
+        key = self._semaphore_key(org_id)
+        removed = await self._client.zrem(key, workflow_id)
+
+        logger.debug(
+            "Semaphore release",
+            org_id=str(org_id),
+            workflow_id=workflow_id,
+            removed=bool(removed),
+        )
+
+    async def heartbeat(self, org_id: OrganizationID, workflow_id: str) -> bool:
+        """Refresh TTL for a long-running workflow.
+
+        Updates the timestamp for the workflow's entry, preventing it from
+        being pruned as stale.
+
+        Args:
+            org_id: Organization ID.
+            workflow_id: Workflow execution ID.
+
+        Returns:
+            True if the workflow was found and updated, False otherwise.
+        """
+        key = self._semaphore_key(org_id)
+        now = int(time.time())
+
+        # Only update if the entry exists (XX flag)
+        result = await self._client.zadd(key, {workflow_id: now}, xx=True)
+
+        logger.debug(
+            "Semaphore heartbeat",
+            org_id=str(org_id),
+            workflow_id=workflow_id,
+            updated=bool(result),
+        )
+
+        return bool(result)
+
+    async def get_count(self, org_id: OrganizationID) -> int:
+        """Get the current count of workflows holding permits.
+
+        Note: This performs TTL pruning before counting.
+
+        Args:
+            org_id: Organization ID.
+
+        Returns:
+            Current count of active workflows.
+        """
+        key = self._semaphore_key(org_id)
+        now = int(time.time())
+
+        # Prune stale entries first
+        await self._client.zremrangebyscore(key, "-inf", now - self._ttl_seconds)
+
+        return await self._client.zcard(key)


### PR DESCRIPTION
## Summary
- Add tier-based enforcement of workflow execution limits
- `max_concurrent_workflows` - Redis semaphore per organization
- `max_action_executions_per_workflow` - counter per workflow run
- `max_concurrent_actions` - caps batch sizes for child workflows

## Implementation
- New `RedisSemaphore` class using sorted sets with TTL-based pruning
- Temporal activities for acquiring/releasing workflow permits
- Exponential backoff with jitter when limit reached
- Gated by `WORKFLOW_CONCURRENCY_LIMITS` feature flag

## Test plan
- [ ] Unit tests for Redis semaphore Lua script logic
- [ ] Integration tests with Temporal for limit enforcement
- [ ] Manual test with `tracecat-admin tier update`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces per‑org workflow and action concurrency limits using Redis semaphores, a reusable permit service, and a cached tier limits lookup. Also caps scheduler pending tasks and child workflow dispatches, and moves init activities into a dedicated module.

- **New Features**
  - Redis semaphores and TierPermitService for workflow/action scopes with heartbeats, backoff, and max‑wait; limits read from a TTL cache and invalidated on tier/org‑tier updates; frontend exposes the workflow-concurrency-limits flag.
  - Count retries toward max_action_executions_per_workflow; cap child fan‑out by tier and TRACECAT__CHILD_WORKFLOW_DISPATCH_WINDOW; throttle DSL scheduler via TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS (> 0); move time‑anchor and flag‑snapshot init activities to tracecat/dsl/init_activities and register tier/init activities in the worker.

- **Bug Fixes**
  - Improve env var fallbacks with bound_env; default DSL scheduler max_pending_tasks to 64.
  - Enforce action permit semantics; reject invalid child loop caps; preserve default detach; release permits on cancellation; snapshot workflow‑concurrency‑limits via a local init activity before checks; scope concurrency with the resolved organization id.
  - Stabilize tests: fix time in token‑bucket rate‑limit tests; harden default org seeding to avoid slug conflicts.

<sup>Written for commit 9dfd4a26314297d71896298634205ea4a147d013. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

