### PR TITLE
feat(okta): add okta private key support

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6510,10 +6510,17 @@ export const $CustomOAuthProviderCreate = {
       $ref: "#/components/schemas/OAuthGrantType",
     },
     authorization_endpoint: {
-      type: "string",
-      minLength: 8,
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Authorization Endpoint",
-      description: "OAuth authorization endpoint URL",
+      description:
+        "OAuth authorization endpoint URL. Required for authorization_code grant type.",
     },
     token_endpoint: {
       type: "string",
@@ -6574,13 +6581,7 @@ export const $CustomOAuthProviderCreate = {
     },
   },
   type: "object",
-  required: [
-    "name",
-    "grant_type",
-    "authorization_endpoint",
-    "token_endpoint",
-    "client_id",
-  ],
+  required: ["name", "grant_type", "token_endpoint", "client_id"],
   title: "CustomOAuthProviderCreate",
   description: "Request payload for creating a custom OAuth provider.",
 } as const
@@ -9873,7 +9874,7 @@ export const $OAuth2AuthorizeResponse = {
 
 export const $OAuthGrantType = {
   type: "string",
-  enum: ["authorization_code", "client_credentials"],
+  enum: ["authorization_code", "client_credentials", "jwt_bearer"],
   title: "OAuthGrantType",
   description: "Grant type for OAuth 2.0.",
 } as const

--- a/frontend/src/client/services.custom.ts
+++ b/frontend/src/client/services.custom.ts
@@ -11,7 +11,7 @@ export type CustomOAuthProviderCreateRequest = {
   name: string
   description?: string | null
   grant_type: OAuthGrantType
-  authorization_endpoint: string
+  authorization_endpoint?: string | null
   token_endpoint: string
   scopes?: string[] | null
   provider_id?: string | null

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1941,9 +1941,9 @@ export type CustomOAuthProviderCreate = {
   description?: string | null
   grant_type: OAuthGrantType
   /**
-   * OAuth authorization endpoint URL
+   * OAuth authorization endpoint URL. Required for authorization_code grant type.
    */
-  authorization_endpoint: string
+  authorization_endpoint?: string | null
   /**
    * OAuth token endpoint URL
    */
@@ -3177,7 +3177,10 @@ export type OAuth2AuthorizeResponse = {
 /**
  * Grant type for OAuth 2.0.
  */
-export type OAuthGrantType = "authorization_code" | "client_credentials"
+export type OAuthGrantType =
+  | "authorization_code"
+  | "client_credentials"
+  | "jwt_bearer"
 
 /**
  * Settings for OAuth authentication.

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -4601,7 +4601,8 @@ export function useCreateCustomProvider(workspaceId: string) {
         ...params,
         name: params.name.trim(),
         description: params.description?.trim() || undefined,
-        authorization_endpoint: params.authorization_endpoint.trim(),
+        authorization_endpoint:
+          params.authorization_endpoint?.trim() || undefined,
         token_endpoint: params.token_endpoint.trim(),
         client_id: params.client_id.trim(),
         client_secret: params.client_secret?.trim() || undefined,

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/activate_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/activate_user.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -28,7 +33,7 @@ definition:
         method: POST
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/lifecycle/activate
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
           Content-Type: "application/json"
         params:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/add_to_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/add_to_group.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -27,7 +32,7 @@ definition:
         method: PUT
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/groups/${{ inputs.group_id }}/users/${{ FN.url_encode(inputs.user_id) }}
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
           Content-Type: "application/json"
   returns: ${{ steps.add_user.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/assign_group_to_app.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/assign_group_to_app.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -47,7 +52,7 @@ definition:
         method: PUT
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/apps/${{ inputs.app_id }}/groups/${{ inputs.group_id }}
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
           Content-Type: "application/json"
         payload: ${{ steps.add_priority.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/clear_user_sessions.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/clear_user_sessions.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -24,6 +29,6 @@ definition:
         method: DELETE
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/sessions
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
   returns: ${{ steps.clear_sessions.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/create_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/create_user.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -65,7 +70,7 @@ definition:
         method: POST
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
           Content-Type: "application/json"
         params:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/expire_password.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/expire_password.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     user_id:
       type: str
@@ -28,5 +33,5 @@ definition:
         method: POST
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/lifecycle/expire_password?revokeSessions=${{ inputs.revoke_sessions }}
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.expire_password.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/expire_password_with_temporary_password.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/expire_password_with_temporary_password.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     user_id:
       type: str
@@ -28,5 +33,5 @@ definition:
         method: POST
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/lifecycle/expire_password_with_temp_password?revokeSessions=${{ inputs.revoke_sessions }}
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.expire_password_with_temp_password.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_group_members.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_group_members.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -44,7 +49,7 @@ definition:
         method: GET
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/groups/${{ inputs.group_id }}/users
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.get_members.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_groups_assigned_to_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_groups_assigned_to_user.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -44,7 +49,7 @@ definition:
         method: GET
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/groups
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.get_groups.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/get_user.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -24,6 +29,6 @@ definition:
         method: GET
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
   returns: ${{ steps.get_user.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_groups_in_org.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_groups_in_org.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -48,7 +53,7 @@ definition:
         method: GET
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/groups
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.list_groups.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/list_users.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -48,7 +53,7 @@ definition:
         method: GET
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.list_users.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/lookup_user_by_email.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/lookup_user_by_email.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     email:
       type: str
@@ -28,7 +33,7 @@ definition:
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users
         method: GET
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
         params:
           search: ${{ steps.search_query.result }}
   # core.http_request returns data, headers, and status_code

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/remove_from_group.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/remove_from_group.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -27,7 +32,7 @@ definition:
         method: DELETE
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/groups/${{ inputs.group_id }}/users/${{ FN.url_encode(inputs.user_id) }}
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
           Content-Type: "application/json"
   returns: ${{ steps.remove_user.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/reset_password.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/reset_password.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     user_id:
       type: str
@@ -32,5 +37,5 @@ definition:
         method: POST
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/lifecycle/reset_password?revokeSessions=${{ inputs.revoke_sessions }}&sendEmail=${{ inputs.send_email }}
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.reset_password.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/revoke_sessions.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/revoke_sessions.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     user_id:
       type: str
@@ -24,5 +29,5 @@ definition:
         method: DELETE
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/sessions
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.revoke_sessions.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/search_users.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/search_users.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -45,7 +50,7 @@ definition:
         method: GET
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
           Accept: "application/json"
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.search_users.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/suspend_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/suspend_user.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     user_id:
       type: str
@@ -24,5 +29,5 @@ definition:
         method: POST
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/lifecycle/suspend
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.suspend_user.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta/unsuspend_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta/unsuspend_user.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     user_id:
       type: str
@@ -24,5 +29,5 @@ definition:
         method: POST
         url: ${{ inputs.base_url || VARS.okta.base_url }}/api/v1/users/${{ FN.url_encode(inputs.user_id) }}/lifecycle/unsuspend
         headers:
-          Authorization: "SSWS ${{ SECRETS.okta.OKTA_API_TOKEN }}"
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
   returns: ${{ steps.unsuspend_user.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/create_message.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/create_message.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -27,9 +32,9 @@ definition:
         url: ${{ inputs.base_url || VARS.okta_oar.base_url }}/governance/api/v1/requests/${{ inputs.request_id }}/messages
         method: POST
         headers:
-          Authorization: ${{ FN.concat("SSWS ", SECRETS.okta.OKTA_API_TOKEN) }}
-          Accept: application/json
-          Content-Type: application/json
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
+          Accept: "application/json"
+          Content-Type: "application/json"
         payload:
           message: ${{ inputs.message }}
     - ref: handle_response

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/get_requests.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/get_requests.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -57,8 +62,7 @@ definition:
         url: ${{ inputs.base_url || VARS.okta_oar.base_url }}/governance/api/v1/requests
         method: GET
         headers:
-          Authorization: ${{ FN.concat("SSWS ", SECRETS.okta.OKTA_API_TOKEN) }}
-          Accept: application/json
-          Content-Type: application/json
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
+          Accept: "application/json"
         params: ${{ steps.build_params.result }}
   returns: ${{ steps.call_api.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/get_specific_request.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/get_specific_request.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -24,7 +29,6 @@ definition:
         url: ${{ inputs.base_url || VARS.okta_oar.base_url }}/governance/api/v1/requests/${{ inputs.request_id }}
         method: GET
         headers:
-          Authorization: ${{ FN.concat("SSWS ", SECRETS.okta.OKTA_API_TOKEN) }}
-          Accept: application/json
-          Content-Type: application/json
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
+          Accept: "application/json"
   returns: ${{ steps.call_api.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/get_user.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/okta_oar/get_user.yml
@@ -9,6 +9,11 @@ definition:
   secrets:
     - name: okta
       keys: ["OKTA_API_TOKEN"]
+      optional: true
+    - type: oauth
+      provider_id: okta
+      grant_type: jwt_bearer
+      optional: true
   expects:
     base_url:
       type: str | None
@@ -24,7 +29,6 @@ definition:
         url: ${{ inputs.base_url || VARS.okta_oar.base_url }}/api/v1/users/${{ inputs.user_id }}
         method: GET
         headers:
-          Authorization: ${{ FN.concat("SSWS ", SECRETS.okta.OKTA_API_TOKEN) }}
-          Accept: application/json
-          Content-Type: application/json
+          Authorization: "${{ \"Bearer \" + SECRETS.okta_oauth.OKTA_SERVICE_TOKEN || \"SSWS \" + SECRETS.okta.OKTA_API_TOKEN }}"
+          Accept: "application/json"
   returns: ${{ steps.call_api.result.data }}

--- a/tracecat/integrations/dependencies.py
+++ b/tracecat/integrations/dependencies.py
@@ -12,6 +12,7 @@ from tracecat.integrations.providers.base import (
     AuthorizationCodeOAuthProvider,
     BaseOAuthProvider,
     ClientCredentialsOAuthProvider,
+    JWTBearerOAuthProvider,
 )
 from tracecat.integrations.schemas import ProviderKey
 from tracecat.integrations.service import IntegrationService
@@ -127,6 +128,37 @@ async def get_cc_provider_impl(
     return ProviderInfo(impl=info.impl, key=info.key)
 
 
+async def get_jwt_bearer_provider_impl(
+    provider_id: str,
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+) -> ProviderInfo[type[JWTBearerOAuthProvider]]:
+    """
+    FastAPI dependency to get JWT bearer provider implementation by name.
+
+    Args:
+        provider_id: The name of the provider to retrieve
+
+    Returns:
+        A JWT bearer OAuth provider class
+
+    Raises:
+        HTTPException: If the provider is not supported or doesn't support JWT bearer flow
+    """
+    info = await _resolve_provider_info(
+        provider_id=provider_id,
+        grant_type=OAuthGrantType.JWT_BEARER,
+        role=role,
+        session=session,
+    )
+    if not issubclass(info.impl, JWTBearerOAuthProvider):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Provider {provider_id} does not support JWT bearer flow",
+        )
+    return ProviderInfo(impl=info.impl, key=info.key)
+
+
 class ProviderInfo[T: type[BaseOAuthProvider]](BaseModel):
     impl: T
     key: ProviderKey
@@ -140,4 +172,7 @@ CCProviderInfoDep = Annotated[
 ]
 ACProviderInfoDep = Annotated[
     ProviderInfo[type[AuthorizationCodeOAuthProvider]], Depends(get_ac_provider_impl)
+]
+JWTBearerProviderInfoDep = Annotated[
+    ProviderInfo[type[JWTBearerOAuthProvider]], Depends(get_jwt_bearer_provider_impl)
 ]

--- a/tracecat/integrations/enums.py
+++ b/tracecat/integrations/enums.py
@@ -19,6 +19,8 @@ class OAuthGrantType(StrEnum):
     """Authorization code grant type. See https://datatracker.ietf.org/doc/html/rfc6749#section-1.3.1"""
     CLIENT_CREDENTIALS = "client_credentials"
     """Client credentials grant type. See https://datatracker.ietf.org/doc/html/rfc6749#section-1.3.4"""
+    JWT_BEARER = "jwt_bearer"
+    """JWT bearer grant type. See https://datatracker.ietf.org/doc/html/rfc7523"""
 
 
 class MCPAuthType(StrEnum):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Okta private key JWT (JWT Bearer) support across backend, UI, and registry tools, enabling service apps to authenticate without API tokens. Also makes authorization_endpoint optional unless using authorization_code.

- **New Features**
  - Backend: Added OAuth grant type jwt_bearer with JWTBearerOAuthProvider (RFC 7523), token refresh flow, and provider dependency. Uses PEM private key in client_secret to sign assertions.
  - Frontend: Added “Private key JWT” grant option. Hides authorization endpoint for jwt_bearer and treats it as optional otherwise. Updated validation, types, and placeholders (PEM input).
  - Registry: Updated all Okta and Okta OAR tools to accept an OAuth secret (provider_id: okta, grant_type: jwt_bearer). Authorization header now prefers Bearer OKTA_SERVICE_TOKEN, with SSWS API token as fallback.

- **Migration**
  - Create a custom provider with grant_type=jwt_bearer, set token_endpoint and client_id, and paste the PEM private key into client_secret.
  - In workflows, add a secret of type: oauth with provider_id: okta and grant_type: jwt_bearer, or keep existing API token for fallback.
  - No authorization endpoint needed for jwt_bearer.

<sup>Written for commit 5e4210586a509eda0382604ba9e98b40cd37a86b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

