### PR TITLE
fix(workspace): resolve membership re-add/remove conflicts

### DIFF
--- a/frontend/src/components/workspaces/workspace-members-table.tsx
+++ b/frontend/src/components/workspaces/workspace-members-table.tsx
@@ -57,7 +57,8 @@ export function WorkspaceMembersTable({
   workspace: WorkspaceRead
 }) {
   const queryClient = useQueryClient()
-  const canManageMembers = useScopeCheck("workspace:member:update")
+  const canUpdateMembers = useScopeCheck("workspace:member:update")
+  const canRemoveMembers = useScopeCheck("workspace:member:remove")
   const [selectedUser, setSelectedUser] = useState<WorkspaceMember | null>(null)
   const [isChangeRoleOpen, setIsChangeRoleOpen] = useState(false)
   const { removeMember } = useWorkspaceMutations()
@@ -220,31 +221,31 @@ export function WorkspaceMembersTable({
                         Copy user ID
                       </DropdownMenuItem>
 
-                      {canManageMembers && (
-                        <>
-                          <DialogTrigger asChild>
-                            <DropdownMenuItem
-                              onClick={() => {
-                                setSelectedUser(row.original)
-                                setIsChangeRoleOpen(true)
-                              }}
-                            >
-                              Change role
-                            </DropdownMenuItem>
-                          </DialogTrigger>
+                      {canUpdateMembers && (
+                        <DialogTrigger asChild>
+                          <DropdownMenuItem
+                            onClick={() => {
+                              setSelectedUser(row.original)
+                              setIsChangeRoleOpen(true)
+                            }}
+                          >
+                            Change role
+                          </DropdownMenuItem>
+                        </DialogTrigger>
+                      )}
 
-                          <AlertDialogTrigger asChild>
-                            <DropdownMenuItem
-                              className="text-rose-500 focus:text-rose-600"
-                              onClick={() => {
-                                setSelectedUser(row.original)
-                                console.debug("Selected user", row.original)
-                              }}
-                            >
-                              Remove from workspace
-                            </DropdownMenuItem>
-                          </AlertDialogTrigger>
-                        </>
+                      {canRemoveMembers && (
+                        <AlertDialogTrigger asChild>
+                          <DropdownMenuItem
+                            className="text-rose-500 focus:text-rose-600"
+                            onClick={() => {
+                              setSelectedUser(row.original)
+                              console.debug("Selected user", row.original)
+                            }}
+                          >
+                            Remove from workspace
+                          </DropdownMenuItem>
+                        </AlertDialogTrigger>
                       )}
                     </DropdownMenuContent>
                   </DropdownMenu>
@@ -272,7 +273,16 @@ export function WorkspaceMembersTable({
                   try {
                     await removeMember(selectedUser.user_id)
                   } catch (error) {
-                    console.log("Failed to remove member", error)
+                    const description =
+                      error instanceof Error
+                        ? error.message
+                        : "The request could not be completed."
+                    console.error("Failed to remove member", error)
+                    toast({
+                      title: "Failed to remove member",
+                      description,
+                      variant: "destructive",
+                    })
                   }
                 }
                 setSelectedUser(null)

--- a/frontend/src/hooks/use-workspace.ts
+++ b/frontend/src/hooks/use-workspace.ts
@@ -45,8 +45,14 @@ export function useWorkspaceMutations() {
     WorkspacesCreateWorkspaceMembershipData
   >({
     mutationFn: workspacesCreateWorkspaceMembership,
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: ["workspace", workspaceId] }),
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ["workspace", workspaceId] }),
+        qc.invalidateQueries({
+          queryKey: ["workspace", workspaceId, "members"],
+        }),
+      ])
+    },
   })
 
   const { mutateAsync: removeMember, isPending: removePending } = useMutation<
