### PR TITLE
feat(admin): add platform user creation from admin users

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -863,6 +863,51 @@ export const $ActionValidationResult = {
   description: "Result of validating a registry action's arguments.",
 } as const
 
+export const $AdminUserCreate = {
+  properties: {
+    email: {
+      type: "string",
+      format: "email",
+      title: "Email",
+    },
+    password: {
+      type: "string",
+      title: "Password",
+    },
+    first_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "First Name",
+    },
+    last_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Name",
+    },
+    is_superuser: {
+      type: "boolean",
+      title: "Is Superuser",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["email", "password"],
+  title: "AdminUserCreate",
+  description: "Create a user from the platform admin control plane.",
+} as const
+
 export const $AdminUserRead = {
   properties: {
     id: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -22,6 +22,8 @@ import type {
   AdminCreateOrganizationResponse,
   AdminCreateTierData,
   AdminCreateTierResponse,
+  AdminCreateUserData,
+  AdminCreateUserResponse,
   AdminDeleteOrganizationData,
   AdminDeleteOrganizationDomainData,
   AdminDeleteOrganizationDomainResponse,
@@ -4579,6 +4581,28 @@ export const adminListUsers = (): CancelablePromise<AdminListUsersResponse> => {
   return __request(OpenAPI, {
     method: "GET",
     url: "/admin/users",
+  })
+}
+
+/**
+ * Create User
+ * Create a platform-level user without org membership.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns AdminUserRead Successful Response
+ * @throws ApiError
+ */
+export const adminCreateUser = (
+  data: AdminCreateUserData
+): CancelablePromise<AdminCreateUserResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/admin/users",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
   })
 }
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -235,6 +235,17 @@ export type ActionValidationResult = {
 export type status = "success" | "error"
 
 /**
+ * Create a user from the platform admin control plane.
+ */
+export type AdminUserCreate = {
+  email: string
+  password: string
+  first_name?: string | null
+  last_name?: string | null
+  is_superuser?: boolean
+}
+
+/**
  * Admin view of a user.
  */
 export type AdminUserRead = {
@@ -7531,6 +7542,12 @@ export type AdminUpdateOrgTierResponse = OrganizationTierRead
 
 export type AdminListUsersResponse = Array<AdminUserRead>
 
+export type AdminCreateUserData = {
+  requestBody: AdminUserCreate
+}
+
+export type AdminCreateUserResponse = AdminUserRead
+
 export type AdminGetUserData = {
   userId: string
 }
@@ -10914,6 +10931,19 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: Array<AdminUserRead>
+      }
+    }
+    post: {
+      req: AdminCreateUserData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: AdminUserRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
       }
     }
   }

--- a/frontend/src/components/admin/admin-users-table.tsx
+++ b/frontend/src/components/admin/admin-users-table.tsx
@@ -1,8 +1,12 @@
 "use client"
 
+import { zodResolver } from "@hookform/resolvers/zod"
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { PlusIcon } from "lucide-react"
 import { useState } from "react"
-import type { AdminUserRead } from "@/client"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { type AdminUserRead, ApiError } from "@/client"
 import {
   DataTable,
   DataTableColumnHeader,
@@ -20,6 +24,16 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,20 +41,91 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { useAdminUsers } from "@/hooks/use-admin"
 import { useAuth } from "@/hooks/use-auth"
 import { getRelativeTime } from "@/lib/event-history"
 
+const createUserFormSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  password: z.string().min(12, "Password must be at least 12 characters long"),
+  firstName: z.string().max(255, "First name is too long"),
+  lastName: z.string().max(255, "Last name is too long"),
+  isSuperuser: z.boolean(),
+})
+
+type CreateUserFormValues = z.infer<typeof createUserFormSchema>
+
 export function AdminUsersTable() {
   const [selectedUser, setSelectedUser] = useState<AdminUserRead | null>(null)
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [actionType, setActionType] = useState<"promote" | "demote" | null>(
     null
   )
   const { user: currentUser } = useAuth()
-  const { users, promoteToSuperuser, demoteFromSuperuser } = useAdminUsers()
+  const {
+    users,
+    createUser,
+    createPending,
+    promoteToSuperuser,
+    promotePending,
+    demoteFromSuperuser,
+    demotePending,
+  } = useAdminUsers()
+  const createUserForm = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserFormSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+      firstName: "",
+      lastName: "",
+      isSuperuser: false,
+    },
+  })
 
   const superuserCount = users?.filter((u) => u.is_superuser).length ?? 0
