### PR TITLE
refactor(registry): separate platform ops behind /admin

### DIFF
--- a/tracecat/admin/registry/service.py
+++ b/tracecat/admin/registry/service.py
@@ -25,7 +25,8 @@ from tracecat.db.models import (
     PlatformRegistryVersion,
 )
 from tracecat.parse import safe_url
-from tracecat.registry.actions.schemas import IndexEntry, RegistryActionRead
+from tracecat.registry.actions.schemas import RegistryActionRead
+from tracecat.registry.actions.types import IndexEntry
 from tracecat.registry.constants import (
     DEFAULT_LOCAL_REGISTRY_ORIGIN,
     DEFAULT_REGISTRY_ORIGIN,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Separated platform registry operations behind /admin and scoped the org router to org repositories only. This clarifies API boundaries and routes platform work through admin-only endpoints.

- **New Features**
  - Added GET /admin/registry/repos to list platform repositories.
  - Added GET /admin/registry/repos/{repository_id} to fetch a platform repository with actions.

- **Refactors**
  - Removed platform branches from org routes: sync, list versions, list repos, get repo, promote version.
  - Simplified org list endpoints to query only org tables; updated docstrings to point to /admin alternatives.
  - Added AdminRegistryService methods: list_repositories, get_repository, and _list_platform_actions (reads from platform index and manifests).

<sup>Written for commit fd785761b512617edb39c98bc7b52f58f2e28ff5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

