### PR TITLE
feat(organization): add read-only domains in org settings

### DIFF
--- a/frontend/src/app/organization/settings/domains/layout.tsx
+++ b/frontend/src/app/organization/settings/domains/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Domains | Organization",
+}
+
+export default function DomainsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/domains/page.tsx
+++ b/frontend/src/app/organization/settings/domains/page.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { OrgSettingsDomains } from "@/components/organization/org-settings-domains"
+
+export default function DomainsSettingsPage() {
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
+        <div className="flex w-full">
+          <div className="items-start space-y-3 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">Domains</h2>
+            <p className="text-base text-muted-foreground">
+              View domains currently assigned to your organization.
+            </p>
+          </div>
+        </div>
+        <OrgSettingsDomains />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9902,77 +9902,6 @@ export const $OrgDomainCreate = {
   description: "Create organization domain request.",
 } as const
 
-export const $OrgDomainRead = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-    },
-    organization_id: {
-      type: "string",
-      format: "uuid",
-      title: "Organization Id",
-    },
-    domain: {
-      type: "string",
-      title: "Domain",
-    },
-    normalized_domain: {
-      type: "string",
-      title: "Normalized Domain",
-    },
-    is_primary: {
-      type: "boolean",
-      title: "Is Primary",
-    },
-    is_active: {
-      type: "boolean",
-      title: "Is Active",
-    },
-    verified_at: {
-      anyOf: [
-        {
-          type: "string",
-          format: "date-time",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Verified At",
-    },
-    verification_method: {
-      type: "string",
-      title: "Verification Method",
-    },
-    created_at: {
-      type: "string",
-      format: "date-time",
-      title: "Created At",
-    },
-    updated_at: {
-      type: "string",
-      format: "date-time",
-      title: "Updated At",
-    },
-  },
-  type: "object",
-  required: [
-    "id",
-    "organization_id",
-    "domain",
-    "normalized_domain",
-    "is_primary",
-    "is_active",
-    "verification_method",
-    "created_at",
-    "updated_at",
-  ],
-  title: "OrgDomainRead",
-  description: "Organization domain response.",
-} as const
-
 export const $OrgDomainUpdate = {
   properties: {
     is_primary: {
@@ -20586,6 +20515,77 @@ export const $tracecat__admin__registry__schemas__RegistryVersionRead = {
   description: "Registry version details.",
 } as const
 
+export const $tracecat__organization__schemas__OrgDomainRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    organization_id: {
+      type: "string",
+      format: "uuid",
+      title: "Organization Id",
+    },
+    domain: {
+      type: "string",
+      title: "Domain",
+    },
+    normalized_domain: {
+      type: "string",
+      title: "Normalized Domain",
+    },
+    is_primary: {
+      type: "boolean",
+      title: "Is Primary",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    verified_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Verified At",
+    },
+    verification_method: {
+      type: "string",
+      title: "Verification Method",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "organization_id",
+    "domain",
+    "normalized_domain",
+    "is_primary",
+    "is_active",
+    "verified_at",
+    "verification_method",
+    "created_at",
+    "updated_at",
+  ],
+  title: "OrgDomainRead",
+} as const
+
 export const $tracecat__organization__schemas__OrgRead = {
   properties: {
     id: {
@@ -20765,6 +20765,77 @@ export const $tracecat__registry__repositories__schemas__RegistryVersionRead = {
   ],
   title: "RegistryVersionRead",
   description: "Response model for reading a registry version.",
+} as const
+
+export const $tracecat_ee__admin__organizations__schemas__OrgDomainRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    organization_id: {
+      type: "string",
+      format: "uuid",
+      title: "Organization Id",
+    },
+    domain: {
+      type: "string",
+      title: "Domain",
+    },
+    normalized_domain: {
+      type: "string",
+      title: "Normalized Domain",
+    },
+    is_primary: {
+      type: "boolean",
+      title: "Is Primary",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    verified_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Verified At",
+    },
+    verification_method: {
+      type: "string",
+      title: "Verification Method",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "organization_id",
+    "domain",
+    "normalized_domain",
+    "is_primary",
+    "is_active",
+    "verification_method",
+    "created_at",
+    "updated_at",
+  ],
+  title: "OrgDomainRead",
+  description: "Organization domain response.",
 } as const
 
 export const $tracecat_ee__admin__organizations__schemas__OrgRead = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -327,6 +327,7 @@ import type {
   OrganizationListInvitationsData,
   OrganizationListInvitationsResponse,
   OrganizationListMyPendingInvitationsResponse,
+  OrganizationListOrganizationDomainsResponse,
   OrganizationListOrgMembersResponse,
   OrganizationListSessionsResponse,
   OrganizationRevokeInvitationData,
@@ -3072,6 +3073,20 @@ export const organizationGetOrganization =
   }
 
 /**
+ * List Organization Domains
+ * List domains assigned to the current organization.
+ * @returns tracecat__organization__schemas__OrgDomainRead Successful Response
+ * @throws ApiError
+ */
+export const organizationListOrganizationDomains =
+  (): CancelablePromise<OrganizationListOrganizationDomainsResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/organization/domains",
+    })
+  }
+
+/**
  * Get Current Org Member
  * Get the current user's organization membership.
  *
@@ -4154,7 +4169,7 @@ export const adminDeleteOrganization = (
  * List all assigned domains for an organization.
  * @param data The data for the request.
  * @param data.orgId
- * @returns OrgDomainRead Successful Response
+ * @returns tracecat_ee__admin__organizations__schemas__OrgDomainRead Successful Response
  * @throws ApiError
  */
 export const adminListOrganizationDomains = (
@@ -4178,7 +4193,7 @@ export const adminListOrganizationDomains = (
  * @param data The data for the request.
  * @param data.orgId
  * @param data.requestBody
- * @returns OrgDomainRead Successful Response
+ * @returns tracecat_ee__admin__organizations__schemas__OrgDomainRead Successful Response
  * @throws ApiError
  */
 export const adminCreateOrganizationDomain = (
@@ -4205,7 +4220,7 @@ export const adminCreateOrganizationDomain = (
  * @param data.orgId
  * @param data.domainId
  * @param data.requestBody
- * @returns OrgDomainRead Successful Response
+ * @returns tracecat_ee__admin__organizations__schemas__OrgDomainRead Successful Response
  * @throws ApiError
  */
 export const adminUpdateOrganizationDomain = (

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3192,22 +3192,6 @@ export type OrgDomainCreate = {
 }
 
 /**
- * Organization domain response.
- */
-export type OrgDomainRead = {
-  id: string
-  organization_id: string
-  domain: string
-  normalized_domain: string
-  is_primary: boolean
-  is_active: boolean
-  verified_at?: string | null
-  verification_method: string
-  created_at: string
-  updated_at: string
-}
-
-/**
  * Update organization domain request.
  */
 export type OrgDomainUpdate = {
@@ -6297,6 +6281,19 @@ export type tracecat__admin__registry__schemas__RegistryVersionRead = {
   created_at: string
 }
 
+export type tracecat__organization__schemas__OrgDomainRead = {
+  id: string
+  organization_id: string
+  domain: string
+  normalized_domain: string
+  is_primary: boolean
+  is_active: boolean
+  verified_at: string | null
+  verification_method: string
+  created_at: string
+  updated_at: string
+}
+
 export type tracecat__organization__schemas__OrgRead = {
   id: string
   name: string
@@ -6337,6 +6334,22 @@ export type tracecat__registry__repositories__schemas__RegistryVersionRead = {
   commit_sha: string | null
   tarball_uri: string | null
   created_at: string
+}
+
+/**
+ * Organization domain response.
+ */
+export type tracecat_ee__admin__organizations__schemas__OrgDomainRead = {
+  id: string
+  organization_id: string
+  domain: string
+  normalized_domain: string
+  is_primary: boolean
+  is_active: boolean
+  verified_at?: string | null
+  verification_method: string
+  created_at: string
+  updated_at: string
 }
 
 /**
@@ -7066,6 +7079,9 @@ export type UsersSearchUserResponse = UserRead
 export type OrganizationGetOrganizationResponse =
   tracecat__organization__schemas__OrgRead
 
+export type OrganizationListOrganizationDomainsResponse =
+  Array<tracecat__organization__schemas__OrgDomainRead>
+
 export type OrganizationGetCurrentOrgMemberResponse = OrgMemberRead
 
 export type OrganizationListOrgMembersResponse = Array<OrgMemberRead>
@@ -7376,14 +7392,16 @@ export type AdminListOrganizationDomainsData = {
   orgId: string
 }
 
-export type AdminListOrganizationDomainsResponse = Array<OrgDomainRead>
+export type AdminListOrganizationDomainsResponse =
+  Array<tracecat_ee__admin__organizations__schemas__OrgDomainRead>
 
 export type AdminCreateOrganizationDomainData = {
   orgId: string
   requestBody: OrgDomainCreate
 }
 
-export type AdminCreateOrganizationDomainResponse = OrgDomainRead
+export type AdminCreateOrganizationDomainResponse =
+  tracecat_ee__admin__organizations__schemas__OrgDomainRead
 
 export type AdminUpdateOrganizationDomainData = {
   domainId: string
@@ -7391,7 +7409,8 @@ export type AdminUpdateOrganizationDomainData = {
   requestBody: OrgDomainUpdate
 }
 
-export type AdminUpdateOrganizationDomainResponse = OrgDomainRead
+export type AdminUpdateOrganizationDomainResponse =
+  tracecat_ee__admin__organizations__schemas__OrgDomainRead
 
 export type AdminDeleteOrganizationDomainData = {
   domainId: string
@@ -10008,6 +10027,16 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/organization/domains": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<tracecat__organization__schemas__OrgDomainRead>
+      }
+    }
+  }
   "/organization/members/me": {
     get: {
       res: {
@@ -10632,7 +10661,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<OrgDomainRead>
+        200: Array<tracecat_ee__admin__organizations__schemas__OrgDomainRead>
         /**
          * Validation Error
          */
@@ -10645,7 +10674,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        201: OrgDomainRead
+        201: tracecat_ee__admin__organizations__schemas__OrgDomainRead
         /**
          * Validation Error
          */
@@ -10660,7 +10689,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: OrgDomainRead
+        200: tracecat_ee__admin__organizations__schemas__OrgDomainRead
         /**
          * Validation Error
          */

--- a/frontend/src/components/organization/org-settings-domains.tsx
+++ b/frontend/src/components/organization/org-settings-domains.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import { Badge } from "@/components/ui/badge"
+import { useOrgDomains } from "@/hooks/use-org-domains"
+
+function formatVerificationMethod(method: string): string {
+  if (method === "platform_admin") {
+    return "Platform-assigned"
+  }
+  return method.replaceAll("_", " ")
+}
+
+export function OrgSettingsDomains() {
+  const { domains, isLoading, error } = useOrgDomains()
+
+  if (isLoading) {
+    return <CenteredSpinner />
+  }
+  if (error) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading organization domains: ${error.message}`}
+      />
+    )
+  }
+
+  if (!domains || domains.length === 0) {
+    return (
+      <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+        No domains assigned yet. Contact a platform administrator to add one.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {domains.map((domain) => (
+        <div
+          key={domain.id}
+          className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="space-y-1">
+            <p className="text-sm font-medium">{domain.domain}</p>
+            <p className="text-xs text-muted-foreground">
+              Verification:{" "}
+              {formatVerificationMethod(domain.verification_method)}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {domain.is_primary && <Badge variant="secondary">Primary</Badge>}
+            <Badge variant={domain.is_active ? "secondary" : "outline"}>
+              {domain.is_active ? "Active" : "Inactive"}
+            </Badge>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   GitBranchIcon,
+  GlobeIcon,
   KeyRoundIcon,
   LockIcon,
   LogInIcon,
@@ -52,6 +53,12 @@ export function OrganizationSidebar({
       url: "/organization/settings/sso",
       icon: LockIcon,
       isActive: pathname?.includes("/organization/settings/sso"),
+    },
+    {
+      title: "Domains",
+      url: "/organization/settings/domains",
+      icon: GlobeIcon,
+      isActive: pathname?.includes("/organization/settings/domains"),
     },
     {
       title: "Application",

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -47,7 +47,7 @@ import {
   type OrganizationTierUpdate,
   type OrgCreate,
   type OrgDomainCreate,
-  type OrgDomainRead,
+  type tracecat_ee__admin__organizations__schemas__OrgDomainRead as OrgDomainRead,
   type OrgDomainUpdate,
   type tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead,
   type OrgUpdate,

--- a/frontend/src/hooks/use-org-domains.ts
+++ b/frontend/src/hooks/use-org-domains.ts
@@ -1,0 +1,22 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { organizationListOrganizationDomains } from "@/client"
+
+export function useOrgDomains() {
+  const {
+    data: domains,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["organization-domains"],
+    queryFn: organizationListOrganizationDomains,
+    retry: false,
+  })
+
+  return {
+    domains,
+    isLoading,
+    error,
+  }
+}

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -18,6 +18,8 @@ from tracecat.auth.types import Role
 from tracecat.cases.router import WorkspaceUser
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session
+from tracecat.organization.router import OrgAdminRole as OrganizationOrgAdminRole
+from tracecat.organization.router import OrgUserRole as OrganizationOrgUserRole
 from tracecat.secrets.router import (
     OrgAdminUser,
     WorkspaceAdminUser,
@@ -75,6 +77,8 @@ def client() -> Generator[TestClient, None, None]:
         OrgAdminUser,
         TablesWorkspaceUser,
         TablesWorkspaceEditorUser,
+        OrganizationOrgUserRole,
+        OrganizationOrgAdminRole,
     ]
 
     for annotated_type in role_dependencies:

--- a/tests/unit/api/test_api_organization_domains.py
+++ b/tests/unit/api/test_api_organization_domains.py
@@ -1,0 +1,75 @@
+"""HTTP-level tests for organization domains endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.api.app import app
+from tracecat.auth.types import Role
+from tracecat.contexts import ctx_role
+from tracecat.db.engine import get_async_session
+
+
+@pytest.mark.anyio
+async def test_list_organization_domains_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    mock_session = await app.dependency_overrides[get_async_session]()
+
+    now = datetime.now(UTC)
+    organization_id = test_admin_role.organization_id
+    assert organization_id is not None
+    domain_id = uuid.uuid4()
+
+    mock_domain = SimpleNamespace(
+        id=domain_id,
+        organization_id=organization_id,
+        domain="acme.com",
+        normalized_domain="acme.com",
+        is_primary=True,
+        is_active=True,
+        verified_at=None,
+        verification_method="platform_admin",
+        created_at=now,
+        updated_at=now,
+    )
+
+    scalar_result = Mock()
+    scalar_result.all.return_value = [mock_domain]
+    query_result = Mock()
+    query_result.scalars.return_value = scalar_result
+
+    mock_session.execute.side_effect = [query_result]
+
+    response = client.get("/organization/domains")
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["id"] == str(domain_id)
+    assert payload[0]["organization_id"] == str(organization_id)
+    assert payload[0]["domain"] == "acme.com"
+    assert payload[0]["normalized_domain"] == "acme.com"
+    assert payload[0]["is_primary"] is True
+    assert payload[0]["is_active"] is True
+    assert payload[0]["verification_method"] == "platform_admin"
+
+
+@pytest.mark.anyio
+async def test_list_organization_domains_requires_org_context(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    role_without_org = test_admin_role.model_copy(update={"organization_id": None})
+    token = ctx_role.set(role_without_org)
+    try:
+        response = client.get("/organization/domains")
+    finally:
+        ctx_role.reset(token)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "No organization context"

--- a/tracecat/organization/schemas.py
+++ b/tracecat/organization/schemas.py
@@ -29,6 +29,19 @@ class OrgRead(BaseModel):
     name: str
 
 
+class OrgDomainRead(BaseModel):
+    id: UUID
+    organization_id: OrganizationID
+    domain: str
+    normalized_domain: str
+    is_primary: bool
+    is_active: bool
+    verified_at: datetime | None
+    verification_method: str
+    created_at: datetime
+    updated_at: datetime
+
+
 # Invitations
 
 


### PR DESCRIPTION
## Description
This PR adds read-only organization domain visibility in organization settings.

## Motivation
After domain assignment moved to SU/admin flows, org admins still need visibility into which domains are mapped to their organization for login/discovery behavior and support workflows.

## Changes
- Adds `GET /organization/domains` endpoint for authenticated org users.
- Adds `OrgDomainRead` response schema in `tracecat/organization/schemas.py`.
- Adds org settings UI page at `/organization/settings/domains` with read-only domain list (primary/active indicators, verification method).
- Adds sidebar navigation entry for Domains.
- Adds frontend hook `useOrgDomains` and wires generated client API.
- Updates API test role dependency overrides for organization router role aliases.
- Adds HTTP tests for `/organization/domains` success and missing-org-context behavior.
- Regenerates frontend API client.

## Related issues
- ENG-1277
- ENG-1288

## Steps to QA
1. Log in as an org member/admin with assigned domains.
2. Navigate to `Organization -> Settings -> Domains`.
3. Confirm domains render read-only with primary/active state.
4. Confirm no edit/add/delete controls are shown.
5. Verify endpoint authorization and no-org-context behavior via tests.

## Validation
- `just gen-client-ci`
- `uv run ruff check .`
- `uv run basedpyright tracecat/organization/router.py tracecat/organization/schemas.py tests/unit/api/conftest.py tests/unit/api/test_api_organization_domains.py`
- `uv run pytest tests/unit/api/test_api_organization_domains.py tests/unit/api/test_api_organization_invitations.py`
- `pnpm -C frontend run typecheck`
- `pnpm -C frontend check`
