### PR TITLE
fix(agent): Allow empty action list in ai agent udf

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -10,7 +10,7 @@ class AgentActionArgs(BaseModel):
     user_prompt: str
     model_name: str
     model_provider: str
-    actions: list[str]
+    actions: list[str] | None = None
     instructions: str | None = None
     output_type: OutputType | None = None
     model_settings: dict[str, Any] | None = None

--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -189,10 +189,10 @@ async def agent(
     model_name: Annotated[str, Doc("Name of the model to use.")],
     model_provider: Annotated[str, Doc("Provider of the model to use.")],
     actions: Annotated[
-        list[str],
+        list[str] | None,
         Doc("Actions (e.g. 'tools.slack.post_message') to include in the agent."),
         ActionType(multiple=True),
-    ],
+    ] = None,
     instructions: Annotated[
         str | None, Doc("Instructions for the agent."), TextArea()
     ] = None,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow the agent UDF to accept an empty or omitted actions list. This prevents validation errors and lets agents run without tools when none are needed.

<sup>Written for commit ad886a6eea156ea2a496840932429147b84462df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

