### PR TITLE
fix(infra): Install helm deps in GH workflow

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add temporal https://go.temporal.io/helm-charts
+
       - name: Resolve chart metadata
         id: chart-metadata
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Helm chart publish workflow by adding the Temporal Helm repo so dependency resolution succeeds. Prevents CI failures during chart metadata and dependency build.

- **Bug Fixes**
  - Add `helm repo add temporal https://go.temporal.io/helm-charts` step in publish-helm-chart workflow before resolving chart metadata.

<sup>Written for commit 6be7e8ccd07ce1dcf47e975e9ea09abdbb15ade6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

