### PR TITLE
feat(ee): Case triggers

### DIFF
--- a/alembic/versions/c8d7e5a4b321_add_case_triggers.py
+++ b/alembic/versions/c8d7e5a4b321_add_case_triggers.py
@@ -1,0 +1,84 @@
+"""add case triggers
+
+Revision ID: c8d7e5a4b321
+Revises: 663883860695
+Create Date: 2026-02-01 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d7e5a4b321"
+down_revision: str | None = "663883860695"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "case_trigger",
+        sa.Column("surrogate_id", sa.Integer(), sa.Identity(), primary_key=True),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column(
+            "event_types",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tag_filters",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("workflow_id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["workflow_id"], ["workflow.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"], ["workspace.id"], ondelete="CASCADE"
+        ),
+        sa.UniqueConstraint("id"),
+        sa.UniqueConstraint("workflow_id"),
+    )
+    op.create_index("ix_case_trigger_id", "case_trigger", ["id"], unique=False)
+
+    op.execute(
+        """
+        INSERT INTO case_trigger
+            (id, workspace_id, workflow_id, status, event_types, tag_filters, created_at, updated_at)
+        SELECT
+            gen_random_uuid(),
+            workspace_id,
+            id,
+            'offline',
+            '[]'::jsonb,
+            '[]'::jsonb,
+            now(),
+            now()
+        FROM workflow;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_case_trigger_id", table_name="case_trigger")
+    op.drop_table("case_trigger")

--- a/frontend/src/client/services.custom.ts
+++ b/frontend/src/client/services.custom.ts
@@ -1,7 +1,11 @@
 import type { CancelablePromise } from "./core/CancelablePromise"
 import { OpenAPI } from "./core/OpenAPI"
 import { request } from "./core/request"
-import type { OAuthGrantType, ProviderReadMinimal } from "./types.gen"
+import type {
+  CaseEventType,
+  OAuthGrantType,
+  ProviderReadMinimal,
+} from "./types.gen"
 
 export type CustomOAuthProviderCreateRequest = {
   name: string
@@ -32,6 +36,99 @@ export const providersCreateCustomProvider = (
     body: data.requestBody,
     mediaType: "application/json",
     errors: {
+      422: "Validation Error",
+    },
+  })
+
+export type CaseTriggerStatus = "online" | "offline"
+
+export type CaseTriggerRead = {
+  id: string
+  workflow_id: string
+  status: CaseTriggerStatus
+  event_types: CaseEventType[]
+  tag_filters: string[]
+}
+
+export type CaseTriggerCreate = {
+  status: CaseTriggerStatus
+  event_types: CaseEventType[]
+  tag_filters: string[]
+}
+
+export type CaseTriggerUpdate = Partial<CaseTriggerCreate>
+
+export type TriggersGetCaseTriggerData = {
+  workspaceId: string
+  workflowId: string
+}
+
+export type TriggersCreateCaseTriggerData = {
+  workspaceId: string
+  workflowId: string
+  requestBody: CaseTriggerCreate
+}
+
+export type TriggersUpdateCaseTriggerData = {
+  workspaceId: string
+  workflowId: string
+  requestBody: CaseTriggerUpdate
+}
+
+export const triggersGetCaseTrigger = (
+  data: TriggersGetCaseTriggerData
+): CancelablePromise<CaseTriggerRead> =>
+  request(OpenAPI, {
+    method: "GET",
+    url: "/workflows/{workflow_id}/case-trigger",
+    path: {
+      workflow_id: data.workflowId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      404: "Not Found",
+      422: "Validation Error",
+    },
+  })
+
+export const triggersCreateCaseTrigger = (
+  data: TriggersCreateCaseTriggerData
+): CancelablePromise<CaseTriggerRead> =>
+  request(OpenAPI, {
+    method: "POST",
+    url: "/workflows/{workflow_id}/case-trigger",
+    path: {
+      workflow_id: data.workflowId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      404: "Not Found",
+      422: "Validation Error",
+    },
+  })
+
+export const triggersUpdateCaseTrigger = (
+  data: TriggersUpdateCaseTriggerData
+): CancelablePromise<void> =>
+  request(OpenAPI, {
+    method: "PATCH",
+    url: "/workflows/{workflow_id}/case-trigger",
+    path: {
+      workflow_id: data.workflowId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      404: "Not Found",
       422: "Validation Error",
     },
   })

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2380,6 +2380,7 @@ export type FeatureFlag =
   | "git-sync"
   | "agent-approvals"
   | "agent-presets"
+  | "case-triggers"
   | "case-dropdowns"
   | "case-durations"
   | "case-tasks"

--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -65,6 +65,7 @@ import { useWorkflow } from "@/providers/workflow"
 const dagreGraph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
 const defaultNodeWidth = 172
 const defaultNodeHeight = 36
+const triggerNodeAutoLayoutGap = 64
 
 const fitViewOptions: FitViewOptions = {
   minZoom: 0.75,
@@ -122,6 +123,30 @@ function getLayoutedElements(
 
     return newNode
   })
+
+  if (!isHorizontal) {
+    const triggerNode = newNodes.find((node) => node.type === TriggerTypename)
+    if (triggerNode) {
+      const triggerY = triggerNode.position.y
+      const adjustedNodes = newNodes.map((node) => {
+        if (node.id === triggerNode.id) {
+          return node
+        }
+        if (node.position.y <= triggerY) {
+          return node
+        }
+        return {
+          ...node,
+          position: {
+            ...node.position,
+            y: node.position.y + triggerNodeAutoLayoutGap,
+          },
+        }
+      })
+
+      return { nodes: adjustedNodes, edges }
+    }
+  }
 
   return { nodes: newNodes, edges }
 }

