### PR TITLE
fix(sandbox): preserve DNS search/options in nsjail

### DIFF
--- a/deployments/helm/tracecat/templates/executor-deployment.yaml
+++ b/deployments/helm/tracecat/templates/executor-deployment.yaml
@@ -65,10 +65,6 @@ spec:
               mountPath: /var/lib/tracecat/sandbox-cache
             - name: tmp
               mountPath: /tmp
-            {{- if not .Values.tracecat.sandbox.disableNsjail }}
-            - name: dev-tun
-              mountPath: /dev/net/tun
-            {{- end }}
           resources:
             {{- toYaml .Values.executor.resources | nindent 12 }}
       volumes:
@@ -76,9 +72,3 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
-        {{- if not .Values.tracecat.sandbox.disableNsjail }}
-        - name: dev-tun
-          hostPath:
-            path: /dev/net/tun
-            type: CharDevice
-        {{- end }}

--- a/deployments/helm/tracecat/templates/executor-deployment.yaml
+++ b/deployments/helm/tracecat/templates/executor-deployment.yaml
@@ -65,6 +65,10 @@ spec:
               mountPath: /var/lib/tracecat/sandbox-cache
             - name: tmp
               mountPath: /tmp
+            {{- if not .Values.tracecat.sandbox.disableNsjail }}
+            - name: dev-tun
+              mountPath: /dev/net/tun
+            {{- end }}
           resources:
             {{- toYaml .Values.executor.resources | nindent 12 }}
       volumes:
@@ -72,3 +76,9 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+        {{- if not .Values.tracecat.sandbox.disableNsjail }}
+        - name: dev-tun
+          hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+        {{- end }}

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -35,6 +35,7 @@ from tracecat.agent.common.config import (
     TRUSTED_MCP_SOCKET_PATH,
 )
 from tracecat.agent.common.exceptions import AgentSandboxValidationError
