### PR TITLE
feat(audit): Add support for custom headers

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2863,6 +2863,20 @@ export const $AuditSettingsRead = {
       ],
       title: "Audit Webhook Api Key Created At",
     },
+    audit_webhook_custom_headers: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: "string",
+          },
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Custom Headers",
+    },
   },
   type: "object",
   required: ["audit_webhook_url"],
@@ -2884,6 +2898,22 @@ export const $AuditSettingsUpdate = {
       title: "Audit Webhook Url",
       description:
         "Webhook URL that receives streamed audit events. When unset, audit events are skipped.",
+    },
+    audit_webhook_custom_headers: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: "string",
+          },
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Custom Headers",
+      description:
+        "Custom headers to include in audit webhook requests. Header names are case-insensitive.",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -754,6 +754,9 @@ export type AuditSettingsRead = {
   audit_webhook_url: string | null
   audit_webhook_api_key_preview?: string | null
   audit_webhook_api_key_created_at?: string | null
+  audit_webhook_custom_headers?: {
+    [key: string]: string
+  } | null
 }
 
 /**
@@ -764,6 +767,12 @@ export type AuditSettingsUpdate = {
    * Webhook URL that receives streamed audit events. When unset, audit events are skipped.
    */
   audit_webhook_url?: string | null
+  /**
+   * Custom headers to include in audit webhook requests. Header names are case-insensitive.
+   */
+  audit_webhook_custom_headers?: {
+    [key: string]: string
+  } | null
 }
 
 export type AuthSettingsRead = {

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -2,8 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { format } from "date-fns"
-import { Copy, Key, Plus, RefreshCw, Settings2, Trash2, X } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { Copy, Key, RefreshCw, Settings2, Trash2 } from "lucide-react"
+import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -46,6 +46,7 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
 import { useOrgAuditSettings } from "@/lib/hooks"
 
@@ -75,24 +76,23 @@ export function OrgSettingsAuditForm() {
 
   const [showNewApiKey, setShowNewApiKey] = useState(false)
   const [newApiKey, setNewApiKey] = useState<string | null>(null)
-  const [customHeaders, setCustomHeaders] = useState<
-    Array<{ key: string; value: string }>
-  >([])
+  const [customHeadersJson, setCustomHeadersJson] = useState("")
+  const [customHeadersError, setCustomHeadersError] = useState<string | null>(
+    null
+  )
   const [customHeadersChanged, setCustomHeadersChanged] = useState(false)
 
-  // Initialize custom headers from settings, but don't overwrite unsaved edits
+  // Initialize custom headers JSON from settings, but don't overwrite unsaved edits
   useEffect(() => {
     if (customHeadersChanged) {
-      // User has unsaved edits, don't overwrite
       return
     }
     if (auditSettings?.audit_webhook_custom_headers) {
-      const headers = Object.entries(
-        auditSettings.audit_webhook_custom_headers
-      ).map(([key, value]) => ({ key, value: String(value) }))
-      setCustomHeaders(headers)
+      setCustomHeadersJson(
+        JSON.stringify(auditSettings.audit_webhook_custom_headers, null, 2)
+      )
     } else {
-      setCustomHeaders([])
+      setCustomHeadersJson("")
     }
   }, [auditSettings?.audit_webhook_custom_headers, customHeadersChanged])
 
@@ -149,46 +149,64 @@ export function OrgSettingsAuditForm() {
     setNewApiKey(null)
   }
 
-  const handleAddHeader = useCallback(() => {
-    setCustomHeaders((prev) => [...prev, { key: "", value: "" }])
+  const handleCustomHeadersChange = (value: string) => {
+    setCustomHeadersJson(value)
     setCustomHeadersChanged(true)
-  }, [])
-
-  const handleRemoveHeader = useCallback((index: number) => {
-    setCustomHeaders((prev) => prev.filter((_, i) => i !== index))
-    setCustomHeadersChanged(true)
-  }, [])
-
-  const handleHeaderChange = useCallback(
-    (index: number, field: "key" | "value", newValue: string) => {
-      setCustomHeaders((prev) =>
-        prev.map((header, i) =>
-          i === index ? { ...header, [field]: newValue } : header
-        )
-      )
-      setCustomHeadersChanged(true)
-    },
-    []
-  )
+    setCustomHeadersError(null)
+  }
 
   const handleSaveCustomHeaders = async () => {
-    // Filter out headers with empty keys
-    const validHeaders = customHeaders.filter((h) => h.key.trim() !== "")
+    const trimmed = customHeadersJson.trim()
 
-    // Convert array to object
-    const headersObject: Record<string, string> = {}
-    for (const header of validHeaders) {
-      headersObject[header.key.trim()] = header.value
+    // Empty = clear headers
+    if (trimmed === "") {
+      try {
+        await updateAuditSettings({
+          requestBody: { audit_webhook_custom_headers: null },
+        })
+        setCustomHeadersChanged(false)
+        setCustomHeadersError(null)
+      } catch {
+        console.error("Failed to update custom headers")
+      }
+      return
+    }
+
+    // Validate JSON
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      setCustomHeadersError("Invalid JSON syntax")
+      return
+    }
+
+    // Validate structure: must be object with string values
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      setCustomHeadersError('Must be a JSON object, e.g. { "Header": "value" }')
+      return
+    }
+
+    const headersObject = parsed as Record<string, unknown>
+    for (const [key, value] of Object.entries(headersObject)) {
+      if (typeof value !== "string") {
+        setCustomHeadersError(`Value for "${key}" must be a string`)
+        return
+      }
     }
 
     try {
       await updateAuditSettings({
         requestBody: {
-          audit_webhook_custom_headers:
-            Object.keys(headersObject).length > 0 ? headersObject : null,
+          audit_webhook_custom_headers: headersObject as Record<string, string>,
         },
       })
       setCustomHeadersChanged(false)
+      setCustomHeadersError(null)
     } catch {
       console.error("Failed to update custom headers")
     }
@@ -365,64 +383,31 @@ export function OrgSettingsAuditForm() {
           </CardTitle>
           <CardDescription>
             Add custom HTTP headers to include in audit webhook requests. Custom
-            headers override the API key if both set an Authorization header.
-            Header values are encrypted at rest.
+            headers override the API key if both set an Authorization header
+            (case-insensitive). Header values are encrypted at rest.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {customHeaders.length > 0 ? (
-            <div className="space-y-2">
-              {customHeaders.map((header, index) => (
-                <div key={index} className="flex items-center gap-2">
-                  <Input
-                    placeholder="Header name"
-                    value={header.key}
-                    onChange={(e) =>
-                      handleHeaderChange(index, "key", e.target.value)
-                    }
-                    className="flex-1"
-                  />
-                  <Input
-                    placeholder="Header value"
-                    value={header.value}
-                    onChange={(e) =>
-                      handleHeaderChange(index, "value", e.target.value)
-                    }
-                    className="flex-1"
-                  />
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleRemoveHeader(index)}
-                    title="Remove header"
-                  >
-                    <X className="size-4" />
-                  </Button>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              No custom headers configured.
-            </p>
+          <Textarea
+            placeholder={'{\n  "X-Custom-Header": "value"\n}'}
+            value={customHeadersJson}
+            onChange={(e) => handleCustomHeadersChange(e.target.value)}
+            className="min-h-[120px] font-mono text-sm"
+          />
+          {customHeadersError && (
+            <p className="text-sm text-destructive">{customHeadersError}</p>
           )}
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleAddHeader}>
-              <Plus className="mr-2 size-3" />
-              Add header
+          {customHeadersChanged && (
+            <Button
+              size="sm"
+              onClick={handleSaveCustomHeaders}
+              disabled={updateAuditSettingsIsPending}
+            >
+              {updateAuditSettingsIsPending
+                ? "Saving..."
+                : "Save custom headers"}
             </Button>
-            {customHeadersChanged && (
-              <Button
-                size="sm"
-                onClick={handleSaveCustomHeaders}
-                disabled={updateAuditSettingsIsPending}
-              >
-                {updateAuditSettingsIsPending
-                  ? "Saving..."
-                  : "Save custom headers"}
-              </Button>
-            )}
-          </div>
+          )}
         </CardContent>
       </Card>
 

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -135,10 +135,9 @@ class AuditService(BaseService):
             custom_headers = await self._get_custom_headers()
             if custom_headers:
                 # HTTP headers are case-insensitive (RFC 7230), but Python dicts are not.
-                # Check if custom headers contain any casing of "authorization" and remove
-                # the API key header to let custom headers fully override it.
-                custom_keys_lower = {k.lower() for k in custom_headers}
-                if "authorization" in custom_keys_lower:
+                # If custom headers contain any casing of "authorization", remove the
+                # API key header to let the custom value fully override it.
+                if any(k.lower() == "authorization" for k in custom_headers):
                     headers.pop("Authorization", None)
                 headers.update(custom_headers)
 

--- a/tracecat/settings/constants.py
+++ b/tracecat/settings/constants.py
@@ -8,6 +8,7 @@ SENSITIVE_SETTINGS_KEYS = {
     "saml_idp_metadata_url",
     "audit_webhook_url",
     "audit_webhook_api_key",
+    "audit_webhook_custom_headers",
 }
 """Settings that are encrypted at rest."""
 

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -168,6 +168,7 @@ class AuditSettingsRead(BaseSettingsGroup):
     audit_webhook_url: str | None
     audit_webhook_api_key_preview: str | None = None
     audit_webhook_api_key_created_at: datetime | None = None
+    audit_webhook_custom_headers: dict[str, str] | None = None
 
 
 class AuditSettingsUpdate(BaseSettingsGroup):
@@ -176,6 +177,10 @@ class AuditSettingsUpdate(BaseSettingsGroup):
     audit_webhook_url: str | None = Field(
         default=None,
         description="Webhook URL that receives streamed audit events. When unset, audit events are skipped.",
+    )
+    audit_webhook_custom_headers: dict[str, str] | None = Field(
+        default=None,
+        description="Custom headers to include in audit webhook requests. Header names are case-insensitive.",
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for custom HTTP headers for audit webhook requests. Configure headers in Org Settings → Audit; they are encrypted and sent with each event. If you set an Authorization header, it overrides the API key.

- **New Features**
  - Add, edit, and remove custom headers in Org Settings → Audit.
  - Headers are encrypted at rest and applied to all webhook requests; names are case-insensitive.
  - Backend applies headers after the API key and picks up changes immediately.
  - API and client schemas updated with audit_webhook_custom_headers.

- **Migration**
  - Optional: set custom headers in Org Settings → Audit.
  - To use header-based auth, add an Authorization header; the API key is no longer needed.

<sup>Written for commit 0ebc3b4d2da0282ded949300301f2d9b2ec23657. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<img width="917" height="819" alt="image" src="https://github.com/user-attachments/assets/9e26d542-d2c7-45b8-aae2-c41c509b652c" />


