### PR TITLE
feat: add paged collection result viewer and indexed object ops

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -20085,6 +20085,171 @@ export const $WorkflowEventType = {
   description: "The event types we care about.",
 } as const
 
+export const $WorkflowExecutionCollectionPageItem = {
+  properties: {
+    index: {
+      type: "integer",
+      minimum: 0,
+      title: "Index",
+      description: "Collection index for this item",
+    },
+    kind: {
+      $ref: "#/components/schemas/WorkflowExecutionCollectionPageItemKind",
+      description: "Descriptor type for this collection page item",
+    },
+    stored: {
+      anyOf: [
+        {
+          oneOf: [
+            {
+              $ref: "#/components/schemas/InlineObject",
+            },
+            {
+              $ref: "#/components/schemas/ExternalObject",
+            },
+            {
+              $ref: "#/components/schemas/CollectionObject",
+            },
+          ],
+          discriminator: {
+            propertyName: "type",
+            mapping: {
+              collection: "#/components/schemas/CollectionObject",
+              external: "#/components/schemas/ExternalObject",
+              inline: "#/components/schemas/InlineObject",
+            },
+          },
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Stored",
+      description: "StoredObject descriptor when kind is stored_object_ref",
+    },
+    value_preview: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Value Preview",
+      description:
+        "UTF-8 preview of serialized inline value when kind is inline_value",
+    },
+    value_size_bytes: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 0,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Value Size Bytes",
+      description:
+        "Serialized inline value size in bytes when kind is inline_value",
+    },
+    truncated: {
+      type: "boolean",
+      title: "Truncated",
+      description: "Whether value_preview was truncated",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["index", "kind"],
+  title: "WorkflowExecutionCollectionPageItem",
+} as const
+
+export const $WorkflowExecutionCollectionPageItemKind = {
+  type: "string",
+  enum: ["stored_object_ref", "inline_value"],
+  title: "WorkflowExecutionCollectionPageItemKind",
+} as const
+
+export const $WorkflowExecutionCollectionPageRequest = {
+  properties: {
+    event_id: {
+      type: "integer",
+      minimum: 1,
+      title: "Event Id",
+      description: "Temporal history event ID",
+    },
+    field: {
+      $ref: "#/components/schemas/WorkflowExecutionObjectField",
+      default: "action_result",
+    },
+    offset: {
+      type: "integer",
+      minimum: 0,
+      title: "Offset",
+      description: "Page start index (0-indexed)",
+      default: 0,
+    },
+    limit: {
+      type: "integer",
+      maximum: 100,
+      minimum: 1,
+      title: "Limit",
+      description: "Maximum number of items to return",
+      default: 25,
+    },
+  },
+  type: "object",
+  required: ["event_id"],
+  title: "WorkflowExecutionCollectionPageRequest",
+} as const
+
+export const $WorkflowExecutionCollectionPageResponse = {
+  properties: {
+    collection: {
+      $ref: "#/components/schemas/CollectionObject",
+      description: "Collection metadata for the requested result",
+    },
+    offset: {
+      type: "integer",
+      minimum: 0,
+      title: "Offset",
+      description: "Requested page offset",
+    },
+    limit: {
+      type: "integer",
+      minimum: 1,
+      title: "Limit",
+      description: "Requested page size",
+    },
+    next_offset: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 0,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Offset",
+      description: "Offset to use for next page, or null if no more items",
+    },
+    items: {
+      items: {
+        $ref: "#/components/schemas/WorkflowExecutionCollectionPageItem",
+      },
+      type: "array",
+      title: "Items",
+      description: "Collection page descriptors",
+    },
+  },
+  type: "object",
+  required: ["collection", "offset", "limit"],
+  title: "WorkflowExecutionCollectionPageResponse",
+} as const
+
 export const $WorkflowExecutionCreate = {
   properties: {
     workflow_id: {
@@ -20507,6 +20672,20 @@ export const $WorkflowExecutionObjectRequest = {
     field: {
       $ref: "#/components/schemas/WorkflowExecutionObjectField",
       default: "action_result",
+    },
+    collection_index: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 0,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Collection Index",
+      description:
+        "Optional index into a CollectionObject result. When omitted, operates on the top-level object result.",
     },
   },
   type: "object",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -592,6 +592,8 @@ import type {
   WorkflowExecutionsCreateDraftWorkflowExecutionResponse,
   WorkflowExecutionsCreateWorkflowExecutionData,
   WorkflowExecutionsCreateWorkflowExecutionResponse,
+  WorkflowExecutionsGetWorkflowExecutionCollectionPageData,
+  WorkflowExecutionsGetWorkflowExecutionCollectionPageResponse,
   WorkflowExecutionsGetWorkflowExecutionCompactData,
   WorkflowExecutionsGetWorkflowExecutionCompactResponse,
   WorkflowExecutionsGetWorkflowExecutionData,
@@ -2037,6 +2039,36 @@ export const workflowExecutionsGetWorkflowExecutionObjectPreview = (
   return __request(OpenAPI, {
     method: "POST",
     url: "/workflow-executions/{execution_id}/objects/preview",
+    path: {
+      execution_id: data.executionId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Workflow Execution Collection Page
+ * Fetch a bounded page of collection item descriptors.
+ * @param data The data for the request.
+ * @param data.executionId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns WorkflowExecutionCollectionPageResponse Successful Response
+ * @throws ApiError
+ */
+export const workflowExecutionsGetWorkflowExecutionCollectionPage = (
+  data: WorkflowExecutionsGetWorkflowExecutionCollectionPageData
+): CancelablePromise<WorkflowExecutionsGetWorkflowExecutionCollectionPageResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workflow-executions/{execution_id}/objects/collection/page",
     path: {
       execution_id: data.executionId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6252,6 +6252,76 @@ export type WorkflowEventType =
   | "WORKFLOW_EXECUTION_UPDATE_REJECTED"
   | "WORKFLOW_EXECUTION_UPDATE_COMPLETED"
 
+export type WorkflowExecutionCollectionPageItem = {
+  /**
+   * Collection index for this item
+   */
+  index: number
+  /**
+   * Descriptor type for this collection page item
+   */
+  kind: WorkflowExecutionCollectionPageItemKind
+  /**
+   * StoredObject descriptor when kind is stored_object_ref
+   */
+  stored?: InlineObject | ExternalObject | CollectionObject | null
+  /**
+   * UTF-8 preview of serialized inline value when kind is inline_value
+   */
+  value_preview?: string | null
+  /**
+   * Serialized inline value size in bytes when kind is inline_value
+   */
+  value_size_bytes?: number | null
+  /**
+   * Whether value_preview was truncated
+   */
+  truncated?: boolean
+}
+
+export type WorkflowExecutionCollectionPageItemKind =
+  | "stored_object_ref"
+  | "inline_value"
+
+export type WorkflowExecutionCollectionPageRequest = {
+  /**
+   * Temporal history event ID
+   */
+  event_id: number
+  field?: WorkflowExecutionObjectField
+  /**
+   * Page start index (0-indexed)
+   */
+  offset?: number
+  /**
+   * Maximum number of items to return
+   */
+  limit?: number
+}
+
+export type WorkflowExecutionCollectionPageResponse = {
+  /**
+   * Collection metadata for the requested result
+   */
+  collection: CollectionObject
+  /**
+   * Requested page offset
+   */
+  offset: number
+  /**
+   * Requested page size
+   */
+  limit: number
+  /**
+   * Offset to use for next page, or null if no more items
+   */
+  next_offset?: number | null
+  /**
+   * Collection page descriptors
+   */
+  items?: Array<WorkflowExecutionCollectionPageItem>
+}
+
 export type WorkflowExecutionCreate = {
   workflow_id: string
   inputs?: unknown | null
@@ -6378,6 +6448,10 @@ export type WorkflowExecutionObjectRequest = {
    */
   event_id: number
   field?: WorkflowExecutionObjectField
+  /**
+   * Optional index into a CollectionObject result. When omitted, operates on the top-level object result.
+   */
+  collection_index?: number | null
 }
 
 export type WorkflowExecutionRead = {
@@ -7304,6 +7378,15 @@ export type WorkflowExecutionsGetWorkflowExecutionObjectPreviewData = {
 
 export type WorkflowExecutionsGetWorkflowExecutionObjectPreviewResponse =
   WorkflowExecutionObjectPreviewResponse
+
+export type WorkflowExecutionsGetWorkflowExecutionCollectionPageData = {
+  executionId: string
+  requestBody: WorkflowExecutionCollectionPageRequest
+  workspaceId: string
+}
+
+export type WorkflowExecutionsGetWorkflowExecutionCollectionPageResponse =
+  WorkflowExecutionCollectionPageResponse
 
 export type WorkflowExecutionsCreateDraftWorkflowExecutionData = {
   requestBody: WorkflowExecutionCreate
@@ -10208,6 +10291,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: WorkflowExecutionObjectPreviewResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workflow-executions/{execution_id}/objects/collection/page": {
+    post: {
+      req: WorkflowExecutionsGetWorkflowExecutionCollectionPageData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowExecutionCollectionPageResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -20,6 +20,7 @@ import {
 import { MessagePart } from "@/components/chat/chat-session-pane"
 import { CodeBlock } from "@/components/code-block"
 import { getWorkflowEventIcon } from "@/components/events/workflow-event-status"
+import { CollectionObjectResult } from "@/components/executions/collection-object-result"
 import { ExternalObjectResult } from "@/components/executions/external-object-result"
 import { JsonViewWithControls } from "@/components/json-viewer"
 import { Spinner } from "@/components/loading/spinner"
@@ -53,7 +54,10 @@ import {
   type WorkflowExecutionEventCompact,
   type WorkflowExecutionReadCompact,
 } from "@/lib/event-history"
-import { isExternalStoredObject } from "@/lib/stored-object"
+import {
+  isCollectionStoredObject,
+  isExternalStoredObject,
+} from "@/lib/stored-object"
 import { useWorkflowBuilder } from "@/providers/builder"
 
 type TabType = "input" | "result" | "interaction"
@@ -262,6 +266,16 @@ function ActionResultViewer({
         executionId={executionId}
         eventId={eventId}
         external={result}
+      />
+    )
+  }
+
+  if (isCollectionStoredObject(result)) {
+    return (
+      <CollectionObjectResult
+        executionId={executionId}
+        eventId={eventId}
+        collection={result}
       />
     )
   }

--- a/frontend/src/components/executions/collection-object-result.tsx
+++ b/frontend/src/components/executions/collection-object-result.tsx
@@ -1,0 +1,432 @@
+"use client"
+
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  DownloadIcon,
+  EyeIcon,
+  LoaderIcon,
+  XIcon,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import {
+  type CollectionObject,
+  type WorkflowExecutionCollectionPageResponse,
+  type WorkflowExecutionObjectPreviewResponse,
+  workflowExecutionsGetWorkflowExecutionCollectionPage,
+  workflowExecutionsGetWorkflowExecutionObjectDownload,
+  workflowExecutionsGetWorkflowExecutionObjectPreview,
+} from "@/client"
+import { CodeBlock } from "@/components/code-block"
+import { ExternalObjectResult } from "@/components/executions/external-object-result"
+import { JsonViewWithControls } from "@/components/json-viewer"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { toast } from "@/components/ui/use-toast"
+import { isExternalStoredObject } from "@/lib/stored-object"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+const DEFAULT_PAGE_SIZE = 25
+
+function getElementKindLabel(kind: CollectionObject["element_kind"]): string {
+  if (kind === "stored_object") {
+    return "Files"
+  }
+  return "Inline values"
+}
+
+function getItemKindLabel(kind: "stored_object_ref" | "inline_value"): string {
+  if (kind === "stored_object_ref") {
+    return "File"
+  }
+  return "Value"
+}
+
+function formatSize(sizeBytes: number): string {
+  if (sizeBytes === 0) {
+    return "0 Bytes"
+  }
+  const units = ["Bytes", "KB", "MB", "GB", "TB"]
+  const exponent = Math.min(
+    Math.floor(Math.log(sizeBytes) / Math.log(1024)),
+    units.length - 1
+  )
+  const value = sizeBytes / 1024 ** exponent
+  return `${value.toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`
+}
+
+function formatPageWindow(
+  offset: number,
+  count: number,
+  total: number
+): string {
+  if (count === 0) {
+    return "0 items"
+  }
+  const start = offset + 1
+  const end = Math.min(offset + count, total)
+  return `${start}–${end} of ${total}`
+}
+
+function shouldProbeDownloadUrl(downloadUrl: string): boolean {
+  try {
+    const parsed = new URL(downloadUrl, window.location.href)
+    return parsed.origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
+export function CollectionObjectResult({
+  executionId,
+  eventId,
+  collection,
+}: {
+  executionId: string
+  eventId: number
+  collection: CollectionObject
+}) {
+  const workspaceId = useWorkspaceId()
+  const [offset, setOffset] = useState(0)
+  const [isLoadingPage, setIsLoadingPage] = useState(false)
+  const [pageError, setPageError] = useState<string | null>(null)
+  const [page, setPage] =
+    useState<WorkflowExecutionCollectionPageResponse | null>(null)
+  const [isPreviewingIndex, setIsPreviewingIndex] = useState<number | null>(
+    null
+  )
+  const [isDownloadingIndex, setIsDownloadingIndex] = useState<number | null>(
+    null
+  )
+  const [previewByIndex, setPreviewByIndex] = useState<
+    Record<number, WorkflowExecutionObjectPreviewResponse | undefined>
+  >({})
+
+  useEffect(() => {
+    setOffset(0)
+    setPreviewByIndex({})
+  }, [eventId, executionId])
+
+  useEffect(() => {
+    let cancelled = false
+    const loadPage = async () => {
+      setIsLoadingPage(true)
+      setPageError(null)
+      try {
+        const response =
+          await workflowExecutionsGetWorkflowExecutionCollectionPage({
+            executionId,
+            workspaceId,
+            requestBody: {
+              event_id: eventId,
+              offset,
+              limit: DEFAULT_PAGE_SIZE,
+            },
+          })
+        if (!cancelled) {
+          setPage(response)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to fetch collection page"
+          setPageError(message)
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingPage(false)
+        }
+      }
+    }
+    void loadPage()
+    return () => {
+      cancelled = true
+    }
+  }, [eventId, executionId, offset, workspaceId])
+
+  const resolvedCollection = page?.collection ?? collection
+  const pageItems = page?.items ?? []
+  const canPrev = offset > 0
+  const canNext = (page?.next_offset ?? null) !== null
+  const summaryLabel = useMemo(
+    () =>
+      `${resolvedCollection.count} items • page size ${resolvedCollection.chunk_size} • ${getElementKindLabel(resolvedCollection.element_kind)}`,
+    [
+      resolvedCollection.chunk_size,
+      resolvedCollection.count,
+      resolvedCollection.element_kind,
+    ]
+  )
+  const pageWindow = formatPageWindow(
+    offset,
+    pageItems.length,
+    resolvedCollection.count
+  )
+
+  function closeInlinePreview(index: number) {
+    setPreviewByIndex((curr) => {
+      if (curr[index] === undefined) {
+        return curr
+      }
+      const next = { ...curr }
+      delete next[index]
+      return next
+    })
+  }
+
+  async function handleInlinePreview(index: number) {
+    setIsPreviewingIndex(index)
+    try {
+      const response =
+        await workflowExecutionsGetWorkflowExecutionObjectPreview({
+          executionId,
+          workspaceId,
+          requestBody: {
+            event_id: eventId,
+            collection_index: index,
+          },
+        })
+      setPreviewByIndex((curr) => ({ ...curr, [index]: response }))
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to preview item"
+      toast({
+        title: "Preview failed",
+        description: message,
+      })
+    } finally {
+      setIsPreviewingIndex(null)
+    }
+  }
+
+  async function handleInlineDownload(index: number) {
+    setIsDownloadingIndex(index)
+    try {
+      const response =
+        await workflowExecutionsGetWorkflowExecutionObjectDownload({
+          executionId,
+          workspaceId,
+          requestBody: {
+            event_id: eventId,
+            collection_index: index,
+          },
+        })
+
+      if (shouldProbeDownloadUrl(response.download_url)) {
+        const probe = await fetch(response.download_url, {
+          method: "GET",
+          headers: {
+            Range: "bytes=0-0",
+          },
+        })
+        if (!probe.ok) {
+          throw new Error(
+            `Object download probe failed (${probe.status} ${probe.statusText})`
+          )
+        }
+      }
+
+      const link = document.createElement("a")
+      link.href = response.download_url
+      link.download = response.file_name
+      link.rel = "noopener"
+      link.style.display = "none"
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to download item"
+      toast({
+        title: "Download failed",
+        description: message,
+      })
+    } finally {
+      setIsDownloadingIndex(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 p-3 text-xs">
+      <div className="flex items-center justify-between gap-2">
+        <div className="space-y-0.5">
+          <p className="text-sm font-medium text-foreground">
+            Collection results
+          </p>
+          <p className="text-muted-foreground">{summaryLabel}</p>
+        </div>
+        <Badge variant="secondary" className="text-[10px]">
+          {pageWindow}
+        </Badge>
+      </div>
+
+      {isLoadingPage && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <LoaderIcon className="size-3 animate-spin" />
+          <span>Loading collection page...</span>
+        </div>
+      )}
+
+      {pageError && (
+        <div className="text-rose-600">
+          Failed to load collection page: {pageError}
+        </div>
+      )}
+
+      {!isLoadingPage && !pageError && (
+        <div className="overflow-hidden rounded-md border bg-background">
+          {pageItems.length === 0 ? (
+            <div className="px-3 py-2 text-muted-foreground">
+              This page has no items.
+            </div>
+          ) : (
+            pageItems.map((item) => (
+              <div
+                key={item.index}
+                className="flex flex-col gap-2 border-b px-3 py-2.5 last:border-b-0"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-foreground">
+                      Item {item.index}
+                    </span>
+                    <span className="text-muted-foreground">•</span>
+                    <span className="text-muted-foreground">
+                      {getItemKindLabel(item.kind)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    {item.value_size_bytes !== null &&
+                    item.value_size_bytes !== undefined ? (
+                      <span>{formatSize(item.value_size_bytes)}</span>
+                    ) : null}
+                    {item.truncated ? (
+                      <>
+                        <span>•</span>
+                        <span>Preview truncated</span>
+                      </>
+                    ) : null}
+                  </div>
+                </div>
+
+                {item.kind === "stored_object_ref" && item.stored ? (
+                  isExternalStoredObject(item.stored) ? (
+                    <ExternalObjectResult
+                      executionId={executionId}
+                      eventId={eventId}
+                      external={item.stored}
+                      collectionIndex={item.index}
+                      compact={true}
+                    />
+                  ) : (
+                    <div className="rounded-sm border border-dashed p-2">
+                      <JsonViewWithControls
+                        src={item.stored}
+                        defaultExpanded={false}
+                      />
+                    </div>
+                  )
+                ) : (
+                  <div className="space-y-2">
+                    {item.value_preview ? (
+                      <CodeBlock title={`Item ${item.index} preview`}>
+                        {item.value_preview}
+                      </CodeBlock>
+                    ) : (
+                      <div className="text-muted-foreground">
+                        No inline preview available.
+                      </div>
+                    )}
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => void handleInlinePreview(item.index)}
+                        disabled={isPreviewingIndex === item.index}
+                      >
+                        {isPreviewingIndex === item.index ? (
+                          <LoaderIcon className="mr-2 size-3 animate-spin" />
+                        ) : (
+                          <EyeIcon className="mr-2 size-3" />
+                        )}
+                        Preview
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => void handleInlineDownload(item.index)}
+                        disabled={isDownloadingIndex === item.index}
+                      >
+                        {isDownloadingIndex === item.index ? (
+                          <LoaderIcon className="mr-2 size-3 animate-spin" />
+                        ) : (
+                          <DownloadIcon className="mr-2 size-3" />
+                        )}
+                        Download
+                      </Button>
+                      {previewByIndex[item.index] ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 px-2 text-xs"
+                          onClick={() => closeInlinePreview(item.index)}
+                        >
+                          <XIcon className="mr-1 size-3" />
+                          Close preview
+                        </Button>
+                      ) : null}
+                    </div>
+                    {previewByIndex[item.index] ? (
+                      <CodeBlock title={`Preview item ${item.index}`}>
+                        {previewByIndex[item.index]?.content ?? ""}
+                      </CodeBlock>
+                    ) : null}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-muted-foreground">{pageWindow}</span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            disabled={!canPrev || isLoadingPage}
+            onClick={() =>
+              setOffset((prev) => Math.max(0, prev - DEFAULT_PAGE_SIZE))
+            }
+          >
+            <ChevronLeftIcon className="mr-2 size-3" />
+            Prev
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            disabled={!canNext || isLoadingPage}
+            onClick={() => {
+              if (
+                page?.next_offset !== null &&
+                page?.next_offset !== undefined
+              ) {
+                setOffset(page.next_offset)
+              }
+            }}
+          >
+            Next
+            <ChevronRightIcon className="ml-2 size-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/executions/collection-object-result.tsx
+++ b/frontend/src/components/executions/collection-object-result.tsx
@@ -85,6 +85,8 @@ export function CollectionObjectResult({
 
   useEffect(() => {
     setOffset(0)
+    setPage(null)
+    setPageError(null)
   }, [eventId, executionId])
 
   useEffect(() => {

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -3,11 +3,15 @@
 import { FileInputIcon, ShapesIcon, TriangleAlert } from "lucide-react"
 import React from "react"
 import { CodeBlock } from "@/components/code-block"
+import { CollectionObjectResult } from "@/components/executions/collection-object-result"
 import { ExternalObjectResult } from "@/components/executions/external-object-result"
 import { JsonViewWithControls } from "@/components/json-viewer"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
-import { isExternalStoredObject } from "@/lib/stored-object"
+import {
+  isCollectionStoredObject,
+  isExternalStoredObject,
+} from "@/lib/stored-object"
 
 export function WorkflowExecutionEventDetailView({
   event,
@@ -107,6 +111,12 @@ export function WorkflowExecutionEventDetailView({
                     executionId={executionId}
                     eventId={event.source_event_id}
                     external={event.action_result}
+                  />
+                ) : isCollectionStoredObject(event.action_result) ? (
+                  <CollectionObjectResult
+                    executionId={executionId}
+                    eventId={event.source_event_id}
+                    collection={event.action_result}
                   />
                 ) : (
                   <JsonViewContent src={event.action_result} />

--- a/frontend/src/lib/stored-object.ts
+++ b/frontend/src/lib/stored-object.ts
@@ -1,9 +1,16 @@
-type UnknownRecord = Record<string, unknown>
+import type {
+  CollectionObject,
+  ExternalObject,
+  InlineObject,
+  ObjectRef,
+} from "@/client"
 
-import type { ExternalObject, ObjectRef } from "@/client"
+type UnknownRecord = Record<string, unknown>
 
 export type ExternalObjectRef = ObjectRef
 export type ExternalStoredObject = ExternalObject
+export type CollectionStoredObject = CollectionObject
+export type StoredObject = InlineObject | ExternalObject | CollectionObject
 
 function isObjectRecord(value: unknown): value is UnknownRecord {
   return typeof value === "object" && value !== null
@@ -57,4 +64,34 @@ export function isExternalStoredObject(
     return false
   }
   return value.type === "external" && isExternalObjectRef(value.ref)
+}
+
+export function isCollectionStoredObject(
+  value: unknown
+): value is CollectionStoredObject {
+  if (!isObjectRecord(value)) {
+    return false
+  }
+  return (
+    value.type === "collection" &&
+    isExternalObjectRef(value.manifest_ref) &&
+    typeof value.count === "number" &&
+    typeof value.chunk_size === "number" &&
+    (value.element_kind === "value" || value.element_kind === "stored_object")
+  )
+}
+
+export function isInlineStoredObject(value: unknown): value is InlineObject {
+  if (!isObjectRecord(value)) {
+    return false
+  }
+  return value.type === "inline" && "data" in value
+}
+
+export function isStoredObject(value: unknown): value is StoredObject {
+  return (
+    isInlineStoredObject(value) ||
+    isExternalStoredObject(value) ||
+    isCollectionStoredObject(value)
+  )
 }

--- a/tests/unit/test_workflow_execution_object_resolution.py
+++ b/tests/unit/test_workflow_execution_object_resolution.py
@@ -95,7 +95,10 @@ class TestWorkflowExecutionObjectResolution:
                 AsyncMock(return_value=[stored_item]),
             ) as mock_get_page,
         ):
-            resolved_collection, items = await workflow_executions_service.get_collection_page(
+            (
+                resolved_collection,
+                items,
+            ) = await workflow_executions_service.get_collection_page(
                 workflow_exec_id,
                 101,
                 offset=0,

--- a/tests/unit/test_workflow_execution_object_resolution.py
+++ b/tests/unit/test_workflow_execution_object_resolution.py
@@ -150,3 +150,25 @@ class TestWorkflowExecutionObjectResolution:
             )
 
         assert item == {"n": 1}
+
+    async def test_get_collection_item_for_object_ops_normalizes_validation_errors(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        collection = create_collection_object(element_kind="stored_object")
+
+        with patch.object(
+            workflow_executions_service,
+            "get_collection_page",
+            AsyncMock(return_value=(collection, [object()])),
+        ):
+            with pytest.raises(
+                TypeError,
+                match="Collection item at index 0 is not a valid StoredObject",
+            ):
+                await workflow_executions_service.get_collection_item_for_object_ops(
+                    workflow_exec_id,
+                    99,
+                    index=0,
+                )

--- a/tests/unit/test_workflow_execution_object_resolution.py
+++ b/tests/unit/test_workflow_execution_object_resolution.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from temporalio.api.enums.v1 import EventType
+from temporalio.client import Client, WorkflowHandle
+
+from tracecat.identifiers.workflow import WorkflowExecutionID
+from tracecat.storage.object import CollectionObject, InlineObject, ObjectRef
+from tracecat.workflow.executions.service import WorkflowExecutionsService
+
+
+@pytest.fixture
+def workflow_exec_id() -> WorkflowExecutionID:
+    return "test-workflow-execution-123"
+
+
+@pytest.fixture
+def workflow_executions_service() -> WorkflowExecutionsService:
+    return WorkflowExecutionsService(client=Mock(spec=Client), role=None)
+
+
+def create_mock_completed_event(*, event_id: int, scheduled_event_id: int) -> Mock:
+    event = Mock()
+    event.event_id = event_id
+    event.event_type = EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED
+    completed_attrs = Mock()
+    completed_attrs.scheduled_event_id = scheduled_event_id
+    event.activity_task_completed_event_attributes = completed_attrs
+    return event
+
+
+def create_collection_object(
+    *,
+    count: int = 3,
+    element_kind: Literal["value", "stored_object"] = "stored_object",
+) -> CollectionObject:
+    return CollectionObject(
+        manifest_ref=ObjectRef(
+            bucket="test-bucket",
+            key="wf/test/manifest.json",
+            size_bytes=128,
+            sha256="abc123",
+        ),
+        count=count,
+        chunk_size=256,
+        element_kind=element_kind,
+    )
+
+
+@pytest.mark.anyio
+class TestWorkflowExecutionObjectResolution:
+    async def test_resolve_completed_event_matches_source_event_id(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        completed_event = create_mock_completed_event(event_id=11, scheduled_event_id=3)
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**_kwargs: Any):
+            yield completed_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        matched = await workflow_executions_service._resolve_completed_event(
+            workflow_exec_id,
+            3,
+        )
+
+        assert matched is completed_event
+
+    async def test_get_collection_page_returns_refs_for_stored_object_collection(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        collection = create_collection_object(element_kind="stored_object")
+        stored_item = InlineObject(data={"foo": "bar"}).model_dump(mode="json")
+
+        with (
+            patch.object(
+                workflow_executions_service,
+                "get_collection_action_result",
+                AsyncMock(return_value=collection),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_storage_collection_page",
+                AsyncMock(return_value=[stored_item]),
+            ) as mock_get_page,
+        ):
+            resolved_collection, items = await workflow_executions_service.get_collection_page(
+                workflow_exec_id,
+                101,
+                offset=0,
+                limit=25,
+            )
+
+        assert resolved_collection == collection
+        assert items == [stored_item]
+        mock_get_page.assert_awaited_once_with(collection, offset=0, limit=25)
+
+    async def test_get_collection_item_for_object_ops_returns_stored_object_handle(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        collection = create_collection_object(element_kind="stored_object")
+        stored_item = InlineObject(data={"foo": "bar"}).model_dump(mode="json")
+
+        with patch.object(
+            workflow_executions_service,
+            "get_collection_page",
+            AsyncMock(return_value=(collection, [stored_item])),
+        ):
+            item = await workflow_executions_service.get_collection_item_for_object_ops(
+                workflow_exec_id,
+                99,
+                index=0,
+            )
+
+        assert isinstance(item, InlineObject)
+        assert item.data == {"foo": "bar"}
+
+    async def test_get_collection_item_for_object_ops_returns_inline_value(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        collection = create_collection_object(element_kind="value")
+
+        with patch.object(
+            workflow_executions_service,
+            "get_collection_page",
+            AsyncMock(return_value=(collection, [{"n": 1}])),
+        ):
+            item = await workflow_executions_service.get_collection_item_for_object_ops(
+                workflow_exec_id,
+                99,
+                index=0,
+            )
+
+        assert item == {"n": 1}

--- a/tests/unit/test_workflow_execution_schemas.py
+++ b/tests/unit/test_workflow_execution_schemas.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tracecat.storage.object import InlineObject
+from tracecat.workflow.executions.schemas import (
+    WorkflowExecutionCollectionPageItem,
+    WorkflowExecutionCollectionPageItemKind,
+)
+
+
+def test_collection_page_item_stored_kind_requires_stored() -> None:
+    with pytest.raises(ValidationError, match="stored.*required"):
+        WorkflowExecutionCollectionPageItem(
+            index=0,
+            kind=WorkflowExecutionCollectionPageItemKind.STORED_OBJECT_REF,
+        )
+
+
+def test_collection_page_item_stored_kind_rejects_inline_fields() -> None:
+    with pytest.raises(ValidationError, match="must be omitted"):
+        WorkflowExecutionCollectionPageItem(
+            index=0,
+            kind=WorkflowExecutionCollectionPageItemKind.STORED_OBJECT_REF,
+            stored=InlineObject(data={"ok": True}),
+            value_preview="{}",
+            value_size_bytes=2,
+        )
+
+
+def test_collection_page_item_inline_kind_rejects_stored() -> None:
+    with pytest.raises(ValidationError, match="stored.*omitted"):
+        WorkflowExecutionCollectionPageItem(
+            index=0,
+            kind=WorkflowExecutionCollectionPageItemKind.INLINE_VALUE,
+            stored=InlineObject(data={"ok": True}),
+            value_preview="{}",
+            value_size_bytes=2,
+        )
+
+
+def test_collection_page_item_inline_kind_requires_inline_fields() -> None:
+    with pytest.raises(ValidationError, match="value_preview.*value_size_bytes"):
+        WorkflowExecutionCollectionPageItem(
+            index=0,
+            kind=WorkflowExecutionCollectionPageItemKind.INLINE_VALUE,
+        )
+
+
+def test_collection_page_item_stored_kind_valid() -> None:
+    item = WorkflowExecutionCollectionPageItem(
+        index=1,
+        kind=WorkflowExecutionCollectionPageItemKind.STORED_OBJECT_REF,
+        stored=InlineObject(data={"ok": True}),
+    )
+
+    assert item.kind == WorkflowExecutionCollectionPageItemKind.STORED_OBJECT_REF
+    assert isinstance(item.stored, InlineObject)
+
+
+def test_collection_page_item_inline_kind_valid() -> None:
+    item = WorkflowExecutionCollectionPageItem(
+        index=2,
+        kind=WorkflowExecutionCollectionPageItemKind.INLINE_VALUE,
+        value_preview='{"ok": true}',
+        value_size_bytes=12,
+        truncated=False,
+    )
+
+    assert item.kind == WorkflowExecutionCollectionPageItemKind.INLINE_VALUE
+    assert item.value_size_bytes == 12

--- a/tests/unit/test_workflow_executions_common.py
+++ b/tests/unit/test_workflow_executions_common.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from tracecat.storage.object import CollectionObject, InlineObject, ObjectRef
+from tracecat.workflow.executions.common import unwrap_action_result
+
+
+def _collection() -> CollectionObject:
+    return CollectionObject(
+        manifest_ref=ObjectRef(
+            bucket="test-bucket",
+            key="wf-123/actions/scatter/manifest.json",
+            size_bytes=256,
+            sha256="abc123",
+        ),
+        count=3,
+        chunk_size=256,
+        element_kind="stored_object",
+    )
+
+
+@pytest.mark.anyio
+async def test_unwrap_action_result_keeps_collection_metadata() -> None:
+    collection = _collection()
+
+    result = await unwrap_action_result(collection)
+
+    assert result == collection
+
+
+@pytest.mark.anyio
+async def test_unwrap_action_result_keeps_inline_payload_data() -> None:
+    inline = InlineObject(data={"ok": True})
+
+    result = await unwrap_action_result(inline)
+
+    assert result == {"ok": True}

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -77,7 +77,9 @@ def _suggest_download_filename(key: str, event_id: int, content_type: str) -> st
     return f"workflow-result-{event_id}{suffix}"
 
 
-def _decode_preview_bytes(content_bytes: bytes) -> tuple[str, Literal["utf-8", "unknown"]]:
+def _decode_preview_bytes(
+    content_bytes: bytes,
+) -> tuple[str, Literal["utf-8", "unknown"]]:
     try:
         return content_bytes.decode("utf-8"), "utf-8"
     except UnicodeDecodeError:

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -55,7 +55,10 @@ from tracecat.workflow.executions.schemas import (
     WorkflowExecutionReadMinimal,
     WorkflowExecutionTerminate,
 )
-from tracecat.workflow.executions.service import WorkflowExecutionsService
+from tracecat.workflow.executions.service import (
+    WorkflowExecutionResultNotFoundError,
+    WorkflowExecutionsService,
+)
 from tracecat.workflow.management.management import WorkflowsManagementService
 
 router = APIRouter(prefix="/workflow-executions", tags=["workflow-executions"])
@@ -449,9 +452,14 @@ async def get_workflow_execution_object_download(
                     event_id=params.event_id,
                     collection_index=params.collection_index,
                 )
-    except ValueError as e:
+    except WorkflowExecutionResultNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(e),
         ) from e
     except IndexError as e:
@@ -510,9 +518,14 @@ async def get_workflow_execution_object_preview(
                 return _inline_preview_response(collection.model_dump(mode="json"))
             case _:
                 return _inline_preview_response(item)
-    except ValueError as e:
+    except WorkflowExecutionResultNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(e),
         ) from e
     except IndexError as e:
@@ -556,9 +569,14 @@ async def get_workflow_execution_collection_page(
             offset=params.offset,
             limit=params.limit,
         )
-    except ValueError as e:
+    except WorkflowExecutionResultNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(e),
         ) from e
     except TypeError as e:

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -14,7 +14,7 @@ from typing import (
 import temporalio.api.enums.v1
 import temporalio.api.history.v1
 from google.protobuf.json_format import MessageToDict
-from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, model_validator
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 from tracecat_ee.agent.types import AgentWorkflowID
 from tracecat_ee.agent.workflows.durable import AgentWorkflowArgs
@@ -208,6 +208,27 @@ class WorkflowExecutionCollectionPageItem(BaseModel):
         default=False,
         description="Whether value_preview was truncated",
     )
+
+    @model_validator(mode="after")
+    def validate_kind_fields(self) -> WorkflowExecutionCollectionPageItem:
+        if self.kind == WorkflowExecutionCollectionPageItemKind.STORED_OBJECT_REF:
+            if self.stored is None:
+                raise ValueError(
+                    "`stored` is required when kind is `stored_object_ref`"
+                )
+            if self.value_preview is not None or self.value_size_bytes is not None:
+                raise ValueError(
+                    "`value_preview` and `value_size_bytes` must be omitted when kind is `stored_object_ref`"
+                )
+            return self
+
+        if self.stored is not None:
+            raise ValueError("`stored` must be omitted when kind is `inline_value`")
+        if self.value_preview is None or self.value_size_bytes is None:
+            raise ValueError(
+                "`value_preview` and `value_size_bytes` are required when kind is `inline_value`"
+            )
+        return self
 
 
 class WorkflowExecutionCollectionPageResponse(BaseModel):

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -45,6 +45,7 @@ from tracecat.identifiers import WorkflowExecutionID, WorkflowID
 from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.sessions import Session
+from tracecat.storage.object import CollectionObject, StoredObject
 from tracecat.workflow.executions.common import (
     HISTORY_TO_WF_EVENT_TYPE,
     extract_first,
@@ -155,6 +156,74 @@ class WorkflowExecutionObjectRequest(BaseModel):
     event_id: int = Field(..., ge=1, description="Temporal history event ID")
     field: WorkflowExecutionObjectField = Field(
         default=WorkflowExecutionObjectField.ACTION_RESULT
+    )
+    collection_index: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Optional index into a CollectionObject result. "
+            "When omitted, operates on the top-level object result."
+        ),
+    )
+
+
+class WorkflowExecutionCollectionPageRequest(BaseModel):
+    event_id: int = Field(..., ge=1, description="Temporal history event ID")
+    field: WorkflowExecutionObjectField = Field(
+        default=WorkflowExecutionObjectField.ACTION_RESULT
+    )
+    offset: int = Field(default=0, ge=0, description="Page start index (0-indexed)")
+    limit: int = Field(
+        default=25,
+        ge=1,
+        le=100,
+        description="Maximum number of items to return",
+    )
+
+
+class WorkflowExecutionCollectionPageItemKind(StrEnum):
+    STORED_OBJECT_REF = "stored_object_ref"
+    INLINE_VALUE = "inline_value"
+
+
+class WorkflowExecutionCollectionPageItem(BaseModel):
+    index: int = Field(..., ge=0, description="Collection index for this item")
+    kind: WorkflowExecutionCollectionPageItemKind = Field(
+        ..., description="Descriptor type for this collection page item"
+    )
+    stored: StoredObject | None = Field(
+        default=None,
+        description="StoredObject descriptor when kind is stored_object_ref",
+    )
+    value_preview: str | None = Field(
+        default=None,
+        description="UTF-8 preview of serialized inline value when kind is inline_value",
+    )
+    value_size_bytes: int | None = Field(
+        default=None,
+        ge=0,
+        description="Serialized inline value size in bytes when kind is inline_value",
+    )
+    truncated: bool = Field(
+        default=False,
+        description="Whether value_preview was truncated",
+    )
+
+
+class WorkflowExecutionCollectionPageResponse(BaseModel):
+    collection: CollectionObject = Field(
+        ..., description="Collection metadata for the requested result"
+    )
+    offset: int = Field(..., ge=0, description="Requested page offset")
+    limit: int = Field(..., ge=1, description="Requested page size")
+    next_offset: int | None = Field(
+        default=None,
+        ge=0,
+        description="Offset to use for next page, or null if no more items",
+    )
+    items: list[WorkflowExecutionCollectionPageItem] = Field(
+        default_factory=list,
+        description="Collection page descriptors",
     )
 
 

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -83,6 +83,10 @@ from tracecat.workflow.executions.schemas import (
 from tracecat.workspaces.service import WorkspaceService
 
 
+class WorkflowExecutionResultNotFoundError(ValueError):
+    """Raised when no matching completed event exists for a given event ID."""
+
+
 class WorkflowExecutionsService:
     """Workflow executions service."""
 
@@ -526,7 +530,9 @@ class WorkflowExecutionsService:
                 source_match = event
 
         if source_match is None:
-            raise ValueError(f"No completed event found for event_id={event_id}")
+            raise WorkflowExecutionResultNotFoundError(
+                f"No completed event found for event_id={event_id}"
+            )
         return source_match
 
     async def _get_stored_result_for_event(

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -469,7 +469,9 @@ class WorkflowExecutionsService:
     ) -> tuple[CollectionObject, list[Any]]:
         """Get a page from a collection result without full materialization."""
         collection = await self.get_collection_action_result(wf_exec_id, event_id)
-        items = await get_storage_collection_page(collection, offset=offset, limit=limit)
+        items = await get_storage_collection_page(
+            collection, offset=offset, limit=limit
+        )
         return collection, items
 
     async def get_collection_item_for_object_ops(

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncGenerator, Awaitable, Sequence
 from typing import Any
 
 import temporalio.api.enums.v1
+from pydantic import ValidationError
 from temporalio.api.enums.v1 import EventType, PendingActivityState
 from temporalio.api.history.v1 import HistoryEvent
 from temporalio.client import (
@@ -498,7 +499,12 @@ class WorkflowExecutionsService:
 
         item = items[0]
         if collection.element_kind == "stored_object":
-            return StoredObjectValidator.validate_python(item)
+            try:
+                return StoredObjectValidator.validate_python(item)
+            except ValidationError as e:
+                raise TypeError(
+                    f"Collection item at index {index} is not a valid StoredObject"
+                ) from e
         return item
 
     async def _resolve_completed_event(


### PR DESCRIPTION
When we fixed CollectionObjects in https://github.com/TracecatHQ/tracecat/pull/2154, they showed up in the UI as just metadata. This PR adds a viewer for it.

## Summary
- add indexed object operations for execution results by extending object preview/download requests with optional `collection_index`
- add a paged collection endpoint (`/workflow-executions/{execution_id}/objects/collection/page`) backed by collection page retrieval in the executions service
- add a collection result viewer in the UI with friendlier labels, per-item preview/download, close-preview controls, and flatter visual structure
- wire collection rendering into both action/event result viewers and regenerate frontend API client types/services
- add unit tests for collection result unwrapping and object-resolution service helpers

## Screens

<img width="598" height="734" alt="image" src="https://github.com/user-attachments/assets/fc43a209-c981-435c-a444-20d9fb6c9681" />


## Testing
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- `uv run ruff check tracecat/workflow/executions/router.py tracecat/workflow/executions/schemas.py tracecat/workflow/executions/service.py tests/unit/test_workflow_execution_object_resolution.py tests/unit/test_workflow_executions_common.py`
- `uv run basedpyright tracecat/workflow/executions/router.py tracecat/workflow/executions/schemas.py tracecat/workflow/executions/service.py tests/unit/test_workflow_execution_object_resolution.py tests/unit/test_workflow_executions_common.py`
- `uv run pytest --confcutdir=tests/unit tests/unit/test_workflow_executions_common.py tests/unit/test_workflow_execution_object_resolution.py tests/unit/test_materialize_context.py -q`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a paged collection result API and a UI viewer to browse large results without loading everything. Adds indexed item preview/download with strict validation and clear errors for inline values and external files.

- **New Features**
  - New POST endpoint: /workflow-executions/{execution_id}/objects/collection/page (returns descriptors, next_offset, and 4 KB UTF-8 previews for inline values).
  - Preview/download APIs accept collection_index to target a specific item (presigned URL for external files; inline JSON preview and data-URL download for inline values).
  - UI collection viewer with paging, item labels, size/truncated flags, per-item preview/download for external files, close-preview, and compact mode; wired into action and event result views; regenerated frontend client types/services.

- **Bug Fixes**
  - Inline collection values no longer show preview/download actions, and inline stored items render as JSON values.
  - Hardened validation and error mapping for collection pages and indexed ops (404 only for missing results, 400 index out of range, 422 invalid item type/unsupported preview); reset collection pagination/preview state on execution/event changes; unit tests added for event matching, page retrieval, item resolution, and schema validation.

<sup>Written for commit 9f0187f71f793a5c71aeafe6898ca0edeabb1ffc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



