### PR TITLE
feat(audit): Add audit logging for user registration events

### DIFF
--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -10,6 +10,7 @@ from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 
 AuditAction = Literal["create", "update", "delete", "accept", "revoke"]
 AuditResourceType = Literal[
+    "user",
     "workspace",
     "workflow",
     "workflow_execution",

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -40,7 +40,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat import config
 from tracecat.api.common import bootstrap_role
 from tracecat.auth.schemas import UserCreate, UserRole, UserUpdate
-from tracecat.auth.types import AccessLevel, Role, system_role
+from tracecat.auth.types import AccessLevel, PlatformRole, Role, system_role
 from tracecat.authz.enums import OrgRole, WorkspaceRole
 from tracecat.authz.service import MembershipService
 from tracecat.contexts import ctx_role
@@ -204,6 +204,19 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         self, user: User, request: Request | None = None
     ) -> None:
         self.logger.info(f"User {user.id} has registered.")
+
+        # Log audit event for user registration
+        from tracecat.audit.service import AuditService
+
+        platform_role = PlatformRole(
+            type="user", user_id=user.id, service_id="tracecat-api"
+        )
+        async with AuditService.with_session(role=platform_role) as audit_svc:
+            await audit_svc.create_event(
+                resource_type="user",
+                action="create",
+                resource_id=user.id,
+            )
 
         # Check if this user should be promoted to superuser
         async with get_async_session_context_manager() as session:

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -39,6 +39,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.api.common import bootstrap_role
+from tracecat.audit.service import AuditService
 from tracecat.auth.schemas import UserCreate, UserRole, UserUpdate
 from tracecat.auth.types import AccessLevel, PlatformRole, Role, system_role
 from tracecat.authz.enums import OrgRole, WorkspaceRole
@@ -206,8 +207,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         self.logger.info(f"User {user.id} has registered.")
 
         # Log audit event for user registration
-        from tracecat.audit.service import AuditService
-
         platform_role = PlatformRole(
             type="user", user_id=user.id, service_id="tracecat-api"
         )


### PR DESCRIPTION
## Description

This PR adds audit logging for user registration events. When a new user registers, an audit event is now created to track the user creation action.

### Changes

- Added `"user"` to the `AuditResourceType` literal in `tracecat/audit/types.py` to support auditing user resources
- Updated imports in `tracecat/auth/users.py` to include `PlatformRole` from `tracecat.auth.types`
- Implemented audit event logging in the `on_after_register` callback to create an audit record whenever a user successfully registers, capturing:
  - Resource type: `"user"`
  - Action: `"create"`
  - Resource ID: the newly created user's ID

### Rationale

This change improves observability and compliance by maintaining an audit trail of user creation events. The audit event is logged using a platform role context to ensure proper authorization and tracking.

## Related Issues

<!-- Link any related issues here if applicable -->

## Steps to QA

1. Register a new user through the authentication flow
2. Verify that an audit event is created in the audit log with:
   - `resource_type` = `"user"`
   - `action` = `"create"`
   - `resource_id` = the new user's ID
3. Confirm that existing user registration functionality is not affected

https://claude.ai/code/session_012uEmLitBQonvHKaZGaaLAT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds audit logging for user registrations. On successful signup, we write a user:create audit event with the new user’s ID.

- **New Features**
  - Added "user" to AuditResourceType.
  - Log audit event in on_after_register with resource_type "user", action "create", resource_id = new user ID.
  - Use PlatformRole for context since new users don’t have org context yet.

<sup>Written for commit d9e3c5ee0afabb1b34c77f561c0c56dc7a605044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

