### PR TITLE
feat(agent): Support azure provider for agents

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -121,12 +121,54 @@ custom_model_provider_secret = RegistrySecret(
     - `CUSTOM_MODEL_PROVIDER_BASE_URL`: Optional custom model provider base URL.
 """
 
+azure_openai_secret = RegistrySecret(
+    name="azure_openai",
+    optional_keys=[
+        "AZURE_API_BASE",
+        "AZURE_API_VERSION",
+        "AZURE_DEPLOYMENT_NAME",
+        "AZURE_API_KEY",
+        "AZURE_AD_TOKEN",
+    ],
+    optional=True,
+)
+"""Azure OpenAI credentials.
+
+- name: `azure_openai`
+- optional_keys:
+    - `AZURE_API_BASE`: Azure OpenAI endpoint (e.g., https://<resource>.openai.azure.com).
+    - `AZURE_API_VERSION`: Azure OpenAI API version.
+    - `AZURE_DEPLOYMENT_NAME`: Azure OpenAI deployment name.
+    - `AZURE_API_KEY`: Azure OpenAI API key. Required if not using Entra token.
+    - `AZURE_AD_TOKEN`: Azure Entra (AD) token. Required if not using API key.
+"""
+
+azure_ai_secret = RegistrySecret(
+    name="azure_ai",
+    optional_keys=[
+        "AZURE_API_BASE",
+        "AZURE_API_KEY",
+        "AZURE_AI_MODEL_NAME",
+    ],
+    optional=True,
+)
+"""Azure AI credentials.
+
+- name: `azure_ai`
+- optional_keys:
+    - `AZURE_API_BASE`: Azure AI endpoint (e.g., https://<resource>.services.ai.azure.com/anthropic).
+    - `AZURE_API_KEY`: Azure AI API key.
+    - `AZURE_AI_MODEL_NAME`: Model name to use (e.g., claude-sonnet-4-5).
+"""
+
 PYDANTIC_AI_REGISTRY_SECRETS: list[RegistrySecretType] = [
     anthropic_secret,
     openai_secret,
     gemini_secret,
     bedrock_secret,
     custom_model_provider_secret,
+    azure_openai_secret,
+    azure_ai_secret,
 ]
 
 

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -7,18 +7,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 
-class HarnessType(str, Enum):
+class HarnessType(StrEnum):
     """Supported agent harnesses."""
 
     PYDANTIC_AI = "pydantic-ai"
     CLAUDE_CODE = "claude_code"
 
 
-class StreamEventType(str, Enum):
+class StreamEventType(StrEnum):
     """Types of streaming events."""
 
     # Text streaming

--- a/tracecat/agent/config.py
+++ b/tracecat/agent/config.py
@@ -79,6 +79,22 @@ MODEL_CONFIGS = {
             "required": ["bedrock"],
         },
     ),
+    "azure_openai": ModelConfig(
+        name="azure_openai",  # Placeholder; deployment name from AZURE_DEPLOYMENT_NAME will be used at runtime
+        provider="azure_openai",
+        org_secret_name="agent-azure_openai-credentials",
+        secrets={
+            "required": ["azure_openai"],
+        },
+    ),
+    "azure_ai": ModelConfig(
+        name="azure_ai",  # Placeholder; model name from AZURE_AI_MODEL_NAME will be used at runtime
+        provider="azure_ai",
+        org_secret_name="agent-azure_ai-credentials",
+        secrets={
+            "required": ["azure_ai"],
+        },
+    ),
     "custom": ModelConfig(
         name="custom",
         provider="custom-model-provider",
@@ -183,6 +199,68 @@ PROVIDER_CREDENTIAL_CONFIGS = {
                 label="Model Name",
                 type="text",
                 description="The name of the model to use from your custom model provider.",
+            ),
+        ],
+    ),
+    "azure_openai": ProviderCredentialConfig(
+        provider="azure_openai",
+        label="Azure OpenAI",
+        fields=[
+            ProviderCredentialField(
+                key="AZURE_API_BASE",
+                label="API Base URL",
+                type="text",
+                description="Your Azure OpenAI resource endpoint (e.g., https://<resource>.openai.azure.com).",
+            ),
+            ProviderCredentialField(
+                key="AZURE_API_VERSION",
+                label="API Version",
+                type="text",
+                description="The Azure OpenAI API version (e.g., 2024-02-15-preview).",
+            ),
+            ProviderCredentialField(
+                key="AZURE_DEPLOYMENT_NAME",
+                label="Deployment Name",
+                type="text",
+                description="The name of your Azure OpenAI model deployment.",
+            ),
+            ProviderCredentialField(
+                key="AZURE_API_KEY",
+                label="API Key",
+                type="password",
+                description="Your Azure OpenAI API key. Required if not using Entra token.",
+                required=False,
+            ),
+            ProviderCredentialField(
+                key="AZURE_AD_TOKEN",
+                label="Entra Token",
+                type="password",
+                description="Your Azure Entra (AD) token. Required if not using API key.",
+                required=False,
+            ),
+        ],
+    ),
+    "azure_ai": ProviderCredentialConfig(
+        provider="azure_ai",
+        label="Azure AI",
+        fields=[
+            ProviderCredentialField(
+                key="AZURE_API_BASE",
+                label="API Base URL",
+                type="text",
+                description="Your Azure AI endpoint (e.g., https://<resource>.services.ai.azure.com/anthropic).",
+            ),
+            ProviderCredentialField(
+                key="AZURE_API_KEY",
+                label="API Key",
+                type="password",
+                description="Your Azure AI API key.",
+            ),
+            ProviderCredentialField(
+                key="AZURE_AI_MODEL_NAME",
+                label="Model Name",
+                type="text",
+                description="The model name to use (e.g., claude-sonnet-4-5).",
             ),
         ],
     ),

--- a/tracecat/agent/litellm_config.yaml
+++ b/tracecat/agent/litellm_config.yaml
@@ -37,6 +37,15 @@ model_list:
     litellm_params:
       model: bedrock/*
 
+  # Azure OpenAI wildcard - catches azure/<deployment-name> models
+  - model_name: azure/*
+    litellm_params:
+      model: azure/*
+
+  # Azure AI wildcard - catches azure_ai/<model-name> models
+  - model_name: azure_ai/*
+    litellm_params:
+      model: azure_ai/*
 
   # Catch-all wildcard for any model not explicitly defined, for custom models
   - model_name: "*"

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -294,6 +294,26 @@ class AgentManagementService(BaseOrgService):
                 )
             model_config = model_config.model_copy(update={"name": model_id})
 
+        # For Azure OpenAI, the deployment name comes from credentials
+        elif provider == "azure_openai":
+            deployment = credentials.get("AZURE_DEPLOYMENT_NAME")
+            if not deployment:
+                raise TracecatNotFoundError(
+                    "No Azure OpenAI deployment configured. Please set "
+                    "AZURE_DEPLOYMENT_NAME in your Azure OpenAI credentials."
+                )
+            model_config = model_config.model_copy(update={"name": deployment})
+
+        # For Azure AI, the model name comes from credentials
+        elif provider == "azure_ai":
+            model_name = credentials.get("AZURE_AI_MODEL_NAME")
+            if not model_name:
+                raise TracecatNotFoundError(
+                    "No Azure AI model configured. Please set "
+                    "AZURE_AI_MODEL_NAME in your Azure AI credentials."
+                )
+            model_config = model_config.model_copy(update={"name": model_name})
+
         # Use the credentials directly in the environment sandbox
         with secrets_manager.env_sandbox(credentials):
             yield model_config

--- a/tracecat/dsl/validation.py
+++ b/tracecat/dsl/validation.py
@@ -53,9 +53,15 @@ def format_input_schema_validation_error(details: list[ValidationDetail]) -> str
 
 
 PYDANTIC_ERR_TYPE_HANDLER: dict[str, Callable[[Sequence[int | str]], str]] = {
-    "pydantic.extra_forbidden": lambda loc: f"The attribute '{'.'.join(str(s) for s in loc)}' is not allowed in the input schema.",
-    "pydantic.missing": lambda loc: f"Missing required field(s): '{'.'.join(str(s) for s in loc)}'.",
-    "pydantic.invalid_type": lambda loc: f"Invalid type at '{'.'.join(str(s) for s in loc)}'.",
+    "pydantic.extra_forbidden": lambda loc: (
+        f"The attribute '{'.'.join(str(s) for s in loc)}' is not allowed in the input schema."
+    ),
+    "pydantic.missing": lambda loc: (
+        f"Missing required field(s): '{'.'.join(str(s) for s in loc)}'."
+    ),
+    "pydantic.invalid_type": lambda loc: (
+        f"Invalid type at '{'.'.join(str(s) for s in loc)}'."
+    ),
 }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Azure OpenAI and Azure AI provider support for agents, including credential handling, model resolution, and LiteLLM routing. This enables running agents on Azure deployments/models with API key or Entra token and improves streaming reliability.

- **New Features**
  - Registry secrets for azure_openai and azure_ai.
  - Provider configs and credential fields added to agent config.
  - Gateway injects Azure credentials (API key or Entra token) and sets model from deployment/name.
  - LiteLLM routing for azure/* and azure_ai/* models.
  - Service resolves model/deployment from credentials.

- **Migration**
  - Create org secrets: agent-azure_openai-credentials and agent-azure_ai-credentials with required fields.
  - Choose provider azure_openai or azure_ai for the agent; deployment/model comes from credentials.
  - Azure OpenAI: provide API base, version, deployment, and API key or Entra token. Azure AI: provide API base, API key, and model name.

<sup>Written for commit 7bdde1ab2838b6888d33e2ffc4cd6b6408ca6982. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

