### PR TITLE
fix(docker,migration): Support external database for migrations

### DIFF
--- a/alembic/versions/4ef4d2e1d57b_update_default_org_uuid.py
+++ b/alembic/versions/4ef4d2e1d57b_update_default_org_uuid.py
@@ -23,18 +23,64 @@ depends_on: str | None = None
 DEFAULT_ORG_UUID = "00000000-0000-0000-0000-000000000000"
 
 
+def _get_fk_constraints(
+    connection: sa.Connection,
+) -> list[tuple[str, str, str, str, str, str, str]]:
+    """Query all single-column FK constraints referencing organization(id).
+
+    Returns list of (constraint_name, table_name, column_name,
+    ref_table, ref_column, on_delete_action, on_update_action).
+
+    Only single-column FKs are supported. Composite FKs are excluded.
+    """
+    rows = connection.execute(
+        sa.text("""
+            SELECT
+                c.conname AS constraint_name,
+                c.conrelid::regclass::text AS table_name,
+                a.attname AS column_name,
+                c.confrelid::regclass::text AS ref_table,
+                af.attname AS ref_column,
+                CASE c.confdeltype
+                    WHEN 'a' THEN 'NO ACTION'
+                    WHEN 'r' THEN 'RESTRICT'
+                    WHEN 'c' THEN 'CASCADE'
+                    WHEN 'n' THEN 'SET NULL'
+                    WHEN 'd' THEN 'SET DEFAULT'
+                END AS on_delete,
+                CASE c.confupdtype
+                    WHEN 'a' THEN 'NO ACTION'
+                    WHEN 'r' THEN 'RESTRICT'
+                    WHEN 'c' THEN 'CASCADE'
+                    WHEN 'n' THEN 'SET NULL'
+                    WHEN 'd' THEN 'SET DEFAULT'
+                END AS on_update
+            FROM pg_constraint c
+            JOIN pg_attribute a
+                ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1]
+            JOIN pg_attribute af
+                ON af.attrelid = c.confrelid AND af.attnum = c.confkey[1]
+            WHERE c.confrelid = 'organization'::regclass
+                AND c.contype = 'f'
+                AND array_length(c.conkey, 1) = 1
+        """)
+    ).fetchall()
+    return [(r[0], r[1], r[2], r[3], r[4], r[5], r[6]) for r in rows]
+
+
 def upgrade() -> None:
     """Update organizations with UUID(0) to a new random UUID.
 
     This migration:
     1. Finds any organization with id = UUID(0)
     2. Generates a new random UUID
-    3. Updates the organization and all FK references
+    3. Temporarily drops FK constraints referencing organization(id)
+    4. Updates the organization PK and all FK references
+    5. Re-creates the FK constraints
 
     Note: This is a data migration, not a schema migration. It only affects
     organizations that were created with the hardcoded default UUID.
     """
-    # Get a connection for raw SQL execution
     connection = op.get_bind()
 
     # Check if any organization has the default UUID
@@ -52,67 +98,86 @@ def upgrade() -> None:
     # Generate a new random UUID for the organization
     new_uuid = str(uuid4())
 
