### PR TITLE
fix(integrations): surface branch-not-found publish errors

### DIFF
--- a/tests/unit/api/test_api_organization_invitations.py
+++ b/tests/unit/api/test_api_organization_invitations.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 
 from tracecat.api.app import app
 from tracecat.auth.types import Role
-from tracecat.auth.users import current_active_user
 from tracecat.authz.enums import OrgRole
 from tracecat.db.engine import get_async_session
 
@@ -41,6 +40,9 @@ async def test_list_my_pending_invitations_success(
     )
     mock_organization = SimpleNamespace(name="Acme Security")
 
+    user_result = Mock()
+    user_result.scalar_one_or_none.return_value = mock_user
+
     tuples_result = Mock()
     tuples_result.all.return_value = [
         (mock_invitation, mock_organization, mock_inviter),
@@ -48,12 +50,9 @@ async def test_list_my_pending_invitations_success(
     pending_result = Mock()
     pending_result.tuples.return_value = tuples_result
 
-    mock_session.execute.side_effect = [pending_result]
-    app.dependency_overrides[current_active_user] = lambda: mock_user
-    try:
-        response = client.get("/organization/invitations/pending/me")
-    finally:
-        app.dependency_overrides.pop(current_active_user, None)
+    mock_session.execute.side_effect = [user_result, pending_result]
+
+    response = client.get("/organization/invitations/pending/me")
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -67,26 +66,16 @@ async def test_list_my_pending_invitations_success(
 
 
 @pytest.mark.anyio
-async def test_list_my_pending_invitations_no_results(
+async def test_list_my_pending_invitations_user_not_found(
     client: TestClient, test_admin_role: Role
 ) -> None:
     mock_session = await app.dependency_overrides[get_async_session]()
 
-    mock_user = SimpleNamespace(
-        id=test_admin_role.user_id,
-        email="missing@example.com",
-    )
-    tuples_result = Mock()
-    tuples_result.all.return_value = []
-    pending_result = Mock()
-    pending_result.tuples.return_value = tuples_result
-    mock_session.execute.side_effect = [pending_result]
+    user_result = Mock()
+    user_result.scalar_one_or_none.return_value = None
+    mock_session.execute.side_effect = [user_result]
 
-    app.dependency_overrides[current_active_user] = lambda: mock_user
-    try:
-        response = client.get("/organization/invitations/pending/me")
-    finally:
-        app.dependency_overrides.pop(current_active_user, None)
+    response = client.get("/organization/invitations/pending/me")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == []
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "User not found"

--- a/tests/unit/api/test_api_organization_invitations.py
+++ b/tests/unit/api/test_api_organization_invitations.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from tracecat.api.app import app
 from tracecat.auth.types import Role
+from tracecat.auth.users import current_active_user
 from tracecat.authz.enums import OrgRole
 from tracecat.db.engine import get_async_session
 
@@ -40,9 +41,6 @@ async def test_list_my_pending_invitations_success(
     )
     mock_organization = SimpleNamespace(name="Acme Security")
 
-    user_result = Mock()
-    user_result.scalar_one_or_none.return_value = mock_user
-
     tuples_result = Mock()
     tuples_result.all.return_value = [
         (mock_invitation, mock_organization, mock_inviter),
@@ -50,9 +48,12 @@ async def test_list_my_pending_invitations_success(
     pending_result = Mock()
     pending_result.tuples.return_value = tuples_result
 
-    mock_session.execute.side_effect = [user_result, pending_result]
-
-    response = client.get("/organization/invitations/pending/me")
+    mock_session.execute.side_effect = [pending_result]
+    app.dependency_overrides[current_active_user] = lambda: mock_user
+    try:
+        response = client.get("/organization/invitations/pending/me")
+    finally:
+        app.dependency_overrides.pop(current_active_user, None)
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -66,16 +67,26 @@ async def test_list_my_pending_invitations_success(
 
 
 @pytest.mark.anyio
-async def test_list_my_pending_invitations_user_not_found(
+async def test_list_my_pending_invitations_no_results(
     client: TestClient, test_admin_role: Role
 ) -> None:
     mock_session = await app.dependency_overrides[get_async_session]()
 
-    user_result = Mock()
-    user_result.scalar_one_or_none.return_value = None
-    mock_session.execute.side_effect = [user_result]
+    mock_user = SimpleNamespace(
+        id=test_admin_role.user_id,
+        email="missing@example.com",
+    )
+    tuples_result = Mock()
+    tuples_result.all.return_value = []
+    pending_result = Mock()
+    pending_result.tuples.return_value = tuples_result
+    mock_session.execute.side_effect = [pending_result]
 
-    response = client.get("/organization/invitations/pending/me")
+    app.dependency_overrides[current_active_user] = lambda: mock_user
+    try:
+        response = client.get("/organization/invitations/pending/me")
+    finally:
+        app.dependency_overrides.pop(current_active_user, None)
 
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "User not found"
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []

--- a/tests/unit/test_api_common.py
+++ b/tests/unit/test_api_common.py
@@ -1,0 +1,47 @@
+"""Tests for API exception handlers."""
+
+import json
+
+from fastapi import status
+from starlette.requests import Request
+
+from tracecat.api.common import tracecat_exception_handler
+from tracecat.exceptions import TracecatException
+
+
+def _build_request(path: str, query_string: str = "") -> Request:
+    """Create a minimal ASGI request object for handler tests."""
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": query_string.encode("utf-8"),
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+def test_tracecat_exception_handler_with_braces_in_message() -> None:
+    """Messages containing braces should not break logger formatting."""
+    request = _build_request(
+        "/workflows/wf_123/publish",
+        query_string="workspace_id=c7e6b746-88dd-443e-bba5-c14e96db9adb",
+    )
+    exc = TracecatException(
+        "GitHub API error: 404 - {'message': 'Branch not found'}",
+        detail={"status": 404},
+    )
+
+    response = tracecat_exception_handler(request, exc)
+    payload = json.loads(bytes(response.body))
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert payload["type"] == "TracecatException"
+    assert payload["message"] == "GitHub API error: 404 - {'message': 'Branch not found'}"
+    assert payload["detail"] == {"status": 404}

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -44,25 +44,25 @@ async def test_verify_auth_type_not_allowed(
 
 @pytest.mark.anyio
 async def test_verify_auth_type_setting_disabled(mocker: MockerFixture):
-    """Test that disabled auth types raise HTTPException."""
-    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.BASIC])
+    """Test that disabled settings-controlled auth types raise HTTPException."""
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=False)
 
     with pytest.raises(HTTPException) as exc:
-        await verify_auth_type(AuthType.BASIC)
+        await verify_auth_type(AuthType.SAML)
 
     assert exc.value.status_code == status.HTTP_403_FORBIDDEN
-    assert exc.value.detail == f"Auth type {AuthType.BASIC.value} is not enabled"
+    assert exc.value.detail == f"Auth type {AuthType.SAML.value} is not enabled"
 
 
 @pytest.mark.anyio
 async def test_verify_auth_type_invalid_setting(mocker: MockerFixture):
-    """Test that invalid settings raise HTTPException."""
-    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.BASIC])
+    """Test that invalid settings for settings-controlled auth types raise."""
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=None)
 
     with pytest.raises(HTTPException) as exc:
-        await verify_auth_type(AuthType.BASIC)
+        await verify_auth_type(AuthType.SAML)
 
     assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert exc.value.detail == "Invalid setting configuration"

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -95,7 +95,9 @@ def tracecat_exception_handler(request: Request, exc: Exception) -> Response:
     )
     msg = str(tracecat_exc)
     logger.error(
-        msg,
+        "Tracecat exception",
+        exception_message=msg,
+        exception_type=type(exc).__name__,
         role=ctx_role.get(),
         params=request.query_params,
         path=request.url.path,

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -61,6 +61,11 @@ async def publish_workflow(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         ) from e
+    except GitHubAppError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
 
 
 @router.get("/sync/commits", response_model=list[GitCommitInfo])


### PR DESCRIPTION
## Summary
- Return a clear, branch-specific error when workflow publish fails because the configured Git branch does not exist.
- Map GitHub publish failures to HTTP 400 in `/workflows/{workflow_id}/publish` so the UI can show the backend error detail.
- Harden Tracecat exception logging so messages containing braces (for example GitHub payload text) do not trigger formatting `KeyError`s.
- Add regression coverage for missing-branch publish failures and brace-containing exception messages.

## Validation
- `uv run ruff check tracecat/workflow/store/sync.py tracecat/api/common.py tracecat/workflow/store/router.py tests/unit/test_workflow_sync_service.py tests/unit/test_api_common.py`
- `uv run basedpyright tracecat/workflow/store/sync.py tracecat/api/common.py tracecat/workflow/store/router.py tests/unit/test_workflow_sync_service.py tests/unit/test_api_common.py`
- `uv run pytest tests/unit/test_workflow_sync_service.py tests/unit/test_api_common.py` (requires local MinIO at `localhost:9000`; not runnable in this environment)
