### PR TITLE
refactor(auth): drop platform role=admin checks in frontend

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -42,12 +42,12 @@ export function userIsPrivileged(
 /**
  * Check if user has platform-level admin privileges.
  *
- * This checks the platform role (superuser or role=admin), NOT the
+ * This checks platform superuser status, NOT the
  * organization membership role. For org-level admin checks, use
  * the useOrgMembership hook's canAdministerOrg.
  */
 export function userIsPlatformAdmin(user?: UserRead | null): boolean {
-  return user?.is_superuser || user?.role === "admin"
+  return Boolean(user?.is_superuser)
 }
 
 export function getDisplayName(
@@ -114,7 +114,7 @@ export class User {
   /**
    * Returns true if the user has platform-level admin privileges.
    *
-   * This checks the platform role (superuser or role=admin), NOT the
+   * This checks platform superuser status, NOT the
    * organization membership role. For org-level admin checks, use
    * the useOrgMembership hook's canAdministerOrg.
    */


### PR DESCRIPTION
## Summary
- remove `role === "admin"` from platform admin detection in `frontend/src/lib/auth.ts`
- make platform admin checks depend on `is_superuser` only
- update inline auth comments to match the new behavior

## Validation
- `pnpm -C frontend exec biome check src/lib/auth.ts`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Platform admin detection now relies only on is_superuser; role="admin" no longer grants platform admin in the frontend. Updated inline comments to clarify this and distinguish from org-level admin checks.

<sup>Written for commit 2f2f02f514c3dfdfc3a68a04cb9e2a660890bfa4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

