### PR TITLE
fix(auth): restore admin profile rename in settings

### DIFF
--- a/tests/unit/api/test_api_organization_invitations.py
+++ b/tests/unit/api/test_api_organization_invitations.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from tracecat.api.app import app
 from tracecat.auth.types import Role
+from tracecat.auth.users import current_active_user
 from tracecat.authz.enums import OrgRole
 from tracecat.db.engine import get_async_session
 
@@ -40,9 +41,6 @@ async def test_list_my_pending_invitations_success(
     )
     mock_organization = SimpleNamespace(name="Acme Security")
 
-    user_result = Mock()
-    user_result.scalar_one_or_none.return_value = mock_user
-
     tuples_result = Mock()
     tuples_result.all.return_value = [
         (mock_invitation, mock_organization, mock_inviter),
@@ -50,9 +48,13 @@ async def test_list_my_pending_invitations_success(
     pending_result = Mock()
     pending_result.tuples.return_value = tuples_result
 
-    mock_session.execute.side_effect = [user_result, pending_result]
+    mock_session.execute.side_effect = [pending_result]
+    app.dependency_overrides[current_active_user] = lambda: mock_user
 
-    response = client.get("/organization/invitations/pending/me")
+    try:
+        response = client.get("/organization/invitations/pending/me")
+    finally:
+        app.dependency_overrides.pop(current_active_user, None)
 
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
@@ -66,16 +68,27 @@ async def test_list_my_pending_invitations_success(
 
 
 @pytest.mark.anyio
-async def test_list_my_pending_invitations_user_not_found(
+async def test_list_my_pending_invitations_empty_result(
     client: TestClient, test_admin_role: Role
 ) -> None:
     mock_session = await app.dependency_overrides[get_async_session]()
+    mock_user = SimpleNamespace(
+        id=test_admin_role.user_id,
+        email="user@example.com",
+    )
 
-    user_result = Mock()
-    user_result.scalar_one_or_none.return_value = None
-    mock_session.execute.side_effect = [user_result]
+    tuples_result = Mock()
+    tuples_result.all.return_value = []
+    pending_result = Mock()
+    pending_result.tuples.return_value = tuples_result
 
-    response = client.get("/organization/invitations/pending/me")
+    mock_session.execute.side_effect = [pending_result]
+    app.dependency_overrides[current_active_user] = lambda: mock_user
 
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json()["detail"] == "User not found"
+    try:
+        response = client.get("/organization/invitations/pending/me")
+    finally:
+        app.dependency_overrides.pop(current_active_user, None)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []

--- a/tests/unit/api/test_api_users_router.py
+++ b/tests/unit/api/test_api_users_router.py
@@ -1,0 +1,27 @@
+from fastapi.routing import APIRoute
+
+from tracecat.api.app import app
+
+
+def test_fastapi_users_routes_set_authenticated_user_context() -> None:
+    routes = [
+        route
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.name.startswith("users:")
+    ]
+
+    route_names = {route.name for route in routes}
+    assert route_names == {
+        "users:current_user",
+        "users:patch_current_user",
+        "users:user",
+        "users:patch_user",
+        "users:delete_user",
+    }
+
+    for route in routes:
+        dependency_names = {
+            getattr(dependency.call, "__name__", None)
+            for dependency in route.dependant.dependencies
+        }
+        assert "authenticated_user_only" in dependency_names

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -45,24 +45,26 @@ async def test_verify_auth_type_not_allowed(
 @pytest.mark.anyio
 async def test_verify_auth_type_setting_disabled(mocker: MockerFixture):
     """Test that disabled auth types raise HTTPException."""
-    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.BASIC])
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
+    mocker.patch("tracecat.auth.dependencies.get_setting_override", return_value=None)
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=False)
 
     with pytest.raises(HTTPException) as exc:
-        await verify_auth_type(AuthType.BASIC)
+        await verify_auth_type(AuthType.SAML)
 
     assert exc.value.status_code == status.HTTP_403_FORBIDDEN
-    assert exc.value.detail == f"Auth type {AuthType.BASIC.value} is not enabled"
+    assert exc.value.detail == f"Auth type {AuthType.SAML.value} is not enabled"
 
 
 @pytest.mark.anyio
 async def test_verify_auth_type_invalid_setting(mocker: MockerFixture):
     """Test that invalid settings raise HTTPException."""
-    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.BASIC])
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
+    mocker.patch("tracecat.auth.dependencies.get_setting_override", return_value=None)
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=None)
 
     with pytest.raises(HTTPException) as exc:
