### PR TITLE
fix(executor): Add tunnel device; Update llm gateway jwt token

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -150,6 +150,8 @@ services:
       - SYS_ADMIN
     security_opt:
       - seccomp:unconfined
+    devices:
+      - /dev/net/tun:/dev/net/tun
     environment:
       # Common
       LOG_LEVEL: ${LOG_LEVEL}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -165,6 +165,9 @@ services:
       - SYS_ADMIN
     security_opt:
       - seccomp:unconfined
+    # Required for pasta userspace networking (creates TAP device in sandbox netns)
+    devices:
+      - /dev/net/tun:/dev/net/tun
     environment:
       # Common
       LOG_LEVEL: ${LOG_LEVEL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,9 @@ services:
       - SYS_ADMIN
     security_opt:
       - seccomp:unconfined
+     # Required for pasta userspace networking (creates TAP device in sandbox netns)
+    devices:
+      - /dev/net/tun:/dev/net/tun
     environment:
       # Common
       LOG_LEVEL: ${LOG_LEVEL}

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -93,7 +93,12 @@ class DurableAgentWorkflow:
         self._turn: int = 0
         if args.role.workspace_id is None:
             raise ApplicationError("Role must have a workspace ID", non_retryable=True)
+        if args.role.organization_id is None:
+            raise ApplicationError(
+                "Role must have an organization ID", non_retryable=True
+            )
         self.workspace_id = args.role.workspace_id
+        self.organization_id = args.role.organization_id
         self.session_id = args.agent_args.session_id
         self.harness_type = args.harness_type or "claude_code"
         self.approvals = ApprovalManager(role=self.role)
@@ -296,6 +301,7 @@ class DurableAgentWorkflow:
         )
         litellm_auth_token = mint_llm_token(
             workspace_id=self.workspace_id,
+            organization_id=self.organization_id,
             session_id=self.session_id,
             model=cfg.model_name,
             provider=cfg.model_provider,

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from tracecat import config
 from tracecat.agent.types import OutputType
-from tracecat.identifiers import UserID, WorkspaceID
+from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
 
 # -----------------------------------------------------------------------------
 # MCP Token (for tool execution)
@@ -209,6 +209,7 @@ LLM_REQUIRED_CLAIMS = (
     "iat",
     "exp",
     "workspace_id",
+    "organization_id",
     "session_id",
     "model",
     "provider",
@@ -224,6 +225,7 @@ class LLMTokenClaims(BaseModel):
 
     # Identity
     workspace_id: WorkspaceID = Field(..., description="Workspace UUID")
+    organization_id: OrganizationID = Field(..., description="Organization UUID")
     session_id: uuid.UUID = Field(..., description="Agent session UUID")
 
     # Model configuration
@@ -255,6 +257,7 @@ class LLMTokenClaims(BaseModel):
 def mint_llm_token(
     *,
     workspace_id: WorkspaceID,
+    organization_id: OrganizationID,
     session_id: uuid.UUID,
     model: str,
     provider: str,
@@ -269,8 +272,9 @@ def mint_llm_token(
     jailed runtime. The runtime cannot decode or modify it - it's opaque.
 
     Args:
-        workspace_id: The workspace UUID as string
-        session_id: The agent session UUID as string
+        workspace_id: The workspace UUID
+        organization_id: The organization UUID
+        session_id: The agent session UUID
         model: The model to use for this run
         provider: The provider for the model (e.g., openai, anthropic, bedrock)
         model_settings: Model-specific settings (temperature, max_tokens,
@@ -297,6 +301,7 @@ def mint_llm_token(
         "exp": int((now + timedelta(seconds=ttl)).timestamp()),
         # Identity claims
         "workspace_id": str(workspace_id),
+        "organization_id": str(organization_id),
         "session_id": str(session_id),
         # Model configuration
         "model": model,


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add TUN device to executor containers to enable userspace TAP networking. Update LLM gateway JWT to include organization_id and use it for org-scoped provider credentials.

- **Fixes**
  - Map /dev/net/tun into executor in docker-compose (dev, local, default) for pasta networking.
  - Require organization_id in durable workflow args; validate and store on init.
  - Include organization_id in LLMTokenClaims and mint_llm_token; add to JWT claims and verification.
  - Propagate organization_id through gateway metadata and pre-call hook; fetch provider credentials using workspace_id + organization_id.

<sup>Written for commit e1b6ae1d7916869f7b3d9019d53a9f2dedd204cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

