### PR TITLE
infra(fix): S3 bucket env vars missing in worker

### DIFF
--- a/deployments/helm/tracecat/templates/_helpers.tpl
+++ b/deployments/helm/tracecat/templates/_helpers.tpl
@@ -651,6 +651,7 @@ Merges: common + temporal + postgres + redis + worker-specific
 {{- define "tracecat.env.worker" -}}
 {{ include "tracecat.env.common" . }}
 {{ include "tracecat.env.temporal" . }}
+{{ include "tracecat.env.blobStorage" . }}
 {{ include "tracecat.env.postgres" . }}
 {{ include "tracecat.env.redis" . }}
 {{- if .Values.tracecat.temporal.metrics.enabled }}

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -75,17 +75,7 @@ async def ensure_bucket_exists(bucket: str) -> None:
             if error_code == "404":
                 # Bucket doesn't exist, create it
                 try:
-                    create_bucket_kwargs: dict[str, object] = {"Bucket": bucket}
-                    # AWS S3 requires a location constraint for all regions except us-east-1.
-                    # MinIO and other S3-compatible endpoints generally do not.
-                    if not config.TRACECAT__BLOB_STORAGE_ENDPOINT:
-                        region = s3_client.meta.region_name
-                        if region and region != "us-east-1":
-                            create_bucket_kwargs["CreateBucketConfiguration"] = {
-                                "LocationConstraint": region
-                            }
-
-                    await s3_client.create_bucket(**create_bucket_kwargs)
+                    await s3_client.create_bucket(Bucket=bucket)
                     logger.info("Created bucket", bucket=bucket)
                 except ClientError as create_error:
                     logger.error(


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699482d0c150833382ce6fb3e8936bed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass blob storage config to workers so workflows have the correct S3 settings. Removed region-specific AWS bucket LocationConstraint handling; bucket creation logic is unchanged.

- **Bug Fixes**
  - Inject blob storage env vars into worker Helm templates via tracecat.env.blobStorage.

<sup>Written for commit bc5879dfd3dbe1f368a81d7512328118d441b46e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

