### PR TITLE
chore: drop rbac feature flag

### DIFF
--- a/frontend/src/app/organization/members/page.tsx
+++ b/frontend/src/app/organization/members/page.tsx
@@ -5,11 +5,15 @@ import { OrgMembersTable } from "@/components/organization/org-members-table"
 import { OrgRbacGroups } from "@/components/organization/org-rbac-groups"
 import { OrgRbacRoles } from "@/components/organization/org-rbac-roles"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useEntitlements } from "@/hooks/use-entitlements"
 
 const tabTriggerClassName =
   "rounded-none border-b-2 border-transparent px-4 py-2.5 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
 
 export default function MembersPage() {
+  const { hasEntitlement } = useEntitlements()
+  const rbacEnabled = hasEntitlement("rbac")
+
   return (
     <div className="size-full overflow-auto">
       <div className="container flex h-full max-w-[1200px] flex-col space-y-8 py-6">
@@ -23,34 +27,38 @@ export default function MembersPage() {
             </p>
           </div>
         </div>
-        <ScopeGuard
-          scope="org:rbac:read"
-          fallback={<OrgMembersTable />}
-          loading={null}
-        >
-          <Tabs defaultValue="members" className="w-full">
-            <TabsList className="inline-flex h-auto w-auto justify-start gap-0 rounded-none border-b border-border/30 bg-transparent p-0">
-              <TabsTrigger value="members" className={tabTriggerClassName}>
-                Members
-              </TabsTrigger>
-              <TabsTrigger value="roles" className={tabTriggerClassName}>
-                Roles
-              </TabsTrigger>
-              <TabsTrigger value="groups" className={tabTriggerClassName}>
-                Groups
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="members" className="mt-6">
-              <OrgMembersTable />
-            </TabsContent>
-            <TabsContent value="roles" className="mt-6">
-              <OrgRbacRoles />
-            </TabsContent>
-            <TabsContent value="groups" className="mt-6">
-              <OrgRbacGroups />
-            </TabsContent>
-          </Tabs>
-        </ScopeGuard>
+        {rbacEnabled ? (
+          <ScopeGuard
+            scope="org:rbac:read"
+            fallback={<OrgMembersTable />}
+            loading={null}
+          >
+            <Tabs defaultValue="members" className="w-full">
+              <TabsList className="inline-flex h-auto w-auto justify-start gap-0 rounded-none border-b border-border/30 bg-transparent p-0">
+                <TabsTrigger value="members" className={tabTriggerClassName}>
+                  Members
+                </TabsTrigger>
+                <TabsTrigger value="roles" className={tabTriggerClassName}>
+                  Roles
+                </TabsTrigger>
+                <TabsTrigger value="groups" className={tabTriggerClassName}>
+                  Groups
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="members" className="mt-6">
+                <OrgMembersTable />
+              </TabsContent>
+              <TabsContent value="roles" className="mt-6">
+                <OrgRbacRoles />
+              </TabsContent>
+              <TabsContent value="groups" className="mt-6">
+                <OrgRbacGroups />
+              </TabsContent>
+            </Tabs>
+          </ScopeGuard>
+        ) : (
+          <OrgMembersTable />
+        )}
       </div>
     </div>
   )

--- a/frontend/src/app/organization/members/page.tsx
+++ b/frontend/src/app/organization/members/page.tsx
@@ -5,15 +5,11 @@ import { OrgMembersTable } from "@/components/organization/org-members-table"
 import { OrgRbacGroups } from "@/components/organization/org-rbac-groups"
 import { OrgRbacRoles } from "@/components/organization/org-rbac-roles"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 
 const tabTriggerClassName =
   "rounded-none border-b-2 border-transparent px-4 py-2.5 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
 
 export default function MembersPage() {
-  const { isFeatureEnabled } = useFeatureFlag()
-  const rbacEnabled = isFeatureEnabled("rbac")
-
   return (
     <div className="size-full overflow-auto">
       <div className="container flex h-full max-w-[1200px] flex-col space-y-8 py-6">
@@ -27,38 +23,34 @@ export default function MembersPage() {
             </p>
           </div>
         </div>
-        {rbacEnabled ? (
-          <ScopeGuard
-            scope="org:rbac:read"
-            fallback={<OrgMembersTable />}
-            loading={null}
-          >
-            <Tabs defaultValue="members" className="w-full">
-              <TabsList className="inline-flex h-auto w-auto justify-start gap-0 rounded-none border-b border-border/30 bg-transparent p-0">
-                <TabsTrigger value="members" className={tabTriggerClassName}>
-                  Members
-                </TabsTrigger>
-                <TabsTrigger value="roles" className={tabTriggerClassName}>
-                  Roles
-                </TabsTrigger>
-                <TabsTrigger value="groups" className={tabTriggerClassName}>
-                  Groups
-                </TabsTrigger>
-              </TabsList>
-              <TabsContent value="members" className="mt-6">
-                <OrgMembersTable />
-              </TabsContent>
-              <TabsContent value="roles" className="mt-6">
-                <OrgRbacRoles />
-              </TabsContent>
-              <TabsContent value="groups" className="mt-6">
-                <OrgRbacGroups />
-              </TabsContent>
-            </Tabs>
-          </ScopeGuard>
-        ) : (
-          <OrgMembersTable />
-        )}
+        <ScopeGuard
+          scope="org:rbac:read"
+          fallback={<OrgMembersTable />}
+          loading={null}
+        >
+          <Tabs defaultValue="members" className="w-full">
+            <TabsList className="inline-flex h-auto w-auto justify-start gap-0 rounded-none border-b border-border/30 bg-transparent p-0">
+              <TabsTrigger value="members" className={tabTriggerClassName}>
+                Members
+              </TabsTrigger>
+              <TabsTrigger value="roles" className={tabTriggerClassName}>
+                Roles
+              </TabsTrigger>
+              <TabsTrigger value="groups" className={tabTriggerClassName}>
+                Groups
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="members" className="mt-6">
+              <OrgMembersTable />
+            </TabsContent>
+            <TabsContent value="roles" className="mt-6">
+              <OrgRbacRoles />
+            </TabsContent>
+            <TabsContent value="groups" className="mt-6">
+              <OrgRbacGroups />
+            </TabsContent>
+          </Tabs>
+        </ScopeGuard>
       </div>
     </div>
   )

--- a/frontend/src/app/organization/members/page.tsx
+++ b/frontend/src/app/organization/members/page.tsx
@@ -11,8 +11,8 @@ const tabTriggerClassName =
   "rounded-none border-b-2 border-transparent px-4 py-2.5 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
 
 export default function MembersPage() {
-  const { hasEntitlement } = useEntitlements()
-  const rbacEnabled = hasEntitlement("rbac")
+  const { hasEntitlement, isLoading } = useEntitlements()
+  const rbacEnabled = !isLoading && hasEntitlement("rbac_addons")
 
   return (
     <div className="size-full overflow-auto">

--- a/frontend/src/app/organization/settings/rbac/page.tsx
+++ b/frontend/src/app/organization/settings/rbac/page.tsx
@@ -21,7 +21,7 @@ type RbacTab =
 export default function RbacSettingsPage() {
   const router = useRouter()
   const { hasEntitlement, isLoading } = useEntitlements()
-  const rbacEnabled = hasEntitlement("rbac")
+  const rbacEnabled = hasEntitlement("rbac_addons")
   const [activeTab, setActiveTab] = useState<RbacTab>("roles")
 
   useEffect(() => {

--- a/frontend/src/app/organization/settings/rbac/page.tsx
+++ b/frontend/src/app/organization/settings/rbac/page.tsx
@@ -1,15 +1,12 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
-import { CenteredSpinner } from "@/components/loading/spinner"
+import { useState } from "react"
 import { OrgRbacAssignments } from "@/components/organization/org-rbac-assignments"
 import { OrgRbacGroups } from "@/components/organization/org-rbac-groups"
 import { OrgRbacRoles } from "@/components/organization/org-rbac-roles"
 import { OrgRbacScopes } from "@/components/organization/org-rbac-scopes"
 import { OrgRbacUserAssignments } from "@/components/organization/org-rbac-user-assignments"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 
 type RbacTab =
   | "roles"
@@ -19,20 +16,7 @@ type RbacTab =
   | "user-assignments"
 
 export default function RbacSettingsPage() {
-  const router = useRouter()
-  const { isFeatureEnabled, isLoading: featureFlagsLoading } = useFeatureFlag()
-  const rbacEnabled = isFeatureEnabled("rbac")
   const [activeTab, setActiveTab] = useState<RbacTab>("roles")
-
-  useEffect(() => {
-    if (!featureFlagsLoading && !rbacEnabled) {
-      router.replace("/organization/members")
-    }
-  }, [featureFlagsLoading, rbacEnabled, router])
-
-  if (featureFlagsLoading || !rbacEnabled) {
-    return <CenteredSpinner />
-  }
 
   return (
     <div className="size-full overflow-auto">

--- a/frontend/src/app/organization/settings/rbac/page.tsx
+++ b/frontend/src/app/organization/settings/rbac/page.tsx
@@ -1,12 +1,15 @@
 "use client"
 
-import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+import { CenteredSpinner } from "@/components/loading/spinner"
 import { OrgRbacAssignments } from "@/components/organization/org-rbac-assignments"
 import { OrgRbacGroups } from "@/components/organization/org-rbac-groups"
 import { OrgRbacRoles } from "@/components/organization/org-rbac-roles"
 import { OrgRbacScopes } from "@/components/organization/org-rbac-scopes"
 import { OrgRbacUserAssignments } from "@/components/organization/org-rbac-user-assignments"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useEntitlements } from "@/hooks/use-entitlements"
 
 type RbacTab =
   | "roles"
@@ -16,7 +19,20 @@ type RbacTab =
   | "user-assignments"
 
 export default function RbacSettingsPage() {
+  const router = useRouter()
+  const { hasEntitlement, isLoading } = useEntitlements()
+  const rbacEnabled = hasEntitlement("rbac")
   const [activeTab, setActiveTab] = useState<RbacTab>("roles")
+
+  useEffect(() => {
+    if (!isLoading && !rbacEnabled) {
+      router.replace("/organization/members")
+    }
+  }, [isLoading, rbacEnabled, router])
+
+  if (isLoading || !rbacEnabled) {
+    return <CenteredSpinner />
+  }
 
   return (
     <div className="size-full overflow-auto">

--- a/frontend/src/app/workspaces/[workspaceId]/members/groups/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/members/groups/page.tsx
@@ -1,14 +1,31 @@
 "use client"
 
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
 import { ScopeGuard } from "@/components/auth/scope-guard"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { WorkspaceRbacGroups } from "@/components/workspaces/workspace-rbac-groups"
+import { useEntitlements } from "@/hooks/use-entitlements"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
+import { useWorkspaceId } from "@/providers/workspace-id"
 
 export default function WorkspaceGroupsPage() {
+  const router = useRouter()
+  const workspaceId = useWorkspaceId()
   const { workspace, workspaceLoading, workspaceError } = useWorkspaceDetails()
+  const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
+  const rbacEnabled = hasEntitlement("rbac")
 
+  useEffect(() => {
+    if (!entitlementsLoading && !rbacEnabled) {
+      router.replace(`/workspaces/${workspaceId}/members`)
+    }
+  }, [entitlementsLoading, rbacEnabled, router, workspaceId])
+
+  if (entitlementsLoading || !rbacEnabled) {
+    return <CenteredSpinner />
+  }
   if (workspaceLoading) {
     return <CenteredSpinner />
   }

--- a/frontend/src/app/workspaces/[workspaceId]/members/groups/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/members/groups/page.tsx
@@ -1,31 +1,14 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
 import { ScopeGuard } from "@/components/auth/scope-guard"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { WorkspaceRbacGroups } from "@/components/workspaces/workspace-rbac-groups"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
-import { useWorkspaceId } from "@/providers/workspace-id"
 
 export default function WorkspaceGroupsPage() {
-  const router = useRouter()
-  const workspaceId = useWorkspaceId()
   const { workspace, workspaceLoading, workspaceError } = useWorkspaceDetails()
-  const { isFeatureEnabled, isLoading: featureFlagsLoading } = useFeatureFlag()
-  const rbacEnabled = isFeatureEnabled("rbac")
 
-  useEffect(() => {
-    if (!featureFlagsLoading && !rbacEnabled) {
-      router.replace(`/workspaces/${workspaceId}/members`)
-    }
-  }, [featureFlagsLoading, rbacEnabled, router, workspaceId])
-
-  if (featureFlagsLoading || !rbacEnabled) {
-    return <CenteredSpinner />
-  }
   if (workspaceLoading) {
     return <CenteredSpinner />
   }

--- a/frontend/src/app/workspaces/[workspaceId]/members/groups/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/members/groups/page.tsx
@@ -15,7 +15,7 @@ export default function WorkspaceGroupsPage() {
   const workspaceId = useWorkspaceId()
   const { workspace, workspaceLoading, workspaceError } = useWorkspaceDetails()
   const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
-  const rbacEnabled = hasEntitlement("rbac")
+  const rbacEnabled = hasEntitlement("rbac_addons")
 
   useEffect(() => {
     if (!entitlementsLoading && !rbacEnabled) {

--- a/frontend/src/app/workspaces/[workspaceId]/members/roles/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/members/roles/page.tsx
@@ -15,7 +15,7 @@ export default function WorkspaceRolesPage() {
   const workspaceId = useWorkspaceId()
   const { workspace, workspaceLoading, workspaceError } = useWorkspaceDetails()
   const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
-  const rbacEnabled = hasEntitlement("rbac")
+  const rbacEnabled = hasEntitlement("rbac_addons")
 
   useEffect(() => {
     if (!entitlementsLoading && !rbacEnabled) {

--- a/frontend/src/app/workspaces/[workspaceId]/members/roles/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/members/roles/page.tsx
@@ -1,14 +1,31 @@
 "use client"
 
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
 import { ScopeGuard } from "@/components/auth/scope-guard"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { WorkspaceRbacRoles } from "@/components/workspaces/workspace-rbac-roles"
+import { useEntitlements } from "@/hooks/use-entitlements"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
+import { useWorkspaceId } from "@/providers/workspace-id"
 
 export default function WorkspaceRolesPage() {
+  const router = useRouter()
+  const workspaceId = useWorkspaceId()
   const { workspace, workspaceLoading, workspaceError } = useWorkspaceDetails()
+  const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
+  const rbacEnabled = hasEntitlement("rbac")
 
+  useEffect(() => {
+    if (!entitlementsLoading && !rbacEnabled) {
+      router.replace(`/workspaces/${workspaceId}/members`)
+    }
+  }, [entitlementsLoading, rbacEnabled, router, workspaceId])
+
+  if (entitlementsLoading || !rbacEnabled) {
+    return <CenteredSpinner />
+  }
   if (workspaceLoading) {
     return <CenteredSpinner />
   }

--- a/frontend/src/app/workspaces/[workspaceId]/members/roles/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/members/roles/page.tsx
@@ -1,31 +1,14 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
 import { ScopeGuard } from "@/components/auth/scope-guard"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { WorkspaceRbacRoles } from "@/components/workspaces/workspace-rbac-roles"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
-import { useWorkspaceId } from "@/providers/workspace-id"
 
 export default function WorkspaceRolesPage() {
-  const router = useRouter()
-  const workspaceId = useWorkspaceId()
   const { workspace, workspaceLoading, workspaceError } = useWorkspaceDetails()
-  const { isFeatureEnabled, isLoading: featureFlagsLoading } = useFeatureFlag()
-  const rbacEnabled = isFeatureEnabled("rbac")
 
-  useEffect(() => {
-    if (!featureFlagsLoading && !rbacEnabled) {
-      router.replace(`/workspaces/${workspaceId}/members`)
-    }
-  }, [featureFlagsLoading, rbacEnabled, router, workspaceId])
-
-  if (featureFlagsLoading || !rbacEnabled) {
-    return <CenteredSpinner />
-  }
   if (workspaceLoading) {
     return <CenteredSpinner />
   }

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -7628,11 +7628,11 @@ export const $EffectiveEntitlements = {
         "Whether add-on case capabilities are enabled (dropdowns, durations, tasks, triggers)",
       default: false,
     },
-    rbac: {
+    rbac_addons: {
       type: "boolean",
-      title: "Rbac",
+      title: "Rbac Addons",
       description:
-        "Whether RBAC is enabled (custom roles, groups, and assignments)",
+        "Whether RBAC add-ons are enabled (custom roles, groups, and assignments)",
       default: false,
     },
   },
@@ -7667,11 +7667,11 @@ export const $EntitlementsDict = {
       description:
         "Whether add-on case capabilities are enabled (dropdowns, durations, tasks, triggers)",
     },
-    rbac: {
+    rbac_addons: {
       type: "boolean",
-      title: "Rbac",
+      title: "Rbac Addons",
       description:
-        "Whether RBAC is enabled (custom roles, groups, and assignments)",
+        "Whether RBAC add-ons are enabled (custom roles, groups, and assignments)",
     },
   },
   type: "object",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8192,7 +8192,7 @@ export const $ExternalObject = {
 
 export const $FeatureFlag = {
   type: "string",
-  enum: ["ai-ranking", "rbac"],
+  enum: ["ai-ranking"],
   title: "FeatureFlag",
   description: "Feature flag enum reserved for engineering rollouts.",
 } as const

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -7628,6 +7628,13 @@ export const $EffectiveEntitlements = {
         "Whether add-on case capabilities are enabled (dropdowns, durations, tasks, triggers)",
       default: false,
     },
+    rbac: {
+      type: "boolean",
+      title: "Rbac",
+      description:
+        "Whether RBAC is enabled (custom roles, groups, and assignments)",
+      default: false,
+    },
   },
   type: "object",
   title: "EffectiveEntitlements",
@@ -7659,6 +7666,12 @@ export const $EntitlementsDict = {
       title: "Case Addons",
       description:
         "Whether add-on case capabilities are enabled (dropdowns, durations, tasks, triggers)",
+    },
+    rbac: {
+      type: "boolean",
+      title: "Rbac",
+      description:
+        "Whether RBAC is enabled (custom roles, groups, and assignments)",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2333,9 +2333,9 @@ export type EffectiveEntitlements = {
    */
   case_addons?: boolean
   /**
-   * Whether RBAC is enabled (custom roles, groups, and assignments)
+   * Whether RBAC add-ons are enabled (custom roles, groups, and assignments)
    */
-  rbac?: boolean
+  rbac_addons?: boolean
 }
 
 /**
@@ -2361,9 +2361,9 @@ export type EntitlementsDict = {
    */
   case_addons?: boolean
   /**
-   * Whether RBAC is enabled (custom roles, groups, and assignments)
+   * Whether RBAC add-ons are enabled (custom roles, groups, and assignments)
    */
-  rbac?: boolean
+  rbac_addons?: boolean
 }
 
 export type ErrorDetails = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2332,6 +2332,10 @@ export type EffectiveEntitlements = {
    * Whether add-on case capabilities are enabled (dropdowns, durations, tasks, triggers)
    */
   case_addons?: boolean
+  /**
+   * Whether RBAC is enabled (custom roles, groups, and assignments)
+   */
+  rbac?: boolean
 }
 
 /**
@@ -2356,6 +2360,10 @@ export type EntitlementsDict = {
    * Whether add-on case capabilities are enabled (dropdowns, durations, tasks, triggers)
    */
   case_addons?: boolean
+  /**
+   * Whether RBAC is enabled (custom roles, groups, and assignments)
+   */
+  rbac?: boolean
 }
 
 export type ErrorDetails = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2508,7 +2508,7 @@ export type ExternalObject = {
 /**
  * Feature flag enum reserved for engineering rollouts.
  */
-export type FeatureFlag = "ai-ranking" | "rbac"
+export type FeatureFlag = "ai-ranking"
 
 /**
  * Response model for feature flags.

--- a/frontend/src/components/members/members-view-toggle.tsx
+++ b/frontend/src/components/members/members-view-toggle.tsx
@@ -38,7 +38,7 @@ export function MembersViewToggle({
 }: MembersViewToggleProps) {
   const { hasEntitlement } = useEntitlements()
 
-  if (!hasEntitlement("rbac")) {
+  if (!hasEntitlement("rbac_addons")) {
     return null
   }
 

--- a/frontend/src/components/members/members-view-toggle.tsx
+++ b/frontend/src/components/members/members-view-toggle.tsx
@@ -9,7 +9,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { cn } from "@/lib/utils"
 
 export enum MembersViewMode {
@@ -36,15 +35,6 @@ export function MembersViewToggle({
   groupsHref,
   rbacScope,
 }: MembersViewToggleProps) {
-  const { isFeatureEnabled } = useFeatureFlag()
-  const rbacEnabled = isFeatureEnabled("rbac")
-
-  // Don't render the toggle at all when RBAC is disabled —
-  // a single "Members" button in a toggle group is pointless.
-  if (!rbacEnabled) {
-    return null
-  }
-
   const toggleItems = [
     {
       mode: MembersViewMode.Members,

--- a/frontend/src/components/members/members-view-toggle.tsx
+++ b/frontend/src/components/members/members-view-toggle.tsx
@@ -9,6 +9,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useEntitlements } from "@/hooks/use-entitlements"
 import { cn } from "@/lib/utils"
 
 export enum MembersViewMode {
@@ -35,6 +36,12 @@ export function MembersViewToggle({
   groupsHref,
   rbacScope,
 }: MembersViewToggleProps) {
+  const { hasEntitlement } = useEntitlements()
+
+  if (!hasEntitlement("rbac")) {
+    return null
+  }
+
   const toggleItems = [
     {
       mode: MembersViewMode.Members,

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -80,7 +80,7 @@ from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.editor.router import router as editor_router
 from tracecat.exceptions import EntitlementRequired, ScopeDeniedError, TracecatException
-from tracecat.feature_flags import FeatureFlag, FlagLike, is_feature_enabled
+from tracecat.feature_flags import FlagLike, is_feature_enabled
 from tracecat.feature_flags.router import router as feature_flags_router
 from tracecat.inbox.router import router as inbox_router
 from tracecat.integrations.router import (
@@ -456,26 +456,11 @@ def create_app(**kwargs) -> FastAPI:
         user_assignments_router as rbac_user_assignments_router,
     )
 
-    app.include_router(
-        rbac_scopes_router,
-        dependencies=[Depends(feature_flag_dep(FeatureFlag.RBAC))],
-    )
-    app.include_router(
-        rbac_roles_router,
-        dependencies=[Depends(feature_flag_dep(FeatureFlag.RBAC))],
-    )
-    app.include_router(
-        rbac_groups_router,
-        dependencies=[Depends(feature_flag_dep(FeatureFlag.RBAC))],
-    )
-    app.include_router(
-        rbac_assignments_router,
-        dependencies=[Depends(feature_flag_dep(FeatureFlag.RBAC))],
-    )
-    app.include_router(
-        rbac_user_assignments_router,
-        dependencies=[Depends(feature_flag_dep(FeatureFlag.RBAC))],
-    )
+    app.include_router(rbac_scopes_router)
+    app.include_router(rbac_roles_router)
+    app.include_router(rbac_groups_router)
+    app.include_router(rbac_assignments_router)
+    app.include_router(rbac_user_assignments_router)
     app.include_router(
         fastapi_users.get_users_router(UserRead, UserUpdate),
         prefix="/users",

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -439,7 +439,7 @@ def create_app(**kwargs) -> FastAPI:
     # RBAC routers - user_scopes_router is always included (OSS)
     app.include_router(user_scopes_router)
 
-    # EE-only RBAC management endpoints - gated by feature flag
+    # EE-only RBAC management endpoints - gated by RBAC entitlement
     from tracecat_ee.rbac.router import (
         assignments_router as rbac_assignments_router,
     )

--- a/tracecat/feature_flags/enums.py
+++ b/tracecat/feature_flags/enums.py
@@ -5,4 +5,3 @@ class FeatureFlag(StrEnum):
     """Feature flag enum reserved for engineering rollouts."""
 
     AI_RANKING = "ai-ranking"
-    RBAC = "rbac"

--- a/tracecat/tiers/defaults.py
+++ b/tracecat/tiers/defaults.py
@@ -53,7 +53,7 @@ def resolve_oss_default_entitlements(
             git_sync=False,
             agent_addons=False,
             case_addons=False,
-            rbac=False,
+            rbac_addons=False,
         )
 
     # Existing install path: map legacy feature flags to entitlement groups.
@@ -73,13 +73,17 @@ def resolve_oss_default_entitlements(
             break
 
     rbac_enabled = False
+    for flag in _RBAC_FLAGS:
+        if flag in normalized_flags:
+            rbac_enabled = True
+            break
 
     return EffectiveEntitlements(
         custom_registry=True,
         git_sync=git_sync_enabled,
         agent_addons=agent_addons_enabled,
         case_addons=case_addons_enabled,
-        rbac=rbac_enabled,
+        rbac_addons=rbac_enabled,
     )
 
 

--- a/tracecat/tiers/defaults.py
+++ b/tracecat/tiers/defaults.py
@@ -20,6 +20,7 @@ DEFAULT_LIMITS = EffectiveLimits(
 
 _AGENT_ADDON_FLAGS = ("agent-approvals", "agent-presets")
 _CASE_ADDON_FLAGS = ("case-dropdowns", "case-durations", "case-tasks", "case-triggers")
+_RBAC_FLAGS = ("rbac",)
 
 
 def get_legacy_feature_flags_env() -> str | None:
@@ -52,6 +53,7 @@ def resolve_oss_default_entitlements(
             git_sync=False,
             agent_addons=False,
             case_addons=False,
+            rbac=False,
         )
 
     # Existing install path: map legacy feature flags to entitlement groups.
@@ -70,11 +72,14 @@ def resolve_oss_default_entitlements(
             case_addons_enabled = True
             break
 
+    rbac_enabled = False
+
     return EffectiveEntitlements(
         custom_registry=True,
         git_sync=git_sync_enabled,
         agent_addons=agent_addons_enabled,
         case_addons=case_addons_enabled,
+        rbac=rbac_enabled,
     )
 
 

--- a/tracecat/tiers/enums.py
+++ b/tracecat/tiers/enums.py
@@ -10,3 +10,4 @@ class Entitlement(StrEnum):
     GIT_SYNC = "git_sync"
     AGENT_ADDONS = "agent_addons"
     CASE_ADDONS = "case_addons"
+    RBAC = "rbac"

--- a/tracecat/tiers/enums.py
+++ b/tracecat/tiers/enums.py
@@ -10,4 +10,4 @@ class Entitlement(StrEnum):
     GIT_SYNC = "git_sync"
     AGENT_ADDONS = "agent_addons"
     CASE_ADDONS = "case_addons"
-    RBAC = "rbac"
+    RBAC_ADDONS = "rbac_addons"

--- a/tracecat/tiers/schemas.py
+++ b/tracecat/tiers/schemas.py
@@ -57,9 +57,10 @@ class EffectiveEntitlements(Schema):
         description="Whether add-on case capabilities are enabled"
         " (dropdowns, durations, tasks, triggers)",
     )
-    rbac: bool = Field(
+    rbac_addons: bool = Field(
         default=False,
-        description="Whether RBAC is enabled (custom roles, groups, and assignments)",
+        description="Whether RBAC add-ons are enabled"
+        " (custom roles, groups, and assignments)",
     )
 
 

--- a/tracecat/tiers/schemas.py
+++ b/tracecat/tiers/schemas.py
@@ -57,6 +57,10 @@ class EffectiveEntitlements(Schema):
         description="Whether add-on case capabilities are enabled"
         " (dropdowns, durations, tasks, triggers)",
     )
+    rbac: bool = Field(
+        default=False,
+        description="Whether RBAC is enabled (custom roles, groups, and assignments)",
+    )
 
 
 class TierRead(Schema):

--- a/tracecat/tiers/service.py
+++ b/tracecat/tiers/service.py
@@ -172,4 +172,5 @@ class TierService(BaseService):
             git_sync=resolve_entitlement("git_sync"),
             agent_addons=resolve_entitlement("agent_addons"),
             case_addons=resolve_entitlement("case_addons"),
+            rbac=resolve_entitlement("rbac"),
         )

--- a/tracecat/tiers/service.py
+++ b/tracecat/tiers/service.py
@@ -172,5 +172,5 @@ class TierService(BaseService):
             git_sync=resolve_entitlement("git_sync"),
             agent_addons=resolve_entitlement("agent_addons"),
             case_addons=resolve_entitlement("case_addons"),
-            rbac=resolve_entitlement("rbac"),
+            rbac_addons=resolve_entitlement("rbac_addons"),
         )

--- a/tracecat/tiers/types.py
+++ b/tracecat/tiers/types.py
@@ -32,10 +32,10 @@ class EntitlementsDict(TypedDict, total=False):
             " (dropdowns, durations, tasks, triggers)"
         ),
     ]
-    rbac: Annotated[
+    rbac_addons: Annotated[
         bool,
         Field(
-            description="Whether RBAC is enabled"
+            description="Whether RBAC add-ons are enabled"
             " (custom roles, groups, and assignments)"
         ),
     ]

--- a/tracecat/tiers/types.py
+++ b/tracecat/tiers/types.py
@@ -32,3 +32,10 @@ class EntitlementsDict(TypedDict, total=False):
             " (dropdowns, durations, tasks, triggers)"
         ),
     ]
+    rbac: Annotated[
+        bool,
+        Field(
+            description="Whether RBAC is enabled"
+            " (custom roles, groups, and assignments)"
+        ),
+    ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Dropped the RBAC feature flag and replaced it with the rbac_addons entitlement. EE RBAC APIs now require this entitlement, and the UI only shows RBAC pages when it’s present; scope checks still apply.

- **Refactors**
  - Enforced rbac_addons on all EE RBAC routers via a router-level dependency; removed app-level feature-flag gating.
  - Removed FeatureFlag.RBAC; added rbac_addons across tiers (enums, schemas, types, service, defaults map legacy “rbac” flag) and in generated TS types.
  - Frontend now uses useEntitlements and the rbac_addons key in org/workspace pages and settings; the members toggle renders only when entitled; loading states handled.

- **Migration**
  - Remove any "rbac" feature flag from config.
  - Set entitlements.rbac_addons to enable RBAC endpoints and UI.

<sup>Written for commit 825d485e100d4fc6c45dbb835b09d356ef8b7b89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

