### PR TITLE
feat(ui): Add org tooltip + fix superuser org access

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5433,6 +5433,116 @@ export const $CaseTaskUpdate = {
   title: "CaseTaskUpdate",
 } as const
 
+export const $CaseTriggerCreate = {
+  properties: {
+    status: {
+      type: "string",
+      enum: ["online", "offline"],
+      title: "Status",
+      default: "offline",
+    },
+    event_types: {
+      items: {
+        $ref: "#/components/schemas/CaseEventType",
+      },
+      type: "array",
+      title: "Event Types",
+    },
+    tag_filters: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Tag Filters",
+    },
+  },
+  type: "object",
+  title: "CaseTriggerCreate",
+} as const
+
+export const $CaseTriggerRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    workflow_id: {
+      type: "string",
+      title: "Workflow Id",
+    },
+    status: {
+      type: "string",
+      enum: ["online", "offline"],
+      title: "Status",
+    },
+    event_types: {
+      items: {
+        $ref: "#/components/schemas/CaseEventType",
+      },
+      type: "array",
+      title: "Event Types",
+    },
+    tag_filters: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Tag Filters",
+    },
+  },
+  type: "object",
+  required: ["id", "workflow_id", "status", "event_types", "tag_filters"],
+  title: "CaseTriggerRead",
+} as const
+
+export const $CaseTriggerUpdate = {
+  properties: {
+    status: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["online", "offline"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Status",
+    },
+    event_types: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/CaseEventType",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Event Types",
+    },
+    tag_filters: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Tag Filters",
+    },
+  },
+  type: "object",
+  title: "CaseTriggerUpdate",
+} as const
+
 export const $CaseUpdate = {
   properties: {
     summary: {
@@ -7815,6 +7925,7 @@ export const $FeatureFlag = {
     "case-dropdowns",
     "case-durations",
     "case-tasks",
+    "case-triggers",
   ],
   title: "FeatureFlag",
   description: "Feature flag enum.",
@@ -10036,49 +10147,6 @@ export const $OrgMemberRead = {
     "last_login_at",
   ],
   title: "OrgMemberRead",
-} as const
-
-export const $OrgRead = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-    },
-    name: {
-      type: "string",
-      title: "Name",
-    },
-    slug: {
-      type: "string",
-      title: "Slug",
-    },
-    is_active: {
-      type: "boolean",
-      title: "Is Active",
-    },
-    created_at: {
-      type: "string",
-      format: "date-time",
-      title: "Created At",
-    },
-    updated_at: {
-      anyOf: [
-        {
-          type: "string",
-          format: "date-time",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Updated At",
-    },
-  },
-  type: "object",
-  required: ["id", "name", "slug", "is_active", "created_at"],
-  title: "OrgRead",
-  description: "Organization response.",
 } as const
 
 export const $OrgRegistryRepositoryRead = {
@@ -13054,6 +13122,7 @@ export const $Role = {
         "tracecat-cli",
         "tracecat-executor",
         "tracecat-agent-executor",
+        "tracecat-case-triggers",
         "tracecat-llm-gateway",
         "tracecat-mcp",
         "tracecat-runner",
@@ -16791,7 +16860,7 @@ export const $Trigger = {
 
 export const $TriggerType = {
   type: "string",
-  enum: ["manual", "scheduled", "webhook"],
+  enum: ["manual", "scheduled", "webhook", "case"],
   title: "TriggerType",
   description: "Trigger type for a workflow execution.",
 } as const
@@ -20157,6 +20226,23 @@ export const $Yaml = {
   title: "Yaml",
 } as const
 
+export const $tracecat__organization__schemas__OrgRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+  },
+  type: "object",
+  required: ["id", "name"],
+  title: "OrgRead",
+} as const
+
 export const $tracecat__registry__repositories__schemas__RegistrySyncResponse =
   {
     properties: {
@@ -20319,6 +20405,49 @@ export const $tracecat__registry__repositories__schemas__RegistryVersionRead = {
   ],
   title: "RegistryVersionRead",
   description: "Response model for reading a registry version.",
+} as const
+
+export const $tracecat_ee__admin__organizations__schemas__OrgRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    slug: {
+      type: "string",
+      title: "Slug",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: ["id", "name", "slug", "is_active", "created_at"],
+  title: "OrgRead",
+  description: "Organization response.",
 } as const
 
 export const $tracecat_ee__admin__registry__schemas__RegistrySyncResponse = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -308,6 +308,7 @@ import type {
   OrganizationGetInvitationByTokenResponse,
   OrganizationGetInvitationTokenData,
   OrganizationGetInvitationTokenResponse,
+  OrganizationGetOrganizationResponse,
   OrganizationListInvitationsData,
   OrganizationListInvitationsResponse,
   OrganizationListOrgMembersResponse,
@@ -462,16 +463,22 @@ import type {
   TagsListTagsResponse,
   TagsUpdateTagData,
   TagsUpdateTagResponse,
+  TriggersCreateCaseTriggerData,
+  TriggersCreateCaseTriggerResponse,
   TriggersCreateWebhookData,
   TriggersCreateWebhookResponse,
   TriggersDeleteWebhookApiKeyData,
   TriggersDeleteWebhookApiKeyResponse,
   TriggersGenerateWebhookApiKeyData,
   TriggersGenerateWebhookApiKeyResponse,
+  TriggersGetCaseTriggerData,
+  TriggersGetCaseTriggerResponse,
   TriggersGetWebhookData,
   TriggersGetWebhookResponse,
   TriggersRevokeWebhookApiKeyData,
   TriggersRevokeWebhookApiKeyResponse,
+  TriggersUpdateCaseTriggerData,
+  TriggersUpdateCaseTriggerResponse,
   TriggersUpdateWebhookData,
   TriggersUpdateWebhookResponse,
   UsersSearchUserData,
@@ -781,6 +788,7 @@ export const publicReceiveInteraction = (
  * ------------
  * - Basic: Can list workspaces where they are a member.
  * - Admin: Can list all workspaces regardless of membership.
+ * - Org Owner/Admin: Can list all workspaces in the organization.
  * @returns WorkspaceReadMinimal Successful Response
  * @throws ApiError
  */
@@ -1547,6 +1555,93 @@ export const triggersUpdateWebhook = (
   return __request(OpenAPI, {
     method: "PATCH",
     url: "/workflows/{workflow_id}/webhook",
+    path: {
+      workflow_id: data.workflowId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Case Trigger
+ * Create or replace the case trigger configuration for a workflow.
+ * @param data The data for the request.
+ * @param data.workflowId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns CaseTriggerRead Successful Response
+ * @throws ApiError
+ */
+export const triggersCreateCaseTrigger = (
+  data: TriggersCreateCaseTriggerData
+): CancelablePromise<TriggersCreateCaseTriggerResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workflows/{workflow_id}/case-trigger",
+    path: {
+      workflow_id: data.workflowId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Case Trigger
+ * Get the case trigger configuration for a workflow.
+ * @param data The data for the request.
+ * @param data.workflowId
+ * @param data.workspaceId
+ * @returns CaseTriggerRead Successful Response
+ * @throws ApiError
+ */
+export const triggersGetCaseTrigger = (
+  data: TriggersGetCaseTriggerData
+): CancelablePromise<TriggersGetCaseTriggerResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workflows/{workflow_id}/case-trigger",
+    path: {
+      workflow_id: data.workflowId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Case Trigger
+ * Update the case trigger configuration for a workflow.
+ * @param data The data for the request.
+ * @param data.workflowId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const triggersUpdateCaseTrigger = (
+  data: TriggersUpdateCaseTriggerData
+): CancelablePromise<TriggersUpdateCaseTriggerResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/workflows/{workflow_id}/case-trigger",
     path: {
       workflow_id: data.workflowId,
     },
@@ -2924,7 +3019,7 @@ export const tagsDeleteTag = (
 
 /**
  * Search User
- * Create new user.
+ * Search for a user by email.
  * @param data The data for the request.
  * @param data.email
  * @param data.workspaceId
@@ -2948,11 +3043,30 @@ export const usersSearchUser = (
 }
 
 /**
+ * Get Organization
+ * Get the current organization.
+ *
+ * Returns basic information about the organization the authenticated user belongs to.
+ * @returns tracecat__organization__schemas__OrgRead Successful Response
+ * @throws ApiError
+ */
+export const organizationGetOrganization =
+  (): CancelablePromise<OrganizationGetOrganizationResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/organization",
+    })
+  }
+
+/**
  * Get Current Org Member
  * Get the current user's organization membership.
  *
  * Returns the organization membership details for the authenticated user,
  * including their org role (member, admin, or owner).
+ *
+ * This endpoint doesn't require admin access - any authenticated org member
+ * can view their own membership details.
  * @returns OrgMemberRead Successful Response
  * @throws ApiError
  */
@@ -3903,7 +4017,7 @@ export const approvalsSubmitApprovals = (
 /**
  * List Organizations
  * List all organizations.
- * @returns OrgRead Successful Response
+ * @returns tracecat_ee__admin__organizations__schemas__OrgRead Successful Response
  * @throws ApiError
  */
 export const adminListOrganizations =
@@ -3919,7 +4033,7 @@ export const adminListOrganizations =
  * Create a new organization.
  * @param data The data for the request.
  * @param data.requestBody
- * @returns OrgRead Successful Response
+ * @returns tracecat_ee__admin__organizations__schemas__OrgRead Successful Response
  * @throws ApiError
  */
 export const adminCreateOrganization = (
@@ -3941,7 +4055,7 @@ export const adminCreateOrganization = (
  * Get organization by ID.
  * @param data The data for the request.
  * @param data.orgId
- * @returns OrgRead Successful Response
+ * @returns tracecat_ee__admin__organizations__schemas__OrgRead Successful Response
  * @throws ApiError
  */
 export const adminGetOrganization = (
@@ -3965,7 +4079,7 @@ export const adminGetOrganization = (
  * @param data The data for the request.
  * @param data.orgId
  * @param data.requestBody
- * @returns OrgRead Successful Response
+ * @returns tracecat_ee__admin__organizations__schemas__OrgRead Successful Response
  * @throws ApiError
  */
 export const adminUpdateOrganization = (

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1516,6 +1516,28 @@ export type CaseTaskUpdate = {
   } | null
 }
 
+export type CaseTriggerCreate = {
+  status?: "online" | "offline"
+  event_types?: Array<CaseEventType>
+  tag_filters?: Array<string>
+}
+
+export type status2 = "online" | "offline"
+
+export type CaseTriggerRead = {
+  id: string
+  workflow_id: string
+  status: "online" | "offline"
+  event_types: Array<CaseEventType>
+  tag_filters: Array<string>
+}
+
+export type CaseTriggerUpdate = {
+  status?: "online" | "offline" | null
+  event_types?: Array<CaseEventType> | null
+  tag_filters?: Array<string> | null
+}
+
 export type CaseUpdate = {
   summary?: string | null
   description?: string | null
@@ -2380,10 +2402,10 @@ export type FeatureFlag =
   | "git-sync"
   | "agent-approvals"
   | "agent-presets"
-  | "case-triggers"
   | "case-dropdowns"
   | "case-durations"
   | "case-tasks"
+  | "case-triggers"
 
 /**
  * Response model for feature flags.
@@ -3226,18 +3248,6 @@ export type OrgMemberRead = {
   is_superuser: boolean
   is_verified: boolean
   last_login_at: string | null
-}
-
-/**
- * Organization response.
- */
-export type OrgRead = {
-  id: string
-  name: string
-  slug: string
-  is_active: boolean
-  created_at: string
-  updated_at?: string | null
 }
 
 /**
@@ -4179,6 +4189,7 @@ export type Role = {
     | "tracecat-cli"
     | "tracecat-executor"
     | "tracecat-agent-executor"
+    | "tracecat-case-triggers"
     | "tracecat-llm-gateway"
     | "tracecat-mcp"
     | "tracecat-runner"
@@ -4196,6 +4207,7 @@ export type service_id =
   | "tracecat-cli"
   | "tracecat-executor"
   | "tracecat-agent-executor"
+  | "tracecat-case-triggers"
   | "tracecat-llm-gateway"
   | "tracecat-mcp"
   | "tracecat-runner"
@@ -4288,8 +4300,6 @@ export type ScheduleCreate = {
    */
   timeout?: number
 }
-
-export type status2 = "online" | "offline"
 
 export type ScheduleRead = {
   id: string
@@ -5350,7 +5360,7 @@ export type type4 = "schedule" | "webhook"
 /**
  * Trigger type for a workflow execution.
  */
-export type TriggerType = "manual" | "scheduled" | "webhook"
+export type TriggerType = "manual" | "scheduled" | "webhook" | "case"
 
 /**
  * Pydantic model for AI SDK UI Messages, used for validation between
@@ -6203,6 +6213,11 @@ export type Yaml = {
   component_id?: "yaml"
 }
 
+export type tracecat__organization__schemas__OrgRead = {
+  id: string
+  name: string
+}
+
 /**
  * Response model for registry sync operation.
  */
@@ -6238,6 +6253,18 @@ export type tracecat__registry__repositories__schemas__RegistryVersionRead = {
   commit_sha: string | null
   tarball_uri: string | null
   created_at: string
+}
+
+/**
+ * Organization response.
+ */
+export type tracecat_ee__admin__organizations__schemas__OrgRead = {
+  id: string
+  name: string
+  slug: string
+  is_active: boolean
+  created_at: string
+  updated_at?: string | null
 }
 
 /**
@@ -6558,6 +6585,29 @@ export type TriggersUpdateWebhookData = {
 }
 
 export type TriggersUpdateWebhookResponse = void
+
+export type TriggersCreateCaseTriggerData = {
+  requestBody: CaseTriggerCreate
+  workflowId: string
+  workspaceId: string
+}
+
+export type TriggersCreateCaseTriggerResponse = CaseTriggerRead
+
+export type TriggersGetCaseTriggerData = {
+  workflowId: string
+  workspaceId: string
+}
+
+export type TriggersGetCaseTriggerResponse = CaseTriggerRead
+
+export type TriggersUpdateCaseTriggerData = {
+  requestBody: CaseTriggerUpdate
+  workflowId: string
+  workspaceId: string
+}
+
+export type TriggersUpdateCaseTriggerResponse = void
 
 export type TriggersGenerateWebhookApiKeyData = {
   workflowId: string
@@ -6962,6 +7012,9 @@ export type UsersSearchUserData = {
 
 export type UsersSearchUserResponse = UserRead
 
+export type OrganizationGetOrganizationResponse =
+  tracecat__organization__schemas__OrgRead
+
 export type OrganizationGetCurrentOrgMemberResponse = OrgMemberRead
 
 export type OrganizationListOrgMembersResponse = Array<OrgMemberRead>
@@ -7234,26 +7287,30 @@ export type ApprovalsSubmitApprovalsData = {
 
 export type ApprovalsSubmitApprovalsResponse = void
 
-export type AdminListOrganizationsResponse = Array<OrgRead>
+export type AdminListOrganizationsResponse =
+  Array<tracecat_ee__admin__organizations__schemas__OrgRead>
 
 export type AdminCreateOrganizationData = {
   requestBody: OrgCreate
 }
 
-export type AdminCreateOrganizationResponse = OrgRead
+export type AdminCreateOrganizationResponse =
+  tracecat_ee__admin__organizations__schemas__OrgRead
 
 export type AdminGetOrganizationData = {
   orgId: string
 }
 
-export type AdminGetOrganizationResponse = OrgRead
+export type AdminGetOrganizationResponse =
+  tracecat_ee__admin__organizations__schemas__OrgRead
 
 export type AdminUpdateOrganizationData = {
   orgId: string
   requestBody: OrgUpdate
 }
 
-export type AdminUpdateOrganizationResponse = OrgRead
+export type AdminUpdateOrganizationResponse =
+  tracecat_ee__admin__organizations__schemas__OrgRead
 
 export type AdminDeleteOrganizationData = {
   orgId: string
@@ -9077,6 +9134,47 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/workflows/{workflow_id}/case-trigger": {
+    post: {
+      req: TriggersCreateCaseTriggerData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: CaseTriggerRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    get: {
+      req: TriggersGetCaseTriggerData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseTriggerRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: TriggersUpdateCaseTriggerData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
   "/workflows/{workflow_id}/webhook/api-key": {
     post: {
       req: TriggersGenerateWebhookApiKeyData
@@ -9793,6 +9891,16 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/organization": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: tracecat__organization__schemas__OrgRead
+      }
+    }
+  }
   "/organization/members/me": {
     get: {
       res: {
@@ -10342,7 +10450,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<OrgRead>
+        200: Array<tracecat_ee__admin__organizations__schemas__OrgRead>
       }
     }
     post: {
@@ -10351,7 +10459,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        201: OrgRead
+        201: tracecat_ee__admin__organizations__schemas__OrgRead
         /**
          * Validation Error
          */
@@ -10366,7 +10474,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: OrgRead
+        200: tracecat_ee__admin__organizations__schemas__OrgRead
         /**
          * Validation Error
          */
@@ -10379,7 +10487,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: OrgRead
+        200: tracecat_ee__admin__organizations__schemas__OrgRead
         /**
          * Validation Error
          */

--- a/frontend/src/components/admin/admin-organizations-table.tsx
+++ b/frontend/src/components/admin/admin-organizations-table.tsx
@@ -4,7 +4,7 @@ import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import Cookies from "js-cookie"
 import Link from "next/link"
 import { useState } from "react"
-import type { OrgRead } from "@/client"
+import type { tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead } from "@/client"
 import {
   DataTable,
   DataTableColumnHeader,

--- a/frontend/src/components/error.tsx
+++ b/frontend/src/components/error.tsx
@@ -7,7 +7,10 @@ import { useRouter } from "next/navigation"
 import TracecatIcon from "public/icon.png"
 // Error components must be Client Components
 import { useEffect } from "react"
-import { ApiError, type OrgRead } from "@/client"
+import {
+  ApiError,
+  type tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead,
+} from "@/client"
 import { type AlertLevel, AlertNotification } from "@/components/notifications"
 import { Button } from "@/components/ui/button"
 import { useAdminOrganizations } from "@/hooks/use-admin"

--- a/frontend/src/components/sidebar/sidebar-user-nav.tsx
+++ b/frontend/src/components/sidebar/sidebar-user-nav.tsx
@@ -9,12 +9,19 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { siteConfig } from "@/config/site"
 import { useAuth } from "@/hooks/use-auth"
+import { useOrganization } from "@/hooks/use-organization"
 
 export function SidebarUserNav() {
   const { user } = useAuth()
   const { setOpen } = useSettingsModal()
+  const { organization, isLoading } = useOrganization()
 
   return (
     <SidebarMenu>
@@ -29,12 +36,19 @@ export function SidebarUserNav() {
 
       {user?.isSuperuser && (
         <SidebarMenuItem>
-          <SidebarMenuButton asChild tooltip="Admin">
-            <Link href="/admin">
-              <ShieldCheckIcon className="size-4" />
-              <span>Admin</span>
-            </Link>
-          </SidebarMenuButton>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <SidebarMenuButton asChild>
+                <Link href="/admin">
+                  <ShieldCheckIcon className="size-4" />
+                  <span>Admin</span>
+                </Link>
+              </SidebarMenuButton>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {isLoading ? "..." : (organization?.name ?? "Organization")}
+            </TooltipContent>
+          </Tooltip>
         </SidebarMenuItem>
       )}
 

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -36,7 +36,7 @@ import {
   adminUpdateTier,
   type OrganizationTierUpdate,
   type OrgCreate,
-  type OrgRead,
+  type tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead,
   type OrgUpdate,
   type PlatformRegistrySettingsUpdate,
   type TierCreate,

--- a/frontend/src/hooks/use-organization.ts
+++ b/frontend/src/hooks/use-organization.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import {
+  type OrganizationGetOrganizationResponse,
+  organizationGetOrganization,
+} from "@/client"
+
+/**
+ * Hook to fetch the current organization.
+ *
+ * Returns basic information about the organization the authenticated user belongs to.
+ */
+export function useOrganization() {
+  const {
+    data: organization,
+    isLoading,
+    error,
+  } = useQuery<OrganizationGetOrganizationResponse>({
+    queryKey: ["current-organization"],
+    queryFn: organizationGetOrganization,
+    retry: false,
+  })
+
+  return {
+    organization,
+    isLoading,
+    error,
+  }
+}

--- a/tracecat/organization/schemas.py
+++ b/tracecat/organization/schemas.py
@@ -26,7 +26,7 @@ class OrgMemberRead(BaseModel):
 
 
 class OrgRead(BaseModel):
-    id: str
+    id: UUID
     name: str
 
 


### PR DESCRIPTION
## Summary
- Add `GET /organization` endpoint to return current organization info (id, name)
- Add `useOrganization` hook for fetching organization data
- Show organization name tooltip on Admin button hover in sidebar
- Fix: Allow platform superusers to access organization pages with implicit owner role

## Test plan
- [ ] Hover over Admin button in sidebar to verify tooltip shows organization name
- [ ] Verify superusers can access organization/registry pages without explicit membership