### PR TITLE
chore(terraform): increase default RDS/ElastiCache sizing, enable Redis HA, and trim README rationale

### DIFF
--- a/deployments/terraform/aws/README.md
+++ b/deployments/terraform/aws/README.md
@@ -81,9 +81,10 @@ capacity_reserved_memory_mib=8192
 capacity_reserved_pod_eni=8
 
 # Persistence services and Temporal mode
-rds_instance_class="db.t4g.medium"
+rds_instance_class="db.m7g.2xlarge"
+rds_allocated_storage=300
 rds_storage_type="gp3"
-elasticache_node_type="cache.t3.micro"
+elasticache_node_type="cache.m7g.xlarge"
 rds_database_insights_mode="advanced"
 ```
 
@@ -148,9 +149,10 @@ capacity_reserved_cpu_millicores=3000
 capacity_reserved_memory_mib=8192
 
 # Persistence services
-rds_instance_class="db.t4g.medium"
+rds_instance_class="db.m7g.large"
+rds_allocated_storage=100
 rds_storage_type="gp3"
-elasticache_node_type="cache.t4g.small"
+elasticache_node_type="cache.m7g.large"
 rds_database_insights_mode="standard"
 ```
 
@@ -301,15 +303,16 @@ To deploy Temporal in self-hosted mode, set `temporal_mode` to `self-hosted`.
 export TF_VAR_temporal_mode="self-hosted"
 ```
 
-RDS defaults are intentionally cost-optimized for non-Temporal-heavy deployments:
-`rds_instance_class="db.t4g.medium"`, `rds_allocated_storage=20`, `rds_storage_type="gp3"`.
+Default persistence profile:
+`rds_instance_class="db.m7g.2xlarge"`, `rds_allocated_storage=300`, `rds_storage_type="gp3"`, `elasticache_node_type="cache.m7g.xlarge"` (3-node Multi-AZ replication group with automatic failover), and `multi_az=true` for RDS.
 
 For Temporal self-hosting, use a larger starting profile:
 
 ```bash
-export TF_VAR_rds_instance_class="db.r7g.2xlarge"
-export TF_VAR_rds_allocated_storage=100
+export TF_VAR_rds_instance_class="db.r7g.4xlarge"
+export TF_VAR_rds_allocated_storage=500
 export TF_VAR_rds_storage_type="io2"
