### PR TITLE
fix: allow core.script.run_python in template step validation

### DIFF
--- a/tests/unit/test_workflow_registry_resolution.py
+++ b/tests/unit/test_workflow_registry_resolution.py
@@ -1,0 +1,220 @@
+"""Tests for workflow registry resolution with template platform actions."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import RegistryIndex, RegistryRepository, RegistryVersion
+from tracecat.dsl.common import DSLInput
+from tracecat.dsl.enums import PlatformAction
+from tracecat.workflow.management.registry_resolution import (
+    resolve_action_origins_from_lock,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+def _create_dsl(action_name: str) -> DSLInput:
+    """Create a minimal DSL with a single action."""
+    return DSLInput(
+        **{
+            "title": "Test workflow",
+            "description": "Test",
+            "entrypoint": {"ref": "template_action", "expects": {}},
+            "actions": [
+                {
+                    "ref": "template_action",
+                    "action": action_name,
+                    "args": {},
+                    "depends_on": [],
+                }
+            ],
+            "triggers": [],
+        }
+    )
+
+
+def _template_manifest(*, template_action: str, step_action: str) -> dict:
+    """Create a manifest containing a template and its referenced step action."""
+    template_namespace, template_name = template_action.rsplit(".", 1)
+    step_namespace, step_name = step_action.rsplit(".", 1)
+
+    step_module = "tracecat_registry.core.script"
+    step_fn = "run_python"
+    if step_action == PlatformAction.CHILD_WORKFLOW_EXECUTE:
+        step_module = "tracecat_registry.core.workflow"
+        step_fn = "execute"
+
+    return {
+        "version": "1.0",
+        "actions": {
+            template_action: {
+                "namespace": template_namespace,
+                "name": template_name,
+                "action_type": "template",
+                "description": "Template action",
+                "interface": {"expects": {}, "returns": None},
+                "implementation": {
+                    "type": "template",
+                    "template_action": {
+                        "type": "action",
+                        "definition": {
+                            "name": template_name,
+                            "namespace": template_namespace,
+                            "title": "Template action",
+                            "display_group": "Testing",
+                            "expects": {},
+                            "steps": [
+                                {
+                                    "ref": "step1",
+                                    "action": step_action,
+                                    "args": {},
+                                }
+                            ],
+                            "returns": "${{ steps.step1.result }}",
+                        },
+                    },
+                },
+            },
+            step_action: {
+                "namespace": step_namespace,
+                "name": step_name,
+                "action_type": "udf",
+                "description": "Step action",
+                "interface": {"expects": {}, "returns": None},
+                "implementation": {
+                    "type": "udf",
+                    "url": "tracecat_registry",
+                    "module": step_module,
+                    "name": step_fn,
+                },
+            },
+        },
+    }
+
+
+async def _seed_registry(
+    *,
+    session: AsyncSession,
+    svc_role: Role,
+    origin: str,
+    version: str,
+    manifest: dict,
+    index_actions: dict[str, str],
+) -> None:
+    """Seed registry repository/version/index for resolution tests."""
+    repo = RegistryRepository(
+        organization_id=svc_role.organization_id,
+        origin=origin,
+    )
+    session.add(repo)
+    await session.flush()
+
+    registry_version = RegistryVersion(
+        organization_id=svc_role.organization_id,
+        repository_id=repo.id,
+        version=version,
+        manifest=manifest,
+        tarball_uri=f"s3://{origin}/{version}.tar.gz",
+    )
+    session.add(registry_version)
+    await session.flush()
+
+    index_entries = []
+    for action_name, action_type in index_actions.items():
+        namespace, name = action_name.rsplit(".", 1)
+        index_entries.append(
+            RegistryIndex(
+                organization_id=svc_role.organization_id,
+                registry_version_id=registry_version.id,
+                namespace=namespace,
+                name=name,
+                action_type=action_type,
+                description=f"Indexed {action_name}",
+            )
+        )
+    session.add_all(index_entries)
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_registry_resolution_allows_run_python_template_step(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Publish-time resolution should allow core.script.run_python in templates."""
+    origin = "test_origin"
+    version = "1.0.0"
+    template_action = "tools.testing.template_with_python"
+    step_action = PlatformAction.RUN_PYTHON
+    org_id = svc_role.organization_id
+    assert org_id is not None
+
+    await _seed_registry(
+        session=session,
+        svc_role=svc_role,
+        origin=origin,
+        version=version,
+        manifest=_template_manifest(
+            template_action=template_action,
+            step_action=step_action,
+        ),
+        index_actions={
+            template_action: "template",
+            step_action: "udf",
+        },
+    )
+
+    resolved, errors = await resolve_action_origins_from_lock(
+        session=session,
+        dsl=_create_dsl(template_action),
+        registry_lock={origin: version},
+        organization_id=org_id,
+    )
+
+    assert errors == []
+    assert resolved[template_action] == origin
+    assert resolved[step_action] == origin
+
+
+@pytest.mark.anyio
+async def test_registry_resolution_rejects_non_run_python_platform_step(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Publish-time resolution should still reject other platform actions in templates."""
+    origin = "test_origin"
+    version = "1.0.0"
+    template_action = "tools.testing.template_with_subflow"
+    step_action = PlatformAction.CHILD_WORKFLOW_EXECUTE
+    org_id = svc_role.organization_id
+    assert org_id is not None
+
+    await _seed_registry(
+        session=session,
+        svc_role=svc_role,
+        origin=origin,
+        version=version,
+        manifest=_template_manifest(
+            template_action=template_action,
+            step_action=step_action,
+        ),
+        index_actions={
+            template_action: "template",
+            step_action: "udf",
+        },
+    )
+
+    resolved, errors = await resolve_action_origins_from_lock(
+        session=session,
+        dsl=_create_dsl(template_action),
+        registry_lock={origin: version},
+        organization_id=org_id,
+    )
+
+    assert resolved == {}
+    assert errors
+    assert errors[0].action == step_action
+    assert "cannot be used inside template" in errors[0].msg

--- a/tracecat/dsl/enums.py
+++ b/tracecat/dsl/enums.py
@@ -36,6 +36,18 @@ class PlatformAction(StrEnum):
     def is_interface(cls, action: str) -> bool:
         return action in cls.interface_actions()
 
+    @classmethod
+    def is_template_step_supported(cls, action: str) -> bool:
+        """Return whether a platform action can be used in template steps.
+
+        Most platform/interface actions are orchestrated by DSLWorkflow and are not safe
+        to embed within template actions. `core.script.run_python` is the exception
+        because executor backends handle it as a concrete runtime action.
+        """
+        if not cls.is_interface(action):
+            return True
+        return action == cls.RUN_PYTHON
+
 
 class FailStrategy(StrEnum):
     ISOLATED = "isolated"

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -148,7 +148,7 @@ class RegistryLockService(BaseOrgService):
                 )
                 if impl.type == "template":
                     for step in impl.template_action.definition.steps:
-                        if PlatformAction.is_interface(step.action):
+                        if not PlatformAction.is_template_step_supported(step.action):
                             raise RegistryError(
                                 f"Template action '{action_name}' contains step '{step.ref}' using "
                                 f"platform action '{step.action}'. Platform actions cannot be used "

--- a/tracecat/workflow/management/registry_resolution.py
+++ b/tracecat/workflow/management/registry_resolution.py
@@ -218,7 +218,7 @@ async def resolve_action_origins_from_lock(
                 )
                 continue
             for step in impl.template_action.definition.steps:
-                if PlatformAction.is_interface(step.action):
+                if not PlatformAction.is_template_step_supported(step.action):
                     errors.append(
                         RegistryActionResolutionError(
                             action=step.action,


### PR DESCRIPTION
## Summary
- allow `core.script.run_python` in template step validation while still rejecting other platform/interface actions
- centralize the template-step rule in `PlatformAction.is_template_step_supported()`
- apply the same rule in both lock resolution paths (`RegistryLockService` and publish-time registry resolution)

## Regression context
- built-in templates already use `core.script.run_python`, and executor runtime supports it
- a lock-time validation guard was blocking all platform actions in template steps, including `run_python`

## Tests
- added lock-service coverage for:
  - allowing template step `core.script.run_python`
  - rejecting template step `core.workflow.execute`
- added publish-time registry resolution coverage for the same allow/reject behavior
- ran:
  - `uv run pytest tests/unit/test_registry_lock_service.py tests/unit/test_workflow_registry_resolution.py`
  - `uv run ruff check tracecat/dsl/enums.py tracecat/registry/lock/service.py tracecat/workflow/management/registry_resolution.py tests/unit/test_registry_lock_service.py tests/unit/test_workflow_registry_resolution.py`
  - `uv run basedpyright tracecat/dsl/enums.py tracecat/registry/lock/service.py tracecat/workflow/management/registry_resolution.py tests/unit/test_registry_lock_service.py tests/unit/test_workflow_registry_resolution.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow core.script.run_python inside template steps during validation and registry resolution, while still blocking other platform/interface actions. Fixes a regression that broke built-in templates using run_python.

- **Bug Fixes**
  - Permit core.script.run_python in template steps; continue rejecting others (e.g., core.workflow.execute).
  - Apply the same rule in both paths: RegistryLockService and publish-time registry resolution.
  - Added unit tests for allow/reject behavior in both paths, and updated lock test to use an org-scoped origin to avoid run_python origin ambiguity.

- **Refactors**
  - Centralized the template-step rule in PlatformAction.is_template_step_supported().

<sup>Written for commit a99bde49ae20fdef4d72a59a3afdc70f03b7c9c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

