### PR TITLE
feat(admin): add editable tier entitlements in admin UI

### DIFF
--- a/frontend/src/components/admin/admin-tier-edit-dialog.tsx
+++ b/frontend/src/components/admin/admin-tier-edit-dialog.tsx
@@ -388,9 +388,11 @@ export function AdminTierEditDialog({
                             <FormLabel className="font-normal">
                               {entitlement.label}
                             </FormLabel>
-                            <FormDescription>
-                              {entitlement.description}
-                            </FormDescription>
+                            {entitlement.description ? (
+                              <FormDescription>
+                                {entitlement.description}
+                              </FormDescription>
+                            ) : null}
                           </div>
                         </FormItem>
                       )}

--- a/frontend/src/components/admin/admin-tier-edit-dialog.tsx
+++ b/frontend/src/components/admin/admin-tier-edit-dialog.tsx
@@ -27,6 +27,11 @@ import {
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { useAdminTier } from "@/hooks/use-admin"
+import {
+  TIER_ENTITLEMENTS,
+  tierEntitlementsSchema,
+  withDefaultTierEntitlements,
+} from "@/lib/tier-entitlements"
 
 const formSchema = z.object({
   display_name: z
@@ -53,6 +58,7 @@ const formSchema = z.object({
     .nullable(),
   api_rate_limit: z.coerce.number().int().positive().optional().nullable(),
   api_burst_capacity: z.coerce.number().int().positive().optional().nullable(),
+  entitlements: tierEntitlementsSchema,
   is_default: z.boolean(),
   is_active: z.boolean(),
   sort_order: z.coerce.number().int().min(0),
@@ -88,6 +94,7 @@ export function AdminTierEditDialog({
     resolver: zodResolver(formSchema),
     defaultValues: {
       display_name: "",
+      entitlements: withDefaultTierEntitlements(),
       is_default: false,
       is_active: true,
       sort_order: 0,
@@ -104,6 +111,7 @@ export function AdminTierEditDialog({
         max_concurrent_actions: tier.max_concurrent_actions,
         api_rate_limit: tier.api_rate_limit,
         api_burst_capacity: tier.api_burst_capacity,
+        entitlements: withDefaultTierEntitlements(tier.entitlements),
         is_default: tier.is_default,
         is_active: tier.is_active,
         sort_order: tier.sort_order,
@@ -121,6 +129,7 @@ export function AdminTierEditDialog({
         max_concurrent_actions: values.max_concurrent_actions ?? null,
         api_rate_limit: values.api_rate_limit ?? null,
         api_burst_capacity: values.api_burst_capacity ?? null,
+        entitlements: values.entitlements,
         is_default: values.is_default,
         is_active: values.is_active,
         sort_order: values.sort_order,
@@ -355,6 +364,38 @@ export function AdminTierEditDialog({
                       </FormItem>
                     )}
                   />
+                </div>
+              </div>
+              <div className="border-t pt-4">
+                <h4 className="mb-3 text-sm font-medium">Entitlements</h4>
+                <div className="space-y-3">
+                  {TIER_ENTITLEMENTS.map((entitlement) => (
+                    <FormField
+                      key={entitlement.key}
+                      control={form.control}
+                      name={`entitlements.${entitlement.key}` as const}
+                      render={({ field }) => (
+                        <FormItem className="flex items-start space-x-3 space-y-0">
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value}
+                              onCheckedChange={(checked) =>
+                                field.onChange(checked === true)
+                              }
+                            />
+                          </FormControl>
+                          <div className="space-y-1 leading-none">
+                            <FormLabel className="font-normal">
+                              {entitlement.label}
+                            </FormLabel>
+                            <FormDescription>
+                              {entitlement.description}
+                            </FormDescription>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+                  ))}
                 </div>
               </div>
 

--- a/frontend/src/components/admin/create-tier-dialog.tsx
+++ b/frontend/src/components/admin/create-tier-dialog.tsx
@@ -262,9 +262,11 @@ export function CreateTierDialog() {
                           <FormLabel className="font-normal">
                             {entitlement.label}
                           </FormLabel>
-                          <FormDescription>
-                            {entitlement.description}
-                          </FormDescription>
+                          {entitlement.description ? (
+                            <FormDescription>
+                              {entitlement.description}
+                            </FormDescription>
+                          ) : null}
                         </div>
                       </FormItem>
                     )}

--- a/frontend/src/components/admin/create-tier-dialog.tsx
+++ b/frontend/src/components/admin/create-tier-dialog.tsx
@@ -28,6 +28,11 @@ import {
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { useAdminTiers } from "@/hooks/use-admin"
+import {
+  TIER_ENTITLEMENTS,
+  tierEntitlementsSchema,
+  withDefaultTierEntitlements,
+} from "@/lib/tier-entitlements"
 
 // Preprocessor to convert empty strings to undefined for optional numeric fields
 const emptyToUndefined = z.preprocess(
@@ -45,6 +50,7 @@ const formSchema = z.object({
   max_concurrent_actions: emptyToUndefined,
   api_rate_limit: emptyToUndefined,
   api_burst_capacity: emptyToUndefined,
+  entitlements: tierEntitlementsSchema,
   is_default: z.boolean().default(false),
   sort_order: z.coerce.number().int().min(0).default(0),
 })
@@ -59,6 +65,7 @@ export function CreateTierDialog() {
     resolver: zodResolver(formSchema),
     defaultValues: {
       display_name: "",
+      entitlements: withDefaultTierEntitlements(),
       is_default: false,
       sort_order: 0,
     },
@@ -74,6 +81,7 @@ export function CreateTierDialog() {
         max_concurrent_actions: values.max_concurrent_actions ?? null,
         api_rate_limit: values.api_rate_limit ?? null,
         api_burst_capacity: values.api_burst_capacity ?? null,
+        entitlements: values.entitlements,
         is_default: values.is_default,
         sort_order: values.sort_order,
       })
@@ -230,6 +238,38 @@ export function CreateTierDialog() {
                     </FormItem>
                   )}
                 />
+              </div>
+            </div>
+            <div className="border-t pt-4">
+              <h4 className="mb-3 text-sm font-medium">Entitlements</h4>
+              <div className="space-y-3">
+                {TIER_ENTITLEMENTS.map((entitlement) => (
+                  <FormField
+                    key={entitlement.key}
+                    control={form.control}
+                    name={`entitlements.${entitlement.key}` as const}
+                    render={({ field }) => (
+                      <FormItem className="flex items-start space-x-3 space-y-0">
+                        <FormControl>
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={(checked) =>
+                              field.onChange(checked === true)
+                            }
+                          />
+                        </FormControl>
+                        <div className="space-y-1 leading-none">
+                          <FormLabel className="font-normal">
+                            {entitlement.label}
+                          </FormLabel>
+                          <FormDescription>
+                            {entitlement.description}
+                          </FormDescription>
+                        </div>
+                      </FormItem>
+                    )}
+                  />
+                ))}
               </div>
             </div>
 

--- a/frontend/src/lib/tier-entitlements.ts
+++ b/frontend/src/lib/tier-entitlements.ts
@@ -8,25 +8,20 @@ type TierEntitlementsFormValue = Record<TierEntitlementKey, boolean>
 type TierEntitlementDefinition = {
   key: TierEntitlementKey
   label: string
-  description: string
+  description?: string
 }
 
 const ENTITLEMENT_PROPERTIES = $EntitlementsDict.properties as Record<
   TierEntitlementKey,
   {
     title?: string
+    description?: string
   }
 >
 
 export const TIER_ENTITLEMENT_KEYS = Object.keys(
   ENTITLEMENT_PROPERTIES
 ) as TierEntitlementKey[]
-
-const ENTITLEMENT_DESCRIPTIONS: Partial<Record<TierEntitlementKey, string>> = {
-  custom_registry: "Allow using non-default registry repositories.",
-  sso: "Allow SSO configuration for the organization.",
-  git_sync: "Allow syncing workflows with external git repositories.",
-}
 
 function titleCaseFromSnakeCase(value: string): string {
   return value
@@ -46,9 +41,7 @@ export const TIER_ENTITLEMENTS: TierEntitlementDefinition[] =
     key,
     label:
       ENTITLEMENT_PROPERTIES[key]?.title ?? titleCaseFromSnakeCase(String(key)),
-    description:
-      ENTITLEMENT_DESCRIPTIONS[key] ??
-      "Enable this feature for organizations on this tier.",
+    description: ENTITLEMENT_PROPERTIES[key]?.description,
   }))
 
 export function withDefaultTierEntitlements(

--- a/frontend/src/lib/tier-entitlements.ts
+++ b/frontend/src/lib/tier-entitlements.ts
@@ -1,0 +1,62 @@
+import { z } from "zod"
+import { $EntitlementsDict, type EntitlementsDict } from "@/client"
+
+type TierEntitlementKey = keyof EntitlementsDict
+
+type TierEntitlementsFormValue = Record<TierEntitlementKey, boolean>
+
+type TierEntitlementDefinition = {
+  key: TierEntitlementKey
+  label: string
+  description: string
+}
+
+const ENTITLEMENT_PROPERTIES = $EntitlementsDict.properties as Record<
+  TierEntitlementKey,
+  {
+    title?: string
+  }
+>
+
+export const TIER_ENTITLEMENT_KEYS = Object.keys(
+  ENTITLEMENT_PROPERTIES
+) as TierEntitlementKey[]
+
+const ENTITLEMENT_DESCRIPTIONS: Partial<Record<TierEntitlementKey, string>> = {
+  custom_registry: "Allow using non-default registry repositories.",
+  sso: "Allow SSO configuration for the organization.",
+  git_sync: "Allow syncing workflows with external git repositories.",
+}
+
+function titleCaseFromSnakeCase(value: string): string {
+  return value
+    .split("_")
+    .map((word) => word.slice(0, 1).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+export const tierEntitlementsSchema = z.object(
+  Object.fromEntries(
+    TIER_ENTITLEMENT_KEYS.map((key) => [key, z.boolean()])
+  ) as Record<TierEntitlementKey, z.ZodBoolean>
+)
+
+export const TIER_ENTITLEMENTS: TierEntitlementDefinition[] =
+  TIER_ENTITLEMENT_KEYS.map((key) => ({
+    key,
+    label:
+      ENTITLEMENT_PROPERTIES[key]?.title ?? titleCaseFromSnakeCase(String(key)),
+    description:
+      ENTITLEMENT_DESCRIPTIONS[key] ??
+      "Enable this feature for organizations on this tier.",
+  }))
+
+export function withDefaultTierEntitlements(
+  entitlements?: EntitlementsDict | null
+): TierEntitlementsFormValue {
+  const resolved = {} as TierEntitlementsFormValue
+  for (const key of TIER_ENTITLEMENT_KEYS) {
+    resolved[key] = entitlements?.[key] ?? false
+  }
+  return resolved
+}

--- a/tracecat/tiers/types.py
+++ b/tracecat/tiers/types.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
+
+from pydantic import Field
 
 
 class EntitlementsDict(TypedDict, total=False):
@@ -11,6 +13,9 @@ class EntitlementsDict(TypedDict, total=False):
     All keys are optional (total=False) to support partial overrides.
     """
 
-    custom_registry: bool
-    sso: bool
-    git_sync: bool
+    custom_registry: Annotated[
+        bool,
+        Field(description="Whether custom registry repositories are enabled"),
+    ]
+    sso: Annotated[bool, Field(description="Whether SSO is enabled")]
+    git_sync: Annotated[bool, Field(description="Whether git sync is enabled")]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add editable tier entitlements to the admin UI and display them in the tiers table. Labels and descriptions are sourced from the backend schema, with defaults and validation applied to new and existing tiers.

- **New Features**
  - Added tier-entitlements.ts: derives keys from $EntitlementsDict, builds a zod schema, pulls titles/descriptions from the backend schema, and provides withDefaultTierEntitlements.
  - Create/Edit Tier dialogs: new Entitlements checkbox section, validated and persisted with sensible defaults.
  - Tiers table: added Entitlements column listing enabled items; added Active column with check/cross icons; Default now shown with an icon.

<sup>Written for commit a44e8ef1064f6d41dc694270044230bdcd0ed74c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

