### PR TITLE
feat(org): add safe organization deletion with confirmation

### DIFF
--- a/frontend/src/client/services.custom.ts
+++ b/frontend/src/client/services.custom.ts
@@ -138,6 +138,30 @@ export type AdminListOrgTiersData = {
   orgIds?: string[]
 }
 
+export type AdminDeleteOrganizationWithConfirmationData = {
+  orgId: string
+  confirm: string
+}
+
+export const adminDeleteOrganizationWithConfirmation = (
+  data: AdminDeleteOrganizationWithConfirmationData
+): CancelablePromise<void> =>
+  request(OpenAPI, {
+    method: "DELETE",
+    url: "/admin/organizations/{org_id}",
+    path: {
+      org_id: data.orgId,
+    },
+    query: {
+      confirm: data.confirm,
+    },
+    errors: {
+      400: "Bad Request",
+      404: "Not Found",
+      422: "Validation Error",
+    },
+  })
+
 export const adminListOrgTiers = (
   data: AdminListOrgTiersData
 ): CancelablePromise<OrganizationTierRead[]> =>

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -19,7 +19,6 @@ import {
   adminCreateOrganizationDomain,
   adminCreateTier,
   adminCreateUser,
-  adminDeleteOrganization,
   adminDeleteOrganizationDomain,
   adminDeleteTier,
   adminDemoteFromSuperuser,
@@ -59,7 +58,10 @@ import {
   type TierRead,
   type TierUpdate,
 } from "@/client"
-import { adminListOrgTiers } from "@/client/services.custom"
+import {
+  adminDeleteOrganizationWithConfirmation,
+  adminListOrgTiers,
+} from "@/client/services.custom"
 
 /* ── ORGANIZATIONS ─────────────────────────────────────────────────────────── */
 
@@ -96,8 +98,12 @@ export function useAdminOrganizations({
     })
 
   const { mutateAsync: deleteOrganization, isPending: deletePending } =
-    useMutation<void, Error, string>({
-      mutationFn: (orgId) => adminDeleteOrganization({ orgId }),
+    useMutation<void, Error, { orgId: string; confirmation: string }>({
+      mutationFn: ({ orgId, confirmation }) =>
+        adminDeleteOrganizationWithConfirmation({
+          orgId,
+          confirm: confirmation,
+        }),
       onSuccess: () =>
         queryClient.invalidateQueries({ queryKey: ["admin", "organizations"] }),
     })

--- a/packages/tracecat-admin/tracecat_admin/client.py
+++ b/packages/tracecat-admin/tracecat_admin/client.py
@@ -170,9 +170,13 @@ class AdminClient:
         )
         return OrgRead.model_validate(response.json())
 
-    async def delete_organization(self, org_id: str) -> None:
+    async def delete_organization(self, org_id: str, *, confirmation: str) -> None:
         """Delete an organization."""
-        await self._request("DELETE", f"/admin/organizations/{org_id}")
+        await self._request(
+            "DELETE",
+            f"/admin/organizations/{org_id}",
+            params={"confirm": confirmation},
+        )
 
     # Registry endpoints
     async def sync_registry(

--- a/packages/tracecat-admin/tracecat_admin/commands/orgs.py
+++ b/packages/tracecat-admin/tracecat_admin/commands/orgs.py
@@ -181,14 +181,16 @@ async def delete_org(
             org = await client.get_organization(org_id)
 
             if not force:
-                confirm = typer.confirm(
-                    f"Are you sure you want to delete organization '{org.name}' ({org.slug})?"
+                typed_confirmation = typer.prompt(
+                    f"Type '{org.name}' to delete organization '{org.slug}'"
                 )
-                if not confirm:
-                    typer.echo("Aborted.")
+                if typed_confirmation.strip() != org.name:
+                    print_error("Confirmation does not match organization name.")
                     raise typer.Exit(0)
+            else:
+                typed_confirmation = org.name
 
-            await client.delete_organization(org_id)
+            await client.delete_organization(org_id, confirmation=typed_confirmation)
             print_success(f"Organization '{org.name}' deleted successfully")
     except AdminClientError as e:
         print_error(str(e))

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
 from tracecat.auth.credentials import SuperuserRole
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatValidationError
 from tracecat_ee.admin.organizations.schemas import (
     OrgCreate,
     OrgDomainCreate,
@@ -99,12 +100,18 @@ async def delete_organization(
     role: SuperuserRole,
     session: AsyncDBSession,
     org_id: uuid.UUID,
+    confirm: str | None = Query(
+        default=None,
+        description="Must exactly match the organization name.",
+    ),
 ) -> None:
     """Delete organization."""
     _require_multi_tenant()
     service = AdminOrgService(session, role)
     try:
-        await service.delete_organization(org_id)
+        await service.delete_organization(org_id, confirmation=confirm)
+    except TracecatValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
@@ -111,7 +111,9 @@ async def delete_organization(
     try:
         await service.delete_organization(org_id, confirmation=confirm)
     except TracecatValidationError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -19,6 +19,7 @@ from tracecat.cases.router import WorkspaceUser
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session
 from tracecat.organization.router import OrgAdminRole as OrganizationOrgAdminRole
+from tracecat.organization.router import OrgOwnerRole as OrganizationOrgOwnerRole
 from tracecat.organization.router import OrgUserRole as OrganizationOrgUserRole
 from tracecat.secrets.router import (
     OrgAdminUser,
@@ -79,6 +80,7 @@ def client() -> Generator[TestClient, None, None]:
         TablesWorkspaceEditorUser,
         OrganizationOrgUserRole,
         OrganizationOrgAdminRole,
+        OrganizationOrgOwnerRole,
     ]
 
     for annotated_type in role_dependencies:

--- a/tests/unit/test_admin_org_domains_service.py
+++ b/tests/unit/test_admin_org_domains_service.py
@@ -191,7 +191,9 @@ async def test_delete_organization_cleans_restrict_children(
     service = AdminOrgService(session, role=platform_role)
     await service.delete_organization(org_a.id, confirmation=org_a.name)
 
-    org_result = await session.execute(select(Organization).where(Organization.id == org_a.id))
+    org_result = await session.execute(
+        select(Organization).where(Organization.id == org_a.id)
+    )
     workspace_result = await session.execute(
         select(Workspace).where(Workspace.organization_id == org_a.id)
     )

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -11,6 +11,7 @@ from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 AuditAction = Literal["create", "update", "delete", "accept", "revoke"]
 AuditResourceType = Literal[
     "user",
+    "organization",
     "workspace",
     "workflow",
     "workflow_execution",

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -187,7 +187,9 @@ async def delete_organization_with_cleanup(
             workspace_role=WorkspaceRole.ADMIN,
             access_level=AccessLevel.ADMIN,
         )
-        schedule_service = WorkflowSchedulesService(session=session, role=bootstrap_role)
+        schedule_service = WorkflowSchedulesService(
+            session=session, role=bootstrap_role
+        )
         for schedule in await schedule_service.list_schedules():
             await schedule_service.delete_schedule(schedule.id, commit=False)
 
@@ -205,7 +207,9 @@ async def delete_organization_with_cleanup(
             delete(Ownership).where(Ownership.resource_id.in_(workspace_resource_ids))
         )
 
-    await session.execute(delete(Ownership).where(Ownership.owner_id == organization.id))
+    await session.execute(
+        delete(Ownership).where(Ownership.owner_id == organization.id)
+    )
     await session.execute(
         delete(OrganizationSecret).where(
             OrganizationSecret.organization_id == organization.id
@@ -215,7 +219,9 @@ async def delete_organization_with_cleanup(
         delete(RegistryIndex).where(RegistryIndex.organization_id == organization.id)
     )
     await session.execute(
-        delete(RegistryVersion).where(RegistryVersion.organization_id == organization.id)
+        delete(RegistryVersion).where(
+            RegistryVersion.organization_id == organization.id
+        )
     )
     await session.execute(
         delete(RegistryAction).where(RegistryAction.organization_id == organization.id)

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -25,6 +25,7 @@ from tracecat.authz.controls import require_org_role
 from tracecat.authz.enums import OrgRole
 from tracecat.db.models import (
     AccessToken,
+    Organization,
     OrganizationInvitation,
     OrganizationMembership,
     User,
@@ -36,6 +37,10 @@ from tracecat.exceptions import (
 )
 from tracecat.identifiers import OrganizationID, SessionID, UserID
 from tracecat.invitations.enums import InvitationStatus
+from tracecat.organization.management import (
+    delete_organization_with_cleanup,
+    validate_organization_delete_confirmation,
+)
 from tracecat.service import BaseOrgService
 
 
@@ -323,6 +328,25 @@ class OrgService(BaseOrgService):
         await self.session.commit()
         await self.session.refresh(membership)
         return membership
+
+    @require_org_role(OrgRole.OWNER)
+    async def delete_organization(self, *, confirmation: str | None) -> None:
+        """Delete the current organization and all associated resources."""
+        statement = select(Organization).where(Organization.id == self.organization_id)
+        result = await self.session.execute(statement)
+        organization = result.scalar_one_or_none()
+        if organization is None:
+            raise TracecatNotFoundError("Organization not found")
+
+        validate_organization_delete_confirmation(
+            organization, confirmation=confirmation
+        )
+        await delete_organization_with_cleanup(
+            self.session,
+            organization=organization,
+            operator_user_id=self.role.user_id,
+        )
+        await self.session.commit()
 
     # === Manage settings ===
 

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -329,6 +329,7 @@ class OrgService(BaseOrgService):
         await self.session.refresh(membership)
         return membership
 
+    @audit_log(resource_type="organization", action="delete")
     @require_org_role(OrgRole.OWNER)
     async def delete_organization(self, *, confirmation: str | None) -> None:
         """Delete the current organization and all associated resources."""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds safe organization deletion that requires typing the exact org name. Restricts self-deletion to org owners, logs the action (with organization resource type), and fully cleans up related resources.

- **New Features**
  - Frontend: admin delete modal requires exact org name; Delete disabled until it matches; sends confirmation.
  - APIs: admin and /organization DELETE accept confirm; return 400 on mismatch; /organization requires owner role and returns 403 for non-owners.
  - Backend: centralized confirmation validation; audit logs organization delete events (adds organization resource type); cleanup removes workspaces, schedules, case fields, memberships, ownerships, secrets, and registry data before deleting the org.
  - Admin CLI/client: CLI prompts for the org name (or uses it with --force); Python client delete_organization now requires a confirmation.

- **Migration**
  - Always send confirm that exactly matches the org name when deleting.
  - Update integrations to use adminDeleteOrganizationWithConfirmation({ orgId, confirm }) and client.delete_organization(org_id, confirmation=...).
  - Use an owner role to call /organization DELETE; platform admins cannot delete organizations via this endpoint.

<sup>Written for commit 90be0cdb0a4b25c0058534c758c9ed03a73dac33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

