### PR TITLE
feat(rbac): RBAC auth layer

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -13197,6 +13197,15 @@ export const $Role = {
       title: "Is Platform Superuser",
       default: false,
     },
+    scopes: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      uniqueItems: true,
+      title: "Scopes",
+      default: [],
+    },
   },
   type: "object",
   required: ["type", "service_id"],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4218,6 +4218,7 @@ export type Role = {
     | "tracecat-service"
     | "tracecat-ui"
   is_platform_superuser?: boolean
+  scopes?: Array<string>
 }
 
 export type type3 = "user" | "service"

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -557,7 +557,11 @@ async def test_organization_id_populated_when_require_workspace_no(mocker):
     org_role_result = MagicMock()
     org_role_result.scalar_one_or_none.return_value = None
 
-    mock_session.execute.side_effect = [org_result, org_role_result]
+    # Third call: compute_effective_scopes query returns empty scopes
+    scopes_result = MagicMock()
+    scopes_result.scalars.return_value.all.return_value = []
+
+    mock_session.execute.side_effect = [org_result, org_role_result, scopes_result]
 
     # Mock is_unprivileged to return False for admin users
     mocker.patch("tracecat.auth.credentials.is_unprivileged", return_value=False)

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -21,7 +21,7 @@ from tracecat.authz.scopes import (
     ORG_MEMBER_SCOPES,
     ORG_OWNER_SCOPES,
     ORG_ROLE_SCOPES,
-    SYSTEM_ROLE_SCOPES,
+    PRESET_ROLE_SCOPES,
     VIEWER_SCOPES,
 )
 from tracecat.contexts import ctx_scopes
@@ -195,9 +195,9 @@ class TestSystemRoleScopes:
         assert EDITOR_SCOPES.issubset(ADMIN_SCOPES)
 
     def test_system_role_mapping(self):
