### PR TITLE
fix(workflow): auto-heal legacy schedule roles missing organization_id

### DIFF
--- a/tests/unit/test_schedule_role_healing.py
+++ b/tests/unit/test_schedule_role_healing.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.dsl.common import DSLRunArgs
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.schedules.service import WorkflowSchedulesService
+
+
+@pytest.mark.anyio
+async def test_get_workspace_organization_id_activity_returns_match(monkeypatch):
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = organization_id
+    mock_session.execute.return_value = mock_result
+
+    @asynccontextmanager
+    async def fake_session_manager():
+        yield mock_session
+
+    monkeypatch.setattr(
+        "tracecat.workflow.schedules.service.get_async_session_context_manager",
+        fake_session_manager,
+    )
+
+    result = await WorkflowSchedulesService.get_workspace_organization_id_activity(
+        workspace_id
+    )
+
+    assert result == organization_id
+
+
+@pytest.mark.anyio
+async def test_get_workspace_organization_id_activity_returns_none_when_missing(
+    monkeypatch,
+):
+    workspace_id = uuid.uuid4()
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = mock_result
+
+    @asynccontextmanager
+    async def fake_session_manager():
+        yield mock_session
+
+    monkeypatch.setattr(
+        "tracecat.workflow.schedules.service.get_async_session_context_manager",
+        fake_session_manager,
+    )
+
+    result = await WorkflowSchedulesService.get_workspace_organization_id_activity(
+        workspace_id
+    )
+
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_dsl_workflow_auto_heals_missing_organization_id():
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    role = Role(
+        type="service",
+        service_id="tracecat-schedule-runner",
+        workspace_id=workspace_id,
+    )
+    args = DSLRunArgs(role=role, wf_id=WorkflowUUID.new_uuid4())
+
+    fake_wf_info = SimpleNamespace(
+        workflow_id="wf-test",
+        run_id="run-test",
+        run_timeout=None,
+        execution_timeout=None,
+        task_timeout=None,
+        retry_policy=None,
+        get_current_history_length=lambda: 0,
+        get_current_history_size=lambda: 0,
+    )
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.info", return_value=fake_wf_info),
+        patch(
+            "tracecat.dsl.workflow.workflow.execute_activity",
+            new=AsyncMock(return_value=organization_id),
+        ),
+    ):
+        dsl_workflow = DSLWorkflow(args)
+        await dsl_workflow._heal_role_organization_id_if_missing()
+
+    assert dsl_workflow.role.organization_id == organization_id
+
+
+@pytest.mark.anyio
+async def test_dsl_workflow_auto_heal_skips_when_workspace_missing():
+    role = Role(type="service", service_id="tracecat-schedule-runner")
+    args = DSLRunArgs(role=role, wf_id=WorkflowUUID.new_uuid4())
+
+    fake_wf_info = SimpleNamespace(
+        workflow_id="wf-test",
+        run_id="run-test",
+        run_timeout=None,
+        execution_timeout=None,
+        task_timeout=None,
+        retry_policy=None,
+        get_current_history_length=lambda: 0,
+        get_current_history_size=lambda: 0,
+    )
+    mock_execute_activity = AsyncMock()
+
+    with (
+        patch("tracecat.dsl.workflow.workflow.info", return_value=fake_wf_info),
+        patch(
+            "tracecat.dsl.workflow.workflow.execute_activity",
+            new=mock_execute_activity,
+        ),
+    ):
+        dsl_workflow = DSLWorkflow(args)
+        await dsl_workflow._heal_role_organization_id_if_missing()
+
+    assert dsl_workflow.role.organization_id is None
+    mock_execute_activity.assert_not_called()

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -263,8 +263,47 @@ class DSLWorkflow:
             raise ValueError("Workspace ID is required")
         return self.role.workspace_id
 