@@ -59,8 +65,14 @@ export function useWorkspaceMutations() {
         workspaceId,
         userId,
       }),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: ["workspace", workspaceId] }),
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ["workspace", workspaceId] }),
+        qc.invalidateQueries({
+          queryKey: ["workspace", workspaceId, "members"],
+        }),
+      ])
+    },
   })
 
   return {

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -1,0 +1,261 @@
+"""Unit tests for MembershipService."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.schemas import UserRole
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import ADMIN_SCOPES
+from tracecat.authz.service import MembershipService
+from tracecat.db.models import (
+    Membership,
+    Organization,
+    User,
+    UserRoleAssignment,
+    Workspace,
+)
+from tracecat.db.models import Role as DBRole
+from tracecat.workspaces.schemas import WorkspaceMembershipCreate
+
+pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("db")]
+
+
+@pytest.fixture
+async def organization(session: AsyncSession) -> Organization:
+    """Create a test organization."""
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Test Org",
+        slug=f"test-org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(org)
+    await session.commit()
+    await session.refresh(org)
+    return org
+
+
+@pytest.fixture
+async def workspace(session: AsyncSession, organization: Organization) -> Workspace:
+    """Create a test workspace."""
+    ws = Workspace(
+        id=uuid.uuid4(),
+        name="Test Workspace",
+        organization_id=organization.id,
+    )
+    session.add(ws)
+    await session.commit()
+    await session.refresh(ws)
+    return ws
+
+
+@pytest.fixture
+async def actor_user(session: AsyncSession) -> User:
+    """Create the acting user for membership operations."""
+    user = User(
+        id=uuid.uuid4(),
+        email=f"actor-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.ADMIN,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def member_user(session: AsyncSession) -> User:
+    """Create the target workspace member user."""
+    user = User(
+        id=uuid.uuid4(),
+        email=f"member-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def workspace_editor_role(
+    session: AsyncSession, organization: Organization
+) -> DBRole:
+    """Create the default workspace-editor role required by create_membership."""
+    role = DBRole(
+        id=uuid.uuid4(),
+        name="Workspace Editor",
+        slug="workspace-editor",
+        description="Default editor role",
+        organization_id=organization.id,
+    )
+    session.add(role)
+    await session.commit()
+    await session.refresh(role)
+    return role
+
+
+@pytest.fixture
+def actor_role(
+    organization: Organization, workspace: Workspace, actor_user: User
+) -> Role:
+    """Create a role with scopes required for membership management."""
+    return Role(
+        type="user",
+        user_id=actor_user.id,
+        organization_id=organization.id,
+        workspace_id=workspace.id,
+        service_id="tracecat-api",
+        scopes=ADMIN_SCOPES,
+    )
+
+
+@pytest.fixture
+def membership_service(session: AsyncSession, actor_role: Role) -> MembershipService:
+    """Create MembershipService under a role with admin workspace scopes."""
+    return MembershipService(session=session, role=actor_role)
+
+
+async def test_delete_membership_removes_membership_and_assignment(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """Deleting membership should also delete workspace direct role assignment."""
+    session.add(
+        Membership(
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+        )
+    )
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+            assigned_by=actor_user.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.delete_membership(
+        workspace_id=workspace.id,
+        user_id=member_user.id,
+    )
+
+    membership = await session.scalar(
+        select(Membership).where(
+            Membership.workspace_id == workspace.id,
+            Membership.user_id == member_user.id,
+        )
+    )
+    assignment = await session.scalar(
+        select(UserRoleAssignment).where(
+            UserRoleAssignment.workspace_id == workspace.id,
+            UserRoleAssignment.user_id == member_user.id,
+        )
+    )
+
+    assert membership is None
+    assert assignment is None
+
+
+async def test_delete_membership_removes_orphan_assignment(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """Delete should clean orphan assignments even when membership row is missing."""
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+            assigned_by=actor_user.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.delete_membership(
+        workspace_id=workspace.id,
+        user_id=member_user.id,
+    )
+
+    assignment = await session.scalar(
+        select(UserRoleAssignment).where(
+            UserRoleAssignment.workspace_id == workspace.id,
+            UserRoleAssignment.user_id == member_user.id,
+        )
+    )
+
+    assert assignment is None
+
+
+async def test_create_membership_heals_stale_workspace_assignment(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """Create should succeed when only a stale workspace assignment exists."""
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+            assigned_by=actor_user.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.create_membership(
+        workspace_id=workspace.id,
+        params=WorkspaceMembershipCreate(user_id=member_user.id),
+    )
+
+    membership = await session.scalar(
+        select(Membership).where(
+            Membership.workspace_id == workspace.id,
+            Membership.user_id == member_user.id,
+        )
+    )
+    assignments = (
+        await session.execute(
+            select(UserRoleAssignment).where(
+                UserRoleAssignment.workspace_id == workspace.id,
+                UserRoleAssignment.user_id == member_user.id,
+            )
+        )
+    ).scalars()
+    assignment_list = list(assignments)
+
+    assert membership is not None
+    assert len(assignment_list) == 1
+    assert assignment_list[0].organization_id == organization.id
+    assert assignment_list[0].role_id == workspace_editor_role.id
+    assert assignment_list[0].assigned_by == actor_user.id

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -156,10 +156,6 @@ class MembershipService(BaseService):
             raise TracecatValidationError("Workspace or default role not found")
         organization_id, role_id = org_role_row
 
-        # Reject existing memberships explicitly and avoid relying on DB integrity errors.
-        if await self.get_membership(workspace_id, params.user_id):
-            raise TracecatValidationError("User is already a member of this workspace")
-
         # Heal stale direct assignments left behind by prior failed remove flows.
         await self.session.execute(
             delete(UserRoleAssignment).where(

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from sqlalchemy import and_, func, literal, select
+from sqlalchemy import and_, delete, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
@@ -156,6 +156,18 @@ class MembershipService(BaseService):
             raise TracecatValidationError("Workspace or default role not found")
         organization_id, role_id = org_role_row
 
+        # Reject existing memberships explicitly and avoid relying on DB integrity errors.
+        if await self.get_membership(workspace_id, params.user_id):
+            raise TracecatValidationError("User is already a member of this workspace")
+
+        # Heal stale direct assignments left behind by prior failed remove flows.
+        await self.session.execute(
+            delete(UserRoleAssignment).where(
+                UserRoleAssignment.user_id == params.user_id,
+                UserRoleAssignment.workspace_id == workspace_id,
+            )
+        )
+
         membership = Membership(
             user_id=params.user_id,
             workspace_id=workspace_id,
@@ -181,6 +193,16 @@ class MembershipService(BaseService):
         Note: The authorization cache is request-scoped, so changes will be
         reflected in subsequent requests automatically.
         """
-        if membership_with_org := await self.get_membership(workspace_id, user_id):
-            await self.session.delete(membership_with_org.membership)
-            await self.session.commit()
+        await self.session.execute(
+            delete(Membership).where(
+                Membership.workspace_id == workspace_id,
+                Membership.user_id == user_id,
+            )
+        )
+        await self.session.execute(
+            delete(UserRoleAssignment).where(
+                UserRoleAssignment.workspace_id == workspace_id,
+                UserRoleAssignment.user_id == user_id,
+            )
+        )
+        await self.session.commit()

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -260,7 +260,7 @@ async def create_workspace_membership(
             detail="User does not have the required scope",
         ) from e
     except IntegrityError as e:
-        logger.error("INTEGRITY ERROR")
+        logger.error("INTEGRITY ERROR", error=str(e))
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="User is already a member of workspace.",


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)? (blocked locally: Postgres on `localhost:5432` is not running)
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes a workspace membership lifecycle bug where removing and re-adding the same user could fail due to stale `user_role_assignments` rows and stale member list cache data.

