### PR TITLE
fix(frontend): add case trigger icon in workflow events

### DIFF
--- a/frontend/src/components/builder/events/events-workflow.tsx
+++ b/frontend/src/components/builder/events/events-workflow.tsx
@@ -3,6 +3,7 @@ import {
   AlarmClockCheckIcon,
   AlarmClockOffIcon,
   AlarmClockPlusIcon,
+  BriefcaseBusinessIcon,
   CalendarIcon,
   CalendarSearchIcon,
   CircleCheck,
@@ -559,6 +560,15 @@ export function getTriggerTypeIcon(
       return (
         <div className="relative rounded-full bg-purple-400">
           <WebhookIcon
+            className={cn("size-3 scale-[0.7] stroke-white", className)}
+            strokeWidth={2.5}
+          />
+        </div>
+      )
+    case "case":
+      return (
+        <div className="relative rounded-full bg-emerald-500">
+          <BriefcaseBusinessIcon
             className={cn("size-3 scale-[0.7] stroke-white", className)}
             strokeWidth={2.5}
           />


### PR DESCRIPTION
### Motivation
- Prevent console error `Unknown trigger type: case` in the workflow canvas when case-triggers are enabled by handling the `case` TriggerType explicitly.

### Description
- Import `BriefcaseBusinessIcon` and update `getTriggerTypeIcon` in `frontend/src/components/builder/events/events-workflow.tsx` to render a dedicated badge for `case` trigger types instead of falling back to the unknown-case handler.

### Testing
- Ran `pnpm -C frontend exec biome check --write src/components/builder/events/events-workflow.tsx` which passed.
- Ran `pnpm -C frontend check` which passed for the full frontend; attempted a Playwright screenshot against `http://localhost:80` but it failed with `net::ERR_EMPTY_RESPONSE` because no local UI server was reachable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3a4afb608333b66c661b47ed7fa1)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render a dedicated badge for "case" workflow triggers to eliminate the "Unknown trigger type: case" console error and show the correct UI. Maps the "case" TriggerType to BriefcaseBusinessIcon in getTriggerTypeIcon.

<sup>Written for commit 770921e0dc7a61746a3b7daea7530c36798e8899. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

