### PR TITLE
chore(audit): Remove api key from audit settings

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2876,31 +2876,6 @@ distinguish multiple files.`,
   title: "AudioUrl",
 } as const
 
-export const $AuditApiKeyGenerateResponse = {
-  properties: {
-    api_key: {
-      type: "string",
-      title: "Api Key",
-      description: "The raw API key. Shown only once.",
-    },
-    preview: {
-      type: "string",
-      title: "Preview",
-      description: "A preview of the key (e.g., tc_ak_...XXXX)",
-    },
-    created_at: {
-      type: "string",
-      format: "date-time",
-      title: "Created At",
-      description: "When the key was created",
-    },
-  },
-  type: "object",
-  required: ["api_key", "preview", "created_at"],
-  title: "AuditApiKeyGenerateResponse",
-  description: "Response when generating a new audit webhook API key.",
-} as const
-
 export const $AuditSettingsRead = {
   properties: {
     audit_webhook_url: {
@@ -2913,29 +2888,6 @@ export const $AuditSettingsRead = {
         },
       ],
       title: "Audit Webhook Url",
-    },
-    audit_webhook_api_key_preview: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Audit Webhook Api Key Preview",
-    },
-    audit_webhook_api_key_created_at: {
-      anyOf: [
-        {
-          type: "string",
-          format: "date-time",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Audit Webhook Api Key Created At",
     },
     audit_webhook_custom_headers: {
       anyOf: [

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -406,7 +406,6 @@ import type {
   SecretsSearchSecretsResponse,
   SecretsUpdateSecretByIdData,
   SecretsUpdateSecretByIdResponse,
-  SettingsGenerateAuditApiKeyResponse,
   SettingsGetAgentSettingsResponse,
   SettingsGetAppSettingsResponse,
   SettingsGetAuditSettingsResponse,
@@ -414,7 +413,6 @@ import type {
   SettingsGetGitSettingsResponse,
   SettingsGetOauthSettingsResponse,
   SettingsGetSamlSettingsResponse,
-  SettingsRevokeAuditApiKeyResponse,
   SettingsUpdateAgentSettingsData,
   SettingsUpdateAgentSettingsResponse,
   SettingsUpdateAppSettingsData,
@@ -5479,36 +5477,6 @@ export const settingsUpdateAuditSettings = (
     },
   })
 }
-
-/**
- * Generate Audit Api Key
- * Generate a new API key for the audit webhook.
- *
- * This replaces any existing key. The raw API key is shown only once.
- * @returns AuditApiKeyGenerateResponse Successful Response
- * @throws ApiError
- */
-export const settingsGenerateAuditApiKey =
-  (): CancelablePromise<SettingsGenerateAuditApiKeyResponse> => {
-    return __request(OpenAPI, {
-      method: "POST",
-      url: "/settings/audit/api-key",
-    })
-  }
-
-/**
- * Revoke Audit Api Key
- * Revoke the current audit webhook API key.
- * @returns void Successful Response
- * @throws ApiError
- */
-export const settingsRevokeAuditApiKey =
-  (): CancelablePromise<SettingsRevokeAuditApiKeyResponse> => {
-    return __request(OpenAPI, {
-      method: "DELETE",
-      url: "/settings/audit/api-key",
-    })
-  }
 
 /**
  * Get Agent Settings

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -758,30 +758,10 @@ export type AudioUrl = {
 }
 
 /**
- * Response when generating a new audit webhook API key.
- */
-export type AuditApiKeyGenerateResponse = {
-  /**
-   * The raw API key. Shown only once.
-   */
-  api_key: string
-  /**
-   * A preview of the key (e.g., tc_ak_...XXXX)
-   */
-  preview: string
-  /**
-   * When the key was created
-   */
-  created_at: string
-}
-
-/**
  * Settings for audit logging.
  */
 export type AuditSettingsRead = {
   audit_webhook_url: string | null
-  audit_webhook_api_key_preview?: string | null
-  audit_webhook_api_key_created_at?: string | null
   audit_webhook_custom_headers?: {
     [key: string]: string
   } | null
@@ -7737,10 +7717,6 @@ export type SettingsUpdateAuditSettingsData = {
 
 export type SettingsUpdateAuditSettingsResponse = void
 
-export type SettingsGenerateAuditApiKeyResponse = AuditApiKeyGenerateResponse
-
-export type SettingsRevokeAuditApiKeyResponse = void
-
 export type SettingsGetAgentSettingsResponse = AgentSettingsRead
 
 export type SettingsUpdateAgentSettingsData = {
@@ -11384,24 +11360,6 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError
-      }
-    }
-  }
-  "/settings/audit/api-key": {
-    post: {
-      res: {
-        /**
-         * Successful Response
-         */
-        200: AuditApiKeyGenerateResponse
-      }
-    }
-    delete: {
-      res: {
-        /**
-         * Successful Response
-         */
-        204: void
       }
     }
   }

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -1,24 +1,12 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { format } from "date-fns"
-import { Copy, Key, RefreshCw, Settings2, Trash2 } from "lucide-react"
+import { Settings2 } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -27,15 +15,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
 import {
   Form,
   FormControl,
@@ -47,7 +26,6 @@ import {
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { toast } from "@/components/ui/use-toast"
 import { useOrgAuditSettings } from "@/lib/hooks"
 
 const auditFormSchema = z.object({
@@ -68,14 +46,8 @@ export function OrgSettingsAuditForm() {
     auditSettingsError,
     updateAuditSettings,
     updateAuditSettingsIsPending,
-    generateAuditApiKey,
-    generateAuditApiKeyIsPending,
-    revokeAuditApiKey,
-    revokeAuditApiKeyIsPending,
   } = useOrgAuditSettings()
 
-  const [showNewApiKey, setShowNewApiKey] = useState(false)
-  const [newApiKey, setNewApiKey] = useState<string | null>(null)
   const [customHeadersJson, setCustomHeadersJson] = useState("")
   const [customHeadersError, setCustomHeadersError] = useState<string | null>(
     null
@@ -114,39 +86,6 @@ export function OrgSettingsAuditForm() {
     } catch {
       console.error("Failed to update audit settings")
     }
-  }
-
-  const handleGenerateApiKey = async () => {
-    try {
-      const response = await generateAuditApiKey()
-      setNewApiKey(response.api_key)
-      setShowNewApiKey(true)
-    } catch {
-      console.error("Failed to generate API key")
-    }
-  }
-
-  const handleRevokeApiKey = async () => {
-    try {
-      await revokeAuditApiKey()
-    } catch {
-      console.error("Failed to revoke API key")
-    }
-  }
-
-  const handleCopyApiKey = async () => {
-    if (newApiKey) {
-      await navigator.clipboard.writeText(newApiKey)
-      toast({
-        title: "Copied",
-        description: "API key copied to clipboard.",
-      })
-    }
-  }
-
-  const handleCloseNewApiKeyDialog = () => {
-    setShowNewApiKey(false)
-    setNewApiKey(null)
   }
 
   const handleCustomHeadersChange = (value: string) => {
@@ -224,8 +163,6 @@ export function OrgSettingsAuditForm() {
     )
   }
 
-  const hasApiKey = !!auditSettings.audit_webhook_api_key_preview
-
   return (
     <div className="space-y-8">
       <Form {...form}>
@@ -265,126 +202,12 @@ export function OrgSettingsAuditForm() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
-            <Key className="size-4" />
-            API key authentication
-          </CardTitle>
-          <CardDescription>
-            Optionally configure an API key to authenticate outgoing audit
-            webhook requests. The key is sent as a Bearer token in the
-            Authorization header.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {hasApiKey ? (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between rounded-md border p-3">
-                <div>
-                  <p className="font-mono text-sm">
-                    {auditSettings.audit_webhook_api_key_preview}
-                  </p>
-                  {auditSettings.audit_webhook_api_key_created_at && (
-                    <p className="text-xs text-muted-foreground">
-                      Created{" "}
-                      {format(
-                        new Date(
-                          auditSettings.audit_webhook_api_key_created_at
-                        ),
-                        "MMM d, yyyy 'at' h:mm a"
-                      )}
-                    </p>
-                  )}
-                </div>
-                <div className="flex gap-2">
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={generateAuditApiKeyIsPending}
-                      >
-                        <RefreshCw className="mr-2 size-3" />
-                        Regenerate
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Regenerate API key?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This will replace the existing API key. Any systems
-                          using the current key will need to be updated.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleGenerateApiKey}>
-                          {generateAuditApiKeyIsPending
-                            ? "Regenerating..."
-                            : "Regenerate"}
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={revokeAuditApiKeyIsPending}
-                      >
-                        <Trash2 className="mr-2 size-3" />
-                        Revoke
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Revoke API key?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This will remove the API key. Audit webhook requests
-                          will no longer include authentication.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={handleRevokeApiKey}
-                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                        >
-                          {revokeAuditApiKeyIsPending
-                            ? "Revoking..."
-                            : "Revoke"}
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <Button
-              variant="outline"
-              onClick={handleGenerateApiKey}
-              disabled={generateAuditApiKeyIsPending}
-            >
-              <Key className="mr-2 size-4" />
-              {generateAuditApiKeyIsPending
-                ? "Generating..."
-                : "Generate API key"}
-            </Button>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
             <Settings2 className="size-4" />
             Custom headers
           </CardTitle>
           <CardDescription>
-            Add custom HTTP headers to include in audit webhook requests. Custom
-            headers override the API key if both set an Authorization header
-            (case-insensitive). Header values are encrypted at rest.
+            Add custom HTTP headers to include in audit webhook requests. Header
+            values are encrypted at rest.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -410,47 +233,6 @@ export function OrgSettingsAuditForm() {
           )}
         </CardContent>
       </Card>
-
-      <Dialog
-        open={showNewApiKey}
-        onOpenChange={(open) => {
-          setShowNewApiKey(open)
-          if (!open) {
-            setNewApiKey(null)
-          }
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>API key generated</DialogTitle>
-            <DialogDescription>
-              Copy this key now. You will not be able to see it again.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Input
-                readOnly
-                value={newApiKey ?? ""}
-                className="font-mono text-sm"
-              />
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={handleCopyApiKey}
-                title="Copy to clipboard"
-              >
-                <Copy className="size-4" />
-              </Button>
-            </div>
-          </div>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button onClick={handleCloseNewApiKeyDialog}>Done</Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -22,7 +22,6 @@ import {
   type AgentSettingsRead,
   ApiError,
   type AppSettingsRead,
-  type AuditApiKeyGenerateResponse,
   type AuditSettingsRead,
   type AuthSettingsRead,
   actionsDeleteAction,
@@ -204,7 +203,6 @@ import {
   secretsListSecretDefinitions,
   secretsListSecrets,
   secretsUpdateSecretById,
-  settingsGenerateAuditApiKey,
   settingsGetAgentSettings,
   settingsGetAppSettings,
   settingsGetAuditSettings,
@@ -212,7 +210,6 @@ import {
   settingsGetGitSettings,
   settingsGetOauthSettings,
   settingsGetSamlSettings,
-  settingsRevokeAuditApiKey,
   settingsUpdateAgentSettings,
   settingsUpdateAppSettings,
   settingsUpdateAuditSettings,
@@ -2910,69 +2907,6 @@ export function useOrgAuditSettings() {
     },
   })
 
-  // Generate API Key
-  const {
-    mutateAsync: generateAuditApiKey,
-    isPending: generateAuditApiKeyIsPending,
-  } = useMutation<AuditApiKeyGenerateResponse, TracecatApiError>({
-    mutationFn: async () => await settingsGenerateAuditApiKey(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["org-audit-settings"] })
-      toast({
-        title: "Generated API key",
-        description:
-          "New API key generated successfully. Make sure to copy it now.",
-      })
-    },
-    onError: (error) => {
-      switch (error.status) {
-        case 403:
-          toast({
-            title: "Forbidden",
-            description: "You cannot perform this action",
-          })
-          break
-        default:
-          console.error("Failed to generate audit API key", error)
-          toast({
-            title: "Failed to generate API key",
-            description: `An error occurred while generating the API key: ${error.body.detail}`,
-          })
-      }
-    },
-  })
-
-  // Revoke API Key
-  const {
-    mutateAsync: revokeAuditApiKey,
-    isPending: revokeAuditApiKeyIsPending,
-  } = useMutation<void, TracecatApiError>({
-    mutationFn: async () => await settingsRevokeAuditApiKey(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["org-audit-settings"] })
-      toast({
-        title: "Revoked API key",
-        description: "The audit webhook API key has been revoked.",
-      })
-    },
-    onError: (error) => {
-      switch (error.status) {
-        case 403:
-          toast({
-            title: "Forbidden",
-            description: "You cannot perform this action",
-          })
-          break
-        default:
-          console.error("Failed to revoke audit API key", error)
-          toast({
-            title: "Failed to revoke API key",
-            description: `An error occurred while revoking the API key: ${error.body.detail}`,
-          })
-      }
-    },
-  })
-
   return {
     // Get
     auditSettings,
@@ -2982,11 +2916,6 @@ export function useOrgAuditSettings() {
     updateAuditSettings,
     updateAuditSettingsIsPending,
     updateAuditSettingsError,
-    // API Key
-    generateAuditApiKey,
-    generateAuditApiKeyIsPending,
-    revokeAuditApiKey,
-    revokeAuditApiKeyIsPending,
   }
 }
 

--- a/tracecat/settings/constants.py
+++ b/tracecat/settings/constants.py
@@ -7,7 +7,6 @@ Currently this is used in /info to serve config to the frontend."""
 SENSITIVE_SETTINGS_KEYS = {
     "saml_idp_metadata_url",
     "audit_webhook_url",
-    "audit_webhook_api_key",
     "audit_webhook_custom_headers",
 }
 """Settings that are encrypted at rest."""

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
@@ -166,8 +165,6 @@ class AuditSettingsRead(BaseSettingsGroup):
     """Settings for audit logging."""
 
     audit_webhook_url: str | None
-    audit_webhook_api_key_preview: str | None = None
-    audit_webhook_api_key_created_at: datetime | None = None
     audit_webhook_custom_headers: dict[str, str] | None = None
 
 
@@ -182,14 +179,6 @@ class AuditSettingsUpdate(BaseSettingsGroup):
         default=None,
         description="Custom headers to include in audit webhook requests. Header names are case-insensitive.",
     )
-
-
-class AuditApiKeyGenerateResponse(BaseModel):
-    """Response when generating a new audit webhook API key."""
-
-    api_key: str = Field(description="The raw API key. Shown only once.")
-    preview: str = Field(description="A preview of the key (e.g., tc_ak_...XXXX)")
-    created_at: datetime = Field(description="When the key was created")
 
 
 class AgentSettingsRead(BaseSettingsGroup):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed audit webhook API key support and UI. Audit webhook auth now relies solely on Custom headers; outgoing requests no longer auto-include an Authorization header.

- **Refactors**
  - Frontend: removed API key generation/revoke UI, hooks, and client schema/types/services.
  - Backend: removed /settings/audit/api-key endpoints and related schema/service logic; audit service sends only configured custom headers.
  - Settings: dropped api key fields from AuditSettingsRead and removed audit_webhook_api_key from sensitive keys.

- **Migration**
  - If you previously used the audit API key, set an Authorization header via Custom headers (e.g., Authorization: Bearer <token>).
  - Update any downstream systems that expect the old auto-added Authorization header.

<sup>Written for commit d8fd7fa547732797e16ed986e837bc9cff159b62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<img width="1408" height="795" alt="image" src="https://github.com/user-attachments/assets/a0621ffc-1486-4e01-bd27-d2084fc81037" />

