### PR TITLE
fix(chart): use enterprise.featureFlags and bump chart version to 0.3.19

### DIFF
--- a/deployments/helm/tracecat/Chart.yaml
+++ b/deployments/helm/tracecat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tracecat
 description: Tracecat is the AI automation platform for mission critical work.
 type: application
-version: 0.3.18
+version: 0.3.19
 appVersion: "1.0.0-beta.13"
 home: https://tracecat.com
 maintainers:

--- a/deployments/helm/tracecat/templates/_helpers.tpl
+++ b/deployments/helm/tracecat/templates/_helpers.tpl
@@ -423,8 +423,8 @@ Common environment variables shared across all backend services
 */}}
 {{- define "tracecat.featureFlags" -}}
 {{- $flags := list -}}
-{{- if .Values.tracecat.featureFlags }}
-{{- $flags = append $flags .Values.tracecat.featureFlags -}}
+{{- if .Values.enterprise.featureFlags }}
+{{- $flags = append $flags .Values.enterprise.featureFlags -}}
 {{- end }}
 {{- join "," $flags -}}
 {{- end }}

--- a/deployments/helm/tracecat/values.yaml
+++ b/deployments/helm/tracecat/values.yaml
@@ -162,8 +162,6 @@ tracecat:
   logLevel: "INFO"
   allowOrigins: ""
   sentryDsn: ""
-  # Core feature flags (comma-separated).
-  featureFlags: ""
 
   sandbox:
     disableNsjail: false
@@ -223,6 +221,8 @@ tracecat:
       scrape: true
 
 enterprise:
+  # Enterprise-only feature flags (comma-separated).
+  featureFlags: ""
   # Enable enterprise multi-tenant mode.
   multiTenant: false
 

--- a/deployments/terraform/aws/main.tf
+++ b/deployments/terraform/aws/main.tf
@@ -127,6 +127,6 @@ module "eks" {
   # Enterprise Edition
   ee_multi_tenant = var.ee_multi_tenant
 
-  # Feature flags (backward-compatible input name; maps to tracecat.featureFlags)
+  # Feature flags (maps to enterprise.featureFlags)
   feature_flags = var.feature_flags
 }

--- a/deployments/terraform/aws/modules/eks/helm.tf
+++ b/deployments/terraform/aws/modules/eks/helm.tf
@@ -134,7 +134,7 @@ resource "helm_release" "tracecat" {
       scheduling = local.tracecat_spot_scheduling
     } : {},
     var.feature_flags != "" ? {
-      tracecat = {
+      enterprise = {
         featureFlags = var.feature_flags
       }
     } : {}

--- a/deployments/terraform/aws/modules/eks/variables.tf
+++ b/deployments/terraform/aws/modules/eks/variables.tf
@@ -500,7 +500,7 @@ variable "tags" {
 
 # Feature Flags
 variable "feature_flags" {
-  description = "Comma-separated Tracecat feature flags (maps to tracecat.featureFlags)"
+  description = "Comma-separated enterprise feature flags (maps to enterprise.featureFlags)"
   type        = string
   default     = ""
 }

--- a/deployments/terraform/aws/variables.tf
+++ b/deployments/terraform/aws/variables.tf
@@ -553,7 +553,7 @@ variable "ee_multi_tenant" {
 
 # Feature Flags
 variable "feature_flags" {
-  description = "Comma-separated Tracecat feature flags (e.g. 'git-sync,case-tasks')"
+  description = "Comma-separated enterprise feature flags (e.g. 'git-sync,case-tasks')"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
### Motivation
- Ensure enterprise-only feature flags are sourced from the `enterprise` values namespace instead of the (removed) `tracecat.featureFlags` to avoid mixing global and enterprise flags.
- Publish a chart version bump so the change is packaged for deployments (`0.3.19`).

### Description
- Rewrote the Helm helper `tracecat.featureFlags` to read `enterprise.featureFlags` directly and removed any usage of `.Values.tracecat.featureFlags` in the helper (`deployments/helm/tracecat/templates/_helpers.tpl`).
- Added `enterprise.featureFlags` to the chart values file and removed the top-level `tracecat.featureFlags` entry from `deployments/helm/tracecat/values.yaml`.
- Updated Terraform → Helm mapping to set `enterprise.featureFlags` (instead of `tracecat.featureFlags`) in `deployments/terraform/aws/modules/eks/helm.tf` and updated related comments and variable descriptions in `deployments/terraform/aws/main.tf`, `deployments/terraform/aws/modules/eks/variables.tf`, and `deployments/terraform/aws/variables.tf`.
- Bumped the Helm chart `version` to `0.3.19` in `deployments/helm/tracecat/Chart.yaml`.

### Testing
- Verified there are no `.Values.tracecat.featureFlags` references with `rg -n "tracecat\.featureFlags" deployments/helm/tracecat deployments/terraform/aws` (search returned expected results showing only the new helper usage). 
- Confirmed the chart version was updated with `grep -n "^version:" deployments/helm/tracecat/Chart.yaml` which shows `version: 0.3.19`.
- Inspected the helper and values snippets with `sed`/`nl` to validate environment variable wiring uses `enterprise.featureFlags` for `TRACECAT__FEATURE_FLAGS`.
- `helm lint` and `terraform fmt` were not executed in this environment because those tools are not available here (skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699741a0511883338495cb306854961a)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch feature flags to enterprise.featureFlags in Helm and Terraform to keep enterprise-only flags separate. Bump Helm chart to 0.3.19.

- **Refactors**
  - Helm helper now reads .Values.enterprise.featureFlags; remove .Values.tracecat.featureFlags.
  - Move featureFlags from tracecat to enterprise in values.yaml.
  - Terraform maps feature_flags to enterprise.featureFlags; update comments and descriptions.

- **Migration**
  - If you set tracecat.featureFlags in Helm values, move it to enterprise.featureFlags.
  - Terraform users can keep using feature_flags; it now maps to enterprise.featureFlags.

<sup>Written for commit 839c8b9617cdf7847fae483c3fcc3b5bfe6bf935. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

