### PR TITLE
fix: hide superuser column in organization members table

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10173,10 +10173,6 @@ export const $OrgMemberRead = {
       type: "boolean",
       title: "Is Active",
     },
-    is_superuser: {
-      type: "boolean",
-      title: "Is Superuser",
-    },
     is_verified: {
       type: "boolean",
       title: "Is Verified",
@@ -10202,7 +10198,6 @@ export const $OrgMemberRead = {
     "email",
     "role",
     "is_active",
-    "is_superuser",
     "is_verified",
     "last_login_at",
   ],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3266,7 +3266,6 @@ export type OrgMemberRead = {
   email: string
   role: OrgRole
   is_active: boolean
-  is_superuser: boolean
   is_verified: boolean
   last_login_at: string | null
 }

--- a/frontend/src/components/organization/org-members-table.tsx
+++ b/frontend/src/components/organization/org-members-table.tsx
@@ -197,25 +197,6 @@ export function OrgMembersTable() {
               enableHiding: false,
             },
             {
-              accessorKey: "is_superuser",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Superuser"
-                />
-              ),
-              cell: ({ row }) => (
-                <div className="text-xs capitalize">
-                  {row.getValue<OrgMemberRead["is_superuser"]>("is_superuser")
-                    ? "Yes"
-                    : "No"}
-                </div>
-              ),
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
               accessorKey: "last_login_at",
               header: ({ column }) => (
                 <DataTableColumnHeader

--- a/tests/unit/api/test_api_organization_members.py
+++ b/tests/unit/api/test_api_organization_members.py
@@ -1,0 +1,70 @@
+"""HTTP-level tests for organization members API endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.authz.enums import OrgRole
+from tracecat.organization import router as organization_router
+
+
+def _member_user(user_id: uuid.UUID | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id or uuid.uuid4(),
+        email="member@example.com",
+        first_name="Member",
+        last_name="User",
+        is_active=True,
+        is_superuser=True,
+        is_verified=True,
+        last_login_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+
+@pytest.mark.anyio
+async def test_list_org_members_omits_superuser_flag(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    user = _member_user()
+
+    with patch.object(organization_router, "OrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_members.return_value = [(user, OrgRole.ADMIN)]
+        MockService.return_value = mock_svc
+
+        response = client.get("/organization/members")
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user_id"] == str(user.id)
+    assert "is_superuser" not in data[0]
+
+
+@pytest.mark.anyio
+async def test_update_org_member_omits_superuser_flag(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    user = _member_user()
+
+    with patch.object(organization_router, "OrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.update_member.return_value = (user, OrgRole.MEMBER)
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            f"/organization/members/{user.id}",
+            json={"role": "basic"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["user_id"] == str(user.id)
+    assert data["role"] == "member"
+    assert "is_superuser" not in data

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -137,7 +137,6 @@ async def get_current_org_member(
             email=user.email,
             role=org_role,
             is_active=user.is_active,
-            is_superuser=user.is_superuser,
             is_verified=user.is_verified,
             last_login_at=user.last_login_at,
         )
@@ -157,7 +156,6 @@ async def get_current_org_member(
                 email=user.email,
                 role=OrgRole.OWNER,  # Superusers have implicit owner role
                 is_active=user.is_active,
-                is_superuser=user.is_superuser,
                 is_verified=user.is_verified,
                 last_login_at=user.last_login_at,
             )
@@ -184,7 +182,6 @@ async def list_org_members(
             email=user.email,
             role=org_role,
             is_active=user.is_active,
-            is_superuser=user.is_superuser,
             is_verified=user.is_verified,
             last_login_at=user.last_login_at,
         )
@@ -235,7 +232,6 @@ async def update_org_member(
             email=user.email,
             role=org_role,
             is_active=user.is_active,
-            is_superuser=user.is_superuser,
             is_verified=user.is_verified,
             last_login_at=user.last_login_at,
         )

--- a/tracecat/organization/schemas.py
+++ b/tracecat/organization/schemas.py
@@ -17,7 +17,6 @@ class OrgMemberRead(BaseModel):
     email: EmailStr
     role: OrgRole
     is_active: bool
-    is_superuser: bool
     is_verified: bool
     last_login_at: datetime | None
 


### PR DESCRIPTION
## Summary
- Remove the `Superuser` column from the Organization members table.
- Remove `is_superuser` from `OrgMemberRead` so organization member endpoints no longer expose platform-level superuser status.
- Update generated frontend API client types to match the new backend response schema.
- Add API regression tests to ensure organization member responses omit `is_superuser`.

## Testing
- `pnpm -C frontend exec biome check src/components/organization/org-members-table.tsx`
- `pnpm -C frontend run typecheck`
- `uv run ruff check tracecat/config.py`
- `uv run basedpyright tracecat/config.py`
- `just gen-client-ci`
- `uv run ruff check tracecat/organization/router.py tracecat/organization/schemas.py tests/unit/api/test_api_organization_members.py`
- `uv run basedpyright tracecat/organization/router.py tracecat/organization/schemas.py tests/unit/api/test_api_organization_members.py`
- `pnpm -C frontend exec biome check src/client/schemas.gen.ts src/client/types.gen.ts`

## Notes
- `uv run pytest tests/unit/api/test_api_organization_members.py` requires MinIO via shared test fixtures and fails locally when MinIO is not running.
