### PR TITLE
fix(auth): use org membership role instead of platform for org-level …

### DIFF
--- a/frontend/src/app/organization/settings/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/organization/settings/workspaces/[workspaceId]/page.tsx
@@ -6,13 +6,13 @@ import { workspacesGetWorkspace } from "@/client"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { OrgWorkspaceSettings } from "@/components/organization/org-workspace-settings"
-import { useAuth } from "@/hooks/use-auth"
+import { useOrgMembership } from "@/hooks/use-org-membership"
 import { useCurrentUserRole } from "@/hooks/use-workspace"
 
 export default function OrganizationWorkspaceSettingsPage() {
   const params = useParams<{ workspaceId: string }>()
   const router = useRouter()
-  const { user } = useAuth()
+  const { canAdministerOrg } = useOrgMembership()
 
   const workspaceId = params?.workspaceId
   const { role } = useCurrentUserRole(workspaceId ?? "")
@@ -45,7 +45,7 @@ export default function OrganizationWorkspaceSettingsPage() {
   }
 
   // Check if user is org admin or workspace admin
-  const isOrgAdmin = user?.isPrivileged()
+  const isOrgAdmin = Boolean(canAdministerOrg)
   const isWorkspaceAdmin = role === "admin"
 
   if (!isOrgAdmin && !isWorkspaceAdmin) {

--- a/frontend/src/components/organization/org-invitations-table.tsx
+++ b/frontend/src/components/organization/org-invitations-table.tsx
@@ -62,7 +62,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
-import { useAuth } from "@/hooks/use-auth"
+import { useOrgMembership } from "@/hooks/use-org-membership"
 import { getRelativeTime } from "@/lib/event-history"
 import { useOrgInvitations } from "@/lib/hooks"
 
@@ -77,7 +77,7 @@ export function OrgInvitationsTable() {
   const [selectedInvitation, setSelectedInvitation] =
     useState<OrgInvitationRead | null>(null)
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
-  const { user } = useAuth()
+  const { canAdministerOrg } = useOrgMembership()
   const { invitations, createInvitation, createPending, revokeInvitation } =
     useOrgInvitations()
 
@@ -130,7 +130,7 @@ export function OrgInvitationsTable() {
 
   return (
     <div className="space-y-4">
-      {user?.isPrivileged() && (
+      {canAdministerOrg && (
         <div className="flex justify-end">
           <Dialog
             open={isCreateDialogOpen}
@@ -360,7 +360,7 @@ export function OrgInvitationsTable() {
                       >
                         Copy invitation ID
                       </DropdownMenuItem>
-                      {user?.isPrivileged() && isPending && (
+                      {canAdministerOrg && isPending && (
                         <DropdownMenuItem
                           onSelect={async () => {
                             try {
@@ -387,7 +387,7 @@ export function OrgInvitationsTable() {
                           Copy invitation link
                         </DropdownMenuItem>
                       )}
-                      {user?.isPrivileged() && (
+                      {canAdministerOrg && (
                         <>
                           <DropdownMenuSeparator />
                           {isPending ? (

--- a/frontend/src/components/organization/org-members-table.tsx
+++ b/frontend/src/components/organization/org-members-table.tsx
@@ -44,7 +44,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
-import { useAuth } from "@/hooks/use-auth"
+import { useOrgMembership } from "@/hooks/use-org-membership"
 import { getRelativeTime } from "@/lib/event-history"
 import { useOrgMembers } from "@/lib/hooks"
 
@@ -53,7 +53,7 @@ export function OrgMembersTable() {
     null
   )
   const [isChangeRoleOpen, setIsChangeRoleOpen] = useState(false)
-  const { user } = useAuth()
+  const { canAdministerOrg } = useOrgMembership()
   const { orgMembers, updateOrgMember, deleteOrgMember } = useOrgMembers()
 
   const handleChangeRole = async (role: UserRole) => {
@@ -244,7 +244,7 @@ export function OrgMembersTable() {
                         Copy user ID
                       </DropdownMenuItem>
 
-                      {user?.isPrivileged() && (
+                      {canAdministerOrg && (
                         <DropdownMenuGroup>
                           <DialogTrigger asChild>
                             <DropdownMenuItem

--- a/frontend/src/components/organization/org-sessions-table.tsx
+++ b/frontend/src/components/organization/org-sessions-table.tsx
@@ -28,7 +28,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { useAuth } from "@/hooks/use-auth"
+import { useOrgMembership } from "@/hooks/use-org-membership"
 import { getRelativeTime } from "@/lib/event-history"
 import { useSessions } from "@/lib/hooks"
 
@@ -37,7 +37,7 @@ export function OrgSessionsTable() {
     null
   )
   const [isChangeRoleOpen, setIsChangeRoleOpen] = useState(false)
-  const { user } = useAuth()
+  const { canAdministerOrg } = useOrgMembership()
   const { sessions, deleteSession } = useSessions()
 
   const handleRevokeSession = useCallback(async () => {
@@ -122,7 +122,7 @@ export function OrgSessionsTable() {
                       >
                         Copy user ID
                       </DropdownMenuItem>
-                      {user?.isPrivileged() && (
+                      {canAdministerOrg && (
                         <DropdownMenuGroup>
                           <AlertDialogTrigger asChild>
                             <DropdownMenuItem

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -308,7 +308,7 @@ Default: true.
 """
 
 TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES = int(
-    os.environ.get("TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES", 128 * 1024)
+    os.environ.get("TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES") or 128 * 1024
 )
 """Threshold in bytes above which payloads are externalized to blob storage.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch org-level admin checks to the user's org membership role instead of platform privileges. Fixes incorrect permission gating for org actions.

- **Bug Fixes**
  - Replace user.isPrivileged() with useOrgMembership.canAdministerOrg in workspace settings, org invitations, org members, and org sessions.
  - Harden TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES parsing: treat empty env values as unset and default to 128 KB.

<sup>Written for commit 6419db8b916012cc1cdc03ea98f260410b907c10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

