### PR TITLE
feat(auth): add no-org-access fallback with pending invitations

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10358,6 +10358,66 @@ export const $OrgMemberRead = {
   title: "OrgMemberRead",
 } as const
 
+export const $OrgPendingInvitationRead = {
+  properties: {
+    token: {
+      type: "string",
+      title: "Token",
+    },
+    organization_id: {
+      type: "string",
+      format: "uuid",
+      title: "Organization Id",
+    },
+    organization_name: {
+      type: "string",
+      title: "Organization Name",
+    },
+    inviter_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Inviter Name",
+    },
+    inviter_email: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Inviter Email",
+    },
+    role: {
+      $ref: "#/components/schemas/OrgRole",
+    },
+    expires_at: {
+      type: "string",
+      format: "date-time",
+      title: "Expires At",
+    },
+  },
+  type: "object",
+  required: [
+    "token",
+    "organization_id",
+    "organization_name",
+    "inviter_name",
+    "inviter_email",
+    "role",
+    "expires_at",
+  ],
+  title: "OrgPendingInvitationRead",
+  description: "Pending invitation visible to the invited authenticated user.",
+} as const
+
 export const $OrgRegistryRepositoryRead = {
   properties: {
     id: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -133,10 +133,10 @@ import type {
   AuthAuthDatabaseLogoutResponse,
   AuthDiscoverAuthMethodData,
   AuthDiscoverAuthMethodResponse,
-  AuthOauthGoogleDatabaseAuthorizeData,
-  AuthOauthGoogleDatabaseAuthorizeResponse,
-  AuthOauthGoogleDatabaseCallbackData,
-  AuthOauthGoogleDatabaseCallbackResponse,
+  AuthOauthOidcDatabaseAuthorizeData,
+  AuthOauthOidcDatabaseAuthorizeResponse,
+  AuthOauthOidcDatabaseCallbackData,
+  AuthOauthOidcDatabaseCallbackResponse,
   AuthRegisterRegisterData,
   AuthRegisterRegisterResponse,
   AuthResetForgotPasswordData,
@@ -326,6 +326,7 @@ import type {
   OrganizationGetOrganizationResponse,
   OrganizationListInvitationsData,
   OrganizationListInvitationsResponse,
+  OrganizationListMyPendingInvitationsResponse,
   OrganizationListOrgMembersResponse,
   OrganizationListSessionsResponse,
   OrganizationRevokeInvitationData,
@@ -3309,6 +3310,20 @@ export const organizationAcceptInvitation = (
     },
   })
 }
+
+/**
+ * List My Pending Invitations
+ * List pending, unexpired invitations for the authenticated user.
+ * @returns OrgPendingInvitationRead Successful Response
+ * @throws ApiError
+ */
+export const organizationListMyPendingInvitations =
+  (): CancelablePromise<OrganizationListMyPendingInvitationsResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/organization/invitations/pending/me",
+    })
+  }
 
 /**
  * Get Invitation By Token
@@ -8773,15 +8788,15 @@ export const authVerifyVerify = (
 }
 
 /**
- * Oauth:Google.Database.Authorize
+ * Oauth:Oidc.Database.Authorize
  * @param data The data for the request.
  * @param data.scopes
  * @returns OAuth2AuthorizeResponse Successful Response
  * @throws ApiError
  */