Backend changes:
- `MembershipService.create_membership` now explicitly rejects duplicate memberships and proactively deletes stale workspace-scoped `UserRoleAssignment` rows before creating fresh records.
- `MembershipService.delete_membership` now always deletes both `Membership` and workspace-scoped `UserRoleAssignment` rows for the target user/workspace pair.
- Added unit coverage for:
  - deleting membership removes direct assignment
  - deleting membership removes orphan direct assignment
  - creating membership heals stale direct assignment

Frontend changes:
- Split workspace member action permissions in `WorkspaceMembersTable`:
  - `workspace:member:update` controls "Change role"
  - `workspace:member:remove` controls "Remove from workspace"
- Added destructive toast feedback when member removal fails.
- `useWorkspaceMutations` now invalidates both workspace summary and workspace members query keys after add/remove membership mutations.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Open a workspace as an admin and remove a member.
2. Re-add the same user to the workspace.
3. Confirm re-add succeeds and the members table refreshes immediately.
4. Validate permission gating:
   - A role with only `workspace:member:update` can see "Change role" but not "Remove from workspace".
   - A role with only `workspace:member:remove` can see "Remove from workspace" but not "Change role".
5. Run backend static checks:
   - `uv run ruff check tracecat/authz/service.py tests/unit/test_authz_membership_service.py`
   - `uv run basedpyright tracecat/authz/service.py tests/unit/test_authz_membership_service.py`
6. Run frontend check:
   - `pnpm -C frontend exec biome check src/components/workspaces/workspace-members-table.tsx src/hooks/use-workspace.ts`
7. Run unit tests (requires local Postgres):
   - `uv run pytest tests/unit/test_authz_membership_service.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace membership conflicts when re-adding a previously removed user. Ensures clean add/remove flows, correct API error handling, and immediate member list updates.

- **Bug Fixes**
  - Backend create: remove stale workspace UserRoleAssignment before creating; duplicate creates raise IntegrityError.
  - Backend delete: unconditionally delete Membership and workspace-scoped UserRoleAssignment for the user/workspace pair.
  - API: return 409 for duplicate membership creates and log IntegrityError details; added API test for 409 on duplicate create.
  - Frontend: split permissions for change role (workspace:member:update) vs remove (workspace:member:remove); show destructive toast on remove failures; invalidate workspace summary and members after add/remove.
  - Tests: unit coverage for removal cleanup, orphan assignment cleanup, stale-assignment healing, and duplicate create conflicts.

<sup>Written for commit 10ac2d72e165866e5a129403abb90584aa584831. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

