### PR TITLE
fix(rbac): sort actions scopes and missing org member scopes

### DIFF
--- a/frontend/src/components/rbac/role-form-dialog.tsx
+++ b/frontend/src/components/rbac/role-form-dialog.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   getCategoryScopes,
   type PermissionLevel,
@@ -57,13 +56,13 @@ export function RoleFormDialog({
     new Set(initialData?.scopes?.map((s) => s.id) ?? [])
   )
 
-  const toggleScope = useCallback((scopeId: string) => {
+  const toggleScope = useCallback((scopeId: string, checked: boolean) => {
     setSelectedScopeIds((prev) => {
       const next = new Set(prev)
-      if (next.has(scopeId)) {
-        next.delete(scopeId)
-      } else {
+      if (checked) {
         next.add(scopeId)
+      } else {
+        next.delete(scopeId)
       }
       return next
     })
@@ -163,7 +162,7 @@ export function RoleFormDialog({
               Set permission levels by category, or expand to select individual
               scopes.
             </div>
-            <ScrollArea className="h-[400px] rounded-md border">
+            <div className="h-[400px] overflow-y-auto rounded-md border">
               <div className="divide-y divide-border/50">
                 {Object.entries(filteredCategories).map(([key, category]) => (
                   <ScopeCategoryRow
@@ -177,7 +176,7 @@ export function RoleFormDialog({
                   />
                 ))}
               </div>
-            </ScrollArea>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/lib/rbac.ts
+++ b/frontend/src/lib/rbac.ts
@@ -87,6 +87,45 @@ export const LEVEL_LABELS: Record<PermissionLevel, string> = {
   mixed: "Custom",
 }
 
+export function getScopeActionNamespace(scope: ScopeRead): string | null {
+  if (scope.resource !== "action") return null
+
+  const sourceRef = scope.source_ref?.trim()
+  if (!sourceRef) return null
+
+  const delimiter = [".", "/", ":"].find((separator) =>
+    sourceRef.includes(separator)
+  )
+  if (!delimiter) return sourceRef
+
+  return sourceRef.slice(0, sourceRef.indexOf(delimiter))
+}
+
+export function getScopeActionLabel(scope: ScopeRead): string {
+  if (scope.resource !== "action") return scope.action
+
+  const namespace = getScopeActionNamespace(scope)
+  const sourceRef = scope.source_ref?.trim()
+  if (!sourceRef || !namespace || sourceRef === namespace) {
+    return scope.action
+  }
+
+  const namespacePrefix = `${namespace}.`
+  if (sourceRef.startsWith(namespacePrefix)) {
+    return sourceRef.slice(namespacePrefix.length)
+  }
+  const colonPrefix = `${namespace}:`
+  if (sourceRef.startsWith(colonPrefix)) {
+    return sourceRef.slice(colonPrefix.length)
+  }
+  const slashPrefix = `${namespace}/`
+  if (sourceRef.startsWith(slashPrefix)) {
+    return sourceRef.slice(slashPrefix.length)
+  }
+
+  return sourceRef
+}
+
 /**
  * Get scopes that match a category's resources
  */

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -285,7 +285,9 @@ class TestOrgRoleScopes:
         assert "org:billing:read" in ORG_ADMIN_SCOPES
 
     def test_member_has_minimal_scopes(self):
-        assert ORG_MEMBER_SCOPES == frozenset({"org:read", "org:member:read"})
+        assert ORG_MEMBER_SCOPES == frozenset(
+            {"org:read", "org:member:read", "org:registry:read"}
+        )
 
 
 class TestRequireScopeDecorator:

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -64,8 +64,7 @@ EDITOR_SCOPES: frozenset[str] = VIEWER_SCOPES | frozenset(
         "tag:update",
         "variable:create",
         "variable:update",
-        # Core actions available to editors
-        "action:core.*:execute",
+        "action:*:execute",
     }
 )
 
@@ -293,6 +292,7 @@ ORG_MEMBER_SCOPES: frozenset[str] = frozenset(
         # Baseline org access; workspace/resource access requires workspace membership
         "org:read",
         "org:member:read",
+        "org:registry:read",
     }
 )
 


### PR DESCRIPTION
## Problem
  RBAC role editing had three issues: default roles missed required action scopes, scope selection in the dialog could
  hit an update-loop error, and action scopes were difficult to scan/select.

## Fix
  - Added missing default action scope coverage (action:*:execute) to the relevant preset roles.
  - Fixed role-form scope selection state handling to stop the rerender/update-depth loop.
  - Improved action-scope UX by sorting and switching actions selection to namespace-based grouping.
  

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorted and simplified action scopes in the RBAC role form with a new namespace selector for quick filtering. Also added the missing org:registry:read scope for org members.

- New Features
  - Namespace selector for action scopes (None, All, or one namespace).
  - Sorted action scopes with clearer labels and faster, stable toggling.

- Bug Fixes
  - Added org:registry:read to default org member scopes.
  - Switched execute scope pattern to action:*:execute to match namespaced actions.

<sup>Written for commit 896cfeda2f36a71a2086e0c86d2bef77c7ec9533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<img width="706" height="387" alt="image" src="https://github.com/user-attachments/assets/28f6f15b-4eaf-4265-8762-de36fbc0d592" />