+export TF_VAR_elasticache_node_type="cache.r7g.xlarge"
 ```
 
 To connect to an external Temporal cluster (cloud or self-hosted), set `temporal_mode` to `cloud`.

--- a/deployments/terraform/aws/modules/eks/elasticache.tf
+++ b/deployments/terraform/aws/modules/eks/elasticache.tf
@@ -72,7 +72,7 @@ resource "aws_elasticache_replication_group" "tracecat" {
   engine             = "redis"
   engine_version     = "7.1"
   node_type          = var.elasticache_node_type
-  num_cache_clusters = 1
+  num_cache_clusters = 3
   port               = 6379
 
   subnet_group_name  = aws_elasticache_subnet_group.tracecat.name
@@ -82,8 +82,8 @@ resource "aws_elasticache_replication_group" "tracecat" {
   transit_encryption_enabled = true
   auth_token                 = random_password.redis_auth.result
 
-  automatic_failover_enabled = false
-  multi_az_enabled           = false
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
 
   snapshot_retention_limit = 1
   snapshot_window          = "03:00-04:00"

--- a/deployments/terraform/aws/modules/eks/rds.tf
+++ b/deployments/terraform/aws/modules/eks/rds.tf
@@ -81,7 +81,7 @@ resource "aws_db_instance" "tracecat" {
   vpc_security_group_ids = [aws_security_group.rds.id]
 
   publicly_accessible = false
-  multi_az            = false
+  multi_az            = true
   storage_encrypted   = true
 
   database_insights_mode = var.rds_database_insights_mode

--- a/deployments/terraform/aws/modules/eks/variables.tf
+++ b/deployments/terraform/aws/modules/eks/variables.tf
@@ -143,13 +143,13 @@ variable "tracecat_secrets_arn" {
 variable "rds_instance_class" {
   description = "RDS instance class"
   type        = string
-  default     = "db.t4g.medium"
+  default     = "db.m7g.2xlarge"
 }
 
 variable "rds_allocated_storage" {
   description = "Allocated storage for RDS in GB"
   type        = number
-  default     = 20
+  default     = 300
 }
 
 variable "rds_storage_type" {
@@ -207,7 +207,7 @@ variable "rds_password_rotation_schedule" {
 variable "elasticache_node_type" {
   description = "ElastiCache node type"
   type        = string
-  default     = "cache.t3.micro"
+  default     = "cache.m7g.xlarge"
 }
 
 # Temporal Configuration

--- a/deployments/terraform/aws/variables.tf
+++ b/deployments/terraform/aws/variables.tf
@@ -159,13 +159,13 @@ variable "tracecat_secrets_arn" {
 variable "rds_instance_class" {
   description = "RDS instance class"
   type        = string
-  default     = "db.t4g.medium"
+  default     = "db.m7g.2xlarge"
 }
 
 variable "rds_allocated_storage" {
   description = "Allocated storage for RDS in GB"
   type        = number
-  default     = 20
+  default     = 300
 }
 
 variable "rds_storage_type" {
@@ -217,7 +217,7 @@ variable "rds_deletion_protection" {
 variable "elasticache_node_type" {
   description = "ElastiCache node type"
   type        = string
-  default     = "cache.t3.micro"
+  default     = "cache.m7g.xlarge"
 }
 
 # Temporal Configuration


### PR DESCRIPTION
### Motivation
- Provide safer defaults for persistence services by increasing RDS and ElastiCache sizing and enabling HA to reduce early operational scaling pain.
- Remove internal sizing rationale from the public AWS Terraform README to keep documentation concise.

### Description
- Updated default `rds_instance_class` to `db.m7g.2xlarge` and `rds_allocated_storage` to `300` in `deployments/terraform/aws/variables.tf` and `deployments/terraform/aws/modules/eks/variables.tf`.
- Updated default `elasticache_node_type` to `cache.m7g.xlarge` in the same `variables.tf` files.
- Enabled Redis HA by setting `num_cache_clusters = 3`, `automatic_failover_enabled = true`, and `multi_az_enabled = true` in `deployments/terraform/aws/modules/eks/elasticache.tf`, and enabled `multi_az = true` for RDS in `deployments/terraform/aws/modules/eks/rds.tf`.
- Trimmed the long internal sizing/rationale paragraphs from `deployments/terraform/aws/README.md`, leaving a concise `Default persistence profile` line and updated the Temporal self-hosted example overrides.

### Testing
- Attempted `terraform fmt -check deployments/terraform/aws/README.md`, but the Terraform CLI is not installed in this environment so formatting verification could not be performed.
- No additional automated tests were run in this environment; changes are confined to Terraform configuration and documentation files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4b950c948333bbe2b0c7e585e7bb)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase default capacity for RDS and ElastiCache and enable HA by default (RDS Multi-AZ, Redis 3-node) to provide safer production defaults. Simplify the AWS Terraform README to a concise default persistence profile with updated Temporal overrides.

- **New Features**
  - RDS: default class db.m7g.2xlarge, 300 GB storage; Multi-AZ enabled.
  - ElastiCache (Redis): default cache.m7g.xlarge; 3-node replication group with automatic failover and Multi-AZ.
  - README: trimmed to a single “Default persistence profile” and refreshed Temporal self-hosted example overrides.

- **Migration**
  - Existing stacks will enable RDS Multi-AZ and scale Redis to 3 nodes; run plan/apply in a maintenance window.
  - Expect higher costs; override with TF_VAR_rds_instance_class, TF_VAR_rds_allocated_storage, and TF_VAR_elasticache_node_type if needed.
  - HA is now default; opting out requires modifying the module.

<sup>Written for commit dd3692346f6d727cf62e7dc014aa0a14f571b56b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

