### PR TITLE
test: add integration test for webhook-triggered workflows

### DIFF
--- a/tests/integration/test_webhook_trigger_integration.py
+++ b/tests/integration/test_webhook_trigger_integration.py
@@ -1,0 +1,97 @@
+"""Integration tests for webhook-triggered workflow execution."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from tests.database import TEST_DB_CONFIG
+from tracecat import config
+from tracecat.api.app import app
+from tracecat.db.engine import get_async_session_context_manager, reset_async_engine
+from tracecat.db.models import Webhook
+from tracecat.dsl.common import DSLInput
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.storage.object import InlineObject, StoredObjectValidator, get_object_storage
+from tracecat.storage.utils import resolve_execution_context
+from tracecat.workflow.store.import_service import WorkflowImportService
+from tracecat.workflow.store.schemas import RemoteWebhook, RemoteWorkflowDefinition
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.usefixtures("db", "registry_version_with_manifest"),
+]
+
+
+@pytest.fixture(autouse=True)
+def use_test_db_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point application DB access at the per-test database."""
+    monkeypatch.setenv("TRACECAT__DB_URI", TEST_DB_CONFIG.test_url)
+    monkeypatch.setattr(config, "TRACECAT__DB_URI", TEST_DB_CONFIG.test_url)
+    reset_async_engine()
+    yield
+    reset_async_engine()
+
+
+@pytest.mark.anyio
+async def test_webhook_trigger_creates_execution(
+    svc_role,
+    temporal_client,
+    test_worker_factory,
+) -> None:
+    dsl = DSLInput.from_yaml(
+        Path("tests/data/workflows/integration_webhook_concat.yml")
+    )
+    remote_definition = RemoteWorkflowDefinition(
+        id="wf_webhookintegration",
+        alias="webhook-integration",
+        webhook=RemoteWebhook(methods=["POST"], status="online"),
+        definition=dsl,
+    )
+    async with get_async_session_context_manager() as session:
+        import_service = WorkflowImportService(session=session, role=svc_role)
+        result = await import_service.import_workflows_atomic(
+            remote_workflows=[remote_definition],
+            commit_sha="a" * 40,
+        )
+        assert result.success is True
+
+        workflow_id = WorkflowUUID.new(remote_definition.id)
+        webhook = (
+            await session.execute(
+                select(Webhook).where(Webhook.workflow_id == workflow_id)
+            )
+        ).scalar_one()
+        webhook_secret = webhook.secret
+
+    transport = ASGITransport(app=app)
+    async with test_worker_factory(temporal_client):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/webhooks/{workflow_id.short()}/{webhook_secret}",
+                json={"text": "hello"},
+            )
+
+        assert response.status_code == 200
+        payload = response.json()
+        wf_exec_id = payload["wf_exec_id"]
+
+        handle = temporal_client.get_workflow_handle_for(DSLWorkflow.run, wf_exec_id)
+        stored_result = await asyncio.wait_for(handle.result(), timeout=30)
+
+    stored = StoredObjectValidator.validate_python(stored_result)
+    data = await get_object_storage().retrieve(stored)
+    resolved_context = await resolve_execution_context(data)
+
+    trigger = resolved_context["TRIGGER"]
+    assert isinstance(trigger, InlineObject)
+    assert trigger.data == {"text": "hello"}
+
+    action_a = resolved_context["ACTIONS"]["a"]
+    assert isinstance(action_a.result, InlineObject)
+    assert action_a.result.data == "hello"


### PR DESCRIPTION
### Motivation
- Add coverage for the external webhook trigger path to verify the end-to-end flow from HTTP webhook to Temporal workflow execution and final execution context.
- Ensure webhook payloads are properly stored and exposed in the workflow execution `TRIGGER` and used by downstream actions.

### Description
- Add `tests/integration/test_webhook_trigger_integration.py` which imports a webhook-enabled DSL workflow into the DB via `WorkflowImportService` and verifies a `Webhook` record was created with a valid secret.
- Exercise the API via an ASGI `AsyncClient` POST to `/webhooks/{workflow_id}/{secret}`, then obtain the Temporal workflow execution ID from the response and wait for the workflow result via `temporal_client`.
- Validate the returned `StoredObject` by retrieving it from the configured object storage and resolving the execution context with `resolve_execution_context`, then assert the `TRIGGER` and action `a` result are Inline objects with expected payloads.
- Test fixture config points the app at the per-test database by setting `TRACECAT__DB_URI` and calling `reset_async_engine()` to ensure the test session is isolated.

### Testing
- No automated tests were executed in this rollout; the new test can be run with `uv run pytest tests/integration/test_webhook_trigger_integration.py` and is marked `@pytest.mark.anyio` and uses `db` and `registry_version_with_manifest` fixtures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698698ee26188320b8e3db5514392509)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an end-to-end integration test for webhook-triggered workflows, verifying the HTTP webhook creates a Temporal execution and that the webhook payload is exposed in TRIGGER and action "a" output. Ensures DB isolation per test and validates the stored result via object storage and execution context resolution.

<sup>Written for commit 2f3effa08b6a0406eaf7393d11f64a67012afac1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

