### PR TITLE
fix(engine): make background execution failures graceful

### DIFF
--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -45,24 +45,24 @@ async def test_verify_auth_type_not_allowed(
 @pytest.mark.anyio
 async def test_verify_auth_type_setting_disabled(mocker: MockerFixture):
     """Test that disabled auth types raise HTTPException."""
-    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.BASIC])
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=False)
 
     with pytest.raises(HTTPException) as exc:
-        await verify_auth_type(AuthType.BASIC)
+        await verify_auth_type(AuthType.SAML)
 
     assert exc.value.status_code == status.HTTP_403_FORBIDDEN
-    assert exc.value.detail == f"Auth type {AuthType.BASIC.value} is not enabled"
+    assert exc.value.detail == f"Auth type {AuthType.SAML.value} is not enabled"
 
 
 @pytest.mark.anyio
 async def test_verify_auth_type_invalid_setting(mocker: MockerFixture):
     """Test that invalid settings raise HTTPException."""
-    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.BASIC])
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=None)
 
     with pytest.raises(HTTPException) as exc:
-        await verify_auth_type(AuthType.BASIC)
+        await verify_auth_type(AuthType.SAML)
 
     assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert exc.value.detail == "Invalid setting configuration"


### PR DESCRIPTION
## Summary
- Update `create_workflow_execution_nowait` and `create_draft_workflow_execution_nowait` to schedule only workflow start acknowledgement in the background.
- Add guarded background start wrappers that catch and log start-time failures.
- Keep synchronous wait paths unchanged.
- Add unit tests for nowait start-only behavior and exception swallowing.

## Problem
Background fire-and-forget dispatches were waiting on full workflow completion. Expected workflow/action failures could then surface as noisy:

`Task exception was never retrieved`

## Validation
- `uv run ruff check tracecat/workflow/executions/service.py tests/unit/test_workflow_executions.py`
- `uv run pyright tracecat/workflow/executions/service.py tests/unit/test_workflow_executions.py`
- `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/test_workflow_executions.py -q`
