### PR TITLE
Resolve org ID for service roles from workspace context

### DIFF
--- a/tracecat/webhooks/dependencies.py
+++ b/tracecat/webhooks/dependencies.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
 from tracecat.auth.api_keys import verify_api_key
+from tracecat.auth.credentials import resolve_workspace_organization_id
 from tracecat.auth.types import Role
 from tracecat.authz.enums import WorkspaceRole
 from tracecat.contexts import ctx_role
@@ -173,10 +174,12 @@ async def validate_incoming_webhook(
             session.add(webhook.api_key)
             await session.commit()
 
+        organization_id = await resolve_workspace_organization_id(webhook.workspace_id)
         ctx_role.set(
             Role(
                 type="service",
                 workspace_id=webhook.workspace_id,
+                organization_id=organization_id,
                 service_id="tracecat-runner",
                 workspace_role=WorkspaceRole.EDITOR,
             )


### PR DESCRIPTION
### Motivation
- Service roles constructed from incoming headers sometimes lacked `organization_id` when only a `workspace_id` was present, which breaks org-scoped authorization and secret access.
- Populate organization context from workspace IDs to ensure consistent authorization for service-initiated requests and webhook handling.

### Description
- Added `resolve_workspace_organization_id(workspace_id)` to `tracecat/auth/credentials.py` which delegates to the cached `_get_workspace_org_id` lookup to resolve a workspace→organization mapping.
- Updated `_authenticate_service` in `tracecat/auth/credentials.py` to call `resolve_workspace_organization_id` and include `organization_id` when constructing the `Role` returned for authenticated services.
- Updated `tracecat/webhooks/dependencies.py` to resolve the organization for the webhook `workspace_id` and include `organization_id` on the `Role` set in `ctx_role` for the webhook runner.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869987c73483209d3b1af578bfeabe)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate organization_id for service roles by resolving it from workspace_id. Restores org-scoped authorization and secret access for service-auth and webhooks.

- **Bug Fixes**
  - Added resolve_workspace_organization_id(...) to map workspace -> organization via cached lookup.
  - Used the resolver in _authenticate_service and webhook dependencies to set organization_id on Role.

<sup>Written for commit 86aa489787afaa4ae7a5108230cda98029cfe199. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

