### PR TITLE
fix: Isolate subprocess protocol from action output

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/ansible.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/ansible.py
@@ -79,6 +79,10 @@ def run_playbook(
 
     extravars = extravars or {}
     runner_kwargs = runner_kwargs or {}
+    # Prevent ansible-runner from writing console output to stdout.
+    # Registry actions are executed in a subprocess where stdout must contain
+    # only the JSON protocol payload returned by minimal_runner.
+    runner_kwargs.setdefault("quiet", True)
 
     if "inventory" in runner_kwargs:
         raise ValueError(

--- a/tests/registry/test_ansible.py
+++ b/tests/registry/test_ansible.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+import tracecat_registry.integrations.ansible as ansible_integration
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.stdout = ""
+        self.events = []
+
+
+def test_run_playbook_sets_quiet_by_default(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(ansible_integration, "Runner", _FakeRunner)
+    monkeypatch.setattr(ansible_integration.secrets, "get", lambda _key: None)
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return _FakeRunner()
+
+    monkeypatch.setattr(ansible_integration, "run", fake_run)
+
+    ansible_integration.run_playbook(
+        playbook=[{"name": "Smoke test", "hosts": "all", "tasks": []}],
+        host="192.168.1.10",
+        host_name="test-host",
+        user="ubuntu",
+    )
+
+    assert captured["quiet"] is True
+
+
+def test_run_playbook_allows_quiet_override(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(ansible_integration, "Runner", _FakeRunner)
+    monkeypatch.setattr(ansible_integration.secrets, "get", lambda _key: None)
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return _FakeRunner()
+
+    monkeypatch.setattr(ansible_integration, "run", fake_run)
+
+    ansible_integration.run_playbook(
+        playbook=[{"name": "Smoke test", "hosts": "all", "tasks": []}],
+        host="192.168.1.10",
+        host_name="test-host",
+        user="ubuntu",
+        runner_kwargs={"quiet": False},
+    )
+
+    assert captured["quiet"] is False

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from tracecat.executor import minimal_runner
+
+
+def test_main_minimal_suppresses_action_stdout_and_stderr(monkeypatch) -> None:
+    test_module = types.ModuleType("test_module")
+
+    def noisy_action() -> dict[str, str]:
+        print("noisy stdout line")
+        print("noisy stderr line", file=sys.stderr)
+        return {"ok": "yes"}
+
+    test_module.noisy_action = noisy_action
+
+    monkeypatch.setattr(
+        minimal_runner.importlib,
+        "import_module",
+        lambda _p, *args, **kwargs: test_module,
+    )
+
+    result = minimal_runner.main_minimal(
+        {
+            "resolved_context": {
+                "action_impl": {
+                    "type": "udf",
+                    "module": "test_module",
+                    "name": "noisy_action",
+                },
+                "secrets": {},
+                "evaluated_args": {},
+            }
+        }
+    )
+
+    assert result == {"success": True, "result": {"ok": "yes"}}
+
+
+def test_main_minimal_returns_structured_error_for_action_exceptions(
+    monkeypatch,
+) -> None:
+    test_module = types.ModuleType("test_module")
+
+    def boom_action() -> None:
+        raise ValueError("boom")
+
+    test_module.boom_action = boom_action
+
+    monkeypatch.setattr(
+        minimal_runner.importlib,
+        "import_module",
+        lambda _p, *args, **kwargs: test_module,
+    )
+
+    result = minimal_runner.main_minimal(
+        {
+            "resolved_context": {
+                "action_impl": {
+                    "type": "udf",
+                    "module": "test_module",
+                    "name": "boom_action",
+                },
+                "secrets": {},
+                "evaluated_args": {},
+            }
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"]["type"] == "ValueError"
+    assert result["error"]["message"] == "boom"

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import sys
 import types
+from typing import Any
 
 from tracecat.executor import minimal_runner
 
 
 def test_main_minimal_suppresses_action_stdout_and_stderr(monkeypatch) -> None:
-    test_module = types.ModuleType("test_module")
+    test_module: Any = types.ModuleType("test_module")
 
     def noisy_action() -> dict[str, str]:
         print("noisy stdout line")
@@ -42,7 +43,7 @@ def test_main_minimal_suppresses_action_stdout_and_stderr(monkeypatch) -> None:
 def test_main_minimal_returns_structured_error_for_action_exceptions(
     monkeypatch,
 ) -> None:
-    test_module = types.ModuleType("test_module")
+    test_module: Any = types.ModuleType("test_module")
 
     def boom_action() -> None:
         raise ValueError("boom")

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import sys
 import types
 from typing import Any
@@ -73,3 +74,53 @@ def test_main_minimal_returns_structured_error_for_action_exceptions(
     assert result["success"] is False
     assert result["error"]["type"] == "ValueError"
     assert result["error"]["message"] == "boom"
+
+
+def test_capped_text_buffer_limits_memory_growth() -> None:
+    buf = minimal_runner._CappedTextBuffer(limit=5)
+
+    written = buf.write("abcdefgh")
+
+    assert written == 8
+    assert buf.getvalue() == "abcde"
+    assert buf.truncated is True
+
+
+def test_main_minimal_still_succeeds_when_warnings_raise(monkeypatch) -> None:
+    test_module: Any = types.ModuleType("test_module")
+
+    def noisy_action() -> dict[str, str]:
+        print("stdout noise")
+        return {"ok": "yes"}
+
+    test_module.noisy_action = noisy_action
+
+    monkeypatch.setattr(
+        minimal_runner.importlib,
+        "import_module",
+        lambda _p, *args, **kwargs: test_module,
+    )
+
+    def raise_runtime_warning(*_args, **_kwargs) -> None:
+        raise RuntimeWarning("warnings are treated as errors")
+
+    monkeypatch.setattr(minimal_runner.warnings, "warn", raise_runtime_warning)
+    fake_stderr = io.StringIO()
+    monkeypatch.setattr(minimal_runner.sys, "stderr", fake_stderr)
+
+    result = minimal_runner.main_minimal(
+        {
+            "resolved_context": {
+                "action_impl": {
+                    "type": "udf",
+                    "module": "test_module",
+                    "name": "noisy_action",
+                },
+                "secrets": {},
+                "evaluated_args": {},
+            }
+        }
+    )
+
+    assert result == {"success": True, "result": {"ok": "yes"}}
+    assert "Action emitted stdout output that was suppressed" in fake_stderr.getvalue()

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import importlib
-import io
 import os
+import sys
 import warnings
 from collections.abc import Mapping
 from types import ModuleType
@@ -52,6 +52,61 @@ except ImportError:
 
 # Static config (read once at module load, immutable)
 _API_URL = os.environ.get("TRACECAT__API_URL", "http://api:8000")
+_CAPTURED_OUTPUT_CHAR_LIMIT = 8192
+_SUPPRESSED_OUTPUT_PREVIEW_CHAR_LIMIT = 500
+
+
+class _CappedTextBuffer:
+    """Lightweight text buffer with a hard character cap."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = max(limit, 0)
+        self._size = 0
+        self._parts: list[str] = []
+        self.truncated = False
+
+    def write(self, text: str) -> int:
+        if not text:
+            return 0
+
+        text_len = len(text)
+        remaining = self._limit - self._size
+        if remaining > 0:
+            chunk = text[:remaining]
+            self._parts.append(chunk)
+            self._size += len(chunk)
+
+        if text_len > remaining:
+            self.truncated = True
+
+        return text_len
+
+    def flush(self) -> None:
+        return None
+
+    def getvalue(self) -> str:
+        return "".join(self._parts)
+
+
+def _emit_suppressed_output_notice(
+    *, stream_name: str, output: str, truncated: bool
+) -> None:
+    preview = output[:_SUPPRESSED_OUTPUT_PREVIEW_CHAR_LIMIT]
+    truncation_text = " (truncated)" if truncated else ""
+    message = (
+        f"Action emitted {stream_name} output that was suppressed"
+        f"{truncation_text}: {preview}"
+    )
+
+    try:
+        warnings.warn(message, RuntimeWarning, stacklevel=2)
+    except Exception:
+        try:
+            sys.stderr.write(f"{message}\n")
+            sys.stderr.flush()
+        except Exception:
+            # Never fail action execution due to telemetry emission issues.
+            return None
 
 
 def run_action_minimal(
@@ -344,8 +399,8 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
         # Run the action with pre-evaluated args.
         # Capture action-level stdout/stderr to prevent protocol corruption.
         # The direct executor parses this process stdout as JSON bytes.
-        action_stdout = io.StringIO()
-        action_stderr = io.StringIO()
+        action_stdout = _CappedTextBuffer(_CAPTURED_OUTPUT_CHAR_LIMIT)
+        action_stderr = _CappedTextBuffer(_CAPTURED_OUTPUT_CHAR_LIMIT)
         with (
             contextlib.redirect_stdout(action_stdout),
             contextlib.redirect_stderr(action_stderr),
@@ -353,16 +408,16 @@ def main_minimal(input_data: dict[str, Any]) -> dict[str, Any]:
             result = run_action_minimal(action_impl, evaluated_args, secrets)
 
         if captured_stdout := action_stdout.getvalue().strip():
-            warnings.warn(
-                f"Action emitted stdout output that was suppressed: {captured_stdout[:500]}",
-                RuntimeWarning,
-                stacklevel=2,
+            _emit_suppressed_output_notice(
+                stream_name="stdout",
+                output=captured_stdout,
+                truncated=action_stdout.truncated,
             )
         if captured_stderr := action_stderr.getvalue().strip():
-            warnings.warn(
-                f"Action emitted stderr output that was suppressed: {captured_stderr[:500]}",
-                RuntimeWarning,
-                stacklevel=2,
+            _emit_suppressed_output_notice(
+                stream_name="stderr",
+                output=captured_stderr,
+                truncated=action_stderr.truncated,
             )
 
         return {"success": True, "result": result}


### PR DESCRIPTION
### Motivation
- The direct executor parses subprocess `stdout` as the JSON protocol payload, so any action or integration that writes to `stdout`/`stderr` can corrupt protocol framing. 
- A targeted change in one integration (e.g., Ansible) is partial and fragile, so the containment must live at the executor boundary where subprocess protocol is enforced. 

### Description
- In `main_minimal` (`tracecat/executor/minimal_runner.py`) capture action-level `stdout` and `stderr` using `contextlib.redirect_stdout`/`redirect_stderr` into `io.StringIO` while invoking `run_action_minimal`. 
- Emit any suppressed output as `RuntimeWarning` (truncated to 500 chars) so noisy output remains observable without corrupting the JSON protocol. 
- Add unit tests in `tests/unit/executor/test_minimal_runner_protocol.py` that mock `importlib.import_module` to verify noisy actions return a clean structured success payload and that raised exceptions return structured error payloads. 

### Testing
- Ran `uv run ruff check tracecat/executor/minimal_runner.py tests/unit/executor/test_minimal_runner_protocol.py` and it passed. 
- Ran `uv run ruff format --check tracecat/executor/minimal_runner.py tests/unit/executor/test_minimal_runner_protocol.py` and it passed after formatting. 
- Attempted `uv run pytest tests/unit/executor/test_minimal_runner_protocol.py` but the repository-level pytest fixtures require a PostgreSQL instance on `localhost:5432`, causing the run to fail in this environment; a focused manual smoke check (`uv run python - <<'PY' ...`) confirmed `main_minimal` returns a structured success even when the action prints to `stdout`/`stderr`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699514f089d0833390051b9d47d5ea5b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the executor’s JSON protocol from action output by capturing and capping action stdout/stderr in minimal_runner and defaulting Ansible runs to quiet. This prevents protocol corruption and limits memory growth while keeping results and errors structured.

- **Bug Fixes**
  - Capture action stdout/stderr with capped buffers (8 KB); emit a RuntimeWarning with up to 500 chars preview, and fall back to stderr if warnings fail.
  - Default ansible-runner to quiet=True (overridable via runner_kwargs).
  - Add tests for noisy actions, structured errors, quiet override, buffer cap, and warning fallback; satisfy basedpyright.

<sup>Written for commit 32105bf7defda890726aaac7288ce0466ca0f780. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

