### PR TITLE
refactor(service): add service hierarchy with BasePlatformService and BaseWorkspaceService

### DIFF
--- a/tests/integration/test_syncv2_execv2_e2e.py
+++ b/tests/integration/test_syncv2_execv2_e2e.py
@@ -412,9 +412,7 @@ async def module_builtin_repo(
         )
 
     # Also create platform-scoped repo (for executor tarball lookups)
-    platform_svc = PlatformRegistryReposService(
-        module_committing_session, role=module_test_role
-    )
+    platform_svc = PlatformRegistryReposService(module_committing_session)
     await platform_svc.get_or_create_repository(DEFAULT_REGISTRY_ORIGIN)
 
     await module_committing_session.commit()
@@ -454,9 +452,7 @@ async def shared_synced_registry(
         )
 
     # Also sync to platform tables (executor queries platform tables for tracecat_registry)
-    platform_svc = PlatformRegistryReposService(
-        module_committing_session, role=module_test_role
-    )
+    platform_svc = PlatformRegistryReposService(module_committing_session)
     platform_repo = await platform_svc.get_or_create_repository(DEFAULT_REGISTRY_ORIGIN)
     platform_sync_service = PlatformRegistrySyncService(module_committing_session)
     await platform_sync_service.sync_repository_v2(

--- a/tests/unit/test_registry_platform_startup.py
+++ b/tests/unit/test_registry_platform_startup.py
@@ -85,7 +85,7 @@ async def test_platform_repos_service_create_repository(
     session: AsyncSession,
 ) -> None:
     """Test creating a platform registry repository."""
-    service = PlatformRegistryReposService(session, role=None)
+    service = PlatformRegistryReposService(session)
 
     # Use DEFAULT_LOCAL_REGISTRY_ORIGIN since DEFAULT_REGISTRY_ORIGIN is pre-seeded by conftest
     repo = await service.create_repository(
@@ -107,7 +107,7 @@ async def test_platform_repos_service_get_repository(
     session.add(repo)
     await session.commit()
 
-    service = PlatformRegistryReposService(session, role=None)
+    service = PlatformRegistryReposService(session)
     found = await service.get_repository("test_platform_origin")
 
     assert found is not None
@@ -120,7 +120,7 @@ async def test_platform_repos_service_get_repository_not_found(
     session: AsyncSession,
 ) -> None:
     """Test getting a non-existent repository returns None."""
-    service = PlatformRegistryReposService(session, role=None)
+    service = PlatformRegistryReposService(session)
     found = await service.get_repository("nonexistent_origin")
 
     assert found is None
@@ -136,7 +136,7 @@ async def test_platform_repos_service_get_or_create_existing(
     session.add(repo)
     await session.commit()
 
-    service = PlatformRegistryReposService(session, role=None)
+    service = PlatformRegistryReposService(session)
     found = await service.get_or_create_repository("existing_origin")
 
     assert found.id == repo.id
@@ -147,7 +147,7 @@ async def test_platform_repos_service_get_or_create_new(
     session: AsyncSession,
 ) -> None:
     """Test get_or_create creates new repository if not exists."""
-    service = PlatformRegistryReposService(session, role=None)
+    service = PlatformRegistryReposService(session)
     repo = await service.get_or_create_repository(DEFAULT_LOCAL_REGISTRY_ORIGIN)
 
     assert repo.origin == DEFAULT_LOCAL_REGISTRY_ORIGIN

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -608,7 +608,7 @@ async def check_ready(session: AsyncDBSession) -> ReadinessResponse:
     expected_version = tracecat_registry.__version__
 
     # Check registry sync status
-    repos_service = PlatformRegistryReposService(session, role=None)
+    repos_service = PlatformRegistryReposService(session)
     repo = await repos_service.get_repository(DEFAULT_REGISTRY_ORIGIN)
 
     if repo is None or repo.current_version is None:

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -34,6 +34,7 @@ class AuditEvent(BaseModel):
     organization_id: uuid.UUID | None = None
     """Organization ID. None for platform-level operations (superuser without org context)."""
     workspace_id: uuid.UUID | None = None
+    """Workspace ID. None for platform/org-level operations."""
     actor_type: AuditEventActor
     actor_id: uuid.UUID
     actor_label: str | None = None

--- a/tracecat/custom_fields/service.py
+++ b/tracecat/custom_fields/service.py
@@ -39,8 +39,8 @@ class CustomFieldsService(BaseWorkspaceService, ABC):
         self._schema_initialized = False
         self.sanitized_table_name = sanitize_identifier(self._table)
         self.editor = TableEditorService(
-            session=self.session,
-            role=self.role,
+            self.session,
+            self.role,
             table_name=self._table,
             schema_name=self.schema_name,
         )

--- a/tracecat/service.py
+++ b/tracecat/service.py
@@ -1,47 +1,104 @@
+"""Base service classes for Tracecat.
+
+Role Semantics
+--------------
+The `role` parameter in service classes represents the **operator context** - the entity
+(user or service) performing the action. It is NOT the subject or target of the operation.
+
+For example, when an admin user updates another user's profile:
+- The `role` is the admin user (the operator performing the action)
+- The target user is passed as a separate parameter to the method
+
+This distinction is important for:
+- Authorization: Checking if the operator has permission to perform the action
+- Audit logging: Recording who performed the action
+- Multi-tenancy: Scoping operations to the operator's organization/workspace
+
+The role is typically injected via FastAPI dependencies at the router level and propagated
+to services. Services can also resolve the role from the `ctx_role` context variable.
+
+Choosing a Base Class
+---------------------
++----------------------+--------------+------------------+---------------------------------------+
+| Base Class           | Scoped To    | Operator Context | Use When                              |
++----------------------+--------------+------------------+---------------------------------------+
+| BaseService          | Nothing      | None             | Internal utilities, background jobs,  |
+|                      |              |                  | read-only lookups without audit needs |
++----------------------+--------------+------------------+---------------------------------------+
+| BaseOrgService       | Organization | Role             | Operations on org-level resources     |
+|                      |              |                  | (org settings, memberships)           |
++----------------------+--------------+------------------+---------------------------------------+
+| BaseWorkspaceService | Workspace    | Role             | Operations on workspace resources     |
+|                      |              |                  | (workflows, cases, tables)            |
++----------------------+--------------+------------------+---------------------------------------+
+| BasePlatformService  | Platform     | PlatformRole     | Superuser operations across all       |
+|                      | (global)     |                  | orgs/workspaces                       |
++----------------------+--------------+------------------+---------------------------------------+
+
+BasePlatformService is specifically for:
+- Cross-org operations: Managing multiple organizations (create/delete orgs, assign tiers)
+- Platform-global resources: Tiers, platform settings, global registry
+- Superuser-only access: Requires SuperuserRole dependency
+- Audit trail needed: Preserves who (superuser) performed the action
+- Not scoped to caller's org: The operator acts on resources they don't "belong" to
+"""
+
+from __future__ import annotations
+
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
-from typing import Any, ClassVar, Self
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.identifiers import OrganizationID, WorkspaceID
 from tracecat.logger import logger
 
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from tracecat.auth.types import PlatformRole, Role
+
 
 class BaseService:
-    """Base class for services."""
+    """Base class for services with no role or org/workspace context.
+
+    Use this for:
+    - Internal utilities and helpers (e.g., TierService for entitlement lookups)
+    - Background jobs that don't need operator attribution
+    - Read-only lookups that don't require audit trails
+
+    If you need operator context for authorization or audit logging, use one of:
+    - BaseOrgService: For org-scoped operations
+    - BaseWorkspaceService: For workspace-scoped operations
+    - BasePlatformService: For superuser/platform admin operations
+    """
 
     service_name: ClassVar[str]
 
-    def __init__(self, session: AsyncSession, role: Role | None = None):
+    def __init__(self, session: AsyncSession):
         self.session = session
-        self.role = role or ctx_role.get()
         self.logger = logger.bind(service=self.service_name)
 
     @classmethod
     @asynccontextmanager
     async def with_session(
         cls,
-        role: Role | None = None,
         *,
         session: AsyncSession | None = None,
     ) -> AsyncGenerator[Self, None]:
         """Create a service instance with a database session.
 
         Args:
-            role: Optional role for authorization context.
             session: Optional existing session. If provided, caller is responsible
                 for managing its lifecycle (it won't be closed by this context manager).
         """
         if session is not None:
-            yield cls(session, role=role)
+            yield cls(session)
         else:
             async with get_async_session_context_manager() as session:
-                yield cls(session, role=role)
+                yield cls(session)
 
     @classmethod
     def get_activities(cls) -> list[Callable[..., Any]]:
@@ -74,26 +131,71 @@ class BasePlatformService(BaseService):
 
 
 class BaseOrgService(BaseService):
-    """Base class for services that require organization context."""
+    """Base class for services scoped to an organization.
 
-    role: Role  # Override parent - always non-None for org services
+    Use this for operations on org-level resources such as:
+    - Organization settings and configuration
+    - Org membership management
+    - Resources shared across all workspaces in an org
+
+    Services extending this class require a Role with organization_id.
+    The role is resolved from the parameter or ctx_role context variable.
+
+    The role represents the operator (the user/service performing the action),
+    not the subject or target of the operation. See module docstring for details.
+    """
+
+    role: Role  # Always non-None for org services
     organization_id: OrganizationID  # Always non-None after __init__
 
     def __init__(self, session: AsyncSession, role: Role | None = None):
-        super().__init__(session, role)
-        if self.role is None:
+        super().__init__(session)
+        resolved_role = role or ctx_role.get()
+        if resolved_role is None:
             raise TracecatAuthorizationError(
                 f"{self.service_name} service requires organization context"
             )
-        if self.role.organization_id is None:
+        if resolved_role.organization_id is None:
             raise TracecatAuthorizationError(
                 f"{self.service_name} service requires organization_id in role"
             )
-        self.organization_id = self.role.organization_id
+        self.role = resolved_role
+        self.organization_id = resolved_role.organization_id
+
+    @classmethod
+    @asynccontextmanager
+    async def with_session(
+        cls,
+        role: Role | None = None,
+        *,
+        session: AsyncSession | None = None,
+    ) -> AsyncGenerator[Self, None]:
+        """Create a service instance with a database session.
+
+        Args:
+            role: Optional role for authorization context. Falls back to ctx_role.
+            session: Optional existing session. If provided, caller is responsible
+                for managing its lifecycle (it won't be closed by this context manager).
+        """
+        if session is not None:
+            yield cls(session, role=role)
+        else:
+            async with get_async_session_context_manager() as session:
+                yield cls(session, role=role)
 
 
 class BaseWorkspaceService(BaseOrgService):
-    """Base class for services that require a workspace."""
+    """Base class for services scoped to a workspace.
+
+    Use this for operations on workspace-level resources such as:
+    - Workflows and workflow executions
+    - Cases and case management
+    - Tables and custom fields
+    - Secrets and credentials
+
+    Services extending this class require a Role with both organization_id
+    and workspace_id. Most user-facing operations use this base class.
+    """
 
     workspace_id: WorkspaceID  # Always non-None after __init__
 
@@ -105,3 +207,27 @@ class BaseWorkspaceService(BaseOrgService):
                 f"{self.service_name} service requires workspace"
             )
         self.workspace_id = self.role.workspace_id
+
+
+class BasePlatformService(BaseService):
+    """Base class for platform-wide superuser operations.
+
+    Use this for operations that span across or are outside the org/workspace hierarchy:
+    - Cross-org operations: Managing multiple organizations (create/delete orgs)
+    - Platform-global resources: Tiers, platform settings, global registry
+    - User management across organizations
+
+    Services extending this class require a PlatformRole (from SuperuserRole dependency).
+    This preserves operator context for audit logging while not being scoped to any
+    specific organization or workspace.
+
+    Note: Unlike BaseOrgService, this class does not provide a with_session context
+    manager since admin services are typically instantiated directly in routers with
+    the role from the SuperuserRole dependency.
+    """
+
+    role: PlatformRole  # Always non-None for platform services
+
+    def __init__(self, session: AsyncSession, role: PlatformRole):
+        super().__init__(session)
+        self.role = role

--- a/tracecat/service.py
+++ b/tracecat/service.py
@@ -207,27 +207,3 @@ class BaseWorkspaceService(BaseOrgService):
                 f"{self.service_name} service requires workspace"
             )
         self.workspace_id = self.role.workspace_id
-
-
-class BasePlatformService(BaseService):
-    """Base class for platform-wide superuser operations.
-
-    Use this for operations that span across or are outside the org/workspace hierarchy:
-    - Cross-org operations: Managing multiple organizations (create/delete orgs)
-    - Platform-global resources: Tiers, platform settings, global registry
-    - User management across organizations
-
-    Services extending this class require a PlatformRole (from SuperuserRole dependency).
-    This preserves operator context for audit logging while not being scoped to any
-    specific organization or workspace.
-
-    Note: Unlike BaseOrgService, this class does not provide a with_session context
-    manager since admin services are typically instantiated directly in routers with
-    the role from the SuperuserRole dependency.
-    """
-
-    role: PlatformRole  # Always non-None for platform services
-
-    def __init__(self, session: AsyncSession, role: PlatformRole):
-        super().__init__(session)
-        self.role = role

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -21,7 +21,7 @@ from tracecat.db.models import OrganizationSetting
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 from tracecat.secrets.encryption import decrypt_value, encrypt_value
-from tracecat.service import BaseService
+from tracecat.service import BaseOrgService
 from tracecat.settings.constants import SENSITIVE_SETTINGS_KEYS
 from tracecat.settings.schemas import (
     AgentSettingsUpdate,
@@ -39,11 +39,10 @@ from tracecat.settings.schemas import (
 )
 
 
-class SettingsService(BaseService):
-    """Service for managing platform settings.
+class SettingsService(BaseOrgService):
+    """Service for managing organization settings.
 
-    Note: This service requires a role with organization_id for most operations.
-    The bootstrap code paths always provide a role with organization_id.
+    Requires a role with organization_id (enforced by BaseOrgService).
     """
 
     service_name = "settings"
@@ -64,19 +63,6 @@ class SettingsService(BaseService):
         if not encryption_key:
             raise KeyError("TRACECAT__DB_ENCRYPTION_KEY is not set")
         self._encryption_key = SecretStr(encryption_key)
-
-    @property
-    def organization_id(self) -> OrganizationID:
-        """Get organization ID from the role.
-
-        Raises:
-            ValueError: If role is None or role has no organization_id.
-        """
-        if self.role is None:
-            raise ValueError("SettingsService requires a role with organization_id")
-        if self.role.organization_id is None:
-            raise ValueError("Role must have an organization_id")
-        return self.role.organization_id
 
     def _serialize_value_bytes(self, value: Any) -> bytes:
         return orjson.dumps(

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -41,7 +41,7 @@ from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
 )
-from tracecat.service import BaseService, BaseWorkspaceService
+from tracecat.service import BaseWorkspaceService
 from tracecat.tables.common import (
     coerce_multi_select_value,
     coerce_select_value,
@@ -1784,18 +1784,25 @@ class TablesService(BaseTablesService):
         return result
 
 
-class TableEditorService(BaseService):
-    """Service for editing tables."""
+class TableEditorService(BaseWorkspaceService):
+    """Service for editing workspace-scoped tables.
+
+    This is a utility service for DDL operations (add/update/delete columns, rows)
+    on tables within a workspace schema.
+
+    The role represents the operator (the user/service performing the action).
+    Authorization is enforced via @require_workspace_role decorators on methods.
+    """
 
     service_name = "table_editor"
 
     def __init__(
         self,
+        session: AsyncSession,
+        role: Role | None = None,
         *,
         table_name: str,
         schema_name: str,
-        session: AsyncSession,
-        role: Role | None = None,
     ):
         super().__init__(session, role)
         self.table_name = sanitize_identifier(table_name)

--- a/tracecat/tiers/entitlements.py
+++ b/tracecat/tiers/entitlements.py
@@ -84,6 +84,6 @@ async def check_entitlement(
     """
     if role.organization_id is None:
         raise ValueError("Role must have organization_id to check entitlements")
-    tier_svc = TierService(session, role=role)
+    tier_svc = TierService(session)
     entitlement_svc = EntitlementService(tier_svc)
     await entitlement_svc.check_entitlement(role.organization_id, entitlement)

--- a/tracecat/workflow/tags/service.py
+++ b/tracecat/workflow/tags/service.py
@@ -5,10 +5,10 @@ from sqlalchemy import select
 from tracecat.db.models import Tag, WorkflowTag
 from tracecat.identifiers import TagID
 from tracecat.identifiers.workflow import WorkflowID
-from tracecat.service import BaseService
+from tracecat.service import BaseWorkspaceService
 
 
-class WorkflowTagsService(BaseService):
+class WorkflowTagsService(BaseWorkspaceService):
     service_name = "workflow_tags"
 
     async def list_tags_for_workflow(self, wf_id: WorkflowID) -> Sequence[Tag]:


### PR DESCRIPTION
## Summary

This PR introduces a service hierarchy with clear role semantics for multi-tenancy support.

### Changes
- Add documentation for service hierarchy and role semantics in `tracecat/service.py`
- Make `TableEditorService` extend `BaseWorkspaceService`
- Update admin services to use `BasePlatformService`
- Update registry services for service hierarchy
- Update various services for the new base class hierarchy

### Service Hierarchy
```
BaseService (abstract)
├── BasePlatformService  - For platform-wide admin operations (requires PlatformRole)
└── BaseWorkspaceService - For workspace-scoped operations (requires Role with workspace_id)
```

### Stack
1. #1972 - Auth foundation (base)
2. **This PR** - Service hierarchy
3. #1975 - Superuser org selection
4. #1973 - Org invitations

## Test plan
- [ ] Run `pytest tests/unit tests/registry -x` to verify all tests pass
- [ ] Verify service inheritance is correct in type checker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes clear service base classes and updates platform/admin and org/workspace code paths accordingly.
> 
> - Add `BasePlatformService`, enhance `BaseOrgService`/`BaseWorkspaceService`, and document role semantics in `tracecat/service.py`; refactor services to use them (admin org/registry/settings/tiers/users now platform-scoped; settings/org services org-scoped; `TableEditorService` and workflow/custom-fields services workspace-scoped)
> - Registry: adjust sync/versions/repositories to accept platform context without role, add `with_session` helper, restrict platform git+ssh sync with explicit error, and gate SSH key lookup to org roles; update readiness and startup jobs to use platform repos/versions without role
> - API/routers: pass `SuperuserRole` directly to admin services (drop kwarg), and update registry endpoints to route platform vs org logic via platform services
> - Audit/entitlements: allow `organization_id` to be optional for platform events; entitlement checks use `TierService(session)`
> - Tests: update unit/integration tests to new constructors and platform behavior (no role for platform repos/versions services, `PlatformRole` in superuser test)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 860f32e784b321533f5163990b1f61b8f1d7911a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->