### PR TITLE
fix(docker): update directory perms for agent-executor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,9 @@ RUN groupadd -g 1001 apiuser && useradd -m -u 1001 -g apiuser apiuser && \
     mkdir -p /home/apiuser/.cache/uv /home/apiuser/.cache/s3 /home/apiuser/.cache/tmp /home/apiuser/.local/bin && \
     chown -R apiuser:apiuser /home/apiuser
 
+# Create MCP socket directory for apiuser
+RUN mkdir -p /var/run/tracecat && chown 1001:1001 /var/run/tracecat
+
 WORKDIR /app
 
 # ====================
@@ -106,9 +109,6 @@ ENV TMPDIR=/tmp TEMP=/tmp TMP=/tmp
 # Set sandbox cache permissions for apiuser
 RUN chown -R 1001:1001 /var/lib/tracecat/sandbox-cache && \
     chmod -R 755 /var/lib/tracecat/sandbox-cache
-
-# Create MCP socket directory for apiuser
-RUN mkdir -p /var/run/tracecat && chown 1001:1001 /var/run/tracecat
 
 # Prime uv cache (as root, before switching user)
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -27,19 +27,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from tracecat.agent.common.config import (
+    CONTROL_SOCKET_NAME,
+    JAILED_CONTROL_SOCKET_PATH,
+    JAILED_LLM_SOCKET_PATH,
     TRACECAT__AGENT_SANDBOX_MEMORY_MB,
     TRACECAT__AGENT_SANDBOX_TIMEOUT,
+    TRUSTED_MCP_SOCKET_PATH,
 )
 from tracecat.agent.common.exceptions import AgentSandboxValidationError
-
-# Well-known socket paths (internal to agent worker, not configurable)
-TRUSTED_MCP_SOCKET_PATH = Path("/var/run/tracecat/mcp.sock")
-CONTROL_SOCKET_NAME = "control.sock"
-JAILED_CONTROL_SOCKET_PATH = Path("/var/run/tracecat/control.sock")
-
-# LLM socket for proxied access to LiteLLM (network isolated)
-LLM_SOCKET_NAME = "llm.sock"
-JAILED_LLM_SOCKET_PATH = Path("/var/run/tracecat/llm.sock")
 
 # Valid environment variable name pattern (POSIX compliant)
 _ENV_VAR_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -202,8 +202,9 @@ async def start_mcp_server() -> None:
 
     import uvicorn
 
-    # Hardcoded socket path - must match TRUSTED_MCP_SOCKET_PATH in proxy_server.py
-    socket_path = Path("/var/run/tracecat/mcp.sock")
+    from tracecat.agent.common.config import TRUSTED_MCP_SOCKET_PATH
+
+    socket_path = TRUSTED_MCP_SOCKET_PATH
     socket_path.parent.mkdir(parents=True, exist_ok=True)
 
     if socket_path.exists():


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MCP socket handling for the agent executor by ensuring the socket directory exists with correct ownership and by centralizing socket path constants to avoid mismatches.

- Bug Fixes
  - Create /var/run/tracecat during build and chown to apiuser (1001:1001).
  - Use TRUSTED_MCP_SOCKET_PATH (and related) from common config in worker/sandbox; remove hardcoded paths.

<sup>Written for commit 36ab3d310873550cb856968df12664ba2614fa89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

