### PR TITLE
infra: Add TRACECAT__FEATURE_FLAGS to migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,9 @@ Available predefined roles:
 - When handling frontend types, don't import variables prefixed with '$' unless you are importing the schema object
 - **NEVER** use `--no-gpg-sign` or `--no-verify` to bypass commit signing. If GPG/SSH signing fails (e.g., 1Password agent not running), stop and ask the user to fix their signing setup rather than creating an unverified commit.
 
+- For infrastructure changes, always verify and update all relevant deployment targets together: `docker-compose*.yml`, Terraform Fargate (`deployments/fargate/`), Terraform EKS (`deployments/aws/` and `deployments/aws/modules/eks/`, or `deployments/terraform/aws/` and `deployments/terraform/aws/modules/eks/` in this repo layout), and Helm (`deployments/helm/`).
+- As part of that infra review, explicitly check `values.yaml`, `variables.tf`, and `main.tf` in the relevant deployment directories before marking the change complete.
+
 ## Pull Request Description Hygiene
 - Never use `gh pr create --body "..."` when the body includes Markdown or backticks.
 - Always write the PR body to a file using a single-quoted heredoc (`<<'EOF'`) and pass it with `gh pr create --body-file <file>`.

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -148,9 +148,10 @@ locals {
   migrations_env = [
     for k, v in merge(
       {
-        LOG_LEVEL             = var.log_level
-        TRACECAT__DB_SSLMODE  = "require"
-        TRACECAT__DB_ENDPOINT = local.core_db_hostname
+        LOG_LEVEL                  = var.log_level
+        TRACECAT__DB_SSLMODE       = "require"
+        TRACECAT__DB_ENDPOINT      = local.core_db_hostname
+        TRACECAT__FEATURE_FLAGS    = var.feature_flags
       },
       local.tracecat_db_configs
     ) :

--- a/deployments/helm/tracecat/templates/_helpers.tpl
+++ b/deployments/helm/tracecat/templates/_helpers.tpl
@@ -429,6 +429,10 @@ Common environment variables shared across all backend services
 {{- join "," $flags -}}
 {{- end }}
 
+{{- define "tracecat.env.migrations" -}}
+{{- include "tracecat.env.common" . -}}
+{{- end }}
+
 {{- define "tracecat.env.common" -}}
 {{- if .Values.tracecat.logLevel }}
 - name: LOG_LEVEL

--- a/deployments/helm/tracecat/templates/migrations-job.yaml
+++ b/deployments/helm/tracecat/templates/migrations-job.yaml
@@ -62,7 +62,7 @@ spec:
               export PGSSLMODE="${TRACECAT__DB_SSLMODE:-require}"
               python3 -m alembic upgrade head
           env:
-            {{- include "tracecat.env.common" . | nindent 12 }}
+            {{- include "tracecat.env.migrations" . | nindent 12 }}
             {{- include "tracecat.env.postgres" . | nindent 12 }}
           resources:
             requests:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -354,6 +354,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__DB_URI: ${TRACECAT__DB_URI}
       TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
+      TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
     volumes:
       - ./tracecat:/app/tracecat
       - ./packages:/app/packages

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -366,6 +366,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__DB_URI: ${TRACECAT__DB_URI}
       TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
+      TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
     command: ["python3", "-m", "alembic", "upgrade", "head"]
     depends_on:
       postgres_db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -353,6 +353,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL}
       TRACECAT__DB_URI: ${TRACECAT__DB_URI}
       TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
+      TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
     command: ["python3", "-m", "alembic", "upgrade", "head"]
     depends_on:
       postgres_db:


### PR DESCRIPTION
### Motivation
- Ensure infrastructure change guidance covers both Terraform EKS path conventions present in the repo layout and forces an explicit file-level review so feature-flag and env wiring doesn't drift across deployment targets.

### Description
- Updated `CLAUDE.md` to mention both `deployments/aws/` + `deployments/aws/modules/eks/` and `deployments/terraform/aws/` + `deployments/terraform/aws/modules/eks/` path conventions and added an explicit checklist item to verify `values.yaml`, `variables.tf`, and `main.tf` in relevant deployment directories.

### Testing
- Ran `rg -n "feature_flags|featureFlags|TRACECAT__FEATURE_FLAGS"` across relevant Helm, Terraform, Fargate, and Docker Compose files and verified occurrences as expected; command succeeded.
- Ran `git status --short` to confirm the working tree was clean after committing the `CLAUDE.md` change; command succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977ae1c4888333a3c3b93c01fc05d3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the infra review checklist to cover both Terraform EKS path layouts and require explicit file checks. Also ensures migrations receive TRACECAT__FEATURE_FLAGS across Fargate, Helm, and Docker Compose, with a small Helm helper update.

- **New Features**
  - Pass TRACECAT__FEATURE_FLAGS to migrations in Fargate (locals.tf), Helm, and all docker-compose files.
  - Update CLAUDE.md to include both EKS path conventions and require checking values.yaml, variables.tf, and main.tf.

- **Refactors**
  - Add Helm helper tracecat.env.migrations and switch migrations-job to use it.

<sup>Written for commit fd8fbfbe9eee672a8d15e4bca5b24419635dcc1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