-        await verify_auth_type(AuthType.BASIC)
+        await verify_auth_type(AuthType.SAML)
 
     assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert exc.value.detail == "Invalid setting configuration"
@@ -71,16 +73,17 @@ async def test_verify_auth_type_invalid_setting(mocker: MockerFixture):
 @pytest.mark.anyio
 async def test_verify_auth_type_success(mocker: MockerFixture):
     """Test successful auth type verification."""
-    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.BASIC])
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
+    mocker.patch("tracecat.auth.dependencies.get_setting_override", return_value=None)
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=True)
 
     # Should not raise any exceptions
-    await verify_auth_type(AuthType.BASIC)
+    await verify_auth_type(AuthType.SAML)
 
 
 @pytest.mark.parametrize(
     "auth_type",
-    [AuthType.OIDC, AuthType.GOOGLE_OAUTH],
+    [AuthType.BASIC, AuthType.OIDC, AuthType.GOOGLE_OAUTH],
 )
 @pytest.mark.anyio
 async def test_verify_auth_type_oidc_is_platform_controlled(

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -31,6 +31,7 @@ from tracecat.api.common import (
     generic_exception_handler,
     tracecat_exception_handler,
 )
+from tracecat.auth.credentials import authenticated_user_only
 from tracecat.auth.dependencies import (
     require_any_auth_type_enabled,
     require_auth_type_enabled,
@@ -442,6 +443,7 @@ def create_app(**kwargs) -> FastAPI:
         fastapi_users.get_users_router(UserRead, UserUpdate),
         prefix="/users",
         tags=["users"],
+        dependencies=[Depends(authenticated_user_only)],
     )
     # Internal routers
     app.include_router(internal_agent_router)

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -972,7 +972,7 @@ are not scoped to any organization or workspace.
 # --- Authenticated User Only (No Organization Context) ---
 
 
-async def _authenticated_user_only(
+async def authenticated_user_only(
     user: Annotated[User, Depends(current_active_user)],
 ) -> Role:
     """Dependency for endpoints requiring only an authenticated user.
@@ -1000,7 +1000,7 @@ async def _authenticated_user_only(
     return role
 
 
-AuthenticatedUserOnly = Annotated[Role, Depends(_authenticated_user_only)]
+AuthenticatedUserOnly = Annotated[Role, Depends(authenticated_user_only)]
 """Dependency for an authenticated user without organization context.
 
 Use this for endpoints where the user is authenticated but may not


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes an issue where admins could not rename themselves from Settings.

Changes included:
- `/users` router now applies `authenticated_user_only` so `ctx_role` is set before FastAPI Users handlers run.
- Updated auth dependency naming to export `authenticated_user_only` while preserving compatibility.
- Added a regression test to ensure all `users:*` routes include the authenticated user context dependency.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Sign in as an admin and open Settings.
2. Change the profile `Name` field and blur/press Enter.
3. Verify the update succeeds and no `401 Missing token or inactive user` error appears.
4. Run checks:
   - `uv run ruff check tracecat/api/app.py tracecat/auth/credentials.py tests/unit/api/test_api_users_router.py`
   - `uv run basedpyright tracecat/api/app.py tracecat/auth/credentials.py tests/unit/api/test_api_users_router.py`

Note: `uv run pytest tests/unit/api/test_api_users_router.py` requires local Postgres on `localhost:5432`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores admin profile rename in Settings. Prevents 401s by using same-origin /api for browser OpenAPI requests and by enforcing authenticated user context on all /users routes.

- **Bug Fixes**
  - Browser OpenAPI client now uses /api so auth cookies are sent; credentials included.
  - /users router enforces authenticated_user_only to set ctx_role on all users endpoints; exported dependency renamed.
  - Tests updated to assert the users route dependency and align auth expectations (current_active_user, settings overrides); invitations test now returns an empty list when none pending.

<sup>Written for commit 2b6d799c61e88733e2f63eaabe569d13caf6a103. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

