### PR TITLE
feat(registry): Add version management APIs and UI

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -11,6 +11,36 @@ export const $AccessLevel = {
     This enum will be removed in a future version.`,
 } as const
 
+export const $ActionChange = {
+  properties: {
+    action_name: {
+      type: "string",
+      title: "Action Name",
+    },
+    change_type: {
+      type: "string",
+      enum: ["added", "removed", "modified"],
+      title: "Change Type",
+    },
+    interface_changes: {
+      items: {
+        $ref: "#/components/schemas/ActionInterfaceChange",
+      },
+      type: "array",
+      title: "Interface Changes",
+    },
+    description_changed: {
+      type: "boolean",
+      title: "Description Changed",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["action_name", "change_type"],
+  title: "ActionChange",
+  description: "Describes a change to an action between two versions.",
+} as const
+
 export const $ActionControlFlow = {
   properties: {
     run_if: {
@@ -216,6 +246,50 @@ export const $ActionEdge = {
   description: `Represents an incoming edge to an action.
 
 Stored in Action.upstream_edges to represent incoming connections.`,
+} as const
+
+export const $ActionInterfaceChange = {
+  properties: {
+    field: {
+      type: "string",
+      enum: ["expects", "returns"],
+      title: "Field",
+    },
+    change_type: {
+      type: "string",
+      enum: ["added", "removed", "modified"],
+      title: "Change Type",
+    },
+    old_value: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Old Value",
+    },
+    new_value: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "New Value",
+    },
+  },
+  type: "object",
+  required: ["field", "change_type"],
+  title: "ActionInterfaceChange",
+  description:
+    "Describes a change to an action's interface (expects or returns).",
 } as const
 
 export const $ActionPositionUpdate = {
@@ -17774,6 +17848,64 @@ export const $VercelChatRequest = {
   required: ["message"],
   title: "VercelChatRequest",
   description: "Vercel AI SDK format request with structured UI messages.",
+} as const
+
+export const $VersionDiff = {
+  properties: {
+    base_version_id: {
+      type: "string",
+      format: "uuid",
+      title: "Base Version Id",
+    },
+    base_version: {
+      type: "string",
+      title: "Base Version",
+    },
+    compare_version_id: {
+      type: "string",
+      format: "uuid",
+      title: "Compare Version Id",
+    },
+    compare_version: {
+      type: "string",
+      title: "Compare Version",
+    },
+    actions_added: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Actions Added",
+    },
+    actions_removed: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Actions Removed",
+    },
+    actions_modified: {
+      items: {
+        $ref: "#/components/schemas/ActionChange",
+      },
+      type: "array",
+      title: "Actions Modified",
+    },
+    total_changes: {
+      type: "integer",
+      title: "Total Changes",
+      default: 0,
+    },
+  },
+  type: "object",
+  required: [
+    "base_version_id",
+    "base_version",
+    "compare_version_id",
+    "compare_version",
+  ],
+  title: "VersionDiff",
+  description: "Result of comparing two registry versions.",
 } as const
 
 export const $VideoUrl = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -357,10 +357,16 @@ import type {
   RegistryActionsListRegistryActionsResponse,
   RegistryActionsUpdateRegistryActionData,
   RegistryActionsUpdateRegistryActionResponse,
+  RegistryRepositoriesCompareRegistryVersionsData,
+  RegistryRepositoriesCompareRegistryVersionsResponse,
   RegistryRepositoriesCreateRegistryRepositoryData,
   RegistryRepositoriesCreateRegistryRepositoryResponse,
   RegistryRepositoriesDeleteRegistryRepositoryData,
   RegistryRepositoriesDeleteRegistryRepositoryResponse,
+  RegistryRepositoriesDeleteRegistryVersionData,
+  RegistryRepositoriesDeleteRegistryVersionResponse,
+  RegistryRepositoriesGetPreviousRegistryVersionData,
+  RegistryRepositoriesGetPreviousRegistryVersionResponse,
   RegistryRepositoriesGetRegistryRepositoryData,
   RegistryRepositoriesGetRegistryRepositoryResponse,
   RegistryRepositoriesListRegistryRepositoriesResponse,
@@ -5056,6 +5062,102 @@ export const registryRepositoriesPromoteRegistryVersion = (
   return __request(OpenAPI, {
     method: "POST",
     url: "/registry/repos/{repository_id}/versions/{version_id}/promote",
+    path: {
+      repository_id: data.repositoryId,
+      version_id: data.versionId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Registry Version
+ * Delete a specific registry version.
+ *
+ * Safety checks:
+ * - Cannot delete the currently promoted version
+ * - Cannot delete versions referenced by published workflow definitions
+ *
+ * For platform registries, use the admin API.
+ * @param data The data for the request.
+ * @param data.repositoryId
+ * @param data.versionId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const registryRepositoriesDeleteRegistryVersion = (
+  data: RegistryRepositoriesDeleteRegistryVersionData
+): CancelablePromise<RegistryRepositoriesDeleteRegistryVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/registry/repos/{repository_id}/versions/{version_id}",
+    path: {
+      repository_id: data.repositoryId,
+      version_id: data.versionId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Compare Registry Versions
+ * Compare two registry versions and return the diff.
+ *
+ * Args:
+ * repository_id: The repository ID
+ * version_id: The base version ID (typically older)
+ * compare_to: The version ID to compare against (typically newer)
+ *
+ * Returns:
+ * VersionDiff with added, removed, and modified actions
+ * @param data The data for the request.
+ * @param data.repositoryId
+ * @param data.versionId
+ * @param data.compareTo
+ * @returns VersionDiff Successful Response
+ * @throws ApiError
+ */
+export const registryRepositoriesCompareRegistryVersions = (
+  data: RegistryRepositoriesCompareRegistryVersionsData
+): CancelablePromise<RegistryRepositoriesCompareRegistryVersionsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/registry/repos/{repository_id}/versions/{version_id}/diff",
+    path: {
+      repository_id: data.repositoryId,
+      version_id: data.versionId,
+    },
+    query: {
+      compare_to: data.compareTo,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Previous Registry Version
+ * Get the previous version before the specified version.
+ *
+ * Useful for quick rollback UX - returns the version to rollback to.
+ * Returns null if there is no previous version.
+ * @param data The data for the request.
+ * @param data.repositoryId
+ * @param data.versionId
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const registryRepositoriesGetPreviousRegistryVersion = (
+  data: RegistryRepositoriesGetPreviousRegistryVersionData
+): CancelablePromise<RegistryRepositoriesGetPreviousRegistryVersionResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/registry/repos/{repository_id}/versions/{version_id}/previous",
     path: {
       repository_id: data.repositoryId,
       version_id: data.versionId,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9,6 +9,18 @@
  */
 export type AccessLevel = 0 | 999
 
+/**
+ * Describes a change to an action between two versions.
+ */
+export type ActionChange = {
+  action_name: string
+  change_type: "added" | "removed" | "modified"
+  interface_changes?: Array<ActionInterfaceChange>
+  description_changed?: boolean
+}
+
+export type change_type = "added" | "removed" | "modified"
+
 export type ActionControlFlow = {
   run_if?: string | null
   for_each?: string | Array<string> | null
@@ -56,6 +68,22 @@ export type ActionEdge = {
 export type source_type = "trigger" | "udf"
 
 export type source_handle = "success" | "error"
+
+/**
+ * Describes a change to an action's interface (expects or returns).
+ */
+export type ActionInterfaceChange = {
+  field: "expects" | "returns"
+  change_type: "added" | "removed" | "modified"
+  old_value?: {
+    [key: string]: unknown
+  } | null
+  new_value?: {
+    [key: string]: unknown
+  } | null
+}
+
+export type field = "expects" | "returns"
 
 /**
  * Position update for a single action.
@@ -5567,6 +5595,20 @@ export type VercelChatRequest = {
   base_url?: string | null
 }
 
+/**
+ * Result of comparing two registry versions.
+ */
+export type VersionDiff = {
+  base_version_id: string
+  base_version: string
+  compare_version_id: string
+  compare_version: string
+  actions_added?: Array<string>
+  actions_removed?: Array<string>
+  actions_modified?: Array<ActionChange>
+  total_changes?: number
+}
+
 export type VideoUrl = {
   url: string
   force_download?: boolean
@@ -7595,6 +7637,29 @@ export type RegistryRepositoriesPromoteRegistryVersionData = {
 
 export type RegistryRepositoriesPromoteRegistryVersionResponse =
   tracecat__registry__repositories__schemas__RegistryVersionPromoteResponse
+
+export type RegistryRepositoriesDeleteRegistryVersionData = {
+  repositoryId: string
+  versionId: string
+}
+
+export type RegistryRepositoriesDeleteRegistryVersionResponse = void
+
+export type RegistryRepositoriesCompareRegistryVersionsData = {
+  compareTo: string
+  repositoryId: string
+  versionId: string
+}
+
+export type RegistryRepositoriesCompareRegistryVersionsResponse = VersionDiff
+
+export type RegistryRepositoriesGetPreviousRegistryVersionData = {
+  repositoryId: string
+  versionId: string
+}
+
+export type RegistryRepositoriesGetPreviousRegistryVersionResponse =
+  tracecat__registry__repositories__schemas__RegistryVersionRead | null
 
 export type RegistryActionsListRegistryActionsResponse =
   Array<RegistryActionReadMinimal>
@@ -11068,6 +11133,51 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: tracecat__registry__repositories__schemas__RegistryVersionPromoteResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/registry/repos/{repository_id}/versions/{version_id}": {
+    delete: {
+      req: RegistryRepositoriesDeleteRegistryVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/registry/repos/{repository_id}/versions/{version_id}/diff": {
+    get: {
+      req: RegistryRepositoriesCompareRegistryVersionsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: VersionDiff
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/registry/repos/{repository_id}/versions/{version_id}/previous": {
+    get: {
+      req: RegistryRepositoriesGetPreviousRegistryVersionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: tracecat__registry__repositories__schemas__RegistryVersionRead | null
         /**
          * Validation Error
          */

--- a/frontend/src/components/registry/dialogs/repository-versions-dialog.tsx
+++ b/frontend/src/components/registry/dialogs/repository-versions-dialog.tsx
@@ -1,0 +1,607 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  ArrowLeftIcon,
+  CheckCircleIcon,
+  DiffIcon,
+  HistoryIcon,
+  TrashIcon,
+} from "lucide-react"
+import { useState } from "react"
+import type {
+  RegistryRepositoryReadMinimal,
+  tracecat__registry__repositories__schemas__RegistryVersionRead,
+  VersionDiff,
+} from "@/client"
+import {
+  registryRepositoriesCompareRegistryVersions,
+  registryRepositoriesDeleteRegistryVersion,
+  registryRepositoriesGetPreviousRegistryVersion,
+  registryRepositoriesListRepositoryVersions,
+  registryRepositoriesPromoteRegistryVersion,
+} from "@/client/services.gen"
+import { Spinner } from "@/components/loading/spinner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { toast } from "@/components/ui/use-toast"
+import { getRelativeTime } from "@/lib/event-history"
+
+interface RepositoryVersionsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedRepo: RegistryRepositoryReadMinimal | null
+}
+
+type DialogView = "versions" | "diff"
+
+export function RepositoryVersionsDialog({
+  open,
+  onOpenChange,
+  selectedRepo,
+}: RepositoryVersionsDialogProps) {
+  const queryClient = useQueryClient()
+  const [view, setView] = useState<DialogView>("versions")
+  const [compareBaseId, setCompareBaseId] = useState<string | null>(null)
+  const [compareToId, setCompareToId] = useState<string | null>(null)
+
+  // Reset state when dialog closes
+  function handleOpenChange(open: boolean) {
+    if (!open) {
+      setView("versions")
+      setCompareBaseId(null)
+      setCompareToId(null)
+    }
+    onOpenChange(open)
+  }
+
+  // Fetch versions
+  const { data: versions, isLoading: versionsLoading } = useQuery({
+    queryKey: ["registry_versions", selectedRepo?.id],
+    queryFn: async () => {
+      if (!selectedRepo?.id) return []
+      return await registryRepositoriesListRepositoryVersions({
+        repositoryId: selectedRepo.id,
+      })
+    },
+    enabled: open && !!selectedRepo?.id,
+  })
+
+  // Fetch previous version for quick rollback
+  const { data: previousVersion } = useQuery({
+    queryKey: [
+      "registry_previous_version",
+      selectedRepo?.id,
+      selectedRepo?.current_version_id,
+    ],
+    queryFn: async () => {
+      if (!selectedRepo?.id || !selectedRepo?.current_version_id) return null
+      return await registryRepositoriesGetPreviousRegistryVersion({
+        repositoryId: selectedRepo.id,
+        versionId: selectedRepo.current_version_id,
+      })
+    },
+    enabled: open && !!selectedRepo?.id && !!selectedRepo?.current_version_id,
+  })
+
+  // Fetch diff when comparing
+  const { data: diff, isLoading: diffLoading } = useQuery({
+    queryKey: ["registry_version_diff", compareBaseId, compareToId],
+    queryFn: async () => {
+      if (!selectedRepo?.id || !compareBaseId || !compareToId) return null
+      return await registryRepositoriesCompareRegistryVersions({
+        repositoryId: selectedRepo.id,
+        versionId: compareBaseId,
+        compareTo: compareToId,
+      })
+    },
+    enabled:
+      view === "diff" && !!selectedRepo?.id && !!compareBaseId && !!compareToId,
+  })
+
+  // Promote version mutation
+  const { mutateAsync: promoteVersion, isPending: promotePending } =
+    useMutation({
+      mutationFn: async ({
+        versionId,
+      }: {
+        versionId: string
+        versionName: string
+      }) => {
+        if (!selectedRepo?.id) throw new Error("No repository selected")
+        return await registryRepositoriesPromoteRegistryVersion({
+          repositoryId: selectedRepo.id,
+          versionId,
+        })
+      },
+      onSuccess: (_, { versionName }) => {
+        queryClient.invalidateQueries({ queryKey: ["registry_repositories"] })
+        queryClient.invalidateQueries({
+          queryKey: ["registry_versions", selectedRepo?.id],
+        })
+        queryClient.invalidateQueries({
+          queryKey: ["registry_previous_version", selectedRepo?.id],
+        })
+        toast({
+          title: "Version promoted",
+          description: `Version ${versionName} is now active.`,
+        })
+      },
+      onError: (error) => {
+        console.error("Failed to promote version", error)
+        toast({
+          title: "Failed to promote version",
+          description: "An error occurred while promoting the version.",
+          variant: "destructive",
+        })
+      },
+    })
+
+  // Delete version mutation
+  const { mutateAsync: deleteVersion, isPending: deletePending } = useMutation({
+    mutationFn: async (versionId: string) => {
+      if (!selectedRepo?.id) throw new Error("No repository selected")
+      return await registryRepositoriesDeleteRegistryVersion({
+        repositoryId: selectedRepo.id,
+        versionId,
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["registry_repositories"] })
+      queryClient.invalidateQueries({
+        queryKey: ["registry_versions", selectedRepo?.id],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["registry_previous_version", selectedRepo?.id],
+      })
+      toast({
+        title: "Version deleted",
+        description: "The version has been deleted.",
+      })
+    },
+    onError: (error: unknown) => {
+      console.error("Failed to delete version", error)
+      const apiError = error as { body?: { detail?: string } }
+      toast({
+        title: "Failed to delete version",
+        description:
+          apiError.body?.detail ||
+          "An error occurred while deleting the version.",
+        variant: "destructive",
+      })
+    },
+  })
+
+  function handleCompare(
+    baseVersion: tracecat__registry__repositories__schemas__RegistryVersionRead
+  ) {
+    setCompareBaseId(baseVersion.id)
+    // Default to comparing with current version if different, otherwise first other version
+    if (selectedRepo?.current_version_id !== baseVersion.id) {
+      setCompareToId(selectedRepo?.current_version_id ?? null)
+    } else if (versions && versions.length > 1) {
+      const otherVersion = versions.find((v) => v.id !== baseVersion.id)
+      setCompareToId(otherVersion?.id ?? null)
+    }
+    setView("diff")
+  }
+
+  function handleQuickRollback() {
+    if (previousVersion) {
+      const prev =
+        previousVersion as tracecat__registry__repositories__schemas__RegistryVersionRead
+      promoteVersion({ versionId: prev.id, versionName: prev.version })
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {view === "diff" && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setView("versions")}
+              >
+                <ArrowLeftIcon className="size-4" />
+              </Button>
+            )}
+            <HistoryIcon className="size-5" />
+            {view === "versions" ? "Manage versions" : "Compare versions"}
+          </DialogTitle>
+          <DialogDescription>
+            {view === "versions"
+              ? `Manage versions for ${selectedRepo?.origin ?? "repository"}`
+              : "View changes between two versions"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {view === "versions" && (
+          <VersionsView
+            versions={versions ?? []}
+            versionsLoading={versionsLoading}
+            currentVersionId={selectedRepo?.current_version_id ?? null}
+            previousVersion={
+              previousVersion as tracecat__registry__repositories__schemas__RegistryVersionRead | null
+            }
+            onPromote={promoteVersion}
+            onDelete={deleteVersion}
+            onCompare={handleCompare}
+            onQuickRollback={handleQuickRollback}
+            promotePending={promotePending}
+            deletePending={deletePending}
+          />
+        )}
+
+        {view === "diff" && (
+          <DiffView
+            diff={diff ?? null}
+            diffLoading={diffLoading}
+            versions={versions ?? []}
+            compareBaseId={compareBaseId}
+            compareToId={compareToId}
+            onBaseChange={setCompareBaseId}
+            onCompareChange={setCompareToId}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface VersionsViewProps {
+  versions: tracecat__registry__repositories__schemas__RegistryVersionRead[]
+  versionsLoading: boolean
+  currentVersionId: string | null
+  previousVersion: tracecat__registry__repositories__schemas__RegistryVersionRead | null
+  onPromote: (params: {
+    versionId: string
+    versionName: string
+  }) => Promise<unknown>
+  onDelete: (versionId: string) => Promise<unknown>
+  onCompare: (
+    version: tracecat__registry__repositories__schemas__RegistryVersionRead
+  ) => void
+  onQuickRollback: () => void
+  promotePending: boolean
+  deletePending: boolean
+}
+
+function VersionsView({
+  versions,
+  versionsLoading,
+  currentVersionId,
+  previousVersion,
+  onPromote,
+  onDelete,
+  onCompare,
+  onQuickRollback,
+  promotePending,
+  deletePending,
+}: VersionsViewProps) {
+  if (versionsLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Spinner className="size-6" />
+      </div>
+    )
+  }
+
+  if (!versions.length) {
+    return (
+      <div className="py-8 text-center text-muted-foreground">
+        No versions found
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {previousVersion && (
+        <div className="flex items-center justify-between rounded-md border bg-muted/50 p-3">
+          <div className="text-sm">
+            <span className="text-muted-foreground">Quick rollback to: </span>
+            <span className="font-mono">{previousVersion.version}</span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onQuickRollback}
+            disabled={promotePending}
+          >
+            <HistoryIcon className="mr-2 size-4" />
+            Rollback
+          </Button>
+        </div>
+      )}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Version</TableHead>
+            <TableHead>Commit</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {versions.map((version) => {
+            const isCurrent = version.id === currentVersionId
+            return (
+              <TableRow key={version.id}>
+                <TableCell className="font-mono text-sm">
+                  {version.version}
+                </TableCell>
+                <TableCell>
+                  {version.commit_sha ? (
+                    <Badge variant="secondary" className="font-mono text-xs">
+                      {version.commit_sha.substring(0, 7)}
+                    </Badge>
+                  ) : (
+                    <span className="text-muted-foreground">-</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {getRelativeTime(new Date(version.created_at))}
+                </TableCell>
+                <TableCell>
+                  {isCurrent && (
+                    <Badge variant="default" className="gap-1">
+                      <CheckCircleIcon className="size-3" />
+                      Current
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  <TooltipProvider>
+                    <div className="flex items-center justify-end gap-1">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onCompare(version)}
+                          >
+                            <DiffIcon className="size-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Compare with another version</p>
+                        </TooltipContent>
+                      </Tooltip>
+                      {!isCurrent && (
+                        <>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() =>
+                                  onPromote({
+                                    versionId: version.id,
+                                    versionName: version.version,
+                                  })
+                                }
+                                disabled={promotePending}
+                              >
+                                <CheckCircleIcon className="size-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Promote this version</p>
+                            </TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => onDelete(version.id)}
+                                disabled={deletePending}
+                                className="text-destructive hover:text-destructive"
+                              >
+                                <TrashIcon className="size-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Delete this version</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </>
+                      )}
+                    </div>
+                  </TooltipProvider>
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+interface DiffViewProps {
+  diff: VersionDiff | null
+  diffLoading: boolean
+  versions: tracecat__registry__repositories__schemas__RegistryVersionRead[]
+  compareBaseId: string | null
+  compareToId: string | null
+  onBaseChange: (id: string | null) => void
+  onCompareChange: (id: string | null) => void
+}
+
+function DiffView({
+  diff,
+  diffLoading,
+  versions,
+  compareBaseId,
+  compareToId,
+  onBaseChange,
+  onCompareChange,
+}: DiffViewProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4">
+        <div className="flex-1">
+          <label className="mb-1 block text-sm font-medium">Base version</label>
+          <Select
+            value={compareBaseId ?? undefined}
+            onValueChange={onBaseChange}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select version" />
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((v) => (
+                <SelectItem key={v.id} value={v.id}>
+                  {v.version}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex-1">
+          <label className="mb-1 block text-sm font-medium">
+            Compare to version
+          </label>
+          <Select
+            value={compareToId ?? undefined}
+            onValueChange={onCompareChange}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select version" />
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((v) => (
+                <SelectItem key={v.id} value={v.id}>
+                  {v.version}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {diffLoading && (
+        <div className="flex items-center justify-center py-8">
+          <Spinner className="size-6" />
+        </div>
+      )}
+
+      {diff && !diffLoading && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-4 text-sm">
+            <Badge variant="secondary" className="gap-1">
+              <span className="text-green-600">
+                +{diff.actions_added?.length ?? 0}
+              </span>
+              <span>added</span>
+            </Badge>
+            <Badge variant="secondary" className="gap-1">
+              <span className="text-red-600">
+                -{diff.actions_removed?.length ?? 0}
+              </span>
+              <span>removed</span>
+            </Badge>
+            <Badge variant="secondary" className="gap-1">
+              <span className="text-amber-600">
+                ~{diff.actions_modified?.length ?? 0}
+              </span>
+              <span>modified</span>
+            </Badge>
+          </div>
+
+          {diff.total_changes === 0 && (
+            <div className="py-4 text-center text-muted-foreground">
+              No changes between these versions
+            </div>
+          )}
+
+          {(diff.actions_added?.length ?? 0) > 0 && (
+            <div>
+              <h4 className="mb-2 font-medium text-green-600">Added actions</h4>
+              <ul className="space-y-1 font-mono text-sm">
+                {diff.actions_added?.map((action) => (
+                  <li key={action} className="text-muted-foreground">
+                    + {action}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {(diff.actions_removed?.length ?? 0) > 0 && (
+            <div>
+              <h4 className="mb-2 font-medium text-red-600">Removed actions</h4>
+              <ul className="space-y-1 font-mono text-sm">
+                {diff.actions_removed?.map((action) => (
+                  <li key={action} className="text-muted-foreground">
+                    - {action}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {(diff.actions_modified?.length ?? 0) > 0 && (
+            <div>
+              <h4 className="mb-2 font-medium text-amber-600">
+                Modified actions
+              </h4>
+              <ul className="space-y-2 font-mono text-sm">
+                {diff.actions_modified?.map((change) => (
+                  <li
+                    key={change.action_name}
+                    className="text-muted-foreground"
+                  >
+                    <div>~ {change.action_name}</div>
+                    {change.description_changed && (
+                      <div className="ml-4 text-xs">Description changed</div>
+                    )}
+                    {change.interface_changes?.map((ic, idx) => (
+                      <div key={idx} className="ml-4 text-xs">
+                        {ic.field} {ic.change_type}
+                      </div>
+                    ))}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/registry/registry-common.tsx
+++ b/frontend/src/components/registry/registry-common.tsx
@@ -2,4 +2,5 @@ export enum RegistryTableActiveDialog {
   RepositorySync,
   RepositoryDelete,
   RepositoryCommit,
+  RepositoryVersions,
 }

--- a/frontend/src/components/registry/registry-repos-table.tsx
+++ b/frontend/src/components/registry/registry-repos-table.tsx
@@ -7,7 +7,7 @@ import {
   ChevronDownIcon,
   CornerDownRightIcon,
 } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type {
   RegistryRepositoryErrorDetail,
   RegistryRepositoryReadMinimal,
@@ -20,6 +20,7 @@ import {
 import { CommitSelectorDialog } from "@/components/registry/dialogs/repository-commit-dialog"
 import { DeleteRepositoryDialog } from "@/components/registry/dialogs/repository-delete-dialog"
 import { SyncRepositoryDialog } from "@/components/registry/dialogs/repository-sync-dialog"
+import { RepositoryVersionsDialog } from "@/components/registry/dialogs/repository-versions-dialog"
 import { RegistryTableActiveDialog } from "@/components/registry/registry-common"
 import { RepositoryActions } from "@/components/registry/table-actions"
 import { Badge } from "@/components/ui/badge"
@@ -54,6 +55,16 @@ export function RegistryRepositoriesTable() {
     useState<RegistryTableActiveDialog | null>(null)
   const [selectedRepo, setSelectedRepo] =
     useState<RegistryRepositoryReadMinimal | null>(null)
+
+  // Keep selectedRepo in sync with latest query data
+  useEffect(() => {
+    if (selectedRepo && registryRepos) {
+      const updatedRepo = registryRepos.find((r) => r.id === selectedRepo.id)
+      if (updatedRepo && updatedRepo !== selectedRepo) {
+        setSelectedRepo(updatedRepo)
+      }
+    }
+  }, [registryRepos, selectedRepo])
 
   const onOpenChange = (open: boolean) => {
     if (!open) {
@@ -176,6 +187,12 @@ export function RegistryRepositoriesTable() {
                     setSelectedRepo(row.original)
                     setActiveDialog(RegistryTableActiveDialog.RepositoryCommit)
                   }}
+                  onVersions={() => {
+                    setSelectedRepo(row.original)
+                    setActiveDialog(
+                      RegistryTableActiveDialog.RepositoryVersions
+                    )
+                  }}
                 />
               )}
             </DropdownMenuContent>
@@ -278,6 +295,12 @@ export function RegistryRepositoriesTable() {
         onOpenChange={onOpenChange}
         selectedRepo={selectedRepo}
         initialCommitSha={selectedRepo?.commit_sha}
+      />
+
+      <RepositoryVersionsDialog
+        open={activeDialog === RegistryTableActiveDialog.RepositoryVersions}
+        onOpenChange={onOpenChange}
+        selectedRepo={selectedRepo}
       />
     </>
   )

--- a/frontend/src/components/registry/table-actions.tsx
+++ b/frontend/src/components/registry/table-actions.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { CopyIcon, GitBranchIcon, RefreshCcw, TrashIcon } from "lucide-react"
+import {
+  CopyIcon,
+  GitBranchIcon,
+  HistoryIcon,
+  RefreshCcw,
+  TrashIcon,
+} from "lucide-react"
 import type { RegistryRepositoryReadMinimal } from "@/client"
 import {
   DropdownMenuGroup,
@@ -14,6 +20,7 @@ interface RepositoryActionsProps {
   onSync: (repo: RegistryRepositoryReadMinimal) => void
   onDelete: (repo: RegistryRepositoryReadMinimal) => void
   onChangeCommit: (repo: RegistryRepositoryReadMinimal) => void
+  onVersions: (repo: RegistryRepositoryReadMinimal) => void
 }
 
 export function RepositoryActions({
@@ -21,6 +28,7 @@ export function RepositoryActions({
   onSync,
   onDelete,
   onChangeCommit,
+  onVersions,
 }: RepositoryActionsProps) {
   const handleCopyOrigin = async (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -83,6 +91,11 @@ export function RepositoryActions({
     onChangeCommit(repository)
   }
 
+  const handleVersionsClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onVersions(repository)
+  }
+
   return (
     <DropdownMenuGroup>
       <DropdownMenuItem
@@ -119,6 +132,16 @@ export function RepositoryActions({
         >
           <GitBranchIcon className="mr-2 size-4" />
           <span>Change commit</span>
+        </DropdownMenuItem>
+      )}
+
+      {repository.current_version_id && (
+        <DropdownMenuItem
+          className="flex items-center text-xs"
+          onClick={handleVersionsClick}
+        >
+          <HistoryIcon className="mr-2 size-4" />
+          <span>Manage versions</span>
         </DropdownMenuItem>
       )}
 

--- a/tests/unit/test_registry_version_management.py
+++ b/tests/unit/test_registry_version_management.py
@@ -1,0 +1,599 @@
+"""Tests for registry version management.
+
+This test suite validates:
+1. Version deletion with safety checks
+2. Version comparison (diff)
+3. Previous version retrieval for rollback
+4. Workflow definition usage detection
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import (
+    RegistryRepository,
+    RegistryVersion,
+    Workflow,
+    WorkflowDefinition,
+)
+from tracecat.exceptions import RegistryError
+from tracecat.registry.repositories.service import RegistryReposService
+from tracecat.registry.versions.service import RegistryVersionsService
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+def _make_manifest(action_names: list[str]) -> dict:
+    """Create a test manifest with given action names."""
+    actions = {}
+    for name in action_names:
+        parts = name.rsplit(".", 1)
+        namespace = parts[0] if len(parts) > 1 else "test"
+        action_name = parts[-1]
+        actions[name] = {
+            "namespace": namespace,
+            "name": action_name,
+            "action_type": "udf",
+            "description": f"Test action {name}",
+            "interface": {"expects": {"input": "str"}, "returns": "str"},
+            "implementation": {
+                "type": "udf",
+                "url": "test_origin",
+                "module": f"test.{namespace}",
+                "name": action_name,
+            },
+        }
+    return {"schema_version": "1.0", "actions": actions}
+
+
+@pytest.mark.anyio
+async def test_delete_version_success(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test that deleting a non-current version without references works."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Create two versions
+    version1 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action_v1"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    version2 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="2.0.0",
+        manifest=_make_manifest(["test.action_v2"]),
+        tarball_uri="s3://test/v2.tar.gz",
+    )
+    session.add_all([version1, version2])
+    await session.flush()
+
+    # Set version 2 as current
+    repo.current_version_id = version2.id
+    session.add(repo)
+    await session.commit()
+
+    # Validate and delete version 1
+    repos_service = RegistryReposService(session, role=svc_admin_role)
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+
+    # Validation should pass for non-current version
+    await repos_service.validate_version_deletion(repo, version1)
+
+    # Delete version 1
+    await versions_service.delete_version(version1)
+
+    # Verify version 1 is deleted
+    deleted = await versions_service.get_version(version1.id)
+    assert deleted is None
+
+    # Verify version 2 still exists
+    remaining = await versions_service.get_version(version2.id)
+    assert remaining is not None
+
+
+@pytest.mark.anyio
+async def test_cannot_delete_current_version(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test that deleting the current version is blocked."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Create version
+    version = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    session.add(version)
+    await session.flush()
+
+    # Set as current version
+    repo.current_version_id = version.id
+    session.add(repo)
+    await session.commit()
+
+    # Try to validate deletion
+    repos_service = RegistryReposService(session, role=svc_admin_role)
+
+    with pytest.raises(RegistryError, match="currently promoted version"):
+        await repos_service.validate_version_deletion(repo, version)
+
+
+@pytest.mark.anyio
+async def test_cannot_delete_version_in_use(
+    svc_admin_role: Role,
+    session: AsyncSession,
+    svc_workspace,
+) -> None:
+    """Test that deleting a version referenced by published workflows is blocked."""
+    workspace_id = svc_workspace.id
+
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Create versions
+    version1 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    version2 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="2.0.0",
+        manifest=_make_manifest(["test.action"]),
+        tarball_uri="s3://test/v2.tar.gz",
+    )
+    session.add_all([version1, version2])
+    await session.flush()
+
+    # Set version 2 as current
+    repo.current_version_id = version2.id
+    session.add(repo)
+    await session.flush()
+
+    # Create a workflow that references version 1 in its registry_lock
+    workflow = Workflow(
+        workspace_id=workspace_id,
+        title="Test Workflow",
+        description="Test workflow for registry version testing",
+    )
+    session.add(workflow)
+    await session.flush()
+
+    # Create a workflow definition referencing version 1
+    # Note: WorkflowDefinition uses workspace_id, not organization_id
+    definition = WorkflowDefinition(
+        workflow_id=workflow.id,
+        workspace_id=workspace_id,
+        version=1,
+        content={},
+        registry_lock={
+            "origins": {"test_origin": "1.0.0"},
+            "actions": {"test.action": "test_origin"},
+        },
+    )
+    session.add(definition)
+    await session.commit()
+
+    # Try to validate deletion
+    repos_service = RegistryReposService(session, role=svc_admin_role)
+
+    with pytest.raises(RegistryError, match="in use by published workflows"):
+        await repos_service.validate_version_deletion(repo, version1)
+
+
+@pytest.mark.anyio
+async def test_get_previous_version(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test getting the previous version for rollback."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Create versions with different created_at times
+    base_time = datetime.now(UTC)
+    version1 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action_v1"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    session.add(version1)
+    await session.flush()
+
+    # Manually set created_at to ensure ordering
+    version1.created_at = base_time - timedelta(hours=2)
+    session.add(version1)
+    await session.flush()
+
+    version2 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="2.0.0",
+        manifest=_make_manifest(["test.action_v2"]),
+        tarball_uri="s3://test/v2.tar.gz",
+    )
+    session.add(version2)
+    await session.flush()
+
+    version2.created_at = base_time - timedelta(hours=1)
+    session.add(version2)
+
+    version3 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="3.0.0",
+        manifest=_make_manifest(["test.action_v3"]),
+        tarball_uri="s3://test/v3.tar.gz",
+    )
+    session.add(version3)
+    await session.flush()
+
+    version3.created_at = base_time
+    session.add(version3)
+    await session.commit()
+
+    # Test getting previous version
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+
+    # Previous to version3 should be version2
+    prev = await versions_service.get_previous_version(repo.id, version3.id)
+    assert prev is not None
+    assert prev.id == version2.id
+
+    # Previous to version2 should be version1
+    prev = await versions_service.get_previous_version(repo.id, version2.id)
+    assert prev is not None
+    assert prev.id == version1.id
+
+
+@pytest.mark.anyio
+async def test_get_previous_version_none(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test that getting previous version returns None for the oldest version."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Create single version
+    version = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    session.add(version)
+    await session.commit()
+
+    # Get previous version (should be None)
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+    prev = await versions_service.get_previous_version(repo.id, version.id)
+    assert prev is None
+
+
+@pytest.mark.anyio
+async def test_compare_versions_added(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test that version diff correctly identifies added actions."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Version 1 with one action
+    version1 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action_a"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    # Version 2 with two actions (one added)
+    version2 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="2.0.0",
+        manifest=_make_manifest(["test.action_a", "test.action_b"]),
+        tarball_uri="s3://test/v2.tar.gz",
+    )
+    session.add_all([version1, version2])
+    await session.commit()
+
+    # Compare versions
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+    diff = await versions_service.compare_versions(version1, version2)
+
+    assert diff.base_version == "1.0.0"
+    assert diff.compare_version == "2.0.0"
+    assert "test.action_b" in diff.actions_added
+    assert len(diff.actions_removed) == 0
+    assert len(diff.actions_modified) == 0
+    assert diff.total_changes == 1
+
+
+@pytest.mark.anyio
+async def test_compare_versions_removed(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test that version diff correctly identifies removed actions."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Version 1 with two actions
+    version1 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action_a", "test.action_b"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    # Version 2 with one action (one removed)
+    version2 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="2.0.0",
+        manifest=_make_manifest(["test.action_a"]),
+        tarball_uri="s3://test/v2.tar.gz",
+    )
+    session.add_all([version1, version2])
+    await session.commit()
+
+    # Compare versions
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+    diff = await versions_service.compare_versions(version1, version2)
+
+    assert "test.action_b" in diff.actions_removed
+    assert len(diff.actions_added) == 0
+    assert len(diff.actions_modified) == 0
+    assert diff.total_changes == 1
+
+
+@pytest.mark.anyio
+async def test_compare_versions_modified(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test that version diff correctly identifies modified actions."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Version 1 with action
+    manifest1 = _make_manifest(["test.action"])
+    version1 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=manifest1,
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+
+    # Version 2 with modified action (different interface)
+    manifest2 = _make_manifest(["test.action"])
+    manifest2["actions"]["test.action"]["interface"]["expects"] = {
+        "input": "str",
+        "extra": "int",
+    }
+    manifest2["actions"]["test.action"]["description"] = "Modified description"
+    version2 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="2.0.0",
+        manifest=manifest2,
+        tarball_uri="s3://test/v2.tar.gz",
+    )
+    session.add_all([version1, version2])
+    await session.commit()
+
+    # Compare versions
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+    diff = await versions_service.compare_versions(version1, version2)
+
+    assert len(diff.actions_added) == 0
+    assert len(diff.actions_removed) == 0
+    assert len(diff.actions_modified) == 1
+    assert diff.actions_modified[0].action_name == "test.action"
+    assert diff.actions_modified[0].description_changed is True
+    assert len(diff.actions_modified[0].interface_changes) > 0
+    assert diff.total_changes == 1
+
+
+@pytest.mark.anyio
+async def test_compare_versions_no_changes(
+    svc_admin_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Test that version diff returns empty when versions are identical."""
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Create two versions with identical manifests
+    manifest = _make_manifest(["test.action"])
+    version1 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=manifest,
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    version2 = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.1",
+        manifest=manifest.copy(),  # Same manifest
+        tarball_uri="s3://test/v2.tar.gz",
+    )
+    session.add_all([version1, version2])
+    await session.commit()
+
+    # Compare versions
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+    diff = await versions_service.compare_versions(version1, version2)
+
+    assert diff.total_changes == 0
+    assert len(diff.actions_added) == 0
+    assert len(diff.actions_removed) == 0
+    assert len(diff.actions_modified) == 0
+
+
+@pytest.mark.anyio
+async def test_get_workflow_definitions_using_version(
+    svc_admin_role: Role,
+    session: AsyncSession,
+    svc_workspace,
+) -> None:
+    """Test finding workflow definitions that reference a specific version."""
+    workspace_id = svc_workspace.id
+
+    # Create a repository
+    repo = RegistryRepository(
+        organization_id=svc_admin_role.organization_id,
+        origin="test_origin",
+    )
+    session.add(repo)
+    await session.flush()
+
+    # Create version
+    version = RegistryVersion(
+        organization_id=svc_admin_role.organization_id,
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    session.add(version)
+    await session.flush()
+
+    # Create workflows with registry_lock referencing this version
+    workflow1 = Workflow(
+        workspace_id=workspace_id,
+        title="Workflow 1",
+        description="Test workflow 1",
+    )
+    workflow2 = Workflow(
+        workspace_id=workspace_id,
+        title="Workflow 2",
+        description="Test workflow 2",
+    )
+    workflow3 = Workflow(
+        workspace_id=workspace_id,
+        title="Workflow 3 (different version)",
+        description="Test workflow 3",
+    )
+    session.add_all([workflow1, workflow2, workflow3])
+    await session.flush()
+
+    # Create definitions - two reference v1.0.0, one references v2.0.0
+    # Note: WorkflowDefinition uses workspace_id, not organization_id
+    def1 = WorkflowDefinition(
+        workflow_id=workflow1.id,
+        workspace_id=workspace_id,
+        version=1,
+        content={},
+        registry_lock={
+            "origins": {"test_origin": "1.0.0"},
+            "actions": {},
+        },
+    )
+    def2 = WorkflowDefinition(
+        workflow_id=workflow2.id,
+        workspace_id=workspace_id,
+        version=1,
+        content={},
+        registry_lock={
+            "origins": {"test_origin": "1.0.0"},
+            "actions": {},
+        },
+    )
+    def3 = WorkflowDefinition(
+        workflow_id=workflow3.id,
+        workspace_id=workspace_id,
+        version=1,
+        content={},
+        registry_lock={
+            "origins": {"test_origin": "2.0.0"},  # Different version
+            "actions": {},
+        },
+    )
+    session.add_all([def1, def2, def3])
+    await session.commit()
+
+    # Query for definitions using version 1.0.0
+    versions_service = RegistryVersionsService(session, role=svc_admin_role)
+    definitions = await versions_service.get_workflow_definitions_using_version(
+        origin="test_origin",
+        version_string="1.0.0",
+    )
+
+    assert len(definitions) == 2
+    workflow_ids = {d.workflow_id for d in definitions}
+    assert workflow1.id in workflow_ids
+    assert workflow2.id in workflow_ids
+    assert workflow3.id not in workflow_ids

--- a/tracecat/registry/versions/schemas.py
+++ b/tracecat/registry/versions/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -179,3 +179,37 @@ class RegistryIndexRead(BaseModel):
     def action(self) -> str:
         """Full action identifier."""
         return f"{self.namespace}.{self.name}"
+
+
+# Version Diff Schemas
+
+
+class ActionInterfaceChange(BaseModel):
+    """Describes a change to an action's interface (expects or returns)."""
+
+    field: Literal["expects", "returns"]
+    change_type: Literal["added", "removed", "modified"]
+    old_value: dict[str, Any] | None = None
+    new_value: dict[str, Any] | None = None
+
+
+class ActionChange(BaseModel):
+    """Describes a change to an action between two versions."""
+
+    action_name: str
+    change_type: Literal["added", "removed", "modified"]
+    interface_changes: list[ActionInterfaceChange] = Field(default_factory=list)
+    description_changed: bool = False
+
+
+class VersionDiff(BaseModel):
+    """Result of comparing two registry versions."""
+
+    base_version_id: UUID
+    base_version: str
+    compare_version_id: UUID
+    compare_version: str
+    actions_added: list[str] = Field(default_factory=list)
+    actions_removed: list[str] = Field(default_factory=list)
+    actions_modified: list[ActionChange] = Field(default_factory=list)
+    total_changes: int = 0

--- a/tracecat/registry/versions/service.py
+++ b/tracecat/registry/versions/service.py
@@ -7,7 +7,8 @@ from typing import ClassVar
 from uuid import UUID
 
 from pydantic_core import to_jsonable_python
-from sqlalchemy import select
+from sqlalchemy import cast, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -17,11 +18,16 @@ from tracecat.db.models import (
     PlatformRegistryVersion,
     RegistryIndex,
     RegistryVersion,
+    WorkflowDefinition,
+    Workspace,
 )
 from tracecat.registry.versions.schemas import (
+    ActionChange,
+    ActionInterfaceChange,
     RegistryIndexCreate,
     RegistryVersionCreate,
     RegistryVersionManifest,
+    VersionDiff,
 )
 from tracecat.service import BaseOrgService, BaseService
 
@@ -220,6 +226,157 @@ class RegistryVersionsService(BaseOrgService):
         else:
             await self.session.flush()
         return index_entry
+
+    async def get_previous_version(
+        self,
+        repository_id: UUID,
+        current_version_id: UUID,
+    ) -> RegistryVersion | None:
+        """Get the most recent version before the current one.
+
+        Useful for quick rollback UX - returns the version to rollback to.
+        """
+        # Get the current version's created_at for comparison
+        current_stmt = select(RegistryVersion.created_at).where(
+            RegistryVersion.id == current_version_id,
+            RegistryVersion.organization_id == self.organization_id,
+        )
+        result = await self.session.execute(current_stmt)
+        current_created_at = result.scalar_one_or_none()
+        if current_created_at is None:
+            return None
+
+        # Find the most recent version before the current one
+        stmt = (
+            select(RegistryVersion)
+            .where(
+                RegistryVersion.repository_id == repository_id,
+                RegistryVersion.organization_id == self.organization_id,
+                RegistryVersion.created_at < current_created_at,
+            )
+            .order_by(RegistryVersion.created_at.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def compare_versions(
+        self,
+        base_version: RegistryVersion,
+        compare_version: RegistryVersion,
+    ) -> VersionDiff:
+        """Compare two versions and return a diff of changes.
+
+        Args:
+            base_version: The base version (typically older)
+            compare_version: The version to compare against (typically newer)
+
+        Returns:
+            VersionDiff containing added, removed, and modified actions
+        """
+        base_manifest = RegistryVersionManifest.model_validate(base_version.manifest)
+        compare_manifest = RegistryVersionManifest.model_validate(
+            compare_version.manifest
+        )
+
+        base_actions = set(base_manifest.actions.keys())
+        compare_actions = set(compare_manifest.actions.keys())
+
+        # Find added and removed actions
+        actions_added = sorted(compare_actions - base_actions)
+        actions_removed = sorted(base_actions - compare_actions)
+
+        # Find modified actions (actions present in both)
+        common_actions = base_actions & compare_actions
+        actions_modified: list[ActionChange] = []
+
+        for action_name in sorted(common_actions):
+            base_action = base_manifest.actions[action_name]
+            compare_action = compare_manifest.actions[action_name]
+
+            interface_changes: list[ActionInterfaceChange] = []
+            description_changed = base_action.description != compare_action.description
+
+            # Compare expects
+            base_expects = base_action.interface["expects"]
+            compare_expects = compare_action.interface["expects"]
+            if base_expects != compare_expects:
+                interface_changes.append(
+                    ActionInterfaceChange(
+                        field="expects",
+                        change_type="modified",
+                        old_value=base_expects,
+                        new_value=compare_expects,
+                    )
+                )
+
+            # Compare returns
+            base_returns = base_action.interface["returns"]
+            compare_returns = compare_action.interface["returns"]
+            if base_returns != compare_returns:
+                interface_changes.append(
+                    ActionInterfaceChange(
+                        field="returns",
+                        change_type="modified",
+                        old_value=base_returns,
+                        new_value=compare_returns,
+                    )
+                )
+
+            if interface_changes or description_changed:
+                actions_modified.append(
+                    ActionChange(
+                        action_name=action_name,
+                        change_type="modified",
+                        interface_changes=interface_changes,
+                        description_changed=description_changed,
+                    )
+                )
+
+        total_changes = (
+            len(actions_added) + len(actions_removed) + len(actions_modified)
+        )
+
+        return VersionDiff(
+            base_version_id=base_version.id,
+            base_version=base_version.version,
+            compare_version_id=compare_version.id,
+            compare_version=compare_version.version,
+            actions_added=actions_added,
+            actions_removed=actions_removed,
+            actions_modified=actions_modified,
+            total_changes=total_changes,
+        )
+
+    async def get_workflow_definitions_using_version(
+        self,
+        origin: str,
+        version_string: str,
+    ) -> Sequence[WorkflowDefinition]:
+        """Find all published workflow definitions that reference this registry version.
+
+        Args:
+            origin: The repository origin (e.g., 'tracecat_registry' or 'git+ssh://...')
+            version_string: The version string to search for
+
+        Returns:
+            List of WorkflowDefinition objects that reference this version
+        """
+        # Use JSONB containment to find definitions with this origin/version in registry_lock
+        # registry_lock structure: {"origins": {"origin": "version_string"}, "actions": {...}}
+        # Join with Workspace to filter by organization_id since WorkflowDefinition uses workspace_id
+        stmt = (
+            select(WorkflowDefinition)
+            .join(Workspace, WorkflowDefinition.workspace_id == Workspace.id)
+            .where(
+                Workspace.organization_id == self.organization_id,
+                WorkflowDefinition.registry_lock.op("@>")(
+                    cast({"origins": {origin: version_string}}, JSONB)
+                ),
+            )
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
 
 
 class PlatformRegistryVersionsService(BaseService):


### PR DESCRIPTION
## Summary
- Add API endpoints for version deletion, comparison, rollback, and usage detection
- New UI dialog for managing repository versions with promote/compare/delete actions
- Safety checks to prevent deleting current or in-use versions
- Unit tests for version management functionality

## Changes
- **Backend**: New endpoints in `/registry/repositories/{id}/versions`
- **Frontend**: `RepositoryVersionsDialog` component with version table and diff view
- **Tests**: 10 unit tests covering deletion, comparison, and usage detection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds version management APIs and a new UI to promote, compare, delete, and quickly rollback repository versions, with safeguards to prevent breaking workflows. This makes registry administration safer and more transparent.

- **New Features**
  - Backend: Delete version with checks, compare versions (diff), and fetch previous version for rollback; deletion blocked for current or workflow-referenced versions.
  - Frontend: RepositoryVersionsDialog with version table (promote/compare/delete), quick rollback, and a diff view showing added/removed/modified actions; wired into the repos table.
  - Tests: Coverage for deletion rules, diffs, previous version retrieval, and workflow usage detection.

<sup>Written for commit dc6947c436e76dd4caccc7febb2a8ca911fa5c71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

