### PR TITLE
fix(inbox): Use unified inbox API in new inbox

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/inbox/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/inbox/layout.tsx
@@ -9,11 +9,11 @@ import { AppSidebar } from "@/components/sidebar/app-sidebar"
 import { Button } from "@/components/ui/button"
 import { ResizableSidebar } from "@/components/ui/resizable-sidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import type { AgentSessionWithStatus } from "@/lib/agents"
+import type { InboxSessionItem } from "@/lib/agents"
 
 interface InboxChatContextValue {
-  selectedSession: AgentSessionWithStatus | null
-  setSelectedSession: (session: AgentSessionWithStatus | null) => void
+  selectedSession: InboxSessionItem | null
+  setSelectedSession: (session: InboxSessionItem | null) => void
   chatOpen: boolean
   setChatOpen: (open: boolean) => void
   registerOnClose: (callback: () => void) => void
@@ -35,7 +35,7 @@ export default function InboxLayout({
   children: React.ReactNode
 }) {
   const [selectedSession, setSelectedSession] =
-    useState<AgentSessionWithStatus | null>(null)
+    useState<InboxSessionItem | null>(null)
   const [chatOpen, setChatOpen] = useState(false)
   const onCloseCallbackRef = useRef<(() => void) | null>(null)
 

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -117,6 +117,15 @@ export interface ChatSessionPaneProps {
    * Used to clear the pending message state in the parent.
    */
   onPendingMessageSent?: () => void
+  /**
+   * Disable the input field. Used when user must take an action
+   * (e.g., make an approval decision) before sending messages.
+   */
+  inputDisabled?: boolean
+  /**
+   * Placeholder to show when input is disabled.
+   */
+  inputDisabledPlaceholder?: string
 }
 
 export function ChatSessionPane({
@@ -133,6 +142,8 @@ export function ChatSessionPane({
   onBeforeSend,
   pendingMessage,
   onPendingMessageSent,
+  inputDisabled = false,
+  inputDisabledPlaceholder,
 }: ChatSessionPaneProps) {
   const queryClient = useQueryClient()
   const processedMessageRef = useRef<
@@ -421,11 +432,13 @@ export function ChatSessionPane({
               placeholder={
                 isReadonly
                   ? "This is a legacy session (read-only)"
-                  : placeholder
+                  : inputDisabled && inputDisabledPlaceholder
+                    ? inputDisabledPlaceholder
+                    : placeholder
               }
               value={input}
-              autoFocus={autoFocusInput && !isReadonly}
-              disabled={isReadonly || !canSubmit}
+              autoFocus={autoFocusInput && !isReadonly && !inputDisabled}
+              disabled={isReadonly || inputDisabled || !canSubmit}
             />
           </PromptInputBody>
           <PromptInputToolbar>
@@ -454,7 +467,7 @@ export function ChatSessionPane({
               </PromptInputTools>
             )}
             <PromptInputSubmit
-              disabled={isReadonly || !canSubmit || !input}
+              disabled={isReadonly || inputDisabled || !canSubmit || !input}
               status={status}
               className="ml-auto text-muted-foreground/80"
             />

--- a/frontend/src/components/inbox/activity-accordion.tsx
+++ b/frontend/src/components/inbox/activity-accordion.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react"
 import { useMemo } from "react"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import type { AgentDerivedStatus, AgentSessionWithStatus } from "@/lib/agents"
+import type { AgentDerivedStatus, InboxSessionItem } from "@/lib/agents"
 import { cn } from "@/lib/utils"
 import { ActivityItem } from "./activity-item"
 
@@ -60,7 +60,7 @@ const GROUP_ORDER: StatusGroup[] = [
 ]
 
 interface ActivityAccordionProps {
-  sessions: AgentSessionWithStatus[]
+  sessions: InboxSessionItem[]
   selectedId: string | null
   onSelect: (id: string) => void
 }
@@ -72,7 +72,7 @@ export function ActivityAccordion({
 }: ActivityAccordionProps) {
   // Group sessions by status category
   const groupedSessions = useMemo(() => {
-    const groups: Record<StatusGroup, AgentSessionWithStatus[]> = {
+    const groups: Record<StatusGroup, InboxSessionItem[]> = {
       review_required: [],
       running: [],
       error: [],

--- a/frontend/src/components/inbox/activity-item.tsx
+++ b/frontend/src/components/inbox/activity-item.tsx
@@ -10,11 +10,11 @@ import {
   EventUpdatedAt,
 } from "@/components/cases/cases-feed-event"
 import { Badge } from "@/components/ui/badge"
-import type { AgentSessionWithStatus } from "@/lib/agents"
+import type { InboxSessionItem } from "@/lib/agents"
 import { cn } from "@/lib/utils"
 
 interface ActivityItemProps {
-  session: AgentSessionWithStatus
+  session: InboxSessionItem
   isSelected: boolean
   onClick: () => void
 }

--- a/frontend/src/components/inbox/inbox-chat.tsx
+++ b/frontend/src/components/inbox/inbox-chat.tsx
@@ -2,12 +2,12 @@
 
 import { useEffect, useState } from "react"
 import { agentSessionsListSessions } from "@/client"
-import type { AgentSessionWithStatus } from "@/lib/agents"
+import type { InboxSessionItem } from "@/lib/agents"
 import { useWorkspaceId } from "@/providers/workspace-id"
 import { InboxDetail } from "./inbox-detail"
 
 interface InboxChatProps {
-  session: AgentSessionWithStatus
+  session: InboxSessionItem
 }
 
 export function InboxChat({ session }: InboxChatProps) {

--- a/frontend/src/components/inbox/inbox-detail.tsx
+++ b/frontend/src/components/inbox/inbox-detail.tsx
@@ -54,6 +54,11 @@ export function InboxDetail({
   // (sessionId differs from parentSessionId when viewing a fork)
   const isForkedSession = sessionId !== parentSessionId
 
+  // Block input when there are pending approvals and we haven't forked yet
+  // User must make an approval decision before they can send messages
+  const hasPendingApprovals = session.pendingApprovalCount > 0
+  const inputDisabled = !isForkedSession && hasPendingApprovals
+
   /**
    * Fork the session and notify parent with the message to send.
    * Parent will switch to the forked session and pass pendingMessage,
@@ -168,6 +173,8 @@ export function InboxDetail({
       onBeforeSend={isForkedSession ? undefined : handleFork}
       pendingMessage={pendingMessage}
       onPendingMessageSent={onPendingMessageSent}
+      inputDisabled={inputDisabled}
+      inputDisabledPlaceholder="Make an approval decision to continue..."
     />
   )
 }

--- a/frontend/src/components/inbox/inbox-detail.tsx
+++ b/frontend/src/components/inbox/inbox-detail.tsx
@@ -9,7 +9,7 @@ import { NoMessages } from "@/components/chat/messages"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { toast } from "@/components/ui/use-toast"
 import { useGetChatVercel } from "@/hooks/use-chat"
-import type { AgentSessionWithStatus } from "@/lib/agents"
+import type { InboxSessionItem } from "@/lib/agents"
 import { useChatReadiness } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -17,7 +17,7 @@ interface InboxDetailProps {
   sessionId: string
   /** The original parent session ID - used for forking */
   parentSessionId: string
-  session: AgentSessionWithStatus
+  session: InboxSessionItem
   /** Called after successfully forking, passes the forked session ID and the message to send */
   onForked?: (forkedSessionId: string, pendingMessage: string) => void
   /** Message to send immediately (passed from parent after fork) */

--- a/frontend/src/components/inbox/index.tsx
+++ b/frontend/src/components/inbox/index.tsx
@@ -5,12 +5,12 @@ import { useInboxChat } from "@/app/workspaces/[workspaceId]/inbox/layout"
 import type { AgentSessionEntity } from "@/client"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import type { DateFilterValue, UseInboxFilters } from "@/hooks/use-inbox"
-import type { AgentSessionWithStatus } from "@/lib/agents"
+import type { InboxSessionItem } from "@/lib/agents"
 import { ActivityAccordion } from "./activity-accordion"
 import { InboxHeader } from "./inbox-header"
 
 interface ActivityLayoutProps {
-  sessions: AgentSessionWithStatus[]
+  sessions: InboxSessionItem[]
   selectedId: string | null
   onSelect: (id: string | null) => void
   isLoading: boolean

--- a/frontend/src/hooks/use-inbox.ts
+++ b/frontend/src/hooks/use-inbox.ts
@@ -4,10 +4,12 @@ import { type Query, useQuery } from "@tanstack/react-query"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   type AgentSessionEntity,
-  type AgentSessionsListSessionsResponse,
-  agentSessionsListSessions,
+  type InboxItemRead,
+  type InboxItemStatus,
+  type InboxListItemsPaginatedResponse,
+  inboxListItemsPaginated,
 } from "@/client"
-import { type AgentSessionWithStatus, enrichAgentSession } from "@/lib/agents"
+import type { AgentStatusTone, InboxSessionItem } from "@/lib/agents"
 import { retryHandler, type TracecatApiError } from "@/lib/errors"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -27,7 +29,7 @@ export interface UseInboxFilters {
 }
 
 export interface UseInboxResult {
-  sessions: AgentSessionWithStatus[]
+  sessions: InboxSessionItem[]
   selectedId: string | null
   setSelectedId: (id: string | null) => void
   isLoading: boolean
@@ -39,6 +41,73 @@ export interface UseInboxResult {
   setLimit: (limit: number) => void
   setUpdatedAfter: (value: DateFilterValue) => void
   setCreatedAfter: (value: DateFilterValue) => void
+}
+
+/**
+ * Maps InboxItemStatus to the derived status and display properties used by the UI.
+ */
+function mapInboxStatusToAgentStatus(status: InboxItemStatus): {
+  derivedStatus: InboxSessionItem["derivedStatus"]
+  statusLabel: string
+  statusPriority: number
+  statusTone: AgentStatusTone
+} {
+  switch (status) {
+    case "pending":
+      return {
+        derivedStatus: "PENDING_APPROVAL",
+        statusLabel: "Pending approvals",
+        statusPriority: 0,
+        statusTone: "warning",
+      }
+    case "failed":
+      return {
+        derivedStatus: "FAILED",
+        statusLabel: "Failed",
+        statusPriority: 1,
+        statusTone: "danger",
+      }
+    case "completed":
+      return {
+        derivedStatus: "COMPLETED",
+        statusLabel: "Completed",
+        statusPriority: 7,
+        statusTone: "success",
+      }
+  }
+}
+
+/**
+ * Converts an InboxItemRead to the InboxSessionItem format expected by UI components.
+ * This bridges the inbox API with inbox UI components.
+ */
+function inboxItemToSessionItem(item: InboxItemRead): InboxSessionItem {
+  const statusInfo = mapInboxStatusToAgentStatus(item.status)
+
+  return {
+    // Core session fields - use source_id as the session identifier
+    id: item.source_id,
+    title: item.title,
+    entity_type: (item.metadata?.entity_type as string) ?? "workflow",
+    entity_id: (item.metadata?.entity_id as string) ?? null,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+
+    // Workflow metadata from inbox item
+    parent_workflow: item.workflow
+      ? {
+          id: item.workflow.id,
+          title: item.workflow.title,
+          alias: item.workflow.alias,
+        }
+      : null,
+
+    // Status fields derived from inbox status
+    ...statusInfo,
+    pendingApprovalCount:
+      (item.metadata?.pending_count as number) ??
+      (item.status === "pending" ? 1 : 0),
+  }
 }
 
 function getDateFromFilter(filter: DateFilterValue): Date | null {
@@ -71,22 +140,22 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
   const [createdAfter, setCreatedAfter] = useState<DateFilterValue>(null)
 
   /**
-   * Computes the refetch interval for sessions based on current state.
+   * Computes the refetch interval for inbox items based on current state.
    *
    * Returns `false` to disable polling when:
    * - Auto-refresh is disabled
    * - The browser tab is hidden
    *
    * Otherwise returns an interval in milliseconds:
-   * - 3000ms (3s): When there are pending approvals or running sessions
-   * - 10000ms (10s): When no sessions exist or all are in terminal states
+   * - 3000ms (3s): When there are pending approvals
+   * - 10000ms (10s): When no items exist or all are in terminal states
    */
   const computeRefetchInterval = useCallback(
     (
       query: Query<
-        AgentSessionsListSessionsResponse,
+        InboxListItemsPaginatedResponse,
         TracecatApiError,
-        AgentSessionsListSessionsResponse,
+        InboxListItemsPaginatedResponse,
         readonly unknown[]
       >
     ) => {
@@ -103,23 +172,14 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
 
       const data = query.state.data
 
-      if (!data || data.length === 0) {
+      if (!data || data.items.length === 0) {
         return 10000
       }
 
-      const enrichedSessions = data.map(enrichAgentSession)
-
-      const hasPendingApproval = enrichedSessions.some(
-        (session) => session.pendingApprovalCount > 0
+      const hasPendingApproval = data.items.some(
+        (item) => item.status === "pending"
       )
       if (hasPendingApproval) {
-        return 3000
-      }
-
-      const hasActiveSession = enrichedSessions.some((session) =>
-        ["RUNNING", "CONTINUED_AS_NEW"].includes(session.derivedStatus)
-      )
-      if (hasActiveSession) {
         return 3000
       }
 
@@ -128,36 +188,29 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
     [autoRefresh]
   )
 
-  // Fetch all sessions (excluding approval sessions which are forks)
+  // Fetch inbox items from the unified inbox endpoint
+  // This endpoint properly aggregates approval status from the backend
   const {
     data: sessions,
     isLoading,
     error,
     refetch,
   } = useQuery<
-    AgentSessionsListSessionsResponse,
+    InboxListItemsPaginatedResponse,
     TracecatApiError,
-    AgentSessionWithStatus[]
+    InboxSessionItem[]
   >({
-    queryKey: [
-      "inbox-sessions",
-      workspaceId,
-      entityType === "all" ? null : entityType,
-      limit,
-    ],
+    queryKey: ["inbox-items", workspaceId, limit],
     queryFn: () =>
-      agentSessionsListSessions({
+      inboxListItemsPaginated({
         workspaceId,
-        // Exclude approval sessions (they are forked sessions for inbox replies)
-        excludeEntityTypes: ["approval"],
-        entityType: entityType === "all" ? undefined : entityType,
         limit,
       }),
     select: (data) => {
-      // Enrich sessions with derived status and sort by priority
-      const enriched = data.map(enrichAgentSession)
+      // Convert inbox items to session format and sort by priority
+      const converted = data.items.map(inboxItemToSessionItem)
       // Sort by status priority (pending approvals first), then by updated_at (most recent first)
-      return enriched.sort((a, b) => {
+      return converted.sort((a, b) => {
         if (a.statusPriority !== b.statusPriority) {
           return a.statusPriority - b.statusPriority
         }

--- a/frontend/src/hooks/use-inbox.ts
+++ b/frontend/src/hooks/use-inbox.ts
@@ -224,7 +224,7 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
     refetchInterval: computeRefetchInterval,
   })
 
-  // Apply client-side filtering (search, date filters)
+  // Apply client-side filtering (search, entity type, date filters)
   const filteredSessions = useMemo(() => {
     if (!sessions) return []
 
@@ -233,6 +233,11 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
     const query = searchQuery.toLowerCase().trim()
 
     return sessions.filter((session) => {
+      // Entity type filter
+      if (entityType !== "all" && session.entity_type !== entityType) {
+        return false
+      }
+
       // Search filter
       if (query) {
         const title = (
@@ -265,7 +270,7 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
 
       return true
     })
-  }, [sessions, searchQuery, updatedAfter, createdAfter])
+  }, [sessions, searchQuery, entityType, updatedAfter, createdAfter])
 
   const enrichedSessions = filteredSessions
 

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -137,6 +137,27 @@ export type AgentSessionWithStatus = AgentSessionReadWithMeta & {
   temporalStatus: AgentTemporalStatus | null
 }
 
+/**
+ * Minimal inbox item type for the inbox list view.
+ * This is a simpler type that works with the unified inbox API
+ * while maintaining compatibility with inbox UI components.
+ */
+export interface InboxSessionItem {
+  /** The agent session ID (source_id from inbox API) */
+  id: string
+  title: string
+  entity_type: string
+  entity_id: string | null
+  created_at: string
+  updated_at: string
+  parent_workflow: WorkflowSummary | null
+  derivedStatus: AgentDerivedStatus
+  statusLabel: string
+  statusPriority: number
+  statusTone: AgentStatusTone
+  pendingApprovalCount: number
+}
+
 export function enrichAgentSession(
   session: AgentSessionReadWithMeta
 ): AgentSessionWithStatus {

--- a/packages/tracecat-ee/tracecat_ee/inbox/providers/approvals.py
+++ b/packages/tracecat-ee/tracecat_ee/inbox/providers/approvals.py
@@ -311,6 +311,8 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
 
             # Build metadata
             metadata: dict[str, Any] = {
+                "entity_type": session.entity_type,
+                "entity_id": str(session.entity_id) if session.entity_id else None,
                 "pending_count": pending_count,
                 "total_approvals": len(session_approvals),
                 "approvals": [

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -371,10 +371,12 @@ class AgentSessionService(BaseWorkspaceService):
 
         # For forked sessions, only fork on the first turn (when child has no sdk_session_id yet)
         # On subsequent turns, child has its own sdk_session_id and should resume normally
+        is_fork = False
         if (
             agent_session.parent_session_id is not None
             and agent_session.sdk_session_id is None
         ):
+            is_fork = True
             parent_session = await self.get_session(agent_session.parent_session_id)
             if parent_session is None:
                 logger.warning(
@@ -428,6 +430,7 @@ class AgentSessionService(BaseWorkspaceService):
         return SessionHistoryData(
             sdk_session_id=sdk_session_id,
             sdk_session_data=sdk_session_data,
+            is_fork=is_fork,
         )
 
     async def get_session_history(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrate the inbox list to the unified inbox API with a new lightweight InboxSessionItem type, and fix a forking bug so child sessions only fork on the first turn. Block chat input until pending approvals are resolved to prevent premature messages and stabilize session flow.

- **Refactors**
  - Replaced AgentSessionWithStatus with InboxSessionItem across inbox components.
  - use-inbox now calls inboxListItemsPaginated, maps inbox item statuses (pending/failed/completed) to UI status, labels, tone, and priority, and restores client-side entity type filtering.
  - Polling simplified: 3s when approvals are pending, otherwise 10s; items sorted by status priority then updated_at.

- **Bug Fixes**
  - Fixed session forking: fork only when the child has no sdk_session_id (first turn), and surface is_fork in SessionHistoryData.
  - Added entity_type and entity_id to approvals provider metadata for correct list rendering and routing.
  - Disabled chat input pre-fork when approvals are pending, with a guidance placeholder.

<sup>Written for commit 598eb3c522c3057b4187de7b4a6de82b2795c8fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