-        assert SYSTEM_ROLE_SCOPES[WorkspaceRole.VIEWER] == VIEWER_SCOPES
-        assert SYSTEM_ROLE_SCOPES[WorkspaceRole.EDITOR] == EDITOR_SCOPES
-        assert SYSTEM_ROLE_SCOPES[WorkspaceRole.ADMIN] == ADMIN_SCOPES
+        assert PRESET_ROLE_SCOPES[WorkspaceRole.VIEWER] == VIEWER_SCOPES
+        assert PRESET_ROLE_SCOPES[WorkspaceRole.EDITOR] == EDITOR_SCOPES
+        assert PRESET_ROLE_SCOPES[WorkspaceRole.ADMIN] == ADMIN_SCOPES
 
 
 class TestOrgRoleScopes:

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -1,0 +1,330 @@
+"""Unit tests for RBAC scope matching and controls."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracecat.authz.controls import (
+    get_missing_scopes,
+    has_all_scopes,
+    has_any_scope,
+    has_scope,
+    require_scope,
+    scope_matches,
+    validate_scope_string,
+)
+from tracecat.authz.enums import OrgRole, WorkspaceRole
+from tracecat.authz.scopes import (
+    ADMIN_SCOPES,
+    EDITOR_SCOPES,
+    ORG_ADMIN_SCOPES,
+    ORG_MEMBER_SCOPES,
+    ORG_OWNER_SCOPES,
+    ORG_ROLE_SCOPES,
+    SYSTEM_ROLE_SCOPES,
+    VIEWER_SCOPES,
+)
+from tracecat.contexts import ctx_scopes
+from tracecat.exceptions import ScopeDeniedError
+
+
+class TestValidateScopeString:
+    """Tests for scope string validation."""
+
+    def test_valid_simple_scope(self):
+        assert validate_scope_string("workflow:read") is True
+        assert validate_scope_string("case:create") is True
+        assert validate_scope_string("org:member:invite") is True
+
+    def test_valid_scope_with_wildcard(self):
+        assert validate_scope_string("workflow:*") is True
+        assert validate_scope_string("action:*:execute") is True
+        assert validate_scope_string("*") is True
+
+    def test_valid_scope_with_special_chars(self):
+        assert validate_scope_string("action:core.http_request:execute") is True
+        assert validate_scope_string("action:tools.okta-client:execute") is True
+
+    def test_invalid_scope_uppercase(self):
+        assert validate_scope_string("Workflow:read") is False
+        assert validate_scope_string("WORKFLOW:READ") is False
+
+    def test_invalid_scope_spaces(self):
+        assert validate_scope_string("workflow: read") is False
+        assert validate_scope_string("workflow :read") is False
+
+    def test_invalid_scope_other_patterns(self):
+        assert validate_scope_string("workflow:?") is False
+        assert validate_scope_string("workflow:[read]") is False
+
+
+class TestScopeMatches:
+    """Tests for scope matching with wildcards."""
+
+    def test_exact_match(self):
+        assert scope_matches("workflow:read", "workflow:read") is True
+        assert scope_matches("workflow:read", "workflow:create") is False
+
+    def test_global_wildcard(self):
+        assert scope_matches("*", "workflow:read") is True
+        assert scope_matches("*", "org:member:invite") is True
+        assert scope_matches("*", "anything:here") is True
+
+    def test_suffix_wildcard(self):
+        assert scope_matches("workflow:*", "workflow:read") is True
+        assert scope_matches("workflow:*", "workflow:create") is True
+        assert scope_matches("workflow:*", "workflow:execute") is True
+        assert scope_matches("workflow:*", "case:read") is False
+
+    def test_middle_wildcard(self):
+        assert scope_matches("action:*:execute", "action:core.http:execute") is True
+        assert scope_matches("action:*:execute", "action:tools.okta:execute") is True
+        assert scope_matches("action:*:execute", "action:tools.okta:read") is False
+
+    def test_prefix_wildcard(self):
+        assert (
+            scope_matches("action:core.*:execute", "action:core.http:execute") is True
+        )
+        assert (
+            scope_matches("action:core.*:execute", "action:core.transform:execute")
+            is True
+        )
+        assert (
+            scope_matches("action:core.*:execute", "action:tools.okta:execute") is False
+        )
+
+    def test_multiple_wildcards(self):
+        # Multiple wildcards in a scope
+        assert scope_matches("action:*.*:execute", "action:core.http:execute") is True
+        assert scope_matches("*:*", "workflow:read") is True
+
+
+class TestHasScope:
+    """Tests for has_scope function."""
+
+    def test_has_exact_scope(self):
+        scopes = frozenset({"workflow:read", "case:create"})
+        assert has_scope(scopes, "workflow:read") is True
+        assert has_scope(scopes, "case:create") is True
+        assert has_scope(scopes, "workflow:delete") is False
+
+    def test_has_scope_via_wildcard(self):
+        scopes = frozenset({"workflow:*", "case:read"})
+        assert has_scope(scopes, "workflow:read") is True
+        assert has_scope(scopes, "workflow:create") is True
+        assert has_scope(scopes, "workflow:delete") is True
+        assert has_scope(scopes, "case:read") is True
+        assert has_scope(scopes, "case:create") is False
+
+    def test_has_scope_global_wildcard(self):
+        scopes = frozenset({"*"})
+        assert has_scope(scopes, "workflow:read") is True
+        assert has_scope(scopes, "org:delete") is True
+        assert has_scope(scopes, "anything:here") is True
+
+    def test_empty_scopes(self):
+        scopes: frozenset[str] = frozenset()
+        assert has_scope(scopes, "workflow:read") is False
+
+
+class TestHasAllScopes:
+    """Tests for has_all_scopes function."""
+
+    def test_has_all_exact_scopes(self):
+        scopes = frozenset({"workflow:read", "workflow:execute", "case:read"})
+        assert has_all_scopes(scopes, {"workflow:read", "workflow:execute"}) is True
+        assert has_all_scopes(scopes, {"workflow:read", "case:create"}) is False
+
+    def test_has_all_via_wildcard(self):
+        scopes = frozenset({"workflow:*"})
+        assert has_all_scopes(scopes, {"workflow:read", "workflow:execute"}) is True
+        assert has_all_scopes(scopes, {"workflow:read", "case:read"}) is False
+
+
+class TestHasAnyScope:
+    """Tests for has_any_scope function."""
+
+    def test_has_any_exact_scope(self):
+        scopes = frozenset({"workflow:read", "case:create"})
+        assert has_any_scope(scopes, {"workflow:read", "workflow:delete"}) is True
+        assert has_any_scope(scopes, {"org:delete", "secret:read"}) is False
+
+    def test_has_any_via_wildcard(self):
+        scopes = frozenset({"workflow:*"})
+        assert has_any_scope(scopes, {"workflow:read", "case:read"}) is True
+        assert has_any_scope(scopes, {"case:read", "org:read"}) is False
+
+
+class TestGetMissingScopes:
+    """Tests for get_missing_scopes function."""
+
+    def test_no_missing_scopes(self):
+        scopes = frozenset({"workflow:read", "workflow:execute"})
+        missing = get_missing_scopes(scopes, {"workflow:read", "workflow:execute"})
+        assert missing == set()
+
+    def test_some_missing_scopes(self):
+        scopes = frozenset({"workflow:read"})
+        missing = get_missing_scopes(scopes, {"workflow:read", "workflow:execute"})
+        assert missing == {"workflow:execute"}
+
+    def test_all_missing_scopes(self):
+        scopes = frozenset({"case:read"})
+        missing = get_missing_scopes(scopes, {"workflow:read", "workflow:execute"})
+        assert missing == {"workflow:read", "workflow:execute"}
+
+    def test_wildcard_covers_scopes(self):
+        scopes = frozenset({"workflow:*"})
+        missing = get_missing_scopes(scopes, {"workflow:read", "workflow:execute"})
+        assert missing == set()
+
+
+class TestSystemRoleScopes:
+    """Tests for system role scope definitions."""
+
+    def test_viewer_scopes_are_read_only(self):
+        for scope in VIEWER_SCOPES:
+            # Viewer should only have read scopes (no create, update, delete, execute)
+            action = scope.split(":")[-1]
+            assert action in ("read", "member:read"), f"Unexpected scope: {scope}"
+
+    def test_editor_includes_viewer(self):
+        assert VIEWER_SCOPES.issubset(EDITOR_SCOPES)
+
+    def test_admin_includes_editor(self):
+        assert EDITOR_SCOPES.issubset(ADMIN_SCOPES)
+
+    def test_system_role_mapping(self):
+        assert SYSTEM_ROLE_SCOPES[WorkspaceRole.VIEWER] == VIEWER_SCOPES
+        assert SYSTEM_ROLE_SCOPES[WorkspaceRole.EDITOR] == EDITOR_SCOPES
+        assert SYSTEM_ROLE_SCOPES[WorkspaceRole.ADMIN] == ADMIN_SCOPES
+
+
+class TestOrgRoleScopes:
+    """Tests for organization role scope definitions."""
+
+    def test_owner_has_org_delete(self):
+        assert "org:delete" in ORG_OWNER_SCOPES
+        assert "org:delete" not in ORG_ADMIN_SCOPES
+        assert "org:delete" not in ORG_MEMBER_SCOPES
+
+    def test_owner_has_billing_manage(self):
+        assert "org:billing:manage" in ORG_OWNER_SCOPES
+        assert "org:billing:manage" not in ORG_ADMIN_SCOPES
+
+    def test_admin_has_billing_read(self):
+        assert "org:billing:read" in ORG_ADMIN_SCOPES
+
+    def test_member_has_minimal_scopes(self):
+        assert ORG_MEMBER_SCOPES == frozenset({"org:read", "org:member:read"})
+
+    def test_org_role_mapping(self):
+        assert ORG_ROLE_SCOPES[OrgRole.OWNER] == ORG_OWNER_SCOPES
+        assert ORG_ROLE_SCOPES[OrgRole.ADMIN] == ORG_ADMIN_SCOPES
+        assert ORG_ROLE_SCOPES[OrgRole.MEMBER] == ORG_MEMBER_SCOPES
+
+
+class TestRequireScopeDecorator:
+    """Tests for the @require_scope decorator."""
+
+    def test_require_scope_passes_with_exact_scope(self):
+        ctx_scopes.set(frozenset({"workflow:read"}))
+
+        @require_scope("workflow:read")
+        def protected_func():
+            return "success"
+
+        assert protected_func() == "success"
+
+    def test_require_scope_passes_with_wildcard(self):
+        ctx_scopes.set(frozenset({"workflow:*"}))
+
+        @require_scope("workflow:read")
+        def protected_func():
+            return "success"
+
+        assert protected_func() == "success"
+
+    def test_require_scope_passes_with_superuser(self):
+        ctx_scopes.set(frozenset({"*"}))
+
+        @require_scope("org:delete")
+        def protected_func():
+            return "success"
+
+        assert protected_func() == "success"
+
+    def test_require_scope_fails_without_scope(self):
+        ctx_scopes.set(frozenset({"case:read"}))
+
+        @require_scope("workflow:read")
+        def protected_func():
+            return "success"
+
+        with pytest.raises(ScopeDeniedError) as exc_info:
+            protected_func()
+
+        assert "workflow:read" in exc_info.value.required_scopes
+        assert "workflow:read" in exc_info.value.missing_scopes
+
+    def test_require_scope_multiple_all_required(self):
+        ctx_scopes.set(frozenset({"workflow:read", "workflow:execute"}))
+
+        @require_scope("workflow:read", "workflow:execute", require_all=True)
+        def protected_func():
+            return "success"
+
+        assert protected_func() == "success"
+
+    def test_require_scope_multiple_missing_one(self):
+        ctx_scopes.set(frozenset({"workflow:read"}))
+
+        @require_scope("workflow:read", "workflow:execute", require_all=True)
+        def protected_func():
+            return "success"
+
+        with pytest.raises(ScopeDeniedError) as exc_info:
+            protected_func()
+
+        assert "workflow:execute" in exc_info.value.missing_scopes
+
+    def test_require_scope_any_one_sufficient(self):
+        ctx_scopes.set(frozenset({"workflow:read"}))
+
+        @require_scope("workflow:read", "workflow:execute", require_all=False)
+        def protected_func():
+            return "success"
+
+        assert protected_func() == "success"
+
+    def test_require_scope_any_none_present(self):
+        ctx_scopes.set(frozenset({"case:read"}))
+
+        @require_scope("workflow:read", "workflow:execute", require_all=False)
+        def protected_func():
+            return "success"
+
+        with pytest.raises(ScopeDeniedError):
+            protected_func()
+
+    @pytest.mark.anyio
+    async def test_require_scope_async_function(self):
+        ctx_scopes.set(frozenset({"workflow:read"}))
+
+        @require_scope("workflow:read")
+        async def async_protected_func():
+            return "async success"
+
+        result = await async_protected_func()
+        assert result == "async success"
+
+    @pytest.mark.anyio
+    async def test_require_scope_async_function_denied(self):
+        ctx_scopes.set(frozenset({"case:read"}))
+
+        @require_scope("workflow:read")
+        async def async_protected_func():
+            return "async success"
+
+        with pytest.raises(ScopeDeniedError):
+            await async_protected_func()

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -14,7 +14,6 @@ from tracecat.authz.controls import (
     scope_matches,
     validate_scope_string,
 )
-from tracecat.authz.enums import OrgRole, WorkspaceRole
 from tracecat.authz.scopes import (
     ADMIN_SCOPES,
     EDITOR_SCOPES,
@@ -202,9 +201,9 @@ class TestSystemRoleScopes:
         assert EDITOR_SCOPES.issubset(ADMIN_SCOPES)
 
     def test_system_role_mapping(self):
-        assert PRESET_ROLE_SCOPES[WorkspaceRole.VIEWER] == VIEWER_SCOPES
-        assert PRESET_ROLE_SCOPES[WorkspaceRole.EDITOR] == EDITOR_SCOPES
-        assert PRESET_ROLE_SCOPES[WorkspaceRole.ADMIN] == ADMIN_SCOPES
+        assert PRESET_ROLE_SCOPES["workspace-viewer"] == VIEWER_SCOPES
+        assert PRESET_ROLE_SCOPES["workspace-editor"] == EDITOR_SCOPES
+        assert PRESET_ROLE_SCOPES["workspace-admin"] == ADMIN_SCOPES
 
 
 class TestOrgRoleScopes:
@@ -226,9 +225,9 @@ class TestOrgRoleScopes:
         assert ORG_MEMBER_SCOPES == frozenset({"org:read", "org:member:read"})
 
     def test_org_role_mapping(self):
-        assert ORG_ROLE_SCOPES[OrgRole.OWNER] == ORG_OWNER_SCOPES
-        assert ORG_ROLE_SCOPES[OrgRole.ADMIN] == ORG_ADMIN_SCOPES
-        assert ORG_ROLE_SCOPES[OrgRole.MEMBER] == ORG_MEMBER_SCOPES
+        assert ORG_ROLE_SCOPES["organization-owner"] == ORG_OWNER_SCOPES
+        assert ORG_ROLE_SCOPES["organization-admin"] == ORG_ADMIN_SCOPES
+        assert ORG_ROLE_SCOPES["organization-member"] == ORG_MEMBER_SCOPES
 
 
 class TestRequireScopeDecorator:

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -114,7 +114,7 @@ def compute_effective_scopes(role: Role) -> frozenset[str]:
     if role.workspace_id and role.workspace_role:
         # Org admins/owners already have workspace scopes via their org role
         # Regular members need their workspace role scopes
-        if role.org_role not in (OrgRole.OWNER, OrgRole.ADMIN):
+        if not role.is_org_admin:
             scope_set |= PRESET_ROLE_SCOPES.get(role.workspace_role, set())
 
     # Note: Group-based scopes (from group_assignment table) will be added in PR 4

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -938,8 +938,8 @@ async def _authenticated_user_only(
         is_platform_superuser=user.is_superuser,
         # organization_id intentionally None - user may not belong to any org
     )
-    # Superusers get "*" scope (all access)
-    ctx_scopes.set(frozenset({"*"}))
+    scopes = compute_effective_scopes(role)
+    ctx_scopes.set(scopes)
     ctx_role.set(role)
     return role
 

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -32,7 +32,7 @@ from tracecat.auth.users import (
     optional_current_active_user,
 )
 from tracecat.authz.enums import OrgRole, WorkspaceRole
-from tracecat.authz.scopes import ORG_ROLE_SCOPES, SYSTEM_ROLE_SCOPES
+from tracecat.authz.scopes import ORG_ROLE_SCOPES, PRESET_ROLE_SCOPES
 from tracecat.authz.service import MembershipService, MembershipWithOrg
 from tracecat.contexts import ctx_role, ctx_scopes
 from tracecat.db.dependencies import AsyncDBSession
@@ -96,7 +96,7 @@ def compute_effective_scopes(role: Role) -> frozenset[str]:
 
     For workspace-scoped requests:
     - Org OWNER/ADMIN: org-level scopes (they can access all workspaces)
-    - Workspace members: workspace role scopes from SYSTEM_ROLE_SCOPES
+    - Workspace members: workspace role scopes from PRESET_ROLE_SCOPES
 
     Note: Group-based scopes will be added in PR 4 (RBAC Service & APIs).
     """
