### PR TITLE
docs: broaden nsjail warnings to cover custom registry & general code execution; clarify script runtime wording

### DIFF
--- a/docs/quickstart/script-actions.mdx
+++ b/docs/quickstart/script-actions.mdx
@@ -6,9 +6,21 @@ icon: code
 
 ## Python Script Action
 
-Use the `core.script.run_python` action to execute Python code in a sandboxed WebAssembly environment using Pyodide.
-This ensures isolation from the host system while providing access to popular Python libraries.
+Use the `core.script.run_python` action to execute Python code in a sandboxed runtime.
+This isolates script execution from the host system while providing access to popular Python libraries.
 You can include 3rd-party Python packages in your script by adding them to the `dependencies` field.
+
+<Warning>
+### Production requirement: enable nsjail
+
+For production deployments, you **must** run Python script actions with **nsjail enabled**.
+
+- `docker compose` deployments have nsjail disabled by default
+- AWS Fargate deployments have nsjail disabled by default
+- Helm chart / Kubernetes deployments have nsjail enabled by default
+
+Do not run `core.script.run_python` in production without nsjail.
+</Warning>
 
 <Note>
 - Scripts must contain at least one function

--- a/docs/quickstart/script-actions.mdx
+++ b/docs/quickstart/script-actions.mdx
@@ -21,6 +21,7 @@ For production deployments, enable `nsjail` before running script actions.
 
 - `docker compose` deployments have `nsjail` disabled by default
 - AWS Fargate deployments have `nsjail` disabled by default
+- AWS Fargate does not provide the required permissions model for `nsjail`; use Kubernetes (Helm chart) for production untrusted-code workloads
 - Helm chart / Kubernetes deployments have `nsjail` enabled by default
 </Warning>
 

--- a/docs/quickstart/script-actions.mdx
+++ b/docs/quickstart/script-actions.mdx
@@ -1,25 +1,27 @@
 ---
 title: Script actions
-description: Execute custom Python scripts in a sandboxed environment.
+description: Execute custom Python scripts.
 icon: code
 ---
 
 ## Python Script Action
 
-Use the `core.script.run_python` action to execute Python code in a sandboxed runtime.
-This isolates script execution from the host system while providing access to popular Python libraries.
+Use the `core.script.run_python` action to execute Python code.
 You can include 3rd-party Python packages in your script by adding them to the `dependencies` field.
 
 <Warning>
-### Production requirement: enable nsjail
+### Security model: `nsjail` is required for true sandboxing
 
-For production deployments, you **must** run Python script actions with **nsjail enabled**.
+`core.script.run_python` is only sandboxed when `nsjail` is enabled.
 
-- `docker compose` deployments have nsjail disabled by default
-- AWS Fargate deployments have nsjail disabled by default
-- Helm chart / Kubernetes deployments have nsjail enabled by default
+Without `nsjail`, execution relies on an AST validator. That is **not** a true sandbox and breakouts are possible.
+In that mode, you are responsible for protecting your own environment and code.
 
-Do not run `core.script.run_python` in production without nsjail.
+For production deployments, enable `nsjail` before running script actions.
+
+- `docker compose` deployments have `nsjail` disabled by default
+- AWS Fargate deployments have `nsjail` disabled by default
+- Helm chart / Kubernetes deployments have `nsjail` enabled by default
 </Warning>
 
 <Note>

--- a/docs/self-hosting/deployment-options/aws-ecs.mdx
+++ b/docs/self-hosting/deployment-options/aws-ecs.mdx
@@ -22,6 +22,8 @@ This includes both:
 
 AWS Fargate deployments have `nsjail` **disabled by default**. Do **not** run these workloads in production until you explicitly enable it.
 
+Fargate does not provide the required permissions model for `nsjail`. For production workloads that execute untrusted code, we recommend Kubernetes (Helm chart), where `nsjail` is enabled by default.
+
 For comparison: Helm chart / Kubernetes deployments have `nsjail` enabled by default.
 </Warning>
 

--- a/docs/self-hosting/deployment-options/aws-ecs.mdx
+++ b/docs/self-hosting/deployment-options/aws-ecs.mdx
@@ -9,6 +9,22 @@ icon: aws
   Default `auth_types` is `saml`, so configure SAML before first login.
 </Warning>
 
+
+<Warning>
+## ⚠️ Critical security requirement for code execution
+
+If you run untrusted or third-party code in production, you **must enable `nsjail`**.
+
+This includes both:
+
+- `core.script.run_python` actions
+- Custom registry actions that execute code pulled from third-party sources
+
+AWS Fargate deployments have `nsjail` **disabled by default**. Do **not** run these workloads in production until you explicitly enable it.
+
+For comparison: Helm chart / Kubernetes deployments have `nsjail` enabled by default.
+</Warning>
+
 ## Prerequisites
 
 - [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)

--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -12,6 +12,22 @@ import BasicAuthWarning from "/snippets/basic-auth-warning.mdx";
 
 <BasicAuthWarning />
 
+
+<Warning>
+## ⚠️ Critical security requirement for code execution
+
+If you run untrusted or third-party code in production, you **must enable `nsjail`**.
+
+This includes both:
+
+- `core.script.run_python` actions
+- Custom registry actions that execute code pulled from third-party sources
+
+`docker compose` deployments have `nsjail` **disabled by default**. Do **not** run these workloads in production until you explicitly enable it.
+
+For comparison: Helm chart / Kubernetes deployments have `nsjail` enabled by default.
+</Warning>
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/engine/install/) version 26.0.0+


### PR DESCRIPTION
### Motivation
- Prevent insecure production runs by making the `nsjail` requirement explicit for any untrusted or third-party code execution, not just inline Python scripts. 
- Clarify that sandboxing in the quickstart is a generic sandboxed runtime (not Pyodide-specific) and that production deployments must enable host-level hardening. 
- Call out deployment-specific defaults so operators know `nsjail` is disabled by default on some platforms and must be enabled for production workloads. 

### Description
- Reworded the quickstart page at `docs/quickstart/script-actions.mdx` to refer to a generic sandboxed runtime and added a production `nsjail` warning. 
- Expanded the Docker Compose warning at `docs/self-hosting/deployment-options/docker-compose.mdx` to cover all untrusted code execution and explicitly list both `core.script.run_python` and custom registry actions that pull and execute third-party code. 
- Applied the same expanded warning to the AWS Fargate docs at `docs/self-hosting/deployment-options/aws-ecs.mdx` and adjusted the heading to reference general code execution. 

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994897461c483338b505caeff14d709)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that nsjail is required to safely run untrusted code (run_python and custom registries), and that run_python is only sandboxed when nsjail is enabled. Adds deployment warnings: Docker Compose and AWS Fargate disable nsjail by default, and Fargate cannot support the required permissions; use Kubernetes/Helm where nsjail is enabled by default.

- **Migration**
  - For Docker Compose, enable nsjail before running untrusted code in production.
  - Do not use AWS Fargate for untrusted-code workloads; use Kubernetes/Helm instead (verify nsjail is enabled).

<sup>Written for commit 258bf90ee018a2125346aa4f87a8766c8d09b3a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

