### PR TITLE
fix(cases): fix incorrect query key

### DIFF
--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -297,7 +297,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     refetch,
   } = useQuery<CaseReadMinimal[], TracecatApiError>({
     queryKey: [
-      "cases-inbox",
+      "cases",
       workspaceId,
       queryParams.searchTerm,
       queryParams.status,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the React Query key in useCases from "cases-inbox" to "cases" to match the app’s standard key. This fixes cache invalidation and stale data issues when updating or refetching the cases list.

<sup>Written for commit d0a6252ae2e51154b08ef6e9144cbd154be5695e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

