### PR TITLE
fix(rbac): org secret perms for services

### DIFF
--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -362,6 +362,7 @@ WORKSPACE_OPERATIONAL_SCOPES: frozenset[str] = frozenset(
         "workspace:delete",
         "workspace:member:read",
         "action:*:execute",
+        "org:secret:read",
     }
 )
 
@@ -371,11 +372,6 @@ SERVICE_PRINCIPAL_SCOPES: dict[InternalServiceID, frozenset[str]] = {
     cast(InternalServiceID, service_id): WORKSPACE_OPERATIONAL_SCOPES
     for service_id in get_args(InternalServiceID)
 }
-
-# tracecat-service needs org-scoped secret reads for registry sync SSH key lookup.
-SERVICE_PRINCIPAL_SCOPES["tracecat-service"] = SERVICE_PRINCIPAL_SCOPES[
-    "tracecat-service"
-] | frozenset({"org:secret:read"})
 
 
 # =============================================================================


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give all internal services org-scoped secret read access by adding org:secret:read to the default service scopes and removing the tracecat-service special case. Add regression tests to ensure the LLM gateway and all service principals have org:secret:read, agent:read, and secret:read, fixing Copilot chat provider lookups and registry sync SSH key retrieval.

<sup>Written for commit 3001ba60c1b2171264e61888171f340cc0e63589. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



 ## Problem
 Copilot chat fails with ScopeDeniedError for all users
  (including super admin). Case chat works fine.

 ### Root cause: The LiteLLM gateway creates a service principal role
  scoped to WORKSPACE_OPERATIONAL_SCOPES. Copilot chat uses
  use_workspace_credentials=False, which calls
  SecretsService.get_org_secret_by_name() — decorated with
  @require_scope("org:secret:read"). That scope was missing from
  WORKSPACE_OPERATIONAL_SCOPES.

  Case chat works because it uses use_workspace_credentials=True,
  calling get_secret_by_name() which requires secret:read (already
  present).

  ### Fix
  Added org:secret:read to WORKSPACE_OPERATIONAL_SCOPES in
  tracecat/authz/scopes.py. Removed the per-service override for
  tracecat-service since it's now in the base set.

  ### Regression
  Case chat is unaffected — it uses the workspace
  credentials path which requires secret:read (unchanged).

