### PR TITLE
fix(sandbox): mount proc instead of procfs

### DIFF
--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -307,7 +307,7 @@ class NsjailExecutor:
                 "",
                 "# Temporary filesystems",
                 'mount { dst: "/tmp" fstype: "tmpfs" rw: true options: "size=256M" }',
-                'mount { dst: "/proc" fstype: "proc" rw: false }',
+                'mount { src: "/proc" dst: "/proc" is_bind: true rw: false }',
             ]
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bind-mount /proc (read-only) from the host instead of creating a new procfs to fix sandbox startup in Docker. This avoids failures from masked paths in /proc while keeping PID namespace isolation intact.

<sup>Written for commit 1769e4b40b27626f1cac33e41fe5a0c34fb0b396. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

