### PR TITLE
fix(tests): align MinIO creds and isolate Redis test DBs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,10 +110,10 @@ def _minio_credentials() -> tuple[str, str]:
 # Redis test configuration
 # ---------------------------------------------------------------------------
 
-# Worker-specific Redis database number for pytest-xdist isolation
-# Each xdist worker uses a different database (0-15) to avoid conflicts
-# when multiple workers run tests in parallel
-REDIS_DB = WORKER_OFFSET % 16
+# Worker-specific Redis database number for pytest-xdist isolation.
+# Reserve DB 0 for dockerized services started by integration tests (api/worker),
+# and run pytest against DBs 1-15 to avoid clobbering app streams/groups.
+REDIS_DB = (WORKER_OFFSET % 15) + 1
 
 # Redis URL - use Docker hostname when inside container, localhost otherwise
 # Ignore REDIS_URL from .env as it contains Docker-internal hostname


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns MinIO test credentials with docker-compose/.env and isolates Redis test databases per xdist worker to prevent cross-test conflicts and CI flakiness.

- **Bug Fixes**
  - Read MinIO credentials from environment (dotenv), falling back to defaults; update fixtures to use them.
  - Reserve Redis DB 0 for app services; use DBs 1–15 per worker for pytest-xdist isolation.
  - Handle MinIO S3Error when ensuring the test bucket to surface clear failures.

<sup>Written for commit 791be728937a104993df90114bd09051e20a1a20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