@@ -115,7 +115,7 @@ def compute_effective_scopes(role: Role) -> frozenset[str]:
         # Org admins/owners already have workspace scopes via their org role
         # Regular members need their workspace role scopes
         if role.org_role not in (OrgRole.OWNER, OrgRole.ADMIN):
-            scope_set |= SYSTEM_ROLE_SCOPES.get(role.workspace_role, set())
+            scope_set |= PRESET_ROLE_SCOPES.get(role.workspace_role, set())
 
     # Note: Group-based scopes (from group_assignment table) will be added in PR 4
     # via RBACService.get_group_scopes()

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -58,6 +58,8 @@ class Role(BaseModel):
     service_id: InternalServiceID = Field(frozen=True)
     is_platform_superuser: bool = Field(default=False, frozen=True)
     """Whether this role belongs to a platform superuser (User.is_superuser=True)."""
+    scopes: frozenset[str] = Field(default=frozenset(), frozen=True)
+    """Effective scopes for this role. Computed during authentication."""
 
     @property
     def is_superuser(self) -> bool:
@@ -97,6 +99,8 @@ class Role(BaseModel):
             headers["x-tracecat-role-workspace-role"] = self.workspace_role.value
         if self.org_role is not None:
             headers["x-tracecat-role-org-role"] = self.org_role.value
