### PR TITLE
ci(infra): Publish OCI Helm chart

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -1,0 +1,38 @@
+name: Publish helm chart
+
+on:
+  push:
+    branches: ["staging", "preview"]
+    tags:
+      - "*.*.*"
+
+env:
+  REGISTRY: ghcr.io
+  CHART_PATH: deployments/helm/tracecat
+  OCI_REPOSITORY: ghcr.io/tracecathq/tracecat-helm-chart
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-helm-chart:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to Container registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Package chart
+        run: helm package "${{ env.CHART_PATH }}" --destination /tmp/chart
+
+      - name: Push chart to GHCR
+        run: helm push /tmp/chart/*.tgz oci://${{ env.OCI_REPOSITORY }}

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -2,7 +2,6 @@ name: Publish helm chart
 
 on:
   push:
-    branches: ["staging", "preview"]
     tags:
       - "*.*.*"
 
@@ -24,6 +23,9 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies
+        run: helm dependency build "${{ env.CHART_PATH }}"
 
       - name: Log in to Container registry
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub Actions workflow to package and publish the Helm chart to GHCR via OCI. Releases run only on semver tag pushes.

- **New Features**
  - Publishes deployments/helm/tracecat to ghcr.io/tracecathq/tracecat-helm-chart.
  - Builds chart dependencies, then packages and pushes the chart.
  - Triggers only on tags matching x.y.z.

<sup>Written for commit 749a8a7b08ca5b6e6b3a88c82a71444b1467059b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



