### PR TITLE
fix(ui): copilot command item dedeup

### DIFF
--- a/frontend/src/components/chat/chat-history-dropdown.tsx
+++ b/frontend/src/components/chat/chat-history-dropdown.tsx
@@ -73,7 +73,7 @@ export function ChatHistoryDropdown({
                 {chats?.map((chat) => (
                   <CommandItem
                     key={chat.id}
-                    value={chat.title}
+                    value={`${chat.title} ${chat.id}`}
                     onSelect={() => handleSelect(chat.id)}
                     className="flex items-start justify-between gap-2 py-2"
                   >


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate collapsing in the chat history dropdown by making each command item value unique. Chats with the same title now show up and can be selected reliably.

- **Bug Fixes**
  - Set CommandItem value to `${chat.title} ${chat.id}` to avoid dedup collisions and ensure correct selection.

<sup>Written for commit 57a41bb0d3c353100ffc7504b537910ff6e670f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