+        if self.scopes:
+            headers["x-tracecat-role-scopes"] = ",".join(sorted(self.scopes))
         return headers
 
 
@@ -127,5 +131,5 @@ def system_role() -> Role:
         type="service",
         service_id="tracecat-api",
         access_level=AccessLevel.ADMIN,
-        is_platform_superuser=True,
+        scopes=frozenset({"*"}),
     )

--- a/tracecat/authz/controls.py
+++ b/tracecat/authz/controls.py
@@ -272,6 +272,10 @@ def require_scope(*scopes: str, require_all: bool = True) -> Callable[[T], T]:
     required = set(scopes)
 
     def check_scopes():
+        # Empty required scopes means no restrictions
+        if not required:
+            return
+
         user_scopes = ctx_scopes.get()
 
         # Platform superuser has "*" scope - bypass all checks

--- a/tracecat/authz/controls.py
+++ b/tracecat/authz/controls.py
@@ -1,14 +1,119 @@
 import asyncio
 import functools
+import re
 from collections.abc import Callable, Coroutine
 from typing import Any, Protocol, TypeVar, cast, runtime_checkable
 
-from tracecat.auth.types import Role
-from tracecat.authz.enums import OrgRole, WorkspaceRole
-from tracecat.exceptions import TracecatAuthorizationError
+from tracecat.auth.types import AccessLevel, Role
+from tracecat.authz.enums import WorkspaceRole
+from tracecat.contexts import ctx_scopes
+from tracecat.exceptions import ScopeDeniedError, TracecatAuthorizationError
 from tracecat.logger import logger
 
 T = TypeVar("T", bound=Callable[..., Coroutine[Any, Any, Any] | Any])
