### PR TITLE
feat(audit): Audit webhook api keys and emissions for auth flows

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2798,6 +2798,31 @@ distinguish multiple files.`,
   title: "AudioUrl",
 } as const
 
+export const $AuditApiKeyGenerateResponse = {
+  properties: {
+    api_key: {
+      type: "string",
+      title: "Api Key",
+      description: "The raw API key. Shown only once.",
+    },
+    preview: {
+      type: "string",
+      title: "Preview",
+      description: "A preview of the key (e.g., tc_ak_...XXXX)",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+      description: "When the key was created",
+    },
+  },
+  type: "object",
+  required: ["api_key", "preview", "created_at"],
+  title: "AuditApiKeyGenerateResponse",
+  description: "Response when generating a new audit webhook API key.",
+} as const
+
 export const $AuditSettingsRead = {
   properties: {
     audit_webhook_url: {
@@ -2810,6 +2835,29 @@ export const $AuditSettingsRead = {
         },
       ],
       title: "Audit Webhook Url",
+    },
+    audit_webhook_api_key_preview: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Api Key Preview",
+    },
+    audit_webhook_api_key_created_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Api Key Created At",
     },
   },
   type: "object",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -372,6 +372,7 @@ import type {
   SecretsSearchSecretsResponse,
   SecretsUpdateSecretByIdData,
   SecretsUpdateSecretByIdResponse,
+  SettingsGenerateAuditApiKeyResponse,
   SettingsGetAgentSettingsResponse,
   SettingsGetAppSettingsResponse,
   SettingsGetAuditSettingsResponse,
@@ -379,6 +380,7 @@ import type {
   SettingsGetGitSettingsResponse,
   SettingsGetOauthSettingsResponse,
   SettingsGetSamlSettingsResponse,
+  SettingsRevokeAuditApiKeyResponse,
   SettingsUpdateAgentSettingsData,
   SettingsUpdateAgentSettingsResponse,
   SettingsUpdateAppSettingsData,
@@ -5159,6 +5161,36 @@ export const settingsUpdateAuditSettings = (
     },
   })
 }
+
+/**
+ * Generate Audit Api Key
+ * Generate a new API key for the audit webhook.
+ *
+ * This replaces any existing key. The raw API key is shown only once.
+ * @returns AuditApiKeyGenerateResponse Successful Response
+ * @throws ApiError
+ */
+export const settingsGenerateAuditApiKey =
+  (): CancelablePromise<SettingsGenerateAuditApiKeyResponse> => {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/settings/audit/api-key",
+    })
+  }
+
+/**
+ * Revoke Audit Api Key
+ * Revoke the current audit webhook API key.
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const settingsRevokeAuditApiKey =
+  (): CancelablePromise<SettingsRevokeAuditApiKeyResponse> => {
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/settings/audit/api-key",
+    })
+  }
 
 /**
  * Get Agent Settings

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -726,10 +726,30 @@ export type AudioUrl = {
 }
 
 /**
+ * Response when generating a new audit webhook API key.
+ */
+export type AuditApiKeyGenerateResponse = {
+  /**
+   * The raw API key. Shown only once.
+   */
+  api_key: string
+  /**
+   * A preview of the key (e.g., tc_ak_...XXXX)
+   */
+  preview: string
+  /**
+   * When the key was created
+   */
+  created_at: string
+}
+
+/**
  * Settings for audit logging.
  */
 export type AuditSettingsRead = {
   audit_webhook_url: string | null
+  audit_webhook_api_key_preview?: string | null
+  audit_webhook_api_key_created_at?: string | null
 }
 
 /**
@@ -7427,6 +7447,10 @@ export type SettingsUpdateAuditSettingsData = {
 
 export type SettingsUpdateAuditSettingsResponse = void
 
+export type SettingsGenerateAuditApiKeyResponse = AuditApiKeyGenerateResponse
+
+export type SettingsRevokeAuditApiKeyResponse = void
+
 export type SettingsGetAgentSettingsResponse = AgentSettingsRead
 
 export type SettingsUpdateAgentSettingsData = {
@@ -10829,6 +10853,24 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError
+      }
+    }
+  }
+  "/settings/audit/api-key": {
+    post: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AuditApiKeyGenerateResponse
+      }
+    }
+    delete: {
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
       }
     }
   }

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -1,11 +1,41 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { format } from "date-fns"
+import { Copy, Key, RefreshCw, Trash2 } from "lucide-react"
+import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import {
   Form,
   FormControl,
@@ -16,6 +46,7 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import { toast } from "@/components/ui/use-toast"
 import { useOrgAuditSettings } from "@/lib/hooks"
 
 const auditFormSchema = z.object({
@@ -36,7 +67,14 @@ export function OrgSettingsAuditForm() {
     auditSettingsError,
     updateAuditSettings,
     updateAuditSettingsIsPending,
+    generateAuditApiKey,
+    generateAuditApiKeyIsPending,
+    revokeAuditApiKey,
+    revokeAuditApiKeyIsPending,
   } = useOrgAuditSettings()
+
+  const [showNewApiKey, setShowNewApiKey] = useState(false)
+  const [newApiKey, setNewApiKey] = useState<string | null>(null)
 
   const form = useForm<AuditFormValues>({
     resolver: zodResolver(auditFormSchema),
@@ -58,6 +96,39 @@ export function OrgSettingsAuditForm() {
     }
   }
 
+  const handleGenerateApiKey = async () => {
+    try {
+      const response = await generateAuditApiKey()
+      setNewApiKey(response.api_key)
+      setShowNewApiKey(true)
+    } catch {
+      console.error("Failed to generate API key")
+    }
+  }
+
+  const handleRevokeApiKey = async () => {
+    try {
+      await revokeAuditApiKey()
+    } catch {
+      console.error("Failed to revoke API key")
+    }
+  }
+
+  const handleCopyApiKey = async () => {
+    if (newApiKey) {
+      await navigator.clipboard.writeText(newApiKey)
+      toast({
+        title: "Copied",
+        description: "API key copied to clipboard.",
+      })
+    }
+  }
+
+  const handleCloseNewApiKeyDialog = () => {
+    setShowNewApiKey(false)
+    setNewApiKey(null)
+  }
+
   if (auditSettingsIsLoading) {
     return <CenteredSpinner />
   }
@@ -70,39 +141,189 @@ export function OrgSettingsAuditForm() {
     )
   }
 
-  return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-        <FormField
-          control={form.control}
-          name="audit_webhook_url"
-          render={({ field }) => (
-            <FormItem className="space-y-3">
-              <div className="space-y-2">
-                <FormLabel>Audit webhook URL</FormLabel>
-                <FormDescription>
-                  Provide an HTTPS endpoint to receive audit events. Leave blank
-                  to disable streaming.
-                </FormDescription>
-              </div>
-              <FormControl>
-                <Input
-                  type="url"
-                  placeholder="https://example.com/webhooks/audit"
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+  const hasApiKey = !!auditSettings.audit_webhook_api_key_preview
 
-        <Button type="submit" disabled={updateAuditSettingsIsPending}>
-          {updateAuditSettingsIsPending
-            ? "Updating..."
-            : "Update audit settings"}
-        </Button>
-      </form>
-    </Form>
+  return (
+    <div className="space-y-8">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <FormField
+            control={form.control}
+            name="audit_webhook_url"
+            render={({ field }) => (
+              <FormItem className="space-y-3">
+                <div className="space-y-2">
+                  <FormLabel>Audit webhook URL</FormLabel>
+                  <FormDescription>
+                    Provide an HTTPS endpoint to receive audit events. Leave
+                    blank to disable streaming.
+                  </FormDescription>
+                </div>
+                <FormControl>
+                  <Input
+                    type="url"
+                    placeholder="https://example.com/webhooks/audit"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" disabled={updateAuditSettingsIsPending}>
+            {updateAuditSettingsIsPending
+              ? "Updating..."
+              : "Update audit settings"}
+          </Button>
+        </form>
+      </Form>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Key className="size-4" />
+            API key authentication
+          </CardTitle>
+          <CardDescription>
+            Optionally configure an API key to authenticate outgoing audit
+            webhook requests. The key is sent as a Bearer token in the
+            Authorization header.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {hasApiKey ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between rounded-md border p-3">
+                <div>
+                  <p className="font-mono text-sm">
+                    {auditSettings.audit_webhook_api_key_preview}
+                  </p>
+                  {auditSettings.audit_webhook_api_key_created_at && (
+                    <p className="text-xs text-muted-foreground">
+                      Created{" "}
+                      {format(
+                        new Date(
+                          auditSettings.audit_webhook_api_key_created_at
+                        ),
+                        "MMM d, yyyy 'at' h:mm a"
+                      )}
+                    </p>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={generateAuditApiKeyIsPending}
+                      >
+                        <RefreshCw className="mr-2 size-3" />
+                        Regenerate
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Regenerate API key?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This will replace the existing API key. Any systems
+                          using the current key will need to be updated.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleGenerateApiKey}>
+                          {generateAuditApiKeyIsPending
+                            ? "Regenerating..."
+                            : "Regenerate"}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={revokeAuditApiKeyIsPending}
+                      >
+                        <Trash2 className="mr-2 size-3" />
+                        Revoke
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Revoke API key?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This will remove the API key. Audit webhook requests
+                          will no longer include authentication.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={handleRevokeApiKey}
+                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                          {revokeAuditApiKeyIsPending
+                            ? "Revoking..."
+                            : "Revoke"}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              onClick={handleGenerateApiKey}
+              disabled={generateAuditApiKeyIsPending}
+            >
+              <Key className="mr-2 size-4" />
+              {generateAuditApiKeyIsPending
+                ? "Generating..."
+                : "Generate API key"}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={showNewApiKey} onOpenChange={setShowNewApiKey}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>API key generated</DialogTitle>
+            <DialogDescription>
+              Copy this key now. You will not be able to see it again.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Input
+                readOnly
+                value={newApiKey ?? ""}
+                className="font-mono text-sm"
+              />
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handleCopyApiKey}
+                title="Copy to clipboard"
+              >
+                <Copy className="size-4" />
+              </Button>
+            </div>
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button onClick={handleCloseNewApiKeyDialog}>Done</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   )
 }

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -292,7 +292,15 @@ export function OrgSettingsAuditForm() {
         </CardContent>
       </Card>
 
-      <Dialog open={showNewApiKey} onOpenChange={setShowNewApiKey}>
+      <Dialog
+        open={showNewApiKey}
+        onOpenChange={(open) => {
+          setShowNewApiKey(open)
+          if (!open) {
+            setNewApiKey(null)
+          }
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>API key generated</DialogTitle>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -22,6 +22,7 @@ import {
   type AgentSettingsRead,
   type ApiError,
   type AppSettingsRead,
+  type AuditApiKeyGenerateResponse,
   type AuditSettingsRead,
   type AuthSettingsRead,
   actionsDeleteAction,
@@ -187,6 +188,7 @@ import {
   secretsListSecretDefinitions,
   secretsListSecrets,
   secretsUpdateSecretById,
+  settingsGenerateAuditApiKey,
   settingsGetAgentSettings,
   settingsGetAppSettings,
   settingsGetAuditSettings,
@@ -194,6 +196,7 @@ import {
   settingsGetGitSettings,
   settingsGetOauthSettings,
   settingsGetSamlSettings,
+  settingsRevokeAuditApiKey,
   settingsUpdateAgentSettings,
   settingsUpdateAppSettings,
   settingsUpdateAuditSettings,
@@ -2812,6 +2815,69 @@ export function useOrgAuditSettings() {
     },
   })
 
+  // Generate API Key
+  const {
+    mutateAsync: generateAuditApiKey,
+    isPending: generateAuditApiKeyIsPending,
+  } = useMutation<AuditApiKeyGenerateResponse, TracecatApiError>({
+    mutationFn: async () => await settingsGenerateAuditApiKey(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-audit-settings"] })
+      toast({
+        title: "Generated API key",
+        description:
+          "New API key generated successfully. Make sure to copy it now.",
+      })
+    },
+    onError: (error) => {
+      switch (error.status) {
+        case 403:
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+          break
+        default:
+          console.error("Failed to generate audit API key", error)
+          toast({
+            title: "Failed to generate API key",
+            description: `An error occurred while generating the API key: ${error.body.detail}`,
+          })
+      }
+    },
+  })
+
+  // Revoke API Key
+  const {
+    mutateAsync: revokeAuditApiKey,
+    isPending: revokeAuditApiKeyIsPending,
+  } = useMutation<void, TracecatApiError>({
+    mutationFn: async () => await settingsRevokeAuditApiKey(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-audit-settings"] })
+      toast({
+        title: "Revoked API key",
+        description: "The audit webhook API key has been revoked.",
+      })
+    },
+    onError: (error) => {
+      switch (error.status) {
+        case 403:
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+          break
+        default:
+          console.error("Failed to revoke audit API key", error)
+          toast({
+            title: "Failed to revoke API key",
+            description: `An error occurred while revoking the API key: ${error.body.detail}`,
+          })
+      }
+    },
+  })
+
   return {
     // Get
     auditSettings,
@@ -2821,6 +2887,11 @@ export function useOrgAuditSettings() {
     updateAuditSettings,
     updateAuditSettingsIsPending,
     updateAuditSettingsError,
+    // API Key
+    generateAuditApiKey,
+    generateAuditApiKeyIsPending,
+    revokeAuditApiKey,
+    revokeAuditApiKeyIsPending,
   }
 }
 

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -55,7 +55,6 @@ class AuditService(BaseOrgService):
         if not isinstance(value, str):
             self.logger.warning(
                 "audit_webhook_api_key must be a string",
-                value=value,
                 value_type=type(value),
             )
             return None

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -40,12 +40,38 @@ class AuditService(BaseOrgService):
         cleaned = value.strip()
         return cleaned or None
 
+    async def _get_api_key(self) -> str | None:
+        """Fetch the configured audit webhook API key."""
+        from tracecat.settings.service import get_setting_cached  # noqa: PLC0415
+
+        value = await get_setting_cached("audit_webhook_api_key")
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            self.logger.warning(
+                "audit_webhook_api_key must be a string",
+                value=value,
+                value_type=type(value),
+            )
+            return None
+
+        cleaned = value.strip()
+        return cleaned or None
+
     async def _post_event(self, *, webhook_url: str, payload: AuditEvent) -> None:
         response: httpx.Response | None = None
         try:
+            # Build headers with optional API key authentication
+            headers: dict[str, str] = {}
+            api_key = await self._get_api_key()
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.post(
-                    webhook_url, json=payload.model_dump(mode="json")
+                    webhook_url,
+                    json=payload.model_dump(mode="json"),
+                    headers=headers if headers else None,
                 )
                 response.raise_for_status()
         except Exception as exc:

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -24,7 +24,8 @@ class AuditService(BaseOrgService):
         1. `AUDIT_WEBHOOK_URL` env var
         2. Organization setting `audit_webhook_url`
         """
-        from tracecat.settings.service import get_setting_cached  # noqa: PLC0415
+
+        from tracecat.settings.service import get_setting_cached
 
         value = await get_setting_cached("audit_webhook_url")
         if value is None:
@@ -41,10 +42,14 @@ class AuditService(BaseOrgService):
         return cleaned or None
 
     async def _get_api_key(self) -> str | None:
-        """Fetch the configured audit webhook API key."""
-        from tracecat.settings.service import get_setting_cached  # noqa: PLC0415
+        """Fetch the configured audit webhook API key.
 
-        value = await get_setting_cached("audit_webhook_api_key")
+        Note: Uses get_setting (uncached) to ensure key rotation/revocation
+        takes effect immediately.
+        """
+        from tracecat.settings.service import get_setting
+
+        value = await get_setting("audit_webhook_api_key", session=self.session)
         if value is None:
             return None
         if not isinstance(value, str):

--- a/tracecat/settings/constants.py
+++ b/tracecat/settings/constants.py
@@ -4,7 +4,11 @@ PUBLIC_SETTINGS_KEYS = {"auth_allowed_types"}
 """Settings that are allowed to be read by unauthenticated users.
 Currently this is used in /info to serve config to the frontend."""
 
-SENSITIVE_SETTINGS_KEYS = {"saml_idp_metadata_url", "audit_webhook_url"}
+SENSITIVE_SETTINGS_KEYS = {
+    "saml_idp_metadata_url",
+    "audit_webhook_url",
+    "audit_webhook_api_key",
+}
 """Settings that are encrypted at rest."""
 
 AUTH_TYPE_TO_SETTING_KEY = {

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
@@ -165,6 +166,8 @@ class AuditSettingsRead(BaseSettingsGroup):
     """Settings for audit logging."""
 
     audit_webhook_url: str | None
+    audit_webhook_api_key_preview: str | None = None
+    audit_webhook_api_key_created_at: datetime | None = None
 
 
 class AuditSettingsUpdate(BaseSettingsGroup):
@@ -174,6 +177,14 @@ class AuditSettingsUpdate(BaseSettingsGroup):
         default=None,
         description="Webhook URL that receives streamed audit events. When unset, audit events are skipped.",
     )
+
+
+class AuditApiKeyGenerateResponse(BaseModel):
+    """Response when generating a new audit webhook API key."""
+
+    api_key: str = Field(description="The raw API key. Shown only once.")
+    preview: str = Field(description="A preview of the key (e.g., tc_ak_...XXXX)")
+    created_at: datetime = Field(description="When the key was created")
 
 
 class AgentSettingsRead(BaseSettingsGroup):

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from typing import Any
 
 import orjson
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.audit.logger import audit_log
+from tracecat.auth.api_keys import generate_api_key
 from tracecat.auth.types import AccessLevel, Role
 from tracecat.authz.controls import require_access_level
 from tracecat.common import UNSET
@@ -24,6 +26,7 @@ from tracecat.settings.constants import PUBLIC_SETTINGS_KEYS, SENSITIVE_SETTINGS
 from tracecat.settings.schemas import (
     AgentSettingsUpdate,
     AppSettingsUpdate,
+    AuditApiKeyGenerateResponse,
     AuditSettingsUpdate,
     AuthSettingsUpdate,
     BaseSettingsGroup,
@@ -32,6 +35,7 @@ from tracecat.settings.schemas import (
     SAMLSettingsUpdate,
     SettingCreate,
     SettingUpdate,
+    ValueType,
 )
 
 
@@ -308,6 +312,98 @@ class SettingsService(BaseService):
     async def update_agent_settings(self, params: AgentSettingsUpdate) -> None:
         agent_settings = await self.list_org_settings(keys=AgentSettingsUpdate.keys())
         await self._update_grouped_settings(agent_settings, params)
+
+    # Audit API Key Management
+
+    @audit_log(resource_type="organization_setting", action="create")
+    @require_access_level(AccessLevel.ADMIN)
+    async def generate_audit_api_key(self) -> AuditApiKeyGenerateResponse:
+        """Generate a new API key for the audit webhook.
+
+        Replaces any existing key. The raw key is returned only once.
+        """
+        # Generate the API key with prefix tc_ak_ (audit key)
+        generated = generate_api_key(prefix="tc_ak_")
+        created_at = datetime.now(UTC)
+
+        # Store the raw key (encrypted) - we need to send it outgoing
+        # Note: Unlike user API keys which are hashed, we store the raw key
+        # because we need to send it in outgoing requests
+        raw_key = generated.raw
+        preview = generated.preview()
+
+        # Create or update the API key setting
+        key_setting = await self.get_org_setting("audit_webhook_api_key")
+        if key_setting:
+            await self._update_setting(
+                key_setting, SettingUpdate(value=raw_key, value_type=ValueType.JSON)
+            )
+        else:
+            await self._create_org_setting(
+                SettingCreate(
+                    key="audit_webhook_api_key",
+                    value=raw_key,
+                    is_sensitive=True,
+                )
+            )
+
+        # Store the preview
+        preview_setting = await self.get_org_setting("audit_webhook_api_key_preview")
+        if preview_setting:
+            await self._update_setting(
+                preview_setting, SettingUpdate(value=preview, value_type=ValueType.JSON)
+            )
+        else:
+            await self._create_org_setting(
+                SettingCreate(
+                    key="audit_webhook_api_key_preview",
+                    value=preview,
+                    is_sensitive=False,
+                )
+            )
+
+        # Store the created_at timestamp
+        created_at_setting = await self.get_org_setting(
+            "audit_webhook_api_key_created_at"
+        )
+        created_at_iso = created_at.isoformat()
+        if created_at_setting:
+            await self._update_setting(
+                created_at_setting,
+                SettingUpdate(value=created_at_iso, value_type=ValueType.JSON),
+            )
+        else:
+            await self._create_org_setting(
+                SettingCreate(
+                    key="audit_webhook_api_key_created_at",
+                    value=created_at_iso,
+                    is_sensitive=False,
+                )
+            )
+
+        await self.session.commit()
+
+        return AuditApiKeyGenerateResponse(
+            api_key=raw_key,
+            preview=preview,
+            created_at=created_at,
+        )
+
+    @audit_log(resource_type="organization_setting", action="delete")
+    @require_access_level(AccessLevel.ADMIN)
+    async def revoke_audit_api_key(self) -> None:
+        """Revoke the current audit webhook API key."""
+        # Clear all API key related settings
+        for key in [
+            "audit_webhook_api_key",
+            "audit_webhook_api_key_preview",
+            "audit_webhook_api_key_created_at",
+        ]:
+            setting = await self.get_org_setting(key)
+            if setting:
+                await self._update_setting(setting, SettingUpdate(value=None))
+
+        await self.session.commit()
 
 
 async def get_setting(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add API key auth for audit webhooks and emit audit events for login/registration. This secures outbound audit requests and expands audit coverage for auth flows.

- **New Features**
  - API key management endpoints: POST/DELETE /settings/audit/api-key.
  - Generate returns api_key (shown once), preview, and created_at.
  - Webhook requests now include Authorization: Bearer <key> when configured.
  - Auth audit emissions for user_session and user_registration events.
  - Org settings UI to generate, copy, regenerate, and revoke the key with preview and timestamp.
  - API key stored encrypted and marked sensitive; preview/timestamp saved.

- **Migration**
  - Set the audit webhook URL, then generate an API key in Org Settings.
  - Update your webhook receiver to validate the Bearer token.
  - Regenerate/revoke keys as needed and rotate credentials on downstream systems.

<sup>Written for commit 9d5923470114bcb1e0b95c5f0f5e913bbb2dda7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

