### PR TITLE
test(organization): align pending invitation empty-results unit case

### DIFF
--- a/tests/unit/api/test_api_organization_invitations.py
+++ b/tests/unit/api/test_api_organization_invitations.py
@@ -50,7 +50,6 @@ async def test_list_my_pending_invitations_success(
 
     mock_session.execute.side_effect = [pending_result]
     app.dependency_overrides[current_active_user] = lambda: mock_user
-
     try:
         response = client.get("/organization/invitations/pending/me")
     finally:
@@ -68,23 +67,22 @@ async def test_list_my_pending_invitations_success(
 
 
 @pytest.mark.anyio
-async def test_list_my_pending_invitations_empty_result(
+async def test_list_my_pending_invitations_no_results(
     client: TestClient, test_admin_role: Role
 ) -> None:
     mock_session = await app.dependency_overrides[get_async_session]()
+
     mock_user = SimpleNamespace(
         id=test_admin_role.user_id,
-        email="user@example.com",
+        email="missing@example.com",
     )
-
     tuples_result = Mock()
     tuples_result.all.return_value = []
     pending_result = Mock()
     pending_result.tuples.return_value = tuples_result
-
     mock_session.execute.side_effect = [pending_result]
-    app.dependency_overrides[current_active_user] = lambda: mock_user
 
+    app.dependency_overrides[current_active_user] = lambda: mock_user
     try:
         response = client.get("/organization/invitations/pending/me")
     finally:


### PR DESCRIPTION
## Summary
- rename the pending-invitations empty-state test to better reflect behavior
- use a distinct email value in the empty-results case to make intent explicit
- keep dependency override structure consistent for `current_active_user`

## Validation
- `uv run ruff check tests/unit/api/test_api_organization_invitations.py`
- `uv run basedpyright tests/unit/api/test_api_organization_invitations.py`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/api/test_api_organization_invitations.py -q` *(fails locally in this environment because PostgreSQL on `localhost:5432` was unavailable at runtime)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the pending invitations empty-results unit test to "no_results" and used a distinct email to make the empty case explicit. Kept dependency override usage consistent across tests.

<sup>Written for commit 5a299bbfe6b6e691f6f3f6394a6a884aba75d94f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

