### PR TITLE
fix(copilot): enable preset selection in new chat draft

### DIFF
--- a/frontend/src/components/copilot/copilot-chat-interface.tsx
+++ b/frontend/src/components/copilot/copilot-chat-interface.tsx
@@ -136,6 +136,7 @@ export function CopilotChatInterface({
         title: `Chat ${(chats?.length || 0) + 1}`,
         entity_type: "copilot",
         entity_id: workspaceId,
+        agent_preset_id: effectivePresetId,
       })
       setPendingCopilotPrompt({ chatId: newChat.id, text: trimmedPrompt })
       router.push(`${pathname}?chatId=${newChat.id}`)


### PR DESCRIPTION
Closes https://github.com/TracecatHQ/tracecat/issues/2082

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enabled preset selection for new Copilot chat drafts and saved the chosen preset when the chat is created. The preset menu now works before a chat exists.

- **Bug Fixes**
  - Track a draft preset ID and use it when no chat is selected.
  - Persist agent_preset_id on new chat creation via effectivePresetId.
  - Allow preset changes in drafts by removing the selectedChatId disable check.
  - Prevent redundant updates if the preset hasn’t changed.

<sup>Written for commit 865b250013317aa3505757e4464456d510732ad8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

