### PR TITLE
fix(ui): Workflow builder node selection persistence

### DIFF
--- a/frontend/src/components/builder/canvas/trigger-node.tsx
+++ b/frontend/src/components/builder/canvas/trigger-node.tsx
@@ -12,7 +12,6 @@ import {
 import React, { useCallback, useLayoutEffect, useMemo, useRef } from "react"
 import { TriggerSourceHandle } from "@/components/builder/canvas/custom-handle"
 import { nodeStyles } from "@/components/builder/canvas/node-styles"
-import { getCaseEventLabel } from "@/components/builder/panel/case-event-suggestions"
 import {
   DEFAULT_TRIGGER_PANEL_TAB,
   type TriggerPanelTab,
@@ -72,24 +71,11 @@ export default React.memo(function TriggerNode({
   const { breakpoint, style } = useTriggerNodeZoomBreakpoint()
   const { hasEntitlement } = useEntitlements()
   const caseAddonsEnabled = hasEntitlement("case_addons")
-  const {
-    data: caseTrigger,
-    isLoading: caseTriggerIsLoading,
-    error: caseTriggerError,
-  } = useCaseTrigger(workspaceId, workflowId)
-  const caseEventTypes = caseTrigger?.event_types ?? []
-  const tagFilters = caseTrigger?.tag_filters ?? []
+  const { data: caseTrigger } = useCaseTrigger(workspaceId, workflowId)
   const isCaseTriggerEnabled = caseTrigger?.status === "online"
-  const eventKey = useMemo(() => caseEventTypes.join("|"), [caseEventTypes])
-  const hasCaseTriggerConfig =
-    caseEventTypes.length > 0 || tagFilters.length > 0
-  const caseEvents = useMemo(
-    () =>
-      caseEventTypes.map((eventType) => ({
-        eventType,
-        label: getCaseEventLabel(eventType),
-      })),
-    [caseEventTypes]
+  const eventKey = useMemo(
+    () => String(isCaseTriggerEnabled),
+    [isCaseTriggerEnabled]
   )
   const cardRef = useRef<HTMLDivElement>(null)
   const previousHeightRef = useRef<number | null>(null)
@@ -247,61 +233,6 @@ export default React.memo(function TriggerNode({
                         : "Webhook is unprotected"}
                   </TooltipContent>
                 </Tooltip>
-                {caseAddonsEnabled && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label="Open case trigger settings"
-                        className="rounded-sm"
-                        onClick={(event) => {
-                          event.stopPropagation()
-                          openTriggerPanel(TriggerPanelTabs.caseTriggers)
-                        }}
-                      >
-                        <SquarePlay
-                          className={cn(
-                            "size-4",
-                            caseTriggerError
-                              ? "text-destructive/70"
-                              : caseTriggerIsLoading
-                                ? "text-muted-foreground/70"
-                                : isCaseTriggerEnabled
-                                  ? "text-emerald-400"
-                                  : hasCaseTriggerConfig
-                                    ? "text-amber-400"
-                                    : "text-muted-foreground/70"
-                          )}
-                        />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent
-                      side="top"
-                      align="end"
-                      sideOffset={4}
-                      className="max-w-56"
-                    >
-                      {caseTriggerIsLoading ? (
-                        <span>Loading case triggers...</span>
-                      ) : caseTriggerError ? (
-                        <span>Failed to load case triggers</span>
-                      ) : caseEvents.length > 0 ? (
-                        <div className="space-y-1">
-                          <p className="font-medium text-xs">Case events</p>
-                          <ul className="space-y-0.5 text-xs">
-                            {caseEvents.map((caseEvent) => (
-                              <li key={caseEvent.eventType}>
-                                {caseEvent.label}
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      ) : (
-                        <span>No case events configured</span>
-                      )}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
               </TooltipProvider>
             </div>
           </div>
@@ -333,6 +264,28 @@ export default React.memo(function TriggerNode({
                   )}
                 />
               </div>
+              {caseAddonsEnabled && (
+                <div
+                  className={cn(
+                    "flex h-8 cursor-pointer items-center justify-center gap-1 rounded-lg border text-xs text-muted-foreground",
+                    isCaseTriggerEnabled
+                      ? "bg-background text-emerald-500"
+                      : "bg-muted-foreground/5 text-muted-foreground/50"
+                  )}
+                  onClick={() =>
+                    openTriggerPanel(TriggerPanelTabs.caseTriggers)
+                  }
+                >
+                  <SquarePlay className="size-3" />
+                  <span>Case triggers</span>
+                  <span
+                    className={cn(
+                      "ml-2 inline-block size-2 rounded-full",
+                      isCaseTriggerEnabled ? "bg-emerald-500" : "bg-gray-300"
+                    )}
+                  />
+                </div>
+              )}
               {/* Schedule table */}
               <div
                 className="rounded-lg border cursor-pointer"

--- a/frontend/src/components/builder/panel/builder-panel.tsx
+++ b/frontend/src/components/builder/panel/builder-panel.tsx
@@ -10,12 +10,17 @@ import { TriggerPanel } from "@/components/builder/panel/trigger-panel"
 import { WorkflowPanel } from "@/components/builder/panel/workflow-panel"
 import { FormLoading } from "@/components/loading/form"
 import { AlertNotification } from "@/components/notifications"
+import { useGraph } from "@/lib/hooks"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 
 export const BuilderPanel = React.forwardRef<ActionPanelRef, object>(() => {
   const { selectedNodeId } = useWorkflowBuilder()
-  const { workflow, isLoading, error } = useWorkflow()
+  const { workflow, isLoading, error, workspaceId, workflowId } = useWorkflow()
+  const { isLoading: graphIsLoading, error: graphError } = useGraph(
+    workspaceId,
+    workflowId ?? ""
+  )
   const nodes = useNodes()
   const selectedNode = nodes.find((node) => node.id === selectedNodeId)
 
@@ -34,6 +39,23 @@ export const BuilderPanel = React.forwardRef<ActionPanelRef, object>(() => {
         <AlertNotification level="error" message={error.message} />
       </div>
     )
+  }
+  if (selectedNodeId && nodes.length === 0) {
+    if (graphError) {
+      return (
+        <div className="flex size-full items-center justify-center">
+          <AlertNotification level="error" message={graphError.message} />
+        </div>
+      )
+    }
+    if (!graphIsLoading) {
+      return (
+        <div className="size-full overflow-auto">
+          <WorkflowPanel workflow={workflow} />
+        </div>
+      )
+    }
+    return <FormLoading />
   }
   if (selectedNodeId && nodes.length > 0 && !selectedNode) {
     return (

--- a/frontend/src/components/builder/panel/case-event-suggestions.ts
+++ b/frontend/src/components/builder/panel/case-event-suggestions.ts
@@ -1,0 +1,148 @@
+import type { CaseEventType } from "@/client"
+import type { Suggestion } from "@/components/tags-input"
+
+export const CASE_EVENT_SUGGESTIONS: Suggestion[] = [
+  {
+    id: "case_created",
+    label: "Case created",
+    value: "case_created",
+    group: "Case",
+  },
+  {
+    id: "case_updated",
+    label: "Case updated",
+    value: "case_updated",
+    group: "Case",
+  },
+  {
+    id: "case_closed",
+    label: "Case closed",
+    value: "case_closed",
+    group: "Case",
+  },
+  {
+    id: "case_reopened",
+    label: "Case reopened",
+    value: "case_reopened",
+    group: "Case",
+  },
+  {
+    id: "case_viewed",
+    label: "Case viewed",
+    value: "case_viewed",
+    group: "Case",
+  },
+  {
+    id: "status_changed",
+    label: "Status changed",
+    value: "status_changed",
+    group: "Fields",
+  },
+  {
+    id: "priority_changed",
+    label: "Priority changed",
+    value: "priority_changed",
+    group: "Fields",
+  },
+  {
+    id: "severity_changed",
+    label: "Severity changed",
+    value: "severity_changed",
+    group: "Fields",
+  },
+  {
+    id: "fields_changed",
+    label: "Fields changed",
+    value: "fields_changed",
+    group: "Fields",
+  },
+  {
+    id: "assignee_changed",
+    label: "Assignee changed",
+    value: "assignee_changed",
+    group: "Fields",
+  },
+  {
+    id: "payload_changed",
+    label: "Payload changed",
+    value: "payload_changed",
+    group: "Fields",
+  },
+  {
+    id: "attachment_created",
+    label: "Attachment added",
+    value: "attachment_created",
+    group: "Attachments",
+  },
+  {
+    id: "attachment_deleted",
+    label: "Attachment removed",
+    value: "attachment_deleted",
+    group: "Attachments",
+  },
+  {
+    id: "tag_added",
+    label: "Tag added",
+    value: "tag_added",
+    group: "Tags",
+  },
+  {
+    id: "tag_removed",
+    label: "Tag removed",
+    value: "tag_removed",
+    group: "Tags",
+  },
+  {
+    id: "task_created",
+    label: "Task created",
+    value: "task_created",
+    group: "Tasks",
+  },
+  {
+    id: "task_deleted",
+    label: "Task deleted",
+    value: "task_deleted",
+    group: "Tasks",
+  },
+  {
+    id: "task_status_changed",
+    label: "Task status changed",
+    value: "task_status_changed",
+    group: "Tasks",
+  },
+  {
+    id: "task_priority_changed",
+    label: "Task priority changed",
+    value: "task_priority_changed",
+    group: "Tasks",
+  },
+  {
+    id: "task_workflow_changed",
+    label: "Task workflow changed",
+    value: "task_workflow_changed",
+    group: "Tasks",
+  },
+  {
+    id: "task_assignee_changed",
+    label: "Task assignee changed",
+    value: "task_assignee_changed",
+    group: "Tasks",
+  },
+  {
+    id: "dropdown_value_changed",
+    label: "Dropdown value changed",
+    value: "dropdown_value_changed",
+    group: "Dropdowns",
+  },
+]
+
+const CASE_EVENT_LABELS = new Map<string, string>(
+  CASE_EVENT_SUGGESTIONS.map(({ value, label }) => [value, label])
+)
+
+export function getCaseEventLabel(value: CaseEventType): string {
+  return (
+    CASE_EVENT_LABELS.get(value) ??
+    value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())
+  )
+}

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -31,6 +31,7 @@ import {
   type WorkflowRead,
 } from "@/client"
 import { TriggerTypename } from "@/components/builder/canvas/trigger-node"
+import { CASE_EVENT_SUGGESTIONS } from "@/components/builder/panel/case-event-suggestions"
 import {
   type TriggerPanelTab,
   TriggerPanelTabs,
@@ -42,7 +43,6 @@ import { AlertNotification } from "@/components/notifications"
 import {
   CustomTagInput,
   MultiTagCommandInput,
-  type Suggestion,
   type Tag,
 } from "@/components/tags-input"
 import {
@@ -139,141 +139,6 @@ import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 const HTTP_METHODS: readonly WebhookMethod[] = $WebhookMethod.enum
-
-const CASE_EVENT_SUGGESTIONS: Suggestion[] = [
-  {
-    id: "case_created",
-    label: "Case created",
-    value: "case_created",
-    group: "Case",
-  },
-  {
-    id: "case_updated",
-    label: "Case updated",
-    value: "case_updated",
-    group: "Case",
-  },
-  {
-    id: "case_closed",
-    label: "Case closed",
-    value: "case_closed",
-    group: "Case",
-  },
-  {
-    id: "case_reopened",
-    label: "Case reopened",
-    value: "case_reopened",
-    group: "Case",
-  },
-  {
-    id: "case_viewed",
-    label: "Case viewed",
-    value: "case_viewed",
-    group: "Case",
-  },
-  {
-    id: "status_changed",
-    label: "Status changed",
-    value: "status_changed",
-    group: "Fields",
-  },
-  {
-    id: "priority_changed",
-    label: "Priority changed",
-    value: "priority_changed",
-    group: "Fields",
-  },
-  {
-    id: "severity_changed",
-    label: "Severity changed",
-    value: "severity_changed",
-    group: "Fields",
-  },
-  {
-    id: "fields_changed",
-    label: "Fields changed",
-    value: "fields_changed",
-    group: "Fields",
-  },
-  {
-    id: "assignee_changed",
-    label: "Assignee changed",
-    value: "assignee_changed",
-    group: "Fields",
-  },
-  {
-    id: "payload_changed",
-    label: "Payload changed",
-    value: "payload_changed",
-    group: "Fields",
-  },
-  {
-    id: "attachment_created",
-    label: "Attachment added",
-    value: "attachment_created",
-    group: "Attachments",
-  },
-  {
-    id: "attachment_deleted",
-    label: "Attachment removed",
-    value: "attachment_deleted",
-    group: "Attachments",
-  },
-  {
-    id: "tag_added",
-    label: "Tag added",
-    value: "tag_added",
-    group: "Tags",
-  },
-  {
-    id: "tag_removed",
-    label: "Tag removed",
-    value: "tag_removed",
-    group: "Tags",
-  },
-  {
-    id: "task_created",
-    label: "Task created",
-    value: "task_created",
-    group: "Tasks",
-  },
-  {
-    id: "task_deleted",
-    label: "Task deleted",
-    value: "task_deleted",
-    group: "Tasks",
-  },
-  {
-    id: "task_status_changed",
-    label: "Task status changed",
-    value: "task_status_changed",
-    group: "Tasks",
-  },
-  {
-    id: "task_priority_changed",
-    label: "Task priority changed",
-    value: "task_priority_changed",
-    group: "Tasks",
-  },
-  {
-    id: "task_workflow_changed",
-    label: "Task workflow changed",
-    value: "task_workflow_changed",
-    group: "Tasks",
-  },
-  {
-    id: "task_assignee_changed",
-    label: "Task assignee changed",
-    value: "task_assignee_changed",
-    group: "Tasks",
-  },
-  {
-    id: "dropdown_value_changed",
-    label: "Dropdown value changed",
-    value: "dropdown_value_changed",
-    group: "Dropdowns",
-  },
-]
 
 const toCanonicalString = (address: ipaddr.IPv4 | ipaddr.IPv6): string => {
   const maybeNormalized =


### PR DESCRIPTION
Summary
- keep builder canvas in sync with stored selection so reopening workflows doesn’t show missing nodes
- persist the last node id per workspace/workflow in session storage and restore it while avoiding stale selections
- surface workflow panel instead of error when nodes aren’t hydrated yet and tidy up case trigger helpers

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow builder node selection so your last selected node is restored per workspace/workflow and stale selections don’t show missing-node errors. Also simplifies the trigger node UI and centralizes case event labels.

- **Bug Fixes**
  - Persist last selected node in sessionStorage and restore on load; keep React Flow node selection in sync.
  - Clear selection if the persisted node no longer exists; clicking the canvas clears selection.
  - Keep selection when the canvas unmounts and while switching workflows; show the workflow panel while the graph hydrates and surface API errors when present.

- **Refactors**
  - Centralized case event suggestions/labels in a new helper and removed duplicates.
  - Reworked trigger node to show a compact “Case triggers” chip with a status dot; clicking opens the Case Triggers panel.

<sup>Written for commit 2b8b6aede03cb2b5ac3704956a047da02613abc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

