### PR TITLE
fix(agent): Port ai action udf

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -8,12 +8,10 @@ from tracecat_registry import (
     RegistrySecret,
     RegistrySecretType,
     registry,
-    types,
 )
 from tracecat_registry._internal.exceptions import ActionIsInterfaceError
-from tracecat_registry.context import get_context
 from tracecat_registry.fields import ActionType, AgentPreset, TextArea
-from tracecat_registry.sdk.agents import AgentConfig, OutputType
+from tracecat_registry.sdk.agents import OutputType
 
 anthropic_secret = RegistrySecret(
     name="anthropic",
@@ -290,22 +288,9 @@ async def action(
     model_settings: Annotated[
         dict[str, Any] | None, Doc("Model settings for the agent.")
     ] = None,
-    max_requests: Annotated[int, Doc("Maximum number of requests for the agent.")] = 20,
-    retries: Annotated[int, Doc("Number of retries for the agent.")] = 6,
+    max_requests: Annotated[int, Doc("Maximum number of requests for the agent.")] = 45,
+    retries: Annotated[int, Doc("Number of retries for the agent.")] = 3,
     base_url: Annotated[str | None, Doc("Base URL of the model to use.")] = None,
-) -> types.AgentOutputRead:
+) -> dict[str, Any]:
     """Call an LLM with a given prompt and model (no tools)."""
-    ctx = get_context()
-    return await ctx.agents.run(
-        user_prompt=user_prompt,
-        config=AgentConfig(
-            model_name=model_name,
-            model_provider=model_provider,
-            instructions=instructions,
-            output_type=output_type,
-            model_settings=model_settings,
-            retries=retries,
-            base_url=base_url,
-        ),
-        max_requests=max_requests,
-    )
+    raise ActionIsInterfaceError()

--- a/tests/registry/test_agent.py
+++ b/tests/registry/test_agent.py
@@ -1,6 +1,5 @@
 import textwrap
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from tracecat_registry import ActionIsInterfaceError
@@ -119,18 +118,8 @@ async def test_action_primitives(output_type: Any) -> None:
         "Draft a brief, empathetic customer update about a resolved incident.",
     )
 
-    mock_result = {
-        "output": "Test output",
-        "message_history": None,
-        "duration": 1.0,
-        "usage": None,
-        "session_id": "test-session-id",
-    }
-    mock_ctx = MagicMock()
-    mock_ctx.agents.run = AsyncMock(return_value=mock_result)
-
-    with patch("tracecat_registry.core.agent.get_context", return_value=mock_ctx):
-        result = await action(
+    with pytest.raises(ActionIsInterfaceError):
+        await action(
             user_prompt=user_prompt,
             model_name="gpt-4o-mini",
             model_provider="openai",
@@ -138,15 +127,6 @@ async def test_action_primitives(output_type: Any) -> None:
             output_type=output_type,
             max_requests=3,
         )
-
-    assert result == mock_result
-    mock_ctx.agents.run.assert_called_once()
-    call_kwargs = mock_ctx.agents.run.call_args.kwargs
-    assert call_kwargs["user_prompt"] == user_prompt
-    assert call_kwargs["config"].model_name == "gpt-4o-mini"
-    assert call_kwargs["config"].model_provider == "openai"
-    assert call_kwargs["config"].output_type == output_type
-    assert call_kwargs["max_requests"] == 3
 
 
 @pytest.mark.anyio
@@ -157,18 +137,8 @@ async def test_action_json_schema(output_type: Any) -> None:
         "Draft a brief, empathetic customer update about a resolved incident.",
     )
 
-    mock_result = {
-        "output": {"summary": "Test summary", "confidence": 0.95},
-        "message_history": None,
-        "duration": 1.0,
-        "usage": None,
-        "session_id": "test-session-id",
-    }
-    mock_ctx = MagicMock()
-    mock_ctx.agents.run = AsyncMock(return_value=mock_result)
-
-    with patch("tracecat_registry.core.agent.get_context", return_value=mock_ctx):
-        result = await action(
+    with pytest.raises(ActionIsInterfaceError):
+        await action(
             user_prompt=user_prompt,
             model_name="gpt-4o-mini",
             model_provider="openai",
@@ -176,12 +146,3 @@ async def test_action_json_schema(output_type: Any) -> None:
             output_type=output_type,
             max_requests=3,
         )
-
-    assert result == mock_result
-    mock_ctx.agents.run.assert_called_once()
-    call_kwargs = mock_ctx.agents.run.call_args.kwargs
-    assert call_kwargs["user_prompt"] == user_prompt
-    assert call_kwargs["config"].model_name == "gpt-4o-mini"
-    assert call_kwargs["config"].model_provider == "openai"
-    assert call_kwargs["config"].output_type == output_type
-    assert call_kwargs["max_requests"] == 3

--- a/tracecat/dsl/enums.py
+++ b/tracecat/dsl/enums.py
@@ -27,6 +27,7 @@ class PlatformAction(StrEnum):
                 cls.TRANSFORM_GATHER,
                 cls.AI_AGENT,
                 cls.AI_PRESET_AGENT,
+                cls.AI_ACTION,
                 cls.RUN_PYTHON,
             )
         )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ported the agent action into the workflow engine and made the registry action interface-only to prevent direct calls. This routes agent runs through a child workflow with session and search metadata.

- **New Features**
  - Added execution for the agent action in DSL workflows: build args, start DurableAgentWorkflow on the agent queue, no tools.

- **Bug Fixes**
  - Updated the registry action to raise ActionIsInterfaceError (interface-only).
  - Added the action to interface_actions so it’s treated as an interface.
  - Simplified tests to assert the interface error for primitive and JSON schema outputs.

<sup>Written for commit 45fdf64b10fdf4fa0c901b8328dde9c66aa35a56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