+
+  const handleCreateUser = async (values: CreateUserFormValues) => {
+    try {
+      await createUser({
+        email: values.email,
+        password: values.password,
+        first_name: values.firstName.trim() || null,
+        last_name: values.lastName.trim() || null,
+        is_superuser: values.isSuperuser,
+      })
+      toast({
+        title: "User created",
+        description: `${values.email} was created successfully.`,
+      })
+      createUserForm.reset()
+      setIsCreateDialogOpen(false)
+    } catch (error) {
+      let description = "Failed to create user. Please try again."
+      if (error instanceof ApiError) {
+        const body = error.body as { detail?: unknown }
+        if (typeof body.detail === "string") {
+          description = body.detail
+        }
+      }
+      console.error("Failed to create user", error)
+      toast({
+        title: "Create user failed",
+        description,
+        variant: "destructive",
+      })
+    }
+  }
 
   const handleConfirmAction = async () => {
     if (!selectedUser || !actionType) return
@@ -73,244 +158,381 @@ export function AdminUsersTable() {
   }
 
   return (
-    <AlertDialog
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          setSelectedUser(null)
-          setActionType(null)
-        }
-      }}
-    >
-      <DataTable
-        data={users ?? []}
-        initialSortingState={[{ id: "email", desc: false }]}
-        columns={[
-          {
-            accessorKey: "email",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Email"
-              />
-            ),
-            cell: ({ row }) => (
-              <div className="text-xs font-medium">
-                {row.getValue<AdminUserRead["email"]>("email")}
-              </div>
-            ),
-            enableSorting: true,
-            enableHiding: false,
-          },
-          {
-            accessorKey: "first_name",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="First name"
-              />
-            ),
-            cell: ({ row }) => (
-              <div className="text-xs">
-                {row.getValue<AdminUserRead["first_name"]>("first_name") || "-"}
-              </div>
-            ),
-            enableSorting: true,
-            enableHiding: true,
-          },
-          {
-            accessorKey: "last_name",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Last name"
-              />
-            ),
-            cell: ({ row }) => (
-              <div className="text-xs">
-                {row.getValue<AdminUserRead["last_name"]>("last_name") || "-"}
-              </div>
-            ),
-            enableSorting: true,
-            enableHiding: true,
-          },
-          {
-            accessorKey: "role",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Role"
-              />
-            ),
-            cell: ({ row }) => (
-              <div className="text-xs capitalize">
-                {row.getValue<AdminUserRead["role"]>("role")}
-              </div>
-            ),
-            enableSorting: true,
-            enableHiding: false,
-          },
-          {
-            accessorKey: "is_superuser",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Superuser"
-              />
-            ),
-            cell: ({ row }) => (
-              <div className="text-xs">
-                {row.getValue<AdminUserRead["is_superuser"]>("is_superuser")
-                  ? "Yes"
-                  : "No"}
-              </div>
-            ),
-            enableSorting: true,
-            enableHiding: false,
-          },
-          {
-            accessorKey: "is_active",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Active"
-              />
-            ),
-            cell: ({ row }) => (
-              <div className="text-xs">
-                {row.getValue<AdminUserRead["is_active"]>("is_active")
-                  ? "Active"
-                  : "Inactive"}
-              </div>
-            ),
-            enableSorting: true,
-            enableHiding: false,
-          },
-          {
-            accessorKey: "last_login_at",
-            header: ({ column }) => (
-              <DataTableColumnHeader
-                className="text-xs"
-                column={column}
-                title="Last login"
-              />
-            ),
-            cell: ({ row }) => {
-              const lastLoginAt =
-                row.getValue<AdminUserRead["last_login_at"]>("last_login_at")
-              if (!lastLoginAt) {
-                return <div className="text-xs text-muted-foreground">-</div>
-              }
-              const date = new Date(lastLoginAt)
-              const ago = getRelativeTime(date)
-              return (
-                <div className="text-xs text-muted-foreground">
-                  <span>{date.toLocaleDateString()}</span>
-                  <span className="ml-1">({ago})</span>
-                </div>
-              )
-            },
-            enableSorting: true,
-            enableHiding: false,
-          },
-          {
-            id: "actions",
-            enableHiding: false,
-            cell: ({ row }) => {
-              const rowUser = row.original
-              const isSelf = currentUser?.id === rowUser.id
-              const isLastSuperuser =
-                rowUser.is_superuser && superuserCount <= 1
-
-              return (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="size-8 p-0">
-                      <span className="sr-only">Open menu</span>
-                      <DotsHorizontalIcon className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      onSelect={() => navigator.clipboard.writeText(rowUser.id)}
-                    >
-                      Copy user ID
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    {rowUser.is_superuser ? (
-                      <AlertDialogTrigger asChild>
-                        <DropdownMenuItem
-                          className="text-rose-500 focus:text-rose-600"
-                          disabled={isSelf || isLastSuperuser}
-                          onSelect={() => {
-                            setSelectedUser(rowUser)
-                            setActionType("demote")
-                          }}
-                        >
-                          {isLastSuperuser
-                            ? "Cannot demote last superuser"
-                            : isSelf
-                              ? "Cannot demote yourself"
-                              : "Demote from superuser"}
-                        </DropdownMenuItem>
-                      </AlertDialogTrigger>
-                    ) : (
-                      <AlertDialogTrigger asChild>
-                        <DropdownMenuItem
-                          onSelect={() => {
-                            setSelectedUser(rowUser)
-                            setActionType("promote")
-                          }}
-                        >
-                          Promote to superuser
-                        </DropdownMenuItem>
-                      </AlertDialogTrigger>
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Dialog
+          open={isCreateDialogOpen}
+          onOpenChange={(isOpen) => {
+            setIsCreateDialogOpen(isOpen)
+            if (!isOpen) {
+              createUserForm.reset()
+            }
+          }}
+        >
+          <DialogTrigger asChild>
+            <Button size="sm">
+              <PlusIcon className="mr-2 size-4" />
+              Create user
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create user</DialogTitle>
+              <DialogDescription>
+                Create a platform user without adding them to an organization.
+              </DialogDescription>
+            </DialogHeader>
+            <Form {...createUserForm}>
+              <form
+                onSubmit={createUserForm.handleSubmit(handleCreateUser)}
+                className="space-y-4"
+              >
+                <FormField
+                  control={createUserForm.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="user@example.com"
+                          type="email"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={createUserForm.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Password</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="password"
+                          placeholder="••••••••••••••••"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Minimum 12 characters. This is the initial password.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <FormField
+                    control={createUserForm.control}
+                    name="firstName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>First name</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Jane" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
                     )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )
+                  />
+                  <FormField
+                    control={createUserForm.control}
+                    name="lastName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Last name</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Doe" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={createUserForm.control}
+                  name="isSuperuser"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                      <div className="space-y-1 leading-none">
+                        <FormLabel>Grant superuser access</FormLabel>
+                        <FormDescription>
+                          Superusers can access all platform admin functions.
+                        </FormDescription>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setIsCreateDialogOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={createPending}>
+                    {createPending ? "Creating..." : "Create"}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <AlertDialog
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setSelectedUser(null)
+            setActionType(null)
+          }
+        }}
+      >
+        <DataTable
+          data={users ?? []}
+          initialSortingState={[{ id: "email", desc: false }]}
+          columns={[
+            {
+              accessorKey: "email",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Email"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs font-medium">
+                  {row.getValue<AdminUserRead["email"]>("email")}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
             },
-          },
-        ]}
-        toolbarProps={defaultToolbarProps}
-      />
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            {actionType === "promote"
-              ? "Promote to superuser"
-              : "Demote from superuser"}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            {actionType === "promote" ? (
-              <>
-                Are you sure you want to promote {selectedUser?.email} to
-                superuser? They will have full access to all admin functions.
-              </>
-            ) : (
-              <>
-                Are you sure you want to demote {selectedUser?.email} from
-                superuser? They will lose access to admin functions.
-              </>
-            )}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            variant={actionType === "demote" ? "destructive" : "default"}
-            onClick={handleConfirmAction}
-          >
-            {actionType === "promote" ? "Promote" : "Demote"}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+            {
+              accessorKey: "first_name",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="First name"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {row.getValue<AdminUserRead["first_name"]>("first_name") ||
+                    "-"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: true,
+            },
+            {
+              accessorKey: "last_name",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Last name"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {row.getValue<AdminUserRead["last_name"]>("last_name") || "-"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: true,
+            },
+            {
+              accessorKey: "role",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Role"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs capitalize">
+                  {row.getValue<AdminUserRead["role"]>("role")}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "is_superuser",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Superuser"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {row.getValue<AdminUserRead["is_superuser"]>("is_superuser")
+                    ? "Yes"
+                    : "No"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "is_active",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Active"
+                />
+              ),
+              cell: ({ row }) => (
+                <div className="text-xs">
+                  {row.getValue<AdminUserRead["is_active"]>("is_active")
+                    ? "Active"
+                    : "Inactive"}
+                </div>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              accessorKey: "last_login_at",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Last login"
+                />
+              ),
+              cell: ({ row }) => {
+                const lastLoginAt =
+                  row.getValue<AdminUserRead["last_login_at"]>("last_login_at")
+                if (!lastLoginAt) {
+                  return <div className="text-xs text-muted-foreground">-</div>
+                }
+                const date = new Date(lastLoginAt)
+                const ago = getRelativeTime(date)
+                return (
+                  <div className="text-xs text-muted-foreground">
+                    <span>{date.toLocaleDateString()}</span>
+                    <span className="ml-1">({ago})</span>
+                  </div>
+                )
+              },
+              enableSorting: true,
+              enableHiding: false,
+            },
+            {
+              id: "actions",
+              enableHiding: false,
+              cell: ({ row }) => {
+                const rowUser = row.original
+                const isSelf = currentUser?.id === rowUser.id
+                const isLastSuperuser =
+                  rowUser.is_superuser && superuserCount <= 1
+
+                return (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" className="size-8 p-0">
+                        <span className="sr-only">Open menu</span>
+                        <DotsHorizontalIcon className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onSelect={() =>
+                          navigator.clipboard.writeText(rowUser.id)
+                        }
+                      >
+                        Copy user ID
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      {rowUser.is_superuser ? (
+                        <AlertDialogTrigger asChild>
+                          <DropdownMenuItem
+                            className="text-rose-500 focus:text-rose-600"
+                            disabled={isSelf || isLastSuperuser}
+                            onSelect={() => {
+                              setSelectedUser(rowUser)
+                              setActionType("demote")
+                            }}
+                          >
+                            {isLastSuperuser
+                              ? "Cannot demote last superuser"
+                              : isSelf
+                                ? "Cannot demote yourself"
+                                : "Demote from superuser"}
+                          </DropdownMenuItem>
+                        </AlertDialogTrigger>
+                      ) : (
+                        <AlertDialogTrigger asChild>
+                          <DropdownMenuItem
+                            onSelect={() => {
+                              setSelectedUser(rowUser)
+                              setActionType("promote")
+                            }}
+                          >
+                            Promote to superuser
+                          </DropdownMenuItem>
+                        </AlertDialogTrigger>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )
+              },
+            },
+          ]}
+          toolbarProps={defaultToolbarProps}
+        />
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {actionType === "promote"
+                ? "Promote to superuser"
+                : "Demote from superuser"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {actionType === "promote" ? (
+                <>
+                  Are you sure you want to promote {selectedUser?.email} to
+                  superuser? They will have full access to all admin functions.
+                </>
+              ) : (
+                <>
+                  Are you sure you want to demote {selectedUser?.email} from
+                  superuser? They will lose access to admin functions.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant={actionType === "demote" ? "destructive" : "default"}
+              disabled={promotePending || demotePending}
+              onClick={handleConfirmAction}
+            >
+              {actionType === "promote" ? "Promote" : "Demote"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
   )
 }
 

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -6,16 +6,19 @@ import {
   type AdminCreateOrganizationDomainResponse,
   type AdminCreateOrganizationResponse,
   type AdminCreateTierResponse,
+  type AdminCreateUserResponse,
   type AdminListOrganizationDomainsResponse,
   type AdminListOrganizationsResponse,
   type AdminListTiersResponse,
   type AdminListUsersResponse,
   type AdminRegistryGetRegistryStatusResponse,
   type AdminRegistryListRegistryVersionsResponse,
+  type AdminUserCreate,
   type AdminUserRead,
   adminCreateOrganization,
   adminCreateOrganizationDomain,
   adminCreateTier,
+  adminCreateUser,
   adminDeleteOrganization,
   adminDeleteOrganizationDomain,
   adminDeleteTier,
@@ -228,6 +231,16 @@ export function useAdminUsers() {
     queryFn: adminListUsers,
   })
 
+  const { mutateAsync: createUser, isPending: createPending } = useMutation<
+    AdminCreateUserResponse,
+    Error,
+    AdminUserCreate
+  >({
+    mutationFn: (data) => adminCreateUser({ requestBody: data }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["admin", "users"] }),
+  })
+
   const { mutateAsync: promoteToSuperuser, isPending: promotePending } =
     useMutation<AdminUserRead, Error, string>({
       mutationFn: (userId) => adminPromoteToSuperuser({ userId }),
@@ -246,6 +259,8 @@ export function useAdminUsers() {
     users,
     isLoading,
     error,
+    createUser,
+    createPending,
     promoteToSuperuser,
     promotePending,
     demoteFromSuperuser,

--- a/packages/tracecat-ee/tracecat_ee/admin/users/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, HTTPException, status
+from fastapi_users import InvalidPasswordException
 
 from tracecat.auth.credentials import SuperuserRole
 from tracecat.db.dependencies import AsyncDBSession
@@ -25,6 +26,10 @@ async def create_user(
     service = AdminUserService(session, role)
     try:
         return await service.create_user(params)
+    except InvalidPasswordException as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
     except ValueError as e:
         detail = str(e)
         if "already exists" in detail.lower():

--- a/packages/tracecat-ee/tracecat_ee/admin/users/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/schemas.py
@@ -9,6 +9,16 @@ from tracecat.auth.schemas import UserRole
 from tracecat.core.schemas import Schema
 
 
+class AdminUserCreate(Schema):
+    """Create a user from the platform admin control plane."""
+
+    email: EmailStr
+    password: str
+    first_name: str | None = None
+    last_name: str | None = None
+    is_superuser: bool = False
+
+
 class AdminUserRead(Schema):
     """Admin view of a user."""
 

--- a/tests/unit/api/test_api_admin_users.py
+++ b/tests/unit/api/test_api_admin_users.py
@@ -34,6 +34,74 @@ def _user_read(
 
 
 @pytest.mark.anyio
+async def test_create_user_success(client: TestClient, test_admin_role: Role) -> None:
+    user = _user_read(email="new-user@example.com")
+
+    with patch.object(users_router, "AdminUserService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_user.return_value = user
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/admin/users",
+            json={
+                "email": "new-user@example.com",
+                "password": "this-is-a-strong-password",
+                "first_name": "New",
+                "last_name": "User",
+                "is_superuser": False,
+            },
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["id"] == str(user.id)
+    assert data["email"] == user.email
+
+
+@pytest.mark.anyio
+async def test_create_user_conflict(client: TestClient, test_admin_role: Role) -> None:
+    with patch.object(users_router, "AdminUserService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_user.side_effect = ValueError(
+            "User with email existing@example.com already exists"
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/admin/users",
+            json={
+                "email": "existing@example.com",
+                "password": "this-is-a-strong-password",
+            },
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_create_user_bad_request(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    with patch.object(users_router, "AdminUserService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_user.side_effect = ValueError(
+            "Password must be at least 12 characters long"
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/admin/users",
+            json={
+                "email": "new-user@example.com",
+                "password": "short",
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
 async def test_list_users_success(client: TestClient, test_admin_role: Role) -> None:
     user = _user_read()
 

--- a/tests/unit/test_admin_users_service.py
+++ b/tests/unit/test_admin_users_service.py
@@ -1,0 +1,112 @@
+"""Tests for platform-level admin user service behavior."""
+
+from __future__ import annotations
+
+import uuid
+from typing import cast
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped
+from tracecat_ee.admin.users.schemas import AdminUserCreate
+from tracecat_ee.admin.users.service import AdminUserService
+
+from tracecat.auth.schemas import UserRole
+from tracecat.auth.types import PlatformRole
+from tracecat.db.models import Membership, OrganizationMembership, User
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+def platform_role() -> PlatformRole:
+    return PlatformRole(
+        type="user",
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+
+
+@pytest.mark.anyio
+async def test_create_user_creates_platform_user_without_memberships(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminUserService(session, role=platform_role)
+    params = AdminUserCreate(
+        email="platform-user@example.com",
+        password="this-is-a-strong-password",
+        first_name="Platform",
+        last_name="User",
+        is_superuser=False,
+    )
+
+    created = await service.create_user(params)
+
+    user_result = await session.execute(
+        select(User).where(cast(Mapped[uuid.UUID], User.id) == created.id)
+    )
+    user = user_result.scalar_one()
+    assert user.email == params.email
+    assert user.first_name == params.first_name
+    assert user.last_name == params.last_name
+    assert user.role == UserRole.BASIC
+    assert user.is_verified is True
+    assert user.is_active is True
+    assert user.is_superuser is False
+    assert user.hashed_password != params.password
+
+    org_membership_result = await session.execute(
+        select(func.count())
+        .select_from(OrganizationMembership)
+        .where(OrganizationMembership.user_id == created.id)
+    )
+    org_membership_count = org_membership_result.scalar_one()
+    assert org_membership_count == 0
+
+    workspace_membership_result = await session.execute(
+        select(func.count())
+        .select_from(Membership)
+        .where(Membership.user_id == created.id)
+    )
+    workspace_membership_count = workspace_membership_result.scalar_one()
+    assert workspace_membership_count == 0
+
+
+@pytest.mark.anyio
+async def test_create_user_respects_superuser_flag(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminUserService(session, role=platform_role)
+    params = AdminUserCreate(
+        email="platform-superuser@example.com",
+        password="this-is-a-strong-password",
+        is_superuser=True,
+    )
+
+    created = await service.create_user(params)
+
+    user_result = await session.execute(
+        select(User).where(cast(Mapped[uuid.UUID], User.id) == created.id)
+    )
+    user = user_result.scalar_one()
+    assert user.is_superuser is True
+
+
+@pytest.mark.anyio
+async def test_create_user_rejects_duplicate_email(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminUserService(session, role=platform_role)
+    params = AdminUserCreate(
+        email="duplicate@example.com",
+        password="this-is-a-strong-password",
+    )
+
+    await service.create_user(params)
+
+    with pytest.raises(ValueError, match="already exists"):
+        await service.create_user(params)


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds platform-level user creation in the admin users panel so superusers can create users without forcing organization membership.

### Backend

- Adds `POST /admin/users` to the admin users router.
- Introduces `AdminUserCreate` request schema.
- Adds `AdminUserService.create_user(...)` that:
  - validates and hashes the provided password,
  - creates the user as a platform user (`is_verified=True`, optional superuser),
  - avoids creating org/workspace memberships,
  - emits a user create audit event.

### Frontend

- Adds `createUser` mutation in `useAdminUsers`.
- Adds a new `Create user` dialog on the admin users page with fields for:
  - email,
  - password,
  - first/last name,
  - optional superuser grant.
- Surfaces API error details in toast feedback.

### Tests

- Extends admin users API tests for create-user success/conflict/bad-request paths.
- Adds service tests validating:
  - no org/workspace memberships are created,
  - superuser flag behavior,
  - duplicate email rejection.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Navigate to `/admin/users` as a platform superuser.
2. Click `Create user` and submit a new user with a valid password.
3. Confirm the user appears in the users table.
4. Verify the user is not added to organization/workspace memberships by default.
5. Attempt to create a duplicate email and confirm a conflict error is shown.

### Commands run

- `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/api/test_api_admin_users.py tests/unit/test_admin_users_service.py`
- `uv run ruff check .`
- `uv run basedpyright packages/tracecat-ee/tracecat_ee/admin/users/router.py packages/tracecat-ee/tracecat_ee/admin/users/schemas.py packages/tracecat-ee/tracecat_ee/admin/users/service.py tests/unit/api/test_api_admin_users.py tests/unit/test_admin_users_service.py`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable platform admins to create platform-level users from the admin users page without adding them to an organization. Adds a POST /admin/users API and a “Create user” dialog with strong password checks and optional superuser grant.

- **New Features**
  - Backend: POST /admin/users (AdminUserCreate → AdminUserRead, 201); validates password via FastAPI Users and hashes it; creates active, verified BASIC user; optional superuser; no org/workspace memberships; emits audit event; returns 409 on duplicate email, 400 on invalid input (including invalid password).
  - Frontend: generated client types and adminCreateUser; “Create user” dialog using React Hook Form + Zod (email, password ≥12, first/last name, superuser); pending state; shows API error details in toasts.
  - Tests: API coverage for success/conflict/bad request/invalid password; service tests for no memberships, superuser flag, and duplicate email rejection.

<sup>Written for commit d6abb062863e8ca8757cb674253bd7c6e37ed566. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

