### PR TITLE
feat(auth): add pre-auth discovery endpoint

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2947,6 +2947,39 @@ export const $AuditSettingsUpdate = {
   description: "Settings for audit logging.",
 } as const
 
+export const $AuthDiscoverRequest = {
+  properties: {
+    email: {
+      type: "string",
+      format: "email",
+      title: "Email",
+    },
+  },
+  type: "object",
+  required: ["email"],
+  title: "AuthDiscoverRequest",
+  description: "Request payload for pre-auth discovery.",
+} as const
+
+export const $AuthDiscoverResponse = {
+  properties: {
+    method: {
+      $ref: "#/components/schemas/AuthDiscoveryMethod",
+    },
+  },
+  type: "object",
+  required: ["method"],
+  title: "AuthDiscoverResponse",
+  description: "Pre-auth routing hint response.",
+} as const
+
+export const $AuthDiscoveryMethod = {
+  type: "string",
+  enum: ["basic", "oidc", "saml"],
+  title: "AuthDiscoveryMethod",
+  description: "Authentication method hint for client-side routing.",
+} as const
+
 export const $AuthSettingsRead = {
   properties: {
     auth_basic_enabled: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -131,6 +131,8 @@ import type {
   AuthAuthDatabaseLoginData,
   AuthAuthDatabaseLoginResponse,
   AuthAuthDatabaseLogoutResponse,
+  AuthDiscoverAuthMethodData,
+  AuthDiscoverAuthMethodResponse,
   AuthOauthGoogleDatabaseAuthorizeData,
   AuthOauthGoogleDatabaseAuthorizeResponse,
   AuthOauthGoogleDatabaseCallbackData,
@@ -8852,6 +8854,28 @@ export const authSsoAcs = (
     url: "/auth/saml/acs",
     formData: data.formData,
     mediaType: "application/x-www-form-urlencoded",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Discover Auth Method
+ * Return the next-step auth method for a given email.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns AuthDiscoverResponse Successful Response
+ * @throws ApiError
+ */
+export const authDiscoverAuthMethod = (
+  data: AuthDiscoverAuthMethodData
+): CancelablePromise<AuthDiscoverAuthMethodResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/auth/discover",
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -783,6 +783,25 @@ export type AuditSettingsUpdate = {
   } | null
 }
 
+/**
+ * Request payload for pre-auth discovery.
+ */
+export type AuthDiscoverRequest = {
+  email: string
+}
+
+/**
+ * Pre-auth routing hint response.
+ */
+export type AuthDiscoverResponse = {
+  method: AuthDiscoveryMethod
+}
+
+/**
+ * Authentication method hint for client-side routing.
+ */
+export type AuthDiscoveryMethod = "basic" | "oidc" | "saml"
+
 export type AuthSettingsRead = {
   auth_basic_enabled: boolean
   auth_require_email_verification: boolean
@@ -8782,6 +8801,12 @@ export type AuthSsoAcsData = {
 
 export type AuthSsoAcsResponse = unknown
 
+export type AuthDiscoverAuthMethodData = {
+  requestBody: AuthDiscoverRequest
+}
+
+export type AuthDiscoverAuthMethodResponse = AuthDiscoverResponse
+
 export type PublicCheckHealthResponse = HealthResponse
 
 export type PublicCheckReadyResponse = ReadinessResponse
@@ -13263,6 +13288,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: unknown
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/auth/discover": {
+    post: {
+      req: AuthDiscoverAuthMethodData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AuthDiscoverResponse
         /**
          * Validation Error
          */

--- a/tests/unit/api/test_api_auth_discovery.py
+++ b/tests/unit/api/test_api_auth_discovery.py
@@ -1,0 +1,36 @@
+"""HTTP-level tests for auth discovery endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+import tracecat.auth.discovery as auth_discovery_module
+from tracecat.auth.discovery import AuthDiscoverResponse, AuthDiscoveryMethod
+
+
+@pytest.mark.anyio
+async def test_auth_discovery_returns_routing_hint(client: TestClient) -> None:
+    with patch.object(auth_discovery_module, "AuthDiscoveryService") as mock_service:
+        service = AsyncMock()
+        service.discover.return_value = AuthDiscoverResponse(
+            method=AuthDiscoveryMethod.SAML
+        )
+        mock_service.return_value = service
+
+        response = client.post("/auth/discover", json={"email": "user@acme.com"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["method"] == AuthDiscoveryMethod.SAML.value
+
+
+@pytest.mark.anyio
+async def test_auth_discovery_returns_validation_error_for_invalid_email(
+    client: TestClient,
+) -> None:
+    response = client.post("/auth/discover", json={"email": "not-an-email"})
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/tests/unit/test_auth_discovery_service.py
+++ b/tests/unit/test_auth_discovery_service.py
@@ -1,0 +1,115 @@
+"""Tests for pre-auth email domain discovery routing."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat import config
+from tracecat.auth.discovery import AuthDiscoveryMethod, AuthDiscoveryService
+from tracecat.auth.enums import AuthType
+from tracecat.db.models import Organization, OrganizationDomain
+from tracecat.organization.domains import normalize_domain
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def organization(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug=f"acme-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _create_domain(
+    session: AsyncSession, organization_id: uuid.UUID, domain: str
+) -> OrganizationDomain:
+    normalized = normalize_domain(domain)
+    organization_domain = OrganizationDomain(
+        id=uuid.uuid4(),
+        organization_id=organization_id,
+        domain=normalized.domain,
+        normalized_domain=normalized.normalized_domain,
+        is_primary=True,
+        is_active=True,
+        verification_method="platform_admin",
+    )
+    session.add(organization_domain)
+    await session.commit()
+    return organization_domain
+
+
+@pytest.mark.anyio
+async def test_discovery_prefers_saml_for_mapped_domains(
+    session: AsyncSession,
+    organization: Organization,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _create_domain(session, organization.id, "acme.com")
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__AUTH_TYPES",
+        {AuthType.BASIC, AuthType.GOOGLE_OAUTH, AuthType.SAML},
+    )
+    service = AuthDiscoveryService(session)
+
+    response = await service.discover("user@acme.com")
+
+    assert response.method == AuthDiscoveryMethod.SAML
+
+
+@pytest.mark.anyio
+async def test_discovery_returns_oidc_for_mapped_non_saml_domains(
+    session: AsyncSession,
+    organization: Organization,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _create_domain(session, organization.id, "acme.io")
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__AUTH_TYPES",
+        {AuthType.BASIC, AuthType.GOOGLE_OAUTH},
+    )
+    service = AuthDiscoveryService(session)
+
+    response = await service.discover("user@acme.io")
+
+    assert response.method == AuthDiscoveryMethod.OIDC
+
+
+@pytest.mark.anyio
+async def test_discovery_returns_safe_platform_fallback_for_unknown_domains(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__AUTH_TYPES",
+        {AuthType.BASIC, AuthType.GOOGLE_OAUTH},
+    )
+    service = AuthDiscoveryService(session)
+
+    response = await service.discover("user@unknown-domain.example")
+
+    assert response.method == AuthDiscoveryMethod.OIDC
+
+
+@pytest.mark.anyio
+async def test_discovery_returns_basic_when_basic_is_only_platform_auth_type(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__AUTH_TYPES", {AuthType.BASIC})
+    service = AuthDiscoveryService(session)
+
+    response = await service.discover("user@unknown-domain.example")
+
+    assert response.method == AuthDiscoveryMethod.BASIC

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -33,6 +33,7 @@ from tracecat.api.common import (
     tracecat_exception_handler,
 )
 from tracecat.auth.dependencies import require_auth_type_enabled
+from tracecat.auth.discovery import router as auth_discovery_router
 from tracecat.auth.enums import AuthType
 from tracecat.auth.router import router as users_router
 from tracecat.auth.saml import router as saml_router
@@ -498,6 +499,7 @@ def create_app(**kwargs) -> FastAPI:
         saml_router,
         dependencies=[require_auth_type_enabled(AuthType.SAML)],
     )
+    app.include_router(auth_discovery_router)
 
     if AuthType.BASIC not in config.TRACECAT__AUTH_TYPES:
         # Need basic auth router for `logout` endpoint

--- a/tracecat/auth/discovery.py
+++ b/tracecat/auth/discovery.py
@@ -1,0 +1,148 @@
+"""Pre-auth domain discovery endpoint and routing hints."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+from fastapi import APIRouter
+from pydantic import EmailStr
+from sqlalchemy import select
+
+from tracecat import config
+from tracecat.api.common import bootstrap_role
+from tracecat.auth.enums import AuthType
+from tracecat.core.schemas import Schema
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.db.models import OrganizationDomain
+from tracecat.identifiers import OrganizationID
+from tracecat.organization.domains import normalize_domain
+from tracecat.service import BaseService
+from tracecat.settings.service import get_setting
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class AuthDiscoveryMethod(StrEnum):
+    """Authentication method hint for client-side routing."""
+
+    BASIC = "basic"
+    OIDC = "oidc"
+    SAML = "saml"
+
+
+class AuthDiscoverRequest(Schema):
+    """Request payload for pre-auth discovery."""
+
+    email: EmailStr
+
+
+class AuthDiscoverResponse(Schema):
+    """Pre-auth routing hint response."""
+
+    method: AuthDiscoveryMethod
+
+
+_SAML_SETTING_KEY: Final[str] = "saml_enabled"
+_GOOGLE_OAUTH_SETTING_KEY: Final[str] = "oauth_google_enabled"
+_BASIC_AUTH_SETTING_KEY: Final[str] = "auth_basic_enabled"
+
+
+class AuthDiscoveryService(BaseService):
+    """Resolve auth routing hints from email domain mappings."""
+
+    service_name = "auth_discovery"
+
+    async def discover(self, email: EmailStr) -> AuthDiscoverResponse:
+        """Resolve the recommended login flow from an email address."""
+        email_domain = self._extract_domain(email)
+        org_id = await self._resolve_organization_id(email_domain)
+        if org_id is None:
+            return AuthDiscoverResponse(method=self._platform_fallback_method())
+
+        return AuthDiscoverResponse(
+            method=await self._organization_discovery_method(org_id)
+        )
+
+    async def _resolve_organization_id(self, domain: str) -> OrganizationID | None:
+        normalized_domain = normalize_domain(domain).normalized_domain
+        stmt = select(OrganizationDomain.organization_id).where(
+            OrganizationDomain.normalized_domain == normalized_domain,
+            OrganizationDomain.is_active.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def _organization_discovery_method(
+        self, org_id: OrganizationID
+    ) -> AuthDiscoveryMethod:
+        if await self._org_saml_enabled(org_id):
+            return AuthDiscoveryMethod.SAML
+        if await self._org_oidc_enabled(org_id):
+            return AuthDiscoveryMethod.OIDC
+        if await self._org_basic_enabled(org_id):
+            return AuthDiscoveryMethod.BASIC
+        return self._platform_fallback_method()
+
+    async def _org_saml_enabled(self, org_id: OrganizationID) -> bool:
+        if AuthType.SAML not in config.TRACECAT__AUTH_TYPES:
+            return False
+        value = await get_setting(
+            _SAML_SETTING_KEY,
+            role=bootstrap_role(org_id),
+            session=self.session,
+            default=True,
+        )
+        return bool(value)
+
+    async def _org_oidc_enabled(self, org_id: OrganizationID) -> bool:
+        if AuthType.OIDC in config.TRACECAT__AUTH_TYPES:
+            return True
+        if AuthType.GOOGLE_OAUTH in config.TRACECAT__AUTH_TYPES:
+            value = await get_setting(
+                _GOOGLE_OAUTH_SETTING_KEY,
+                role=bootstrap_role(org_id),
+                session=self.session,
+                default=True,
+            )
+            return bool(value)
+        return False
+
+    async def _org_basic_enabled(self, org_id: OrganizationID) -> bool:
+        if AuthType.BASIC not in config.TRACECAT__AUTH_TYPES:
+            return False
+        value = await get_setting(
+            _BASIC_AUTH_SETTING_KEY,
+            role=bootstrap_role(org_id),
+            session=self.session,
+            default=True,
+        )
+        return bool(value)
+
+    @staticmethod
+    def _extract_domain(email: str) -> str:
+        _, _, domain = email.rpartition("@")
+        return domain
+
+    @staticmethod
+    def _platform_fallback_method() -> AuthDiscoveryMethod:
+        if (
+            AuthType.OIDC in config.TRACECAT__AUTH_TYPES
+            or AuthType.GOOGLE_OAUTH in config.TRACECAT__AUTH_TYPES
+        ):
+            return AuthDiscoveryMethod.OIDC
+        if AuthType.BASIC in config.TRACECAT__AUTH_TYPES:
+            return AuthDiscoveryMethod.BASIC
+        if AuthType.SAML in config.TRACECAT__AUTH_TYPES:
+            return AuthDiscoveryMethod.SAML
+        return AuthDiscoveryMethod.BASIC
+
+
+@router.post("/discover", response_model=AuthDiscoverResponse)
+async def discover_auth_method(
+    params: AuthDiscoverRequest,
+    session: AsyncDBSession,
+) -> AuthDiscoverResponse:
+    """Return the next-step auth method for a given email."""
+    service = AuthDiscoveryService(session)
+    return await service.discover(params.email)


### PR DESCRIPTION
## Why
We need a pre-auth decision step that can route users by email domain to the correct auth method (`saml` or `oidc`) before triggering provider flows.

This is required for multi-tenant login correctness and prepares the frontend for discovery-first sign-in.

## What changed
- Added backend auth discovery service to resolve `email domain -> organization` using active assigned domains.
- Added `POST /auth/discover` endpoint to return routing hints.
- Implemented safe routing logic for known and unknown domains.
- Updated generated frontend client types/services for the discovery API.
- Added unit/API tests for routing behavior and input validation.

## Motivation for design choices
- **Domain-first routing** lets us preserve per-org policy (`saml` enforced vs non-saml) without org-level OAuth toggles.
- **Safe unknown-domain fallback** avoids leaking tenant metadata while still returning actionable auth methods.
- **Backend-owned policy evaluation** keeps auth decisions centralized and testable.

## Out of scope
- Replacing the current sign-in UI with discovery-first UX (follow-up PR).
- Final removal of legacy org OAuth settings surfaces.

## Validation
- `uv run pytest tests/unit/test_auth_discovery_service.py tests/unit/api/test_api_auth_discovery.py`
