### PR TITLE
feat(auth): require explicit org selection for superusers

### DIFF
--- a/frontend/src/app/workspaces/layout.tsx
+++ b/frontend/src/app/workspaces/layout.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { ReactFlowProvider } from "@xyflow/react"
-import { LogOut } from "lucide-react"
+import { LogOut, Shield } from "lucide-react"
 import Image from "next/image"
+import Link from "next/link"
 import { useParams, usePathname } from "next/navigation"
 import TracecatIcon from "public/icon.png"
 import type React from "react"
@@ -14,7 +15,7 @@ import { DynamicNavbar } from "@/components/nav/dynamic-nav"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
 import { Button } from "@/components/ui/button"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import { useAuthActions } from "@/hooks/use-auth"
+import { useAuth, useAuthActions } from "@/hooks/use-auth"
 import { useWorkspaceManager } from "@/lib/hooks"
 import { WorkflowBuilderProvider } from "@/providers/builder"
 import { WorkflowProvider } from "@/providers/workflow"
@@ -159,6 +160,7 @@ function WorkflowView({
 }
 
 function NoWorkspaces() {
+  const { user } = useAuth()
   const { logout } = useAuthActions()
   const handleLogout = async () => {
     await logout()
@@ -171,10 +173,20 @@ function NoWorkspaces() {
         You are not a member of any workspace. Please contact your
         administrator.
       </span>
-      <Button variant="outline" onClick={handleLogout}>
-        <LogOut className="mr-2 size-4" />
-        <span>Logout</span>
-      </Button>
+      <div className="flex gap-2">
+        {user?.isSuperuser && (
+          <Button variant="default" asChild>
+            <Link href="/admin">
+              <Shield className="mr-2 size-4" />
+              <span>Admin</span>
+            </Link>
+          </Button>
+        )}
+        <Button variant="outline" onClick={handleLogout}>
+          <LogOut className="mr-2 size-4" />
+          <span>Logout</span>
+        </Button>
+      </div>
     </main>
   )
 }

--- a/frontend/src/app/workspaces/layout.tsx
+++ b/frontend/src/app/workspaces/layout.tsx
@@ -55,6 +55,7 @@ export default function WorkspaceLayout({
       setLastWorkspaceId(workspaceId)
     }
   }, [setLastWorkspaceId, workspaceId])
+
   if (workspacesLoading) {
     return <CenteredSpinner />
   }

--- a/frontend/src/components/admin/admin-organizations-table.tsx
+++ b/frontend/src/components/admin/admin-organizations-table.tsx
@@ -3,7 +3,6 @@
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import Cookies from "js-cookie"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { useState } from "react"
 import type { OrgRead } from "@/client"
 import {
@@ -36,7 +35,6 @@ import { useAdminOrganizations } from "@/hooks/use-admin"
 export function AdminOrganizationsTable() {
   const [selectedOrg, setSelectedOrg] = useState<OrgRead | null>(null)
   const { organizations, deleteOrganization } = useAdminOrganizations()
-  const router = useRouter()
 
   const handleDeleteOrganization = async () => {
     if (selectedOrg) {
@@ -51,8 +49,12 @@ export function AdminOrganizationsTable() {
   }
 
   const handleEnterOrganization = (orgId: string) => {
+    // Set the org override cookie
     Cookies.set("tracecat-org-id", orgId, { path: "/", sameSite: "lax" })
-    router.push("/organization/invitations")
+    // Clear the last-viewed workspace cookie to avoid redirecting to a workspace from another org
+    Cookies.remove("__tracecat:workspaces:last-viewed", { path: "/" })
+    // Force a full page reload to clear React Query cache
+    window.location.href = "/workspaces"
   }
 
   return (

--- a/frontend/src/components/error.tsx
+++ b/frontend/src/components/error.tsx
@@ -1,14 +1,16 @@
 "use client"
 
 import type { AxiosError } from "axios"
+import Cookies from "js-cookie"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
 import TracecatIcon from "public/icon.png"
 // Error components must be Client Components
 import { useEffect } from "react"
-import { ApiError } from "@/client"
+import { ApiError, type OrgRead } from "@/client"
 import { type AlertLevel, AlertNotification } from "@/components/notifications"
 import { Button } from "@/components/ui/button"
+import { useAdminOrganizations } from "@/hooks/use-admin"
 
 type ErrorProps = Error & { digest?: string }
 
@@ -54,6 +56,77 @@ function GoHome() {
   )
 }
 
+function OrgSelector() {
+  const router = useRouter()
+  const { organizations, isLoading, error } = useAdminOrganizations()
+
+  const handleSelectOrg = (org: OrgRead) => {
+    Cookies.set("tracecat-org-id", org.id, { path: "/", sameSite: "lax" })
+    // Full page reload to ensure React Query refetches with new cookie
+    window.location.reload()
+  }
+
+  if (isLoading) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Loading organizations...
+      </div>
+    )
+  }
+
+  if (error || !organizations) {
+    return (
+      <Button
+        variant="outline"
+        onClick={() => router.replace("/admin/organizations")}
+      >
+        Go to organizations
+      </Button>
+    )
+  }
+
+  if (organizations.length === 0) {
+    return (
+      <div className="flex w-full flex-col items-center gap-4">
+        <div className="text-sm text-muted-foreground">
+          No organizations available
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => router.push("/admin/organizations")}
+        >
+          Go to admin
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex w-full flex-col gap-2">
+        {organizations.map((org) => (
+          <Button
+            key={org.id}
+            variant="outline"
+            className="w-full justify-start"
+            onClick={() => handleSelectOrg(org)}
+          >
+            {org.name}
+          </Button>
+        ))}
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground"
+        onClick={() => router.push("/admin/organizations")}
+      >
+        Go to admin
+      </Button>
+    </div>
+  )
+}
+
 function unexpectedError(error: ErrorProps | AxiosError): CustomError {
   console.log("HANDLING ERROR", error)
   return {
@@ -93,6 +166,13 @@ function apiErrorHandler(error: ApiError): CustomError {
         level,
         message: "The resource you are looking for does not exist.",
         action: <GoHome />,
+      }
+    case 428:
+      return {
+        headline: "Organization selection required",
+        level: "info",
+        message: "Please select an organization to continue.",
+        action: <OrgSelector />,
       }
     case 503:
       return {

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -82,10 +82,10 @@ export function AdminSidebar({
           </SidebarMenuItem>
         </SidebarMenu>
         <div className="flex items-center gap-2 px-2 py-1.5">
-          <div className="flex size-6 items-center justify-center rounded bg-amber-500/10">
-            <CrownIcon className="size-4 text-amber-500" />
+          <div className="flex size-6 items-center justify-center rounded bg-muted">
+            <CrownIcon className="size-4" />
           </div>
-          <span className="font-semibold text-amber-500">Admin</span>
+          <span className="font-semibold">Admin</span>
         </div>
       </SidebarHeader>
       <SidebarContent>

--- a/frontend/src/components/sidebar/app-menu.tsx
+++ b/frontend/src/components/sidebar/app-menu.tsx
@@ -6,7 +6,6 @@ import {
   ChevronsUpDown,
   CircleCheck,
   Plus,
-  ShieldCheckIcon,
 } from "lucide-react"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
@@ -220,19 +219,6 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
                     <BuildingIcon className="size-4" />
                   </div>
                   <span>Organization</span>
-                </Link>
-              </DropdownMenuItem>
-            )}
-            {user?.isSuperuser && (
-              <DropdownMenuItem asChild>
-                <Link
-                  href="/admin"
-                  className="flex items-center gap-2 py-1 px-2 cursor-default"
-                >
-                  <div className="flex size-6 items-center justify-center text-amber-500">
-                    <ShieldCheckIcon className="size-4" />
-                  </div>
-                  <span className="text-amber-500">Admin</span>
                 </Link>
               </DropdownMenuItem>
             )}

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import Cookies from "js-cookie"
 import {
   BotIcon,
   ChevronLeftIcon,
@@ -9,7 +8,6 @@ import {
   KeyRoundIcon,
   LockIcon,
   LogInIcon,
-  LogOutIcon,
   LogsIcon,
   MailIcon,
   SendIcon,
@@ -18,10 +16,9 @@ import {
   UsersIcon,
 } from "lucide-react"
 import Link from "next/link"
-import { usePathname, useRouter } from "next/navigation"
+import { usePathname } from "next/navigation"
 import type * as React from "react"
 import { SidebarUserNav } from "@/components/sidebar/sidebar-user-nav"
-import { Button } from "@/components/ui/button"
 import {
   Sidebar,
   SidebarContent,
@@ -35,28 +32,14 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from "@/components/ui/sidebar"
-import { useAuth } from "@/hooks/use-auth"
 import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useWorkspaceManager } from "@/lib/hooks"
-
-const ORG_OVERRIDE_COOKIE = "tracecat-org-id"
 
 export function OrganizationSidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname()
-  const router = useRouter()
   const { isFeatureEnabled } = useFeatureFlag()
-  const { user } = useAuth()
-
-  // Check if superuser is in org override mode
-  const orgOverrideCookie = Cookies.get(ORG_OVERRIDE_COOKIE)
-  const isInOrgOverrideMode = user?.isSuperuser && !!orgOverrideCookie
-
-  const handleExitOrgContext = () => {
-    Cookies.remove(ORG_OVERRIDE_COOKIE, { path: "/" })
-    router.push("/admin/organizations")
-  }
 
   // Fetch workspaces for the sidebar
   const { workspaces } = useWorkspaceManager()
@@ -162,22 +145,6 @@ export function OrganizationSidebar({
   return (
     <Sidebar collapsible="offcanvas" variant="inset" {...props}>
       <SidebarHeader>
-        {isInOrgOverrideMode && (
-          <div className="flex items-center justify-between gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2">
-            <span className="text-xs font-medium text-amber-600 dark:text-amber-400">
-              Viewing as admin
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 px-2 text-xs text-amber-600 hover:bg-amber-500/20 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
-              onClick={handleExitOrgContext}
-            >
-              <LogOutIcon className="mr-1 size-3" />
-              Exit
-            </Button>
-          </div>
-        )}
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton asChild>

--- a/frontend/src/components/sidebar/sidebar-user-nav.tsx
+++ b/frontend/src/components/sidebar/sidebar-user-nav.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { BookText, ExternalLink, LogOut, ShieldIcon, User } from "lucide-react"
+import {
+  BookText,
+  ExternalLink,
+  LogOut,
+  ShieldCheckIcon,
+  ShieldIcon,
+  User,
+} from "lucide-react"
 import Link from "next/link"
 import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
@@ -73,6 +80,20 @@ export function SidebarUserNav() {
                 </DropdownMenuItem>
               </Link>
             </DropdownMenuGroup>
+
+            {user?.isSuperuser && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                  <Link href="/admin" className="w-full">
+                    <DropdownMenuItem className="text-xs hover:cursor-pointer">
+                      <ShieldCheckIcon className="mr-2 size-4" />
+                      <span>Admin</span>
+                    </DropdownMenuItem>
+                  </Link>
+                </DropdownMenuGroup>
+              </>
+            )}
 
             <DropdownMenuSeparator />
             <DropdownMenuGroup>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -753,6 +753,7 @@ export function useWorkspaceManager() {
     queryKey: ["workspaces"],
     queryFn: async () => await workspacesListWorkspaces(),
     staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: retryHandler,
   })
 
   // Create workspace

--- a/frontend/src/providers/query.tsx
+++ b/frontend/src/providers/query.tsx
@@ -3,13 +3,32 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 // import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { type ReactNode, useState } from "react"
+import { ApiError } from "@/client"
 
 export const DefaultQueryClientProvider = ({
   children,
 }: {
   children: ReactNode
 }) => {
-  const [client] = useState(new QueryClient())
+  const [client] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          // Don't retry on 4xx client errors (they won't change on retry)
+          retry: (failureCount, error) => {
+            if (
+              error instanceof ApiError &&
+              error.status >= 400 &&
+              error.status < 500
+            ) {
+              return false
+            }
+            return failureCount < 3
+          },
+        },
+      },
+    })
+  )
 
   return (
     <QueryClientProvider client={client}>

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -326,24 +326,30 @@ async def _role_dependency(
             workspace_role = membership_with_org.membership.role
             organization_id = membership_with_org.org_id
         else:
-            # No workspace specified; infer org from memberships when possible.
+            # No workspace specified; determine org context
             workspace_role = None
             organization_id: UUID4 | None = None
 
-            # Superusers can override org via cookie
-            org_override = request.cookies.get(ORG_OVERRIDE_COOKIE)
-            if org_override and user.is_superuser:
-                try:
-                    organization_id = uuid.UUID(org_override)
-                except ValueError:
-                    logger.warning(
-                        "Invalid org override cookie, falling back to membership",
-                        user_id=user.id,
-                        org_override=org_override,
+            if user.is_superuser:
+                # Superusers must explicitly select an organization via cookie
+                org_override = request.cookies.get(ORG_OVERRIDE_COOKIE)
+                if org_override:
+                    try:
+                        organization_id = uuid.UUID(org_override)
+                    except ValueError:
+                        logger.warning(
+                            "Invalid org override cookie format",
+                            user_id=user.id,
+                            org_override=org_override,
+                        )
+                if organization_id is None:
+                    # No cookie or invalid cookie - prompt for org selection
+                    raise HTTPException(
+                        status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+                        detail="Organization selection required",
                     )
-
-            # If no override applied, infer from memberships
-            if organization_id is None:
+            else:
+                # Regular users: infer org from memberships
                 svc = MembershipService(session)
                 memberships_with_org = await svc.list_user_memberships_with_org(
                     user_id=user.id

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -37,7 +37,7 @@ from tracecat.authz.service import MembershipService, MembershipWithOrg
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.db.models import OrganizationMembership, User, Workspace
+from tracecat.db.models import Organization, OrganizationMembership, User, Workspace
 from tracecat.identifiers import InternalServiceID
 from tracecat.logger import logger
 
@@ -335,7 +335,20 @@ async def _role_dependency(
                 org_override = request.cookies.get(ORG_OVERRIDE_COOKIE)
                 if org_override:
                     try:
-                        organization_id = uuid.UUID(org_override)
+                        candidate_org_id = uuid.UUID(org_override)
+                        # Validate that the organization actually exists
+                        org_exists_stmt = select(Organization.id).where(
+                            Organization.id == candidate_org_id
+                        )
+                        org_exists_result = await session.execute(org_exists_stmt)
+                        if org_exists_result.scalar_one_or_none() is not None:
+                            organization_id = candidate_org_id
+                        else:
+                            logger.warning(
+                                "Organization from cookie does not exist",
+                                user_id=user.id,
+                                org_id=candidate_org_id,
+                            )
                     except ValueError:
                         logger.warning(
                             "Invalid org override cookie format",
@@ -343,7 +356,7 @@ async def _role_dependency(
                             org_override=org_override,
                         )
                 if organization_id is None:
-                    # No cookie or invalid cookie - prompt for org selection
+                    # No cookie, invalid cookie, or org doesn't exist - prompt for org selection
                     raise HTTPException(
                         status_code=status.HTTP_428_PRECONDITION_REQUIRED,
                         detail="Organization selection required",

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -11,32 +11,75 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import AccessLevel, Role
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.db.models import Organization
+from tracecat.db.models import Organization, Workspace
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 from tracecat.settings.service import SettingsService
+from tracecat.tiers.exceptions import DefaultTierNotConfiguredError
+from tracecat.tiers.service import TierService
 from tracecat.workspaces.service import WorkspaceService
 
 
-async def create_organization_with_defaults(
+async def ensure_organization_defaults(
+    session: AsyncSession,
+    org_id: OrganizationID,
+) -> None:
+    """Ensure an organization has default settings, workspace, and tier.
+
+    This is idempotent - safe to call multiple times on the same org.
+
+    Args:
+        session: Database session.
+        org_id: Organization ID to ensure defaults for.
+    """
+    org_role = Role(
+        type="service",
+        access_level=AccessLevel.ADMIN,
+        service_id="tracecat-service",
+        organization_id=org_id,
+    )
+
+    # Ensure settings exist (idempotent)
+    settings_service = SettingsService(session, role=org_role)
+    await settings_service.init_default_settings()
+
+    # Ensure at least one workspace exists
+    workspace_count_result = await session.execute(
+        select(func.count())
+        .select_from(Workspace)
+        .where(Workspace.organization_id == org_id)
+    )
+    if workspace_count_result.scalar_one() == 0:
+        logger.info("Creating default workspace", organization_id=str(org_id))
+        workspace_service = WorkspaceService(session, role=org_role)
+        await workspace_service.create_workspace(name="Default Workspace")
+
+    # Ensure org tier exists (assigns default tier if configured)
+    tier_service = TierService(session)
+    try:
+        await tier_service.get_or_create_org_tier(org_id)
+    except DefaultTierNotConfiguredError:
+        # No default tier configured - skip tier assignment
+        logger.debug(
+            "No default tier configured, skipping tier assignment",
+            organization_id=str(org_id),
+        )
+
+
+async def create_organization(
     session: AsyncSession,
     *,
     name: str,
     slug: str,
     org_id: UUID4 | None = None,
 ) -> Organization:
-    """Create a new organization with default settings and workspace.
-
-    This is the canonical way to create an organization. It:
-    1. Creates the Organization record
-    2. Initializes default settings for the organization
-    3. Creates a default workspace
+    """Create an organization record.
 
     Args:
         session: Database session.
         name: Organization name.
         slug: Organization slug (must be unique).
-        org_id: Optional UUID for the organization. If not provided, a random UUID is generated.
+        org_id: Optional UUID for the organization.
 
     Returns:
         The created Organization.
@@ -58,22 +101,34 @@ async def create_organization_with_defaults(
         await session.rollback()
         raise ValueError(f"Organization with slug '{slug}' already exists") from e
 
-    # Create a service role for the new organization
-    org_role = Role(
-        type="service",
-        access_level=AccessLevel.ADMIN,
-        service_id="tracecat-service",
-        organization_id=org.id,
-    )
+    return org
 
-    # Initialize default settings for the organization
-    settings_service = SettingsService(session, role=org_role)
-    await settings_service.init_default_settings()
 
-    # Create a default workspace for the new organization
-    workspace_service = WorkspaceService(session, role=org_role)
-    await workspace_service.create_workspace(name="Default Workspace")
+async def create_organization_with_defaults(
+    session: AsyncSession,
+    *,
+    name: str,
+    slug: str,
+    org_id: UUID4 | None = None,
+) -> Organization:
+    """Create a new organization with default settings and workspace.
 
+    This is the canonical way to create an organization.
+
+    Args:
+        session: Database session.
+        name: Organization name.
+        slug: Organization slug (must be unique).
+        org_id: Optional UUID for the organization.
+
+    Returns:
+        The created Organization.
+
+    Raises:
+        ValueError: If an organization with the given slug already exists.
+    """
+    org = await create_organization(session, name=name, slug=slug, org_id=org_id)
+    await ensure_organization_defaults(session, org.id)
     await session.refresh(org)
     return org
 
@@ -91,15 +146,11 @@ async def get_default_organization_id(session: AsyncSession) -> OrganizationID:
         NoResultFound: If no organization exists.
     """
     result = await session.execute(select(Organization).limit(1))
-    org = result.scalar_one()
-    return org.id
+    return result.scalar_one().id
 
 
 async def ensure_default_organization() -> OrganizationID:
     """Ensure a default organization exists with settings and workspace.
-
-    If no organizations exist, creates one with default settings and workspace.
-    If organizations already exist, returns the first one's ID.
 
     Returns:
         OrganizationID: The ID of the default (or first) organization.
@@ -109,10 +160,8 @@ async def ensure_default_organization() -> OrganizationID:
         count_result = await session.execute(
             select(func.count()).select_from(Organization)
         )
-        org_count = count_result.scalar_one()
 
-        if org_count == 0:
-            # Create a default organization with settings and workspace
+        if count_result.scalar_one() == 0:
             org = await create_organization_with_defaults(
                 session,
                 name="Default Organization",
@@ -125,7 +174,7 @@ async def ensure_default_organization() -> OrganizationID:
             )
             return org.id
 
-        # Return the first organization's ID
+        # Get existing org and ensure it has defaults
         result = await session.execute(select(Organization).limit(1))
         org = result.scalar_one()
         logger.debug(
@@ -133,4 +182,5 @@ async def ensure_default_organization() -> OrganizationID:
             organization_id=str(org.id),
             name=org.name,
         )
+        await ensure_organization_defaults(session, org.id)
         return org.id

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -1,0 +1,136 @@
+"""Organization management utilities."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import UUID4
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import AccessLevel, Role
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import Organization
+from tracecat.identifiers import OrganizationID
+from tracecat.logger import logger
+from tracecat.settings.service import SettingsService
+from tracecat.workspaces.service import WorkspaceService
+
+
+async def create_organization_with_defaults(
+    session: AsyncSession,
+    *,
+    name: str,
+    slug: str,
+    org_id: UUID4 | None = None,
+) -> Organization:
+    """Create a new organization with default settings and workspace.
+
+    This is the canonical way to create an organization. It:
+    1. Creates the Organization record
+    2. Initializes default settings for the organization
+    3. Creates a default workspace
+
+    Args:
+        session: Database session.
+        name: Organization name.
+        slug: Organization slug (must be unique).
+        org_id: Optional UUID for the organization. If not provided, a random UUID is generated.
+
+    Returns:
+        The created Organization.
+
+    Raises:
+        ValueError: If an organization with the given slug already exists.
+    """
+    org = Organization(
+        id=org_id or uuid.uuid4(),
+        name=name,
+        slug=slug,
+        is_active=True,
+    )
+    session.add(org)
+
+    try:
+        await session.flush()
+    except IntegrityError as e:
+        await session.rollback()
+        raise ValueError(f"Organization with slug '{slug}' already exists") from e
+
+    # Create a service role for the new organization
+    org_role = Role(
+        type="service",
+        access_level=AccessLevel.ADMIN,
+        service_id="tracecat-service",
+        organization_id=org.id,
+    )
+
+    # Initialize default settings for the organization
+    settings_service = SettingsService(session, role=org_role)
+    await settings_service.init_default_settings()
+
+    # Create a default workspace for the new organization
+    workspace_service = WorkspaceService(session, role=org_role)
+    await workspace_service.create_workspace(name="Default Workspace")
+
+    await session.refresh(org)
+    return org
+
+
+async def get_default_organization_id(session: AsyncSession) -> OrganizationID:
+    """Get the ID of the first/default organization.
+
+    Args:
+        session: Database session.
+
+    Returns:
+        OrganizationID: The ID of the first organization.
+
+    Raises:
+        NoResultFound: If no organization exists.
+    """
+    result = await session.execute(select(Organization).limit(1))
+    org = result.scalar_one()
+    return org.id
+
+
+async def ensure_default_organization() -> OrganizationID:
+    """Ensure a default organization exists with settings and workspace.
+
+    If no organizations exist, creates one with default settings and workspace.
+    If organizations already exist, returns the first one's ID.
+
+    Returns:
+        OrganizationID: The ID of the default (or first) organization.
+    """
+    async with get_async_session_context_manager() as session:
+        # Check if any organization exists
+        count_result = await session.execute(
+            select(func.count()).select_from(Organization)
+        )
+        org_count = count_result.scalar_one()
+
+        if org_count == 0:
+            # Create a default organization with settings and workspace
+            org = await create_organization_with_defaults(
+                session,
+                name="Default Organization",
+                slug="default",
+            )
+            logger.info(
+                "Created default organization",
+                organization_id=str(org.id),
+                name=org.name,
+            )
+            return org.id
+
+        # Return the first organization's ID
+        result = await session.execute(select(Organization).limit(1))
+        org = result.scalar_one()
+        logger.debug(
+            "Using existing organization",
+            organization_id=str(org.id),
+            name=org.name,
+        )
+        return org.id


### PR DESCRIPTION
## Summary

This PR requires superusers to explicitly select an organization context before accessing workspaces, rather than using a hardcoded default.

### Changes
- Add organization cookie-based org selection for superusers
- Validate that the selected organization exists before accepting the cookie
- Add admin fallback button in the UI when no workspaces are available
- Add `OrgSelector` component for organization switching

### Stack
1. #1972 - Auth foundation (base)
2. #1974 - Service hierarchy
3. **This PR** - Superuser org selection
4. #1973 - Org invitations (parallel branch)

## Test plan
- [ ] Login as superuser and verify org selection is required
- [ ] Test org switching via UI
- [ ] Verify admin fallback button appears when no workspaces exist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces explicit organization context for superusers and wires up frontend handling.
> 
> - Backend `credentials.py`: superusers must select org via `tracecat-org-id` cookie; validates org exists; otherwise returns `428 Precondition Required`.
> - Frontend `Error` component: adds `OrgSelector` to handle `428`, list orgs, set cookie, and reload; fallback buttons to admin routes.
> - `workspaces/layout.tsx`: shows Admin button for superusers when no workspaces; integrates `useAuth`.
> - Client schemas/types: `organization_id` now nullable in generated `schemas.gen.ts` and `types.gen.ts`.
> - React Query: global retry policy skips retries for 4xx `ApiError`; workspaces list query now uses `retry` handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f42a86026b939443d79ce12819f433d141eafca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->