### PR TITLE
feat(executor): userspace network isolation

### DIFF
--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -366,17 +366,40 @@ def build_agent_nsjail_config(
         ]
     )
 
-    # DNS resolution: pasta provides DNS forwarding at the gateway IP (10.255.255.1)
-    # when enable_dns: true. Write resolv.conf to socket_dir (not job_dir) because
-    # job_dir is mounted read-write at /work inside the sandbox.
+    # Network config: pasta provides DNS forwarding at the gateway IP (10.255.255.1)
+    # when enable_dns: true. Docker export leaves /etc files empty since Docker
+    # manages them at runtime. Write to socket_dir (not job_dir) because job_dir
+    # is mounted read-write at /work inside the sandbox.
     if enable_internet_access:
         resolv_conf_path = socket_dir / "resolv.conf"
         resolv_conf_path.write_text("nameserver 10.255.255.1\n")
+
+        hosts_path = socket_dir / "hosts"
+        hosts_path.write_text(
+            "127.0.0.1\tlocalhost\n::1\tlocalhost ip6-localhost ip6-loopback\n"
+        )
+
+        # nsswitch.conf tells glibc how to resolve hostnames: check /etc/hosts
+        # first ("files"), then fall back to DNS. Without this, hostname
+        # resolution may fail even with valid /etc/hosts and /etc/resolv.conf.
+        nsswitch_path = socket_dir / "nsswitch.conf"
+        nsswitch_path.write_text(
+            "passwd:         files\n"
+            "group:          files\n"
+            "shadow:         files\n"
+            "hosts:          files dns\n"
+            "networks:       files\n"
+            "protocols:      files\n"
+            "services:       files\n"
+        )
+
         lines.extend(
             [
                 "",
-                "# DNS resolution - point to pasta gateway for DNS forwarding",
+                "# Network config - DNS and hostname resolution",
                 f'mount {{ src: "{resolv_conf_path}" dst: "/etc/resolv.conf" is_bind: true rw: false }}',
+                f'mount {{ src: "{hosts_path}" dst: "/etc/hosts" is_bind: true rw: false }}',
+                f'mount {{ src: "{nsswitch_path}" dst: "/etc/nsswitch.conf" is_bind: true rw: false }}',
             ]
         )
 

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -170,30 +170,54 @@ class NsjailExecutor:
         # - Execute phase: per config.network_enabled
         network_enabled = phase == "install" or config.network_enabled
 
+        # Network namespace is always isolated (clone_newnet: true)
+        # When network access is needed, pasta provides userspace networking
         lines = [
             'name: "python_sandbox"',
             "mode: ONCE",
             'hostname: "sandbox"',
             "keep_env: false",
             "",
-            "# Namespace isolation",
-            f"clone_newnet: {'false' if network_enabled else 'true'}",
+            "# Namespace isolation - network always isolated, pasta for outbound access",
+            "clone_newnet: true",
             "clone_newuser: true",
             "clone_newns: true",
             "clone_newpid: true",
             "clone_newipc: true",
             "clone_newuts: true",
-            "",
-            "# UID/GID mapping - map container user to current user",
-            f'uidmap {{ inside_id: "1000" outside_id: "{os.getuid()}" count: 1 }}',
-            f'gidmap {{ inside_id: "1000" outside_id: "{os.getgid()}" count: 1 }}',
-            "",
-            "# Rootfs mounts - read-only base system",
-            f'mount {{ src: "{self.rootfs}/usr" dst: "/usr" is_bind: true rw: false }}',
-            f'mount {{ src: "{self.rootfs}/lib" dst: "/lib" is_bind: true rw: false }}',
-            f'mount {{ src: "{self.rootfs}/bin" dst: "/bin" is_bind: true rw: false }}',
-            f'mount {{ src: "{self.rootfs}/etc" dst: "/etc" is_bind: true rw: false }}',
         ]
+
+        # Userspace networking via pasta when network access is needed
+        if network_enabled:
+            lines.extend(
+                [
+                    "",
+                    "# Userspace networking via pasta - provides internet access with isolation",
+                    "user_net {",
+                    "  enable: true",
+                    '  ip: "10.255.255.2"',
+                    '  gw: "10.255.255.1"',
+                    '  ip6: "fc00::2"',
+                    '  gw6: "fc00::1"',
+                    "  enable_dns: true",
+                    "}",
+                ]
+            )
+
+        lines.extend(
+            [
+                "",
+                "# UID/GID mapping - map container user to current user",
+                f'uidmap {{ inside_id: "1000" outside_id: "{os.getuid()}" count: 1 }}',
+                f'gidmap {{ inside_id: "1000" outside_id: "{os.getgid()}" count: 1 }}',
+                "",
+                "# Rootfs mounts - read-only base system",
+                f'mount {{ src: "{self.rootfs}/usr" dst: "/usr" is_bind: true rw: false }}',
+                f'mount {{ src: "{self.rootfs}/lib" dst: "/lib" is_bind: true rw: false }}',
+                f'mount {{ src: "{self.rootfs}/bin" dst: "/bin" is_bind: true rw: false }}',
+                f'mount {{ src: "{self.rootfs}/etc" dst: "/etc" is_bind: true rw: false }}',
+            ]
+        )
 
         # Optional mounts - only include if the directories exist in rootfs
         lib64_path = self.rootfs / "lib64"