+
+# Regex for validating scope strings: lowercase alphanumeric with : _ . - and *
+# Only * is allowed as wildcard, no ? or [] patterns
+SCOPE_PATTERN = re.compile(r"^[a-z0-9:_.*-]+$")
+
+
+def validate_scope_string(scope: str) -> bool:
+    """Validate that a scope string follows the allowed format.
+
+    Rules:
+    - Lowercase alphanumeric characters
+    - Allowed special characters: : _ . - *
+    - Only * is allowed as wildcard (no ? or [] patterns)
+    """
+    return bool(SCOPE_PATTERN.match(scope))
+
+
+def scope_matches(granted_scope: str, required_scope: str) -> bool:
+    """Check if a granted scope (potentially with wildcards) matches a required scope.
+
+    Uses fnmatch-style matching with only * as the wildcard character.
+    * matches any sequence of characters.
+
+    Args:
+        granted_scope: A scope that was granted (may contain wildcards)
+        required_scope: A scope that is required (should be exact, no wildcards)
+
+    Returns:
+        True if the granted scope matches the required scope
+
+    Examples:
+        scope_matches("workflow:*", "workflow:read") -> True
+        scope_matches("workflow:read", "workflow:read") -> True
+        scope_matches("action:core.*:execute", "action:core.http_request:execute") -> True
+        scope_matches("action:*:execute", "action:tools.okta.list_users:execute") -> True
+        scope_matches("*", "anything:here") -> True
+    """
+    if granted_scope == "*":
+        # Global wildcard matches everything
+        return True
+
+    if "*" not in granted_scope:
+        # No wildcard - exact match required
+        return granted_scope == required_scope
+
+    # Convert fnmatch-style pattern to regex
+    # Escape all regex special chars except *, then convert * to .*
+    pattern = re.escape(granted_scope).replace(r"\*", ".*")
+    return bool(re.fullmatch(pattern, required_scope))
+
+
+def has_scope(user_scopes: frozenset[str], required_scope: str) -> bool:
+    """Check if a user has a required scope.
+
+    Args:
+        user_scopes: The set of scopes granted to the user
+        required_scope: The scope required for the operation
+
+    Returns:
+        True if any granted scope matches the required scope
+    """
+    return any(scope_matches(granted, required_scope) for granted in user_scopes)
+
+
+def has_all_scopes(user_scopes: frozenset[str], required_scopes: set[str]) -> bool:
+    """Check if a user has all required scopes.
+
+    Args:
+        user_scopes: The set of scopes granted to the user
+        required_scopes: The scopes required for the operation
+
+    Returns:
+        True if all required scopes are satisfied
+    """
+    return all(has_scope(user_scopes, scope) for scope in required_scopes)
+
+
+def has_any_scope(user_scopes: frozenset[str], required_scopes: set[str]) -> bool:
+    """Check if a user has any of the required scopes.
+
+    Args:
+        user_scopes: The set of scopes granted to the user
+        required_scopes: The scopes, any of which satisfies the requirement
+
+    Returns:
+        True if at least one required scope is satisfied
+    """
+    return any(has_scope(user_scopes, scope) for scope in required_scopes)
+
+
+def get_missing_scopes(
+    user_scopes: frozenset[str], required_scopes: set[str]
+) -> set[str]:
+    """Get the scopes that are required but not granted.
+
+    Args:
+        user_scopes: The set of scopes granted to the user
+        required_scopes: The scopes required for the operation
+
+    Returns:
+        Set of scopes that are not satisfied
+    """
+    return {scope for scope in required_scopes if not has_scope(user_scopes, scope)}
 
 
 @runtime_checkable
