### PR TITLE
feat(admin): add superuser organization domain assignment APIs

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9953,6 +9953,127 @@ export const $OrgCreate = {
   description: "Create organization request.",
 } as const
 
+export const $OrgDomainCreate = {
+  properties: {
+    domain: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Domain",
+    },
+    is_primary: {
+      type: "boolean",
+      title: "Is Primary",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["domain"],
+  title: "OrgDomainCreate",
+  description: "Create organization domain request.",
+} as const
+
+export const $OrgDomainRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    organization_id: {
+      type: "string",
+      format: "uuid",
+      title: "Organization Id",
+    },
+    domain: {
+      type: "string",
+      title: "Domain",
+    },
+    normalized_domain: {
+      type: "string",
+      title: "Normalized Domain",
+    },
+    is_primary: {
+      type: "boolean",
+      title: "Is Primary",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    verified_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Verified At",
+    },
+    verification_method: {
+      type: "string",
+      title: "Verification Method",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "organization_id",
+    "domain",
+    "normalized_domain",
+    "is_primary",
+    "is_active",
+    "verification_method",
+    "created_at",
+    "updated_at",
+  ],
+  title: "OrgDomainRead",
+  description: "Organization domain response.",
+} as const
+
+export const $OrgDomainUpdate = {
+  properties: {
+    is_primary: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Is Primary",
+    },
+    is_active: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Is Active",
+    },
+  },
+  type: "object",
+  title: "OrgDomainUpdate",
+  description: "Update organization domain request.",
+} as const
+
 export const $OrgInvitationAccept = {
   properties: {
     token: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -17,10 +17,14 @@ import type {
   ActionsUpdateActionData,
   ActionsUpdateActionResponse,
   AdminCreateOrganizationData,
+  AdminCreateOrganizationDomainData,
+  AdminCreateOrganizationDomainResponse,
   AdminCreateOrganizationResponse,
   AdminCreateTierData,
   AdminCreateTierResponse,
   AdminDeleteOrganizationData,
+  AdminDeleteOrganizationDomainData,
+  AdminDeleteOrganizationDomainResponse,
   AdminDeleteOrganizationResponse,
   AdminDeleteTierData,
   AdminDeleteTierResponse,
@@ -35,11 +39,15 @@ import type {
   AdminGetTierResponse,
   AdminGetUserData,
   AdminGetUserResponse,
+  AdminListOrganizationDomainsData,
+  AdminListOrganizationDomainsResponse,
   AdminListOrganizationsResponse,
   AdminListOrgRepositoriesData,
   AdminListOrgRepositoriesResponse,
   AdminListOrgRepositoryVersionsData,
   AdminListOrgRepositoryVersionsResponse,
+  AdminListOrgTiersData,
+  AdminListOrgTiersResponse,
   AdminListTiersData,
   AdminListTiersResponse,
   AdminListUsersResponse,
@@ -62,6 +70,8 @@ import type {
   AdminSyncOrgRepositoryData,
   AdminSyncOrgRepositoryResponse,
   AdminUpdateOrganizationData,
+  AdminUpdateOrganizationDomainData,
+  AdminUpdateOrganizationDomainResponse,
   AdminUpdateOrganizationResponse,
   AdminUpdateOrgTierData,
   AdminUpdateOrgTierResponse,
@@ -4129,6 +4139,108 @@ export const adminDeleteOrganization = (
 }
 
 /**
+ * List Organization Domains
+ * List all assigned domains for an organization.
+ * @param data The data for the request.
+ * @param data.orgId
+ * @returns OrgDomainRead Successful Response
+ * @throws ApiError
+ */
+export const adminListOrganizationDomains = (
+  data: AdminListOrganizationDomainsData
+): CancelablePromise<AdminListOrganizationDomainsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/admin/organizations/{org_id}/domains",
+    path: {
+      org_id: data.orgId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Organization Domain
+ * Create a new assigned domain for an organization.
+ * @param data The data for the request.
+ * @param data.orgId
+ * @param data.requestBody
+ * @returns OrgDomainRead Successful Response
+ * @throws ApiError
+ */
+export const adminCreateOrganizationDomain = (
+  data: AdminCreateOrganizationDomainData
+): CancelablePromise<AdminCreateOrganizationDomainResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/admin/organizations/{org_id}/domains",
+    path: {
+      org_id: data.orgId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Organization Domain
+ * Update active/primary state for an assigned organization domain.
+ * @param data The data for the request.
+ * @param data.orgId
+ * @param data.domainId
+ * @param data.requestBody
+ * @returns OrgDomainRead Successful Response
+ * @throws ApiError
+ */
+export const adminUpdateOrganizationDomain = (
+  data: AdminUpdateOrganizationDomainData
+): CancelablePromise<AdminUpdateOrganizationDomainResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/admin/organizations/{org_id}/domains/{domain_id}",
+    path: {
+      org_id: data.orgId,
+      domain_id: data.domainId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Organization Domain
+ * Delete an assigned organization domain.
+ * @param data The data for the request.
+ * @param data.orgId
+ * @param data.domainId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const adminDeleteOrganizationDomain = (
+  data: AdminDeleteOrganizationDomainData
+): CancelablePromise<AdminDeleteOrganizationDomainResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/admin/organizations/{org_id}/domains/{domain_id}",
+    path: {
+      org_id: data.orgId,
+      domain_id: data.domainId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * List Org Repositories
  * List registry repositories for an organization.
  * @param data The data for the request.
@@ -4306,6 +4418,29 @@ export const adminCreateTier = (
     url: "/admin/tiers",
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Org Tiers
+ * List tier assignments for organizations.
+ * @param data The data for the request.
+ * @param data.orgIds Optional list of organization IDs to filter results
+ * @returns OrganizationTierRead Successful Response
+ * @throws ApiError
+ */
+export const adminListOrgTiers = (
+  data: AdminListOrgTiersData = {}
+): CancelablePromise<AdminListOrgTiersResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/admin/tiers/organizations",
+    query: {
+      org_ids: data.orgIds,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3213,6 +3213,38 @@ export type OrgCreate = {
 }
 
 /**
+ * Create organization domain request.
+ */
+export type OrgDomainCreate = {
+  domain: string
+  is_primary?: boolean
+}
+
+/**
+ * Organization domain response.
+ */
+export type OrgDomainRead = {
+  id: string
+  organization_id: string
+  domain: string
+  normalized_domain: string
+  is_primary: boolean
+  is_active: boolean
+  verified_at?: string | null
+  verification_method: string
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Update organization domain request.
+ */
+export type OrgDomainUpdate = {
+  is_primary?: boolean | null
+  is_active?: boolean | null
+}
+
+/**
  * Request body for accepting an organization invitation via token.
  */
 export type OrgInvitationAccept = {
@@ -7353,6 +7385,34 @@ export type AdminDeleteOrganizationData = {
 
 export type AdminDeleteOrganizationResponse = void
 
+export type AdminListOrganizationDomainsData = {
+  orgId: string
+}
+
+export type AdminListOrganizationDomainsResponse = Array<OrgDomainRead>
+
+export type AdminCreateOrganizationDomainData = {
+  orgId: string
+  requestBody: OrgDomainCreate
+}
+
+export type AdminCreateOrganizationDomainResponse = OrgDomainRead
+
+export type AdminUpdateOrganizationDomainData = {
+  domainId: string
+  orgId: string
+  requestBody: OrgDomainUpdate
+}
+
+export type AdminUpdateOrganizationDomainResponse = OrgDomainRead
+
+export type AdminDeleteOrganizationDomainData = {
+  domainId: string
+  orgId: string
+}
+
+export type AdminDeleteOrganizationDomainResponse = void
+
 export type AdminListOrgRepositoriesData = {
   orgId: string
 }
@@ -7406,6 +7466,15 @@ export type AdminCreateTierData = {
 }
 
 export type AdminCreateTierResponse = TierRead
+
+export type AdminListOrgTiersData = {
+  /**
+   * Optional list of organization IDs to filter results
+   */
+  orgIds?: Array<string> | null
+}
+
+export type AdminListOrgTiersResponse = Array<OrganizationTierRead>
 
 export type AdminGetTierData = {
   tierId: string
@@ -10569,6 +10638,62 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/admin/organizations/{org_id}/domains": {
+    get: {
+      req: AdminListOrganizationDomainsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<OrgDomainRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AdminCreateOrganizationDomainData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: OrgDomainRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/organizations/{org_id}/domains/{domain_id}": {
+    patch: {
+      req: AdminUpdateOrganizationDomainData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: OrgDomainRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AdminDeleteOrganizationDomainData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
   "/admin/organizations/{org_id}/registry/repositories": {
     get: {
       req: AdminListOrgRepositoriesData
@@ -10673,6 +10798,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         201: TierRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/tiers/organizations": {
+    get: {
+      req: AdminListOrgTiersData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<OrganizationTierRead>
         /**
          * Validation Error
          */

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
@@ -143,7 +143,12 @@ async def create_organization_domain(
         return await service.create_org_domain(org_id, params)
     except ValueError as e:
         detail = str(e)
-        if "already assigned" in detail.lower():
+        detail_lower = detail.lower()
+        if "not found" in detail_lower:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=detail
+            ) from e
+        if "already assigned" in detail_lower:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail=detail
             ) from e

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/schemas.py
@@ -38,6 +38,40 @@ class OrgRead(Schema):
     model_config = {"from_attributes": True}
 
 
+# Org Domain Schemas
+
+
+class OrgDomainCreate(Schema):
+    """Create organization domain request."""
+
+    domain: str = Field(..., min_length=1, max_length=255)
+    is_primary: bool = False
+
+
+class OrgDomainUpdate(Schema):
+    """Update organization domain request."""
+
+    is_primary: bool | None = None
+    is_active: bool | None = None
+
+
+class OrgDomainRead(Schema):
+    """Organization domain response."""
+
+    id: uuid.UUID
+    organization_id: uuid.UUID
+    domain: str
+    normalized_domain: str
+    is_primary: bool
+    is_active: bool
+    verified_at: datetime | None = None
+    verification_method: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 # Org Registry Schemas
 
 

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
@@ -10,16 +10,24 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.service import AuditService
+from tracecat.audit.types import AuditAction
 from tracecat.auth.types import AccessLevel, Role
 from tracecat.db.models import (
     Organization,
+    OrganizationDomain,
     RegistryRepository,
     RegistryVersion,
 )
+from tracecat.organization.domains import normalize_domain
 from tracecat.organization.management import create_organization_with_defaults
 from tracecat.service import BasePlatformService
 from tracecat_ee.admin.organizations.schemas import (
     OrgCreate,
+    OrgDomainCreate,
+    OrgDomainRead,
+    OrgDomainUpdate,
     OrgRead,
     OrgRegistryRepositoryRead,
     OrgRegistrySyncResponse,
@@ -89,6 +97,270 @@ class AdminOrgService(BasePlatformService):
 
         await self.session.delete(org)
         await self.session.commit()
+
+    # Org Domain Methods
+
+    async def list_org_domains(self, org_id: uuid.UUID) -> Sequence[OrgDomainRead]:
+        """List assigned domains for an organization."""
+        await self.get_organization(org_id)
+        stmt = (
+            select(OrganizationDomain)
+            .where(OrganizationDomain.organization_id == org_id)
+            .order_by(
+                OrganizationDomain.is_primary.desc(),
+                OrganizationDomain.created_at.asc(),
+                OrganizationDomain.id.asc(),
+            )
+        )
+        result = await self.session.execute(stmt)
+        return OrgDomainRead.list_adapter().validate_python(result.scalars().all())
+
+    async def create_org_domain(
+        self, org_id: uuid.UUID, params: OrgDomainCreate
+    ) -> OrgDomainRead:
+        """Create and assign a domain to an organization."""
+        await self.get_organization(org_id)
+        normalized = normalize_domain(params.domain)
+        await self._audit_domain_event(action="create", status=AuditEventStatus.ATTEMPT)
+
+        stmt = select(OrganizationDomain).where(
+            OrganizationDomain.organization_id == org_id,
+            OrganizationDomain.is_active.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        active_domains = list(result.scalars().all())
+        is_primary = params.is_primary or len(active_domains) == 0
+
+        if is_primary:
+            await self._demote_active_primaries(org_id=org_id)
+
+        domain = OrganizationDomain(
+            organization_id=org_id,
+            domain=normalized.domain,
+            normalized_domain=normalized.normalized_domain,
+            is_primary=is_primary,
+            is_active=True,
+            verification_method="platform_admin",
+            verified_at=None,
+        )
+        self.session.add(domain)
+
+        try:
+            await self.session.commit()
+        except IntegrityError as exc:
+            await self.session.rollback()
+            await self._audit_domain_event(
+                action="create",
+                status=AuditEventStatus.FAILURE,
+            )
+            raise self._domain_integrity_error(
+                exc, normalized.normalized_domain
+            ) from exc
+
+        await self._audit_domain_event(
+            action="create",
+            resource_id=domain.id,
+            status=AuditEventStatus.SUCCESS,
+        )
+        await self.session.refresh(domain)
+        return OrgDomainRead.model_validate(domain)
+
+    async def update_org_domain(
+        self, org_id: uuid.UUID, domain_id: uuid.UUID, params: OrgDomainUpdate
+    ) -> OrgDomainRead:
+        """Update primary/active state for an organization domain."""
+        domain = await self._get_org_domain(org_id=org_id, domain_id=domain_id)
+        previous_primary = domain.is_primary
+        previous_active = domain.is_active
+        await self._audit_domain_event(
+            action="update",
+            resource_id=domain.id,
+            status=AuditEventStatus.ATTEMPT,
+        )
+
+        if params.is_primary is True and params.is_active is False:
+            await self._audit_domain_event(
+                action="update",
+                resource_id=domain.id,
+                status=AuditEventStatus.FAILURE,
+            )
+            raise ValueError("Primary domain must be active")
+
+        next_active = (
+            params.is_active if params.is_active is not None else domain.is_active
+        )
+        next_primary = (
+            params.is_primary if params.is_primary is not None else domain.is_primary
+        )
+        if not next_active:
+            next_primary = False
+
+        domain.is_active = next_active
+        domain.is_primary = next_primary
+
+        if next_primary:
+            domain.is_active = True
+            await self._demote_active_primaries(org_id=org_id, keep_domain_id=domain.id)
+
+        if not domain.is_active:
+            domain.is_primary = False
+
+        self.session.add(domain)
+        await self._ensure_primary_invariant(org_id=org_id)
+
+        try:
+            await self.session.commit()
+        except IntegrityError as exc:
+            await self.session.rollback()
+            await self._audit_domain_event(
+                action="update",
+                resource_id=domain.id,
+                status=AuditEventStatus.FAILURE,
+            )
+            raise self._domain_integrity_error(exc, domain.normalized_domain) from exc
+
+        await self.session.refresh(domain)
+
+        if previous_primary != domain.is_primary or previous_active != domain.is_active:
+            self.logger.info(
+                "Organization domain updated",
+                organization_id=str(org_id),
+                domain_id=str(domain.id),
+                is_primary=domain.is_primary,
+                is_active=domain.is_active,
+            )
+
+        await self._audit_domain_event(
+            action="update",
+            resource_id=domain.id,
+            status=AuditEventStatus.SUCCESS,
+        )
+
+        return OrgDomainRead.model_validate(domain)
+
+    async def delete_org_domain(self, org_id: uuid.UUID, domain_id: uuid.UUID) -> None:
+        """Delete an assigned organization domain."""
+        domain = await self._get_org_domain(org_id=org_id, domain_id=domain_id)
+        await self._audit_domain_event(
+            action="delete",
+            resource_id=domain.id,
+            status=AuditEventStatus.ATTEMPT,
+        )
+
+        await self.session.delete(domain)
+        await self.session.flush()
+        await self._ensure_primary_invariant(org_id=org_id)
+        try:
+            await self.session.commit()
+        except IntegrityError as exc:
+            await self.session.rollback()
+            await self._audit_domain_event(
+                action="delete",
+                resource_id=domain.id,
+                status=AuditEventStatus.FAILURE,
+            )
+            raise ValueError("Failed to delete organization domain") from exc
+
+        await self._audit_domain_event(
+            action="delete",
+            resource_id=domain.id,
+            status=AuditEventStatus.SUCCESS,
+        )
+
+    async def _audit_domain_event(
+        self,
+        *,
+        action: AuditAction,
+        status: AuditEventStatus,
+        resource_id: uuid.UUID | None = None,
+    ) -> None:
+        """Emit audit events for organization domain operations."""
+        async with AuditService.with_session(self.role, session=self.session) as svc:
+            await svc.create_event(
+                resource_type="organization_domain",
+                action=action,
+                resource_id=resource_id,
+                status=status,
+            )
+
+    async def _demote_active_primaries(
+        self, *, org_id: uuid.UUID, keep_domain_id: uuid.UUID | None = None
+    ) -> None:
+        """Demote existing active primary domains for an organization."""
+        stmt = select(OrganizationDomain).where(
+            OrganizationDomain.organization_id == org_id,
+            OrganizationDomain.is_active.is_(True),
+            OrganizationDomain.is_primary.is_(True),
+        )
+        if keep_domain_id is not None:
+            stmt = stmt.where(OrganizationDomain.id != keep_domain_id)
+
+        result = await self.session.execute(stmt)
+        for existing_primary in result.scalars().all():
+            existing_primary.is_primary = False
+            self.session.add(existing_primary)
+
+    async def _ensure_primary_invariant(self, *, org_id: uuid.UUID) -> None:
+        """Ensure at most one active primary and deterministic fallback promotion."""
+        stmt = (
+            select(OrganizationDomain)
+            .where(
+                OrganizationDomain.organization_id == org_id,
+                OrganizationDomain.is_active.is_(True),
+            )
+            .order_by(
+                OrganizationDomain.created_at.asc(),
+                OrganizationDomain.normalized_domain.asc(),
+                OrganizationDomain.id.asc(),
+            )
+        )
+        result = await self.session.execute(stmt)
+        active_domains = list(result.scalars().all())
+
+        if not active_domains:
+            return
+
+        active_primary_domains = [
+            domain for domain in active_domains if domain.is_primary
+        ]
+        selected_primary = (
+            active_primary_domains[0] if active_primary_domains else active_domains[0]
+        )
+
+        for active_domain in active_domains:
+            should_be_primary = active_domain.id == selected_primary.id
+            if active_domain.is_primary != should_be_primary:
+                active_domain.is_primary = should_be_primary
+                self.session.add(active_domain)
+
+    async def _get_org_domain(
+        self, *, org_id: uuid.UUID, domain_id: uuid.UUID
+    ) -> OrganizationDomain:
+        """Get a domain by ID and organization."""
+        stmt = select(OrganizationDomain).where(
+            OrganizationDomain.id == domain_id,
+            OrganizationDomain.organization_id == org_id,
+        )
+        result = await self.session.execute(stmt)
+        domain = result.scalar_one_or_none()
+        if domain is None:
+            raise ValueError(f"Domain {domain_id} not found in organization {org_id}")
+        return domain
+
+    def _domain_integrity_error(
+        self, error: IntegrityError, normalized_domain: str
+    ) -> ValueError:
+        """Translate domain-related integrity errors into user-facing messages."""
+        message = (
+            str(error.orig).lower() if error.orig is not None else str(error).lower()
+        )
+        if "ix_org_domain_normalized_domain_active_unique" in message:
+            return ValueError(
+                f"Domain {normalized_domain!r} is already assigned to another organization"
+            )
+        if "ix_org_domain_org_primary_active_unique" in message:
+            return ValueError("Organization already has an active primary domain")
+        return ValueError("Organization domain operation failed")
 
     # Org Registry Methods
 

--- a/tests/unit/api/test_api_admin_organizations.py
+++ b/tests/unit/api/test_api_admin_organizations.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 from tracecat_ee.admin.organizations import router as organizations_router
-from tracecat_ee.admin.organizations.schemas import OrgRead
+from tracecat_ee.admin.organizations.schemas import OrgDomainRead, OrgRead
 
 from tracecat.auth.types import Role
 
@@ -20,6 +20,25 @@ def _org_read(org_id: uuid.UUID | None = None) -> OrgRead:
         name="Test Org",
         slug="test-org",
         is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _org_domain_read(
+    org_id: uuid.UUID,
+    domain_id: uuid.UUID | None = None,
+) -> OrgDomainRead:
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    return OrgDomainRead(
+        id=domain_id or uuid.uuid4(),
+        organization_id=org_id,
+        domain="example.com",
+        normalized_domain="example.com",
+        is_primary=True,
+        is_active=True,
+        verified_at=None,
+        verification_method="platform_admin",
         created_at=now,
         updated_at=now,
     )
@@ -141,3 +160,81 @@ async def test_delete_organization_blocked_without_multi_tenant(
     response = client.delete(f"/admin/organizations/{org_id}")
 
     assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+
+
+@pytest.mark.anyio
+async def test_list_org_domains_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+    domain = _org_domain_read(org_id)
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_org_domains.return_value = [domain]
+        MockService.return_value = mock_svc
+
+        response = client.get(f"/admin/organizations/{org_id}/domains")
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data[0]["id"] == str(domain.id)
+    assert data[0]["organization_id"] == str(org_id)
+
+
+@pytest.mark.anyio
+async def test_create_org_domain_conflict(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_org_domain.side_effect = ValueError(
+            "Domain 'example.com' is already assigned to another organization"
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/admin/organizations/{org_id}/domains",
+            json={"domain": "example.com"},
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_update_org_domain_not_found(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+    domain_id = uuid.uuid4()
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.update_org_domain.side_effect = ValueError("Domain not found")
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            f"/admin/organizations/{org_id}/domains/{domain_id}",
+            json={"is_primary": True},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_delete_org_domain_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+    domain_id = uuid.uuid4()
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.delete_org_domain.return_value = None
+        MockService.return_value = mock_svc
+
+        response = client.delete(f"/admin/organizations/{org_id}/domains/{domain_id}")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/tests/unit/api/test_api_admin_organizations.py
+++ b/tests/unit/api/test_api_admin_organizations.py
@@ -204,6 +204,27 @@ async def test_create_org_domain_conflict(
 
 
 @pytest.mark.anyio
+async def test_create_org_domain_not_found(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_org_domain.side_effect = ValueError(
+            f"Organization {org_id} not found"
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/admin/organizations/{org_id}/domains",
+            json={"domain": "example.com"},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
 async def test_update_org_domain_not_found(
     client: TestClient, test_admin_role: Role
 ) -> None:

--- a/tests/unit/test_admin_org_domains_service.py
+++ b/tests/unit/test_admin_org_domains_service.py
@@ -1,0 +1,149 @@
+"""Tests for superuser organization domain assignment service behavior."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.admin.organizations.schemas import OrgDomainCreate, OrgDomainUpdate
+from tracecat_ee.admin.organizations.service import AdminOrgService
+
+from tracecat.auth.types import PlatformRole
+from tracecat.db.models import Organization
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+def platform_role() -> PlatformRole:
+    return PlatformRole(
+        type="user",
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+
+
+@pytest.fixture
+async def org_a(session: AsyncSession) -> Organization:
+    organization = Organization(
+        id=uuid.uuid4(),
+        name="Org A",
+        slug=f"org-a-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(organization)
+    await session.commit()
+    return organization
+
+
+@pytest.fixture
+async def org_b(session: AsyncSession) -> Organization:
+    organization = Organization(
+        id=uuid.uuid4(),
+        name="Org B",
+        slug=f"org-b-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(organization)
+    await session.commit()
+    return organization
+
+
+@pytest.mark.anyio
+async def test_first_active_domain_is_primary_by_default(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    service = AdminOrgService(session, role=platform_role)
+
+    created = await service.create_org_domain(
+        org_a.id, OrgDomainCreate(domain="  Acme.com.  ")
+    )
+
+    assert created.domain == "acme.com"
+    assert created.normalized_domain == "acme.com"
+    assert created.is_primary is True
+    assert created.is_active is True
+
+
+@pytest.mark.anyio
+async def test_duplicate_active_domain_across_orgs_is_rejected(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+    org_b: Organization,
+) -> None:
+    service = AdminOrgService(session, role=platform_role)
+
+    await service.create_org_domain(org_a.id, OrgDomainCreate(domain="example.com"))
+
+    with pytest.raises(ValueError, match="already assigned"):
+        await service.create_org_domain(org_b.id, OrgDomainCreate(domain="EXAMPLE.COM"))
+
+
+@pytest.mark.anyio
+async def test_deactivating_primary_promotes_next_active_domain(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    service = AdminOrgService(session, role=platform_role)
+    first = await service.create_org_domain(
+        org_a.id, OrgDomainCreate(domain="a.example")
+    )
+    second = await service.create_org_domain(
+        org_a.id, OrgDomainCreate(domain="b.example")
+    )
+
+    updated_first = await service.update_org_domain(
+        org_a.id, first.id, OrgDomainUpdate(is_active=False)
+    )
+    domains = await service.list_org_domains(org_a.id)
+    updated_second = next(domain for domain in domains if domain.id == second.id)
+
+    assert updated_first.is_active is False
+    assert updated_first.is_primary is False
+    assert updated_second.is_primary is True
+
+
+@pytest.mark.anyio
+async def test_deleting_primary_promotes_next_active_domain(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    service = AdminOrgService(session, role=platform_role)
+    first = await service.create_org_domain(
+        org_a.id, OrgDomainCreate(domain="a.example")
+    )
+    second = await service.create_org_domain(
+        org_a.id, OrgDomainCreate(domain="b.example")
+    )
+
+    await service.delete_org_domain(org_a.id, first.id)
+    domains = await service.list_org_domains(org_a.id)
+
+    assert len(domains) == 1
+    assert domains[0].id == second.id
+    assert domains[0].is_primary is True
+
+
+@pytest.mark.anyio
+async def test_primary_domain_cannot_be_set_inactive_in_same_update(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    service = AdminOrgService(session, role=platform_role)
+    domain = await service.create_org_domain(
+        org_a.id, OrgDomainCreate(domain="a.example")
+    )
+
+    with pytest.raises(ValueError, match="Primary domain must be active"):
+        await service.update_org_domain(
+            org_a.id,
+            domain.id,
+            OrgDomainUpdate(is_primary=True, is_active=False),
+        )

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -24,6 +24,7 @@ AuditResourceType = Literal[
     "case",
     "agent_preset",
     "agent_session",
+    "organization_domain",
     "organization_member",
     "organization_session",
     "organization_invitation",


### PR DESCRIPTION
## Why
With platform-owner domain assignment as phase 1, we need a safe operational path for superusers to manage org-domain mappings without direct DB edits.

This PR adds that management surface and enforces invariants in one place so domain claims remain globally safe before we add DNS TXT self-serve verification.

## What changed
- Added superuser admin API endpoints for organization domains:
  - list,
  - create,
  - update,
  - delete.
- Added service-layer rules:
  - first active domain becomes primary,
  - primary domain must remain active,
  - deterministic primary promotion on primary delete/deactivate,
  - normalized-domain conflict handling.
- Added audit event types for org-domain create/update/delete actions.
- Regenerated frontend API client types/services for the new admin endpoints.
- Added service and API tests for invariants and failure paths.

## Motivation for design choices
- **SU-only assignment first** minimizes takeover risk while we defer DNS verification.
- **Service-level invariant enforcement** avoids drift between API callers and keeps behavior deterministic.
- **Audit coverage** is necessary because domain assignment changes login routing behavior.

## Out of scope
- Admin UI for managing domains (next PR in stack).
- Discovery/auth routing logic.
- Tenant self-serve verification.

## Validation
- `uv run pytest tests/unit/test_admin_org_domains_service.py tests/unit/api/test_api_admin_organizations.py`
