### PR TITLE
feat(integrations): Support headers flag for SIDs in splunk search events

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/splunk/search_events.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/splunk/search_events.yml
@@ -35,6 +35,10 @@ definition:
       type: bool
       description: Whether to verify SSL certificates.
       default: true
+    include_headers:
+      type: bool
+      description: Include headers in the response?
+      default: false
   steps:
     - ref: search_job
       action: core.http_request
@@ -53,4 +57,4 @@ definition:
           output_mode: json
           max_count: ${{ inputs.limit }}
           count: 0
-  returns: ${{ steps.search_job.result.data }}
+  returns: ${{ inputs.include_headers && steps.search_job.result || steps.search_job.result.data }}


### PR DESCRIPTION
## Description

Creating an update to the current version of Splunk Search Events to optionally include headers in the response which is useful for SIDs and debugging.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an include_headers option to Splunk Search Events to optionally return the full HTTP response (headers + body) for SID access and debugging. Default is false, so existing calls still return only the data payload.

<sup>Written for commit 0601d7f80fc1f88790764eec557e0f7ad6a309a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