-    # List of tables with organization_id foreign key
-    fk_tables = [
-        # Direct FK to organization.id
-        "organization_settings",
-        "organization_membership",
-        "organization_invitation",
-        "organization_tier",
-        "workspace",
-        # Tables inheriting from OrganizationModel
-        "organization_secret",
-        "registry_repository",
-        "registry_action",
-        "registry_version",
-        "registry_index",
+    # Dynamically discover all FK constraints referencing organization(id).
+    # This avoids hardcoding table names and works on managed databases
+    # (e.g. RDS, Cloud SQL) that don't grant superuser privileges needed
+    # for DISABLE TRIGGER ALL.
+    fk_constraints = _get_fk_constraints(connection)
+
+    # Also find ALL tables with an organization_id column. Some tables may
+    # have the column but no FK constraint yet (FK added in a later migration).
+    # We need to update those too, otherwise the later FK migration would fail.
+    all_org_id_tables = [
+        r[0]
+        for r in connection.execute(
+            sa.text("""
+                SELECT c.relname
+                FROM pg_attribute a
+                JOIN pg_class c ON c.oid = a.attrelid
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE a.attname = 'organization_id'
+                    AND c.relkind = 'r'
+                    AND n.nspname = 'public'
+                    AND c.relname != 'organization'
+            """)
+        ).fetchall()
     ]
 
-    # Track which tables had triggers disabled for cleanup
-    disabled_tables: list[str] = []
+    # Drop all FK constraints referencing organization(id)
+    for constraint_name, table_name, *_ in fk_constraints:
+        connection.execute(
+            sa.text(f"ALTER TABLE {table_name} DROP CONSTRAINT {constraint_name}")
+        )
 
-    try:
-        # Temporarily disable FK constraint triggers on all affected tables
-        # This allows us to update the PK and FKs without constraint violations
-        # Note: DISABLE TRIGGER ALL requires table ownership or superuser privileges.
-        # Alembic migrations typically run with appropriate DB privileges.
-        for table in fk_tables:
-            table_exists = connection.execute(
-                sa.text(
-                    "SELECT EXISTS (SELECT FROM information_schema.tables "
-                    "WHERE table_name = :table_name)"
-                ),
-                {"table_name": table},
-            ).scalar()
-            if table_exists:
-                connection.execute(sa.text(f"ALTER TABLE {table} DISABLE TRIGGER ALL"))
-                disabled_tables.append(table)
+    # Disable user-defined triggers on all affected tables (e.g. immutability
+    # guards). DISABLE TRIGGER USER only affects user triggers and requires
+    # table ownership, not superuser — safe for managed databases.
+    for table_name in all_org_id_tables:
+        connection.execute(sa.text(f"ALTER TABLE {table_name} DISABLE TRIGGER USER"))
+    connection.execute(sa.text("ALTER TABLE organization DISABLE TRIGGER USER"))
 
-        connection.execute(sa.text("ALTER TABLE organization DISABLE TRIGGER ALL"))
+    # Update the organization PK
+    connection.execute(
+        sa.text(
+            "UPDATE organization SET id = CAST(:new_uuid AS uuid) "
+            "WHERE id = CAST(:old_uuid AS uuid)"
+        ),
+        {"new_uuid": new_uuid, "old_uuid": DEFAULT_ORG_UUID},
+    )
 
-        # Update the organization table first (parent)
+    # Update organization_id in ALL tables that have the column
+    for table_name in all_org_id_tables:
         connection.execute(
             sa.text(
-                "UPDATE organization SET id = CAST(:new_uuid AS uuid) "
-                "WHERE id = CAST(:old_uuid AS uuid)"
+                f"UPDATE {table_name} "
+                f"SET organization_id = CAST(:new_uuid AS uuid) "
+                f"WHERE organization_id = CAST(:old_uuid AS uuid)"
             ),
             {"new_uuid": new_uuid, "old_uuid": DEFAULT_ORG_UUID},
         )
 
-        # Update all FK references in child tables
-        for table in disabled_tables:
-            connection.execute(
-                sa.text(
-                    f"UPDATE {table} SET organization_id = CAST(:new_uuid AS uuid) "
-                    f"WHERE organization_id = CAST(:old_uuid AS uuid)"
-                ),
-                {"new_uuid": new_uuid, "old_uuid": DEFAULT_ORG_UUID},
+    # Re-enable user-defined triggers
+    connection.execute(sa.text("ALTER TABLE organization ENABLE TRIGGER USER"))
+    for table_name in all_org_id_tables:
+        connection.execute(sa.text(f"ALTER TABLE {table_name} ENABLE TRIGGER USER"))
+
+    # Re-create all FK constraints with original ON DELETE/ON UPDATE actions
+    for (
+        constraint_name,
+        table_name,
+        column_name,
+        ref_table,
+        ref_column,
+        on_delete,
+        on_update,
+    ) in fk_constraints:
+        connection.execute(
+            sa.text(
+                f"ALTER TABLE {table_name} ADD CONSTRAINT {constraint_name} "
+                f"FOREIGN KEY ({column_name}) REFERENCES {ref_table}({ref_column}) "
+                f"ON DELETE {on_delete} ON UPDATE {on_update}"
             )
-    finally:
-        # Re-enable FK constraint triggers - always run even if migration fails
-        connection.execute(sa.text("ALTER TABLE organization ENABLE TRIGGER ALL"))
-        for table in disabled_tables:
-            connection.execute(sa.text(f"ALTER TABLE {table} ENABLE TRIGGER ALL"))
+        )
 
 
 def downgrade() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,6 +332,7 @@ services:
     container_name: migrations
     restart: "no"
     networks:
+      - core
       - core-db
     environment:
       LOG_LEVEL: ${LOG_LEVEL}


### PR DESCRIPTION
## Summary
- Add `core` network to `migrations` service in `docker-compose.yml` — the `core-db` network is `internal: true`, which blocks DNS resolution for external database hostnames
- Replace `DISABLE TRIGGER ALL` (requires PostgreSQL superuser) in migration `4ef4d2e1d57b` with a drop/recreate FK constraints approach that works on managed databases (RDS, Cloud SQL, etc.)
- Use `DISABLE TRIGGER USER` for user-defined triggers (e.g. workspace org immutability guard), which only requires table ownership

## Test plan
- [x] Verified full migration chain passes on fresh DB (superuser)
- [x] Verified full migration chain passes as non-superuser (`restricted_user`)
- [x] Verified UUID(0) org + child rows (workspace, organization_settings) are correctly updated
- [x] Verified FK constraints and user triggers are restored after migration
- [x] Verified subsequent migration (`5a3b7c8d9e0f` add_organization_fk_constraints) passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Alembic migrations to run against external/managed Postgres by fixing Docker networking and replacing superuser-only trigger logic with a safe FK drop/recreate flow.

- **Bug Fixes**
  - Docker: add core network to the migrations service so it can resolve external DB hosts (core-db is internal).
  - Migration 4ef4d2e1d57b: dynamically discover single-column FKs to organization(id), drop/recreate them preserving ON DELETE/ON UPDATE, update all tables with organization_id, and use DISABLE TRIGGER USER for user-defined triggers.
  - Compatible with non-superuser roles on RDS/Cloud SQL; verified full migration chain and restoration of constraints/triggers.

<sup>Written for commit 7b33bfe5dd9e27b04f02c9ebdbc3cb02648dc919. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

