### PR TITLE
feat(ui): Revamped workflows runs view and shortkeys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,7 @@ Available predefined roles:
 - Always use proper TypeScript type hints and avoid using `any` - use `unknown` if necessary
 - Avoid nested ternary statements - use `if/else` or `switch/case` instead
 - Place React hooks in `frontend/src/hooks/` directory (e.g., `use-inbox.ts`, `use-auth.ts`)
+- For keyboard shortcut UI, render each key with the `Kbd` component and prefer `parseShortcutKeys` from `frontend/src/lib/tiptap-utils.ts` to ensure consistent macOS symbols (`⌘`, `⇧`) and non-mac labels (`Ctrl`, `Shift`).
 
 ### UI Component Best Practices
 - **Flat, Linear-inspired design**: Follow a minimal, flat design aesthetic inspired by Linear. Key principles:

--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import React from "react"
-import type { WorkflowExecutionEvent } from "@/client"
 
 import {
   ResizableHandle,
@@ -11,14 +10,17 @@ import {
 
 import "react18-json-view/src/style.css"
 
-import { History } from "lucide-react"
+import { CalendarSearchIcon } from "lucide-react"
 import { useParams } from "next/navigation"
 import { WorkflowExecutionEventDetailView } from "@/components/executions/event-details"
 import { WorkflowExecutionEventHistory } from "@/components/executions/event-history"
 import { SectionHead } from "@/components/executions/section"
-import { formatExecutionId } from "@/lib/event-history"
+import {
+  formatExecutionId,
+  type WorkflowExecutionEventCompact,
+} from "@/lib/event-history"
 
-const defaultLayout = [15, 15, 70]
+const defaultLayout = [15, 24, 61]
 
 export default function ExecutionPage() {
   const params = useParams<{
@@ -42,7 +44,7 @@ export default function ExecutionPage() {
   const { workflowId, executionId } = params
 
   const [selectedEvent, setSelectedEvent] = React.useState<
-    WorkflowExecutionEvent | undefined
+    WorkflowExecutionEventCompact | undefined
   >()
 
   const fullExecutionId = formatExecutionId(workflowId, executionId)
@@ -56,15 +58,13 @@ export default function ExecutionPage() {
         )}`
       }}
     >
-      {/* Panel 2: Event History */}
-      <ResizablePanel defaultSize={defaultLayout[1]} minSize={15}>
-        <div className="flex h-full flex-col overflow-hidden p-2">
-          <div className="flex-none">
-            <SectionHead
-              text="Event History"
-              icon={<History className="mr-2 size-4" strokeWidth={2} />}
-            />
-          </div>
+      {/* Panel 2: Events */}
+      <ResizablePanel defaultSize={defaultLayout[1]} minSize={18}>
+        <div className="flex h-full flex-col overflow-hidden">
+          <SectionHead
+            text="Events"
+            icon={<CalendarSearchIcon className="size-4" strokeWidth={2} />}
+          />
           <div className="flex-1 overflow-auto">
             {fullExecutionId ? (
               <WorkflowExecutionEventHistory
@@ -74,7 +74,7 @@ export default function ExecutionPage() {
               />
             ) : (
               <span className="flex justify-center p-4 text-center text-xs text-muted-foreground">
-                Select a Workflow Execution.
+                Select a workflow execution.
               </span>
             )}
           </div>
@@ -100,7 +100,7 @@ export default function ExecutionPage() {
                   Select an event
                 </h1>
                 <span className="text-center text-sm text-muted-foreground">
-                  Click on an event in the event history to view details.
+                  Click on an event in events to view details.
                 </span>
               </main>
             )}

--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/layout.tsx
@@ -48,7 +48,7 @@ export default function WorkflowExecutionsLayout({
 const REFETCH_INTERVAL = 2000
 function WorkflowExecutionsPanelGroup({
   workflowId,
-  defaultLayout = [15, 15, 70],
+  defaultLayout = [22, 15, 63],
   defaultCollapsed = false,
   navCollapsedSize,
   children,
@@ -105,19 +105,17 @@ function WorkflowExecutionsPanelGroup({
           defaultSize={defaultLayout[0]}
           collapsedSize={navCollapsedSize}
           collapsible={true}
-          minSize={15}
-          maxSize={20}
+          minSize={18}
+          maxSize={30}
           onCollapse={handleCollapse}
           onExpand={handleExpand}
           className={cn(isCollapsed && "min-w-14")}
         >
-          <div className="flex h-full flex-col overflow-hidden p-2">
-            <div className="flex-none">
-              <SectionHead
-                text="Workflow Runs"
-                icon={<ListVideoIcon className="mr-2 size-4" strokeWidth={2} />}
-              />
-            </div>
+          <div className="flex h-full flex-col overflow-hidden">
+            <SectionHead
+              text="Workflow runs"
+              icon={<ListVideoIcon className="size-4" strokeWidth={2} />}
+            />
             <div className="flex-1 overflow-auto">
               <WorkflowExecutionNav executions={workflowExecutions} />
             </div>

--- a/frontend/src/components/builder/builder.tsx
+++ b/frontend/src/components/builder/builder.tsx
@@ -20,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { parseShortcutKeys } from "@/lib/tiptap-utils"
 import { cn } from "@/lib/utils"
 import { useWorkflowBuilder } from "@/providers/builder"
 
@@ -36,6 +37,14 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
     actionPanelRef,
     toggleActionPanel,
   } = useWorkflowBuilder()
+  const toggleSidebarShortcut = React.useMemo(
+    () => parseShortcutKeys({ shortcutKeys: "mod+e" }),
+    []
+  )
+  const toggleActionPanelShortcut = React.useMemo(
+    () => parseShortcutKeys({ shortcutKeys: "mod+shift+e" }),
+    []
+  )
 
   // Toggle builder panels with Cmd/Ctrl+E (left) and Cmd/Ctrl+Shift+E (right)
   React.useEffect(() => {
@@ -103,8 +112,9 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
                   className="border-0 bg-transparent p-0 shadow-none"
                 >
                   <span className="inline-flex items-center gap-1">
-                    <Kbd>Cmd/Ctrl</Kbd>
-                    <Kbd>E</Kbd>
+                    {toggleSidebarShortcut.map((key) => (
+                      <Kbd key={key}>{key}</Kbd>
+                    ))}
                   </span>
                 </TooltipContent>
               </CustomResizableHandle>
@@ -134,9 +144,9 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
                   className="border-0 bg-transparent p-0 shadow-none"
                 >
                   <span className="inline-flex items-center gap-1">
-                    <Kbd>Cmd/Ctrl</Kbd>
-                    <Kbd>Shift</Kbd>
-                    <Kbd>E</Kbd>
+                    {toggleActionPanelShortcut.map((key) => (
+                      <Kbd key={key}>{key}</Kbd>
+                    ))}
                   </span>
                 </TooltipContent>
               </CustomResizableHandle>

--- a/frontend/src/components/builder/builder.tsx
+++ b/frontend/src/components/builder/builder.tsx
@@ -8,6 +8,7 @@ import { EventsSidebarToolbar } from "@/components/builder/events/events-sidebar
 import { BuilderPanel } from "@/components/builder/panel/builder-panel"
 import { WorkflowBuilderErrorBoundary } from "@/components/error-boundaries"
 import { Button } from "@/components/ui/button"
+import { Kbd } from "@/components/ui/kbd"
 import {
   CustomResizableHandle,
   ResizablePanel,
@@ -31,45 +32,31 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
   const {
     canvasRef,
     sidebarRef,
-    isSidebarCollapsed,
     toggleSidebar,
     actionPanelRef,
-    isActionPanelCollapsed,
     toggleActionPanel,
   } = useWorkflowBuilder()
 
-  // Add keyboard shortcut for toggling sidebar (Cmd+E)
+  // Toggle builder panels with Cmd/Ctrl+E (left) and Cmd/Ctrl+Shift+E (right)
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Check for Cmd+E (or Ctrl+E for non-Mac)
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "e") {
-        event.preventDefault() // Prevent default browser behavior
+      if (!(event.metaKey || event.ctrlKey) || event.repeat) {
+        return
+      }
+      const key = event.key.toLowerCase()
+      if (key === "e") {
+        event.preventDefault()
+        if (event.shiftKey) {
+          toggleActionPanel()
+          return
+        }
         toggleSidebar()
       }
     }
 
-    // Add event listener
     window.addEventListener("keydown", handleKeyDown)
-
-    // Clean up on component unmount
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [toggleSidebar])
-
-  // Add keyboard shortcut for toggling action panel (Cmd+Shift+E or Ctrl+Shift+E)
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "u") {
-        event.preventDefault() // Prevent default browser behavior
-        toggleActionPanel()
-      }
-    }
-
-    // Add event listener
-    window.addEventListener("keydown", handleKeyDown)
-
-    // Clean up on component unmount
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [toggleActionPanel])
+  }, [toggleActionPanel, toggleSidebar])
 
   return (
     <WorkflowBuilderErrorBoundary>
@@ -111,9 +98,15 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
                     </div>
                   </Button>
                 </TooltipTrigger>
-                {isSidebarCollapsed && (
-                  <TooltipContent side="right">View Events</TooltipContent>
-                )}
+                <TooltipContent
+                  side="right"
+                  className="border-0 bg-transparent p-0 shadow-none"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    <Kbd>Cmd/Ctrl</Kbd>
+                    <Kbd>E</Kbd>
+                  </span>
+                </TooltipContent>
               </CustomResizableHandle>
             </Tooltip>
           </TooltipProvider>
@@ -136,9 +129,16 @@ export function Builder({ defaultLayout = [0, 68, 24] }: BuilderProps) {
                     </div>
                   </Button>
                 </TooltipTrigger>
-                {isActionPanelCollapsed && (
-                  <TooltipContent side="right">View Side Panel</TooltipContent>
-                )}
+                <TooltipContent
+                  side="left"
+                  className="border-0 bg-transparent p-0 shadow-none"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    <Kbd>Cmd/Ctrl</Kbd>
+                    <Kbd>Shift</Kbd>
+                    <Kbd>E</Kbd>
+                  </span>
+                </TooltipContent>
               </CustomResizableHandle>
             </Tooltip>
           </TooltipProvider>

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -17,9 +17,9 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation"
-import { getWorkflowEventIcon } from "@/components/builder/events/events-workflow"
 import { MessagePart } from "@/components/chat/chat-session-pane"
 import { CodeBlock } from "@/components/code-block"
+import { getWorkflowEventIcon } from "@/components/events/workflow-event-status"
 import { ExternalObjectResult } from "@/components/executions/external-object-result"
 import { JsonViewWithControls } from "@/components/json-viewer"
 import { Spinner } from "@/components/loading/spinner"

--- a/frontend/src/components/events/workflow-event-status.tsx
+++ b/frontend/src/components/events/workflow-event-status.tsx
@@ -1,0 +1,81 @@
+import {
+  AlarmClockOffIcon,
+  CircleCheck,
+  CircleMinusIcon,
+  CircleX,
+  GitForkIcon,
+} from "lucide-react"
+import type { WorkflowExecutionEventStatus } from "@/client"
+import { Spinner } from "@/components/loading/spinner"
+import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
+import { cn } from "@/lib/utils"
+
+export function getAggregateWorkflowEventStatus(
+  relatedEvents: WorkflowExecutionEventCompact[]
+): WorkflowExecutionEventStatus {
+  const statuses = relatedEvents.map((event) => event.status)
+
+  if (statuses.some((status) => status === "FAILED")) return "FAILED"
+  if (statuses.some((status) => status === "TIMED_OUT")) return "TIMED_OUT"
+  if (statuses.some((status) => status === "CANCELED")) return "CANCELED"
+  if (statuses.some((status) => status === "TERMINATED")) return "TERMINATED"
+  if (statuses.some((status) => status === "STARTED")) return "STARTED"
+  if (statuses.some((status) => status === "SCHEDULED")) return "SCHEDULED"
+  if (statuses.every((status) => status === "COMPLETED")) return "COMPLETED"
+  if (statuses.some((status) => status === "DETACHED")) return "DETACHED"
+
+  return "UNKNOWN"
+}
+
+export function getWorkflowEventIcon(
+  status: WorkflowExecutionEventStatus,
+  className?: string
+) {
+  switch (status) {
+    case "SCHEDULED":
+      return <Spinner className={cn("!size-3", className)} />
+    case "STARTED":
+      return <Spinner className={className} />
+    case "COMPLETED":
+      return (
+        <CircleCheck
+          className={cn(
+            "border-none border-emerald-500 fill-emerald-500 stroke-white",
+            className
+          )}
+        />
+      )
+    case "FAILED":
+      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
+    case "CANCELED":
+      return (
+        <CircleMinusIcon
+          className={cn("fill-orange-500 stroke-white", className)}
+        />
+      )
+    case "TERMINATED":
+      return (
+        <CircleMinusIcon
+          className={cn("fill-rose-500 stroke-white", className)}
+        />
+      )
+    case "TIMED_OUT":
+      return (
+        <AlarmClockOffIcon
+          className={cn("!size-3 stroke-rose-500", className)}
+          strokeWidth={2.5}
+        />
+      )
+    case "DETACHED":
+      return (
+        <GitForkIcon
+          className={cn("!size-3 stroke-emerald-500", className)}
+          strokeWidth={2.5}
+        />
+      )
+    case "UNKNOWN":
+      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
+    default:
+      throw new Error("Invalid status")
+  }
+}

--- a/frontend/src/components/events/workflow-events-list.tsx
+++ b/frontend/src/components/events/workflow-events-list.tsx
@@ -1,0 +1,111 @@
+import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { Link2Icon } from "lucide-react"
+import Link from "next/link"
+import type React from "react"
+import { Badge } from "@/components/ui/badge"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+export type WorkflowEventsListRow = {
+  key: string
+  label: string
+  time: string
+  icon: React.ReactNode
+  selected?: boolean
+  count?: number
+  subflowLink?: string
+  trailing?: React.ReactNode
+  onSelect?: () => void
+}
+
+export function WorkflowEventsList({
+  rows,
+  className,
+}: {
+  rows: WorkflowEventsListRow[]
+  className?: string
+}) {
+  return (
+    <div className={cn("relative", className)}>
+      {rows.length > 0 && (
+        <div className="pointer-events-none absolute bottom-6 left-[22px] top-6 w-px bg-gray-300" />
+      )}
+      {rows.map((row) => {
+        const isInteractive = Boolean(row.onSelect)
+        return (
+          <div key={row.key}>
+            <div
+              role={isInteractive ? "button" : undefined}
+              tabIndex={isInteractive ? 0 : undefined}
+              className={cn(
+                "group flex h-11 items-center px-3 text-xs transition-all",
+                isInteractive && "cursor-pointer hover:bg-muted/50",
+                row.selected && "bg-muted-foreground/10"
+              )}
+              onClick={() => {
+                row.onSelect?.()
+              }}
+              onKeyDown={(event) => {
+                if (
+                  isInteractive &&
+                  (event.key === "Enter" || event.key === " ")
+                ) {
+                  event.preventDefault()
+                  row.onSelect?.()
+                }
+              }}
+            >
+              <div className="relative z-10 mr-3 flex size-5 items-center justify-center">
+                {row.icon}
+              </div>
+              <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2 text-xs">
+                  <div className="truncate text-foreground/70">{row.label}</div>
+                  {row.count && row.count > 1 && (
+                    <Badge
+                      variant="secondary"
+                      className="h-4 px-1.5 text-[10px] font-medium text-foreground/60"
+                    >
+                      {row.count}x
+                    </Badge>
+                  )}
+                  {row.subflowLink && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Link
+                          href={row.subflowLink}
+                          className="inline-flex text-foreground/70 hover:text-foreground"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                          }}
+                          aria-label="View subflow run"
+                        >
+                          <Link2Icon className="size-4" />
+                        </Link>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        <span>View subflow run</span>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="whitespace-nowrap text-foreground/70">
+                    {row.time}
+                  </div>
+                  {row.trailing ?? (
+                    <DotsHorizontalIcon className="size-4 text-foreground/70" />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/events/workflow-events-list.tsx
+++ b/frontend/src/components/events/workflow-events-list.tsx
@@ -65,7 +65,7 @@ export function WorkflowEventsList({
               <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
                 <div className="flex min-w-0 items-center gap-2 text-xs">
                   <div className="truncate text-foreground/70">{row.label}</div>
-                  {row.count && row.count > 1 && (
+                  {(row.count ?? 0) > 1 && (
                     <Badge
                       variant="secondary"
                       className="h-4 px-1.5 text-[10px] font-medium text-foreground/60"

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -2,14 +2,12 @@
 
 import { FileInputIcon, ShapesIcon, TriangleAlert } from "lucide-react"
 import React from "react"
-import JsonView from "react18-json-view"
 import { CodeBlock } from "@/components/code-block"
 import { ExternalObjectResult } from "@/components/executions/external-object-result"
+import { JsonViewWithControls } from "@/components/json-viewer"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
 import { isExternalStoredObject } from "@/lib/stored-object"
-
-import "react18-json-view/src/style.css"
 
 export function WorkflowExecutionEventDetailView({
   event,
@@ -132,15 +130,8 @@ export function WorkflowExecutionEventDetailView({
 
 function JsonViewContent({ src }: { src: unknown }): JSX.Element {
   return (
-    <div className="border-b bg-muted-foreground/5 p-3">
-      <JsonView
-        collapsed={false}
-        displaySize
-        enableClipboard
-        src={src}
-        className="break-all text-xs"
-        theme="atom"
-      />
+    <div className="p-3">
+      <JsonViewWithControls src={src} defaultExpanded={false} />
     </div>
   )
 }

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -1,564 +1,146 @@
 "use client"
 
+import { FileInputIcon, ShapesIcon, TriangleAlert } from "lucide-react"
 import React from "react"
 import JsonView from "react18-json-view"
-import type {
-  DSLRunArgs,
-  RunActionInput,
-  WorkflowExecutionEvent,
-} from "@/client"
-
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion"
+import { CodeBlock } from "@/components/code-block"
+import { ExternalObjectResult } from "@/components/executions/external-object-result"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
+import { isExternalStoredObject } from "@/lib/stored-object"
 
 import "react18-json-view/src/style.css"
 
-import {
-  InfoIcon,
-  SquareArrowOutUpRightIcon,
-  TriangleAlert,
-} from "lucide-react"
-import Link from "next/link"
-import { useParams } from "next/navigation"
-import { CodeBlock } from "@/components/code-block"
-import { ExternalObjectResult } from "@/components/executions/external-object-result"
-import { GenericWorkflowIcon, getIcon } from "@/components/icons"
-import { Badge } from "@/components/ui/badge"
-import { Label } from "@/components/ui/label"
-import { Switch } from "@/components/ui/switch"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
-import { useWorkspaceMembers } from "@/hooks/use-workspace"
-import {
-  ERROR_EVENT_TYPES,
-  getRelativeTime,
-  isDSLRunArgs,
-  isInteractionInput,
-  isRunActionInput,
-  parseEventType,
-  parseExecutionId,
-} from "@/lib/event-history"
-import { isExternalStoredObject } from "@/lib/stored-object"
-import { cn } from "@/lib/utils"
-import { useWorkspaceId } from "@/providers/workspace-id"
-
-/**
- * Event history for a specific workflow execution
- * @param param0
- * @returns
- */
 export function WorkflowExecutionEventDetailView({
   event,
   executionId,
 }: {
-  event: WorkflowExecutionEvent
+  event: WorkflowExecutionEventCompact
   executionId: string
 }) {
-  const { event_group, result, failure } = event
-  const action_input = event_group?.action_input
+  const hasFailure = Boolean(event.action_error)
+  const hasResult =
+    event.action_result !== null && event.action_result !== undefined
+  const hasInput =
+    event.action_input !== null && event.action_input !== undefined
+  const tabItems: {
+    value: "input" | "result"
+    label: "Input" | "Result"
+    icon: typeof FileInputIcon | typeof ShapesIcon
+  }[] = []
+
+  if (hasInput) {
+    tabItems.push({
+      value: "input",
+      label: "Input",
+      icon: FileInputIcon,
+    })
+  }
+  if (hasResult) {
+    tabItems.push({
+      value: "result",
+      label: "Result",
+      icon: ShapesIcon,
+    })
+  }
+
+  const initialTab = tabItems[0]?.value
+  const [activeTab, setActiveTab] = React.useState<"input" | "result" | null>(
+    initialTab ?? null
+  )
+
+  React.useEffect(() => {
+    setActiveTab(initialTab ?? null)
+  }, [event.source_event_id, initialTab])
+
   return (
-    <div className="size-full overflow-auto">
-      {/* Metadata */}
-      <Accordion
-        type="multiple"
-        defaultValue={["general", "execution-context", "failure", "result"]}
-      >
-        {/* General */}
-        <AccordionItem value="general">
-          <AccordionTrigger className="px-4 text-xs font-bold">
-            <div className="flex items-center">
-              <InfoIcon
-                className="mr-2 size-5 fill-sky-500 stroke-white"
+    <div className="size-full overflow-hidden">
+      <div className="flex h-full flex-col">
+        {hasFailure && (
+          <div className="border-b">
+            <div className="flex h-8 items-center border-b px-3 text-[11px] font-semibold text-muted-foreground">
+              <TriangleAlert
+                className="mr-2 size-4 fill-rose-500 stroke-white"
                 strokeWidth={2}
               />
-              <span>Event Information</span>
+              <span>Event failure</span>
             </div>
-          </AccordionTrigger>
-          <AccordionContent className="space-y-4">
-            <EventGeneralInfo event={event} />
-          </AccordionContent>
-        </AccordionItem>
-
-        {/* Urgent */}
-        {failure && (
-          <AccordionItem value="failure">
-            <AccordionTrigger className="px-4 text-xs font-bold">
-              <div className="flex items-end">
-                <TriangleAlert
-                  className="mr-2 size-5 fill-rose-500 stroke-white"
-                  strokeWidth={2}
-                />
-                <span>Event Failure</span>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="my-4 flex flex-col space-y-8 px-4">
-                <CodeBlock title="Message">{failure.message}</CodeBlock>
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {/* Action details */}
-        {result !== null && result !== undefined && (
-          <AccordionItem value="result">
-            <AccordionTrigger className="px-4 text-xs font-bold">
-              <div className="flex items-end">
-                <span>Event Result</span>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="my-4 flex flex-col space-y-8 px-4">
-                {isExternalStoredObject(result) ? (
-                  <ExternalObjectResult
-                    executionId={executionId}
-                    eventId={event.event_id}
-                    external={result}
-                  />
-                ) : (
-                  <JsonViewWithControls src={result} />
-                )}
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {isDSLRunArgs(action_input) && (
-          <AccordionItem value="result">
-            <AccordionTrigger className="px-4 text-xs font-bold">
-              <div className="flex items-end">
-                <span>Child Workflow Input</span>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="my-4 flex flex-col space-y-8 px-4">
-                <JsonViewWithControls src={action_input} />
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {isRunActionInput(action_input) && (
-          <AccordionItem value="result">
-            <AccordionTrigger className="px-4 text-xs font-bold">
-              <div className="flex items-end">
-                <span>Action Input</span>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="my-4 flex flex-col space-y-8 px-4">
-                <JsonViewWithControls src={action_input} />
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-
-        {isInteractionInput(action_input) && (
-          <AccordionItem value="result">
-            <AccordionTrigger className="px-4 text-xs font-bold">
-              <div className="flex items-end">
-                <span>Received Input</span>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <div className="my-4 flex flex-col space-y-8 px-4">
-                <JsonViewWithControls src={action_input} />
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        )}
-      </Accordion>
-    </div>
-  )
-}
-
-export function EventGeneralInfo({ event }: { event: WorkflowExecutionEvent }) {
-  const {
-    event_group,
-    role,
-    event_type,
-    event_id,
-    parent_wf_exec_id,
-    workflow_timeout,
-  } = event
-  const {
-    udf_key,
-    action_title,
-    action_description,
-    retry_policy: action_retry_policy,
-    action_input,
-    join_strategy,
-    start_delay,
-    related_wf_exec_id,
-  } = event_group || {}
-  const formattedEventType = parseEventType(event_type)
-  const eventTimeDate = new Date(event.event_time)
-  const { max_attempts, timeout } = action_retry_policy || {}
-
-  const workspaceId = useWorkspaceId()
-  const { members } = useWorkspaceMembers(workspaceId)
-
-  const triggeredBy = React.useMemo(() => {
-    if (!role) {
-      return undefined
-    }
-
-    if (role.type === "user") {
-      const matchedMember = members?.find(
-        (member) => member.user_id === role.user_id
-      )
-
-      if (matchedMember?.email) {
-        return { text: matchedMember.email }
-      }
-
-      if (role.user_id) {
-        return { text: role.user_id }
-      }
-
-      return { text: "User" }
-    }
-
-    if (role.type === "service") {
-      return { text: role.service_id ?? "Service" }
-    }
-
-    return undefined
-  }, [members, role])
-
-  // Construct the link within the same workspace to the related workflow execution
-  const params = useParams()
-  const workspaceIdForLinks = params?.workspaceId ?? workspaceId
-  let relatedWorkflowExecutionLink: string | undefined
-  if (related_wf_exec_id) {
-    const [relatedWorkflowId, relatedExecutionId] =
-      parseExecutionId(related_wf_exec_id)
-
-    relatedWorkflowExecutionLink = `/workspaces/${workspaceIdForLinks}/workflows/${relatedWorkflowId}/executions/${relatedExecutionId}`
-  }
-
-  let parentWorkflowExecutionLink: string | undefined
-  if (parent_wf_exec_id) {
-    const [parentWorkflowId, parentExecutionId] =
-      parseExecutionId(parent_wf_exec_id)
-    parentWorkflowExecutionLink = `/workspaces/${workspaceIdForLinks}/workflows/${parentWorkflowId}/executions/${parentExecutionId}`
-  }
-
-  return (
-    <div className="my-4 flex flex-col space-y-2 px-4">
-      <div className="flex w-full items-center space-x-4">
-        {udf_key ? (
-          getIcon(udf_key, {
-            className: "size-10 p-2",
-            flairsize: "md",
-          })
-        ) : (
-          <GenericWorkflowIcon className="size-10 p-2" />
-        )}
-        <div className="flex w-full flex-1 justify-between space-x-12">
-          <div className="flex flex-col">
-            <div className="text-md flex w-full items-center justify-between font-medium leading-none">
-              <div className="flex w-full">
-                {action_title || formattedEventType}
-              </div>
+            <div className="p-3">
+              <CodeBlock title="Message">
+                <span className="text-xs">
+                  {event.action_error?.message ?? "No error message"}
+                </span>
+              </CodeBlock>
             </div>
           </div>
-        </div>
-      </div>
-      <div className="space-x-2">
-        <Label className="text-xs text-muted-foreground">Event Type</Label>
-        <DescriptorBadge
-          text={formattedEventType}
-          className={cn(
-            "bg-gray-100/80",
-            ERROR_EVENT_TYPES.includes(event_type) && "bg-rose-200",
-            event_type == "WORKFLOW_EXECUTION_STARTED" && "bg-sky-200/70",
-            event_type == "WORKFLOW_EXECUTION_COMPLETED" && "bg-emerald-200/70",
-            event_type == "ACTIVITY_TASK_SCHEDULED" && "bg-amber-200/70",
-            event_type == "ACTIVITY_TASK_STARTED" && "bg-sky-200/70",
-            event_type == "ACTIVITY_TASK_COMPLETED" && "bg-emerald-200/70",
-            event_type == "START_CHILD_WORKFLOW_EXECUTION_INITIATED" &&
-              "bg-amber-200/70",
-            event_type == "CHILD_WORKFLOW_EXECUTION_STARTED" &&
-              "bg-amber-200/70",
-            event_type == "CHILD_WORKFLOW_EXECUTION_COMPLETED" &&
-              "bg-emerald-200/70",
-            event_type == "CHILD_WORKFLOW_EXECUTION_FAILED" && "bg-rose-200"
-          )}
-        />
-        {event_type.includes("CHILD_WORKFLOW_EXECUTION") &&
-          related_wf_exec_id &&
-          relatedWorkflowExecutionLink && (
-            <Tooltip>
-              <TooltipTrigger>
-                <Badge variant="outline">
-                  <Link href={relatedWorkflowExecutionLink}>
-                    <div className="flex items-center gap-1">
-                      <span className="font-normal">Go to workflow run</span>
-                      <SquareArrowOutUpRightIcon className="size-3" />
-                    </div>
-                  </Link>
-                </Badge>
-              </TooltipTrigger>
-              <TooltipContent>
-                <span>{related_wf_exec_id}</span>
-              </TooltipContent>
-            </Tooltip>
-          )}
-        {event_type == "WORKFLOW_EXECUTION_STARTED" &&
-          parent_wf_exec_id &&
-          parentWorkflowExecutionLink && (
-            <Tooltip>
-              <TooltipTrigger>
-                <Badge variant="outline">
-                  <Link href={parentWorkflowExecutionLink}>
-                    <div className="flex items-center gap-1">
-                      <span className="font-normal">
-                        Go to parent workflow run
-                      </span>
-                      <SquareArrowOutUpRightIcon className="size-3" />
-                    </div>
-                  </Link>
-                </Badge>
-              </TooltipTrigger>
-              <TooltipContent>
-                <span>{parent_wf_exec_id}</span>
-              </TooltipContent>
-            </Tooltip>
-          )}
-      </div>
-      <div className="space-x-2">
-        <Label className="w-24 text-xs text-muted-foreground">Event ID</Label>
-        <DescriptorBadge text={event_id.toString()} />
-      </div>
-      <div className="space-x-2">
-        <Label className="w-24 text-xs text-muted-foreground">Event Time</Label>
-        <DescriptorBadge
-          text={
-            eventTimeDate.toLocaleString() +
-            " (" +
-            getRelativeTime(eventTimeDate) +
-            ")"
-          }
-        />
-      </div>
-      {triggeredBy && (
-        <div className="space-x-2">
-          <Label className="w-24 text-xs text-muted-foreground">
-            Triggered By
-          </Label>
-          <DescriptorBadge text={triggeredBy.text} />
-        </div>
-      )}
-      {event_type == "WORKFLOW_EXECUTION_STARTED" && workflow_timeout && (
-        <div className="space-x-2">
-          <Label className="w-24 text-xs text-muted-foreground">
-            Workflow Timeout
-          </Label>
-          <DescriptorBadge text={`${workflow_timeout}s`} />
-        </div>
-      )}
-
-      {/* Action event group fields */}
-      <div className="space-x-2">
-        {udf_key && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">
-              Action Type
-            </Label>
-            <DescriptorBadge
-              text={udf_key}
-              className="font-mono font-semibold tracking-tight"
-            />
-          </>
         )}
-      </div>
-      <div className="space-x-2">
-        {udf_key && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">
-              Description
-            </Label>
-            <DescriptorBadge
-              text={action_description || "No description"}
-              className="font-semibold"
-            />
-          </>
-        )}
-      </div>
 
-      {/* Action Retry policy */}
-      {action_retry_policy && (
-        <div className="space-x-2">
-          <Label className="w-24 text-xs text-muted-foreground">
-            Retry Policy
-          </Label>
-          <DescriptorBadge
-            className="font-mono"
-            text={`${max_attempts && max_attempts > 0 ? `Max ${max_attempts} attempt(s)` : "Unlimited attempts"}${timeout ? `, ${timeout}s timeout` : ""}`}
-          />
-        </div>
-      )}
-
-      {/* Start delay */}
-      {start_delay !== undefined && start_delay > 0 && (
-        <div className="space-x-2">
-          <Label className="w-24 text-xs text-muted-foreground">
-            Start Delay
-          </Label>
-          <DescriptorBadge
-            className="font-mono"
-            text={`${start_delay.toFixed(1)}s`}
-          />
-        </div>
-      )}
-
-      {/* Join policy */}
-      {join_strategy && (
-        <div className="space-x-2">
-          <Label className="w-24 text-xs text-muted-foreground">
-            Join Strategy
-          </Label>
-          <DescriptorBadge className="font-mono" text={join_strategy} />
-        </div>
-      )}
-      {isRunActionInput(action_input) && (
-        <ActionEventGeneralInfo input={action_input} />
-      )}
-      {isDSLRunArgs(action_input) && (
-        <ChildWorkflowEventGeneralInfo input={action_input} />
-      )}
-    </div>
-  )
-}
-
-export function DescriptorBadge({
-  text,
-  className,
-}: { text: string } & React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <Badge
-      variant="secondary"
-      className={cn("bg-muted-foreground/5 text-foreground/60", className)}
-    >
-      {text}
-    </Badge>
-  )
-}
-function ChildWorkflowEventGeneralInfo({ input }: { input: DSLRunArgs }) {
-  return (
-    <div className="space-x-2">
-      <Label className="w-24 text-xs text-muted-foreground">
-        Workflow Title
-      </Label>
-      <DescriptorBadge
-        text={input.dsl?.title || "No title"}
-        className="font-mono font-semibold"
-      />
-    </div>
-  )
-}
-
-function ActionEventGeneralInfo({
-  input: {
-    task: { depends_on, run_if, for_each },
-  },
-}: {
-  input: RunActionInput
-}) {
-  return (
-    <div>
-      <div className="space-x-2">
-        {depends_on && depends_on.length > 0 && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">
-              Dependencies ({depends_on.length})
-            </Label>
-            {depends_on.map((dep) => (
-              <DescriptorBadge
-                key={dep}
-                text={dep}
-                className="font-mono font-semibold"
-              />
-            ))}
-          </>
-        )}
-      </div>
-      <div className="space-x-2">
-        {run_if && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">Run If</Label>
-            <DescriptorBadge
-              text={run_if}
-              className="font-mono font-semibold tracking-tight"
-            />
-          </>
-        )}
-      </div>
-      <div className="space-x-2">
-        {for_each && (
-          <>
-            <Label className="w-24 text-xs text-muted-foreground">
-              For Each
-            </Label>
-            {(Array.isArray(for_each) ? for_each : [for_each ?? []]).map(
-              (dep, index) => (
-                <DescriptorBadge
-                  key={`${dep}-${index}`}
-                  text={dep}
-                  className="font-mono font-semibold"
-                />
-              )
+        {tabItems.length > 0 && activeTab ? (
+          <Tabs
+            value={activeTab}
+            onValueChange={(value: string) => {
+              setActiveTab(value as "input" | "result")
+            }}
+            className="flex min-h-0 flex-1 flex-col"
+          >
+            <div className="sticky top-0 z-10 border-b bg-background">
+              <TabsList className="inline-flex h-8 items-center justify-start bg-transparent px-0 py-0">
+                {tabItems.map((tab) => (
+                  <TabsTrigger
+                    key={tab.value}
+                    value={tab.value}
+                    className="flex h-full min-w-20 items-center justify-start rounded-none px-3 py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  >
+                    <tab.icon className="mr-2 size-4" />
+                    <span>{tab.label}</span>
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
+            {hasInput && (
+              <TabsContent value="input" className="m-0 flex-1 overflow-auto">
+                <JsonViewContent src={event.action_input} />
+              </TabsContent>
             )}
-          </>
+            {hasResult && (
+              <TabsContent value="result" className="m-0 flex-1 overflow-auto">
+                {isExternalStoredObject(event.action_result) ? (
+                  <ExternalObjectResult
+                    executionId={executionId}
+                    eventId={event.source_event_id}
+                    external={event.action_result}
+                  />
+                ) : (
+                  <JsonViewContent src={event.action_result} />
+                )}
+              </TabsContent>
+            )}
+          </Tabs>
+        ) : !hasFailure ? (
+          <div className="px-4 py-6 text-sm text-muted-foreground">
+            No input or result is available for this event.
+          </div>
+        ) : (
+          <div className="px-4 py-4 text-sm text-muted-foreground">
+            No input or result is available for this event.
+          </div>
         )}
       </div>
     </div>
   )
 }
 
-function JsonViewWithControls({
-  src,
-  title = "JSON",
-}: {
-  src: unknown
-  title?: string
-}): JSX.Element {
-  const [isExpanded, setIsExpanded] = React.useState(false)
+function JsonViewContent({ src }: { src: unknown }): JSX.Element {
   return (
-    <div className="space-y-2">
-      <div className="flex w-full items-center gap-4">
-        <span className="text-xs font-semibold text-foreground/50">
-          {title}
-        </span>
-        <div className="flex items-center gap-2">
-          <Switch
-            checked={isExpanded}
-            onCheckedChange={setIsExpanded}
-            className="data-[state=checked]:bg-muted-foreground"
-          />
-          <p className="text-xs text-foreground/70">
-            {isExpanded ? "Collapse" : "Expand"}
-          </p>
-        </div>
-      </div>
-      <div className="rounded-md border bg-muted-foreground/5 p-4">
-        <JsonView
-          collapsed={!isExpanded}
-          displaySize
-          enableClipboard
-          src={src}
-          className="break-all text-xs"
-          theme="atom"
-        />
-      </div>
+    <div className="border-b bg-muted-foreground/5 p-3">
+      <JsonView
+        collapsed={false}
+        displaySize
+        enableClipboard
+        src={src}
+        className="break-all text-xs"
+        theme="atom"
+      />
     </div>
   )
 }

--- a/frontend/src/components/executions/event-history.tsx
+++ b/frontend/src/components/executions/event-history.tsx
@@ -2,41 +2,38 @@
 
 import {
   AlarmClockOffIcon,
-  BookCheckIcon,
-  CalendarCheckIcon,
-  CircleArrowRightIcon,
   CircleCheck,
-  CircleDotIcon,
   CircleMinusIcon,
-  CircleXIcon,
-  PlayIcon,
-  WorkflowIcon,
+  CircleX,
+  GitForkIcon,
 } from "lucide-react"
-import type React from "react"
-import type { WorkflowEventType, WorkflowExecutionEvent } from "@/client"
-import { CenteredSpinner } from "@/components/loading/spinner"
+import type { WorkflowExecutionEventStatus } from "@/client"
+import {
+  WorkflowEventsList,
+  type WorkflowEventsListRow,
+} from "@/components/events/workflow-events-list"
+import { CenteredSpinner, Spinner } from "@/components/loading/spinner"
 import NoContent from "@/components/no-content"
 import { AlertNotification } from "@/components/notifications"
-import { Badge } from "@/components/ui/badge"
-import { Button, buttonVariants } from "@/components/ui/button"
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
-import { useWorkflowExecution } from "@/lib/hooks"
-import { cn, undoSlugify } from "@/lib/utils"
+  groupEventsByActionRef,
+  executionId as parseWorkflowExecutionId,
+  refToLabel,
+  type WorkflowExecutionEventCompact,
+} from "@/lib/event-history"
+import { useCompactWorkflowExecution } from "@/lib/hooks"
+import { cn } from "@/lib/utils"
+import { useWorkspaceId } from "@/providers/workspace-id"
 
 import "react18-json-view/src/style.css"
 
-import { ERROR_EVENT_TYPES, parseEventType } from "@/lib/event-history"
-
-const REFETCH_INTERVAL = 2000 // 2 seconds
+const INTERMEDIATE_EVENT_STATUSES = new Set<WorkflowExecutionEventStatus>([
+  "SCHEDULED",
+  "STARTED",
+])
 
 /**
- * Event history for a specific workflow execution
- * @param param0
- * @returns
+ * Events for a specific workflow execution
  */
 export function WorkflowExecutionEventHistory({
   executionId,
@@ -44,13 +41,13 @@ export function WorkflowExecutionEventHistory({
   setSelectedEvent,
 }: {
   executionId: string
-  selectedEvent?: WorkflowExecutionEvent
-  setSelectedEvent: (event: WorkflowExecutionEvent) => void
+  selectedEvent?: WorkflowExecutionEventCompact
+  setSelectedEvent: (event: WorkflowExecutionEventCompact) => void
 }) {
+  const workspaceId = useWorkspaceId()
+  const decodedExecutionId = decodeURIComponent(executionId)
   const { execution, executionIsLoading, executionError } =
-    useWorkflowExecution(executionId, {
-      refetchInterval: REFETCH_INTERVAL,
-    })
+    useCompactWorkflowExecution(decodedExecutionId)
 
   if (executionIsLoading) {
     return <CenteredSpinner />
@@ -59,208 +56,198 @@ export function WorkflowExecutionEventHistory({
     return <AlertNotification message={executionError.message} />
   }
   if (!execution) {
-    return <NoContent message="No event history found." />
+    return <NoContent message="No events found." />
   }
-  return (
-    <div className="group flex flex-col gap-4 py-2">
-      <nav className="grid gap-1 px-2">
-        {execution.events.map((event, index) => (
-          <Button
-            key={index}
-            className={cn(
-              buttonVariants({ variant: "default", size: "sm" }),
-              "justify-start space-x-1 bg-background text-muted-foreground shadow-none hover:cursor-default hover:bg-gray-100",
-              event.event_id === selectedEvent?.event_id && "bg-gray-200",
-              ERROR_EVENT_TYPES.includes(event.event_type) &&
-                "bg-red-100 hover:bg-red-200"
-            )}
-            onClick={() => {
-              setSelectedEvent(event)
-            }}
-          >
-            <div className="flex items-center justify-items-start">
-              <div className="flex w-10">
-                <Badge
-                  variant="secondary"
-                  className="max-w-10 flex-none rounded-md bg-indigo-50 p-1 text-xs font-light text-muted-foreground"
-                >
-                  {event.event_id}
-                </Badge>
-              </div>
-              <EventHistoryItemIcon
-                eventType={event.event_type}
-                className="size-4 w-8 flex-none"
-              />
 
-              <span className="text-xs text-muted-foreground">
-                <EventDescriptor event={event} />
-              </span>
-            </div>
-          </Button>
-        ))}
-      </nav>
+  const terminalEvents = execution.events.filter(
+    (event) => !INTERMEDIATE_EVENT_STATUSES.has(event.status)
+  )
+
+  const eventRows = Object.entries(groupEventsByActionRef(terminalEvents))
+    .map(([actionRef, relatedEvents]) => {
+      const aggregateStatus = getAggregateStatus(relatedEvents)
+      const latestEvent = getLatestEvent(relatedEvents)
+      const latestEventTime = latestEvent
+        ? new Date(
+            latestEvent.close_time ||
+              latestEvent.start_time ||
+              latestEvent.schedule_time
+          ).toLocaleTimeString()
+        : "-"
+      const childWorkflowRunLink = getChildWorkflowRunLink(
+        relatedEvents,
+        workspaceId
+      )
+
+      return {
+        actionRef,
+        relatedEvents,
+        aggregateStatus,
+        latestEvent,
+        latestEventTime,
+        childWorkflowRunLink,
+      }
+    })
+    .sort((a, b) => {
+      if (!a.latestEvent || !b.latestEvent) {
+        return 0
+      }
+      return getEventTimestamp(a.latestEvent) - getEventTimestamp(b.latestEvent)
+    })
+
+  if (eventRows.length === 0) {
+    return (
+      <div className="flex h-16 items-center justify-center text-center text-xs text-muted-foreground">
+        {execution.status === "RUNNING" ? (
+          <div className="flex items-center justify-center gap-2">
+            <Spinner className="size-3" />
+            <span>Waiting for events...</span>
+          </div>
+        ) : (
+          <span>No events</span>
+        )}
+      </div>
+    )
+  }
+
+  const rows: WorkflowEventsListRow[] = eventRows.map(
+    ({
+      actionRef,
+      relatedEvents,
+      aggregateStatus,
+      latestEvent,
+      latestEventTime,
+      childWorkflowRunLink,
+    }) => ({
+      key: actionRef,
+      label: refToLabel(actionRef),
+      time: latestEventTime,
+      icon: <WorkflowEventStatusIcon status={aggregateStatus} />,
+      selected: selectedEvent?.action_ref === actionRef,
+      count: relatedEvents.length,
+      subflowLink: childWorkflowRunLink,
+      onSelect: latestEvent ? () => setSelectedEvent(latestEvent) : undefined,
+    })
+  )
+
+  return (
+    <div className="group h-full">
+      <WorkflowEventsList rows={rows} />
     </div>
   )
 }
 
-export function EventDescriptor({
-  event,
-}: {
-  event: WorkflowExecutionEvent
-}): React.ReactNode {
-  if (event.event_type.startsWith("ACTIVITY_TASK")) {
-    return (
-      <span className="flex items-center space-x-2 text-xs">
-        <span>{event.event_group?.action_title ?? "Unnamed action"}</span>
-      </span>
-    )
-  }
-  if (event.event_type.includes("CHILD_WORKFLOW_EXECUTION")) {
-    return (
-      <span className="flex items-center space-x-2 text-xs">
-        <span>{event.event_group?.action_title ?? "Unnamed action"}</span>
-      </span>
-    )
-  }
-  return <span className="capitalize">{parseEventType(event.event_type)}</span>
-}
-export function EventHistoryItemIcon({
-  eventType,
-  className,
-}: {
-  eventType: WorkflowEventType
-} & React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        {getEventHistoryIcon(eventType, className)}
-      </TooltipTrigger>
-      <TooltipContent side="top" className="flex items-center gap-4  shadow-lg">
-        <span>{undoSlugify(eventType.toLowerCase())}</span>
-      </TooltipContent>
-    </Tooltip>
-  )
+function getAggregateStatus(
+  relatedEvents: WorkflowExecutionEventCompact[]
+): WorkflowExecutionEventStatus {
+  const statuses = relatedEvents.map((event) => event.status)
+
+  if (statuses.some((status) => status === "FAILED")) return "FAILED"
+  if (statuses.some((status) => status === "TIMED_OUT")) return "TIMED_OUT"
+  if (statuses.some((status) => status === "CANCELED")) return "CANCELED"
+  if (statuses.some((status) => status === "TERMINATED")) return "TERMINATED"
+  if (statuses.some((status) => status === "STARTED")) return "STARTED"
+  if (statuses.some((status) => status === "SCHEDULED")) return "SCHEDULED"
+  if (statuses.every((status) => status === "COMPLETED")) return "COMPLETED"
+  if (statuses.some((status) => status === "DETACHED")) return "DETACHED"
+
+  return "UNKNOWN"
 }
 
-function getEventHistoryIcon(eventType: WorkflowEventType, className?: string) {
-  switch (eventType) {
-    /* === Workflow Execution Events === */
-    case "WORKFLOW_EXECUTION_STARTED":
+function getEventTimestamp(event: WorkflowExecutionEventCompact): number {
+  const eventTime = event.close_time || event.start_time || event.schedule_time
+  return new Date(eventTime).getTime()
+}
+
+function getLatestEvent(
+  relatedEvents: WorkflowExecutionEventCompact[]
+): WorkflowExecutionEventCompact | undefined {
+  return [...relatedEvents].sort(
+    (a, b) => getEventTimestamp(b) - getEventTimestamp(a)
+  )[0]
+}
+
+function getChildWorkflowRunLink(
+  relatedEvents: WorkflowExecutionEventCompact[],
+  workspaceId: string
+): string | undefined {
+  const eventWithChildRun = [...relatedEvents]
+    .filter((event) => Boolean(event.child_wf_exec_id))
+    .sort((a, b) => getEventTimestamp(b) - getEventTimestamp(a))[0]
+
+  if (!eventWithChildRun?.child_wf_exec_id) {
+    return undefined
+  }
+
+  try {
+    const childExecution = parseWorkflowExecutionId(
+      eventWithChildRun.child_wf_exec_id
+    )
+    return `/workspaces/${workspaceId}/workflows/${childExecution.wf}/executions/${childExecution.exec}`
+  } catch {
+    return undefined
+  }
+}
+
+function WorkflowEventStatusIcon({
+  status,
+  className = "size-5",
+}: {
+  status: WorkflowExecutionEventStatus
+  className?: string
+}) {
+  return getWorkflowEventIcon(status, className)
+}
+
+function getWorkflowEventIcon(
+  status: WorkflowExecutionEventStatus,
+  className?: string
+) {
+  switch (status) {
+    case "SCHEDULED":
+      return <Spinner className={cn("!size-3", className)} />
+    case "STARTED":
+      return <Spinner className={className} />
+    case "COMPLETED":
       return (
-        <WorkflowIcon
-          className={cn("fill-white stroke-sky-500/80", className)}
+        <CircleCheck
+          className={cn(
+            "border-none border-emerald-500 fill-emerald-500 stroke-white",
+            className
+          )}
         />
       )
-    case "WORKFLOW_EXECUTION_COMPLETED":
-      return (
-        <WorkflowIcon
-          className={cn("fill-white stroke-emerald-500", className)}
-        />
-      )
-    case "WORKFLOW_EXECUTION_FAILED":
-      return (
-        <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
-      )
-    case "WORKFLOW_EXECUTION_CANCELED":
+    case "FAILED":
+      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
+    case "CANCELED":
       return (
         <CircleMinusIcon
           className={cn("fill-orange-500 stroke-white", className)}
         />
       )
-    case "WORKFLOW_EXECUTION_TERMINATED":
+    case "TERMINATED":
       return (
         <CircleMinusIcon
           className={cn("fill-rose-500 stroke-white", className)}
         />
       )
-    case "WORKFLOW_EXECUTION_CONTINUED_AS_NEW":
-      return (
-        <CircleArrowRightIcon
-          className={cn("fill-sky-500/80 stroke-white", className)}
-        />
-      )
-    case "WORKFLOW_EXECUTION_TIMED_OUT":
+    case "TIMED_OUT":
       return (
         <AlarmClockOffIcon
-          className={cn("stroke-rose-500", className)}
+          className={cn("!size-3 stroke-rose-500", className)}
           strokeWidth={2.5}
         />
       )
-    /* === Child Workflow Execution Events === */
-    case "START_CHILD_WORKFLOW_EXECUTION_INITIATED":
+    case "DETACHED":
       return (
-        <WorkflowIcon
-          className={cn("fill-orange-200/50 stroke-orange-500/70", className)}
-        />
-      )
-    case "CHILD_WORKFLOW_EXECUTION_STARTED":
-      return (
-        <WorkflowIcon
-          className={cn("fill-orange-200/50 stroke-orange-500/70", className)}
-        />
-      )
-    case "CHILD_WORKFLOW_EXECUTION_COMPLETED":
-      return (
-        <CircleCheck
-          className={cn("fill-emerald-500 stroke-white", className)}
-        />
-      )
-    case "CHILD_WORKFLOW_EXECUTION_FAILED":
-      return (
-        <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
-      )
-    /* === Activity Task Events === */
-    case "ACTIVITY_TASK_SCHEDULED":
-      return (
-        <CalendarCheckIcon
-          className={cn("fill-orange-200/50 stroke-orange-500/70", className)}
-        />
-      )
-    case "ACTIVITY_TASK_STARTED":
-      return (
-        <PlayIcon className={cn("fill-white stroke-sky-500/80", className)} />
-      )
-    case "ACTIVITY_TASK_COMPLETED":
-      return (
-        <CircleCheck
-          className={cn("fill-emerald-500 stroke-white", className)}
-        />
-      )
-    case "ACTIVITY_TASK_FAILED":
-      return (
-        <CircleXIcon className={cn("fill-rose-500 stroke-white", className)} />
-      )
-    case "ACTIVITY_TASK_TIMED_OUT":
-      return (
-        <AlarmClockOffIcon
-          className={cn("stroke-orange-500", className)}
+        <GitForkIcon
+          className={cn("!size-3 stroke-emerald-500", className)}
           strokeWidth={2.5}
         />
       )
-    case "WORKFLOW_EXECUTION_UPDATE_ACCEPTED":
-      return (
-        <BookCheckIcon
-          className={cn("fill-indigo-500/20 stroke-indigo-500/50", className)}
-        />
-      )
-    case "WORKFLOW_EXECUTION_UPDATE_REJECTED":
-      return (
-        <CircleXIcon
-          className={cn("fill-indigo-500/50 stroke-white", className)}
-        />
-      )
-    case "WORKFLOW_EXECUTION_UPDATE_COMPLETED":
-      return (
-        <CircleCheck
-          className={cn("fill-emerald-500/50 stroke-white", className)}
-        />
-      )
-
+    case "UNKNOWN":
+      return <CircleX className={cn("fill-rose-500 stroke-white", className)} />
     default:
-      return (
-        <CircleDotIcon
-          className={cn("fill-indigo-500/50 stroke-white", className)}
-        />
-      )
+      throw new Error("Invalid status")
   }
 }

--- a/frontend/src/components/executions/nav.tsx
+++ b/frontend/src/components/executions/nav.tsx
@@ -92,8 +92,8 @@ export function WorkflowExecutionNav({
   }
 
   return (
-    <div className="group flex flex-col gap-4 py-2">
-      <nav className="grid gap-1 px-2">
+    <div className="group flex h-full flex-col">
+      <nav className="grid">
         {workflowExecutions.map((execution, index) => {
           const executionId = parseExecutionId(execution.id)[1]
           return (
@@ -102,8 +102,9 @@ export function WorkflowExecutionNav({
                 href={`${baseUrl}/executions/${executionId}`}
                 className={cn(
                   buttonVariants({ variant: "default", size: "sm" }),
-                  "justify-start bg-background text-muted-foreground shadow-none hover:cursor-default hover:bg-gray-100",
-                  executionId === currExecutionIdDecoded && "bg-gray-200"
+                  "h-11 justify-start rounded-none bg-background px-3 text-muted-foreground shadow-none hover:cursor-default hover:bg-muted/50",
+                  executionId === currExecutionIdDecoded &&
+                    "bg-muted-foreground/10"
                 )}
               >
                 <div className="flex items-center">
@@ -141,7 +142,7 @@ export function WorkflowExecutionNav({
                             side="left"
                             className="flex items-center gap-4  shadow-lg"
                           >
-                            <span>Terminate Run</span>
+                            <span>Terminate run</span>
                           </TooltipContent>
                         </Tooltip>
                       ) : (
@@ -161,19 +162,19 @@ export function WorkflowExecutionNav({
                 <div className="flex flex-col items-start justify-between space-y-2 text-start text-xs">
                   <div className="flex flex-col">
                     <Label className="text-xs text-muted-foreground">
-                      Execution ID
+                      Execution id
                     </Label>
                     <span>{executionId}</span>
                   </div>
                   <div className="flex flex-col">
                     <Label className="text-xs text-muted-foreground">
-                      Run ID
+                      Run id
                     </Label>
                     <span>{execution.run_id}</span>
                   </div>
                   <div className="flex flex-col">
                     <Label className="text-xs text-muted-foreground">
-                      Start Time
+                      Start time
                     </Label>
                     <span>
                       {new Date(execution.start_time).toLocaleString()}
@@ -181,7 +182,7 @@ export function WorkflowExecutionNav({
                   </div>
                   <div className="flex flex-col">
                     <Label className="text-xs text-muted-foreground">
-                      End Time
+                      End time
                     </Label>
                     <span>
                       {execution.close_time

--- a/frontend/src/components/executions/section.tsx
+++ b/frontend/src/components/executions/section.tsx
@@ -8,7 +8,7 @@ export function SectionHead({
   text: string
 }) {
   return (
-    <div className="flex w-full justify-start p-2 text-center text-xs font-semibold">
+    <div className="flex h-[33px] w-full items-center justify-start gap-2 border-b px-3 text-left text-xs font-semibold">
       {icon}
       <span>{text}</span>
     </div>

--- a/frontend/src/components/ui/kbd.tsx
+++ b/frontend/src/components/ui/kbd.tsx
@@ -1,0 +1,15 @@
+import type * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex h-5 min-w-5 items-center justify-center rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/lib/event-history.ts
+++ b/frontend/src/lib/event-history.ts
@@ -18,6 +18,8 @@ export type WorkflowExecutionReadCompact =
 // Safe because refs are slugified. Use `workflow` to namespace from regular action refs.
 export const WF_FAILURE_EVENT_REF = "__workflow_failure__"
 export const WF_FAILURE_EVENT_LABEL = "Workflow Failure"
+export const WF_COMPLETED_EVENT_REF = "__workflow_completed__"
+export const WF_COMPLETED_EVENT_LABEL = "Workflow result"
 
 export const ERROR_EVENT_TYPES: WorkflowEventType[] = [
   "WORKFLOW_EXECUTION_FAILED",
@@ -217,6 +219,9 @@ export function isAgentOutput(
 export function refToLabel(actionRef: string) {
   if (actionRef === WF_FAILURE_EVENT_REF) {
     return WF_FAILURE_EVENT_LABEL
+  }
+  if (actionRef === WF_COMPLETED_EVENT_REF) {
+    return WF_COMPLETED_EVENT_LABEL
   }
   return undoSlugify(actionRef, ACTION_REF_DELIMITER)
 }

--- a/frontend/tests/event-history.test.ts
+++ b/frontend/tests/event-history.test.ts
@@ -1,5 +1,6 @@
 import {
   groupEventsByActionRef,
+  WF_COMPLETED_EVENT_REF,
   WF_FAILURE_EVENT_REF,
   type WorkflowExecutionEventCompact,
 } from "@/lib/event-history"
@@ -8,6 +9,12 @@ describe("event-history", () => {
   describe("WF_FAILURE_EVENT_REF", () => {
     it("should export the correct sentinel value", () => {
       expect(WF_FAILURE_EVENT_REF).toBe("__workflow_failure__")
+    })
+  })
+
+  describe("WF_COMPLETED_EVENT_REF", () => {
+    it("should export the correct sentinel value", () => {
+      expect(WF_COMPLETED_EVENT_REF).toBe("__workflow_completed__")
     })
   })
 

--- a/frontend/tests/events-workflow.test.tsx
+++ b/frontend/tests/events-workflow.test.tsx
@@ -4,7 +4,7 @@
 
 import { render } from "@testing-library/react"
 import type { WorkflowExecutionEventStatus } from "@/client"
-import { getWorkflowEventIcon } from "@/components/builder/events/events-workflow"
+import { getWorkflowEventIcon } from "@/components/events/workflow-event-status"
 
 // Mock the Lucide React icons
 jest.mock("lucide-react", () => ({

--- a/tracecat/workflow/executions/constants.py
+++ b/tracecat/workflow/executions/constants.py
@@ -1,2 +1,5 @@
 WF_FAILURE_REF = "__workflow_failure__"
 """Sentinel constant for workflow-level failures in compact events."""
+
+WF_COMPLETED_REF = "__workflow_completed__"
+"""Sentinel constant for workflow-level completion in compact events."""

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -54,7 +54,7 @@ from tracecat.workflow.executions.common import (
     is_scheduled_event,
     is_start_event,
 )
-from tracecat.workflow.executions.constants import WF_FAILURE_REF
+from tracecat.workflow.executions.constants import WF_COMPLETED_REF, WF_FAILURE_REF
 from tracecat.workflow.executions.enums import (
     ExecutionType,
     TemporalSearchAttr,
@@ -272,6 +272,20 @@ class WorkflowExecutionsService:
                     action_name=WF_FAILURE_REF,
                     action_ref=WF_FAILURE_REF,
                     action_error=failure,
+                )
+                continue
+            # ── synthetic compact event for top-level workflow completion ──
+            elif event.event_type is EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
+                id2event[event.event_id] = WorkflowExecutionEventCompact(
+                    source_event_id=event.event_id,
+                    schedule_time=event.event_time.ToDatetime(datetime.UTC),
+                    start_time=event.event_time.ToDatetime(datetime.UTC),
+                    close_time=event.event_time.ToDatetime(datetime.UTC),
+                    curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
+                    status=WorkflowExecutionEventStatus.COMPLETED,
+                    action_name=WF_COMPLETED_REF,
+                    action_ref=WF_COMPLETED_REF,
+                    action_result=await get_result(event),
                 )
                 continue
             else:


### PR DESCRIPTION
Summary
- remove extra JSON toggle/details and redundant separators across execution events to declutter the UI
- tweak execution tabs/events layout spacing and container height for better alignment and sizing
- consolidate event list/detail styling so spacing, text size, and shared components stay consistent

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamped the workflow run Events view with grouped rows, unified status icons, and faster navigation. Added platform-aware shortcuts and a simpler event details view with input/result tabs and collapsible JSON; completion events now appear as a “Workflow result” with the final output.

- **New Features**
  - Added WorkflowEventsList to render grouped events with status, count, time, actions, and a subflow run link when available.
  - Show a “Workflow result” row for completed runs using a new completion event reference; loads final results (including external objects) alongside action events.
  - Keyboard shortcuts: Cmd/Ctrl+E toggles the Events panel, Cmd/Ctrl+Shift+E toggles the right panel, and double-tap W or R jumps to Workflow or Runs; tooltips use Kbd with platform-aware labels.

- **Refactors**
  - Consolidated status handling into shared utilities (icons and aggregate status) used across builder and execution views.
  - Switched to compact events and grouped terminal states (hides scheduled/started) with improved empty/loading messages; updated headers (“Events”, “Workflow runs”), spacing, and panel sizes.
  - Simplified Event Details: failure message at the top, unified JSON rendering, removed accordions and extra toggles.

<sup>Written for commit 3339111106bb8e35afb8eb28cc214268ab806e31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

