### PR TITLE
fix(terraform): allow Terraform 1.14 patch updates

### DIFF
--- a/deployments/terraform/aws/versions.tf
+++ b/deployments/terraform/aws/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.14.4"
+  required_version = ">= 1.14.4, < 1.15.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Motivation
- Relax the Terraform core constraint so the deployment can accept patch-level updates in the 1.14 line (e.g. 1.14.5) while preventing unreviewed minor-version upgrades.

### Description
- Update `deployments/terraform/aws/versions.tf` to change `required_version` from the exact pin `"1.14.4"` to the bounded range `">= 1.14.4, < 1.15.0"`, which is equivalent to a pessimistic patch allowance without permitting 1.15+.

### Testing
- Queried HashiCorp's checkpoint API with `curl -fsSL https://checkpoint-api.hashicorp.com/v1/check/terraform` which returned `current_version: 1.14.5`; `terraform version` could not be run in this environment because the CLI is not installed (`command not found`), and the file change was verified in `deployments/terraform/aws/versions.tf` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4dc067008333a926b99e50f05c67)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows Terraform 1.14 patch updates (e.g., 1.14.5) while blocking 1.15+. Updates required_version in deployments/terraform/aws/versions.tf from "1.14.4" to ">= 1.14.4, < 1.15.0".

<sup>Written for commit 082d2b2b7ac77b5562a3d619a7d61d125acf8cf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

