### PR TITLE
fix(docker): update temporal UI port for multi-cluster support

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -400,7 +400,7 @@ services:
       - ${TEMPORAL_UI_PORT:-8081}:8081
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:8081
+      - TEMPORAL_CORS_ORIGINS=http://localhost:${TEMPORAL_UI_PORT:-8081}
     depends_on:
       - temporal
     attach: false

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -418,10 +418,10 @@ services:
       - temporal
       - core
     ports:
-      - 8081:8080
+      - ${TEMPORAL_UI_PORT:-8081}:8081
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:8080
+      - TEMPORAL_CORS_ORIGINS=http://localhost:${TEMPORAL_UI_PORT:-8081}
     depends_on:
       - temporal
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -403,7 +403,7 @@ services:
       - temporal
       - core
     # ports:
-    #   - 8081:8080
+    #   - 8081:8081
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:8081


### PR DESCRIPTION
## Summary
- Fix `docker-compose.local.yml` temporal UI internal port `8080` → `8081` (missed in aaf0c0f8b)
- Parameterize `TEMPORAL_CORS_ORIGINS` with `${TEMPORAL_UI_PORT}` in dev and local compose files so multi-cluster setups get correct CORS origins
- Fix stale commented-out port in `docker-compose.yml`

## Test plan
- [ ] `just cluster up -d` works with default cluster (port 8081)
- [ ] Multi-cluster (cluster 2+) gets correct Temporal UI CORS origin


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix mismatched Temporal UI ports and CORS origins in Docker Compose to enable multi-cluster support. Temporal UI now listens on 8081, and CORS origin is derived from TEMPORAL_UI_PORT.

- **Bug Fixes**
  - Update docker-compose.local to map ${TEMPORAL_UI_PORT:-8081}:8081 (internal port 8081).
  - Parameterize TEMPORAL_CORS_ORIGINS as http://localhost:${TEMPORAL_UI_PORT:-8081} in dev and local.
  - Correct stale commented port in docker-compose.yml (8081:8081).

<sup>Written for commit 33aed52c1a800a44841d56423de7f1d84cf81c66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

