### PR TITLE
chore: pin griffe==1.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
     "python-slugify==8.0.4",
     "redis[hiredis]==7.1.0",
     "sentry-sdk==2.24.1",
+    "griffe==1.14.0",
     "sqlalchemy==2.0.45",
     "starlette==0.49.3",
     "temporalio==1.19.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -494,7 +494,7 @@ colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via
     #   click
-    #   griffecli
+    #   griffe
     #   loguru
     #   pytest
     #   tqdm
@@ -1005,17 +1005,12 @@ greenlet==3.0.3 \
     # via
     #   sqlalchemy
     #   tracecat
-griffe==2.0.0 \
-    --hash=sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa
-    # via pydantic-ai-slim
-griffecli==2.0.0 \
-    --hash=sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d
-    # via griffe
-griffelib==2.0.0 \
-    --hash=sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f
+griffe==1.14.0 \
+    --hash=sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0 \
+    --hash=sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13
     # via
-    #   griffe
-    #   griffecli
+    #   pydantic-ai-slim
+    #   tracecat
 grpcio==1.75.1 \
     --hash=sha256:06373a94fd16ec287116a825161dca179a0402d0c60674ceeec8c9fba344fe66 \
     --hash=sha256:07a554fa31c668cf0e7a188678ceeca3cb8fead29bbe455352e712ec33ca701c \

--- a/uv.lock
+++ b/uv.lock
@@ -1621,34 +1621,14 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffecli" },
-    { name = "griffelib" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
-]
-
-[[package]]
-name = "griffecli"
-version = "2.0.0"
+version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
-    { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/d7/6c09dd7ce4c7837e4cdb11dce980cb45ae3cd87677298dc3b781b6bce7d3/griffe-1.14.0.tar.gz", hash = "sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13", size = 424684, upload-time = "2025-09-05T15:02:29.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
-]
-
-[[package]]
-name = "griffelib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b1/9ff6578d789a89812ff21e4e0f80ffae20a65d5dd84e7a17873fe3b365be/griffe-1.14.0-py3-none-any.whl", hash = "sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0", size = 144439, upload-time = "2025-09-05T15:02:27.511Z" },
 ]
 
 [[package]]
@@ -4782,6 +4762,7 @@ dependencies = [
     { name = "filelock" },
     { name = "google-auth" },
     { name = "greenlet" },
+    { name = "griffe" },
     { name = "hatchling" },
     { name = "httpx" },
     { name = "jsonpath-ng" },
@@ -4873,6 +4854,7 @@ requires-dist = [
     { name = "filelock", specifier = "==3.20.3" },
     { name = "google-auth", specifier = "==2.48.0" },
     { name = "greenlet", specifier = "==3.0.3" },
+    { name = "griffe", specifier = "==1.14.0" },
     { name = "hatchling", specifier = "==1.27.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jsonpath-ng", specifier = "==1.7.0" },


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin griffe to 1.14.0 to avoid 2.0 breaking changes as a result of the pydantic-ai upgrade and ensure reproducible installs. Adds griffe as an explicit dependency and updates lockfiles accordingly.

- **Dependencies**
  - Added griffe==1.14.0 to pyproject; regenerated requirements and uv.lock.
  - Replaced griffe==2.0.0 and removed griffecli/griffelib entries in lockfiles.
  - Updated transitive references so pydantic-ai-slim and tracecat resolve to griffe 1.14.0.

<sup>Written for commit ebad7004fc012edc057959374652ab5dd4fe64f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

