### PR TITLE
feat(api): add temporal schedule sync management

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -397,10 +397,10 @@ services:
   temporal_ui:
     image: temporalio/ui:${TEMPORAL__UI_VERSION:-latest}
     ports:
-      - ${TEMPORAL_UI_PORT:-8081}:8081
+      - ${TEMPORAL_UI_PORT:-8081}:8080
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:8081
+      - TEMPORAL_CORS_ORIGINS=http://localhost:${TEMPORAL_UI_PORT:-8081}
     depends_on:
       - temporal
     attach: false

--- a/frontend/src/app/organization/settings/schedules/layout.tsx
+++ b/frontend/src/app/organization/settings/schedules/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Schedules | Organization",
+}
+
+export default function SchedulesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/schedules/page.tsx
+++ b/frontend/src/app/organization/settings/schedules/page.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { OrgSettingsSchedules } from "@/components/organization/org-settings-schedules"
+
+export default function SchedulesSettingsPage() {
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
+        <div className="flex w-full">
+          <div className="items-start space-y-3 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">Schedules</h2>
+            <p className="text-base text-muted-foreground">
+              Inspect Temporal schedule sync and recreate missing schedules for
+              this organization.
+            </p>
+          </div>
+        </div>
+        <OrgSettingsSchedules />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/client/services.custom.ts
+++ b/frontend/src/client/services.custom.ts
@@ -175,3 +175,76 @@ export const adminListOrgTiers = (
       422: "Validation Error",
     },
   })
+
+export type OrgScheduleTemporalStatus = "present" | "missing"
+export type OrgScheduleDbStatus = "online" | "offline"
+
+export type OrgScheduleTemporalItem = {
+  schedule_id: string
+  workspace_id: string
+  workspace_name: string
+  workflow_id: string | null
+  workflow_title: string | null
+  db_status: OrgScheduleDbStatus
+  temporal_status: OrgScheduleTemporalStatus
+  last_checked_at: string
+  error?: string | null
+}
+
+export type OrgScheduleTemporalSummary = {
+  total_schedules: number
+  present_count: number
+  missing_count: number
+}
+
+export type OrgScheduleTemporalSyncRead = {
+  summary: OrgScheduleTemporalSummary
+  items: OrgScheduleTemporalItem[]
+}
+
+export type OrgScheduleRecreateAction = "created" | "skipped_present" | "failed"
+
+export type OrgScheduleRecreateResult = {
+  schedule_id: string
+  action: OrgScheduleRecreateAction
+  error?: string | null
+}
+
+export type OrgScheduleRecreateResponse = {
+  processed_count: number
+  created_count: number
+  already_present_count: number
+  failed_count: number
+  results: OrgScheduleRecreateResult[]
+}
+
+export type OrganizationRecreateMissingTemporalSchedulesData = {
+  requestBody: {
+    schedule_ids?: string[] | null
+  }
+}
+
+export const organizationGetScheduleTemporalSync =
+  (): CancelablePromise<OrgScheduleTemporalSyncRead> =>
+    request(OpenAPI, {
+      method: "GET",
+      url: "/organization/schedules/temporal-sync",
+      errors: {
+        403: "Forbidden",
+        422: "Validation Error",
+      },
+    })
+
+export const organizationRecreateMissingTemporalSchedules = (
+  data: OrganizationRecreateMissingTemporalSchedulesData
+): CancelablePromise<OrgScheduleRecreateResponse> =>
+  request(OpenAPI, {
+    method: "POST",
+    url: "/organization/schedules/temporal-sync/recreate-missing",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      403: "Forbidden",
+      422: "Validation Error",
+    },
+  })