+from tracecat.sandbox.executor import build_sandbox_resolv_conf
 
 # Valid environment variable name pattern (POSIX compliant)
 _ENV_VAR_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -368,7 +369,7 @@ def build_agent_nsjail_config(
     # is mounted read-write at /work inside the sandbox.
     if enable_internet_access:
         resolv_conf_path = socket_dir / "resolv.conf"
-        resolv_conf_path.write_text("nameserver 10.255.255.1\n")
+        resolv_conf_path.write_text(build_sandbox_resolv_conf())
 
         hosts_path = socket_dir / "hosts"
         hosts_path.write_text(

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -221,39 +221,23 @@ class NsjailExecutor:
         # - Execute phase: per config.network_enabled
         network_enabled = phase == "install" or config.network_enabled
 
-        # Network namespace is always isolated (clone_newnet: true)
-        # When network access is needed, pasta provides userspace networking
+        # Network behavior:
+        # - network enabled: share pod netns (no pasta) for host DNS/routing reliability
+        # - network disabled: isolate netns
         lines = [
             'name: "python_sandbox"',
             "mode: ONCE",
             'hostname: "sandbox"',
             "keep_env: false",
             "",
-            "# Namespace isolation - network always isolated, pasta for outbound access",
-            "clone_newnet: true",
+            "# Namespace isolation",
+            f"clone_newnet: {'false' if network_enabled else 'true'}",
             "clone_newuser: true",
             "clone_newns: true",
             "clone_newpid: true",
             "clone_newipc: true",
             "clone_newuts: true",
         ]
-
-        # Userspace networking via pasta when network access is needed
-        if network_enabled:
-            lines.extend(
-                [
-                    "",
-                    "# Userspace networking via pasta - provides internet access with isolation",
-                    "user_net {",
-                    "  enable: true",
-                    '  ip: "10.255.255.2"',
-                    '  gw: "10.255.255.1"',
-                    '  ip6: "fc00::2"',
-                    '  gw6: "fc00::1"',
-                    "  enable_dns: true",
-                    "}",
-                ]
-            )
 
         lines.extend(
             [
@@ -283,38 +267,14 @@ class NsjailExecutor:
                 f'mount {{ src: "{sbin_path}" dst: "/sbin" is_bind: true rw: false }}'
             )
 
-        # Network config: when using pasta, generate /etc files for hostname resolution
-        # Docker export leaves these empty since Docker manages them at runtime
         if network_enabled:
-            resolv_conf_path = job_dir / "resolv.conf"
-            resolv_conf_path.write_text(build_sandbox_resolv_conf())
-
-            hosts_path = job_dir / "hosts"
-            hosts_path.write_text(
-                "127.0.0.1\tlocalhost\n::1\tlocalhost ip6-localhost ip6-loopback\n"
-            )
-
-            # nsswitch.conf tells glibc how to resolve hostnames: check /etc/hosts
-            # first ("files"), then fall back to DNS. Without this, hostname
-            # resolution may fail even with valid /etc/hosts and /etc/resolv.conf.
-            nsswitch_path = job_dir / "nsswitch.conf"
-            nsswitch_path.write_text(
-                "passwd:         files\n"
-                "group:          files\n"
-                "shadow:         files\n"
-                "hosts:          files dns\n"
-                "networks:       files\n"
-                "protocols:      files\n"
-                "services:       files\n"
-            )
-
             lines.extend(
                 [
                     "",
-                    "# Network config - DNS and hostname resolution",
-                    f'mount {{ src: "{resolv_conf_path}" dst: "/etc/resolv.conf" is_bind: true rw: false }}',
-                    f'mount {{ src: "{hosts_path}" dst: "/etc/hosts" is_bind: true rw: false }}',
-                    f'mount {{ src: "{nsswitch_path}" dst: "/etc/nsswitch.conf" is_bind: true rw: false }}',
+                    "# DNS config - use pod resolver files directly",
+                    'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
+                    'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
+                    'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
                 ]
             )
 
@@ -689,31 +649,19 @@ class NsjailExecutor:
         if config.site_packages_dir:
             _validate_path(config.site_packages_dir, "site_packages_dir")
 
-        # Network namespace isolated with pasta for userspace networking
-        # This provides outbound connectivity while maintaining network isolation
         lines = [
             'name: "action_sandbox"',
             "mode: ONCE",
             'hostname: "sandbox"',
             "keep_env: false",
             "",
-            "# Namespace isolation - network isolated with pasta for outbound access",
-            "clone_newnet: true",
+            "# Namespace isolation (share pod network namespace for reliability)",
+            "clone_newnet: false",
             "clone_newuser: true",
             "clone_newns: true",
             "clone_newpid: true",
             "clone_newipc: true",
             "clone_newuts: true",
-            "",
-            "# Userspace networking via pasta - provides internet access with isolation",
-            "user_net {",
-            "  enable: true",
-            '  ip: "10.255.255.2"',
-            '  gw: "10.255.255.1"',
-            '  ip6: "fc00::2"',
-            '  gw6: "fc00::1"',
-            "  enable_dns: true",
-            "}",
             "",
             "# UID/GID mapping - map container user to current user",
             f'uidmap {{ inside_id: "1000" outside_id: "{os.getuid()}" count: 1 }}',
@@ -739,37 +687,18 @@ class NsjailExecutor:
                 f'mount {{ src: "{sbin_path}" dst: "/sbin" is_bind: true rw: false }}'
             )
 
-        # Network config: pasta provides DNS forwarding at the gateway IP (10.255.255.1)
-        # Docker export leaves /etc files empty since Docker manages them at runtime
-        resolv_conf_path = job_dir / "resolv.conf"
-        resolv_conf_path.write_text(build_sandbox_resolv_conf())
-
-        hosts_path = job_dir / "hosts"
-        hosts_path.write_text(
-            "127.0.0.1\tlocalhost\n::1\tlocalhost ip6-localhost ip6-loopback\n"
-        )
-
-        # nsswitch.conf tells glibc how to resolve hostnames: check /etc/hosts
-        # first ("files"), then fall back to DNS. Without this, hostname
-        # resolution may fail even with valid /etc/hosts and /etc/resolv.conf.
-        nsswitch_path = job_dir / "nsswitch.conf"
-        nsswitch_path.write_text(
-            "passwd:         files\n"
-            "group:          files\n"
-            "shadow:         files\n"
-            "hosts:          files dns\n"
-            "networks:       files\n"
-            "protocols:      files\n"
-            "services:       files\n"
+        lines.extend(
+            [
+                "",
+                "# DNS config - use pod resolver files directly",
+                'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
+                'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
+                'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
+            ]
         )
 
         lines.extend(
             [
-                "",
-                "# Network config - DNS and hostname resolution",
-                f'mount {{ src: "{resolv_conf_path}" dst: "/etc/resolv.conf" is_bind: true rw: false }}',
-                f'mount {{ src: "{hosts_path}" dst: "/etc/hosts" is_bind: true rw: false }}',
-                f'mount {{ src: "{nsswitch_path}" dst: "/etc/nsswitch.conf" is_bind: true rw: false }}',
                 "",
                 "# /dev essentials",
                 'mount { src: "/dev/null" dst: "/dev/null" is_bind: true rw: true }',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix DNS resolution in nsjail by dropping pasta and using the pod’s network namespace and resolver files when network access is allowed. This restores short service name lookups and stabilizes networking in Kubernetes.

- **Bug Fixes**
  - Share pod netns when internet/network is enabled; isolate when disabled.
  - Bind-mount pod /etc/resolv.conf, /etc/hosts, and /etc/nsswitch.conf into agent, executor, and action sandboxes to preserve cluster search/options.
  - Remove pasta user_net config and generated resolver files.

<sup>Written for commit 3d7686a8565939aa1df82d188b3646ff0e6d832c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

