### PR TITLE
fix(registry): avoid index installs for builtin sync tarball

### DIFF
--- a/tests/unit/test_registry_sync_tarball.py
+++ b/tests/unit/test_registry_sync_tarball.py
@@ -111,11 +111,11 @@ async def test_build_tarball_from_installed_environment_overlays_symlinked_packa
 
 
 @pytest.mark.anyio
-async def test_build_tarball_from_installed_environment_dereferences_unrelated_symlink_entries(
+async def test_build_tarball_from_installed_environment_skips_unrelated_symlink_entries(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Archive symlink targets as regular entries for extraction compatibility."""
+    """Skip unrelated symlink entries to keep tarballs extractable and small."""
     purelib = tmp_path / "purelib"
     purelib.mkdir()
     (purelib / "dependency.py").write_text("DEP = True\n")
@@ -148,8 +148,7 @@ async def test_build_tarball_from_installed_environment_dereferences_unrelated_s
             if member.name == "linked_dependency"
             or member.name.startswith("linked_dependency/")
         ]
-        assert linked_members
-        assert all(not member.issym() and not member.islnk() for member in linked_members)
+        assert not linked_members
 
         extract_dir = tmp_path / "extract"
         extract_dir.mkdir()
@@ -157,5 +156,4 @@ async def test_build_tarball_from_installed_environment_dereferences_unrelated_s
 
     assert (extract_dir / "dependency.py").exists()
     assert (extract_dir / "tracecat_registry" / "__init__.py").exists()
-    assert (extract_dir / "linked_dependency" / "__init__.py").exists()
-    assert not (extract_dir / "linked_dependency").is_symlink()
+    assert not (extract_dir / "linked_dependency").exists()

--- a/tests/unit/test_registry_sync_tarball.py
+++ b/tests/unit/test_registry_sync_tarball.py
@@ -1,0 +1,67 @@
+"""Tests for registry sync tarball building utilities."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from tracecat.registry.sync import tarball
+
+
+def test_get_installed_site_packages_paths_includes_platlib(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolve both purelib and platlib when they differ."""
+    purelib = tmp_path / "purelib"
+    platlib = tmp_path / "platlib"
+    purelib.mkdir()
+    platlib.mkdir()
+
+    def mock_get_path(name: str) -> str:
+        mapping = {"purelib": purelib, "platlib": platlib}
+        return str(mapping[name])
+
+    monkeypatch.setattr(tarball.sysconfig, "get_path", mock_get_path)
+
+    paths = tarball.get_installed_site_packages_paths()
+
+    assert paths == [purelib, platlib]
+
+
+@pytest.mark.anyio
+async def test_build_tarball_from_installed_environment_includes_platlib_contents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Include both purelib and platlib files in the produced tarball."""
+    purelib = tmp_path / "purelib"
+    platlib = tmp_path / "platlib"
+    purelib.mkdir()
+    platlib.mkdir()
+    (purelib / "pure_only.py").write_text("PURE = True\n")
+    (platlib / "plat_only.so").write_bytes(b"binary")
+
+    package_dir = tmp_path / "src" / "tracecat_registry"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("__version__ = '0.0.0'\n")
+
+    monkeypatch.setattr(
+        tarball,
+        "get_installed_site_packages_paths",
+        lambda: [purelib, platlib],
+    )
+
+    result = await tarball.build_tarball_venv_from_installed_environment(
+        package_name="tracecat_registry",
+        package_dir=package_dir,
+        output_dir=tmp_path / "out",
+    )
+
+    with tarfile.open(result.tarball_path, "r:gz") as archive:
+        tar_names = set(archive.getnames())
+
+    assert "pure_only.py" in tar_names
+    assert "plat_only.so" in tar_names

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -815,6 +815,16 @@ TRACECAT__REGISTRY_SYNC_DISCOVER_TIMEOUT = int(
 )
 """Timeout for action discovery during registry sync in seconds. Defaults to 300 (5 min)."""
 
+TRACECAT__REGISTRY_SYNC_BUILTIN_USE_INSTALLED_SITE_PACKAGES = os.environ.get(
+    "TRACECAT__REGISTRY_SYNC_BUILTIN_USE_INSTALLED_SITE_PACKAGES", "true"
+).lower() in ("true", "1")
+"""Use installed site-packages for builtin registry tarball builds.
+
+When True (default), builtin tracecat_registry sync packages the current
+interpreter's installed site-packages into a tarball. This avoids creating
+a fresh venv and re-installing dependencies from package indexes at runtime.
+"""
+
 TRACECAT__BUILTIN_REGISTRY_SOURCE_PATH = os.environ.get(
     "TRACECAT__BUILTIN_REGISTRY_SOURCE_PATH", "/app/packages/tracecat-registry"
 )

--- a/tracecat/registry/sync/base_service.py
+++ b/tracecat/registry/sync/base_service.py
@@ -413,7 +413,6 @@ class BaseRegistrySyncService[
                 "Tarball venv uploaded",
                 tarball_uri=tarball_uri,
                 compressed_size_bytes=tarball_result.compressed_size_bytes,
-                uncompressed_size_bytes=tarball_result.uncompressed_size_bytes,
             )
 
             return ArtifactsBuildResult(tarball_uri=tarball_uri)

--- a/tracecat/registry/sync/tarball.py
+++ b/tracecat/registry/sync/tarball.py
@@ -195,7 +195,9 @@ async def build_tarball_venv_from_installed_environment(
         return member
 
     def _create_tarball() -> None:
-        with tarfile.open(tarball_path, "w:gz", compresslevel=6) as tar:
+        with tarfile.open(
+            tarball_path, "w:gz", compresslevel=6, dereference=True
+        ) as tar:
             for site_packages in site_packages_paths:
                 for item in site_packages.iterdir():
                     tar.add(item, arcname=item.name, filter=_filter_link_entries)

--- a/tracecat/registry/sync/tarball.py
+++ b/tracecat/registry/sync/tarball.py
@@ -161,7 +161,9 @@ async def build_tarball_venv_from_installed_environment(
         for site_packages in site_packages_paths
         if (site_packages / package_name).exists()
     ]
-    package_site_entry = existing_package_entries[0] if existing_package_entries else None
+    package_site_entry = (
+        existing_package_entries[0] if existing_package_entries else None
+    )
     package_site_entry_is_symlink = (
         package_site_entry.is_symlink() if package_site_entry is not None else False
     )

--- a/tracecat/registry/sync/tarball.py
+++ b/tracecat/registry/sync/tarball.py
@@ -195,9 +195,7 @@ async def build_tarball_venv_from_installed_environment(
         return member
 
     def _create_tarball() -> None:
-        with tarfile.open(
-            tarball_path, "w:gz", compresslevel=6, dereference=True
-        ) as tar:
+        with tarfile.open(tarball_path, "w:gz", compresslevel=6) as tar:
             for site_packages in site_packages_paths:
                 for item in site_packages.iterdir():
                     tar.add(item, arcname=item.name, filter=_filter_link_entries)


### PR DESCRIPTION
## Summary
- switch builtin registry tarball generation to package from the current interpreter's installed `site-packages` instead of creating a fresh venv and reinstalling from index
- add editable-install handling so `tracecat_registry` source is included when installed outside `site-packages`
- add a config toggle `TRACECAT__REGISTRY_SYNC_BUILTIN_USE_INSTALLED_SITE_PACKAGES` (default `true`) to control this behavior

## Why
Startup platform registry sync was failing in restricted environments because builtin tarball build invoked `uv pip install` and attempted to resolve build dependencies from package indexes.

## Testing
- `uv run ruff check tracecat/registry/sync/tarball.py tracecat/config.py`
- `uv run basedpyright tracecat/registry/sync/tarball.py tracecat/config.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid index installs by building the builtin registry tarball from the current interpreter’s site-packages (purelib + platlib). This fixes startup registry sync in air‑gapped environments and produces stable extracts.

- **Bug Fixes**
  - Overlay tracecat_registry source for editable installs when the site entry is missing or a symlink.
  - Skip symlink and hard-link entries in site-packages and exclude link metadata for consistent extraction.
  - Remove uncompressed size calculation and logging to simplify build output.

- **Migration**
  - Default uses installed site-packages. No action needed.
  - To restore the old behavior, set TRACECAT__REGISTRY_SYNC_BUILTIN_USE_INSTALLED_SITE_PACKAGES=false.

<sup>Written for commit 30e36fbbe68d9c7cdab0ade82eb1bd5d2ef96244. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

