### PR TITLE
ci: add manual `workflow_dispatch` tag input to publish images workflow

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -8,6 +8,12 @@ on:
       - "nightly-*"
   schedule:
     - cron: "0 0 * * *"  # Nightly at midnight UTC
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (for example: 1.2.3 or nightly-20250101)"
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -56,6 +62,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
             type=match,pattern=nightly-(.*),group=0
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker builder
         uses: useblacksmith/setup-docker-builder@78f41686563c732ccc097f7baac2f092f67538f0 # v1
@@ -117,6 +124,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
             type=match,pattern=nightly-(.*),group=0
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
@@ -169,6 +177,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
             type=match,pattern=nightly-(.*),group=0
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker builder
         uses: useblacksmith/setup-docker-builder@78f41686563c732ccc097f7baac2f092f67538f0 # v1
@@ -242,6 +251,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=nightly-{{date 'YYYYMMDD'}}-{{sha}},enable=${{ github.event_name == 'schedule' }}
             type=match,pattern=nightly-(.*),group=0
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
### Motivation
- Allow publishing OCI images on-demand with an explicit tag instead of only via pushes or schedule. 
- Provide a safe manual entry point so maintainers can publish specific semver or nightly tags (e.g. `1.2.3` or `nightly-20250101`).

### Description
- Add a `workflow_dispatch` trigger to `.github/workflows/build-push-images.yml` that requires a `tag` string input. 
- Plumb the provided `inputs.tag` into the Docker metadata step so the manually supplied tag is included when the event is `workflow_dispatch`. 
- Apply the `inputs.tag` change to the API and UI image `docker/metadata-action` usages and the corresponding merge/push steps so both images can be published with the manual tag.

### Testing
- Verified the workflow YAML parses successfully using `python - <<'PY' ... yaml.safe_load(...) ... PY`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4a4e95348333b3d930c6bd3d8e8b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a manual trigger to publish OCI images with a specific tag. Lets maintainers push versioned or dated nightly tags on demand.

- **New Features**
  - Added workflow_dispatch with a required tag input to build-push-images.yml.
  - Passes inputs.tag to docker/metadata-action when manually triggered to publish that tag.
  - Applies to both API and UI images; existing push/schedule behavior is unchanged.

<sup>Written for commit 2a3920ebf0b5182e1d6beaaa71c294e859b37f23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