--- a/frontend/src/components/builder/canvas/trigger-node.tsx
+++ b/frontend/src/components/builder/canvas/trigger-node.tsx
@@ -2,9 +2,9 @@ import type { Node, NodeProps } from "@xyflow/react"
 import {
   CalendarCheck,
   CalendarClockIcon,
-  Tag,
   Shield,
   ShieldOff,
+  Tag,
   TimerOffIcon,
   UnplugIcon,
   WebhookIcon,
@@ -78,10 +78,7 @@ export default React.memo(function TriggerNode({
   const tagFilters = caseTrigger?.tag_filters ?? []
   const isCaseTriggerEnabled = caseTrigger?.status === "online"
   const caseTriggerStatusLabel = isCaseTriggerEnabled ? "Enabled" : "Disabled"
-  const eventKey = useMemo(
-    () => caseEventTypes.join("|"),
-    [caseEventTypes]
-  )
+  const eventKey = useMemo(() => caseEventTypes.join("|"), [caseEventTypes])
   const { caseTags } = useCaseTagCatalog(workspaceId, {
     enabled: tagFilters.length > 0,
   })
@@ -289,7 +286,9 @@ export default React.memo(function TriggerNode({
                           : "border-muted-foreground/30 bg-muted text-muted-foreground"
                       )}
                     >
-                      {caseTriggerError ? "Unavailable" : caseTriggerStatusLabel}
+                      {caseTriggerError
+                        ? "Unavailable"
+                        : caseTriggerStatusLabel}
                     </Badge>
                   )}
                 </div>

--- a/frontend/src/components/builder/canvas/trigger-node.tsx
+++ b/frontend/src/components/builder/canvas/trigger-node.tsx
@@ -41,6 +41,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useTriggerNodeZoomBreakpoint } from "@/hooks/canvas"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useCaseTrigger, useSchedules } from "@/lib/hooks"
 import { durationToHumanReadable } from "@/lib/time"
 import { cn } from "@/lib/utils"
@@ -68,6 +69,7 @@ export default React.memo(function TriggerNode({
     setTriggerPanelTab,
   } = useWorkflowBuilder()
   const { breakpoint, style } = useTriggerNodeZoomBreakpoint()
+  const { isFeatureEnabled } = useFeatureFlag()
   const {
     data: caseTrigger,
     isLoading: caseTriggerIsLoading,
@@ -274,17 +276,21 @@ export default React.memo(function TriggerNode({
                 <TriggerNodeSchedulesTable workflowId={workflow.id} />
               </div>
               {/* Case triggers */}
-              <div
-                className="rounded-lg border cursor-pointer"
-                onClick={() => openTriggerPanel(TriggerPanelTabs.caseTriggers)}
-              >
-                <TriggerNodeCaseTriggersTable
-                  isLoading={caseTriggerIsLoading}
-                  error={caseTriggerError}
-                  enabled={isCaseTriggerEnabled}
-                  hasConfig={hasCaseTriggerConfig}
-                />
-              </div>
+              {isFeatureEnabled("case-triggers") && (
+                <div
+                  className="rounded-lg border cursor-pointer"
+                  onClick={() =>
+                    openTriggerPanel(TriggerPanelTabs.caseTriggers)
+                  }
+                >
+                  <TriggerNodeCaseTriggersTable
+                    isLoading={caseTriggerIsLoading}
+                    error={caseTriggerError}
+                    enabled={isCaseTriggerEnabled}
+                    hasConfig={hasCaseTriggerConfig}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </>

--- a/frontend/src/components/builder/canvas/trigger-node.tsx
+++ b/frontend/src/components/builder/canvas/trigger-node.tsx
@@ -2,16 +2,19 @@ import type { Node, NodeProps } from "@xyflow/react"
 import {
   CalendarCheck,
   CalendarClockIcon,
+  Tag,
   Shield,
   ShieldOff,
   TimerOffIcon,
   UnplugIcon,
   WebhookIcon,
+  Zap,
 } from "lucide-react"
-import React from "react"
+import React, { useCallback, useLayoutEffect, useMemo, useRef } from "react"
 import { TriggerSourceHandle } from "@/components/builder/canvas/custom-handle"
 import { nodeStyles } from "@/components/builder/canvas/node-styles"
 import { getIcon } from "@/components/icons"
+import { Badge } from "@/components/ui/badge"
 import {
   Card,
   CardDescription,
@@ -35,9 +38,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useTriggerNodeZoomBreakpoint } from "@/hooks/canvas"
-import { useSchedules } from "@/lib/hooks"
+import { useCaseTagCatalog, useCaseTrigger, useSchedules } from "@/lib/hooks"
 import { durationToHumanReadable } from "@/lib/time"
 import { cn } from "@/lib/utils"
+import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 
 export type TriggerNodeData = {
@@ -46,19 +50,142 @@ export type TriggerNodeData = {
 export type TriggerNodeType = Node<TriggerNodeData, "trigger">
 export const TriggerTypename = "trigger" as const
 
+const formatCaseEventLabel = (value: string) =>
+  value
+    .split("_")
+    .map((segment) =>
+      segment.length > 0
+        ? `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`
+        : segment
+    )
+    .join(" ")
+
 export default React.memo(function TriggerNode({
+  id,
   type,
   data: { title },
   selected,
 }: NodeProps<TriggerNodeType>) {
   const { workflow } = useWorkflow()
+  const { reactFlow, workspaceId, workflowId } = useWorkflowBuilder()
   const { breakpoint, style } = useTriggerNodeZoomBreakpoint()
+  const {
+    data: caseTrigger,
+    isLoading: caseTriggerIsLoading,
+    error: caseTriggerError,
+  } = useCaseTrigger(workspaceId, workflowId)
+  const caseEventTypes = caseTrigger?.event_types ?? []
+  const tagFilters = caseTrigger?.tag_filters ?? []
+  const isCaseTriggerEnabled = caseTrigger?.status === "online"
+  const caseTriggerStatusLabel = isCaseTriggerEnabled ? "Enabled" : "Disabled"
+  const eventKey = useMemo(
+    () => caseEventTypes.join("|"),
+    [caseEventTypes]
+  )
+  const { caseTags } = useCaseTagCatalog(workspaceId, {
+    enabled: tagFilters.length > 0,
+  })
+  const caseTagLabelMap = useMemo(() => {
+    return new Map((caseTags ?? []).map((tag) => [tag.ref, tag.name]))
+  }, [caseTags])
+  const tagFilterLabels = useMemo(
+    () => tagFilters.map((tagRef) => caseTagLabelMap.get(tagRef) ?? tagRef),
+    [caseTagLabelMap, tagFilters]
+  )
+  const tagFilterCount = tagFilters.length
+  const cardRef = useRef<HTMLDivElement>(null)
+  const previousHeightRef = useRef<number | null>(null)
+  const pendingHeightAdjustmentRef = useRef(false)
+  const lastEventKeyRef = useRef<string | null>(null)
+
+  const pushNodesDown = useCallback(
+    (delta: number) => {
+      if (delta <= 0) return
+      reactFlow.setNodes((nodes) => {
+        const triggerNode = nodes.find((node) => node.id === id)
+        if (!triggerNode) {
+          return nodes
+        }
+        const triggerY = triggerNode.position.y
+        return nodes.map((node) => {
+          if (node.id === id) {
+            return node
+          }
+          if (node.position.y <= triggerY) {
+            return node
+          }
+          return {
+            ...node,
+            position: {
+              ...node.position,
+              y: node.position.y + delta,
+            },
+          }
+        })
+      })
+    },
+    [id, reactFlow]
+  )
+
+  useLayoutEffect(() => {
+    if (!cardRef.current) {
+      return
+    }
+    if (
+      eventKey === lastEventKeyRef.current &&
+      previousHeightRef.current !== null
+    ) {
+      return
+    }
+    lastEventKeyRef.current = eventKey
+    const currentHeight = cardRef.current.getBoundingClientRect().height
+
+    if (previousHeightRef.current == null) {
+      previousHeightRef.current = currentHeight
+      return
+    }
+
+    if (!style.showContent) {
+      pendingHeightAdjustmentRef.current = true
+      return
+    }
+
+    const delta = currentHeight - previousHeightRef.current
+    if (delta > 0) {
+      pushNodesDown(delta)
+      previousHeightRef.current = currentHeight
+    }
+    pendingHeightAdjustmentRef.current = false
+  }, [eventKey, pushNodesDown, style.showContent])
+
+  useLayoutEffect(() => {
+    if (!style.showContent || !pendingHeightAdjustmentRef.current) {
+      return
+    }
+    if (!cardRef.current) {
+      return
+    }
+    const currentHeight = cardRef.current.getBoundingClientRect().height
+    const previousHeight = previousHeightRef.current
+    if (previousHeight == null) {
+      previousHeightRef.current = currentHeight
+      pendingHeightAdjustmentRef.current = false
+      return
+    }
+    const delta = currentHeight - previousHeight
+    if (delta > 0) {
+      pushNodesDown(delta)
+      previousHeightRef.current = currentHeight
+    }
+    pendingHeightAdjustmentRef.current = false
+  }, [pushNodesDown, style.showContent])
   if (!workflow) {
     return null
   }
 
   return (
     <Card
+      ref={cardRef}
       className={cn(
         "w-64",
         nodeStyles.common,
@@ -142,6 +269,103 @@ export default React.memo(function TriggerNode({
               {/* Schedule table */}
               <div className="rounded-lg border">
                 <TriggerNodeSchedulesTable workflowId={workflow.id} />
+              </div>
+              {/* Case triggers */}
+              <div className="rounded-lg border p-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1 text-xs font-medium">
+                    <Zap className="size-3" />
+                    <span>Case triggers</span>
+                  </div>
+                  {caseTriggerIsLoading ? (
+                    <Skeleton className="h-4 w-16" />
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "text-[11px] font-semibold",
+                        isCaseTriggerEnabled
+                          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600"
+                          : "border-muted-foreground/30 bg-muted text-muted-foreground"
+                      )}
+                    >
+                      {caseTriggerError ? "Unavailable" : caseTriggerStatusLabel}
+                    </Badge>
+                  )}
+                </div>
+                <div className="mt-2 space-y-2">
+                  {caseTriggerIsLoading ? (
+                    <div className="space-y-2">
+                      <Skeleton className="h-3 w-24" />
+                      <div className="flex flex-wrap gap-1">
+                        <Skeleton className="h-4 w-20" />
+                        <Skeleton className="h-4 w-16" />
+                      </div>
+                      <Skeleton className="h-3 w-20" />
+                    </div>
+                  ) : (
+                    <>
+                      <div className="space-y-1">
+                        <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                          <span>Case events</span>
+                          <span>{caseEventTypes.length} selected</span>
+                        </div>
+                        <div className="flex flex-wrap gap-1">
+                          {caseEventTypes.length > 0 ? (
+                            caseEventTypes.map((eventType) => (
+                              <Badge
+                                key={eventType}
+                                variant="secondary"
+                                className="text-[11px] font-medium"
+                              >
+                                {formatCaseEventLabel(eventType)}
+                              </Badge>
+                            ))
+                          ) : (
+                            <span className="text-[11px] text-muted-foreground">
+                              No case events selected
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                        <div className="flex items-center gap-1">
+                          <Tag className="size-3" />
+                          <span>Tag filter</span>
+                        </div>
+                        {tagFilterCount > 0 ? (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge
+                                  variant="outline"
+                                  className="cursor-default text-[11px] font-semibold"
+                                >
+                                  Enabled ({tagFilterCount})
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent side="top" align="end">
+                                <div className="flex max-w-56 flex-wrap gap-1">
+                                  {tagFilterLabels.map((tagLabel) => (
+                                    <Badge
+                                      key={tagLabel}
+                                      variant="secondary"
+                                      className="text-[11px]"
+                                    >
+                                      {tagLabel}
+                                    </Badge>
+                                  ))}
+                                </div>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        ) : (
+                          <span>Disabled</span>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/builder/panel/trigger-panel-tabs.ts
+++ b/frontend/src/components/builder/panel/trigger-panel-tabs.ts
@@ -1,0 +1,12 @@
+export type TriggerPanelTab =
+  | "trigger-webhooks"
+  | "trigger-schedules"
+  | "trigger-case-triggers"
+
+export const DEFAULT_TRIGGER_PANEL_TAB: TriggerPanelTab = "trigger-webhooks"
+
+export const TriggerPanelTabs = {
+  webhook: "trigger-webhooks",
+  schedules: "trigger-schedules",
+  caseTriggers: "trigger-case-triggers",
+} as const satisfies Record<string, TriggerPanelTab>

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -1373,10 +1373,7 @@ export function ScheduleControls({ workflowId }: { workflowId: string }) {
   }
   if (schedulesError || !schedules) {
     return (
-      <AlertNotification
-        level="error"
-        message="Failed to load schedules."
-      />
+      <AlertNotification level="error" message="Failed to load schedules." />
     )
   }
 

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -129,8 +129,13 @@ import {
   durationToISOString,
 } from "@/lib/time"
 import { cn } from "@/lib/utils"
+import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
+import {
+  type TriggerPanelTab,
+  TriggerPanelTabs,
+} from "@/components/builder/panel/trigger-panel-tabs"
 
 const HTTP_METHODS: readonly WebhookMethod[] = $WebhookMethod.enum
 
@@ -386,6 +391,8 @@ const formatScheduleDate = (value?: string | null) => {
 }
 
 export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
+  const { triggerPanelTab, setTriggerPanelTab } = useWorkflowBuilder()
+
   return (
     <div className="overflow-auto size-full">
       <div className="grid grid-cols-3">
@@ -411,7 +418,10 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
         </div>
       </div>
       <Tabs
-        defaultValue="trigger-webhooks"
+        value={triggerPanelTab}
+        onValueChange={(value) => {
+          setTriggerPanelTab(value as TriggerPanelTab)
+        }}
         className="mt-1 flex h-full w-full flex-col"
       >
         <div className="w-full">
@@ -419,21 +429,21 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
             <TabsList className="h-8 justify-start rounded-none bg-transparent p-0">
               <TabsTrigger
                 className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                value="trigger-webhooks"
+                value={TriggerPanelTabs.webhook}
               >
                 <WebhookIcon className="mr-2 size-4" />
                 <span>Webhook</span>
               </TabsTrigger>
               <TabsTrigger
                 className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                value="trigger-schedules"
+                value={TriggerPanelTabs.schedules}
               >
                 <CalendarClockIcon className="mr-2 size-4" />
                 <span>Schedules</span>
               </TabsTrigger>
               <TabsTrigger
                 className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                value="trigger-case-triggers"
+                value={TriggerPanelTabs.caseTriggers}
               >
                 <SquarePlay className="mr-2 size-4" />
                 <span>Case triggers</span>
@@ -443,7 +453,7 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
           <Separator />
         </div>
         <div className="flex-1 overflow-auto">
-          <TabsContent value="trigger-webhooks" className="pb-8">
+          <TabsContent value={TriggerPanelTabs.webhook} className="pb-8">
             <div className="px-4 my-4 space-y-2">
               <WebhookControls
                 webhook={workflow.webhook}
@@ -451,12 +461,15 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
               />
             </div>
           </TabsContent>
-          <TabsContent value="trigger-schedules" className="pb-8">
+          <TabsContent value={TriggerPanelTabs.schedules} className="pb-8">
             <div className="px-4 my-4 space-y-2">
               <ScheduleControls workflowId={workflow.id} />
             </div>
           </TabsContent>
-          <TabsContent value="trigger-case-triggers" className="pb-8">
+          <TabsContent
+            value={TriggerPanelTabs.caseTriggers}
+            className="pb-8"
+          >
             <div className="px-4 my-4 space-y-2">
               <CaseTriggerControls workflowId={workflow.id} />
             </div>

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -1296,9 +1296,8 @@ export function CaseTriggerControls({ workflowId }: { workflowId: string }) {
   if (caseTriggerError) {
     return (
       <AlertNotification
-        variant="destructive"
-        title="Failed to load case triggers"
-        description="We couldn't load the case trigger configuration."
+        level="error"
+        message="Failed to load case trigger configuration."
       />
     )
   }
@@ -1375,8 +1374,8 @@ export function ScheduleControls({ workflowId }: { workflowId: string }) {
   if (schedulesError || !schedules) {
     return (
       <AlertNotification
-        title="Failed to load schedules"
-        message="There was an error when loading schedules."
+        level="error"
+        message="Failed to load schedules."
       />
     )
   }

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -117,6 +117,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import {
   useCaseTagCatalog,
   useCaseTrigger,
@@ -392,6 +393,7 @@ const formatScheduleDate = (value?: string | null) => {
 
 export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
   const { triggerPanelTab, setTriggerPanelTab } = useWorkflowBuilder()
+  const { isFeatureEnabled } = useFeatureFlag()
 
   return (
     <div className="overflow-auto size-full">
@@ -441,13 +443,15 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
                 <CalendarClockIcon className="mr-2 size-4" />
                 <span>Schedules</span>
               </TabsTrigger>
-              <TabsTrigger
-                className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                value={TriggerPanelTabs.caseTriggers}
-              >
-                <SquarePlay className="mr-2 size-4" />
-                <span>Case triggers</span>
-              </TabsTrigger>
+              {isFeatureEnabled("case-triggers") && (
+                <TabsTrigger
+                  className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  value={TriggerPanelTabs.caseTriggers}
+                >
+                  <SquarePlay className="mr-2 size-4" />
+                  <span>Case triggers</span>
+                </TabsTrigger>
+              )}
             </TabsList>
           </div>
           <Separator />
@@ -466,11 +470,13 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
               <ScheduleControls workflowId={workflow.id} />
             </div>
           </TabsContent>
-          <TabsContent value={TriggerPanelTabs.caseTriggers} className="pb-8">
-            <div className="px-4 my-4 space-y-2">
-              <CaseTriggerControls workflowId={workflow.id} />
-            </div>
-          </TabsContent>
+          {isFeatureEnabled("case-triggers") && (
+            <TabsContent value={TriggerPanelTabs.caseTriggers} className="pb-8">
+              <div className="px-4 my-4 space-y-2">
+                <CaseTriggerControls workflowId={workflow.id} />
+              </div>
+            </TabsContent>
+          )}
         </div>
       </Tabs>
     </div>

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -6,7 +6,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { CheckIcon, DotsHorizontalIcon } from "@radix-ui/react-icons"
 import * as ipaddr from "ipaddr.js"
 import {
-  ActivityIcon,
   BanIcon,
   CalendarClockIcon,
   ChevronDownIcon,
@@ -14,6 +13,7 @@ import {
   MoreHorizontalIcon,
   PlusCircleIcon,
   RotateCcwIcon,
+  SquarePlay,
   Trash2Icon,
   WebhookIcon,
 } from "lucide-react"
@@ -41,12 +41,6 @@ import {
   type Suggestion,
   type Tag,
 } from "@/components/tags-input"
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -118,6 +112,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   useCaseTagCatalog,
   useCaseTrigger,
@@ -415,65 +410,59 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
           </h3>
         </div>
       </div>
-      <Separator />
-      {/* Metadata */}
-      <Accordion
-        type="multiple"
-        defaultValue={[
-          "trigger-settings",
-          "trigger-webhooks",
-          "trigger-case-triggers",
-          "trigger-schedules",
-        ]}
+      <Tabs
+        defaultValue="trigger-webhooks"
+        className="mt-1 flex h-full w-full flex-col"
       >
-        {/* Webhooks */}
-        <AccordionItem value="trigger-webhooks" id="trigger-webhooks">
-          <AccordionTrigger className="px-4 text-xs font-bold">
-            <div className="flex items-center">
-              <WebhookIcon className="mr-3 size-4" />
-              <span>Webhook</span>
-            </div>
-          </AccordionTrigger>
-          <AccordionContent>
+        <div className="w-full">
+          <div className="flex items-center justify-start">
+            <TabsList className="h-8 justify-start rounded-none bg-transparent p-0">
+              <TabsTrigger
+                className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                value="trigger-webhooks"
+              >
+                <WebhookIcon className="mr-2 size-4" />
+                <span>Webhook</span>
+              </TabsTrigger>
+              <TabsTrigger
+                className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                value="trigger-schedules"
+              >
+                <CalendarClockIcon className="mr-2 size-4" />
+                <span>Schedules</span>
+              </TabsTrigger>
+              <TabsTrigger
+                className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                value="trigger-case-triggers"
+              >
+                <SquarePlay className="mr-2 size-4" />
+                <span>Case triggers</span>
+              </TabsTrigger>
+            </TabsList>
+          </div>
+          <Separator />
+        </div>
+        <div className="flex-1 overflow-auto">
+          <TabsContent value="trigger-webhooks" className="pb-8">
             <div className="px-4 my-4 space-y-2">
               <WebhookControls
                 webhook={workflow.webhook}
                 workflowId={workflow.id}
               />
             </div>
-          </AccordionContent>
-        </AccordionItem>
-
-        {/* Schedules */}
-        <AccordionItem value="trigger-schedules" id="trigger-schedules">
-          <AccordionTrigger className="px-4 text-xs font-bold">
-            <div className="flex items-center">
-              <CalendarClockIcon className="mr-3 size-4" />
-              <span>Schedules</span>
-            </div>
-          </AccordionTrigger>
-          <AccordionContent>
+          </TabsContent>
+          <TabsContent value="trigger-schedules" className="pb-8">
             <div className="px-4 my-4 space-y-2">
               <ScheduleControls workflowId={workflow.id} />
             </div>
-          </AccordionContent>
-        </AccordionItem>
-
-        {/* Case Triggers */}
-        <AccordionItem value="trigger-case-triggers" id="trigger-case-triggers">
-          <AccordionTrigger className="px-4 text-xs font-bold">
-            <div className="flex items-center">
-              <ActivityIcon className="mr-3 size-4" />
-              <span>Case triggers</span>
-            </div>
-          </AccordionTrigger>
-          <AccordionContent>
+          </TabsContent>
+          <TabsContent value="trigger-case-triggers" className="pb-8">
             <div className="px-4 my-4 space-y-2">
               <CaseTriggerControls workflowId={workflow.id} />
             </div>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
+          </TabsContent>
+        </div>
+      </Tabs>
     </div>
   )
 }
@@ -722,10 +711,15 @@ export function WebhookControls({
           name="status"
           render={({ field }) => (
             <FormItem>
-              <div className="flex justify-between items-center">
-                <FormLabel className="flex gap-2 items-center text-xs font-medium">
-                  <span>Toggle Webhook</span>
-                </FormLabel>
+              <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+                <div className="space-y-1">
+                  <Label className="text-xs font-semibold">Enable webhook</Label>
+                  <p className="text-xs text-muted-foreground">
+                    {field.value === "online"
+                      ? "Webhook is currently active and receiving requests"
+                      : "Webhook is disabled"}
+                  </p>
+                </div>
                 <FormControl>
                   <Switch
                     checked={field.value === "online"}
@@ -735,11 +729,6 @@ export function WebhookControls({
                   />
                 </FormControl>
               </div>
-              <FormDescription className="text-xs">
-                {field.value === "online"
-                  ? "Webhook is currently active and receiving requests"
-                  : "Webhook is disabled"}
-              </FormDescription>
             </FormItem>
           )}
         />
@@ -750,7 +739,7 @@ export function WebhookControls({
           render={({ field }) => (
             <FormItem>
               <FormLabel className="flex gap-2 items-center text-xs font-medium">
-                <span>Allowed HTTP Methods</span>
+                <span>Allowed HTTP methods</span>
               </FormLabel>
               <FormControl>
                 <DropdownMenu>
@@ -809,7 +798,7 @@ export function WebhookControls({
           render={({ field }) => (
             <FormItem>
               <FormLabel className="text-xs font-medium">
-                <span>IP Allowlist</span>
+                <span>IP allowlist</span>
               </FormLabel>
               <FormControl>
                 <CustomTagInput
@@ -838,7 +827,7 @@ export function WebhookControls({
 
       <div className="space-y-3">
         <Label className="flex items-center gap-2 text-xs font-medium">
-          <span>API Key</span>
+          <span>API key</span>
         </Label>
         {hasActiveApiKey ? (
           <div className="rounded-lg border bg-muted/40 p-4 text-xs shadow-sm">
@@ -1895,7 +1884,7 @@ export function CreateScheduleDialog({ workflowId }: { workflowId: string }) {
               })
             })}
           >
-            <ScrollArea className="flex-1 px-6">
+            <ScrollArea className="flex-1 px-6 pr-10">
               <div className="space-y-4 py-4">
                 <FormField
                   control={form.control}

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -37,9 +37,9 @@ import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import {
   CustomTagInput,
+  MultiTagCommandInput,
   type Suggestion,
   type Tag,
-  MultiTagCommandInput,
 } from "@/components/tags-input"
 import {
   Accordion,
@@ -119,14 +119,14 @@ import {
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import {
+  useCaseTagCatalog,
+  useCaseTrigger,
   useDeleteWebhookApiKey,
   useGenerateWebhookApiKey,
   useRevokeWebhookApiKey,
   useSchedules,
-  useCaseTagCatalog,
-  useCaseTrigger,
-  useUpsertCaseTrigger,
   useUpdateWebhook,
+  useUpsertCaseTrigger,
 } from "@/lib/hooks"
 import {
   durationSchema,
@@ -460,10 +460,7 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
         </AccordionItem>
 
         {/* Case Triggers */}
-        <AccordionItem
-          value="trigger-case-triggers"
-          id="trigger-case-triggers"
-        >
+        <AccordionItem value="trigger-case-triggers" id="trigger-case-triggers">
           <AccordionTrigger className="px-4 text-xs font-bold">
             <div className="flex items-center">
               <ActivityIcon className="mr-3 size-4" />
@@ -1207,7 +1204,11 @@ export function CaseTriggerControls({ workflowId }: { workflowId: string }) {
   }, [caseTrigger])
 
   const persist = useCallback(
-    async (nextStatus: "online" | "offline", nextEvents: CaseEventType[], nextTags: string[]) => {
+    async (
+      nextStatus: "online" | "offline",
+      nextEvents: CaseEventType[],
+      nextTags: string[]
+    ) => {
       await upsertCaseTrigger({
         status: nextStatus,
         event_types: nextEvents,

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -31,6 +31,10 @@ import {
   type WorkflowRead,
 } from "@/client"
 import { TriggerTypename } from "@/components/builder/canvas/trigger-node"
+import {
+  type TriggerPanelTab,
+  TriggerPanelTabs,
+} from "@/components/builder/panel/trigger-panel-tabs"
 import { CopyButton } from "@/components/copy-button"
 import { getIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -105,6 +109,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   Tooltip,
   TooltipContent,
@@ -112,7 +117,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   useCaseTagCatalog,
   useCaseTrigger,
@@ -132,10 +136,6 @@ import { cn } from "@/lib/utils"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
-import {
-  type TriggerPanelTab,
-  TriggerPanelTabs,
-} from "@/components/builder/panel/trigger-panel-tabs"
 
 const HTTP_METHODS: readonly WebhookMethod[] = $WebhookMethod.enum
 
@@ -466,10 +466,7 @@ export function TriggerPanel({ workflow }: { workflow: WorkflowRead }) {
               <ScheduleControls workflowId={workflow.id} />
             </div>
           </TabsContent>
-          <TabsContent
-            value={TriggerPanelTabs.caseTriggers}
-            className="pb-8"
-          >
+          <TabsContent value={TriggerPanelTabs.caseTriggers} className="pb-8">
             <div className="px-4 my-4 space-y-2">
               <CaseTriggerControls workflowId={workflow.id} />
             </div>
@@ -726,7 +723,9 @@ export function WebhookControls({
             <FormItem>
               <div className="flex items-center justify-between gap-4 rounded-md border p-3">
                 <div className="space-y-1">
-                  <Label className="text-xs font-semibold">Enable webhook</Label>
+                  <Label className="text-xs font-semibold">
+                    Enable webhook
+                  </Label>
                   <p className="text-xs text-muted-foreground">
                     {field.value === "online"
                       ? "Webhook is currently active and receiving requests"

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -20,7 +20,7 @@ import {
   type AgentSessionsListSessionsData,
   type AgentSessionsListSessionsResponse,
   type AgentSettingsRead,
-  type ApiError,
+  ApiError,
   type AppSettingsRead,
   type AuditApiKeyGenerateResponse,
   type AuditSettingsRead,

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -316,12 +316,10 @@ import {
 import {
   type CaseTriggerCreate,
   type CaseTriggerRead,
-  type CaseTriggerUpdate,
   type CustomOAuthProviderCreateRequest,
   providersCreateCustomProvider,
   triggersCreateCaseTrigger,
   triggersGetCaseTrigger,
-  triggersUpdateCaseTrigger,
 } from "@/client/services.custom"
 import { toast } from "@/components/ui/use-toast"
 import { type AgentSessionWithStatus, enrichAgentSession } from "@/lib/agents"
@@ -548,31 +546,6 @@ export function useUpsertCaseTrigger(workspaceId: string, workflowId: string) {
   return useMutation({
     mutationFn: async (params: CaseTriggerCreate) =>
       await triggersCreateCaseTrigger({
-        workspaceId,
-        workflowId,
-        requestBody: params,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["case-trigger", workspaceId, workflowId],
-      })
-    },
-    onError: (error) => {
-      console.error("Failed to update case trigger:", error)
-      toast({
-        title: "Error updating case trigger",
-        description: "Could not update case trigger. Please try again.",
-        variant: "destructive",
-      })
-    },
-  })
-}
-
-export function useUpdateCaseTrigger(workspaceId: string, workflowId: string) {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async (params: CaseTriggerUpdate) =>
-      await triggersUpdateCaseTrigger({
         workspaceId,
         workflowId,
         requestBody: params,

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -557,6 +557,9 @@ export function useUpsertCaseTrigger(workspaceId: string, workflowId: string) {
     },
     onError: (error) => {
       console.error("Failed to update case trigger:", error)
+      queryClient.invalidateQueries({
+        queryKey: ["case-trigger", workspaceId, workflowId],
+      })
       toast({
         title: "Error updating case trigger",
         description: "Could not update case trigger. Please try again.",

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -314,8 +314,14 @@ import {
   workspacesUpdateWorkspace,
 } from "@/client"
 import {
+  type CaseTriggerCreate,
+  type CaseTriggerRead,
+  type CaseTriggerUpdate,
   type CustomOAuthProviderCreateRequest,
   providersCreateCustomProvider,
+  triggersCreateCaseTrigger,
+  triggersGetCaseTrigger,
+  triggersUpdateCaseTrigger,
 } from "@/client/services.custom"
 import { toast } from "@/components/ui/use-toast"
 import { type AgentSessionWithStatus, enrichAgentSession } from "@/lib/agents"
@@ -519,6 +525,72 @@ export function useUpdateWebhook(workspaceId: string, workflowId: string) {
   })
 
   return mutation
+}
+
+export function useCaseTrigger(workspaceId: string, workflowId: string) {
+  return useQuery<CaseTriggerRead | null, ApiError>({
+    queryKey: ["case-trigger", workspaceId, workflowId],
+    queryFn: async () => {
+      try {
+        return await triggersGetCaseTrigger({ workspaceId, workflowId })
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 404) {
+          return null
+        }
+        throw error
+      }
+    },
+  })
+}
+
+export function useUpsertCaseTrigger(workspaceId: string, workflowId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (params: CaseTriggerCreate) =>
+      await triggersCreateCaseTrigger({
+        workspaceId,
+        workflowId,
+        requestBody: params,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["case-trigger", workspaceId, workflowId],
+      })
+    },
+    onError: (error) => {
+      console.error("Failed to update case trigger:", error)
+      toast({
+        title: "Error updating case trigger",
+        description: "Could not update case trigger. Please try again.",
+        variant: "destructive",
+      })
+    },
+  })
+}
+
+export function useUpdateCaseTrigger(workspaceId: string, workflowId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (params: CaseTriggerUpdate) =>
+      await triggersUpdateCaseTrigger({
+        workspaceId,
+        workflowId,
+        requestBody: params,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["case-trigger", workspaceId, workflowId],
+      })
+    },
+    onError: (error) => {
+      console.error("Failed to update case trigger:", error)
+      toast({
+        title: "Error updating case trigger",
+        description: "Could not update case trigger. Please try again.",
+        variant: "destructive",
+      })
+    },
+  })
 }
 
 export function useGenerateWebhookApiKey(

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -23,6 +23,10 @@ import type {
 } from "@/components/builder/canvas/canvas"
 import type { EventsSidebarRef } from "@/components/builder/events/events-sidebar"
 import type { ActionPanelRef } from "@/components/builder/panel/action-panel"
+import {
+  DEFAULT_TRIGGER_PANEL_TAB,
+  type TriggerPanelTab,
+} from "@/components/builder/panel/trigger-panel-tabs"
 import { useWorkflow } from "@/providers/workflow"
 
 interface ReactFlowContextType {
@@ -42,6 +46,8 @@ interface ReactFlowContextType {
   toggleSidebar: () => void
   toggleActionPanel: () => void
   expandSidebarAndFocusEvents: () => void
+  triggerPanelTab: TriggerPanelTab
+  setTriggerPanelTab: React.Dispatch<SetStateAction<TriggerPanelTab>>
   selectedActionEventRef?: string
   setSelectedActionEventRef: React.Dispatch<SetStateAction<string | undefined>>
   currentExecutionId: string | null
@@ -72,6 +78,9 @@ export const WorkflowBuilderProvider: React.FC<
   const [isSidebarCollapsed, setIsSidebarCollapsed] = React.useState(false)
   const [isActionPanelCollapsed, setIsActionPanelCollapsed] =
     React.useState(false)
+  const [triggerPanelTab, setTriggerPanelTab] = useState<TriggerPanelTab>(
+    DEFAULT_TRIGGER_PANEL_TAB
+  )
   const [currentExecutionId, setCurrentExecutionId] = useState<string | null>(
     null
   )
@@ -89,6 +98,7 @@ export const WorkflowBuilderProvider: React.FC<
     setSelectedNodeId(null)
     setCurrentExecutionId(null)
     setActionDrafts({})
+    setTriggerPanelTab(DEFAULT_TRIGGER_PANEL_TAB)
   }, [workflowId])
 
   const setReactFlowNodes = useCallback(
@@ -186,6 +196,8 @@ export const WorkflowBuilderProvider: React.FC<
       isSidebarCollapsed,
       toggleSidebar,
       expandSidebarAndFocusEvents,
+      triggerPanelTab,
+      setTriggerPanelTab,
       actionPanelRef,
       isActionPanelCollapsed,
       toggleActionPanel,
@@ -210,6 +222,8 @@ export const WorkflowBuilderProvider: React.FC<
       isSidebarCollapsed,
       toggleSidebar,
       expandSidebarAndFocusEvents,
+      triggerPanelTab,
+      setTriggerPanelTab,
       actionPanelRef,
       isActionPanelCollapsed,
       toggleActionPanel,

--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -1,0 +1,222 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import AccessLevel, Role
+from tracecat.cases.triggers.consumer import CaseTriggerConsumer
+from tracecat.db.models import CaseTrigger, Workflow
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.mark.anyio
+async def test_case_trigger_consumer_matches_event_type(
+    session: AsyncSession, svc_role
+):
+    workflow = Workflow(
+        title="Case Trigger Consumer",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.flush()
+
+    case_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=workflow.id,
+        status="online",
+        event_types=["case_created"],
+        tag_filters=[],
+    )
+    session.add(case_trigger)
+    await session.commit()
+
+    consumer = CaseTriggerConsumer(client=AsyncMock())
+    matched = await consumer._load_triggers(
+        session, svc_role.workspace_id, "case_created"
+    )
+    assert len(matched) == 1
+
+    unmatched = await consumer._load_triggers(
+        session, svc_role.workspace_id, "case_closed"
+    )
+    assert unmatched == []
+
+
+def _build_role(workspace_id: uuid.UUID) -> Role:
+    return Role(
+        type="service",
+        access_level=AccessLevel.ADMIN,
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        user_id=None,
+        service_id="tracecat-case-triggers",
+    )
+
+
+def _build_consumer_with_mocks(
+    client: AsyncMock,
+    *,
+    event,
+    case,
+    triggers,
+    role: Role,
+    dispatch: AsyncMock | None = None,
+) -> CaseTriggerConsumer:
+    consumer = CaseTriggerConsumer(client=client)
+    consumer._load_event = AsyncMock(return_value=event)
+    consumer._load_case = AsyncMock(return_value=case)
+    consumer._load_triggers = AsyncMock(return_value=triggers)
+    consumer._get_service_role = AsyncMock(return_value=role)
+    if dispatch is not None:
+        consumer._dispatch_workflow = dispatch
+    return consumer
+
+
+@pytest.mark.anyio
+async def test_case_trigger_consumer_lock_prevents_ack():
+    event_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    workflow_id = uuid.uuid4()
+
+    event = SimpleNamespace(
+        id=event_id,
+        data={},
+        created_at=None,
+        type="case_created",
+        user_id=None,
+    )
+    case = SimpleNamespace(
+        id=case_id,
+        workspace_id=workspace_id,
+        tags=[],
+    )
+    trigger = SimpleNamespace(
+        workflow_id=workflow_id,
+        tag_filters=[],
+    )
+
+    client = AsyncMock()
+    client.exists = AsyncMock(return_value=False)
+    client.set_if_not_exists = AsyncMock(return_value=False)
+
+    dispatch = AsyncMock(return_value=True)
+    consumer = _build_consumer_with_mocks(
+        client,
+        event=event,
+        case=case,
+        triggers=[trigger],
+        role=_build_role(workspace_id),
+        dispatch=dispatch,
+    )
+
+    fields = {
+        "event_id": str(event_id),
+        "case_id": str(case_id),
+        "workspace_id": str(workspace_id),
+        "event_type": "case_created",
+    }
+    should_ack = await consumer._process_message(fields)
+    assert should_ack is False
+    dispatch.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_case_trigger_consumer_done_allows_ack():
+    event_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    workflow_id = uuid.uuid4()
+
+    event = SimpleNamespace(
+        id=event_id,
+        data={},
+        created_at=None,
+        type="case_created",
+        user_id=None,
+    )
+    case = SimpleNamespace(
+        id=case_id,
+        workspace_id=workspace_id,
+        tags=[],
+    )
+    trigger = SimpleNamespace(
+        workflow_id=workflow_id,
+        tag_filters=[],
+    )
+
+    client = AsyncMock()
+    client.exists = AsyncMock(return_value=True)
+    client.set_if_not_exists = AsyncMock(return_value=True)
+
+    dispatch = AsyncMock(return_value=True)
+    consumer = _build_consumer_with_mocks(
+        client,
+        event=event,
+        case=case,
+        triggers=[trigger],
+        role=_build_role(workspace_id),
+        dispatch=dispatch,
+    )
+
+    fields = {
+        "event_id": str(event_id),
+        "case_id": str(case_id),
+        "workspace_id": str(workspace_id),
+        "event_type": "case_created",
+    }
+    should_ack = await consumer._process_message(fields)
+    assert should_ack is True
+    dispatch.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_case_trigger_consumer_missing_definition_no_ack():
+    event_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    workflow_id = uuid.uuid4()
+
+    event = SimpleNamespace(
+        id=event_id,
+        data={},
+        created_at=None,
+        type="case_created",
+        user_id=None,
+    )
+    case = SimpleNamespace(
+        id=case_id,
+        workspace_id=workspace_id,
+        tags=[],
+    )
+    trigger = SimpleNamespace(
+        workflow_id=workflow_id,
+        tag_filters=[],
+    )
+
+    client = AsyncMock()
+    client.exists = AsyncMock(return_value=False)
+    client.set_if_not_exists = AsyncMock(return_value=True)
+    client.delete = AsyncMock(return_value=1)
+
+    consumer = _build_consumer_with_mocks(
+        client,
+        event=event,
+        case=case,
+        triggers=[trigger],
+        role=_build_role(workspace_id),
+    )
+
+    fields = {
+        "event_id": str(event_id),
+        "case_id": str(case_id),
+        "workspace_id": str(workspace_id),
+        "event_type": "case_created",
+    }
+    should_ack = await consumer._process_message(fields)
+    assert should_ack is False

--- a/tests/unit/test_case_triggers.py
+++ b/tests/unit/test_case_triggers.py
@@ -1,0 +1,116 @@
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.cases.tags.service import CaseTagsService
+from tracecat.db.models import CaseTrigger, Workflow
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig, CaseTriggerUpdate
+from tracecat.workflow.case_triggers.service import CaseTriggersService
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.mark.anyio
+async def test_case_trigger_config_requires_event_types_when_online():
+    with pytest.raises(ValidationError):
+        CaseTriggerConfig(status="online", event_types=[], tag_filters=[])
+
+
+@pytest.mark.anyio
+async def test_case_trigger_update_requires_events_when_online(
+    session: AsyncSession, svc_role
+):
+    workflow = Workflow(
+        title="Case Trigger Test",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.flush()
+
+    case_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=workflow.id,
+        status="offline",
+        event_types=[],
+        tag_filters=[],
+    )
+    session.add(case_trigger)
+    await session.commit()
+
+    service = CaseTriggersService(session, role=svc_role)
+    with pytest.raises(TracecatValidationError):
+        await service.update_case_trigger(
+            workflow.id, CaseTriggerUpdate(status="online")
+        )
+
+
+@pytest.mark.anyio
+async def test_case_trigger_create_missing_tags(
+    session: AsyncSession, svc_role
+):
+    workflow = Workflow(
+        title="Case Trigger Tags",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.flush()
+
+    case_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=workflow.id,
+        status="offline",
+        event_types=[],
+        tag_filters=[],
+    )
+    session.add(case_trigger)
+    await session.commit()
+
+    service = CaseTriggersService(session, role=svc_role)
+    config = CaseTriggerConfig(
+        status="offline",
+        event_types=[],
+        tag_filters=["phishing"],
+    )
+    await service.upsert_case_trigger(
+        workflow.id, config, create_missing_tags=True
+    )
+
+    tags_service = CaseTagsService(session, role=svc_role)
+    created = await tags_service.get_tag_by_ref("phishing")
+    assert created.ref == "phishing"
+
+
+@pytest.mark.anyio
+async def test_case_trigger_rejects_unknown_tags(
+    session: AsyncSession, svc_role
+):
+    workflow = Workflow(
+        title="Case Trigger Tags",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.flush()
+
+    case_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=workflow.id,
+        status="offline",
+        event_types=[],
+        tag_filters=[],
+    )
+    session.add(case_trigger)
+    await session.commit()
+
+    service = CaseTriggersService(session, role=svc_role)
+    with pytest.raises(TracecatNotFoundError):
+        await service.update_case_trigger(
+            workflow.id,
+            CaseTriggerUpdate(tag_filters=["missing-tag"]),
+        )

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,14 +1,14 @@
 from typing import Any
 
 import pytest
-
-from tracecat.auth.types import Role
-from tracecat.dsl.common import DSLInput
-from tracecat.identifiers.workflow import WorkflowUUID
-from tracecat.workflow.management.management import WorkflowsManagementService
 from sqlalchemy import select
 
+from tracecat.auth.types import Role
 from tracecat.db.models import CaseTag, CaseTrigger
+from tracecat.dsl.common import DSLInput
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
+from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.schemas import ExternalWorkflowDefinition
 
 
@@ -92,11 +92,11 @@ async def test_workflow_import_case_trigger_creates_tags(test_role: Role):
                 "returns": "${{ ACTIONS.entrypoint_1.result }}",
             }
         ),
-        case_trigger={
-            "status": "offline",
-            "event_types": [],
-            "tag_filters": ["phishing"],
-        },
+        case_trigger=CaseTriggerConfig(
+            status="offline",
+            event_types=[],
+            tag_filters=["phishing"],
+        ),
     )
 
     async with WorkflowsManagementService.with_session(test_role) as service:

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -528,6 +528,7 @@ class TestWorkflowImportServiceFolders:
         )
         workflow_import_service._create_schedules = AsyncMock()
         workflow_import_service._update_webhook = AsyncMock()
+        workflow_import_service._update_case_trigger = AsyncMock()
         workflow_import_service._create_tags = AsyncMock()
 
         with patch(
@@ -566,6 +567,7 @@ class TestWorkflowImportServiceFolders:
         workflow_import_service._ensure_folder_exists = AsyncMock()
         workflow_import_service._create_schedules = AsyncMock()
         workflow_import_service._update_webhook = AsyncMock()
+        workflow_import_service._update_case_trigger = AsyncMock()
         workflow_import_service._create_tags = AsyncMock()
 
         with patch(

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -12,6 +12,8 @@ from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.admin.router import router as admin_router
+from tracecat_ee.agent.approvals.router import router as approvals_router
 
 from tracecat import __version__ as APP_VERSION
 from tracecat import config
@@ -48,7 +50,6 @@ from tracecat.cases.attachments.router import router as case_attachments_router
 from tracecat.cases.dropdowns.router import definitions_router as case_dropdowns_router
 from tracecat.cases.dropdowns.router import values_router as case_dropdown_values_router
 from tracecat.cases.durations.router import router as case_durations_router
-from tracecat.cases.triggers.consumer import start_case_trigger_consumer
 from tracecat.cases.internal_router import (
     comments_router as internal_comments_router,
 )
@@ -65,6 +66,7 @@ from tracecat.cases.tag_definitions.router import (
 )
 from tracecat.cases.tags.internal_router import router as internal_case_tags_router
 from tracecat.cases.tags.router import router as case_tags_router
+from tracecat.cases.triggers.consumer import start_case_trigger_consumer
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.editor.router import router as editor_router
@@ -124,8 +126,6 @@ from tracecat.workflow.store.router import router as workflow_store_router
 from tracecat.workflow.tags.router import router as workflow_tags_router
 from tracecat.workspaces.router import router as workspaces_router
 from tracecat.workspaces.service import WorkspaceService
-from tracecat_ee.admin.router import router as admin_router
-from tracecat_ee.agent.approvals.router import router as approvals_router
 
 
 @asynccontextmanager

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -12,8 +12,6 @@ from pydantic import BaseModel
 from pydantic_core import to_jsonable_python
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from tracecat_ee.admin.router import router as admin_router
-from tracecat_ee.agent.approvals.router import router as approvals_router
 
 from tracecat import __version__ as APP_VERSION
 from tracecat import config
@@ -126,6 +124,8 @@ from tracecat.workflow.store.router import router as workflow_store_router
 from tracecat.workflow.tags.router import router as workflow_tags_router
 from tracecat.workspaces.router import router as workspaces_router
 from tracecat.workspaces.service import WorkspaceService
+from tracecat_ee.admin.router import router as admin_router
+from tracecat_ee.agent.approvals.router import router as approvals_router
 
 
 @asynccontextmanager

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -281,7 +281,7 @@ class CaseDropdownValuesService(BaseWorkspaceService):
         params: CaseDropdownValueSet,
     ) -> CaseDropdownValueRead:
         """Set (upsert) or clear a dropdown value for a case. Records an event."""
-        await self._get_case(case_id)
+        case = await self._get_case(case_id)
 
         # Resolve old value
         stmt = select(CaseDropdownValue).where(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -20,7 +20,6 @@ from tracecat.auth.types import Role
 from tracecat.cases.attachments import CaseAttachmentService
 from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
 from tracecat.cases.durations.service import CaseDurationService
-from tracecat.cases.triggers.publisher import publish_case_event_payload
 from tracecat.cases.enums import (
     CaseEventType,
     CasePriority,
@@ -58,6 +57,7 @@ from tracecat.cases.schemas import (
 )
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
+from tracecat.cases.triggers.publisher import publish_case_event_payload
 from tracecat.contexts import ctx_run
 from tracecat.custom_fields import CustomFieldsService
 from tracecat.custom_fields.schemas import CustomFieldCreate, CustomFieldUpdate

--- a/tracecat/cases/triggers/__init__.py
+++ b/tracecat/cases/triggers/__init__.py
@@ -1,0 +1,1 @@
+"""Case trigger stream publisher and consumer."""

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import uuid
+from datetime import UTC, datetime
+from time import monotonic
+from typing import Any
+
+from redis.exceptions import ResponseError
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from tracecat import config
+from tracecat.auth.types import AccessLevel, Role
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import Case, CaseEvent, CaseTrigger, Workspace
+from tracecat.dsl.common import DSLInput
+from tracecat.logger import logger
+from tracecat.redis.client import RedisClient, get_redis_client
+from tracecat.registry.lock.types import RegistryLock
+from tracecat.workflow.executions.enums import TriggerType
+from tracecat.workflow.executions.service import WorkflowExecutionsService
+from tracecat.workflow.management.definitions import WorkflowDefinitionsService
+
+
+class CaseTriggerConsumer:
+    """Consume case events and dispatch workflows based on configured triggers."""
+
+    def __init__(self, client: RedisClient, *, consumer_name: str | None = None) -> None:
+        self.client = client
+        self.stream_key = config.TRACECAT__CASE_TRIGGERS_STREAM_KEY
+        self.group = config.TRACECAT__CASE_TRIGGERS_GROUP
+        self.block_ms = config.TRACECAT__CASE_TRIGGERS_BLOCK_MS
+        self.batch = config.TRACECAT__CASE_TRIGGERS_BATCH
+        self.claim_idle_ms = config.TRACECAT__CASE_TRIGGERS_CLAIM_IDLE_MS
+        self.dedup_ttl = config.TRACECAT__CASE_TRIGGERS_DEDUP_TTL_SECONDS
+        self.lock_ttl = config.TRACECAT__CASE_TRIGGERS_LOCK_TTL_SECONDS
+        self.consumer_name = consumer_name or f"{socket.gethostname()}:{os.getpid()}"
+        self._workspace_role_cache: dict[uuid.UUID, Role] = {}
+        self._pending_check_interval = max(self.claim_idle_ms / 1000.0, 30.0)
+
+    async def run(self) -> None:
+        if not config.TRACECAT__CASE_TRIGGERS_ENABLED:
+            logger.info("Case triggers disabled; skipping consumer")
+            return
+
+        await self._ensure_group()
+        logger.info(
+            "Case trigger consumer started",
+            stream_key=self.stream_key,
+            group=self.group,
+            consumer=self.consumer_name,
+        )
+        last_pending_check = monotonic()
+        try:
+            while True:
+                messages = await self.client.xreadgroup(
+                    group_name=self.group,
+                    consumer_name=self.consumer_name,
+                    streams={self.stream_key: ">"},
+                    count=self.batch,
+                    block=self.block_ms,
+                )
+                if messages:
+                    for _stream, entries in messages:
+                        for message_id, fields in entries:
+                            await self._handle_message(message_id, fields)
+                else:
+                    now = monotonic()
+                    if now - last_pending_check >= self._pending_check_interval:
+                        await self._claim_idle_messages()
+                        last_pending_check = now
+                await asyncio.sleep(0)
+        except asyncio.CancelledError:
+            logger.info("Case trigger consumer cancelled")
+            raise
+        except Exception as e:
+            logger.error("Case trigger consumer stopped due to error", error=str(e))
+            raise
+
+    async def _ensure_group(self) -> None:
+        try:
+            await self.client.xgroup_create(
+                self.stream_key,
+                self.group,
+                id="$",
+                ignore_busygroup=True,
+            )
+        except ResponseError as e:
+            if "BUSYGROUP" in str(e):
+                return
+            raise
+
+    async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
+        should_ack = False
+        try:
+            should_ack = await self._process_message(fields)
+        except Exception as e:
+            logger.error(
+                "Failed to process case trigger message",
+                message_id=message_id,
+                error=str(e),
+            )
+        if should_ack:
+            await self.client.xack(self.stream_key, self.group, [message_id])
+
+    async def _process_message(self, fields: dict[str, str]) -> bool:
+        event_id = fields.get("event_id")
+        case_id = fields.get("case_id")
+        workspace_id = fields.get("workspace_id")
+        event_type = fields.get("event_type")
+        if not (event_id and case_id and workspace_id and event_type):
+            logger.warning("Malformed case trigger message", fields=fields)
+            return True
+
+        try:
+            event_uuid = uuid.UUID(event_id)
+            case_uuid = uuid.UUID(case_id)
+            workspace_uuid = uuid.UUID(workspace_id)
+        except ValueError:
+            logger.warning("Invalid IDs in case trigger message", fields=fields)
+            return True
+
+        async with get_async_session_context_manager() as session:
+            event = await self._load_event(session, event_uuid, case_uuid, workspace_uuid)
+            if event is None:
+                return True
+
+            wf_exec_id = None
+            if isinstance(event.data, dict):
+                wf_exec_id = event.data.get("wf_exec_id")
+            if wf_exec_id:
+                logger.debug(
+                    "Skipping workflow-originated case event",
+                    event_id=event_id,
+                    wf_exec_id=wf_exec_id,
+                )
+                return True
+
+            case = await self._load_case(session, case_uuid, workspace_uuid)
+            if case is None:
+                return True
+
+            triggers = await self._load_triggers(session, workspace_uuid, event_type)
+            if not triggers:
+                return True
+
+            case_tag_refs = {tag.ref for tag in case.tags}
+            role = await self._get_service_role(session, workspace_uuid)
+
+            should_ack = True
+            for trigger in triggers:
+                if trigger.tag_filters:
+                    if not case_tag_refs.intersection(trigger.tag_filters):
+                        continue
+                done_key = f"case-trigger:done:{event_id}:{trigger.workflow_id}"
+                lock_key = f"case-trigger:lock:{event_id}:{trigger.workflow_id}"
+
+                if await self.client.exists(done_key):
+                    continue
+
+                lock_acquired = await self.client.set_if_not_exists(
+                    lock_key,
+                    value="1",
+                    expire_seconds=self.lock_ttl,
+                )
+                if not lock_acquired:
+                    should_ack = False
+                    continue
+
+                try:
+                    dispatched = await self._dispatch_workflow(
+                        session=session,
+                        role=role,
+                        trigger=trigger,
+                        case=case,
+                        event=event,
+                    )
+                    if not dispatched:
+                        should_ack = False
+                        continue
+
+                    await self.client.set(
+                        done_key,
+                        value="1",
+                        expire_seconds=self.dedup_ttl,
+                    )
+                except Exception as e:
+                    should_ack = False
+                    logger.error(
+                        "Failed to dispatch workflow for case trigger",
+                        error=str(e),
+                        workflow_id=str(trigger.workflow_id),
+                        event_id=event_id,
+                    )
+                finally:
+                    await self.client.delete(lock_key)
+
+            return should_ack
+
+    async def _load_event(
+        self,
+        session,
+        event_id: uuid.UUID,
+        case_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+    ) -> CaseEvent | None:
+        result = await session.execute(
+            select(CaseEvent).where(
+                CaseEvent.id == event_id,
+                CaseEvent.case_id == case_id,
+                CaseEvent.workspace_id == workspace_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _load_case(
+        self, session, case_id: uuid.UUID, workspace_id: uuid.UUID
+    ) -> Case | None:
+        result = await session.execute(
+            select(Case)
+            .options(selectinload(Case.tags))
+            .where(
+                Case.id == case_id,
+                Case.workspace_id == workspace_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _load_triggers(
+        self, session, workspace_id: uuid.UUID, event_type: str
+    ) -> list[CaseTrigger]:
+        stmt = select(CaseTrigger).where(
+            CaseTrigger.workspace_id == workspace_id,
+            CaseTrigger.status == "online",
+            CaseTrigger.event_types.contains([event_type]),
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def _get_service_role(self, session, workspace_id: uuid.UUID) -> Role:
+        if workspace_id in self._workspace_role_cache:
+            return self._workspace_role_cache[workspace_id]
+
+        result = await session.execute(
+            select(Workspace).where(Workspace.id == workspace_id)
+        )
+        workspace = result.scalar_one()
+        role = Role(
+            type="service",
+            workspace_id=workspace_id,
+            organization_id=workspace.organization_id,
+            access_level=AccessLevel.ADMIN,
+            user_id=None,
+            service_id="tracecat-case-triggers",
+        )
+        self._workspace_role_cache[workspace_id] = role
+        return role
+
+    async def _dispatch_workflow(
+        self,
+        *,
+        session,
+        role: Role,
+        trigger: CaseTrigger,
+        case: Case,
+        event: CaseEvent,
+    ) -> bool:
+        defn_service = WorkflowDefinitionsService(session, role=role)
+        defn = await defn_service.get_definition_by_workflow_id(trigger.workflow_id)
+        if not defn:
+            logger.warning(
+                "No workflow definition found for workflow",
+                workflow_id=str(trigger.workflow_id),
+                event_id=str(event.id),
+            )
+            return False
+        if not defn.content:
+            logger.warning(
+                "Workflow definition content missing",
+                workflow_id=str(trigger.workflow_id),
+                event_id=str(event.id),
+            )
+            return False
+
+        dsl = DSLInput.model_validate(defn.content)
+        workflow_service = await WorkflowExecutionsService.connect(role=role)
+
+        created_at = event.created_at or datetime.now(UTC)
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=UTC)
+
+        payload: dict[str, Any] = {
+            "case_id": str(case.id),
+            "event": {
+                "id": str(event.id),
+                "type": event.type.value if hasattr(event.type, "value") else event.type,
+                "data": event.data,
+                "created_at": created_at.isoformat(),
+                "user_id": str(event.user_id) if event.user_id else None,
+                "wf_exec_id": event.data.get("wf_exec_id") if event.data else None,
+            },
+            "tags": [
+                {
+                    "id": str(tag.id),
+                    "ref": tag.ref,
+                    "name": tag.name,
+                    "color": tag.color,
+                }
+                for tag in case.tags
+            ],
+            "workspace_id": str(case.workspace_id),
+        }
+
+        workflow_service.create_workflow_execution_nowait(
+            dsl=dsl,
+            wf_id=trigger.workflow_id,
+            payload=payload,
+            trigger_type=TriggerType.CASE,
+            registry_lock=RegistryLock.model_validate(defn.registry_lock)
+            if defn.registry_lock
+            else None,
+        )
+        return True
+
+    async def _claim_idle_messages(self) -> None:
+        pending = await self.client.xpending_range(
+            self.stream_key,
+            self.group,
+            min_id="-",
+            max_id="+",
+            count=self.batch,
+            idle=self.claim_idle_ms,
+        )
+        if not pending:
+            return
+
+        message_ids: list[str] = []
+        for entry in pending:
+            msg_id = None
+            if isinstance(entry, dict):
+                msg_id = entry.get("message_id") or entry.get("id")
+            else:
+                msg_id = getattr(entry, "message_id", None)
+            if msg_id:
+                message_ids.append(msg_id)
+
+        if not message_ids:
+            return
+
+        claimed = await self.client.xclaim(
+            self.stream_key,
+            self.group,
+            self.consumer_name,
+            self.claim_idle_ms,
+            message_ids,
+        )
+        for message_id, fields in claimed:
+            await self._handle_message(message_id, fields)
+
+
+async def start_case_trigger_consumer() -> None:
+    client = await get_redis_client()
+    consumer = CaseTriggerConsumer(client)
+    await consumer.run()

--- a/tracecat/cases/triggers/publisher.py
+++ b/tracecat/cases/triggers/publisher.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from tracecat import config
+from tracecat.db.models import Case, CaseEvent
+from tracecat.logger import logger
+from tracecat.redis.client import get_redis_client
+
+
+async def publish_case_event_payload(
+    *,
+    event_id: str,
+    case_id: str,
+    workspace_id: str,
+    event_type: str,
+    created_at: datetime,
+) -> None:
+    """Publish a case event to the Redis streams pipeline."""
+    if not config.TRACECAT__CASE_TRIGGERS_ENABLED:
+        return
+
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+
+    payload = {
+        "event_id": event_id,
+        "case_id": case_id,
+        "workspace_id": workspace_id,
+        "event_type": event_type,
+        "created_at": created_at.isoformat(),
+    }
+
+    client = await get_redis_client()
+    await client.xadd(
+        stream_key=config.TRACECAT__CASE_TRIGGERS_STREAM_KEY,
+        fields=payload,
+        maxlen=config.TRACECAT__CASE_TRIGGERS_MAXLEN,
+        approximate=True,
+    )
+
+
+async def publish_case_event(event: CaseEvent, case: Case) -> None:
+    """Publish a case event to the Redis streams pipeline."""
+    if event.id is None:
+        logger.warning("Skipping case event publish; event has no id")
+        return
+
+    created_at = event.created_at or datetime.now(UTC)
+    await publish_case_event_payload(
+        event_id=str(event.id),
+        case_id=str(case.id),
+        workspace_id=str(case.workspace_id),
+        event_type=event.type.value if hasattr(event.type, "value") else event.type,
+        created_at=created_at,
+    )

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -43,6 +43,7 @@ TRACECAT__SERVICE_ROLES_WHITELIST = [
     "tracecat-llm-gateway",
     "tracecat-runner",
     "tracecat-schedule-runner",
+    "tracecat-case-triggers",
     "tracecat-ui",
 ]
 TRACECAT__DEFAULT_USER_ID = uuid.UUID(int=0)
@@ -581,6 +582,51 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 
 REDIS_URL__ARN = os.environ.get("REDIS_URL__ARN")
 """(AWS only) ARN of the secret containing the Redis URL."""
+
+TRACECAT__CASE_TRIGGERS_ENABLED = (
+    os.environ.get("TRACECAT__CASE_TRIGGERS_ENABLED", "true").lower() == "true"
+)
+"""Enable case event workflow triggers. Defaults to true."""
+
+TRACECAT__CASE_TRIGGERS_STREAM_KEY = os.environ.get(
+    "TRACECAT__CASE_TRIGGERS_STREAM_KEY", "case-events"
+)
+"""Redis stream key for case events."""
+
+TRACECAT__CASE_TRIGGERS_GROUP = os.environ.get(
+    "TRACECAT__CASE_TRIGGERS_GROUP", "case-triggers"
+)
+"""Redis consumer group for case trigger processing."""
+
+TRACECAT__CASE_TRIGGERS_BLOCK_MS = int(
+    os.environ.get("TRACECAT__CASE_TRIGGERS_BLOCK_MS", 2000)
+)
+"""XREADGROUP block timeout in milliseconds."""
+
+TRACECAT__CASE_TRIGGERS_BATCH = int(
+    os.environ.get("TRACECAT__CASE_TRIGGERS_BATCH", 100)
+)
+"""Maximum number of events to read per batch."""
+
+TRACECAT__CASE_TRIGGERS_CLAIM_IDLE_MS = int(
+    os.environ.get("TRACECAT__CASE_TRIGGERS_CLAIM_IDLE_MS", 300000)
+)
+"""Idle time before claiming pending messages (milliseconds)."""
+
+TRACECAT__CASE_TRIGGERS_MAXLEN = int(
+    os.environ.get("TRACECAT__CASE_TRIGGERS_MAXLEN", 30000)
+)
+"""Approximate max length for the case events stream."""
+
+TRACECAT__CASE_TRIGGERS_DEDUP_TTL_SECONDS = int(
+    os.environ.get("TRACECAT__CASE_TRIGGERS_DEDUP_TTL_SECONDS", 21600)
+)
+"""TTL for case trigger dedup keys in seconds."""
+
+TRACECAT__CASE_TRIGGERS_LOCK_TTL_SECONDS = int(
+    os.environ.get("TRACECAT__CASE_TRIGGERS_LOCK_TTL_SECONDS", 300)
+)
+"""TTL for case trigger lock keys in seconds."""
 
 # === File limits === #
 TRACECAT__MAX_ATTACHMENT_SIZE_BYTES = int(

--- a/tracecat/dsl/validation.py
+++ b/tracecat/dsl/validation.py
@@ -77,7 +77,7 @@ def resolve_time_anchor_activity(
     ensuring the same time anchor is used across workflow resets.
 
     For scheduled workflows, uses TemporalScheduledStartTime (the intended schedule time).
-    For other triggers (webhook, manual), uses the workflow start time.
+    For other triggers (webhook, manual, case), uses the workflow start time.
     """
     if inputs.trigger_type == TriggerType.SCHEDULED and inputs.scheduled_start_time:
         return inputs.scheduled_start_time

--- a/tracecat/feature_flags/enums.py
+++ b/tracecat/feature_flags/enums.py
@@ -10,3 +10,4 @@ class FeatureFlag(StrEnum):
     CASE_DROPDOWNS = "case-dropdowns"
     CASE_DURATIONS = "case-durations"
     CASE_TASKS = "case-tasks"
+    CASE_TRIGGERS = "case-triggers"

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -89,6 +89,7 @@ InternalServiceID = Literal[
     "tracecat-cli",
     "tracecat-executor",
     "tracecat-agent-executor",
+    "tracecat-case-triggers",
     "tracecat-llm-gateway",
     "tracecat-mcp",
     "tracecat-runner",

--- a/tracecat/redis/client.py
+++ b/tracecat/redis/client.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import base64
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Sequence
 from typing import Any
 
 import boto3
@@ -353,7 +353,7 @@ class RedisClient:
         group_name: str,
         consumer_name: str,
         min_idle_time: int,
-        message_ids: list[str],
+        message_ids: Sequence[StreamIdT],
     ) -> list[tuple[str, dict[str, str]]]:
         """Claim pending messages for a consumer."""
         try:

--- a/tracecat/redis/client.py
+++ b/tracecat/redis/client.py
@@ -9,7 +9,7 @@ import boto3
 import redis.asyncio as redis
 from botocore.exceptions import ClientError
 from redis.asyncio.connection import ConnectionPool
-from redis.exceptions import RedisError
+from redis.exceptions import RedisError, ResponseError
 from redis.typing import KeyT, StreamIdT
 from tenacity import (
     retry,
@@ -207,6 +207,180 @@ class RedisClient:
         wait=wait_exponential(multiplier=1, min=1, max=10),
         retry=retry_if_exception_type((RedisError, RuntimeError)),
     )
+    async def xgroup_create(
+        self,
+        stream_key: str,
+        group_name: str,
+        *,
+        id: str = "$",
+        mkstream: bool = True,
+        ignore_busygroup: bool = False,
+    ) -> bool:
+        """Create a consumer group for a Redis stream."""
+        try:
+            client = await self._get_client()
+            return await client.xgroup_create(
+                name=stream_key, groupname=group_name, id=id, mkstream=mkstream
+            )
+        except ResponseError as e:
+            if ignore_busygroup and "BUSYGROUP" in str(e):
+                logger.debug(
+                    "Redis consumer group already exists",
+                    stream_key=stream_key,
+                    group_name=group_name,
+                )
+                return False
+            logger.error(
+                "Failed to create Redis consumer group",
+                stream_key=stream_key,
+                group_name=group_name,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+        except (RedisError, RuntimeError) as e:
+            logger.error(
+                "Failed to create Redis consumer group",
+                stream_key=stream_key,
+                group_name=group_name,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def xreadgroup(
+        self,
+        group_name: str,
+        consumer_name: str,
+        streams: dict[KeyT, StreamIdT],
+        count: int | None = None,
+        block: int | None = None,
+    ) -> list[tuple[str, list[tuple[str, dict[str, str]]]]]:
+        """Read from Redis streams using a consumer group."""
+        try:
+            client = await self._get_client()
+            return await client.xreadgroup(
+                groupname=group_name,
+                consumername=consumer_name,
+                streams=streams,
+                count=count,
+                block=block,
+            )
+        except (RedisError, RuntimeError) as e:
+            logger.error(
+                "Failed to read from Redis consumer group",
+                streams=list(streams.keys()),
+                group_name=group_name,
+                consumer_name=consumer_name,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def xack(
+        self, stream_key: str, group_name: str, message_ids: list[str]
+    ) -> int:
+        """Acknowledge messages in a consumer group."""
+        try:
+            client = await self._get_client()
+            return await client.xack(stream_key, group_name, *message_ids)
+        except (RedisError, RuntimeError) as e:
+            logger.error(
+                "Failed to ack Redis stream messages",
+                stream_key=stream_key,
+                group_name=group_name,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def xpending_range(
+        self,
+        stream_key: str,
+        group_name: str,
+        min_id: str,
+        max_id: str,
+        count: int,
+        *,
+        consumer: str | None = None,
+        idle: int | None = None,
+    ) -> list[Any]:
+        """Fetch pending messages in a consumer group."""
+        try:
+            client = await self._get_client()
+            return await client.xpending_range(
+                name=stream_key,
+                groupname=group_name,
+                min=min_id,
+                max=max_id,
+                count=count,
+                consumername=consumer,
+                idle=idle,
+            )
+        except (RedisError, RuntimeError) as e:
+            logger.error(
+                "Failed to fetch pending Redis messages",
+                stream_key=stream_key,
+                group_name=group_name,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def xclaim(
+        self,
+        stream_key: str,
+        group_name: str,
+        consumer_name: str,
+        min_idle_time: int,
+        message_ids: list[str],
+    ) -> list[tuple[str, dict[str, str]]]:
+        """Claim pending messages for a consumer."""
+        try:
+            client = await self._get_client()
+            return await client.xclaim(
+                name=stream_key,
+                groupname=group_name,
+                consumername=consumer_name,
+                min_idle_time=min_idle_time,
+                message_ids=message_ids,
+            )
+        except (RedisError, RuntimeError) as e:
+            logger.error(
+                "Failed to claim Redis pending messages",
+                stream_key=stream_key,
+                group_name=group_name,
+                consumer_name=consumer_name,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
     async def xrange(
         self,
         stream_key: str,
@@ -255,6 +429,85 @@ class RedisClient:
             resolved = await value
             return bool(resolved)
         return bool(value)
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def set_if_not_exists(
+        self, key: str, value: str, *, expire_seconds: int
+    ) -> bool:
+        """Set a value only if the key does not exist (SET NX)."""
+        try:
+            client = await self._get_client()
+            result = await client.set(name=key, value=value, nx=True, ex=expire_seconds)
+            return bool(result)
+        except (RedisError, RuntimeError) as e:
+            logger.error(
+                "Failed to set Redis key if not exists",
+                key=key,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def set(
+        self,
+        key: str,
+        value: str,
+        *,
+        expire_seconds: int | None = None,
+    ) -> bool:
+        """Set a Redis key with an optional TTL."""
+        try:
+            client = await self._get_client()
+            result = await client.set(name=key, value=value, ex=expire_seconds)
+            return bool(result)
+        except (RedisError, RuntimeError) as e:
+            logger.error(
+                "Failed to set Redis key",
+                key=key,
+                error=str(e),
+            )
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def exists(self, key: str) -> bool:
+        """Check if a Redis key exists."""
+        try:
+            client = await self._get_client()
+            result = await client.exists(key)
+            return bool(result)
+        except (RedisError, RuntimeError) as e:
+            logger.error("Failed to check Redis key existence", key=key, error=str(e))
+            await self._reset_connection()
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((RedisError, RuntimeError)),
+    )
+    async def delete(self, key: str) -> int:
+        """Delete a Redis key."""
+        try:
+            client = await self._get_client()
+            return await client.delete(key)
+        except (RedisError, RuntimeError) as e:
+            logger.error("Failed to delete Redis key", key=key, error=str(e))
+            await self._reset_connection()
+            raise
 
     async def close(self) -> None:
         """Close the Redis connection."""

--- a/tracecat/redis/client.py
+++ b/tracecat/redis/client.py
@@ -363,7 +363,7 @@ class RedisClient:
                 groupname=group_name,
                 consumername=consumer_name,
                 min_idle_time=min_idle_time,
-                message_ids=message_ids,
+                message_ids=list(message_ids),
             )
         except (RedisError, RuntimeError) as e:
             logger.error(

--- a/tracecat/workflow/case_triggers/__init__.py
+++ b/tracecat/workflow/case_triggers/__init__.py
@@ -1,0 +1,1 @@
+"""Case trigger models and services."""

--- a/tracecat/workflow/case_triggers/schemas.py
+++ b/tracecat/workflow/case_triggers/schemas.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from tracecat.cases.enums import CaseEventType
+from tracecat.core.schemas import Schema
+from tracecat.identifiers import WorkflowID
+
+CaseTriggerStatus = Literal["online", "offline"]
+
+
+def _dedupe_items[T](items: list[T]) -> list[T]:
+    seen: set[T] = set()
+    deduped: list[T] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        deduped.append(item)
+    return deduped
+
+
+class CaseTriggerConfig(BaseModel):
+    status: CaseTriggerStatus = "offline"
+    event_types: list[CaseEventType] = Field(default_factory=list)
+    tag_filters: list[str] = Field(default_factory=list)
+
+    @field_validator("event_types")
+    @classmethod
+    def dedupe_event_types(cls, value: list[CaseEventType]) -> list[CaseEventType]:
+        return _dedupe_items(value)
+
+    @field_validator("tag_filters")
+    @classmethod
+    def normalize_tag_filters(cls, value: list[str]) -> list[str]:
+        normalized = [ref.strip() for ref in value if ref and ref.strip()]
+        return _dedupe_items(normalized)
+
+    @model_validator(mode="after")
+    def validate_online_has_events(self) -> "CaseTriggerConfig":
+        if self.status == "online" and not self.event_types:
+            raise ValueError("event_types must be non-empty when status is online")
+        return self
+
+
+class CaseTriggerCreate(CaseTriggerConfig):
+    pass
+
+
+class CaseTriggerUpdate(BaseModel):
+    status: CaseTriggerStatus | None = None
+    event_types: list[CaseEventType] | None = None
+    tag_filters: list[str] | None = None
+
+    @field_validator("event_types")
+    @classmethod
+    def dedupe_event_types(cls, value: list[CaseEventType] | None) -> list[CaseEventType] | None:
+        if value is None:
+            return None
+        return _dedupe_items(value)
+
+    @field_validator("tag_filters")
+    @classmethod
+    def normalize_tag_filters(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        normalized = [ref.strip() for ref in value if ref and ref.strip()]
+        return _dedupe_items(normalized)
+
+
+class CaseTriggerRead(Schema):
+    id: uuid.UUID
+    workflow_id: WorkflowID
+    status: CaseTriggerStatus
+    event_types: list[CaseEventType]
+    tag_filters: list[str]

--- a/tracecat/workflow/case_triggers/schemas.py
+++ b/tracecat/workflow/case_triggers/schemas.py
@@ -40,7 +40,7 @@ class CaseTriggerConfig(BaseModel):
         return _dedupe_items(normalized)
 
     @model_validator(mode="after")
-    def validate_online_has_events(self) -> "CaseTriggerConfig":
+    def validate_online_has_events(self) -> CaseTriggerConfig:
         if self.status == "online" and not self.event_types:
             raise ValueError("event_types must be non-empty when status is online")
         return self
@@ -57,7 +57,9 @@ class CaseTriggerUpdate(BaseModel):
 
     @field_validator("event_types")
     @classmethod
-    def dedupe_event_types(cls, value: list[CaseEventType] | None) -> list[CaseEventType] | None:
+    def dedupe_event_types(
+        cls, value: list[CaseEventType] | None
+    ) -> list[CaseEventType] | None:
         if value is None:
             return None
         return _dedupe_items(value)

--- a/tracecat/workflow/case_triggers/service.py
+++ b/tracecat/workflow/case_triggers/service.py
@@ -92,9 +92,12 @@ class CaseTriggersService(BaseWorkspaceService):
             )
 
         tag_filters = updates.get("tag_filters", case_trigger.tag_filters)
-        resolved_tags = await self._resolve_tag_filters(
-            tag_filters, create_missing=create_missing_tags
-        )
+        if tag_filters is None:
+            resolved_tags = []
+        else:
+            resolved_tags = await self._resolve_tag_filters(
+                tag_filters, create_missing=create_missing_tags
+            )
 
         case_trigger.status = status
         case_trigger.event_types = list(event_types) if event_types is not None else []
@@ -132,9 +135,7 @@ class CaseTriggersService(BaseWorkspaceService):
         missing = [ref for ref in deduped if ref not in existing]
 
         if missing and not create_missing:
-            raise TracecatNotFoundError(
-                f"Case tag(s) not found: {', '.join(missing)}"
-            )
+            raise TracecatNotFoundError(f"Case tag(s) not found: {', '.join(missing)}")
 
         if missing and create_missing:
             for ref in missing:

--- a/tracecat/workflow/case_triggers/service.py
+++ b/tracecat/workflow/case_triggers/service.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+
+from tracecat.db.models import CaseTag, CaseTrigger
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.identifiers.workflow import WorkflowID, WorkflowUUID
+from tracecat.service import BaseWorkspaceService
+from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig, CaseTriggerUpdate
+
+
+class CaseTriggersService(BaseWorkspaceService):
+    """Manage workflow case trigger configuration."""
+
+    service_name = "case_triggers"
+
+    async def get_case_trigger(self, workflow_id: WorkflowID) -> CaseTrigger:
+        stmt = select(CaseTrigger).where(
+            CaseTrigger.workspace_id == self.workspace_id,
+            CaseTrigger.workflow_id == WorkflowUUID.new(workflow_id),
+        )
+        result = await self.session.execute(stmt)
+        try:
+            return result.scalar_one()
+        except NoResultFound as exc:
+            raise TracecatNotFoundError(
+                f"Case trigger for workflow {workflow_id} not found"
+            ) from exc
+
+    async def upsert_case_trigger(
+        self,
+        workflow_id: WorkflowID,
+        params: CaseTriggerConfig,
+        *,
+        create_missing_tags: bool = False,
+        commit: bool = True,
+    ) -> CaseTrigger:
+        try:
+            case_trigger = await self.get_case_trigger(workflow_id)
+            return await self.update_case_trigger(
+                workflow_id,
+                CaseTriggerUpdate(
+                    status=params.status,
+                    event_types=params.event_types,
+                    tag_filters=params.tag_filters,
+                ),
+                create_missing_tags=create_missing_tags,
+                commit=commit,
+            )
+        except TracecatNotFoundError:
+            resolved_tags = await self._resolve_tag_filters(
+                params.tag_filters, create_missing=create_missing_tags
+            )
+            case_trigger = CaseTrigger(
+                workspace_id=self.workspace_id,
+                workflow_id=WorkflowUUID.new(workflow_id),
+                status=params.status,
+                event_types=[evt.value for evt in params.event_types],
+                tag_filters=resolved_tags,
+            )
+            self.session.add(case_trigger)
+            if commit:
+                await self.session.commit()
+                await self.session.refresh(case_trigger)
+            else:
+                await self.session.flush()
+            return case_trigger
+
+    async def update_case_trigger(
+        self,
+        workflow_id: WorkflowID,
+        params: CaseTriggerUpdate,
+        *,
+        create_missing_tags: bool = False,
+        commit: bool = True,
+    ) -> CaseTrigger:
+        case_trigger = await self.get_case_trigger(workflow_id)
+        updates = params.model_dump(exclude_unset=True)
+
+        status = updates.get("status", case_trigger.status)
+        event_types = updates.get("event_types", case_trigger.event_types)
+        if isinstance(event_types, list):
+            event_types = [
+                evt.value if hasattr(evt, "value") else evt for evt in event_types
+            ]
+        if status == "online" and not event_types:
+            raise TracecatValidationError(
+                "event_types must be non-empty when status is online"
+            )
+
+        tag_filters = updates.get("tag_filters", case_trigger.tag_filters)
+        resolved_tags = await self._resolve_tag_filters(
+            tag_filters, create_missing=create_missing_tags
+        )
+
+        case_trigger.status = status
+        case_trigger.event_types = list(event_types) if event_types is not None else []
+        case_trigger.tag_filters = resolved_tags
+
+        self.session.add(case_trigger)
+        if commit:
+            await self.session.commit()
+            await self.session.refresh(case_trigger)
+        else:
+            await self.session.flush()
+        return case_trigger
+
+    async def _resolve_tag_filters(
+        self, tag_filters: Iterable[str], *, create_missing: bool = False
+    ) -> list[str]:
+        refs = [ref.strip() for ref in tag_filters if ref and ref.strip()]
+        if not refs:
+            return []
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for ref in refs:
+            if ref in seen:
+                continue
+            seen.add(ref)
+            deduped.append(ref)
+
+        stmt = select(CaseTag).where(
+            CaseTag.workspace_id == self.workspace_id,
+            CaseTag.ref.in_(deduped),
+        )
+        result = await self.session.execute(stmt)
+        existing = {tag.ref for tag in result.scalars().all()}
+        missing = [ref for ref in deduped if ref not in existing]
+
+        if missing and not create_missing:
+            raise TracecatNotFoundError(
+                f"Case tag(s) not found: {', '.join(missing)}"
+            )
+
+        if missing and create_missing:
+            for ref in missing:
+                tag = CaseTag(
+                    workspace_id=self.workspace_id,
+                    name=ref,
+                    ref=ref,
+                    color=None,
+                )
+                self.session.add(tag)
+            await self.session.flush()
+
+        return deduped

--- a/tracecat/workflow/executions/enums.py
+++ b/tracecat/workflow/executions/enums.py
@@ -98,6 +98,7 @@ class TriggerType(StrEnum):
     MANUAL = "manual"
     SCHEDULED = "scheduled"
     WEBHOOK = "webhook"
+    CASE = "case"
 
     def to_temporal_search_attr_pair(self) -> SearchAttributePair[str]:
         return TemporalSearchAttr.TRIGGER_TYPE.create_pair(self.value)

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -855,6 +855,7 @@ class WorkflowExecutionsService:
         if time_anchor is None and trigger_type in (
             TriggerType.WEBHOOK,
             TriggerType.MANUAL,
+            TriggerType.CASE,
         ):
             time_anchor = datetime.datetime.now(datetime.UTC)
 

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -643,7 +643,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
 
             case_trigger_service = CaseTriggersService(self.session, role=self.role)
             await case_trigger_service.upsert_case_trigger(
-                workflow.id,
+                WorkflowUUID.new(workflow.id),
                 external_defn.case_trigger,
                 create_missing_tags=True,
                 commit=False,

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -16,6 +16,7 @@ from tracecat.audit.logger import audit_log
 from tracecat.contexts import ctx_logical_time
 from tracecat.db.models import (
     Action,
+    CaseTrigger,
     Tag,
     Webhook,
     Workflow,
@@ -527,6 +528,17 @@ class WorkflowsManagementService(BaseWorkspaceService):
         self.session.add(webhook)
         workflow.webhook = webhook
 
+        case_trigger = CaseTrigger(
+            workspace_id=self.workspace_id,
+            workflow_id=workflow.id,
+            status="offline",
+            event_types=[],
+            tag_filters=[],
+        )
+        case_trigger.workflow = workflow
+        self.session.add(case_trigger)
+        workflow.case_trigger = case_trigger
+
         await self.session.commit()
         await self.session.refresh(workflow)
         return workflow
@@ -626,6 +638,17 @@ class WorkflowsManagementService(BaseWorkspaceService):
             created_at=external_defn.created_at,
             updated_at=external_defn.updated_at,
         )
+        if external_defn.case_trigger is not None:
+            from tracecat.workflow.case_triggers.service import CaseTriggersService
+
+            case_trigger_service = CaseTriggersService(self.session, role=self.role)
+            await case_trigger_service.upsert_case_trigger(
+                workflow.id,
+                external_defn.case_trigger,
+                create_missing_tags=True,
+                commit=False,
+            )
+            await self.session.commit()
         return workflow
 
     async def create_db_workflow_from_dsl(
@@ -679,6 +702,16 @@ class WorkflowsManagementService(BaseWorkspaceService):
         )
         self.session.add(webhook)
         workflow.webhook = webhook
+
+        case_trigger = CaseTrigger(
+            workspace_id=self.workspace_id,
+            workflow_id=workflow.id,
+            status="offline",
+            event_types=[],
+            tag_filters=[],
+        )
+        self.session.add(case_trigger)
+        workflow.case_trigger = case_trigger
 
         # Create actions from DSL (actions have workflow_id set, relationship managed by FK)
         await self.create_actions_from_dsl(dsl, workflow.id)

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -561,10 +561,12 @@ async def export_workflow(
             workspace_id=workflow.workspace_id,
             workflow_id=WorkflowUUID.new(workflow.id),
             definition=dsl,
-            case_trigger=CaseTriggerConfig(
-                status=workflow.case_trigger.status,
-                event_types=workflow.case_trigger.event_types,
-                tag_filters=workflow.case_trigger.tag_filters,
+            case_trigger=CaseTriggerConfig.model_validate(
+                {
+                    "status": workflow.case_trigger.status,
+                    "event_types": workflow.case_trigger.event_types,
+                    "tag_filters": workflow.case_trigger.tag_filters,
+                }
             )
             if workflow.case_trigger
             else None,

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -7,6 +7,7 @@ import yaml
 from asyncpg import UniqueViolationError
 from fastapi import (
     APIRouter,
+    Depends,
     File,
     Form,
     HTTPException,
@@ -28,6 +29,7 @@ from tracecat.db.models import Webhook, WebhookApiKey, Workflow
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.schemas import DSLConfig
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.feature_flags import FeatureFlag, is_feature_enabled
 from tracecat.identifiers.workflow import AnyWorkflowIDPath, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
@@ -744,11 +746,19 @@ async def update_webhook(
 # ----- Workflow Case Triggers ----- #
 
 
+def _check_case_triggers_flag() -> None:
+    if not is_feature_enabled(FeatureFlag.CASE_TRIGGERS):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Feature not enabled"
+        )
+
+
 @router.post(
     "/{workflow_id}/case-trigger",
     status_code=status.HTTP_201_CREATED,
     tags=["triggers"],
     response_model=CaseTriggerRead,
+    dependencies=[Depends(_check_case_triggers_flag)],
 )
 async def create_case_trigger(
     role: WorkspaceUserRole,
@@ -773,6 +783,7 @@ async def create_case_trigger(
     "/{workflow_id}/case-trigger",
     tags=["triggers"],
     response_model=CaseTriggerRead,
+    dependencies=[Depends(_check_case_triggers_flag)],
 )
 async def get_case_trigger(
     role: WorkspaceUserRole,
@@ -792,6 +803,7 @@ async def get_case_trigger(
     "/{workflow_id}/case-trigger",
     tags=["triggers"],
     status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(_check_case_triggers_flag)],
 )
 async def update_case_trigger(
     role: WorkspaceUserRole,

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -48,6 +48,12 @@ from tracecat.webhooks.schemas import (
     WebhookUpdate,
 )
 from tracecat.workflow.actions.schemas import ActionRead
+from tracecat.workflow.case_triggers.schemas import (
+    CaseTriggerCreate,
+    CaseTriggerRead,
+    CaseTriggerUpdate,
+)
+from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.folders.service import WorkflowFolderService
 from tracecat.workflow.management.management import WorkflowsManagementService
@@ -554,6 +560,12 @@ async def export_workflow(
             workspace_id=workflow.workspace_id,
             workflow_id=WorkflowUUID.new(workflow.id),
             definition=dsl,
+            case_trigger=workflow.case_trigger
+            and {
+                "status": workflow.case_trigger.status,
+                "event_types": workflow.case_trigger.event_types,
+                "tag_filters": workflow.case_trigger.tag_filters,
+            },
         )
     else:
         # Existing behavior: fetch from WorkflowDefinition
@@ -723,6 +735,82 @@ async def update_webhook(
     session.add(webhook)
     await session.commit()
     await session.refresh(webhook)
+
+
+# ----- Workflow Case Triggers ----- #
+
+
+@router.post(
+    "/{workflow_id}/case-trigger",
+    status_code=status.HTTP_201_CREATED,
+    tags=["triggers"],
+    response_model=CaseTriggerRead,
+)
+async def create_case_trigger(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+    params: CaseTriggerCreate,
+) -> CaseTriggerRead:
+    """Create or replace the case trigger configuration for a workflow."""
+    service = CaseTriggersService(session, role=role)
+    try:
+        case_trigger = await service.upsert_case_trigger(workflow_id, params)
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+        ) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
+    return CaseTriggerRead.model_validate(case_trigger, from_attributes=True)
+
+
+@router.get(
+    "/{workflow_id}/case-trigger",
+    tags=["triggers"],
+    response_model=CaseTriggerRead,
+)
+async def get_case_trigger(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+) -> CaseTriggerRead:
+    """Get the case trigger configuration for a workflow."""
+    service = CaseTriggersService(session, role=role)
+    try:
+        case_trigger = await service.get_case_trigger(workflow_id)
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+        ) from e
+    return CaseTriggerRead.model_validate(case_trigger, from_attributes=True)
+
+
+@router.patch(
+    "/{workflow_id}/case-trigger",
+    tags=["triggers"],
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def update_case_trigger(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+    params: CaseTriggerUpdate,
+) -> None:
+    """Update the case trigger configuration for a workflow."""
+    service = CaseTriggersService(session, role=role)
+    try:
+        await service.update_case_trigger(workflow_id, params)
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+        ) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
 
 
 @router.post(

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -202,10 +202,12 @@ class ExternalWorkflowDefinition(BaseModel):
         case_trigger: CaseTriggerConfig | None = None,
     ) -> ExternalWorkflowDefinition:
         if case_trigger is None and defn.workflow and defn.workflow.case_trigger:
-            case_trigger = CaseTriggerConfig(
-                status=defn.workflow.case_trigger.status,
-                event_types=defn.workflow.case_trigger.event_types,
-                tag_filters=defn.workflow.case_trigger.tag_filters,
+            case_trigger = CaseTriggerConfig.model_validate(
+                {
+                    "status": defn.workflow.case_trigger.status,
+                    "event_types": defn.workflow.case_trigger.event_types,
+                    "tag_filters": defn.workflow.case_trigger.tag_filters,
+                }
             )
         return ExternalWorkflowDefinition(
             workspace_id=defn.workspace_id,

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -21,6 +21,7 @@ from tracecat.tags.schemas import TagRead
 from tracecat.validation.schemas import ValidationResult
 from tracecat.webhooks.schemas import WebhookRead
 from tracecat.workflow.actions.schemas import ActionRead
+from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
 from tracecat.workflow.schedules.schemas import ScheduleRead
 
 
@@ -192,9 +193,20 @@ class ExternalWorkflowDefinition(BaseModel):
     )
     version: int = Field(default=1, gt=0)
     definition: DSLInput
+    case_trigger: CaseTriggerConfig | None = None
 
     @staticmethod
-    def from_database(defn: WorkflowDefinition) -> ExternalWorkflowDefinition:
+    def from_database(
+        defn: WorkflowDefinition,
+        *,
+        case_trigger: CaseTriggerConfig | None = None,
+    ) -> ExternalWorkflowDefinition:
+        if case_trigger is None and defn.workflow and defn.workflow.case_trigger:
+            case_trigger = CaseTriggerConfig(
+                status=defn.workflow.case_trigger.status,
+                event_types=defn.workflow.case_trigger.event_types,
+                tag_filters=defn.workflow.case_trigger.tag_filters,
+            )
         return ExternalWorkflowDefinition(
             workspace_id=defn.workspace_id,
             workflow_id=WorkflowUUID.new(defn.workflow_id),
@@ -202,6 +214,7 @@ class ExternalWorkflowDefinition(BaseModel):
             updated_at=defn.updated_at,
             version=defn.version,
             definition=DSLInput.model_validate(defn.content),
+            case_trigger=case_trigger,
         )
 
     @field_validator("workflow_id", mode="before")

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -434,7 +434,7 @@ class WorkflowImportService(BaseWorkspaceService):
         service = CaseTriggersService(session=self.session, role=self.role)
         config = CaseTriggerConfig.model_validate(remote_case_trigger)
         await service.upsert_case_trigger(
-            workflow.id,
+            WorkflowUUID.new(workflow.id),
             config,
             create_missing_tags=True,
             commit=False,

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -15,16 +15,16 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import PullDiagnostic, PullResult
+from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
+from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.folders.service import WorkflowFolderService
 from tracecat.workflow.management.management import WorkflowsManagementService
-from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
-from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.schedules.schemas import ScheduleCreate
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
 from tracecat.workflow.store.schemas import (
-    RemoteWebhook,
     RemoteCaseTrigger,
+    RemoteWebhook,
     RemoteWorkflowDefinition,
     RemoteWorkflowSchedule,
     RemoteWorkflowTag,
@@ -325,9 +325,7 @@ class WorkflowImportService(BaseWorkspaceService):
         # 6. Update related entities
         await self._update_schedules(existing_workflow, remote_workflow.schedules)
         await self._update_webhook(existing_workflow.webhook, remote_workflow.webhook)
-        await self._update_case_trigger(
-            existing_workflow, remote_workflow.case_trigger
-        )
+        await self._update_case_trigger(existing_workflow, remote_workflow.case_trigger)
         await self._update_tags(existing_workflow, remote_workflow.tags)
 
     async def _create_new_workflow(self, remote_defn: RemoteWorkflowDefinition) -> None:

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -10,6 +10,7 @@ from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import Author, PushObject, PushOptions
 from tracecat.workflow.store.schemas import (
+    RemoteCaseTrigger,
     RemoteWebhook,
     RemoteWorkflowDefinition,
     RemoteWorkflowSchedule,
@@ -75,7 +76,7 @@ class WorkflowStoreService(BaseWorkspaceService):
         stable_path = get_definition_path(workflow_id)
         webhook = workflow.webhook
 
-        await self.session.refresh(workflow, ["tags", "folder"])
+        await self.session.refresh(workflow, ["tags", "folder", "case_trigger"])
 
         # Get folder path if workflow is in a folder
         folder_path = None
@@ -105,6 +106,19 @@ class WorkflowStoreService(BaseWorkspaceService):
                 methods=webhook.methods,
                 status=cast(Status, webhook.status),
             ),
+            case_trigger=RemoteCaseTrigger(
+                status=cast(Status, workflow.case_trigger.status)
+                if workflow.case_trigger
+                else "offline",
+                event_types=workflow.case_trigger.event_types
+                if workflow.case_trigger
+                else [],
+                tag_filters=workflow.case_trigger.tag_filters
+                if workflow.case_trigger
+                else [],
+            )
+            if workflow.case_trigger
+            else None,
             definition=dsl,
         )
         push_obj = PushObject(data=defn, path=stable_path)

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import cast
 
+from tracecat.cases.enums import CaseEventType
 from tracecat.db.models import Workflow
 from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import TracecatSettingsError, TracecatValidationError
@@ -110,7 +111,10 @@ class WorkflowStoreService(BaseWorkspaceService):
                 status=cast(Status, workflow.case_trigger.status)
                 if workflow.case_trigger
                 else "offline",
-                event_types=workflow.case_trigger.event_types
+                event_types=[
+                    CaseEventType(event_type)
+                    for event_type in workflow.case_trigger.event_types
+                ]
                 if workflow.case_trigger
                 else [],
                 tag_filters=workflow.case_trigger.tag_filters


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds case triggers so workflows can run on case events. Includes Redis-backed stream processing, APIs, and a UI to configure event types and tag filters; gated by the "case-triggers" feature flag.

- **New Features**
  - CaseTrigger model and Alembic migration; created per workflow.
  - Redis stream publisher/consumer for case events with dedup and locking.
  - Background consumer task gated by TRACECAT__CASE_TRIGGERS_ENABLED.
  - API endpoints: GET/POST/PATCH /workspaces/{workspace_id}/workflows/{workflow_id}/case-trigger.
  - Tag allowlist with validation and auto-create on import/sync; tag updates propagate to trigger filters and null clears filters.
  - Builder panel UI to enable triggers, pick events, select tag filters, and view status.
  - Import/export and remote store sync now include case_trigger.
  - TriggerType.CASE added; time anchor updated for case-triggered runs.
  - Feature flag "case-triggers" added; UI and APIs are gated.

- **Migration**
  - Run the new Alembic migration.
  - Ensure Redis is configured; set TRACECAT__CASE_TRIGGERS_* env vars as needed (enabled by default).
  - Enable the "case-triggers" feature flag to access UI and APIs.
  - Existing workflows get an offline case trigger; enable and select events to activate.
  - Remote workflow import/sync may create missing tags when specified.

<sup>Written for commit 179f6ae144f46d4b9d833b23b2b08d6a1d6bce99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

