### PR TITLE
ci: add manual trigger to helm chart publish workflow

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -1,6 +1,7 @@
 name: Publish helm chart
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "*.*.*"

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -1,15 +1,11 @@
 name: Publish helm chart
 
 on:
-  workflow_dispatch:
-    inputs:
-      chart_version:
-        description: "Chart version to publish (defaults to Chart.yaml version)"
-        required: false
-        type: string
   push:
-    tags:
-      - "*.*.*"
+    branches:
+      - main
+    paths:
+      - deployments/helm/tracecat/Chart.yaml
 
 env:
   REGISTRY: ghcr.io
@@ -30,34 +26,20 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
-      - name: Resolve chart version
-        id: chart-version
+      - name: Resolve chart metadata
+        id: chart-metadata
         run: |
-          INPUT_VERSION="${{ inputs.chart_version }}"
-          if [ -n "$INPUT_VERSION" ]; then
-            CHART_VERSION="$INPUT_VERSION"
-          else
-            CHART_VERSION="$(helm show chart "${{ env.CHART_PATH }}" | awk -F': ' '$1 == "version" {print $2}')"
-          fi
+          CHART_NAME="$(helm show chart "${{ env.CHART_PATH }}" | awk -F': ' '$1 == "name" {print $2}')"
+          CHART_VERSION="$(helm show chart "${{ env.CHART_PATH }}" | awk -F': ' '$1 == "version" {print $2}')"
 
-          if [ -z "$CHART_VERSION" ]; then
-            echo "Unable to determine chart version."
+          if [ -z "$CHART_NAME" ] || [ -z "$CHART_VERSION" ]; then
+            echo "Unable to determine chart name or version."
             exit 1
           fi
 
+          echo "name=$CHART_NAME" >> "$GITHUB_OUTPUT"
           echo "version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
 
-
-      - name: Validate tag matches chart version
-        if: github.event_name == 'push'
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          CHART_VERSION="${{ steps.chart-version.outputs.version }}"
-
-          if [ "$TAG_VERSION" != "$CHART_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match chart version ($CHART_VERSION)."
-            exit 1
-          fi
       - name: Build chart dependencies
         run: helm dependency build "${{ env.CHART_PATH }}"
 
@@ -69,9 +51,10 @@ jobs:
 
       - name: Package chart
         run: |
-          helm package "${{ env.CHART_PATH }}" \
-            --version "${{ steps.chart-version.outputs.version }}" \
-            --destination /tmp/chart
+          helm package "${{ env.CHART_PATH }}" --destination /tmp/chart
 
       - name: Push chart to GHCR
-        run: helm push /tmp/chart/*.tgz oci://${{ env.OCI_REPOSITORY }}
+        run: |
+          helm push \
+            "/tmp/chart/${{ steps.chart-metadata.outputs.name }}-${{ steps.chart-metadata.outputs.version }}.tgz" \
+            oci://${{ env.OCI_REPOSITORY }}

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -2,6 +2,11 @@ name: Publish helm chart
 
 on:
   workflow_dispatch:
+    inputs:
+      chart_version:
+        description: "Chart version to publish (defaults to Chart.yaml version)"
+        required: false
+        type: string
   push:
     tags:
       - "*.*.*"
@@ -25,6 +30,34 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
+      - name: Resolve chart version
+        id: chart-version
+        run: |
+          INPUT_VERSION="${{ inputs.chart_version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            CHART_VERSION="$INPUT_VERSION"
+          else
+            CHART_VERSION="$(helm show chart "${{ env.CHART_PATH }}" | awk -F': ' '$1 == "version" {print $2}')"
+          fi
+
+          if [ -z "$CHART_VERSION" ]; then
+            echo "Unable to determine chart version."
+            exit 1
+          fi
+
+          echo "version=$CHART_VERSION" >> "$GITHUB_OUTPUT"
+
+
+      - name: Validate tag matches chart version
+        if: github.event_name == 'push'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CHART_VERSION="${{ steps.chart-version.outputs.version }}"
+
+          if [ "$TAG_VERSION" != "$CHART_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match chart version ($CHART_VERSION)."
+            exit 1
+          fi
       - name: Build chart dependencies
         run: helm dependency build "${{ env.CHART_PATH }}"
 
@@ -35,7 +68,10 @@ jobs:
             --password-stdin
 
       - name: Package chart
-        run: helm package "${{ env.CHART_PATH }}" --destination /tmp/chart
+        run: |
+          helm package "${{ env.CHART_PATH }}" \
+            --version "${{ steps.chart-version.outputs.version }}" \
+            --destination /tmp/chart
 
       - name: Push chart to GHCR
         run: helm push /tmp/chart/*.tgz oci://${{ env.OCI_REPOSITORY }}

--- a/deployments/helm/tracecat/Chart.yaml
+++ b/deployments/helm/tracecat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tracecat
 description: Tracecat is the AI automation platform for work.
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "1.0.0-beta.6"
 home: https://tracecat.com
 maintainers:


### PR DESCRIPTION
### Motivation
- Enable maintainers to run the OCI Helm chart publish workflow manually from the Actions UI while preserving the existing tag-based publish trigger.

### Description
- Add `workflow_dispatch` to the `on:` block in `.github/workflows/publish-helm-chart.yml` to enable manual workflow runs without removing the `push`-tags trigger.

### Testing
- Ran `git diff --check` which returned no issues and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4e05120c8333ab89073bd2b682ca)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a manual trigger to the OCI Helm chart publish workflow and auto-publish when Chart.yaml on main changes. The workflow now reads the chart name/version from Chart.yaml and pushes that exact .tgz to GHCR; tag-based publishing is replaced by the main+path trigger, and the chart version is bumped to 0.3.4.

<sup>Written for commit 5d5f549d314c1d20bd809ed99757d1259387a7ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

