### PR TITLE
fix(executor): pass sdk auth context to direct subprocess runner

### DIFF
--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -531,6 +531,16 @@ class ActionRunner:
         if env_vars:
             env.update(env_vars)
 
+        # Ensure SDK context is available for registry actions executed by minimal_runner.
+        if resolved_context is not None:
+            env["TRACECAT__API_URL"] = config.TRACECAT__API_URL
+            env["TRACECAT__WORKSPACE_ID"] = resolved_context.workspace_id
+            env["TRACECAT__WORKFLOW_ID"] = resolved_context.workflow_id
+            env["TRACECAT__RUN_ID"] = resolved_context.run_id
+            env["TRACECAT__WF_EXEC_ID"] = str(input.run_context.wf_exec_id)
+            env["TRACECAT__ENVIRONMENT"] = input.run_context.environment
+            env["TRACECAT__EXECUTOR_TOKEN"] = resolved_context.executor_token
+
         # Build PYTHONPATH with multiple registry paths (deterministic order)
         pythonpath_parts = [str(p) for p in registry_paths if p.exists()]
         existing_pythonpath = env.get("PYTHONPATH", "")


### PR DESCRIPTION
## Summary
- Fix direct subprocess executor to pass registry SDK context/auth env variables (`TRACECAT__API_URL`, `TRACECAT__WORKSPACE_ID`, `TRACECAT__WORKFLOW_ID`, `TRACECAT__RUN_ID`, `TRACECAT__WF_EXEC_ID`, `TRACECAT__ENVIRONMENT`, `TRACECAT__EXECUTOR_TOKEN`) to `minimal_runner`.
- Add regression coverage for env propagation in direct subprocess execution.
- Add an integration-style unit test that executes `tracecat_registry.core.table.search_rows` through the direct subprocess path against a mock `/internal/tables/.../search` endpoint and verifies bearer auth + successful SDK response.

## What failed
- In the `direct` backend subprocess path, `minimal_runner` initializes registry SDK auth/context from environment variables.
- `ActionRunner._execute_direct()` did not set SDK auth/context env vars for subprocess execution.
- As a result, registry SDK calls from actions like `core.table.search_rows` were executed without a bearer token and returned `401 Unauthorized` (`TracecatAuthError`).

## How this PR fixes it
- `tracecat/executor/action_runner.py` now injects the full SDK context + executor token into subprocess env before launching `minimal_runner`.
- This aligns direct subprocess behavior with sandboxed/other execution paths where SDK auth context is available.
- Added tests to prevent regression:
  - env propagation test for direct subprocess execution
  - end-to-end SDK call test for `core.table.search_rows` that verifies auth header + successful response

## Manual verification (before/after)
- I manually reproduced the regression by running the new SDK-call test with only the test applied (without the fix):
  - `uv run pytest tests/unit/test_action_runner.py -k registry_sdk_call_succeeds`
  - Result before fix: failed with `TracecatAuthError: Authentication failed (status=401): Unauthorized`.
- I then re-applied the fix and re-ran the same test:
  - `uv run pytest tests/unit/test_action_runner.py -k registry_sdk_call_succeeds`
  - Result after fix: passed.

## Validation
- `uv run pytest tests/unit/test_action_runner.py`
- `uv run pytest tests/unit/test_action_runner.py -k registry_sdk_call_succeeds`
- `uv run pytest tests/unit/executor/test_direct_backend_subprocess.py`
- `uv run ruff check tracecat/executor/action_runner.py tests/unit/test_action_runner.py`
- `uv run basedpyright tracecat/executor/action_runner.py tests/unit/test_action_runner.py`