@@ -123,6 +228,97 @@ def require_workspace_role(*roles: WorkspaceRole) -> Callable[[T], T]:
             def wrapper(self, *args, **kwargs):
                 check(self)
                 return fn(self, *args, **kwargs)
+
+            return cast(T, wrapper)
+
+    return decorator
+
+
+# =============================================================================
+# Scope-based Authorization Decorator
+# =============================================================================
+
+
+def require_scope(*scopes: str, require_all: bool = True) -> Callable[[T], T]:
+    """Decorator that requires specific scopes to access an endpoint or method.
+
+    This decorator checks the current request's scopes (from ctx_scopes) against
+    the required scopes. Platform superusers with the "*" scope bypass all checks.
+
+    Args:
+        *scopes: The scope(s) required for access (e.g., "workflow:read", "org:member:invite")
+        require_all: If True (default), all scopes must be present.
+                    If False, any one of the scopes is sufficient.
+
+    Raises:
+        ScopeDeniedError: If the user doesn't have the required scope(s)
+
+    Examples:
+        # Single scope required
+        @require_scope("workflow:create")
+        async def create_workflow(...):
+            ...
+
+        # Multiple scopes, all required
+        @require_scope("workflow:read", "workflow:execute")
+        async def execute_workflow(...):
+            ...
+
+        # Multiple scopes, any one sufficient
+        @require_scope("org:admin", "workspace:admin", require_all=False)
+        async def admin_operation(...):
+            ...
+    """
+    required = set(scopes)
+
+    def check_scopes():
+        user_scopes = ctx_scopes.get()
+
+        # Platform superuser has "*" scope - bypass all checks
+        if "*" in user_scopes:
+            return
+
+        if require_all:
+            missing = get_missing_scopes(user_scopes, required)
+            if missing:
+                logger.warning(
+                    "Scope check failed - missing required scopes",
+                    required_scopes=list(required),
+                    missing_scopes=list(missing),
+                )
+                raise ScopeDeniedError(
+                    required_scopes=list(required),
+                    missing_scopes=list(missing),
+                )
+        else:
+            if not has_any_scope(user_scopes, required):
+                logger.warning(
+                    "Scope check failed - none of required scopes present",
+                    required_scopes=list(required),
+                )
+                raise ScopeDeniedError(
+                    required_scopes=list(required),
+                    missing_scopes=list(required),
+                )
+
+        logger.debug("Scope check passed", required_scopes=list(required))
+
+    def decorator(fn: T) -> T:
+        if asyncio.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args, **kwargs):
+                check_scopes()
+                return await fn(*args, **kwargs)
+
+            return cast(T, async_wrapper)
+
+        else:
+
+            @functools.wraps(fn)
+            def wrapper(*args, **kwargs):
+                check_scopes()
+                return fn(*args, **kwargs)
 
             return cast(T, wrapper)
 

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -1,0 +1,232 @@
+"""RBAC scope definitions for Tracecat.
+
+This module defines the default scope sets for:
+- System workspace roles (Viewer, Editor, Admin)
+- Organization roles (Owner, Admin, Member)
+
+Scopes follow the OAuth 2.0 format: `{resource}:{action}`
+
+Standard actions (ordered by privilege):
+- read: View/list resources
+- create: Create new resources
+- update: Modify existing resources
+- delete: Remove resources
+- execute: Run/trigger resources
+"""
+
+from __future__ import annotations
+
+from tracecat.authz.enums import OrgRole, WorkspaceRole
+
+# =============================================================================
+# Viewer Role Scopes (read-only)
+# =============================================================================
+
+VIEWER_SCOPES: frozenset[str] = frozenset(
+    {
+        "workflow:read",
+        "case:read",
+        "table:read",
+        "schedule:read",
+        "agent:read",
+        "secret:read",
+        "workspace:read",
+        "workspace:member:read",
+    }
+)
+
+# =============================================================================
+# Editor Role Scopes (create/edit, no delete or admin)
+# =============================================================================
+
+EDITOR_SCOPES: frozenset[str] = VIEWER_SCOPES | frozenset(
+    {
+        "workflow:create",
+        "workflow:update",
+        "workflow:execute",
+        "case:create",
+        "case:update",
+        "table:create",
+        "table:update",
+        "schedule:create",
+        "schedule:update",
+        "agent:execute",
+        "secret:create",
+        "secret:update",
+        # Core actions available to editors
+        "action:core.*:execute",
+    }
+)
+
+# =============================================================================
+# Admin Role Scopes (full workspace capabilities)
+# =============================================================================
+
+ADMIN_SCOPES: frozenset[str] = EDITOR_SCOPES | frozenset(
+    {
+        "workflow:delete",
+        "case:delete",
+        "table:delete",
+        "schedule:delete",
+        "secret:delete",
+        "agent:create",
+        "agent:update",
+        "agent:delete",
+        "workspace:update",
+        "workspace:delete",
+        "workspace:member:invite",
+        "workspace:member:remove",
+        "workspace:member:update",
+        # Full action execution
+        "action:*:execute",
+    }
+)
+
+# =============================================================================
+# System Role -> Scope Set Mapping
+# =============================================================================
+
+SYSTEM_ROLE_SCOPES: dict[WorkspaceRole, frozenset[str]] = {
+    WorkspaceRole.VIEWER: VIEWER_SCOPES,
+    WorkspaceRole.EDITOR: EDITOR_SCOPES,
+    WorkspaceRole.ADMIN: ADMIN_SCOPES,
+}
+
+# =============================================================================
+# Organization Role Scopes
+# =============================================================================
+
+# Note: Org OWNER/ADMIN roles grant implicit access to ALL workspaces in the org.
+# These scopes define WHAT they can do, not WHERE (tier determines container access).
+
+ORG_OWNER_SCOPES: frozenset[str] = frozenset(
+    {
+        # Org settings
+        "org:read",
+        "org:update",
+        "org:delete",  # OWNER-only
+        # Org member management
+        "org:member:read",
+        "org:member:invite",
+        "org:member:remove",
+        "org:member:update",
+        # Billing (OWNER-only for manage)
+        "org:billing:read",
+        "org:billing:manage",
+        # RBAC management
+        "org:rbac:read",
+        "org:rbac:manage",
+        # Full workspace control across the org
+        "workspace:read",
+        "workspace:create",
+        "workspace:update",
+        "workspace:delete",
+        "workspace:member:read",
+        "workspace:member:invite",
+        "workspace:member:remove",
+        "workspace:member:update",
+        # Full resource control
+        "workflow:read",
+        "workflow:create",
+        "workflow:update",
+        "workflow:delete",
+        "workflow:execute",
+        "case:read",
+        "case:create",
+        "case:update",
+        "case:delete",
+        "table:read",
+        "table:create",
+        "table:update",
+        "table:delete",
+        "schedule:read",
+        "schedule:create",
+        "schedule:update",
+        "schedule:delete",
+        "agent:read",
+        "agent:create",
+        "agent:update",
+        "agent:delete",
+        "agent:execute",
+        "secret:read",
+        "secret:create",
+        "secret:update",
+        "secret:delete",
+        # Full action execution
+        "action:*:execute",
+    }
+)
+
+ORG_ADMIN_SCOPES: frozenset[str] = frozenset(
+    {
+        # Org settings (no delete)
+        "org:read",
+        "org:update",
+        # Org member management
+        "org:member:read",
+        "org:member:invite",
+        "org:member:remove",
+        "org:member:update",
+        # Billing (read only for admin)
+        "org:billing:read",
+        # RBAC management
+        "org:rbac:read",
+        "org:rbac:manage",
+        # Full workspace control across the org
+        "workspace:read",
+        "workspace:create",
+        "workspace:update",
+        "workspace:delete",
+        "workspace:member:read",
+        "workspace:member:invite",
+        "workspace:member:remove",
+        "workspace:member:update",
+        # Full resource control
+        "workflow:read",
+        "workflow:create",
+        "workflow:update",
+        "workflow:delete",
+        "workflow:execute",
+        "case:read",
+        "case:create",
+        "case:update",
+        "case:delete",
+        "table:read",
+        "table:create",
+        "table:update",
+        "table:delete",
+        "schedule:read",
+        "schedule:create",
+        "schedule:update",
+        "schedule:delete",
+        "agent:read",
+        "agent:create",
+        "agent:update",
+        "agent:delete",
+        "agent:execute",
+        "secret:read",
+        "secret:create",
+        "secret:update",
+        "secret:delete",
+        # Full action execution
+        "action:*:execute",
+    }
+)
+
+ORG_MEMBER_SCOPES: frozenset[str] = frozenset(
+    {
+        # Baseline org access; workspace/resource access requires workspace membership
+        "org:read",
+        "org:member:read",
+    }
+)
+
+# =============================================================================
+# Organization Role -> Scope Set Mapping
+# =============================================================================
+
+ORG_ROLE_SCOPES: dict[OrgRole, frozenset[str]] = {
+    OrgRole.OWNER: ORG_OWNER_SCOPES,
+    OrgRole.ADMIN: ORG_ADMIN_SCOPES,
+    OrgRole.MEMBER: ORG_MEMBER_SCOPES,
+}

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -16,8 +16,6 @@ Standard actions (ordered by privilege):
 
 from __future__ import annotations
 
