### PR TITLE
fix(registry): gate custom registry operations by entitlement

### DIFF
--- a/frontend/src/app/admin/tiers/page.tsx
+++ b/frontend/src/app/admin/tiers/page.tsx
@@ -27,7 +27,7 @@ export default function AdminTiersPage() {
           <div className="items-start space-y-3 text-left">
             <h2 className="text-2xl font-semibold tracking-tight">Tiers</h2>
             <p className="text-base text-muted-foreground">
-              Manage subscription tiers and resource limits.
+              Manage plans and resource limits.
             </p>
           </div>
           <div className="ml-auto flex items-center space-x-2">

--- a/frontend/src/app/organization/settings/git/page.tsx
+++ b/frontend/src/app/organization/settings/git/page.tsx
@@ -1,24 +1,17 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
+import { ArrowUpRight } from "lucide-react"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { OrgSettingsGitForm } from "@/components/organization/org-settings-git"
+import { Button } from "@/components/ui/button"
 import { useEntitlements } from "@/hooks/use-entitlements"
 
 export default function GitSettingsPage() {
   const { hasEntitlement, isLoading } = useEntitlements()
-  const router = useRouter()
   const customRegistryEnabled = hasEntitlement("custom_registry")
 
-  useEffect(() => {
-    if (!isLoading && !customRegistryEnabled) {
-      router.replace("/organization/settings/sso")
-    }
-  }, [customRegistryEnabled, isLoading, router])
-
   if (isLoading) return <CenteredSpinner />
-  if (!customRegistryEnabled) return null
 
   return (
     <div className="size-full overflow-auto">
@@ -34,7 +27,31 @@ export default function GitSettingsPage() {
           </div>
         </div>
 
-        <OrgSettingsGitForm />
+        {customRegistryEnabled ? (
+          <OrgSettingsGitForm />
+        ) : (
+          <div className="flex flex-1 items-center justify-center pb-8">
+            <EntitlementRequiredEmptyState
+              title="Upgrade required"
+              description="Custom registry Git settings are unavailable on your current subscription tier."
+            >
+              <Button
+                variant="link"
+                asChild
+                className="text-muted-foreground"
+                size="sm"
+              >
+                <a
+                  href="https://tracecat.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn more <ArrowUpRight className="size-4" />
+                </a>
+              </Button>
+            </EntitlementRequiredEmptyState>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/app/organization/settings/git/page.tsx
+++ b/frontend/src/app/organization/settings/git/page.tsx
@@ -33,7 +33,7 @@ export default function GitSettingsPage() {
           <div className="flex flex-1 items-center justify-center pb-8">
             <EntitlementRequiredEmptyState
               title="Upgrade required"
-              description="Custom registry Git settings are unavailable on your current subscription tier."
+              description="Custom registry Git settings are unavailable on your current plan."
             >
               <Button
                 variant="link"

--- a/frontend/src/app/organization/settings/git/page.tsx
+++ b/frontend/src/app/organization/settings/git/page.tsx
@@ -1,8 +1,25 @@
 "use client"
 
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+import { CenteredSpinner } from "@/components/loading/spinner"
 import { OrgSettingsGitForm } from "@/components/organization/org-settings-git"
+import { useEntitlements } from "@/hooks/use-entitlements"
 
 export default function GitSettingsPage() {
+  const { hasEntitlement, isLoading } = useEntitlements()
+  const router = useRouter()
+  const customRegistryEnabled = hasEntitlement("custom_registry")
+
+  useEffect(() => {
+    if (!isLoading && !customRegistryEnabled) {
+      router.replace("/organization/settings/sso")
+    }
+  }, [customRegistryEnabled, isLoading, router])
+
+  if (isLoading) return <CenteredSpinner />
+  if (!customRegistryEnabled) return null
+
   return (
     <div className="size-full overflow-auto">
       <div className="container flex h-full max-w-[1000px] flex-col space-y-12">

--- a/frontend/src/app/registry/repositories/page.tsx
+++ b/frontend/src/app/registry/repositories/page.tsx
@@ -1,15 +1,23 @@
 "use client"
 
+import { ArrowUpRight } from "lucide-react"
 import { useScopeCheck } from "@/components/auth/scope-guard"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { RegistryRepositoriesTable } from "@/components/registry/registry-repos-table"
+import { Button } from "@/components/ui/button"
+import { useEntitlements } from "@/hooks/use-entitlements"
 
 export default function RegistryRepositoriesPage() {
   const canReadRegistry = useScopeCheck("org:registry:read")
-  const isLoading = canReadRegistry === undefined
+  const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
+  const customRegistryEnabled = hasEntitlement("custom_registry")
+
+  const isLoading = canReadRegistry === undefined || entitlementsLoading
 
   if (isLoading) return <CenteredSpinner />
   if (!canReadRegistry) return null
+
   return (
     <div className="size-full overflow-auto">
       <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
@@ -23,7 +31,31 @@ export default function RegistryRepositoriesPage() {
             </p>
           </div>
         </div>
-        <RegistryRepositoriesTable />
+        {customRegistryEnabled ? (
+          <RegistryRepositoriesTable />
+        ) : (
+          <div className="flex flex-1 items-center justify-center pb-8">
+            <EntitlementRequiredEmptyState
+              title="Upgrade required"
+              description="Custom registry repositories are unavailable on your current plan."
+            >
+              <Button
+                variant="link"
+                asChild
+                className="text-muted-foreground"
+                size="sm"
+              >
+                <a
+                  href="https://tracecat.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn more <ArrowUpRight className="size-4" />
+                </a>
+              </Button>
+            </EntitlementRequiredEmptyState>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/app/workspaces/[workspaceId]/agents/[presetId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/agents/[presetId]/page.tsx
@@ -3,7 +3,7 @@
 import { useParams } from "next/navigation"
 import { useEffect } from "react"
 import { AgentPresetsBuilder } from "@/components/agents/agent-presets-builder"
-import { FeatureFlagEmptyState } from "@/components/feature-flag-empty-state"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useEntitlements } from "@/hooks/use-entitlements"
 
@@ -27,7 +27,7 @@ export default function AgentPresetsPage() {
     return (
       <div className="size-full overflow-auto">
         <div className="mx-auto flex w-full h-full max-w-3xl flex-1 items-center justify-center py-12">
-          <FeatureFlagEmptyState
+          <EntitlementRequiredEmptyState
             title="Enterprise only"
             description="Advanced AI agents (human-in-the-loop and subagents) are only available on enterprise plans."
           />

--- a/frontend/src/app/workspaces/[workspaceId]/agents/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/agents/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react"
 import { AgentsTable } from "@/components/agents/agents-table"
-import { FeatureFlagEmptyState } from "@/components/feature-flag-empty-state"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useEntitlements } from "@/hooks/use-entitlements"
 
@@ -24,7 +24,7 @@ export default function AgentsPage() {
     return (
       <div className="size-full overflow-auto">
         <div className="mx-auto flex w-full h-full max-w-3xl flex-1 items-center justify-center py-12">
-          <FeatureFlagEmptyState
+          <EntitlementRequiredEmptyState
             title="Enterprise only"
             description="Advanced AI agents (human-in-the-loop and subagents) are only available on enterprise plans."
           />

--- a/frontend/src/app/workspaces/[workspaceId]/inbox/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/inbox/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react"
 import { useScopeCheck } from "@/components/auth/scope-guard"
-import { FeatureFlagEmptyState } from "@/components/feature-flag-empty-state"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { ActivityLayout } from "@/components/inbox"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useEntitlements } from "@/hooks/use-entitlements"
@@ -43,7 +43,7 @@ export default function InboxPage() {
     return (
       <div className="size-full overflow-auto">
         <div className="mx-auto flex h-full w-full max-w-3xl flex-1 items-center justify-center py-12">
-          <FeatureFlagEmptyState
+          <EntitlementRequiredEmptyState
             title="Enterprise only"
             description="Advanced AI agents (human-in-the-loop and subagents) are only available on enterprise plans."
           />

--- a/frontend/src/components/cases/case-durations-view.tsx
+++ b/frontend/src/components/cases/case-durations-view.tsx
@@ -5,7 +5,7 @@ import { ArrowUpRight, Timer } from "lucide-react"
 import { useState } from "react"
 import type { CaseDurationDefinitionUpdate } from "@/client"
 import { CaseDurationsTable } from "@/components/cases/case-durations-table"
-import { FeatureFlagEmptyState } from "@/components/feature-flag-empty-state"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { Button } from "@/components/ui/button"
@@ -139,7 +139,7 @@ export function CaseDurationsView() {
     return (
       <div className="size-full overflow-auto">
         <div className="container flex h-full max-w-[1000px] items-center justify-center py-8">
-          <FeatureFlagEmptyState
+          <EntitlementRequiredEmptyState
             title="Enterprise only"
             description="Case durations are only available on enterprise plans."
           >
@@ -157,7 +157,7 @@ export function CaseDurationsView() {
                 Learn more <ArrowUpRight className="size-4" />
               </a>
             </Button>
-          </FeatureFlagEmptyState>
+          </EntitlementRequiredEmptyState>
         </div>
       </div>
     )

--- a/frontend/src/components/cases/dropdowns-view.tsx
+++ b/frontend/src/components/cases/dropdowns-view.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowUpRight, ListIcon } from "lucide-react"
 import { DropdownsTable } from "@/components/cases/dropdowns-table"
-import { FeatureFlagEmptyState } from "@/components/feature-flag-empty-state"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { Button } from "@/components/ui/button"
@@ -48,7 +48,7 @@ export function DropdownsView() {
     return (
       <div className="size-full overflow-auto">
         <div className="container flex h-full max-w-[1000px] items-center justify-center py-8">
-          <FeatureFlagEmptyState
+          <EntitlementRequiredEmptyState
             title="Enterprise only"
             description="Case dropdowns are only available on enterprise plans."
           >
@@ -66,7 +66,7 @@ export function DropdownsView() {
                 Learn more <ArrowUpRight className="size-4" />
               </a>
             </Button>
-          </FeatureFlagEmptyState>
+          </EntitlementRequiredEmptyState>
         </div>
       </div>
     )

--- a/frontend/src/components/entitlement-required-empty-state.tsx
+++ b/frontend/src/components/entitlement-required-empty-state.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/empty"
 import { cn } from "@/lib/utils"
 
-type FeatureFlagEmptyStateProps = {
+type EntitlementRequiredEmptyStateProps = {
   title: string
   description: ReactNode
   icon?: ReactNode
@@ -18,13 +18,17 @@ type FeatureFlagEmptyStateProps = {
   children?: ReactNode
 }
 
-export function FeatureFlagEmptyState({
+/**
+ * Reusable empty state for routes or sections that remain visible
+ * but are unavailable without the required entitlement.
+ */
+export function EntitlementRequiredEmptyState({
   title,
   description,
   icon,
   className,
   children,
-}: FeatureFlagEmptyStateProps) {
+}: EntitlementRequiredEmptyStateProps) {
   const iconNode = icon ?? <Lock className="h-6 w-6" />
 
   return (

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
+  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
@@ -37,6 +38,7 @@ export function OrganizationSidebar({
 }: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname()
   const { hasEntitlement } = useEntitlements()
+  const customRegistryEnabled = hasEntitlement("custom_registry")
 
   // Fetch workspaces for the sidebar
   const { workspaces } = useWorkspaceManager()
@@ -52,6 +54,7 @@ export function OrganizationSidebar({
       icon: GitBranchIcon,
       isActive: pathname?.includes("/organization/settings/git"),
       visible: canViewSettings === true,
+      locked: !customRegistryEnabled,
     },
     {
       title: "Single sign-on",
@@ -59,6 +62,7 @@ export function OrganizationSidebar({
       icon: LockIcon,
       isActive: pathname?.includes("/organization/settings/sso"),
       visible: canViewSettings === true,
+      locked: false,
     },
     {
       title: "Domains",
@@ -66,6 +70,7 @@ export function OrganizationSidebar({
       icon: GlobeIcon,
       isActive: pathname?.includes("/organization/settings/domains"),
       visible: canViewSettings === true,
+      locked: false,
     },
     {
       title: "Application",
@@ -73,6 +78,7 @@ export function OrganizationSidebar({
       icon: Settings2,
       isActive: pathname?.includes("/organization/settings/app"),
       visible: canViewSettings === true,
+      locked: false,
     },
     {
       title: "Audit Logs",
@@ -80,6 +86,7 @@ export function OrganizationSidebar({
       icon: LogsIcon,
       isActive: pathname?.includes("/organization/settings/audit"),
       visible: canViewSettings === true,
+      locked: false,
     },
     {
       title: "Agent",
@@ -87,6 +94,7 @@ export function OrganizationSidebar({
       icon: BotIcon,
       isActive: pathname?.includes("/organization/settings/agent"),
       visible: canViewSettings === true,
+      locked: false,
     },
     ...(hasEntitlement("git_sync")
       ? [
@@ -96,6 +104,7 @@ export function OrganizationSidebar({
             icon: GitBranchIcon,
             isActive: pathname?.includes("/organization/vcs"),
             visible: canViewSettings === true,
+            locked: false,
           },
         ]
       : []),
@@ -171,6 +180,12 @@ export function OrganizationSidebar({
                           <span>{item.title}</span>
                         </Link>
                       </SidebarMenuButton>
+                      {item.locked ? (
+                        <SidebarMenuBadge>
+                          <LockIcon aria-hidden="true" className="size-3.5" />
+                          <span className="sr-only">Requires upgrade</span>
+                        </SidebarMenuBadge>
+                      ) : null}
                     </SidebarMenuItem>
                   ))}
               </SidebarMenu>

--- a/frontend/src/components/sidebar/registry-sidebar.tsx
+++ b/frontend/src/components/sidebar/registry-sidebar.tsx
@@ -14,16 +14,22 @@ import {
   SidebarGroupContent,
   SidebarHeader,
   SidebarMenu,
+  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
 } from "@/components/ui/sidebar"
+import { useEntitlements } from "@/hooks/use-entitlements"
+import { useOrgMembership } from "@/hooks/use-org-membership"
 
 export function RegistrySidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar>) {
   const canReadRegistry = useScopeCheck("org:registry:read")
+  const { canAdministerOrg } = useOrgMembership()
+  const { hasEntitlement } = useEntitlements()
   const pathname = usePathname()
+  const customRegistryEnabled = hasEntitlement("custom_registry")
 
   const navMain = [
     ...(canReadRegistry
@@ -33,13 +39,19 @@ export function RegistrySidebar({
             url: "/registry/actions",
             icon: BookOpenIcon,
             isActive: pathname?.includes("/registry/actions"),
+            locked: false,
           },
-          {
-            title: "Repositories",
-            url: "/registry/repositories",
-            icon: GitBranchIcon,
-            isActive: pathname?.includes("/registry/repositories"),
-          },
+          ...(canAdministerOrg
+            ? [
+                {
+                  title: "Repositories",
+                  url: "/registry/repositories",
+                  icon: GitBranchIcon,
+                  isActive: pathname?.includes("/registry/repositories"),
+                  locked: !customRegistryEnabled,
+                },
+              ]
+            : []),
         ]
       : []),
   ]
@@ -70,6 +82,9 @@ export function RegistrySidebar({
                       <span>{item.title}</span>
                     </Link>
                   </SidebarMenuButton>
+                  {item.locked ? (
+                    <SidebarMenuBadge>Requires upgrade</SidebarMenuBadge>
+                  ) : null}
                 </SidebarMenuItem>
               ))}
             </SidebarMenu>

--- a/frontend/src/components/sidebar/registry-sidebar.tsx
+++ b/frontend/src/components/sidebar/registry-sidebar.tsx
@@ -20,13 +20,12 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar"
 import { useEntitlements } from "@/hooks/use-entitlements"
-import { useOrgMembership } from "@/hooks/use-org-membership"
 
 export function RegistrySidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar>) {
   const canReadRegistry = useScopeCheck("org:registry:read")
-  const { canAdministerOrg } = useOrgMembership()
+  const canAdministerOrg = useScopeCheck("org:update")
   const { hasEntitlement } = useEntitlements()
   const pathname = usePathname()
   const customRegistryEnabled = hasEntitlement("custom_registry")

--- a/frontend/src/hooks/use-entitlements.ts
+++ b/frontend/src/hooks/use-entitlements.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { organizationGetOrganizationEntitlements } from "@/client"
+import { useOrganization } from "@/hooks/use-organization"
 
 type EntitlementKey = keyof Awaited<
   ReturnType<typeof organizationGetOrganizationEntitlements>
@@ -11,13 +12,15 @@ export function useEntitlements(): {
   isLoading: boolean
   hasEntitlementData: boolean
 } {
+  const { organization, isLoading: organizationLoading } = useOrganization()
   const {
     data: entitlements,
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["organization-entitlements"],
+    queryKey: ["organization-entitlements", organization?.id],
     queryFn: async () => await organizationGetOrganizationEntitlements(),
+    enabled: Boolean(organization?.id),
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   })
@@ -26,10 +29,10 @@ export function useEntitlements(): {
 
   return {
     hasEntitlement: (key: EntitlementKey) => {
-      if (isLoading || error) return false
+      if (organizationLoading || isLoading || error) return false
       return Boolean(entitlements?.[key])
     },
-    isLoading,
+    isLoading: organizationLoading || isLoading,
     hasEntitlementData,
   }
 }

--- a/tests/unit/api/test_api_registry_repositories_entitlements.py
+++ b/tests/unit/api/test_api_registry_repositories_entitlements.py
@@ -1,0 +1,142 @@
+"""HTTP-level tests for custom-registry entitlement gating."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+import tracecat.registry.repositories.router as repos_router_module
+from tracecat.auth.types import Role
+from tracecat.exceptions import EntitlementRequired
+
+
+@pytest.mark.anyio
+async def test_sync_custom_repository_requires_entitlement(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    repository_id = uuid4()
+    repository = SimpleNamespace(
+        id=repository_id,
+        origin="git+ssh://git@github.com/acme/custom-registry.git",
+        current_version_id=None,
+    )
+
+    with (
+        patch.object(repos_router_module, "RegistryReposService") as MockReposService,
+        patch.object(
+            repos_router_module,
+            "check_entitlement",
+            new_callable=AsyncMock,
+        ) as mock_check_entitlement,
+    ):
+        mock_repos_service = AsyncMock()
+        mock_repos_service.get_repository_by_id.return_value = repository
+        MockReposService.return_value = mock_repos_service
+        mock_check_entitlement.side_effect = EntitlementRequired("custom_registry")
+
+        response = client.post(f"/registry/repos/{repository_id}/sync")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mock_check_entitlement.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_update_custom_repository_requires_entitlement(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    repository_id = uuid4()
+    repository = SimpleNamespace(
+        id=repository_id,
+        origin="git+ssh://git@github.com/acme/custom-registry.git",
+        current_version_id=None,
+    )
+
+    with (
+        patch.object(repos_router_module, "RegistryReposService") as MockReposService,
+        patch.object(
+            repos_router_module, "RegistryActionsService"
+        ) as MockActionsService,
+        patch.object(
+            repos_router_module,
+            "check_entitlement",
+            new_callable=AsyncMock,
+        ) as mock_check_entitlement,
+    ):
+        mock_repos_service = AsyncMock()
+        mock_repos_service.get_repository_by_id.return_value = repository
+        MockReposService.return_value = mock_repos_service
+        MockActionsService.return_value = AsyncMock()
+        mock_check_entitlement.side_effect = EntitlementRequired("custom_registry")
+
+        response = client.patch(
+            f"/registry/repos/{repository_id}",
+            json={"commit_sha": "a" * 40},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mock_check_entitlement.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_delete_custom_repository_requires_entitlement(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    repository_id = uuid4()
+    repository = SimpleNamespace(
+        id=repository_id,
+        origin="git+ssh://git@github.com/acme/custom-registry.git",
+    )
+
+    with (
+        patch.object(repos_router_module, "RegistryReposService") as MockReposService,
+        patch.object(
+            repos_router_module,
+            "check_entitlement",
+            new_callable=AsyncMock,
+        ) as mock_check_entitlement,
+    ):
+        mock_repos_service = AsyncMock()
+        mock_repos_service.get_repository_by_id.return_value = repository
+        MockReposService.return_value = mock_repos_service
+        mock_check_entitlement.side_effect = EntitlementRequired("custom_registry")
+
+        response = client.delete(f"/registry/repos/{repository_id}")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mock_check_entitlement.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_promote_custom_repository_requires_entitlement(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    repository_id = uuid4()
+    version_id = uuid4()
+    repository = SimpleNamespace(
+        id=repository_id,
+        origin="git+ssh://git@github.com/acme/custom-registry.git",
+        current_version_id=None,
+    )
+
+    with (
+        patch.object(repos_router_module, "RegistryReposService") as MockReposService,
+        patch.object(
+            repos_router_module,
+            "check_entitlement",
+            new_callable=AsyncMock,
+        ) as mock_check_entitlement,
+    ):
+        mock_repos_service = AsyncMock()
+        mock_repos_service.get_repository_by_id.return_value = repository
+        MockReposService.return_value = mock_repos_service
+        mock_check_entitlement.side_effect = EntitlementRequired("custom_registry")
+
+        response = client.post(
+            f"/registry/repos/{repository_id}/versions/{version_id}/promote"
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mock_check_entitlement.assert_awaited_once()

--- a/tests/unit/api/test_api_settings_entitlements.py
+++ b/tests/unit/api/test_api_settings_entitlements.py
@@ -1,0 +1,48 @@
+"""HTTP-level tests for settings entitlement gating."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+import tracecat.settings.router as settings_router_module
+from tracecat.auth.types import Role
+from tracecat.exceptions import EntitlementRequired
+
+
+@pytest.mark.anyio
+async def test_get_git_settings_requires_custom_registry_entitlement(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    with patch.object(
+        settings_router_module,
+        "check_entitlement",
+        new_callable=AsyncMock,
+    ) as mock_check_entitlement:
+        mock_check_entitlement.side_effect = EntitlementRequired("custom_registry")
+
+        response = client.get("/settings/git")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mock_check_entitlement.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_update_git_settings_requires_custom_registry_entitlement(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    with patch.object(
+        settings_router_module,
+        "check_entitlement",
+        new_callable=AsyncMock,
+    ) as mock_check_entitlement:
+        mock_check_entitlement.side_effect = EntitlementRequired("custom_registry")
+
+        response = client.patch(
+            "/settings/git",
+            json={"git_repo_url": "git+ssh://git@github.com/acme/repo.git"},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    mock_check_entitlement.assert_awaited_once()

--- a/tests/unit/api/test_api_workflow_execution_path_ids.py
+++ b/tests/unit/api/test_api_workflow_execution_path_ids.py
@@ -196,7 +196,7 @@ async def test_internal_get_execution_status_unwraps_nested_failure_cause(
             self.cause = cause
 
     root_cause = ApplicationError(
-        "EntitlementRequired: Feature 'custom_registry' requires a higher subscription tier"
+        "EntitlementRequired: Feature 'custom_registry' requires an upgraded plan"
     )
     activity_wrapper = FakeActivityError("Activity task failed", cause=root_cause)
 

--- a/tests/unit/api/test_api_workflow_execution_path_ids.py
+++ b/tests/unit/api/test_api_workflow_execution_path_ids.py
@@ -174,6 +174,56 @@ async def test_internal_get_execution_status_returns_error_for_failed_workflow(
     assert "connection timeout" in payload["error"]
 
 
+@pytest.mark.anyio
+async def test_internal_get_execution_status_unwraps_nested_failure_cause(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test that nested ActivityError-style causes are unwrapped to root message."""
+    from temporalio.client import WorkflowFailureError
+    from temporalio.exceptions import ApplicationError
+
+    wf_exec_id = "wf_abc/exec_failed_nested"
+
+    mock_execution = Mock()
+    mock_execution.status = WorkflowExecutionStatus.FAILED
+    mock_execution.start_time = datetime(2024, 1, 1, tzinfo=UTC)
+    mock_execution.close_time = datetime(2024, 1, 1, 0, 1, tzinfo=UTC)
+
+    class FakeActivityError(Exception):
+        def __init__(self, message: str, cause: Exception | None = None) -> None:
+            super().__init__(message)
+            self.cause = cause
+
+    root_cause = ApplicationError(
+        "EntitlementRequired: Feature 'custom_registry' requires a higher subscription tier"
+    )
+    activity_wrapper = FakeActivityError("Activity task failed", cause=root_cause)
+
+    mock_handle = Mock()
+    mock_handle.result = AsyncMock(
+        side_effect=WorkflowFailureError(cause=activity_wrapper)
+    )
+
+    mock_svc = AsyncMock()
+    mock_svc.get_execution.return_value = mock_execution
+    mock_svc.handle = Mock(return_value=mock_handle)
+
+    with patch.object(
+        internal_executions_router.WorkflowExecutionsService,
+        "connect",
+        AsyncMock(return_value=mock_svc),
+    ):
+        response = client.get(f"/internal/workflows/executions/{wf_exec_id}")
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["status"] == "FAILED"
+    assert payload["error"] is not None
+    assert "custom_registry" in payload["error"]
+    assert "Activity task failed" not in payload["error"]
+
+
 # --- Internal Router: POST /executions ---
 
 

--- a/tests/unit/test_registry_actions_custom_entitlement.py
+++ b/tests/unit/test_registry_actions_custom_entitlement.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import (
+    PlatformRegistryIndex,
+    PlatformRegistryRepository,
+    PlatformRegistryVersion,
+    RegistryIndex,
+    RegistryRepository,
+    RegistryVersion,
+)
+from tracecat.registry.actions.service import RegistryActionsService
+from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+def _make_manifest(action_names: list[str], *, origin: str) -> dict:
+    actions: dict[str, dict] = {}
+    for action_name in action_names:
+        namespace, name = action_name.rsplit(".", 1)
+        actions[action_name] = {
+            "namespace": namespace,
+            "name": name,
+            "action_type": "udf",
+            "description": f"Test action {action_name}",
+            "interface": {"expects": {}, "returns": None},
+            "implementation": {
+                "type": "udf",
+                "url": origin,
+                "module": "test.module",
+                "name": name,
+            },
+        }
+    return {"version": "1.0", "actions": actions}
+
+
+async def _seed_platform_registry(
+    session: AsyncSession,
+    *,
+    origin: str,
+    version: str,
+    action_names: list[str],
+) -> PlatformRegistryRepository:
+    repo = await session.scalar(
+        select(PlatformRegistryRepository).where(PlatformRegistryRepository.origin == origin)
+    )
+    if repo is None:
+        repo = PlatformRegistryRepository(origin=origin)
+        session.add(repo)
+        await session.flush()
+
+    registry_version = PlatformRegistryVersion(
+        repository_id=repo.id,
+        version=version,
+        manifest=_make_manifest(action_names, origin=origin),
+        tarball_uri=f"s3://platform/{version}.tar.gz",
+    )
+    session.add(registry_version)
+    await session.flush()
+
+    repo.current_version_id = registry_version.id
+    session.add(repo)
+
+    for action_name in action_names:
+        namespace, name = action_name.rsplit(".", 1)
+        session.add(
+            PlatformRegistryIndex(
+                registry_version_id=registry_version.id,
+                namespace=namespace,
+                name=name,
+                action_type="udf",
+                description=f"Platform action {action_name}",
+                options={"include_in_schema": True},
+            )
+        )
+    await session.commit()
+    return repo
+
+
+async def _seed_org_registry(
+    session: AsyncSession,
+    *,
+    role: Role,
+    origin: str,
+    version: str,
+    action_names: list[str],
+) -> RegistryRepository:
+    repo = RegistryRepository(
+        organization_id=role.organization_id,
+        origin=origin,
+    )
+    session.add(repo)
+    await session.flush()
+
+    registry_version = RegistryVersion(
+        organization_id=role.organization_id,
+        repository_id=repo.id,
+        version=version,
+        manifest=_make_manifest(action_names, origin=origin),
+        tarball_uri=f"s3://org/{version}.tar.gz",
+    )
+    session.add(registry_version)
+    await session.flush()
+
+    repo.current_version_id = registry_version.id
+    session.add(repo)
+
+    for action_name in action_names:
+        namespace, name = action_name.rsplit(".", 1)
+        session.add(
+            RegistryIndex(
+                organization_id=role.organization_id,
+                registry_version_id=registry_version.id,
+                namespace=namespace,
+                name=name,
+                action_type="udf",
+                description=f"Org action {action_name}",
+                options={"include_in_schema": True},
+            )
+        )
+    await session.commit()
+    return repo
+
+
+@pytest.mark.anyio
+async def test_index_list_hides_custom_actions_without_entitlement(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    shared_action = "acme.test.shared"
+    custom_only_action = "acme.test.custom_only"
+    custom_origin = "git+ssh://git@github.com/acme/custom-registry.git"
+
+    await _seed_platform_registry(
+        session,
+        origin=DEFAULT_REGISTRY_ORIGIN,
+        version="platform-1.0",
+        action_names=[shared_action],
+    )
+    await _seed_org_registry(
+        session,
+        role=svc_role,
+        origin=custom_origin,
+        version="org-1.0",
+        action_names=[shared_action, custom_only_action],
+    )
+
+    service = RegistryActionsService(session, role=svc_role)
+    with patch.object(
+        service, "has_entitlement", new=AsyncMock(return_value=False)
+    ) as mock_has_entitlement:
+        entries = await service.list_actions_from_index(namespace="acme.test")
+
+    actions_to_origin = {f"{entry.namespace}.{entry.name}": origin for entry, origin in entries}
+    assert actions_to_origin[shared_action] == DEFAULT_REGISTRY_ORIGIN
+    assert custom_only_action not in actions_to_origin
+    mock_has_entitlement.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_get_action_from_index_uses_platform_fallback_without_entitlement(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    shared_action = "acme.detail.shared"
+    custom_only_action = "acme.detail.custom_only"
+    custom_origin = "git+ssh://git@github.com/acme/custom-registry.git"
+
+    await _seed_platform_registry(
+        session,
+        origin=DEFAULT_REGISTRY_ORIGIN,
+        version="platform-1.0",
+        action_names=[shared_action],
+    )
+    await _seed_org_registry(
+        session,
+        role=svc_role,
+        origin=custom_origin,
+        version="org-1.0",
+        action_names=[shared_action, custom_only_action],
+    )
+
+    service = RegistryActionsService(session, role=svc_role)
+    with patch.object(
+        service, "has_entitlement", new=AsyncMock(return_value=False)
+    ):
+        shared = await service.get_action_from_index(shared_action)
+        custom_only = await service.get_action_from_index(custom_only_action)
+
+    assert shared is not None
+    assert shared.origin == DEFAULT_REGISTRY_ORIGIN
+    assert custom_only is None
+
+
+@pytest.mark.anyio
+async def test_get_actions_from_index_filters_custom_and_keeps_platform_fallback(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    shared_action = "acme.batch.shared"
+    custom_only_action = "acme.batch.custom_only"
+    custom_origin = "git+ssh://git@github.com/acme/custom-registry.git"
+
+    await _seed_platform_registry(
+        session,
+        origin=DEFAULT_REGISTRY_ORIGIN,
+        version="platform-1.0",
+        action_names=[shared_action],
+    )
+    await _seed_org_registry(
+        session,
+        role=svc_role,
+        origin=custom_origin,
+        version="org-1.0",
+        action_names=[shared_action, custom_only_action],
+    )
+
+    service = RegistryActionsService(session, role=svc_role)
+    with patch.object(
+        service, "has_entitlement", new=AsyncMock(return_value=False)
+    ):
+        results = await service.get_actions_from_index(
+            [shared_action, custom_only_action]
+        )
+
+    assert set(results.keys()) == {shared_action}
+    assert results[shared_action].origin == DEFAULT_REGISTRY_ORIGIN
+
+
+@pytest.mark.anyio
+async def test_list_actions_from_index_by_repository_returns_empty_for_custom_repo_without_entitlement(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    custom_origin = "git+ssh://git@github.com/acme/custom-registry.git"
+    custom_repo = await _seed_org_registry(
+        session,
+        role=svc_role,
+        origin=custom_origin,
+        version="org-1.0",
+        action_names=["acme.repo.only_action"],
+    )
+
+    service = RegistryActionsService(session, role=svc_role)
+    with patch.object(
+        service, "has_entitlement", new=AsyncMock(return_value=False)
+    ):
+        actions = await service.list_actions_from_index_by_repository(custom_repo.id)
+
+    assert actions == []
+
+
+@pytest.mark.anyio
+async def test_search_actions_from_index_hides_custom_actions_without_entitlement(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    shared_action = "acme.search.shared"
+    custom_only_action = "acme.search.custom_only"
+    custom_origin = "git+ssh://git@github.com/acme/custom-registry.git"
+
+    await _seed_platform_registry(
+        session,
+        origin=DEFAULT_REGISTRY_ORIGIN,
+        version="platform-1.0",
+        action_names=[shared_action],
+    )
+    await _seed_org_registry(
+        session,
+        role=svc_role,
+        origin=custom_origin,
+        version="org-1.0",
+        action_names=[shared_action, custom_only_action],
+    )
+
+    service = RegistryActionsService(session, role=svc_role)
+    with patch.object(
+        service, "has_entitlement", new=AsyncMock(return_value=False)
+    ):
+        entries = await service.search_actions_from_index("acme.search")
+
+    actions_to_origin = {f"{entry.namespace}.{entry.name}": origin for entry, origin in entries}
+    assert actions_to_origin[shared_action] == DEFAULT_REGISTRY_ORIGIN
+    assert custom_only_action not in actions_to_origin

--- a/tests/unit/test_registry_common.py
+++ b/tests/unit/test_registry_common.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import tracecat.registry.common as registry_common
+from tracecat.registry.constants import DEFAULT_LOCAL_REGISTRY_ORIGIN
+from tracecat.registry.repositories.schemas import RegistryRepositoryCreate
+
+
+@pytest.mark.anyio
+async def test_ensure_org_repositories_skips_when_custom_registry_not_entitled(
+    test_role,
+) -> None:
+    session = AsyncMock()
+
+    with (
+        patch.object(
+            registry_common.config, "TRACECAT__LOCAL_REPOSITORY_ENABLED", True
+        ),
+        patch.object(registry_common.config, "TRACECAT__LOCAL_REPOSITORY_PATH", "/tmp"),
+        patch.object(
+            registry_common,
+            "get_setting",
+            new=AsyncMock(return_value="git+ssh://git@github.com/acme/repo.git"),
+        ),
+        patch.object(
+            registry_common,
+            "is_org_entitled",
+            new=AsyncMock(return_value=False),
+        ) as mock_is_org_entitled,
+        patch.object(registry_common, "RegistryReposService") as MockReposService,
+    ):
+        await registry_common.ensure_org_repositories(session, test_role)
+
+    mock_is_org_entitled.assert_awaited_once()
+    MockReposService.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_ensure_org_repositories_creates_local_and_remote_when_entitled(
+    test_role,
+) -> None:
+    session = AsyncMock()
+    remote_url = "git+ssh://git@github.com/acme/repo.git"
+
+    with (
+        patch.object(
+            registry_common.config, "TRACECAT__LOCAL_REPOSITORY_ENABLED", True
+        ),
+        patch.object(registry_common.config, "TRACECAT__LOCAL_REPOSITORY_PATH", "/tmp"),
+        patch.object(
+            registry_common,
+            "get_setting",
+            new=AsyncMock(return_value=remote_url),
+        ),
+        patch.object(
+            registry_common,
+            "is_org_entitled",
+            new=AsyncMock(return_value=True),
+        ),
+        patch.object(registry_common, "RegistryReposService") as MockReposService,
+    ):
+        mock_repos_service = AsyncMock()
+        mock_repos_service.get_repository.return_value = None
+        MockReposService.return_value = mock_repos_service
+
+        await registry_common.ensure_org_repositories(session, test_role)
+
+    expected = {
+        DEFAULT_LOCAL_REGISTRY_ORIGIN,
+        remote_url,
+    }
+    created = {
+        call.args[0].origin
+        for call in mock_repos_service.create_repository.await_args_list
+        if isinstance(call.args[0], RegistryRepositoryCreate)
+    }
+    assert created == expected

--- a/tests/unit/test_registry_lock_service.py
+++ b/tests/unit/test_registry_lock_service.py
@@ -302,9 +302,7 @@ async def test_resolve_lock_requires_entitlement_for_custom_only_action(
         "tools.custom.only_action"
     ]
     assert "tools.custom.only_action" in str(exc_info.value)
-    assert "\n\nUnavailable actions on your current subscription tier:\n-" in str(
-        exc_info.value
-    )
+    assert "\n\nUnavailable actions on your current plan:\n-" in str(exc_info.value)
     assert "git+ssh://git@github.com/acme/custom.git" not in str(exc_info.value)
 
 

--- a/tests/unit/test_workflow_definitions_activities.py
+++ b/tests/unit/test_workflow_definitions_activities.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.exceptions import EntitlementRequired
+from tracecat.workflow.management.definitions import resolve_registry_lock_activity
+from tracecat.workflow.management.schemas import ResolveRegistryLockActivityInputs
+
+
+@pytest.fixture
+def mock_role() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-executor",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-executor"],
+    )
+
+
+@pytest.mark.anyio
+async def test_resolve_registry_lock_activity_maps_entitlement_error(
+    mock_role: Role,
+) -> None:
+    inputs = ResolveRegistryLockActivityInputs(
+        role=mock_role,
+        action_names={"tools.custom.only_action"},
+    )
+    mock_service = AsyncMock()
+    mock_service.resolve_lock_with_bindings.side_effect = EntitlementRequired(
+        "custom_registry"
+    )
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value = mock_service
+
+    with patch(
+        "tracecat.workflow.management.definitions.RegistryLockService.with_session",
+        return_value=mock_ctx,
+    ):
+        with pytest.raises(ApplicationError) as exc_info:
+            await resolve_registry_lock_activity(inputs)
+
+    app_error = exc_info.value
+    assert app_error.type == "EntitlementRequired"
+    assert app_error.non_retryable is True
+    assert len(app_error.details) > 0
+    detail = app_error.details[0]
+    assert isinstance(detail, dict)
+    assert detail["entitlement"] == "custom_registry"

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -34,7 +34,7 @@ from tracecat.agent.tokens import MCPTokenClaims, verify_mcp_token
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
-from tracecat.exceptions import ExecutionError
+from tracecat.exceptions import EntitlementRequired, ExecutionError
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
 
@@ -113,6 +113,8 @@ async def execute_action_tool(
             error=error_msg,
         )
         raise ToolError(error_msg) from e
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
     except Exception as e:
         # Unexpected platform errors - log full details but return generic message
         logger.error(

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -222,7 +222,7 @@ class PayloadSizeExceeded(TracecatException):
 
 
 class EntitlementRequired(TracecatException):
-    """Exception raised when a feature requires a higher subscription tier.
+    """Exception raised when a feature requires an upgraded plan.
 
     Raised when an organization attempts to use a feature they are not entitled to.
     """
@@ -242,14 +242,14 @@ class EntitlementRequired(TracecatException):
             return "\n".join(lines)
 
         self.entitlement = entitlement
-        message = f"Feature '{entitlement}' requires a higher subscription tier."
+        message = f"Feature '{entitlement}' requires an upgraded plan."
         detail: dict[str, object] = {"entitlement": entitlement}
 
         if unavailable_actions:
             unique_actions = list(dict.fromkeys(unavailable_actions))
             detail["unavailable_actions"] = unique_actions
             message += (
-                "\n\nUnavailable actions on your current subscription tier:\n"
+                "\n\nUnavailable actions on your current plan:\n"
                 f"{_format_bulleted_preview(unique_actions)}"
             )
 
@@ -258,8 +258,6 @@ class EntitlementRequired(TracecatException):
             # Origins can include sensitive repository details; keep only a count.
             detail["unavailable_origin_count"] = len(unique_origins)
             if not unavailable_actions:
-                message += (
-                    "\n\nSome actions are unavailable on your current subscription tier."
-                )
+                message += "\n\nSome actions are unavailable on your current plan."
 
         super().__init__(message, detail=detail)

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -755,10 +755,13 @@ async def invoke_once(
     if role.organization_id is None:
         raise ValueError("organization_id is required for action dispatch")
 
-    # Prefetch registry lock manifests into cache for O(1) resolution
-    await registry_resolver.prefetch_lock(input.registry_lock, role.organization_id)
-
     try:
+        # Prefetch registry lock manifests into cache for O(1) resolution.
+        # Keep this inside the error wrapper so entitlement failures are
+        # normalized into ExecutionError and then ApplicationError at activity
+        # boundaries.
+        await registry_resolver.prefetch_lock(input.registry_lock, role.organization_id)
+
         # Prepare resolved context (secrets, variables, action impl, evaluated args)
         # This is done once here and passed to all backends
         # For templates, secrets are fetched recursively for all steps

--- a/tracecat/registry/common.py
+++ b/tracecat/registry/common.py
@@ -32,7 +32,9 @@ async def ensure_org_repositories(session: AsyncSession, role: Role) -> None:
             role=role,
         ),
     )
-    needs_custom_registry = config.TRACECAT__LOCAL_REPOSITORY_ENABLED or bool(remote_url)
+    needs_custom_registry = config.TRACECAT__LOCAL_REPOSITORY_ENABLED or bool(
+        remote_url
+    )
     if needs_custom_registry:
         if role.organization_id is None:
             logger.warning(

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -127,9 +127,9 @@ class RegistryLockService(BaseOrgService):
         if not custom_registry_enabled:
             for origin, _version, manifest_dict in org_rows:
                 origin_str = str(origin)
-                excluded_custom_origin_manifests[
-                    origin_str
-                ] = RegistryVersionManifest.model_validate(manifest_dict)
+                excluded_custom_origin_manifests[origin_str] = (
+                    RegistryVersionManifest.model_validate(manifest_dict)
+                )
 
         # 3. Build action -> origin mapping using BFS to include template step actions
         actions: dict[str, str] = {}

--- a/tracecat/settings/router.py
+++ b/tracecat/settings/router.py
@@ -19,6 +19,7 @@ from tracecat.settings.schemas import (
     SAMLSettingsUpdate,
 )
 from tracecat.settings.service import SettingsService
+from tracecat.tiers.entitlements import Entitlement, check_entitlement
 
 router = APIRouter(prefix="/settings", tags=["settings"])
 
@@ -55,6 +56,7 @@ async def get_git_settings(
     role: OrgUserRole,
     session: AsyncDBSession,
 ) -> GitSettingsRead:
+    await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
     service = SettingsService(session, role)
     keys = GitSettingsRead.keys()
     settings = await service.list_org_settings(keys=keys)
@@ -70,6 +72,7 @@ async def update_git_settings(
     session: AsyncDBSession,
     params: GitSettingsUpdate,
 ) -> None:
+    await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
     service = SettingsService(session, role)
     await service.update_git_settings(params)
 

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -412,7 +412,7 @@ async def validate_dsl_actions(
                         type="action",
                         msg=(
                             "`tool_approvals` requires the 'agent_addons' entitlement. "
-                            "Remove the field or upgrade your subscription tier."
+                            "Remove the field or upgrade your plan."
                         ),
                         loc=(act_stmt.ref, "tool_approvals"),
                     )

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -251,7 +251,7 @@ async def get_execution_status(
                 result = await handle.result()
             except WorkflowFailureError as e:
                 # Extract the failure message from the workflow error
-                error = str(e.cause) if e.cause else str(e)
+                error = WorkflowExecutionsService.format_failure_cause(e.cause)
             except Exception as e:
                 logger.warning(
                     "Failed to get workflow result",


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated all custom registry setup, repo operations, lock prefetch/resolution, and Git settings behind the CUSTOM_REGISTRY entitlement. UI uses plan-based wording with lock badges and an Upgrade CTA; the default Tracecat registry is unaffected.

- **Bug Fixes**
  - API: Enforce entitlement on registry repo sync/update/delete/promote and Git settings (403 EntitlementRequired); block changing a default repo to a custom origin.
  - Resolver/executor: Check entitlement during lock prefetch and lock resolution; raise non-retryable ApplicationError with clear “Upgrade required” text and unavailable actions; ignore org overrides and prefer platform actions when custom registry is disabled.
  - Workflow execution: Preserve ApplicationError details from activities and unwrap nested failure causes in the status API.
  - Registry actions: Hide custom-origin actions in list/search/detail and by-repository views when not entitled; keep platform fallback for shared actions.
  - Setup: ensure_org_repositories skips when not entitled; otherwise creates local and remote repos.
  - UI: Gate Git settings and Registry Repositories pages with an upgrade empty state; show lock badges in Organization/Registry sidebars; replace FeatureFlagEmptyState with EntitlementRequiredEmptyState across agents, inbox, and cases; entitlements hook is org-aware and waits for org data; “tiers” copy changed to “plans”.
  - MCP tools: Map entitlement errors to ToolError with user-facing messages.
  - Tests: Add HTTP-level checks for Git settings and registry repo routes and expand resolver/activity/execution tests for entitlement gates.

<sup>Written for commit 959aade66df75f34683d538b698deb4000ad0d73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

