### PR TITLE
fix(invitations): workspace-level privilege

### DIFF
--- a/frontend/src/components/workspaces/add-workspace-member.tsx
+++ b/frontend/src/components/workspaces/add-workspace-member.tsx
@@ -36,6 +36,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useAuth } from "@/hooks/use-auth"
+import { useOrgMembership } from "@/hooks/use-org-membership"
 import {
   useCurrentUserRole,
   useWorkspaceMutations,
@@ -54,6 +55,7 @@ export function AddWorkspaceMember({
 }: { workspace: WorkspaceRead } & React.HTMLAttributes<HTMLButtonElement>) {
   const { user } = useAuth()
   const { role } = useCurrentUserRole(workspace.id)
+  const { canAdministerOrg } = useOrgMembership()
   const { addMember: addWorkspaceMember } = useWorkspaceMutations()
   const [showDialog, setShowDialog] = useState(false)
   const form = useForm<AddUser>({
@@ -112,7 +114,10 @@ export function AddWorkspaceMember({
         <Button
           variant="outline"
           size="sm"
-          disabled={!user?.isPrivileged({ role } as WorkspaceMembershipRead)}
+          disabled={
+            !canAdministerOrg &&
+            !user?.isPrivileged({ role } as WorkspaceMembershipRead)
+          }
           className="h-7 bg-white disabled:cursor-not-allowed"
         >
           <Plus className="mr-1 h-3.5 w-3.5" />

--- a/frontend/src/components/workspaces/workspace-members-table.tsx
+++ b/frontend/src/components/workspaces/workspace-members-table.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
 import { useAuth } from "@/hooks/use-auth"
+import { useOrgMembership } from "@/hooks/use-org-membership"
 import {
   useCurrentUserRole,
   useWorkspaceMembers,
@@ -65,6 +66,7 @@ export function WorkspaceMembersTable({
   const [selectedUser, setSelectedUser] = useState<WorkspaceMember | null>(null)
   const [isChangeRoleOpen, setIsChangeRoleOpen] = useState(false)
   const { role } = useCurrentUserRole(workspace.id)
+  const { canAdministerOrg } = useOrgMembership()
   const { removeMember, updateMember } = useWorkspaceMutations()
   const { members, membersLoading, membersError } = useWorkspaceMembers(
     workspace.id
@@ -208,9 +210,10 @@ export function WorkspaceMembersTable({
                         Copy user ID
                       </DropdownMenuItem>
 
-                      {user?.isPrivileged({
-                        role,
-                      } as WorkspaceMembershipRead) && (
+                      {(canAdministerOrg ||
+                        user?.isPrivileged({
+                          role,
+                        } as WorkspaceMembershipRead)) && (
                         <>
                           <DialogTrigger asChild>
                             <DropdownMenuItem


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes workspace member invites and management permissions so org admins can add and manage members even without workspace-level privileges. Prevents blocked actions in the UI when the user has org admin rights.

- Bug Fixes
  - Use canAdministerOrg OR workspace privilege to enable invite and member actions (AddWorkspaceMember, WorkspaceMembersTable).
  - Updated disabled states and menu visibility to match the new permission checks.

<sup>Written for commit db18ffd5ef1f861bbd0e6ae9108622de90deb6f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

