### PR TITLE
fix(agents): support iam role creds

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -316,6 +316,8 @@ import type {
   OrganizationAcceptInvitationResponse,
   OrganizationCreateInvitationData,
   OrganizationCreateInvitationResponse,
+  OrganizationDeleteOrganizationData,
+  OrganizationDeleteOrganizationResponse,
   OrganizationDeleteOrgMemberData,
   OrganizationDeleteOrgMemberResponse,
   OrganizationDeleteSessionData,
@@ -3073,6 +3075,31 @@ export const organizationGetOrganization =
   }
 
 /**
+ * Delete Organization
+ * Delete the current organization.
+ *
+ * Restricted to organization owners and platform superusers.
+ * @param data The data for the request.
+ * @param data.confirm Must exactly match the organization name.
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const organizationDeleteOrganization = (
+  data: OrganizationDeleteOrganizationData = {}
+): CancelablePromise<OrganizationDeleteOrganizationResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/organization",
+    query: {
+      confirm: data.confirm,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * List Organization Domains
  * List domains assigned to the current organization.
  * @returns tracecat__organization__schemas__OrgDomainRead Successful Response
@@ -4123,6 +4150,7 @@ export const adminUpdateOrganization = (
  * Delete organization.
  * @param data The data for the request.
  * @param data.orgId
+ * @param data.confirm Must exactly match the organization name.
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -4134,6 +4162,9 @@ export const adminDeleteOrganization = (
     url: "/admin/organizations/{org_id}",
     path: {
       org_id: data.orgId,
+    },
+    query: {
+      confirm: data.confirm,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -7147,6 +7147,15 @@ export type UsersSearchUserResponse = UserRead
 export type OrganizationGetOrganizationResponse =
   tracecat__organization__schemas__OrgRead
 
+export type OrganizationDeleteOrganizationData = {
+  /**
+   * Must exactly match the organization name.
+   */
+  confirm?: string | null
+}
+
+export type OrganizationDeleteOrganizationResponse = void
+
 export type OrganizationListOrganizationDomainsResponse =
   Array<tracecat__organization__schemas__OrgDomainRead>
 
@@ -7445,6 +7454,10 @@ export type AdminUpdateOrganizationResponse =
   tracecat_ee__admin__organizations__schemas__OrgRead
 
 export type AdminDeleteOrganizationData = {
+  /**
+   * Must exactly match the organization name.
+   */
+  confirm?: string | null
   orgId: string
 }
 
@@ -10092,6 +10105,19 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: tracecat__organization__schemas__OrgRead
+      }
+    }
+    delete: {
+      req: OrganizationDeleteOrganizationData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
       }
     }
   }

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -225,19 +225,11 @@ def _inject_provider_credentials(
             else:
                 access_key = creds.get("AWS_ACCESS_KEY_ID")
                 secret_key = creds.get("AWS_SECRET_ACCESS_KEY")
-                if not access_key or not secret_key:
-                    logger.warning(
-                        "Required credential keys missing for provider",
-                        provider=provider,
-                    )
-                    raise ProxyException(
-                        message="Provider credentials incomplete",
-                        type="auth_error",
-                        param=None,
-                        code=401,
-                    )
-                data["aws_access_key_id"] = access_key
-                data["aws_secret_access_key"] = secret_key
+                if access_key and secret_key:
+                    data["aws_access_key_id"] = access_key
+                    data["aws_secret_access_key"] = secret_key
+                # else: no explicit credentials — LiteLLM will use boto3 default
+                # credential chain (IAM role, instance profile, IRSA, env vars)
             if region := creds.get("AWS_REGION"):
                 data["aws_region_name"] = region
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow Bedrock agents to use IAM role credentials by not requiring explicit AWS keys. Adds client SDK support to delete an organization with a confirm check.

- **Bug Fixes**
  - Agents: Only inject AWS access/secret keys when provided; otherwise rely on boto3’s default credential chain (IAM role, instance profile, IRSA, env vars). Prevents auth errors on AWS.

- **New Features**
  - Frontend client: Added organizationDeleteOrganization API with confirm query.
  - Admin client: adminDeleteOrganization now supports a confirm query.

<sup>Written for commit 6d2f0cfdd2b4d132e19320bdeb9db7c173d8ff19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

