### PR TITLE
fix(sandbox): Logging cleanup in auth sandbox

### DIFF
--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -7,6 +7,8 @@ import {
   type AdminListOrganizationsResponse,
   type AdminListTiersResponse,
   type AdminListUsersResponse,
+  type AdminRegistryGetRegistryStatusResponse,
+  type AdminRegistryListRegistryVersionsResponse,
   type AdminUserRead,
   adminCreateOrganization,
   adminCreateTier,
@@ -389,7 +391,7 @@ export function useAdminRegistryStatus() {
     isLoading,
     error,
     refetch,
-  } = useQuery({
+  } = useQuery<AdminRegistryGetRegistryStatusResponse>({
     queryKey: ["admin", "registry", "status"],
     queryFn: adminRegistryGetRegistryStatus,
   })
@@ -410,7 +412,7 @@ export function useAdminRegistryVersions(
     data: versions,
     isLoading,
     error,
-  } = useQuery({
+  } = useQuery<AdminRegistryListRegistryVersionsResponse>({
     queryKey: ["admin", "registry", "versions", { repositoryId, limit }],
     queryFn: () => adminRegistryListRegistryVersions({ repositoryId, limit }),
   })

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -105,7 +105,6 @@ class AuthSandbox:
         logger.info(
             "Setting secrets",
             paths=self._secret_paths,
-            objs=self._secret_objs,
         )
         for name, kv in self._iter_secrets():
             if name not in self._context:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove sensitive object logging in the auth sandbox to avoid leaking secret details. Typed admin registry hooks to use explicit response types for status and versions.

- **Bug Fixes**
  - Removed logging of secret objects in auth sandbox (_set_secrets).

- **Refactors**
  - Added explicit generics to useQuery in useAdminRegistryStatus and useAdminRegistryVersions to match AdminRegistry* response types.

<sup>Written for commit e4dc865d43ea26478d9e528580a20c3f1eb9f52c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

