### PR TITLE
fix(agent): fix Gemini model prefixing in gateway

### DIFF
--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -4,13 +4,23 @@ from litellm.proxy._types import ProxyException
 from tracecat.agent.gateway import _inject_provider_credentials
 
 
-def test_gemini_injects_api_key():
+def test_gemini_injects_api_key_and_prefixes_model():
     data = {"model": "gemini-2.5-flash"}
     creds = {"GEMINI_API_KEY": "test-gemini-key"}
 
     _inject_provider_credentials(data, "gemini", creds)
 
     assert data["api_key"] == "test-gemini-key"
+    assert data["model"] == "gemini/gemini-2.5-flash"
+
+
+def test_gemini_does_not_double_prefix_model():
+    data = {"model": "gemini/gemini-3-flash-preview"}
+    creds = {"GEMINI_API_KEY": "test-gemini-key"}
+
+    _inject_provider_credentials(data, "gemini", creds)
+
+    assert data["model"] == "gemini/gemini-3-flash-preview"
 
 
 def test_vertex_ai_injects_project_credentials_and_model():

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -232,6 +232,9 @@ def _inject_provider_credentials(
                     code=401,
                 )
             data["api_key"] = api_key
+            # Prefix model name for LiteLLM routing (e.g. gemini-2.5-flash -> gemini/gemini-2.5-flash)
+            if not data.get("model", "").startswith("gemini/"):
+                data["model"] = f"gemini/{data['model']}"
 
         case "vertex_ai":
             credentials = creds.get("GOOGLE_API_CREDENTIALS")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Gemini model handling in the gateway by prefixing models with "gemini/" for LiteLLM routing and avoiding double-prefixes. Also keeps API key injection intact.

- **Bug Fixes**
  - Prefix "gemini/" only when missing (e.g., gemini-2.5-flash -> gemini/gemini-2.5-flash).
  - Do not re-prefix already prefixed models.
  - Added unit tests for API key injection, prefixing, and idempotency.

<sup>Written for commit 12218ac013c6a56157c5494557ce6bbe86298c5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

