### PR TITLE
refactor(sandbox): remove test-only dependency parsing helpers

### DIFF
--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -4,16 +4,7 @@ import asyncio
 
 import pytest
 
-from tracecat.sandbox.unsafe_pid_executor import (
-    UnsafePidExecutor,
-    _extract_package_name,
-)
-
-
-class TestDependencyParsing:
-    def test_extract_package_name(self) -> None:
-        assert _extract_package_name("requests==2.31.0") == "requests"
-        assert _extract_package_name("py-ocsf-models>=0.8.0") == "py_ocsf_models"
+from tracecat.sandbox.unsafe_pid_executor import UnsafePidExecutor
 
 
 class TestUnsafePidExecutor:


### PR DESCRIPTION
### Motivation
- Remove dead runtime helpers that existed only to satisfy unit tests and simplify cache-key behavior to reflect actual runtime normalization. 
- Keep the prior safety fixes for PID probe cleanup and deterministic one-time warning emission intact so executor behavior remains stable.

### Description
- Deleted the test-only helpers `_extract_dependency_base_name` and `_extract_package_name` from `tracecat/sandbox/unsafe_pid_executor.py` and simplified `_compute_cache_key` to `sorted(dep.lower().strip() for dep in dependencies)` to avoid no-op/unused code. 
- Initialized the `probe` variable and guarded `kill()`/`wait()` during `_is_pid_namespace_available()` timeout paths to prevent referencing an unbound variable. 
- Retained and exposed a module-level logger `module_logger` and emit PID/network isolation warnings via both `logger` and `module_logger` so they are observed reliably by `caplog`. 
- Removed the `TestDependencyParsing` test class and the private-helper import from `tests/unit/test_unsafe_pid_executor.py` so tests only exercise public/runtime behavior.

### Testing
- Ran type checks: `uv run --no-sync basedpyright --warnings --threads 4 tracecat/sandbox/unsafe_pid_executor.py tests/unit/test_unsafe_pid_executor.py` which passed. 
- Ran lint/format checks: `uv run ruff check tracecat/sandbox/unsafe_pid_executor.py tests/unit/test_unsafe_pid_executor.py` which passed. 
- Ran unit tests: `uv run pytest tests/unit/test_unsafe_pid_executor.py -q` which could not complete in this environment because PostgreSQL at `localhost:5432` is unavailable, causing test DB fixtures to fail (pytest errored due to `psycopg.OperationalError`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a4513b8883338296c34a26c665c9)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed test-only dependency parsing and simplified cache key normalization. Hardened PID namespace probe and made isolation warnings deterministic and visible in tests.

- **Refactors**
  - Removed _extract_dependency_base_name and _extract_package_name.
  - Cache key now normalizes by lowercasing, stripping, and sorting dependencies.
  - Dropped TestDependencyParsing and the private helper import in tests.

- **Bug Fixes**
  - Initialized and guarded the probe process to avoid unbound variable on timeout.
  - Emitted PID/network isolation warnings once and via both logger and module_logger for reliable caplog capture.

<sup>Written for commit b80598fbca2d2441ac02033bf9758c94c13f49f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

