### PR TITLE
fix(ui): use named volume for node_modules in dev container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -290,7 +290,7 @@ services:
     volumes:
       - ./frontend/src:/app/src
       - ./frontend/.next:/app/.next
-      - ./frontend/node_modules:/app/node_modules
+      - ui-node-modules:/app/node_modules  # Named volume to preserve linux-arm64 binaries (SWC, etc.)
     restart: unless-stopped
     ports:
       - ${UI_PORT:-3000}:3000
@@ -426,3 +426,4 @@ volumes:
   minio-data:
   redis-data:
   sandbox-cache:
+  ui-node-modules:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,4 +11,7 @@ RUN corepack enable
 COPY . /app
 WORKDIR /app
 
+# Install dependencies inside the container to get correct platform-specific binaries (e.g., SWC for linux-arm64)
+RUN pnpm install --frozen-lockfile
+
 CMD [ "pnpm", "dev" ]


### PR DESCRIPTION
## Summary
- Fix UI container failing to start due to SWC binary mismatch
- Host macOS `node_modules` were overwriting container's linux-arm64 binaries
- Use named volume for `node_modules` instead of host bind mount
- Add `pnpm install` to Dockerfile to install correct platform binaries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UI dev container startup by preventing SWC binary mismatches. Uses a named volume for node_modules and installs dependencies inside the container to ensure linux-arm64 binaries.

- **Bug Fixes**
  - Replace host bind mount with named volume ui-node-modules to avoid macOS node_modules overwriting container binaries.
  - Run pnpm install in Dockerfile to install correct platform-specific dependencies (e.g., SWC for linux-arm64).

<sup>Written for commit efcd62e9e11782d3b42d20d6dac367b5907b6603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

