### PR TITLE
fix(agent): Update gateway for custom models and bedrock

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -298,6 +298,7 @@ class DurableAgentWorkflow:
             workspace_id=self.workspace_id,
             session_id=self.session_id,
             model=cfg.model_name,
+            provider=cfg.model_provider,
             model_settings=cfg.model_settings,
             output_type=cfg.output_type,
             use_workspace_credentials=args.agent_args.use_workspace_credentials,

--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -62,24 +62,29 @@ bedrock_secret = RegistrySecret(
         "AWS_ROLE_ARN",
         "AWS_ROLE_SESSION_NAME",
         "AWS_SESSION_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_MODEL_ID",
+        "AWS_INFERENCE_PROFILE_ID",
     ],
     optional=True,
 )
-"""AWS credentials.
+"""AWS Bedrock credentials.
 
 - name: `amazon_bedrock`
 - optional_keys:
-    Either:
-        - `AWS_ACCESS_KEY_ID`
-        - `AWS_SECRET_ACCESS_KEY`
-        - `AWS_REGION`
-    Or:
+    Authentication (one of):
+        - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
+        - `AWS_BEARER_TOKEN_BEDROCK`
         - `AWS_PROFILE`
-    Or:
-        - `AWS_ROLE_ARN`
-        - `AWS_ROLE_SESSION_NAME` (optional)
-    Or:
+        - `AWS_ROLE_ARN` + `AWS_ROLE_SESSION_NAME` (optional)
         - `AWS_SESSION_TOKEN`
