### PR TITLE
fix(integrations): Incorrect Credentials on Google Suites Integrations

### DIFF
--- a/frontend/src/components/integrations/oauth-integration-details-dialog.tsx
+++ b/frontend/src/components/integrations/oauth-integration-details-dialog.tsx
@@ -52,7 +52,8 @@ export function OAuthIntegrationDetailsDialog({
     grantType,
   })
 
-  const isServiceAccountProvider = provider?.metadata.id === "google"
+  const serviceAccountProviders = ["google", "google_sheets", "google_docs"]
+  const isServiceAccountProvider = serviceAccountProviders.includes(provider?.metadata.id ?? "")
   const clientIdLabel = isServiceAccountProvider
     ? "Service account email"
     : "Client ID"

--- a/frontend/src/components/provider-config-form.tsx
+++ b/frontend/src/components/provider-config-form.tsx
@@ -141,7 +141,8 @@ export function ProviderConfigForm({
     token_endpoint_help: providerTokenHelp,
   } = provider
 
-  const isServiceAccountProvider = id === "google"
+  const serviceAccountProviders = ["google", "google_sheets", "google_docs"]
+  const isServiceAccountProvider = serviceAccountProviders.includes(id)
   const clientSecretMaxLength = isServiceAccountProvider ? 16384 : 512
   const validationSchema = useMemo(
     () => createOAuthSchema(clientSecretMaxLength),


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Currently, Tracecat provides several built-in Google Suites integrations (e.g., Google Docs, Google Sheets). These integrations requires a Service Accounts credentials, which Google provides in JSON key file format.

However, currently the input form in Tracecat UI incorrectly renders OAuth credentials form, which accepts a Client ID and Client Secret instead of a Service Account .json key file.

## Related Issues

Fixes https://github.com/TracecatHQ/tracecat/issues/2026

## Screenshots / Recordings



## Steps to QA

1. Click Integrations sidebar.
2. From the available list, select one of Google Suites-related integrations
  2.1. In this case, i will use Google Sheets (Service account).
3. Navigate to Configuration tab.
4. Verify that the Client Credentials Section asks for a Service Account Credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the credentials form for Google Suites integrations to show Service Account fields instead of OAuth client fields. Google Docs and Sheets now render the correct inputs and validation.

- **Bug Fixes**
  - Treat "google", "google_sheets", and "google_docs" as service-account providers.
  - Show "Service account email" and use the larger secret max length (16384) for service accounts.

<sup>Written for commit 12117a50d6a71d34788350750ccaa0ce5a224c18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

