### PR TITLE
fix(registry): scope deduplicate cache keys by workspace

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/transform.py
+++ b/packages/tracecat-registry/tracecat_registry/core/transform.py
@@ -19,12 +19,21 @@ def _resolve_dedup_scope() -> str:
 
     Prefer the registry execution context workspace ID. Fall back to the
     workspace ID environment variable when context isn't set (e.g. some tests).
+    Raise explicitly when no workspace scope is available.
     """
 
     try:
-        return get_context().workspace_id
+        workspace_id = get_context().workspace_id
     except RuntimeError:
-        return os.environ.get("TRACECAT__WORKSPACE_ID", "global")
+        workspace_id = os.environ.get("TRACECAT__WORKSPACE_ID")
+
+    if not workspace_id:
+        raise ValueError(
+            "Deduplication could not determine this run's workspace scope. "
+            "This indicates a platform execution-context issue. Retry the run; "
+            "if it persists, contact your Tracecat administrator with the run ID."
+        )
+    return workspace_id
 
 
 @registry.register(

--- a/tests/registry/test_core_transform.py
+++ b/tests/registry/test_core_transform.py
@@ -564,6 +564,28 @@ async def test_deduplicate_ttl_expiry(redis_server, clean_redis_db) -> None:
         pytest.skip("Redis not available")
 
 
+@pytest.mark.anyio
+async def test_deduplicate_is_scoped_by_workspace_id(
+    redis_server, clean_redis_db, monkeypatch
+) -> None:
+    """Deduplication keys should be isolated between workspaces."""
+    payload = [{"id": 7, "value": "same-key"}]
+
+    try:
+        monkeypatch.setenv("TRACECAT__WORKSPACE_ID", "workspace-a")
+        first_workspace_a = await deduplicate(payload, ["id"])
+        assert first_workspace_a == payload
+
+        second_workspace_a = await deduplicate(payload, ["id"])
+        assert second_workspace_a == []
+
+        monkeypatch.setenv("TRACECAT__WORKSPACE_ID", "workspace-b")
+        first_workspace_b = await deduplicate(payload, ["id"])
+        assert first_workspace_b == payload
+    except ConnectionError:
+        pytest.skip("Redis not available")
+
+
 @pytest.mark.parametrize(
     "items,keys,error_type",
     [


### PR DESCRIPTION
### Motivation
- The `core.transform.deduplicate` implementation previously generated global Redis keys, which can cause dedupe state to leak between workspaces and poison caches. 
- Deduplication should be isolated to the workspace executing the registry action to avoid accidental cross-tenant data sharing.

### Description
- Resolve a deduplication scope via `RegistryContext.workspace_id` by calling `get_context()` with a safe fallback to the `TRACECAT__WORKSPACE_ID` environment variable when no context is set. 
- Prefix Redis keys with the workspace scope so keys are `dedup:{scope}:{sha256(...)}` in both pipeline and sequential code paths. 
- Add a regression test `test_deduplicate_is_scoped_by_workspace_id` to verify identical payloads dedupe independently across different workspace IDs. 

### Testing
- Ran `uv run ruff check packages/tracecat-registry/tracecat_registry/core/transform.py tests/registry/test_core_transform.py` and the linter/format checks passed. 
- Ran `uv run pytest tests/registry/test_core_transform.py -k "deduplicate_is_scoped_by_workspace_id or deduplicate_ttl_expiry"`, but the run errored in this environment due to a missing local PostgreSQL instance on `localhost:5432` (environment-related), so the new test could not be fully validated here. 
- The change is limited to key naming and context resolution and includes a dedicated unit test to validate workspace isolation when executed in a full test environment (CI or a local cluster with required services).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf452865c8320907762fd0b0f2aaf)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped deduplication cache keys by workspace and fail fast when no workspace scope is available to prevent cross-tenant collisions and cache poisoning in registry actions.

- **Bug Fixes**
  - Resolve scope via RegistryContext.workspace_id with TRACECAT__WORKSPACE_ID fallback.
  - Raise a ValueError when neither context nor env provides a workspace ID.
  - Prefix Redis keys as dedup:{scope}:{sha256(...)} in pipeline and sequential paths.
  - Tests: verify per-workspace isolation and explicit failure when scope is missing; add default TRACECAT__WORKSPACE_ID in tests.

<sup>Written for commit 6d534099631b0478e31d7ddd32ebd02b2d1dbb2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