@@ -208,13 +232,20 @@ class NsjailExecutor:
                 f'mount {{ src: "{sbin_path}" dst: "/sbin" is_bind: true rw: false }}'
             )
 
+        # DNS resolution: when using pasta, point to gateway for DNS forwarding
+        if network_enabled:
+            resolv_conf_path = job_dir / "resolv.conf"
+            resolv_conf_path.write_text("nameserver 10.255.255.1\n")
+            lines.extend(
+                [
+                    "",
+                    "# DNS resolution - point to pasta gateway for DNS forwarding",
+                    f'mount {{ src: "{resolv_conf_path}" dst: "/etc/resolv.conf" is_bind: true rw: false }}',
+                ]
+            )
+
         lines.extend(
             [
-                "",
-                "# DNS/host resolution - mount container resolver config",
-                'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
-                'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
-                'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
                 "",
                 "# /dev essentials",
                 'mount { src: "/dev/null" dst: "/dev/null" is_bind: true rw: true }',
@@ -584,20 +615,31 @@ class NsjailExecutor:
         if config.site_packages_dir:
             _validate_path(config.site_packages_dir, "site_packages_dir")
 
-        # Network always enabled for action execution (DB, S3, external APIs)
+        # Network namespace isolated with pasta for userspace networking
+        # This provides outbound connectivity while maintaining network isolation
         lines = [
             'name: "action_sandbox"',
             "mode: ONCE",
             'hostname: "sandbox"',
             "keep_env: false",
             "",
-            "# Namespace isolation - network enabled for DB/S3/external APIs",
-            "clone_newnet: false",
+            "# Namespace isolation - network isolated with pasta for outbound access",
+            "clone_newnet: true",
             "clone_newuser: true",
             "clone_newns: true",
             "clone_newpid: true",
             "clone_newipc: true",
             "clone_newuts: true",
+            "",
+            "# Userspace networking via pasta - provides internet access with isolation",
+            "user_net {",
+            "  enable: true",
+            '  ip: "10.255.255.2"',
+            '  gw: "10.255.255.1"',
+            '  ip6: "fc00::2"',
+            '  gw6: "fc00::1"',
+            "  enable_dns: true",
+            "}",
             "",
             "# UID/GID mapping - map container user to current user",
             f'uidmap {{ inside_id: "1000" outside_id: "{os.getuid()}" count: 1 }}',
@@ -623,13 +665,16 @@ class NsjailExecutor:
                 f'mount {{ src: "{sbin_path}" dst: "/sbin" is_bind: true rw: false }}'
             )
 
+        # DNS resolution: pasta provides DNS forwarding at the gateway IP (10.255.255.1)
+        # Write custom resolv.conf to job_dir pointing to pasta gateway
+        resolv_conf_path = job_dir / "resolv.conf"
+        resolv_conf_path.write_text("nameserver 10.255.255.1\n")
+
         lines.extend(
             [
                 "",
-                "# DNS/host resolution - mount container resolver config",
-                'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
-                'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
-                'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
+                "# DNS resolution - point to pasta gateway for DNS forwarding",
+                f'mount {{ src: "{resolv_conf_path}" dst: "/etc/resolv.conf" is_bind: true rw: false }}',
                 "",
                 "# /dev essentials",
                 'mount { src: "/dev/null" dst: "/dev/null" is_bind: true rw: true }',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch executor sandboxes to userspace network isolation via pasta. Network is always isolated; when needed, outbound access is provided without exposing the host network.

- **New Features**
  - Always isolate with clone_newnet; enable user_net only when needed.
  - Static IPs and DNS via pasta (10.255.255.2, gateway 10.255.255.1; IPv6 supported).
  - Write and mount job-scoped resolv.conf, hosts, and nsswitch.conf; stop binding host resolv.conf/hosts/nsswitch.
  - Action sandbox now uses userspace networking by default for DB/S3/API calls.

- **Migration**
  - Ensure pasta and nsjail with user_net support are installed on executor hosts.

<sup>Written for commit 04443d979fa31e1da4acbdb509d03af4d1db491f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