+    Model configuration (one of):
+        - `AWS_INFERENCE_PROFILE_ID`: Required for newer models (Claude 4, etc.).
+          Use system profile ID like 'us.anthropic.claude-sonnet-4-20250514-v1:0'
+          or custom inference profile ARN for cost tracking.
+        - `AWS_MODEL_ID`: Direct model ID for older models that support on-demand throughput.
+    Region:
+        - `AWS_REGION`: AWS region (e.g., us-east-1)
 """
 
 

--- a/tracecat/agent/config.py
+++ b/tracecat/agent/config.py
@@ -72,7 +72,7 @@ MODEL_CONFIGS = {
         },
     ),
     "bedrock": ModelConfig(
-        name="bedrock",  # Placeholder; actual ARN from AWS_MODEL_ARN credential will be used at runtime
+        name="bedrock",  # Placeholder; actual model ID from AWS_MODEL_ID credential will be used at runtime
         provider="bedrock",
         org_secret_name="agent-bedrock-credentials",
         secrets={
@@ -140,10 +140,18 @@ PROVIDER_CREDENTIAL_CONFIGS = {
                 required=False,
             ),
             ProviderCredentialField(
-                key="AWS_MODEL_ARN",
-                label="Model ARN",
+                key="AWS_MODEL_ID",
+                label="Model ID (legacy models only)",
                 type="text",
-                description="Your model ARN for Bedrock access.",
+                description="Direct model ID for older models that support on-demand throughput (e.g., anthropic.claude-3-haiku-20240307-v1:0). Leave empty if using Inference Profile ID.",
+                required=False,
+            ),
+            ProviderCredentialField(
+                key="AWS_INFERENCE_PROFILE_ID",
+                label="Inference Profile ID",
+                type="text",
+                description="Required for newer models (Claude 4, etc.). Use system profile ID like 'us.anthropic.claude-sonnet-4-20250514-v1:0' or your custom inference profile ARN for cost tracking.",
+                required=False,
             ),
             ProviderCredentialField(
                 key="AWS_REGION",

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -251,6 +251,13 @@ def _inject_provider_credentials(
         # Legacy: Direct model ID for older models that support on-demand throughput
         elif model_id := creds.get("AWS_MODEL_ID"):
             data["model"] = f"bedrock/{model_id}"
+        else:
+            raise ProxyException(
+                message="No Bedrock model configured. Set AWS_INFERENCE_PROFILE_ID (for newer models) or AWS_MODEL_ID (for legacy models) in your credentials.",
+                type="config_error",
+                param=None,
+                code=400,
+            )
 
     elif provider == "custom-model-provider":
         # Custom provider for OpenAI-compatible endpoints (Ollama, vLLM, etc.)

--- a/tracecat/agent/litellm_config.yaml
+++ b/tracecat/agent/litellm_config.yaml
@@ -32,15 +32,16 @@ model_list:
     litellm_params:
       model: anthropic/claude-opus-4-5-20251101
 
-  # Bedrock (model ARN injected from credentials)
-  - model_name: bedrock
+  # Bedrock wildcard - catches dynamically-set ARN models (bedrock/arn:aws:...)
+  - model_name: bedrock/*
     litellm_params:
-      model: bedrock/placeholder
+      model: bedrock/*
 
-  # Custom model provider (base_url, model injected from credentials)
-  - model_name: custom
+
+  # Catch-all wildcard for any model not explicitly defined, for custom models
+  - model_name: "*"
     litellm_params:
-      model: openai/placeholder
+      model: openai/*
 
 general_settings:
   custom_auth: tracecat.agent.gateway.user_api_key_auth

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -281,12 +281,16 @@ class AgentManagementService(BaseOrgService):
             )
 
         # For Bedrock, the model ID must come from credentials
+        # Prefer inference profile ID (required for newer models like Claude 4)
         if provider == "bedrock":
-            model_id = credentials.get("AWS_MODEL_ID")
+            model_id = credentials.get("AWS_INFERENCE_PROFILE_ID") or credentials.get(
+                "AWS_MODEL_ID"
+            )
             if not model_id:
                 raise TracecatNotFoundError(
-                    "AWS_MODEL_ID not found in Bedrock credentials. "
-                    "Please configure the Model ID in your Bedrock credentials."
+                    "No Bedrock model configured. Please set either "
+                    "AWS_INFERENCE_PROFILE_ID (for newer models like Claude 4) or "
+                    "AWS_MODEL_ID (for legacy models) in your Bedrock credentials."
                 )
             model_config = model_config.model_copy(update={"name": model_id})
 

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -211,6 +211,7 @@ LLM_REQUIRED_CLAIMS = (
     "workspace_id",
     "session_id",
     "model",
+    "provider",
 )
 
 
@@ -227,6 +228,9 @@ class LLMTokenClaims(BaseModel):
 
     # Model configuration
     model: str = Field(..., description="The model to use for this run")
+    provider: str = Field(
+        ..., description="The provider for the model (e.g., openai, anthropic, bedrock)"
+    )
 
     # Model settings - passed through to LLM provider as-is
     # Supports: temperature, max_tokens, reasoning_effort, etc.
@@ -253,6 +257,7 @@ def mint_llm_token(
     workspace_id: WorkspaceID,
     session_id: uuid.UUID,
     model: str,
+    provider: str,
     model_settings: dict[str, Any] | None = None,
     output_type: OutputType | None = None,
     use_workspace_credentials: bool = False,
@@ -267,6 +272,7 @@ def mint_llm_token(
         workspace_id: The workspace UUID as string
         session_id: The agent session UUID as string
         model: The model to use for this run
+        provider: The provider for the model (e.g., openai, anthropic, bedrock)
         model_settings: Model-specific settings (temperature, max_tokens,
             reasoning_effort, etc.) passed through to LLM provider
         output_type: Expected output type for structured outputs
@@ -294,6 +300,7 @@ def mint_llm_token(
         "session_id": str(session_id),
         # Model configuration
         "model": model,
+        "provider": provider,
         "model_settings": model_settings or {},
         # Credential scope
         "use_workspace_credentials": use_workspace_credentials,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes LLM routing for custom OpenAI-compatible endpoints and AWS Bedrock. Provider is now carried in tokens and credentials are injected correctly, enabling Bedrock inference profiles and stable custom model support.

- **Bug Fixes**
  - Pass provider in LLM tokens and through the gateway and durable runs; stop inferring provider from model.
  - Bedrock: prioritize AWS_INFERENCE_PROFILE_ID; fall back to AWS_MODEL_ID for legacy models. Inject region and auth, and route via bedrock/* in LiteLLM.
  - Custom provider: support OpenAI-compatible endpoints (base_url + model). Prefix models with openai/ and allow a dummy api_key when absent. Route via wildcard in LiteLLM.
  - Registry and service: update Bedrock credential schema and docs; map provider "bedrock" to workspace secret "amazon_bedrock".

- **Migration**
  - Bedrock credentials: replace AWS_MODEL_ARN with AWS_INFERENCE_PROFILE_ID (recommended) or AWS_MODEL_ID. Ensure AWS_REGION is set. Use either AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, AWS_BEARER_TOKEN_BEDROCK, AWS_PROFILE, or role-based auth.
  - Custom models: set CUSTOM_MODEL_PROVIDER_BASE_URL and CUSTOM_MODEL_PROVIDER_MODEL_NAME; CUSTOM_MODEL_PROVIDER_API_KEY is optional.

<sup>Written for commit 39402fedebfe849bee167ebacbb52a57fd62a09c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

