### PR TITLE
feat(admin): add superuser override for encrypted org settings

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10169,6 +10169,55 @@ export const $OrgDomainUpdate = {
   description: "Update organization domain request.",
 } as const
 
+export const $OrgEncryptedSettingResetRequest = {
+  properties: {
+    value: {
+      title: "Value",
+    },
+  },
+  type: "object",
+  required: ["value"],
+  title: "OrgEncryptedSettingResetRequest",
+  description: "Reset encrypted organization setting request.",
+} as const
+
+export const $OrgEncryptedSettingResetResponse = {
+  properties: {
+    organization_id: {
+      type: "string",
+      format: "uuid",
+      title: "Organization Id",
+    },
+    key: {
+      type: "string",
+      title: "Key",
+    },
+    value_type: {
+      type: "string",
+      title: "Value Type",
+    },
+    is_encrypted: {
+      type: "boolean",
+      title: "Is Encrypted",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "organization_id",
+    "key",
+    "value_type",
+    "is_encrypted",
+    "updated_at",
+  ],
+  title: "OrgEncryptedSettingResetResponse",
+  description: "Reset encrypted organization setting response.",
+} as const
+
 export const $OrgInvitationAccept = {
   properties: {
     token: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -69,6 +69,8 @@ import type {
   AdminRegistrySyncAllRepositoriesResponse,
   AdminRegistrySyncRepositoryData,
   AdminRegistrySyncRepositoryResponse,
+  AdminResetEncryptedOrgSettingData,
+  AdminResetEncryptedOrgSettingResponse,
   AdminSyncOrgRepositoryData,
   AdminSyncOrgRepositoryResponse,
   AdminUpdateOrganizationData,
@@ -4230,6 +4232,34 @@ export const adminDeleteOrganization = (
     query: {
       confirm: data.confirm,
     },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Reset Encrypted Org Setting
+ * Reset an existing encrypted organization setting.
+ * @param data The data for the request.
+ * @param data.orgId
+ * @param data.key
+ * @param data.requestBody
+ * @returns OrgEncryptedSettingResetResponse Successful Response
+ * @throws ApiError
+ */
+export const adminResetEncryptedOrgSetting = (
+  data: AdminResetEncryptedOrgSettingData
+): CancelablePromise<AdminResetEncryptedOrgSettingResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/admin/organizations/{org_id}/settings/{key}/reset-encrypted",
+    path: {
+      org_id: data.orgId,
+      key: data.key,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3286,6 +3286,24 @@ export type OrgDomainUpdate = {
 }
 
 /**
+ * Reset encrypted organization setting request.
+ */
+export type OrgEncryptedSettingResetRequest = {
+  value: unknown
+}
+
+/**
+ * Reset encrypted organization setting response.
+ */
+export type OrgEncryptedSettingResetResponse = {
+  organization_id: string
+  key: string
+  value_type: string
+  is_encrypted: boolean
+  updated_at: string
+}
+
+/**
  * Request body for accepting an organization invitation via token.
  */
 export type OrgInvitationAccept = {
@@ -7600,6 +7618,15 @@ export type AdminDeleteOrganizationData = {
 
 export type AdminDeleteOrganizationResponse = void
 
+export type AdminResetEncryptedOrgSettingData = {
+  key: string
+  orgId: string
+  requestBody: OrgEncryptedSettingResetRequest
+}
+
+export type AdminResetEncryptedOrgSettingResponse =
+  OrgEncryptedSettingResetResponse
+
 export type AdminListOrganizationDomainsData = {
   orgId: string
 }
@@ -10895,6 +10922,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/organizations/{org_id}/settings/{key}/reset-encrypted": {
+    post: {
+      req: AdminResetEncryptedOrgSettingData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: OrgEncryptedSettingResetResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/admin/admin-org-encrypted-setting-reset-dialog.tsx
+++ b/frontend/src/components/admin/admin-org-encrypted-setting-reset-dialog.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/use-toast"
+import {
+  useAdminOrganization,
+  useAdminOrgEncryptedSettingReset,
+} from "@/hooks/use-admin"
+
+interface AdminOrgEncryptedSettingResetDialogProps {
+  orgId: string
+  trigger?: React.ReactNode
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+interface ApiErrorLike {
+  body?: {
+    detail?: unknown
+  }
+}
+
+const SUGGESTED_ENCRYPTED_KEYS = [
+  "audit_webhook_url",
+  "audit_webhook_custom_headers",
+  "saml_idp_metadata_url",
+]
+
+function getErrorDetail(error: unknown, fallback: string): string {
+  if (typeof error === "object" && error !== null) {
+    const apiError = error as ApiErrorLike
+    if (typeof apiError.body?.detail === "string") {
+      return apiError.body.detail
+    }
+  }
+  return fallback
+}
+
+export function AdminOrgEncryptedSettingResetDialog({
+  orgId,
+  trigger,
+  open: controlledOpen,
+  onOpenChange,
+}: AdminOrgEncryptedSettingResetDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+  const [settingKey, setSettingKey] = useState("audit_webhook_url")
+  const [jsonValue, setJsonValue] = useState('"https://example.com/webhook"')
+
+  const isControlled = controlledOpen !== undefined
+  const dialogOpen = isControlled ? controlledOpen : internalOpen
+  const setDialogOpen = (nextOpen: boolean) => {
+    if (!isControlled) {
+      setInternalOpen(nextOpen)
+    }
+    onOpenChange?.(nextOpen)
+  }
+
+  const { organization } = useAdminOrganization(orgId)
+  const { resetEncryptedSetting, resetPending } =
+    useAdminOrgEncryptedSettingReset(orgId)
+
+  useEffect(() => {
+    if (!dialogOpen) {
+      setSettingKey("audit_webhook_url")
+      setJsonValue('"https://example.com/webhook"')
+    }
+  }, [dialogOpen])
+
+  const handleReset = async () => {
+    const key = settingKey.trim()
+    if (!key) {
+      toast({
+        title: "Missing setting key",
+        description: "Enter the setting key to update.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    let parsedValue: unknown
+    try {
+      parsedValue = JSON.parse(jsonValue)
+    } catch {
+      toast({
+        title: "Invalid JSON value",
+        description:
+          "Enter a valid JSON value. For strings, wrap the value in double quotes.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    try {
+      await resetEncryptedSetting({ key, value: parsedValue })
+      toast({
+        title: "Setting updated",
+        description: `${key} was overwritten and re-encrypted with the current key.`,
+      })
+      setDialogOpen(false)
+    } catch (error) {
+      toast({
+        title: "Failed to update setting",
+        description: getErrorDetail(error, "Please try again."),
+        variant: "destructive",
+      })
+    }
+  }
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      {trigger ? <DialogTrigger asChild>{trigger}</DialogTrigger> : null}
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Manage settings</DialogTitle>
+          <DialogDescription>
+            Override an encrypted organization setting for{" "}
+            {organization?.name ?? "organization"}. This writes a new value
+            encrypted with the current key.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Setting key</p>
+            <Input
+              value={settingKey}
+              onChange={(event) => setSettingKey(event.target.value)}
+              placeholder="audit_webhook_url"
+              disabled={resetPending}
+            />
+            <div className="flex flex-wrap gap-2">
+              {SUGGESTED_ENCRYPTED_KEYS.map((key) => (
+                <Button
+                  key={key}
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setSettingKey(key)}
+                  disabled={resetPending}
+                >
+                  {key}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium">JSON value</p>
+            <Textarea
+              value={jsonValue}
+              onChange={(event) => setJsonValue(event.target.value)}
+              className="min-h-36 font-mono"
+              disabled={resetPending}
+            />
+            <p className="text-xs text-muted-foreground">
+              Use valid JSON. Example string:{" "}
+              <span className="font-mono">&quot;https://example.com&quot;</span>
+              .
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setDialogOpen(false)}
+            disabled={resetPending}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleReset} disabled={resetPending}>
+            {resetPending ? "Saving..." : "Save setting"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/admin/admin-organizations-table.tsx
+++ b/frontend/src/components/admin/admin-organizations-table.tsx
@@ -5,6 +5,7 @@ import Cookies from "js-cookie"
 import { useState } from "react"
 import type { tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead } from "@/client"
 import { AdminOrgDomainsDialog } from "@/components/admin/admin-org-domains-dialog"
+import { AdminOrgEncryptedSettingResetDialog } from "@/components/admin/admin-org-encrypted-setting-reset-dialog"
 import { AdminOrgRegistryDialog } from "@/components/admin/admin-org-registry-dialog"
 import { AdminOrgTierDialog } from "@/components/admin/admin-org-tier-dialog"
 import { AdminOrganizationEditDialog } from "@/components/admin/admin-organization-edit-dialog"
@@ -40,6 +41,9 @@ export function AdminOrganizationsTable() {
   const [tierOrgId, setTierOrgId] = useState<string | null>(null)
   const [domainsOrgId, setDomainsOrgId] = useState<string | null>(null)
   const [registryOrgId, setRegistryOrgId] = useState<string | null>(null)
+  const [settingsResetOrgId, setSettingsResetOrgId] = useState<string | null>(
+    null
+  )
   const [selectedOrg, setSelectedOrg] = useState<OrgRead | null>(null)
   const [deleteConfirmation, setDeleteConfirmation] = useState("")
   const { organizations, deleteOrganization } = useAdminOrganizations()
@@ -241,6 +245,11 @@ export function AdminOrganizationsTable() {
                       >
                         Manage registry
                       </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onSelect={() => setSettingsResetOrgId(row.original.id)}
+                      >
+                        Manage settings
+                      </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         onSelect={() =>
@@ -342,6 +351,17 @@ export function AdminOrganizationsTable() {
           onOpenChange={(isOpen) => {
             if (!isOpen) {
               setRegistryOrgId(null)
+            }
+          }}
+        />
+      )}
+      {settingsResetOrgId && (
+        <AdminOrgEncryptedSettingResetDialog
+          orgId={settingsResetOrgId}
+          open
+          onOpenChange={(isOpen) => {
+            if (!isOpen) {
+              setSettingsResetOrgId(null)
             }
           }}
         />

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -13,6 +13,7 @@ import {
   type AdminListUsersResponse,
   type AdminRegistryGetRegistryStatusResponse,
   type AdminRegistryListRegistryVersionsResponse,
+  type AdminResetEncryptedOrgSettingResponse,
   type AdminUserCreate,
   type AdminUserRead,
   adminCreateOrganization,
@@ -39,6 +40,7 @@ import {
   adminRegistryPromoteRegistryVersion,
   adminRegistrySyncAllRepositories,
   adminRegistrySyncRepository,
+  adminResetEncryptedOrgSetting,
   adminSyncOrgRepository,
   adminUpdateOrganization,
   adminUpdateOrganizationDomain,
@@ -152,6 +154,39 @@ export function useAdminOrganization(orgId: string) {
     error,
     updateOrganization,
     updatePending,
+  }
+}
+
+export function useAdminOrgEncryptedSettingReset(orgId: string) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: resetEncryptedSetting,
+    isPending: resetPending,
+    error,
+  } = useMutation<
+    AdminResetEncryptedOrgSettingResponse,
+    Error,
+    { key: string; value: unknown }
+  >({
+    mutationFn: ({ key, value }) =>
+      adminResetEncryptedOrgSetting({
+        orgId,
+        key,
+        requestBody: { value },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "organizations", orgId],
+      })
+      queryClient.invalidateQueries({ queryKey: ["admin", "organizations"] })
+    },
+  })
+
+  return {
+    resetEncryptedSetting,
+    resetPending,
+    error,
   }
 }
 

--- a/packages/tracecat-admin/tracecat_admin/client.py
+++ b/packages/tracecat-admin/tracecat_admin/client.py
@@ -10,6 +10,7 @@ import httpx
 from tracecat_admin.config import Config, get_config, load_cookies
 from tracecat_admin.schemas import (
     OrganizationTierRead,
+    OrgEncryptedSettingResetResponse,
     OrgRead,
     OrgRegistryRepositoryRead,
     OrgRegistrySyncResponse,
@@ -177,6 +178,21 @@ class AdminClient:
             f"/admin/organizations/{org_id}",
             params={"confirm": confirmation},
         )
+
+    async def reset_org_encrypted_setting(
+        self,
+        org_id: str,
+        key: str,
+        *,
+        value: Any,
+    ) -> OrgEncryptedSettingResetResponse:
+        """Reset an existing encrypted organization setting."""
+        response = await self._request(
+            "POST",
+            f"/admin/organizations/{org_id}/settings/{key}/reset-encrypted",
+            json={"value": value},
+        )
+        return OrgEncryptedSettingResetResponse.model_validate(response.json())
 
     # Registry endpoints
     async def sync_registry(

--- a/packages/tracecat-admin/tracecat_admin/commands/orgs.py
+++ b/packages/tracecat-admin/tracecat_admin/commands/orgs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Callable
 from functools import wraps
 from typing import Annotated, Any
@@ -192,6 +193,51 @@ async def delete_org(
 
             await client.delete_organization(org_id, confirmation=typed_confirmation)
             print_success(f"Organization '{org.name}' deleted successfully")
+    except AdminClientError as e:
+        print_error(str(e))
+        raise typer.Exit(1) from None
+
+
+@app.command("reset-encrypted-setting")
+@async_command
+async def reset_encrypted_setting(
+    org_id: Annotated[str, typer.Argument(help="Organization ID (UUID)")],
+    key: Annotated[str, typer.Argument(help="Organization setting key")],
+    json_value: Annotated[
+        str,
+        typer.Option(
+            "--json-value",
+            help="JSON-encoded setting value to encrypt and store",
+        ),
+    ],
+    json_output: Annotated[
+        bool, typer.Option("--json", "-j", help="Output as JSON")
+    ] = False,
+) -> None:
+    """Reset an encrypted organization setting value."""
+    try:
+        value = json.loads(json_value)
+    except json.JSONDecodeError as e:
+        print_error(f"Invalid --json-value: {e.msg}")
+        raise typer.Exit(1) from e
+
+    try:
+        async with AdminClient() as client:
+            result = await client.reset_org_encrypted_setting(
+                org_id=org_id,
+                key=key,
+                value=value,
+            )
+
+        if json_output:
+            typer.echo(json.dumps(result.model_dump(mode="json"), indent=2))
+        else:
+            print_success(f"Encrypted setting '{key}' reset successfully")
+            typer.echo(f"Organization ID: {result.organization_id}")
+            typer.echo(f"Key: {result.key}")
+            typer.echo(f"Value type: {result.value_type}")
+            typer.echo(f"Encrypted: {result.is_encrypted}")
+            typer.echo(f"Updated at: {result.updated_at.isoformat()}")
     except AdminClientError as e:
         print_error(str(e))
         raise typer.Exit(1) from None

--- a/packages/tracecat-admin/tracecat_admin/schemas.py
+++ b/packages/tracecat-admin/tracecat_admin/schemas.py
@@ -34,6 +34,16 @@ class OrgRead(BaseModel):
     updated_at: datetime | None = None
 
 
+class OrgEncryptedSettingResetResponse(BaseModel):
+    """Encrypted organization setting reset response."""
+
+    organization_id: uuid.UUID
+    key: str
+    value_type: str
+    is_encrypted: bool
+    updated_at: datetime
+
+
 class RepositorySyncResult(BaseModel):
     """Result of syncing a single repository."""
 

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
@@ -15,6 +15,8 @@ from tracecat_ee.admin.organizations.schemas import (
     OrgDomainCreate,
     OrgDomainRead,
     OrgDomainUpdate,
+    OrgEncryptedSettingResetRequest,
+    OrgEncryptedSettingResetResponse,
     OrgRead,
     OrgRegistryRepositoryRead,
     OrgRegistrySyncRequest,
@@ -116,6 +118,38 @@ async def delete_organization(
         ) from e
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.post(
+    "/{org_id}/settings/{key}/reset-encrypted",
+    response_model=OrgEncryptedSettingResetResponse,
+)
+async def reset_encrypted_org_setting(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    org_id: uuid.UUID,
+    key: str,
+    params: OrgEncryptedSettingResetRequest,
+) -> OrgEncryptedSettingResetResponse:
+    """Reset an existing encrypted organization setting."""
+    service = AdminOrgService(session, role)
+    try:
+        return await service.reset_encrypted_org_setting(
+            org_id,
+            key,
+            value=params.value,
+        )
+    except ValueError as e:
+        detail = str(e)
+        if "not found" in detail.lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=detail,
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=detail,
+        ) from e
 
 
 # Org Domain Endpoints

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/schemas.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from typing import Any
 
 from pydantic import Field
 
@@ -70,6 +71,22 @@ class OrgDomainRead(Schema):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class OrgEncryptedSettingResetRequest(Schema):
+    """Reset encrypted organization setting request."""
+
+    value: Any
+
+
+class OrgEncryptedSettingResetResponse(Schema):
+    """Reset encrypted organization setting response."""
+
+    organization_id: uuid.UUID
+    key: str
+    value_type: str
+    is_encrypted: bool
+    updated_at: datetime
 
 
 # Org Registry Schemas

--- a/tests/unit/api/test_api_admin_organizations.py
+++ b/tests/unit/api/test_api_admin_organizations.py
@@ -8,7 +8,11 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 from tracecat_ee.admin.organizations import router as organizations_router
-from tracecat_ee.admin.organizations.schemas import OrgDomainRead, OrgRead
+from tracecat_ee.admin.organizations.schemas import (
+    OrgDomainRead,
+    OrgEncryptedSettingResetResponse,
+    OrgRead,
+)
 
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
@@ -41,6 +45,20 @@ def _org_domain_read(
         verified_at=None,
         verification_method="platform_admin",
         created_at=now,
+        updated_at=now,
+    )
+
+
+def _org_encrypted_setting_reset_read(
+    org_id: uuid.UUID,
+    key: str,
+) -> OrgEncryptedSettingResetResponse:
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    return OrgEncryptedSettingResetResponse(
+        organization_id=org_id,
+        key=key,
+        value_type="json",
+        is_encrypted=True,
         updated_at=now,
     )
 
@@ -284,3 +302,67 @@ async def test_delete_org_domain_success(
         response = client.delete(f"/admin/organizations/{org_id}/domains/{domain_id}")
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_reset_encrypted_org_setting_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+    key = "audit_webhook_url"
+    reset = _org_encrypted_setting_reset_read(org_id, key)
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.reset_encrypted_org_setting.return_value = reset
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/admin/organizations/{org_id}/settings/{key}/reset-encrypted",
+            json={"value": "https://example.com/new"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["key"] == key
+
+
+@pytest.mark.anyio
+async def test_reset_encrypted_org_setting_not_found(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+    key = "audit_webhook_url"
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.reset_encrypted_org_setting.side_effect = ValueError("not found")
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/admin/organizations/{org_id}/settings/{key}/reset-encrypted",
+            json={"value": "https://example.com/new"},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_reset_encrypted_org_setting_rejects_non_encrypted(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+    key = "saml_enabled"
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.reset_encrypted_org_setting.side_effect = ValueError(
+            "Organization setting is not encrypted"
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/admin/organizations/{org_id}/settings/{key}/reset-encrypted",
+            json={"value": True},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/test_admin_org_settings_service.py
+++ b/tests/unit/test_admin_org_settings_service.py
@@ -1,0 +1,161 @@
+"""Tests for superuser encrypted organization setting reset behavior."""
+
+from __future__ import annotations
+
+import uuid
+
+import orjson
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.admin.organizations.service import AdminOrgService
+
+from tracecat import config
+from tracecat.auth.types import PlatformRole
+from tracecat.db.models import Organization, OrganizationSetting
+from tracecat.secrets.encryption import decrypt_value, encrypt_value
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+def _encryption_key() -> str:
+    key = config.TRACECAT__DB_ENCRYPTION_KEY
+    if not key:
+        raise RuntimeError("TRACECAT__DB_ENCRYPTION_KEY is not set")
+    return key
+
+
+@pytest.fixture
+def platform_role() -> PlatformRole:
+    return PlatformRole(
+        type="user",
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+
+
+@pytest.fixture
+async def org_a(session: AsyncSession) -> Organization:
+    organization = Organization(
+        id=uuid.uuid4(),
+        name="Org A",
+        slug=f"org-a-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(organization)
+    await session.commit()
+    return organization
+
+
+@pytest.mark.anyio
+async def test_reset_encrypted_org_setting_success(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    key = _encryption_key()
+    encrypted_value = encrypt_value(
+        orjson.dumps("https://example.com/old"),
+        key=key,
+    )
+    setting = OrganizationSetting(
+        organization_id=org_a.id,
+        key="audit_webhook_url",
+        value=encrypted_value,
+        value_type="json",
+        is_encrypted=True,
+    )
+    session.add(setting)
+    await session.commit()
+
+    service = AdminOrgService(session, role=platform_role)
+    result = await service.reset_encrypted_org_setting(
+        org_a.id,
+        "audit_webhook_url",
+        value="https://example.com/new",
+    )
+
+    assert result.organization_id == org_a.id
+    assert result.key == "audit_webhook_url"
+    assert result.is_encrypted is True
+
+    refreshed = await session.scalar(
+        select(OrganizationSetting).where(
+            OrganizationSetting.organization_id == org_a.id,
+            OrganizationSetting.key == "audit_webhook_url",
+        )
+    )
+    assert refreshed is not None
+    decrypted = decrypt_value(refreshed.value, key=key)
+    assert orjson.loads(decrypted) == "https://example.com/new"
+
+
+@pytest.mark.anyio
+async def test_reset_encrypted_org_setting_succeeds_with_invalid_ciphertext(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    key = _encryption_key()
+    setting = OrganizationSetting(
+        organization_id=org_a.id,
+        key="audit_webhook_custom_headers",
+        value=b"invalid-ciphertext",
+        value_type="json",
+        is_encrypted=True,
+    )
+    session.add(setting)
+    await session.commit()
+
+    service = AdminOrgService(session, role=platform_role)
+    await service.reset_encrypted_org_setting(
+        org_a.id,
+        "audit_webhook_custom_headers",
+        value={"X-Test": "new-value"},
+    )
+
+    refreshed = await session.scalar(
+        select(OrganizationSetting).where(
+            OrganizationSetting.organization_id == org_a.id,
+            OrganizationSetting.key == "audit_webhook_custom_headers",
+        )
+    )
+    assert refreshed is not None
+    decrypted = decrypt_value(refreshed.value, key=key)
+    assert orjson.loads(decrypted) == {"X-Test": "new-value"}
+
+
+@pytest.mark.anyio
+async def test_reset_encrypted_org_setting_rejects_non_encrypted_setting(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    setting = OrganizationSetting(
+        organization_id=org_a.id,
+        key="saml_enabled",
+        value=orjson.dumps(True),
+        value_type="json",
+        is_encrypted=False,
+    )
+    session.add(setting)
+    await session.commit()
+
+    service = AdminOrgService(session, role=platform_role)
+    with pytest.raises(ValueError, match="not encrypted"):
+        await service.reset_encrypted_org_setting(org_a.id, "saml_enabled", value=False)
+
+
+@pytest.mark.anyio
+async def test_reset_encrypted_org_setting_not_found(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    org_a: Organization,
+) -> None:
+    service = AdminOrgService(session, role=platform_role)
+    with pytest.raises(ValueError, match="not found"):
+        await service.reset_encrypted_org_setting(
+            org_a.id,
+            "audit_webhook_url",
+            value="https://example.com/new",
+        )


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds a superuser recovery path to overwrite encrypted organization settings when existing ciphertext is no longer decryptable (for example, after Fernet key mismatch/loss).

### Backend
- Adds `POST /admin/organizations/{org_id}/settings/{key}/reset-encrypted`.
- Re-encrypts the provided JSON value with the current `TRACECAT__DB_ENCRYPTION_KEY` without decrypting the old value.
- Validates org/setting existence and that the target setting is encrypted.

### Admin CLI
- Adds `tracecat orgs reset-encrypted-setting <org_id> <key> --json-value '<json>' [--json]`.

### Admin UI
- Adds an org-level settings override dialog reachable from org actions (`Manage settings`).
- Allows setting key entry + JSON value input and calls the new admin endpoint.

### Frontend client generation
- Regenerates OpenAPI client types/services to include the new endpoint.

## Related Issues

N/A

## Screenshots / Recordings

N/A (small admin dialog addition; can provide on request)

## Steps to QA

1. Start stack in this worktree with `just cluster up -d`.
2. Ensure you are logged in as a superuser.
3. Open Admin orgs table and select an org.
4. Open actions menu -> `Manage settings`.
5. Enter an encrypted setting key (for example `audit_webhook_url`) and a valid JSON value.
6. Click `Save setting` and verify success toast.
7. Optionally verify via CLI:
   - `uv run --package tracecat-admin tracecat orgs reset-encrypted-setting <org_id> <key> --json-value '"value"' --json`

### Automated checks run
- `uv run ruff check <changed-python-files>`
- `uv run basedpyright <changed-python-files>`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- `uv run pytest tests/unit/api/test_api_admin_organizations.py tests/unit/test_admin_org_settings_service.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a superuser override to reset encrypted organization settings when existing ciphertext is unreadable. Accepts a JSON value, validates known keys (now also in the Admin UI), and re‑encrypts it with the current key without decrypting the old value.

- **New Features**
  - Backend: POST /admin/organizations/{org_id}/settings/{key}/reset-encrypted; validates org/setting, enforces encrypted-only, typed validation for known keys, uses TRACECAT__DB_ENCRYPTION_KEY, returns 404 when not found and 400 for invalid/non-encrypted.
  - Admin UI: “Manage settings” dialog with setting key + JSON input and suggested encrypted keys; adds client-side validation for known keys with type hints and examples.
  - Admin CLI: tracecat orgs reset-encrypted-setting <org_id> <key> --json-value '<json>' [--json].
  - Frontend: Regenerated client types/services and added useAdminOrgEncryptedSettingReset hook for the new endpoint.
  - Tests: API and service tests for success, not found, non-encrypted, invalid ciphertext, typed validation, and unknown encrypted keys.

<sup>Written for commit 734c0164beec3f130d9b951e0ee981e933cc4e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