-export const authOauthGoogleDatabaseAuthorize = (
-  data: AuthOauthGoogleDatabaseAuthorizeData = {}
-): CancelablePromise<AuthOauthGoogleDatabaseAuthorizeResponse> => {
+export const authOauthOidcDatabaseAuthorize = (
+  data: AuthOauthOidcDatabaseAuthorizeData = {}
+): CancelablePromise<AuthOauthOidcDatabaseAuthorizeResponse> => {
   return __request(OpenAPI, {
     method: "GET",
     url: "/auth/oauth/authorize",
@@ -8795,7 +8810,7 @@ export const authOauthGoogleDatabaseAuthorize = (
 }
 
 /**
- * Oauth:Google.Database.Callback
+ * Oauth:Oidc.Database.Callback
  * The response varies based on the authentication backend used.
  * @param data The data for the request.
  * @param data.code
@@ -8805,9 +8820,9 @@ export const authOauthGoogleDatabaseAuthorize = (
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const authOauthGoogleDatabaseCallback = (
-  data: AuthOauthGoogleDatabaseCallbackData = {}
-): CancelablePromise<AuthOauthGoogleDatabaseCallbackResponse> => {
+export const authOauthOidcDatabaseCallback = (
+  data: AuthOauthOidcDatabaseCallbackData = {}
+): CancelablePromise<AuthOauthOidcDatabaseCallbackResponse> => {
   return __request(OpenAPI, {
     method: "GET",
     url: "/auth/oauth/callback",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3322,6 +3322,19 @@ export type OrgMemberRead = {
 }
 
 /**
+ * Pending invitation visible to the invited authenticated user.
+ */
+export type OrgPendingInvitationRead = {
+  token: string
+  organization_id: string
+  organization_name: string
+  inviter_name: string | null
+  inviter_email: string | null
+  role: OrgRole
+  expires_at: string
+}
+
+/**
  * Organization registry repository response.
  */
 export type OrgRegistryRepositoryRead = {
@@ -7160,6 +7173,9 @@ export type OrganizationAcceptInvitationResponse = {
   [key: string]: string
 }
 
+export type OrganizationListMyPendingInvitationsResponse =
+  Array<OrgPendingInvitationRead>
+
 export type OrganizationGetInvitationByTokenData = {
   token: string
 }
@@ -8778,20 +8794,20 @@ export type AuthVerifyVerifyData = {
 
 export type AuthVerifyVerifyResponse = UserRead
 
-export type AuthOauthGoogleDatabaseAuthorizeData = {
+export type AuthOauthOidcDatabaseAuthorizeData = {
   scopes?: Array<string>
 }
 
-export type AuthOauthGoogleDatabaseAuthorizeResponse = OAuth2AuthorizeResponse
+export type AuthOauthOidcDatabaseAuthorizeResponse = OAuth2AuthorizeResponse
 
-export type AuthOauthGoogleDatabaseCallbackData = {
+export type AuthOauthOidcDatabaseCallbackData = {
   code?: string | null
   codeVerifier?: string | null
   error?: string | null
   state?: string | null
 }
 
-export type AuthOauthGoogleDatabaseCallbackResponse = unknown
+export type AuthOauthOidcDatabaseCallbackResponse = unknown
 
 export type AuthSamlDatabaseLoginResponse = SAMLDatabaseLoginResponse
 
@@ -10203,6 +10219,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/invitations/pending/me": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<OrgPendingInvitationRead>
       }
     }
   }
@@ -13238,7 +13264,7 @@ export type $OpenApiTs = {
   }
   "/auth/oauth/authorize": {
     get: {
-      req: AuthOauthGoogleDatabaseAuthorizeData
+      req: AuthOauthOidcDatabaseAuthorizeData
       res: {
         /**
          * Successful Response
@@ -13253,7 +13279,7 @@ export type $OpenApiTs = {
   }
   "/auth/oauth/callback": {
     get: {
-      req: AuthOauthGoogleDatabaseCallbackData
+      req: AuthOauthOidcDatabaseCallbackData
       res: {
         /**
          * Successful Response

--- a/frontend/src/components/auth/no-organization-access.tsx
+++ b/frontend/src/components/auth/no-organization-access.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { AlertCircle, LogOut } from "lucide-react"
+import Link from "next/link"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { useAuthActions } from "@/hooks/use-auth"
+import { usePendingOrgInvitations } from "@/hooks/use-pending-org-invitations"
+
+export function NoOrganizationAccess() {
+  const { logout } = useAuthActions()
+  const {
+    pendingInvitations,
+    pendingInvitationsIsLoading,
+    pendingInvitationsError,
+  } = usePendingOrgInvitations()
+
+  if (pendingInvitationsIsLoading) {
+    return <CenteredSpinner />
+  }
+
+  const invitations = pendingInvitations ?? []
+
+  return (
+    <main className="container flex size-full max-w-[520px] flex-col items-center justify-center p-4">
+      <Card className="w-full">
+        <CardHeader className="items-center text-center">
+          <AlertCircle className="mb-2 size-10 text-muted-foreground" />
+          <CardTitle>No organization access yet</CardTitle>
+          <CardDescription>
+            Your account is authenticated, but it has not joined an
+            organization.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {pendingInvitationsError ? (
+            <p className="text-sm text-muted-foreground">
+              Could not load pending invitations. If you have an invitation
+              link, open it directly.
+            </p>
+          ) : invitations.length > 0 ? (
+            <>
+              <p className="text-sm text-muted-foreground">
+                We found pending invitations for your account.
+              </p>
+              <div className="space-y-2">
+                {invitations.map((invitation) => (
+                  <div
+                    key={invitation.token}
+                    className="flex items-center justify-between rounded-md border p-3"
+                  >
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium">
+                        {invitation.organization_name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Role: {invitation.role}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Expires:{" "}
+                        {new Date(invitation.expires_at).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <Button asChild size="sm" variant="outline">
+                      <Link
+                        href={`/invitations/accept?token=${encodeURIComponent(invitation.token)}`}
+                      >
+                        Review
+                      </Link>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No pending invitations were found for this account. Ask your
+              organization administrator to invite this email address.
+            </p>
+          )}
+        </CardContent>
+        <CardFooter>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => logout("/sign-in")}
+          >
+            <LogOut className="mr-2 size-4" />
+            Sign out
+          </Button>
+        </CardFooter>
+      </Card>
+    </main>
+  )
+}

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { type ComponentPropsWithoutRef, useState } from "react"
-import { authOauthGoogleDatabaseAuthorize } from "@/client"
+import { authOauthOidcDatabaseAuthorize } from "@/client"
 import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import {
@@ -53,7 +53,7 @@ export function GoogleOAuthButton({ returnUrl, ...props }: OAuthButtonProps) {
   const handleClick = async () => {
     try {
       setIsLoading(true)
-      const { authorization_url } = await authOauthGoogleDatabaseAuthorize({
+      const { authorization_url } = await authOauthOidcDatabaseAuthorize({
         scopes: ["openid", "email", "profile"],
       })
       setPostAuthReturnUrlCookie(returnUrl)

--- a/frontend/src/hooks/use-pending-org-invitations.ts
+++ b/frontend/src/hooks/use-pending-org-invitations.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import {
+  type OrgPendingInvitationRead,
+  organizationListMyPendingInvitations,
+} from "@/client"
+
+export function usePendingOrgInvitations() {
+  const {
+    data: pendingInvitations,
+    isLoading: pendingInvitationsIsLoading,
+    error: pendingInvitationsError,
+  } = useQuery<OrgPendingInvitationRead[]>({
+    queryKey: ["pending-org-invitations"],
+    queryFn: organizationListMyPendingInvitations,
+    retry: false,
+  })
+
+  return {
+    pendingInvitations,
+    pendingInvitationsIsLoading,
+    pendingInvitationsError,
+  }
+}

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -12,7 +12,7 @@ from tracecat.agent.router import (
     OrganizationUserRole,
 )
 from tracecat.api.app import app
-from tracecat.auth.credentials import SuperuserRole
+from tracecat.auth.credentials import AuthenticatedUserOnly, SuperuserRole
 from tracecat.auth.dependencies import ExecutorWorkspaceRole, WorkspaceUserRole
 from tracecat.auth.types import Role
 from tracecat.cases.router import WorkspaceUser
@@ -65,6 +65,7 @@ def client() -> Generator[TestClient, None, None]:
         WorkspaceUserInPath,
         WorkspaceAdminUserInPath,
         SuperuserRole,
+        AuthenticatedUserOnly,
         OrganizationUserRole,
         OrganizationAdminUserRole,
         OrgUser,

--- a/tests/unit/api/test_api_organization_invitations.py
+++ b/tests/unit/api/test_api_organization_invitations.py
@@ -1,0 +1,81 @@
+"""HTTP-level tests for organization invitation endpoints."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.api.app import app
+from tracecat.auth.types import Role
+from tracecat.authz.enums import OrgRole
+from tracecat.db.engine import get_async_session
+
+
+@pytest.mark.anyio
+async def test_list_my_pending_invitations_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    mock_session = await app.dependency_overrides[get_async_session]()
+
+    mock_user = SimpleNamespace(
+        id=test_admin_role.user_id,
+        email="user@example.com",
+    )
+    mock_inviter = SimpleNamespace(
+        first_name="Alice",
+        last_name="Admin",
+        email="alice@example.com",
+    )
+    organization_id = uuid.uuid4()
+    mock_invitation = SimpleNamespace(
+        token="invitation-token-123",
+        organization_id=organization_id,
+        role=OrgRole.MEMBER,
+        expires_at=datetime.now(UTC) + timedelta(days=7),
+        created_at=datetime.now(UTC),
+    )
+    mock_organization = SimpleNamespace(name="Acme Security")
+
+    user_result = Mock()
+    user_result.scalar_one_or_none.return_value = mock_user
+
+    tuples_result = Mock()
+    tuples_result.all.return_value = [
+        (mock_invitation, mock_organization, mock_inviter),
+    ]
+    pending_result = Mock()
+    pending_result.tuples.return_value = tuples_result
+
+    mock_session.execute.side_effect = [user_result, pending_result]
+
+    response = client.get("/organization/invitations/pending/me")
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["token"] == mock_invitation.token
+    assert payload[0]["organization_id"] == str(organization_id)
+    assert payload[0]["organization_name"] == "Acme Security"
+    assert payload[0]["inviter_name"] == "Alice Admin"
+    assert payload[0]["inviter_email"] == "alice@example.com"
+    assert payload[0]["role"] == "member"
+
+
+@pytest.mark.anyio
+async def test_list_my_pending_invitations_user_not_found(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    mock_session = await app.dependency_overrides[get_async_session]()
+
+    user_result = Mock()
+    user_result.scalar_one_or_none.return_value = None
+    mock_session.execute.side_effect = [user_result]
+
+    response = client.get("/organization/invitations/pending/me")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "User not found"

--- a/tracecat/organization/schemas.py
+++ b/tracecat/organization/schemas.py
@@ -76,6 +76,18 @@ class OrgInvitationReadMinimal(BaseModel):
     """
 
 
+class OrgPendingInvitationRead(BaseModel):
+    """Pending invitation visible to the invited authenticated user."""
+
+    token: str
+    organization_id: OrganizationID
+    organization_name: str
+    inviter_name: str | None
+    inviter_email: str | None
+    role: OrgRole
+    expires_at: datetime
+
+
 class OrgInvitationAccept(BaseModel):
     """Request body for accepting an organization invitation via token."""
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a fallback page when a signed-in user has no organization memberships and list their pending invitations with review links and a sign-out option. Implements ENG-1284.

- **New Features**
  - Frontend: Workspace layout detects "User has no organization memberships" and renders NoOrganizationAccess with pending invites.
  - Backend: Added GET /organization/invitations/pending/me to return pending, unexpired invites for the authenticated user with inviter name/email; uses current_active_user; returns 404 if user not found; includes HTTP tests.
  - Client: Added OrgPendingInvitationRead type, organizationListMyPendingInvitations service, and usePendingOrgInvitations hook.

- **Refactors**
  - OAuth: Renamed Google client methods to OIDC and updated the Google button.
  - Organization router: Centralized inviter name/email formatting and removed redundant user fetch.

<sup>Written for commit 59a09bca5d3739fcebf956381338d146e0d2c923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