-from tracecat.authz.enums import OrgRole, WorkspaceRole
-
 # =============================================================================
 # Viewer Role Scopes (read-only)
 # =============================================================================
@@ -86,10 +84,10 @@ ADMIN_SCOPES: frozenset[str] = EDITOR_SCOPES | frozenset(
 # Preset Role -> Scope Set Mapping
 # =============================================================================
 
-PRESET_ROLE_SCOPES: dict[WorkspaceRole, frozenset[str]] = {
-    WorkspaceRole.VIEWER: VIEWER_SCOPES,
-    WorkspaceRole.EDITOR: EDITOR_SCOPES,
-    WorkspaceRole.ADMIN: ADMIN_SCOPES,
+PRESET_ROLE_SCOPES: dict[str, frozenset[str]] = {
+    "workspace-viewer": VIEWER_SCOPES,
+    "workspace-editor": EDITOR_SCOPES,
+    "workspace-admin": ADMIN_SCOPES,
 }
 
 # =============================================================================
@@ -225,8 +223,8 @@ ORG_MEMBER_SCOPES: frozenset[str] = frozenset(
 # Organization Role -> Scope Set Mapping
 # =============================================================================
 
-ORG_ROLE_SCOPES: dict[OrgRole, frozenset[str]] = {
-    OrgRole.OWNER: ORG_OWNER_SCOPES,
-    OrgRole.ADMIN: ORG_ADMIN_SCOPES,
-    OrgRole.MEMBER: ORG_MEMBER_SCOPES,
+ORG_ROLE_SCOPES: dict[str, frozenset[str]] = {
+    "organization-owner": ORG_OWNER_SCOPES,
+    "organization-admin": ORG_ADMIN_SCOPES,
+    "organization-member": ORG_MEMBER_SCOPES,
 }

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -83,10 +83,10 @@ ADMIN_SCOPES: frozenset[str] = EDITOR_SCOPES | frozenset(
 )
 
 # =============================================================================
-# System Role -> Scope Set Mapping
+# Preset Role -> Scope Set Mapping
 # =============================================================================
 
-SYSTEM_ROLE_SCOPES: dict[WorkspaceRole, frozenset[str]] = {
+PRESET_ROLE_SCOPES: dict[WorkspaceRole, frozenset[str]] = {
     WorkspaceRole.VIEWER: VIEWER_SCOPES,
     WorkspaceRole.EDITOR: EDITOR_SCOPES,
     WorkspaceRole.ADMIN: ADMIN_SCOPES,

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -15,6 +15,7 @@ from tracecat.interactions.schemas import InteractionContext
 __all__ = [
     "ctx_run",
     "ctx_role",
+    "ctx_scopes",
     "ctx_logger",
     "ctx_interaction",
     "ctx_stream_id",
@@ -26,6 +27,8 @@ __all__ = [
 
 ctx_run: ContextVar[RunContext | None] = ContextVar("run", default=None)
 ctx_role: ContextVar[Role | None] = ContextVar("role", default=None)
+ctx_scopes: ContextVar[frozenset[str]] = ContextVar("scopes", default=frozenset())
+"""Effective scopes for the current request. Computed during authentication."""
 ctx_logger: ContextVar[loguru.Logger | None] = ContextVar("logger", default=None)
 ctx_interaction: ContextVar[InteractionContext | None] = ContextVar(
     "interaction", default=None

--- a/tracecat/contexts.py
+++ b/tracecat/contexts.py
@@ -15,7 +15,6 @@ from tracecat.interactions.schemas import InteractionContext
 __all__ = [
     "ctx_run",
     "ctx_role",
-    "ctx_scopes",
     "ctx_logger",
     "ctx_interaction",
     "ctx_stream_id",
@@ -27,8 +26,6 @@ __all__ = [
 
 ctx_run: ContextVar[RunContext | None] = ContextVar("run", default=None)
 ctx_role: ContextVar[Role | None] = ContextVar("role", default=None)
-ctx_scopes: ContextVar[frozenset[str]] = ContextVar("scopes", default=frozenset())
-"""Effective scopes for the current request. Computed during authentication."""
 ctx_logger: ContextVar[loguru.Logger | None] = ContextVar("logger", default=None)
 ctx_interaction: ContextVar[InteractionContext | None] = ContextVar(
     "interaction", default=None

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -51,6 +51,33 @@ class TracecatAuthorizationError(TracecatException):
     """Tracecat user-facing authorization error"""
 
 
+class ScopeDeniedError(TracecatAuthorizationError):
+    """Raised when a user lacks required scopes for an operation.
+
+    This exception provides detailed information about which scopes were
+    required and which were missing, enabling proper 403 responses with
+    machine-readable error details.
+    """
+
+    def __init__(
+        self,
+        required_scopes: list[str],
+        missing_scopes: list[str],
+        message: str | None = None,
+    ):
+        self.required_scopes = required_scopes
+        self.missing_scopes = missing_scopes
+        default_message = "You don't have permission to perform this action."
+        super().__init__(
+            message or default_message,
+            detail={
+                "code": "insufficient_scope",
+                "required_scopes": required_scopes,
+                "missing_scopes": missing_scopes,
+            },
+        )
+
+
 class TracecatManagementError(TracecatException):
     """Tracecat user-facing management error"""
 


### PR DESCRIPTION
---
## Summary by cubic
Introduce a scope-based RBAC authorization layer that computes effective scopes from org/workspace roles, enforces them via a @require_scope decorator, and returns consistent 403 errors when access is denied.

- **New Features**
  - Scope sets for WorkspaceRole (viewer, editor, admin) and OrgRole (member, admin, owner).
  - Effective scopes computed during auth and stored in ctx_scopes; superusers get "*".
  - @require_scope(..., require_all=True|False) to guard endpoints and service methods; supports wildcards and async.
  - Scope helpers: validate_scope_string, scope_matches, has_scope, has_all_scopes, has_any_scope, get_missing_scopes.
  - FastAPI handler for ScopeDeniedError returns 403 with code "insufficient_scope", required_scopes, and missing_scopes.
  - Unit tests covering scope matching, role mappings, and decorator behavior.

- **Migration**
  - Protect routes/methods with @require_scope using scopes from the new definitions.
  - Ensure role dependency runs on protected endpoints so ctx_scopes is set.

<sup>Written for commit 25cd48dde1907a0a41d96f2224bf0e5d95549558. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

