### PR TITLE
fix(sandbox): propagate host DNS search domains into nsjail resolv.conf

### DIFF
--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -35,7 +35,7 @@ from tracecat.agent.common.config import (
     TRUSTED_MCP_SOCKET_PATH,
 )
 from tracecat.agent.common.exceptions import AgentSandboxValidationError
-from tracecat.sandbox.executor import _build_sandbox_resolv_conf
+from tracecat.sandbox.executor import build_sandbox_resolv_conf
 
 # Valid environment variable name pattern (POSIX compliant)
 _ENV_VAR_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -369,7 +369,7 @@ def build_agent_nsjail_config(
     # is mounted read-write at /work inside the sandbox.
     if enable_internet_access:
         resolv_conf_path = socket_dir / "resolv.conf"
-        resolv_conf_path.write_text(_build_sandbox_resolv_conf())
+        resolv_conf_path.write_text(build_sandbox_resolv_conf())
 
         hosts_path = socket_dir / "hosts"
         hosts_path.write_text(

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -23,7 +23,7 @@ from tracecat.sandbox.types import ResourceLimits, SandboxConfig, SandboxResult
 _PASTA_GATEWAY_IP = "10.255.255.1"
 
 
-def _build_sandbox_resolv_conf() -> str:
+def build_sandbox_resolv_conf() -> str:
     """Build resolv.conf for the sandbox with pasta nameserver + host search domains.
 
     Reads the host's /etc/resolv.conf to extract `search` and `options` lines
@@ -288,7 +288,7 @@ class NsjailExecutor:
         # Docker export leaves these empty since Docker manages them at runtime
         if network_enabled:
             resolv_conf_path = job_dir / "resolv.conf"
-            resolv_conf_path.write_text(_build_sandbox_resolv_conf())
+            resolv_conf_path.write_text(build_sandbox_resolv_conf())
 
             hosts_path = job_dir / "hosts"
             hosts_path.write_text(
@@ -743,7 +743,7 @@ class NsjailExecutor:
         # Network config: pasta provides DNS forwarding at the gateway IP (10.255.255.1)
         # Docker export leaves /etc files empty since Docker manages them at runtime
         resolv_conf_path = job_dir / "resolv.conf"
-        resolv_conf_path.write_text(_build_sandbox_resolv_conf())
+        resolv_conf_path.write_text(build_sandbox_resolv_conf())
 
         hosts_path = job_dir / "hosts"
         hosts_path.write_text(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes DNS resolution in nsjail sandboxes by adding host DNS search and options lines to the generated resolv.conf, alongside the pasta gateway nameserver. Restores resolution of short Kubernetes service names (e.g., tracecat-api) on EKS.

- **Bug Fixes**
  - Read host /etc/resolv.conf and include its search/options lines in the sandbox.
  - Use a shared helper (build_sandbox_resolv_conf) to build resolv.conf across agent and executor.
  - Fallback to nameserver-only if host resolv.conf is unreadable (no change for docker-compose).

<sup>Written for commit b66cadd573b4533d2bb8c68ef5cd2205c124148a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

