### PR TITLE
fix(terraform): pin Terraform < 1.14 to avoid TFC EKS planning regression

### DIFF
--- a/deployments/terraform/aws/versions.tf
+++ b/deployments/terraform/aws/versions.tf
@@ -1,5 +1,8 @@
 terraform {
-  required_version = "~> 1.14.0"
+  # NOTE: Terraform 1.14 currently breaks planning for this stack in TFC because
+  # the kubernetes/helm providers attempt to initialize before EKS connection
+  # details exist, falling back to localhost and failing with cluster-unreachable.
+  required_version = ">= 1.11.0, < 1.14.0"
 
   required_providers {
     aws = {

--- a/deployments/terraform/aws/versions.tf
+++ b/deployments/terraform/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   # NOTE: Terraform 1.14 currently breaks planning for this stack in TFC because
   # the kubernetes/helm providers attempt to initialize before EKS connection
   # details exist, falling back to localhost and failing with cluster-unreachable.
-  required_version = ">= 1.11.0, < 1.14.0"
+  required_version = "~> 1.13.0"
 
   required_providers {
     aws = {

--- a/deployments/terraform/aws/versions.tf
+++ b/deployments/terraform/aws/versions.tf
@@ -1,7 +1,4 @@
 terraform {
-  # NOTE: Terraform 1.14 currently breaks planning for this stack in TFC because
-  # the kubernetes/helm providers attempt to initialize before EKS connection
-  # details exist, falling back to localhost and failing with cluster-unreachable.
   required_version = "~> 1.13.0"
 
   required_providers {


### PR DESCRIPTION
### Motivation
- Terraform 1.14 in Terraform Cloud causes the `kubernetes`/`helm` providers to initialize before EKS connection details are available, falling back to `localhost` and producing "cluster unreachable" errors during plan.

### Description
- Update `deployments/terraform/aws/versions.tf` to set `required_version = ">= 1.11.0, < 1.14.0"` and add an inline note explaining the 1.14 planning regression with the kubernetes/helm providers.

### Testing
- Attempted `terraform -chdir=deployments/terraform/aws init -backend=false`, but the `terraform` CLI is not installed in this environment so initialization/plan could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e778cbb2883338b92ff04523627b1)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Terraform to 1.13.x for the AWS stack to avoid TFC EKS planning failures when kubernetes/helm providers initialize before cluster details. Restores stable planning for the Kubernetes configuration issue investigation.

- **Bug Fixes**
  - Set required_version in deployments/terraform/aws/versions.tf to "~> 1.13.0".
  - Removed the inline note about the 1.14 planning regression to keep the constraint clean.

<sup>Written for commit 2ce0028463e8f56f662fb7481508ed672f354f5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