--- a/frontend/src/components/organization/org-settings-schedules.tsx
+++ b/frontend/src/components/organization/org-settings-schedules.tsx
@@ -1,0 +1,227 @@
+"use client"
+
+import { RefreshCwIcon } from "lucide-react"
+import { useMemo, useState } from "react"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useOrgScheduleSync } from "@/hooks/use-org-schedule-sync"
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown"
+  }
+  return date.toLocaleString()
+}
+
+function formatShortId(value: string): string {
+  if (value.length <= 12) {
+    return value
+  }
+  return `${value.slice(0, 8)}...`
+}
+
+export function OrgSettingsSchedules() {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const {
+    scheduleSync,
+    scheduleSyncIsLoading,
+    scheduleSyncIsFetching,
+    scheduleSyncError,
+    refreshScheduleSync,
+    recreateMissingSchedules,
+    recreateMissingSchedulesIsPending,
+  } = useOrgScheduleSync()
+
+  const summary = useMemo(
+    () =>
+      scheduleSync?.summary ?? {
+        total_schedules: 0,
+        present_count: 0,
+        missing_count: 0,
+      },
+    [scheduleSync?.summary]
+  )
+  const items = scheduleSync?.items ?? []
+
+  if (scheduleSyncIsLoading) {
+    return <CenteredSpinner />
+  }
+  if (scheduleSyncError) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading organization schedule sync status: ${scheduleSyncError.message}`}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-lg border p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Total schedules
+          </p>
+          <p className="mt-2 text-2xl font-semibold">
+            {summary.total_schedules}
+          </p>
+        </div>
+        <div className="rounded-lg border p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Present in Temporal
+          </p>
+          <p className="mt-2 text-2xl font-semibold">{summary.present_count}</p>
+        </div>
+        <div className="rounded-lg border p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Missing in Temporal
+          </p>
+          <p className="mt-2 text-2xl font-semibold">{summary.missing_count}</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => refreshScheduleSync()}
+          disabled={scheduleSyncIsFetching || recreateMissingSchedulesIsPending}
+        >
+          <RefreshCwIcon className="mr-2 size-4" />
+          Refresh status
+        </Button>
+
+        <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              disabled={
+                summary.missing_count === 0 || recreateMissingSchedulesIsPending
+              }
+            >
+              Create missing Temporal schedules
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                Recreate missing Temporal schedules
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                This will attempt to create {summary.missing_count} missing
+                schedule{summary.missing_count === 1 ? "" : "s"} in Temporal.
+                Existing schedules will be skipped.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={recreateMissingSchedulesIsPending}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={recreateMissingSchedulesIsPending}
+                onClick={async (event) => {
+                  event.preventDefault()
+                  await recreateMissingSchedules({})
+                  setDialogOpen(false)
+                }}
+              >
+                {recreateMissingSchedulesIsPending ? "Creating..." : "Create"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Workspace</TableHead>
+              <TableHead>Workflow</TableHead>
+              <TableHead>Schedule ID</TableHead>
+              <TableHead>DB status</TableHead>
+              <TableHead>Temporal status</TableHead>
+              <TableHead>Last checked</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.length > 0 ? (
+              items.map((item) => (
+                <TableRow key={item.schedule_id}>
+                  <TableCell className="font-medium">
+                    {item.workspace_name}
+                  </TableCell>
+                  <TableCell>
+                    {item.workflow_title ?? "Unknown workflow"}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {formatShortId(item.schedule_id)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        item.db_status === "online" ? "secondary" : "outline"
+                      }
+                    >
+                      {item.db_status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="space-y-1">
+                      <Badge
+                        variant={
+                          item.temporal_status === "present"
+                            ? "secondary"
+                            : "destructive"
+                        }
+                      >
+                        {item.temporal_status}
+                      </Badge>
+                      {item.error ? (
+                        <p className="text-xs text-destructive">{item.error}</p>
+                      ) : null}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatTimestamp(item.last_checked_at)}
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  className="h-16 text-center text-sm text-muted-foreground"
+                  colSpan={6}
+                >
+                  No schedules found in this organization.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
   BotIcon,
+  CalendarClockIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   GitBranchIcon,
@@ -64,6 +65,12 @@ export function OrganizationSidebar({
       url: "/organization/settings/app",
       icon: Settings2,
       isActive: pathname?.includes("/organization/settings/app"),
+    },
+    {
+      title: "Schedules",
+      url: "/organization/settings/schedules",
+      icon: CalendarClockIcon,
+      isActive: pathname?.includes("/organization/settings/schedules"),
     },
     {
       title: "Audit Logs",

--- a/frontend/src/hooks/use-org-schedule-sync.ts
+++ b/frontend/src/hooks/use-org-schedule-sync.ts
@@ -1,0 +1,73 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type { ApiError } from "@/client"
+import {
+  type OrgScheduleRecreateResponse,
+  type OrgScheduleTemporalSyncRead,
+  organizationGetScheduleTemporalSync,
+  organizationRecreateMissingTemporalSchedules,
+} from "@/client/services.custom"
+import { toast } from "@/components/ui/use-toast"
+
+const TEMPORAL_SYNC_QUERY_KEY = ["organization", "schedules", "temporal-sync"]
+
+export function useOrgScheduleSync() {
+  const queryClient = useQueryClient()
+  const { data, isLoading, isFetching, error, refetch } = useQuery<
+    OrgScheduleTemporalSyncRead,
+    ApiError
+  >({
+    queryKey: TEMPORAL_SYNC_QUERY_KEY,
+    queryFn: organizationGetScheduleTemporalSync,
+    retry: false,
+  })
+
+  const {
+    mutateAsync: recreateMissingSchedules,
+    isPending: recreateMissingSchedulesIsPending,
+  } = useMutation<
+    OrgScheduleRecreateResponse,
+    ApiError,
+    { scheduleIds?: string[] }
+  >({
+    mutationFn: async ({ scheduleIds }) =>
+      await organizationRecreateMissingTemporalSchedules({
+        requestBody:
+          scheduleIds && scheduleIds.length > 0
+            ? { schedule_ids: scheduleIds }
+            : {},
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: TEMPORAL_SYNC_QUERY_KEY })
+      toast({
+        title: "Temporal schedule sync complete",
+        description: `${result.created_count} created, ${result.already_present_count} already present, ${result.failed_count} failed.`,
+      })
+    },
+    onError: (err) => {
+      const detail =
+        typeof err.body === "object" &&
+        err.body !== null &&
+        "detail" in err.body &&
+        typeof err.body.detail === "string"
+          ? err.body.detail
+          : "Could not recreate missing schedules."
+      toast({
+        title: "Temporal schedule sync failed",
+        description: detail,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    scheduleSync: data,
+    scheduleSyncIsLoading: isLoading,
+    scheduleSyncIsFetching: isFetching,
+    scheduleSyncError: error,
+    refreshScheduleSync: refetch,
+    recreateMissingSchedules,
+    recreateMissingSchedulesIsPending,
+  }
+}

--- a/tests/unit/api/test_api_organization_schedule_sync.py
+++ b/tests/unit/api/test_api_organization_schedule_sync.py
@@ -1,0 +1,112 @@
+"""HTTP-level tests for organization schedule sync endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.identifiers import ScheduleUUID, WorkflowID
+from tracecat.organization import router as organization_router
+from tracecat.organization.schemas import (
+    OrgScheduleRecreateAction,
+    OrgScheduleRecreateResponse,
+    OrgScheduleRecreateResult,
+    OrgScheduleTemporalItem,
+    OrgScheduleTemporalStatus,
+    OrgScheduleTemporalSummary,
+    OrgScheduleTemporalSyncRead,
+)
+
+
+@pytest.mark.anyio
+async def test_get_temporal_schedule_sync_status_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    schedule_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    workflow_id = uuid.uuid4()
+    response_model = OrgScheduleTemporalSyncRead(
+        summary=OrgScheduleTemporalSummary(
+            total_schedules=1,
+            present_count=1,
+            missing_count=0,
+        ),
+        items=[
+            OrgScheduleTemporalItem(
+                schedule_id=ScheduleUUID.new(schedule_id),
+                workspace_id=workspace_id,
+                workspace_name="Default workspace",
+                workflow_id=WorkflowID.new(workflow_id),
+                workflow_title="Daily workflow",
+                db_status="online",
+                temporal_status=OrgScheduleTemporalStatus.PRESENT,
+                last_checked_at=datetime.now(UTC),
+                error=None,
+            )
+        ],
+    )
+
+    with patch.object(
+        organization_router, "OrganizationScheduleSyncService"
+    ) as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_temporal_sync_status.return_value = response_model
+        mock_service_cls.return_value = mock_service
+
+        response = client.get("/organization/schedules/temporal-sync")
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["summary"]["total_schedules"] == 1
+    assert payload["summary"]["present_count"] == 1
+    assert payload["summary"]["missing_count"] == 0
+    assert payload["items"][0]["schedule_id"] == str(schedule_id)
+    assert payload["items"][0]["workspace_id"] == str(workspace_id)
+    assert payload["items"][0]["workflow_id"] == str(workflow_id)
+    assert payload["items"][0]["temporal_status"] == "present"
+
+
+@pytest.mark.anyio
+async def test_recreate_missing_temporal_schedules_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    schedule_id = uuid.uuid4()
+    response_model = OrgScheduleRecreateResponse(
+        processed_count=1,
+        created_count=1,
+        already_present_count=0,
+        failed_count=0,
+        results=[
+            OrgScheduleRecreateResult(
+                schedule_id=ScheduleUUID.new(schedule_id),
+                action=OrgScheduleRecreateAction.CREATED,
+            )
+        ],
+    )
+
+    with patch.object(
+        organization_router, "OrganizationScheduleSyncService"
+    ) as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.recreate_missing_temporal_schedules.return_value = response_model
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            "/organization/schedules/temporal-sync/recreate-missing",
+            json={"schedule_ids": [str(schedule_id)]},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["processed_count"] == 1
+    assert payload["created_count"] == 1
+    assert payload["already_present_count"] == 0
+    assert payload["failed_count"] == 0
+    assert payload["results"][0]["schedule_id"] == str(schedule_id)
+    assert payload["results"][0]["action"] == "created"

--- a/tests/unit/test_organization_schedule_sync_service.py
+++ b/tests/unit/test_organization_schedule_sync_service.py
@@ -1,0 +1,101 @@
+"""Tests for organization schedule Temporal sync service."""
+
+import uuid
+from datetime import timedelta
+from typing import Literal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.identifiers import ScheduleUUID, WorkflowID
+from tracecat.organization.schedule_sync_service import (
+    OrganizationScheduleRecord,
+    OrganizationScheduleSyncService,
+)
+from tracecat.organization.schemas import OrgScheduleTemporalStatus
+
+
+def _record(
+    *,
+    status: Literal["online", "offline"] = "online",
+) -> OrganizationScheduleRecord:
+    return OrganizationScheduleRecord(
+        schedule_id=ScheduleUUID.new(uuid.uuid4()),
+        workspace_id=uuid.uuid4(),
+        workspace_name="Default workspace",
+        workflow_id=WorkflowID.new(uuid.uuid4()),
+        workflow_title="Test workflow",
+        db_status=status,
+        cron="0 * * * *",
+        every=timedelta(hours=1),
+        offset=None,
+        start_at=None,
+        end_at=None,
+        timeout=60.0,
+    )
+
+
+@pytest.mark.anyio
+async def test_recreate_missing_schedules_pauses_offline_schedule(
+    test_admin_role: Role,
+) -> None:
+    service = OrganizationScheduleSyncService(AsyncMock(), role=test_admin_role)
+    schedule = _record(status="offline")
+
+    with (
+        patch.object(
+            service, "_list_schedule_records", AsyncMock(return_value=[schedule])
+        ),
+        patch(
+            "tracecat.organization.schedule_sync_service.get_temporal_client",
+            AsyncMock(return_value=AsyncMock()),
+        ),
+        patch.object(
+            service,
+            "_check_temporal_schedule",
+            AsyncMock(return_value=(OrgScheduleTemporalStatus.MISSING, None)),
+        ),
+        patch(
+            "tracecat.organization.schedule_sync_service.bridge.create_schedule",
+            AsyncMock(return_value=AsyncMock(id="sch-test")),
+        ) as mock_create,
+    ):
+        response = await service.recreate_missing_temporal_schedules()
+
+    assert response.created_count == 1
+    assert response.failed_count == 0
+    assert mock_create.await_args is not None
+    assert mock_create.await_args.kwargs["paused"] is True
+
+
+@pytest.mark.anyio
+async def test_recreate_missing_schedules_skips_existing_schedule(
+    test_admin_role: Role,
+) -> None:
+    service = OrganizationScheduleSyncService(AsyncMock(), role=test_admin_role)
+    schedule = _record(status="online")
+
+    with (
+        patch.object(
+            service, "_list_schedule_records", AsyncMock(return_value=[schedule])
+        ),
+        patch(
+            "tracecat.organization.schedule_sync_service.get_temporal_client",
+            AsyncMock(return_value=AsyncMock()),
+        ),
+        patch.object(
+            service,
+            "_check_temporal_schedule",
+            AsyncMock(return_value=(OrgScheduleTemporalStatus.PRESENT, None)),
+        ),
+        patch(
+            "tracecat.organization.schedule_sync_service.bridge.create_schedule",
+            AsyncMock(return_value=AsyncMock(id="sch-test")),
+        ) as mock_create,
+    ):
+        response = await service.recreate_missing_temporal_schedules()
+
+    assert response.created_count == 0
+    assert response.already_present_count == 1
+    mock_create.assert_not_called()

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -31,6 +31,7 @@ from tracecat.exceptions import (
 )
 from tracecat.identifiers import SessionID, UserID
 from tracecat.invitations.enums import InvitationStatus
+from tracecat.organization.schedule_sync_service import OrganizationScheduleSyncService
 from tracecat.organization.schemas import (
     OrgDomainRead,
     OrgInvitationAccept,
@@ -42,6 +43,9 @@ from tracecat.organization.schemas import (
     OrgMemberStatus,
     OrgPendingInvitationRead,
     OrgRead,
+    OrgScheduleRecreateMissingRequest,
+    OrgScheduleRecreateResponse,
+    OrgScheduleTemporalSyncRead,
 )
 from tracecat.organization.service import OrgService, accept_invitation_for_user
 
@@ -154,6 +158,32 @@ async def list_organization_domains(
         )
         for domain in domains
     ]
+
+
+@router.get("/schedules/temporal-sync", response_model=OrgScheduleTemporalSyncRead)
+async def get_temporal_schedule_sync_status(
+    *,
+    role: OrgAdminRole,
+    session: AsyncDBSession,
+) -> OrgScheduleTemporalSyncRead:
+    """List org schedules with whether each has a matching Temporal schedule."""
+    service = OrganizationScheduleSyncService(session, role=role)
+    return await service.get_temporal_sync_status()
+
+
+@router.post(
+    "/schedules/temporal-sync/recreate-missing",
+    response_model=OrgScheduleRecreateResponse,
+)
+async def recreate_missing_temporal_schedules(
+    *,
+    role: OrgAdminRole,
+    session: AsyncDBSession,
+    params: OrgScheduleRecreateMissingRequest,
+) -> OrgScheduleRecreateResponse:
+    """Create missing Temporal schedules for the organization."""
+    service = OrganizationScheduleSyncService(session, role=role)
+    return await service.recreate_missing_temporal_schedules(params.schedule_ids)
 
 
 @router.delete("", status_code=status.HTTP_204_NO_CONTENT)

--- a/tracecat/organization/schedule_sync_service.py
+++ b/tracecat/organization/schedule_sync_service.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+
+from sqlalchemy import select
+from temporalio.client import Client
+
+from tracecat.auth.types import AccessLevel, Role
+from tracecat.db.models import Schedule, Workflow, Workspace
+from tracecat.dsl.client import get_temporal_client
+from tracecat.identifiers import ScheduleUUID, WorkflowID, WorkspaceID
+from tracecat.organization.schemas import (
+    OrgScheduleRecreateAction,
+    OrgScheduleRecreateResponse,
+    OrgScheduleRecreateResult,
+    OrgScheduleTemporalItem,
+    OrgScheduleTemporalStatus,
+    OrgScheduleTemporalSummary,
+    OrgScheduleTemporalSyncRead,
+)
+from tracecat.service import BaseOrgService
+from tracecat.workflow.schedules import bridge
+
+TEMPORAL_CHECK_CONCURRENCY = 20
+
+
+@dataclass(frozen=True)
+class OrganizationScheduleRecord:
+    schedule_id: ScheduleUUID
+    workspace_id: WorkspaceID
+    workspace_name: str
+    workflow_id: WorkflowID | None
+    workflow_title: str | None
+    db_status: Literal["online", "offline"]
+    cron: str | None
+    every: timedelta | None
+    offset: timedelta | None
+    start_at: datetime | None
+    end_at: datetime | None
+    timeout: float | None
+
+
+def _is_temporal_not_found_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(
+        phrase in message
+        for phrase in ("schedule not found", "not found", "does not exist")
+    )
+
+
+def _is_temporal_already_exists_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return "already exists" in message or "already started" in message
+
+
+class OrganizationScheduleSyncService(BaseOrgService):
+    service_name = "organization_schedule_sync"
+
+    async def _list_schedule_records(
+        self,
+        schedule_ids: set[ScheduleUUID] | None = None,
+    ) -> list[OrganizationScheduleRecord]:
+        statement = (
+            select(
+                Schedule.id.label("schedule_id"),
+                Schedule.workspace_id.label("workspace_id"),
+                Workspace.name.label("workspace_name"),
+                Schedule.workflow_id.label("workflow_id"),
+                Workflow.title.label("workflow_title"),
+                Schedule.status.label("db_status"),
+                Schedule.cron,
+                Schedule.every,
+                Schedule.offset,
+                Schedule.start_at,
+                Schedule.end_at,
+                Schedule.timeout,
+            )
+            .join(Workspace, Workspace.id == Schedule.workspace_id)
+            .outerjoin(Workflow, Workflow.id == Schedule.workflow_id)
+            .where(Workspace.organization_id == self.organization_id)
+            .order_by(Workspace.name.asc(), Schedule.workflow_id.asc(), Schedule.id.asc())
+        )
+
+        if schedule_ids is not None:
+            if not schedule_ids:
+                return []
+            statement = statement.where(Schedule.id.in_(schedule_ids))
+
+        result = await self.session.execute(statement)
+        rows = result.mappings().all()
+
+        records: list[OrganizationScheduleRecord] = []
+        for row in rows:
+            records.append(
+                OrganizationScheduleRecord(
+                    schedule_id=ScheduleUUID.new(row["schedule_id"]),
+                    workspace_id=row["workspace_id"],
+                    workspace_name=row["workspace_name"],
+                    workflow_id=(
+                        WorkflowID.new(row["workflow_id"])
+                        if row["workflow_id"] is not None
+                        else None
+                    ),
+                    workflow_title=row["workflow_title"],
+                    db_status=row["db_status"],
+                    cron=row["cron"],
+                    every=row["every"],
+                    offset=row["offset"],
+                    start_at=row["start_at"],
+                    end_at=row["end_at"],
+                    timeout=row["timeout"],
+                )
+            )
+        return records
+
+    async def _check_temporal_schedule(
+        self,
+        client: Client,
+        schedule_id: ScheduleUUID,
+    ) -> tuple[OrgScheduleTemporalStatus, str | None]:
+        handle = client.get_schedule_handle(schedule_id.to_legacy())
+        try:
+            await handle.describe()
+        except Exception as e:
+            if _is_temporal_not_found_error(e):
+                return OrgScheduleTemporalStatus.MISSING, None
+            return OrgScheduleTemporalStatus.MISSING, str(e)
+        return OrgScheduleTemporalStatus.PRESENT, None
+
+    def _build_schedule_runner_role(self, workspace_id: WorkspaceID) -> Role:
+        return Role(
+            type="service",
+            service_id="tracecat-schedule-runner",
+            access_level=AccessLevel.ADMIN,
+            user_id=None,
+            organization_id=self.organization_id,
+            workspace_id=workspace_id,
+            workspace_role=None,
+            org_role=None,
+        )
+
+    async def get_temporal_sync_status(self) -> OrgScheduleTemporalSyncRead:
+        records = await self._list_schedule_records()
+        if not records:
+            return OrgScheduleTemporalSyncRead(
+                summary=OrgScheduleTemporalSummary(
+                    total_schedules=0,
+                    present_count=0,
+                    missing_count=0,
+                ),
+                items=[],
+            )
+
+        client = await get_temporal_client()
+        checked_at = datetime.now(UTC)
+        semaphore = asyncio.Semaphore(TEMPORAL_CHECK_CONCURRENCY)
+
+        async def _check_record(
+            record: OrganizationScheduleRecord,
+        ) -> OrgScheduleTemporalItem:
+            async with semaphore:
+                temporal_status, error = await self._check_temporal_schedule(
+                    client, record.schedule_id
+                )
+            return OrgScheduleTemporalItem(
+                schedule_id=record.schedule_id,
+                workspace_id=record.workspace_id,
+                workspace_name=record.workspace_name,
+                workflow_id=record.workflow_id,
+                workflow_title=record.workflow_title,
+                db_status=record.db_status,
+                temporal_status=temporal_status,
+                last_checked_at=checked_at,
+                error=error,
+            )
+
+        items = await asyncio.gather(*(_check_record(record) for record in records))
+        present_count = sum(
+            1
+            for item in items
+            if item.temporal_status == OrgScheduleTemporalStatus.PRESENT
+        )
+        missing_count = len(items) - present_count
+
+        return OrgScheduleTemporalSyncRead(
+            summary=OrgScheduleTemporalSummary(
+                total_schedules=len(items),
+                present_count=present_count,
+                missing_count=missing_count,
+            ),
+            items=list(items),
+        )
+
+    async def recreate_missing_temporal_schedules(
+        self,
+        schedule_ids: list[ScheduleUUID] | None = None,
+    ) -> OrgScheduleRecreateResponse:
+        schedule_id_filter = (
+            {ScheduleUUID.new(schedule_id) for schedule_id in schedule_ids}
+            if schedule_ids is not None
+            else None
+        )
+        records = await self._list_schedule_records(schedule_ids=schedule_id_filter)
+        if not records:
+            return OrgScheduleRecreateResponse(
+                processed_count=0,
+                created_count=0,
+                already_present_count=0,
+                failed_count=0,
+                results=[],
+            )
+
+        client = await get_temporal_client()
+        results: list[OrgScheduleRecreateResult] = []
+
+        for record in records:
+            temporal_status, check_error = await self._check_temporal_schedule(
+                client, record.schedule_id
+            )
+            if temporal_status == OrgScheduleTemporalStatus.PRESENT:
+                results.append(
+                    OrgScheduleRecreateResult(
+                        schedule_id=record.schedule_id,
+                        action=OrgScheduleRecreateAction.SKIPPED_PRESENT,
+                    )
+                )
+                continue
+            if check_error is not None:
+                results.append(
+                    OrgScheduleRecreateResult(
+                        schedule_id=record.schedule_id,
+                        action=OrgScheduleRecreateAction.FAILED,
+                        error=f"Failed to verify Temporal schedule: {check_error}",
+                    )
+                )
+                continue
+            if record.workflow_id is None:
+                results.append(
+                    OrgScheduleRecreateResult(
+                        schedule_id=record.schedule_id,
+                        action=OrgScheduleRecreateAction.FAILED,
+                        error="Schedule is missing workflow_id in database.",
+                    )
+                )
+                continue
+
+            role = self._build_schedule_runner_role(record.workspace_id)
+            paused = record.db_status == "offline"
+            try:
+                await bridge.create_schedule(
+                    workflow_id=record.workflow_id,
+                    schedule_id=record.schedule_id,
+                    role=role,
+                    cron=record.cron,
+                    every=record.every,
+                    offset=record.offset,
+                    start_at=record.start_at,
+                    end_at=record.end_at,
+                    timeout=record.timeout,
+                    paused=paused,
+                )
+                results.append(
+                    OrgScheduleRecreateResult(
+                        schedule_id=record.schedule_id,
+                        action=OrgScheduleRecreateAction.CREATED,
+                    )
+                )
+            except Exception as e:
+                if _is_temporal_already_exists_error(e):
+                    results.append(
+                        OrgScheduleRecreateResult(
+                            schedule_id=record.schedule_id,
+                            action=OrgScheduleRecreateAction.SKIPPED_PRESENT,
+                        )
+                    )
+                else:
+                    results.append(
+                        OrgScheduleRecreateResult(
+                            schedule_id=record.schedule_id,
+                            action=OrgScheduleRecreateAction.FAILED,
+                            error=str(e),
+                        )
+                    )
+
+        created_count = sum(
+            1 for result in results if result.action == OrgScheduleRecreateAction.CREATED
+        )
+        already_present_count = sum(
+            1
+            for result in results
+            if result.action == OrgScheduleRecreateAction.SKIPPED_PRESENT
+        )
+        failed_count = sum(
+            1 for result in results if result.action == OrgScheduleRecreateAction.FAILED
+        )
+
+        return OrgScheduleRecreateResponse(
+            processed_count=len(results),
+            created_count=created_count,
+            already_present_count=already_present_count,
+            failed_count=failed_count,
+            results=results,
+        )

--- a/tracecat/organization/schedule_sync_service.py
+++ b/tracecat/organization/schedule_sync_service.py
@@ -81,7 +81,9 @@ class OrganizationScheduleSyncService(BaseOrgService):
             .join(Workspace, Workspace.id == Schedule.workspace_id)
             .outerjoin(Workflow, Workflow.id == Schedule.workflow_id)
             .where(Workspace.organization_id == self.organization_id)
-            .order_by(Workspace.name.asc(), Schedule.workflow_id.asc(), Schedule.id.asc())
+            .order_by(
+                Workspace.name.asc(), Schedule.workflow_id.asc(), Schedule.id.asc()
+            )
         )
 
         if schedule_ids is not None:
@@ -286,7 +288,9 @@ class OrganizationScheduleSyncService(BaseOrgService):
                     )
 
         created_count = sum(
-            1 for result in results if result.action == OrgScheduleRecreateAction.CREATED
+            1
+            for result in results
+            if result.action == OrgScheduleRecreateAction.CREATED
         )
         already_present_count = sum(
             1

--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -45,6 +45,7 @@ async def create_schedule(
     start_at: datetime | None = None,
     end_at: datetime | None = None,
     timeout: float | None = None,
+    paused: bool = False,
 ) -> temporalio.client.ScheduleHandle:
     # Importing here to avoid circular imports...
     from tracecat.dsl.workflow import DSLWorkflow
@@ -95,6 +96,7 @@ async def create_schedule(
                 # Allow overlapping workflows to run in parallel
                 overlap=temporalio.client.ScheduleOverlapPolicy.ALLOW_ALL,
             ),
+            state=temporalio.client.ScheduleState(paused=paused),
         ),
     )
 


### PR DESCRIPTION
## Screens

https://github.com/user-attachments/assets/0526bc8c-b502-4ba4-8c0a-f0c104255c55


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds organization-level Temporal schedule sync tooling so admins can detect and repair missing schedules.

Backend changes:
- Add `OrganizationScheduleSyncService` to list org schedules, check whether each exists in Temporal, and recreate missing schedules.
- Add org admin API endpoints:
  - `GET /organization/schedules/temporal-sync`
  - `POST /organization/schedules/temporal-sync/recreate-missing`
- Add schema models for sync status and recreate results.
- Update schedule creation bridge to support creating paused schedules (used when DB schedule status is offline).

Frontend changes:
- Add organization settings page at `/organization/settings/schedules`.
- Add sidebar entry for Schedules.
- Add UI to view sync summary/status and trigger missing schedule recreation.
- Add client service typings and request helpers for new endpoints.

Infra/dev changes:
- Update Temporal UI port mapping in `docker-compose.dev.yml` to map host `${TEMPORAL_UI_PORT:-8081}` to container `8080`.

## Related Issues

N/A

## Screenshots / Recordings

N/A (new admin page added; can provide screenshots if needed)

## Steps to QA

1. Start a local stack with Temporal and API available.
2. Sign in as an org admin and open `/organization/settings/schedules`.
3. Confirm schedule summary and per-schedule Temporal status load successfully.
4. Create a missing Temporal schedule scenario and verify the row shows `missing`.
5. Click `Create missing Temporal schedules` and confirm counts/toast update.
6. Verify offline DB schedules are recreated in Temporal as paused.

## Validation run

- `uv run ruff check tracecat/organization/router.py tracecat/organization/schemas.py tracecat/workflow/schedules/bridge.py tracecat/organization/schedule_sync_service.py tests/unit/api/test_api_organization_schedule_sync.py tests/unit/test_organization_schedule_sync_service.py`
- `uv run basedpyright tracecat/organization/router.py tracecat/organization/schemas.py tracecat/workflow/schedules/bridge.py tracecat/organization/schedule_sync_service.py tests/unit/api/test_api_organization_schedule_sync.py tests/unit/test_organization_schedule_sync_service.py`
- `pnpm -C frontend exec biome check src/client/services.custom.ts src/components/sidebar/organization-sidebar.tsx src/components/organization/org-settings-schedules.tsx src/hooks/use-org-schedule-sync.ts src/app/organization/settings/schedules/page.tsx src/app/organization/settings/schedules/layout.tsx`
- `uv run pytest tests/unit/api/test_api_organization_schedule_sync.py tests/unit/test_organization_schedule_sync_service.py` (fails in this environment because PostgreSQL at `localhost:5432` is not running)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds org-level Temporal schedule sync so org admins can see which schedules exist in Temporal and recreate missing ones. Includes a new settings page; offline DB schedules are recreated as paused.

- **New Features**
  - Backend: OrganizationScheduleSyncService with GET /organization/schedules/temporal-sync and POST /organization/schedules/temporal-sync/recreate-missing; schedule bridge supports creating paused schedules.
  - Frontend: New page at /organization/settings/schedules with status table and a “Create missing Temporal schedules” action; sidebar link added.
  - Tests: Unit tests for the service and API endpoints.
  - Dev: Updated docker-compose Temporal UI port mapping (host ${TEMPORAL_UI_PORT:-8081} -> container 8080) and CORS origin to respect TEMPORAL_UI_PORT.

- **Refactors**
  - Formatted schedule sync service to satisfy ruff.

<sup>Written for commit 763d20ee0f6b6ab3847514daad7cd4d9ef39b920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

