### PR TITLE
fix(auth): preserve invitation return url through auth callbacks

### DIFF
--- a/frontend/src/app/auth/oauth/callback/route.ts
+++ b/frontend/src/app/auth/oauth/callback/route.ts
@@ -30,6 +30,9 @@ export const GET = async (request: NextRequest) => {
     console.error(
       `OAuth callback failed with status ${response.status}: ${await response.text()}`
     )
+    const resp = await fetch(buildUrl("/info"))
+    const { public_app_url } = await resp.json()
+    return NextResponse.redirect(new URL("/auth/error", public_app_url))
   }
 
   // Get redirect

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -4,8 +4,24 @@ import { type ComponentPropsWithoutRef, useState } from "react"
 import { authOauthGoogleDatabaseAuthorize } from "@/client"
 import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
+import {
+  sanitizeReturnUrl,
+  serializeClearPostAuthReturnUrlCookie,
+  serializePostAuthReturnUrlCookie,
+} from "@/lib/auth-return-url"
 
-type OAuthButtonProps = ComponentPropsWithoutRef<typeof Button>
+type OAuthButtonProps = ComponentPropsWithoutRef<typeof Button> & {
+  returnUrl?: string | null
+}
+
+function setPostAuthReturnUrlCookie(returnUrl?: string | null): void {
+  const secure = window.location.protocol === "https:"
+  const sanitizedReturnUrl = sanitizeReturnUrl(returnUrl)
+  document.cookie = sanitizedReturnUrl
+    ? serializePostAuthReturnUrlCookie(sanitizedReturnUrl, secure)
+    : serializeClearPostAuthReturnUrlCookie(secure)
+}
+
 export function GithubOAuthButton(props: OAuthButtonProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const handleClick = async () => {
@@ -29,7 +45,7 @@ export function GithubOAuthButton(props: OAuthButtonProps) {
     </Button>
   )
 }
-export function GoogleOAuthButton(props: OAuthButtonProps) {
+export function GoogleOAuthButton({ returnUrl, ...props }: OAuthButtonProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const handleClick = async () => {
     try {
@@ -37,6 +53,7 @@ export function GoogleOAuthButton(props: OAuthButtonProps) {
       const { authorization_url } = await authOauthGoogleDatabaseAuthorize({
         scopes: ["openid", "email", "profile"],
       })
+      setPostAuthReturnUrlCookie(returnUrl)
       window.location.href = authorization_url
     } catch (error) {
       console.error("Error authorizing with Google", error)

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -22,7 +22,10 @@ function setPostAuthReturnUrlCookie(returnUrl?: string | null): void {
     : serializeClearPostAuthReturnUrlCookie(secure)
 }
 
-export function GithubOAuthButton(props: OAuthButtonProps) {
+export function GithubOAuthButton({
+  returnUrl: _,
+  ...props
+}: OAuthButtonProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const handleClick = async () => {
     setIsLoading(true)

--- a/frontend/src/components/auth/saml.tsx
+++ b/frontend/src/components/auth/saml.tsx
@@ -4,15 +4,32 @@ import { type ComponentPropsWithoutRef, useState } from "react"
 import { authSamlDatabaseLogin } from "@/client"
 import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
+import {
+  sanitizeReturnUrl,
+  serializeClearPostAuthReturnUrlCookie,
+  serializePostAuthReturnUrlCookie,
+} from "@/lib/auth-return-url"
 
-type SamlSSOButtonProps = ComponentPropsWithoutRef<typeof Button>
-export function SamlSSOButton(props: SamlSSOButtonProps) {
+type SamlSSOButtonProps = ComponentPropsWithoutRef<typeof Button> & {
+  returnUrl?: string | null
+}
+
+function setPostAuthReturnUrlCookie(returnUrl?: string | null): void {
+  const secure = window.location.protocol === "https:"
+  const sanitizedReturnUrl = sanitizeReturnUrl(returnUrl)
+  document.cookie = sanitizedReturnUrl
+    ? serializePostAuthReturnUrlCookie(sanitizedReturnUrl, secure)
+    : serializeClearPostAuthReturnUrlCookie(secure)
+}
+
+export function SamlSSOButton({ returnUrl, ...props }: SamlSSOButtonProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const handleClick = async () => {
     try {
       setIsLoading(true)
       // Call api/auth/saml/login
       const { redirect_url } = await authSamlDatabaseLogin()
+      setPostAuthReturnUrlCookie(returnUrl)
       window.location.href = redirect_url
     } catch (error) {
       console.error("Error authorizing with SAML", error)

--- a/frontend/src/components/auth/sign-in.tsx
+++ b/frontend/src/components/auth/sign-in.tsx
@@ -90,8 +90,12 @@ export function SignIn({ className, returnUrl }: SignInProps) {
               </div>
             </div>
           )}
-          {showGoogleOauthAuth && <GoogleOAuthButton className="w-full" />}
-          {showSamlAuth && <SamlSSOButton className="w-full" />}
+          {showGoogleOauthAuth && (
+            <GoogleOAuthButton className="w-full" returnUrl={returnUrl} />
+          )}
+          {showSamlAuth && (
+            <SamlSSOButton className="w-full" returnUrl={returnUrl} />
+          )}
           {/* <GithubOAuthButton disabled className="hover:cur" /> */}
         </CardContent>
         {showBasicAuth && (

--- a/frontend/src/lib/auth-return-url.ts
+++ b/frontend/src/lib/auth-return-url.ts
@@ -3,6 +3,11 @@ export const POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS = 60 * 15
 
 const APP_URL_PLACEHOLDER = "https://tracecat.local"
 
+function getPostAuthReturnUrlCookieSameSite(secure: boolean): "None" | "Lax" {
+  // Cross-site POSTs (SAML ACS) require SameSite=None; browsers require Secure with None.
+  return secure ? "None" : "Lax"
+}
+
 export function sanitizeReturnUrl(
   value: string | null | undefined
 ): string | null {
@@ -44,11 +49,13 @@ export function serializePostAuthReturnUrlCookie(
   value: string,
   secure: boolean
 ): string {
+  const sameSite = getPostAuthReturnUrlCookieSameSite(secure)
   const secureAttr = secure ? "; Secure" : ""
-  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=${encodeURIComponent(value)}; Path=/; Max-Age=${POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secureAttr}`
+  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=${encodeURIComponent(value)}; Path=/; Max-Age=${POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS}; SameSite=${sameSite}${secureAttr}`
 }
 
 export function serializeClearPostAuthReturnUrlCookie(secure: boolean): string {
+  const sameSite = getPostAuthReturnUrlCookieSameSite(secure)
   const secureAttr = secure ? "; Secure" : ""
-  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax${secureAttr}`
+  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}`
 }

--- a/frontend/src/lib/auth-return-url.ts
+++ b/frontend/src/lib/auth-return-url.ts
@@ -1,0 +1,54 @@
+export const POST_AUTH_RETURN_URL_COOKIE_NAME = "tracecat_post_auth_return_url"
+export const POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS = 60 * 15
+
+const APP_URL_PLACEHOLDER = "https://tracecat.local"
+
+export function sanitizeReturnUrl(
+  value: string | null | undefined
+): string | null {
+  if (!value) {
+    return null
+  }
+
+  const trimmedValue = value.trim()
+  if (!trimmedValue.startsWith("/") || trimmedValue.startsWith("//")) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(trimmedValue, APP_URL_PLACEHOLDER)
+    if (parsed.origin !== APP_URL_PLACEHOLDER) {
+      return null
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return null
+  }
+}
+
+export function decodeAndSanitizeReturnUrl(
+  value: string | null | undefined
+): string | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    return sanitizeReturnUrl(decodeURIComponent(value))
+  } catch {
+    return sanitizeReturnUrl(value)
+  }
+}
+
+export function serializePostAuthReturnUrlCookie(
+  value: string,
+  secure: boolean
+): string {
+  const secureAttr = secure ? "; Secure" : ""
+  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=${encodeURIComponent(value)}; Path=/; Max-Age=${POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secureAttr}`
+}
+
+export function serializeClearPostAuthReturnUrlCookie(secure: boolean): string {
+  const secureAttr = secure ? "; Secure" : ""
+  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax${secureAttr}`
+}


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the invitation return URL through OAuth and SAML so users land on the intended page after sign-in. Uses a short-lived cookie with strict sanitization and clears it after callbacks. Addresses Linear ENG-1283.

- Bug Fixes
  - Store a post-auth return path in a cookie (15‑min TTL). Google OAuth and SAML set it from SignIn’s optional returnUrl; GitHub OAuth ignores it.
  - Callbacks read, decode, and sanitize the cookie, redirect to the target path or “/”, then clear it. OAuth forwards incoming cookies to the backend, uses no-store, fails fast to “/auth/error” on non‑OK, and appends backend Set-Cookie plus a clear-cookie header. SAML responds with 303 GET, appends backend Set-Cookie, and the clear-cookie header.
  - Helpers enforce same‑origin paths and set cookie flags: SameSite=None + Secure on HTTPS; Lax otherwise.

<sup>Written for commit 0e74e0f17349306d1f5817f5abcd77fb1bf2c891. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

