### PR TITLE
feat(org): improve organization invitation UX

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -3112,6 +3112,10 @@ export const organizationGetInvitationToken = (
 /**
  * Accept Invitation
  * Accept an invitation and join the organization.
+ *
+ * This endpoint doesn't require organization context since the user
+ * may not belong to any organization yet. Uses AuthenticatedUserOnly
+ * which only requires an authenticated user (role.organization_id is None).
  * @param data The data for the request.
  * @param data.requestBody
  * @returns string Successful Response

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -283,6 +283,8 @@ import type {
   OrganizationDeleteSessionResponse,
   OrganizationGetInvitationByTokenData,
   OrganizationGetInvitationByTokenResponse,
+  OrganizationGetInvitationTokenData,
+  OrganizationGetInvitationTokenResponse,
   OrganizationListInvitationsData,
   OrganizationListInvitationsResponse,
   OrganizationListOrgMembersResponse,
@@ -3073,6 +3075,31 @@ export const organizationRevokeInvitation = (
   return __request(OpenAPI, {
     method: "DELETE",
     url: "/organization/invitations/{invitation_id}",
+    path: {
+      invitation_id: data.invitationId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Invitation Token
+ * Get the token for a specific invitation (admin only).
+ *
+ * This endpoint is used to generate shareable invitation links.
+ * @param data The data for the request.
+ * @param data.invitationId
+ * @returns string Successful Response
+ * @throws ApiError
+ */
+export const organizationGetInvitationToken = (
+  data: OrganizationGetInvitationTokenData
+): CancelablePromise<OrganizationGetInvitationTokenResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/organization/invitations/{invitation_id}/token",
     path: {
       invitation_id: data.invitationId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6865,6 +6865,14 @@ export type OrganizationRevokeInvitationData = {
 
 export type OrganizationRevokeInvitationResponse = void
 
+export type OrganizationGetInvitationTokenData = {
+  invitationId: string
+}
+
+export type OrganizationGetInvitationTokenResponse = {
+  [key: string]: string
+}
+
 export type OrganizationAcceptInvitationData = {
   requestBody: OrgInvitationAccept
 }
@@ -9641,6 +9649,23 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/invitations/{invitation_id}/token": {
+    get: {
+      req: OrganizationGetInvitationTokenData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: {
+          [key: string]: string
+        }
         /**
          * Validation Error
          */

--- a/frontend/src/components/organization/org-invitations-table.tsx
+++ b/frontend/src/components/organization/org-invitations-table.tsx
@@ -5,7 +5,11 @@ import { DotsHorizontalIcon, PlusIcon } from "@radix-ui/react-icons"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
-import type { OrgInvitationRead, OrgRole } from "@/client"
+import {
+  type OrgInvitationRead,
+  type OrgRole,
+  organizationGetInvitationToken,
+} from "@/client"
 import {
   DataTable,
   DataTableColumnHeader,
@@ -57,6 +61,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
 import { useAuth } from "@/hooks/use-auth"
 import { getRelativeTime } from "@/lib/event-history"
 import { useOrgInvitations } from "@/lib/hooks"
@@ -355,6 +360,33 @@ export function OrgInvitationsTable() {
                       >
                         Copy invitation ID
                       </DropdownMenuItem>
+                      {user?.isPrivileged() && isPending && (
+                        <DropdownMenuItem
+                          onSelect={async () => {
+                            try {
+                              const { token } =
+                                await organizationGetInvitationToken({
+                                  invitationId: invitation.id,
+                                })
+                              const url = `${window.location.origin}/invitations/accept?token=${token}`
+                              await navigator.clipboard.writeText(url)
+                              toast({
+                                title: "Copied",
+                                description:
+                                  "Invitation link copied to clipboard",
+                              })
+                            } catch {
+                              toast({
+                                title: "Error",
+                                description: "Failed to copy invitation link",
+                                variant: "destructive",
+                              })
+                            }
+                          }}
+                        >
+                          Copy invitation link
+                        </DropdownMenuItem>
+                      )}
                       {user?.isPrivileged() && (
                         <>
                           <DropdownMenuSeparator />

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -9,7 +9,7 @@ from tracecat.auth.credentials import OptionalUserDep, RoleACL
 from tracecat.auth.schemas import SessionRead, UserUpdate
 from tracecat.auth.types import AccessLevel, Role
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.db.models import Organization, User
+from tracecat.db.models import Organization, OrganizationInvitation, User
 from tracecat.exceptions import (
     TracecatAuthorizationError,
     TracecatNotFoundError,
@@ -256,6 +256,27 @@ async def revoke_invitation(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
 
 
+@router.get("/invitations/{invitation_id}/token")
+async def get_invitation_token(
+    *,
+    role: OrgAdminRole,
+    session: AsyncDBSession,
+    invitation_id: UUID,
+) -> dict[str, str]:
+    """Get the token for a specific invitation (admin only).
+
+    This endpoint is used to generate shareable invitation links.
+    """
+    service = OrgService(session, role=role)
+    try:
+        invitation = await service.get_invitation(invitation_id)
+        return {"token": invitation.token}
+    except NoResultFound as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found"
+        ) from e
+
+
 @router.post("/invitations/accept")
 async def accept_invitation(
     *,
@@ -293,15 +314,14 @@ async def get_invitation_by_token(
     Returns organization name and inviter info for the acceptance page.
     If user is authenticated, also returns whether their email matches the invitation.
     """
-    # Create a minimal role for unauthenticated access
-    role = Role(
-        type="service",
-        service_id="tracecat-api",
-        access_level=AccessLevel.BASIC,
-    )
-    service = OrgService(session, role=role)
+    # Query invitation directly without OrgService since we don't have org context yet
     try:
-        invitation = await service.get_invitation_by_token(token)
+        result = await session.execute(
+            select(OrganizationInvitation).where(OrganizationInvitation.token == token)
+        )
+        invitation = result.scalar_one_or_none()
+        if invitation is None:
+            raise TracecatNotFoundError("Invitation not found")
 
         # Fetch organization name
         org_result = await session.execute(


### PR DESCRIPTION
## Summary

This PR improves the organization invitation experience with better UX and error handling.

### Changes
- Add "Copy invitation link" button to the invitations table
- Improve invitation acceptance flow with better error messages
- Add new API endpoint to get invitation link

### Stack
1. #1972 - Auth foundation (base)
2. **This PR** - Org invitations (parallel to #1974, #1975)

## Test plan
- [ ] Test copying invitation links from the invitations table
- [ ] Test invitation acceptance flow
- [ ] Verify error messages are clear for edge cases (expired, revoked, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches invitation acceptance and membership creation logic, including new validation and atomic updates; bugs here could block onboarding or incorrectly accept/reject invites.
> 
> **Overview**
> Adds an admin-only endpoint `GET /organization/invitations/{invitation_id}/token` (and regenerated frontend client/types) so privileged users can generate shareable invitation URLs.
> 
> Updates the invitations table UI to include **Copy invitation link** for pending invites, copying an accept URL to the clipboard with success/failure toasts.
> 
> Refactors invitation acceptance to not require organization context by switching the route dependency to `AuthenticatedUserOnly` and introducing `accept_invitation_for_user()` which validates email/expiry, performs an atomic status update to avoid race conditions, and logs audit attempt/success/failure. The public “get invitation by token” handler now queries the invitation directly instead of using `OrgService`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f5ba717f1518839cfa401c02074cc4fa74c7b35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->