### PR TITLE
fix(agents): Fallbacks to implicit creds for bedrock llm agents

### DIFF
--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -48,3 +48,14 @@ def test_bedrock_rejects_partial_static_keys():
 
     with pytest.raises(ProxyException):
         _inject_provider_credentials(data, "bedrock", creds)
+
+
+def test_bedrock_rejects_session_token_without_static_keys():
+    data = {"model": "bedrock"}
+    creds = {
+        "AWS_SESSION_TOKEN": "session-token",
+        "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    }
+
+    with pytest.raises(ProxyException):
+        _inject_provider_credentials(data, "bedrock", creds)

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -232,12 +232,13 @@ def _inject_provider_credentials(
                     data["aws_secret_access_key"] = secret_key
                     if session_token:
                         data["aws_session_token"] = session_token
-                elif access_key or secret_key:
+                elif access_key or secret_key or session_token:
                     logger.warning(
                         "Partial static AWS credentials configured for Bedrock",
                         provider=provider,
                         has_access_key=bool(access_key),
                         has_secret_key=bool(secret_key),
+                        has_session_token=bool(session_token),
                     )
                     raise ProxyException(
                         message="Provider credentials incomplete",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default Bedrock LLM agents now fall back to ambient IAM role credentials when static AWS keys aren’t configured. Tightened credential validation and expanded tests to cover session token cases.

- **Bug Fixes**
  - Use ambient IAM role if both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are missing; keep AWS_REGION.
  - Allow AWS_SESSION_TOKEN only when both static keys are set; raise 401 ProxyException for any partial or session-token-only config.
  - Added unit tests for fallback, full static creds, partial keys, and session-token-without-keys.

<sup>Written for commit c202db16d9b0efb31262aa95614d8c21eba1170d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