+    async def _heal_role_organization_id_if_missing(self) -> None:
+        """Recover missing organization_id for legacy scheduled workflow roles."""
+        if self.role.organization_id is not None:
+            return
+
+        if self.role.workspace_id is None:
+            self.logger.warning(
+                "Role is missing organization_id and workspace_id; skipping auto-heal"
+            )
+            return
+
+        self.logger.warning(
+            "Role missing organization_id; attempting workspace-based auto-heal",
+            workspace_id=self.role.workspace_id,
+        )
+        organization_id = await workflow.execute_activity(
+            WorkflowSchedulesService.get_workspace_organization_id_activity,
+            arg=self.role.workspace_id,
+            start_to_close_timeout=self.start_to_close_timeout,
+            retry_policy=RETRY_POLICIES["activity:fail_slow"],
+        )
+        if organization_id is None:
+            self.logger.warning(
+                "Auto-heal could not resolve organization_id from workspace",
+                workspace_id=self.role.workspace_id,
+            )
+            return
+
+        self.role = self.role.model_copy(update={"organization_id": organization_id})
+        self.logger = self.logger.bind(role=self.role)
+        ctx_role.set(self.role)
+        self.logger.info(
+            "Auto-healed role organization_id",
+            organization_id=organization_id,
+            workspace_id=self.role.workspace_id,
+        )
+
     @workflow.run
     async def run(self, args: DSLRunArgs) -> StoredObject:
+        await self._heal_role_organization_id_if_missing()
+
         # Set DSL and registry_lock
         registry_lock = None
         if args.dsl:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -294,6 +294,7 @@ class DSLWorkflow:
         self.role = self.role.model_copy(update={"organization_id": organization_id})
         self.logger = self.logger.bind(role=self.role)
         ctx_role.set(self.role)
+        ctx_logger.set(self.logger)
         self.logger.info(
             "Auto-healed role organization_id",
             organization_id=organization_id,

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -5,10 +5,11 @@ from sqlalchemy.exc import NoResultFound
 from temporalio import activity
 
 from tracecat.auth.types import AccessLevel
-from tracecat.db.models import Schedule
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import Schedule, Workspace
 from tracecat.db.session_events import add_after_commit_callback
 from tracecat.exceptions import TracecatNotFoundError
-from tracecat.identifiers import ScheduleUUID, WorkflowID
+from tracecat.identifiers import OrganizationID, ScheduleUUID, WorkflowID, WorkspaceID
 from tracecat.identifiers.schedules import AnyScheduleID
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
@@ -275,6 +276,21 @@ class WorkflowSchedulesService(BaseWorkspaceService):
             await self.session.commit()
         else:
             await self.session.flush()
+
+    @staticmethod
+    @activity.defn
+    async def get_workspace_organization_id_activity(
+        workspace_id: WorkspaceID,
+    ) -> OrganizationID | None:
+        """Resolve organization_id for a workspace.
+
+        This activity is used to heal legacy scheduled workflow roles that are
+        missing organization_id in their serialized schedule arguments.
+        """
+        async with get_async_session_context_manager() as session:
+            stmt = select(Workspace.organization_id).where(Workspace.id == workspace_id)
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
 
     @staticmethod
     @activity.defn


### PR DESCRIPTION
## Summary
- add runtime auto-heal in `DSLWorkflow` for legacy roles missing `organization_id`
- resolve `organization_id` from `workspace_id` via a new Temporal activity in schedules service
- update role/context/logger bindings after healing so downstream activities get the corrected role
- add unit tests for workspace lookup and role-heal behavior
- add temporal coverage in `tests/temporal/test_workflows.py` verifying scheduled execution and legacy role self-heal

## Testing
- `uv run ruff check tracecat/dsl/workflow.py tracecat/workflow/schedules/service.py tests/unit/test_schedule_role_healing.py tests/temporal/test_workflows.py`
- `uv run basedpyright tracecat/dsl/workflow.py tracecat/workflow/schedules/service.py tests/unit/test_schedule_role_healing.py tests/temporal/test_workflows.py`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_schedule_role_healing.py`
- `COMPOSE_PROJECT_NAME=tracecat TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/temporal/test_workflows.py -k legacy_role_auto_heals_organization_id`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-heals legacy scheduled workflow roles missing organization_id at workflow start by looking it up from workspace_id. Prevents schedule runs from failing and keeps role and logging context consistent.

- **Bug Fixes**
  - Added Temporal activity get_workspace_organization_id_activity to resolve organization_id from a workspace, with a fail_slow retry policy.
  - DSLWorkflow heals on start, updates role, ctx_role, and ctx_logger, and skips with a warning when workspace_id is absent or lookup returns None. Added unit and Temporal tests, including verification that the activity is scheduled during scheduled runs.

- **Migration**
  - No action needed. Healing occurs automatically at runtime for existing schedules.

<sup>Written for commit fd3647c7bd4560a6c36993999e891c51be52166e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

