### PR TITLE
fix(rbac): move basic auth out of ee

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -8704,6 +8704,168 @@ export const usersGetMyScopes = (
 }
 
 /**
+ * List Roles
+ * List roles for the organization.
+ *
+ * Requires: authenticated organization member.
+ * @returns RoleList Successful Response
+ * @throws ApiError
+ */
+export const rbacListRoles = (): CancelablePromise<RbacListRolesResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/rbac/roles",
+  })
+}
+
+/**
+ * Create Role
+ * Create a custom role.
+ *
+ * Requires: org:rbac:create scope
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns RoleReadWithScopes Successful Response
+ * @throws ApiError
+ */
+export const rbacCreateRole = (
+  data: RbacCreateRoleData
+): CancelablePromise<RbacCreateRoleResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/rbac/roles",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List User Assignments
+ * List user role assignments for the organization.
+ * @param data The data for the request.
+ * @param data.userId Filter by user ID
+ * @param data.workspaceId Filter by workspace ID
+ * @returns UserRoleAssignmentList Successful Response
+ * @throws ApiError
+ */
+export const rbacListUserAssignments = (
+  data: RbacListUserAssignmentsData = {}
+): CancelablePromise<RbacListUserAssignmentsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/rbac/user-assignments",
+    query: {
+      user_id: data.userId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create User Assignment
+ * Create a user role assignment.
+ *
+ * Assigns a role directly to a user. If workspace_id is None, creates an org-wide
+ * assignment that applies to all workspaces. Each user can have at most
+ * one assignment per workspace (or one org-wide assignment).
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns UserRoleAssignmentReadWithDetails Successful Response
+ * @throws ApiError
+ */
+export const rbacCreateUserAssignment = (
+  data: RbacCreateUserAssignmentData
+): CancelablePromise<RbacCreateUserAssignmentResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/rbac/user-assignments",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get User Assignment
+ * Get a user role assignment by ID.
+ * @param data The data for the request.
+ * @param data.assignmentId
+ * @returns UserRoleAssignmentReadWithDetails Successful Response
+ * @throws ApiError
+ */
+export const rbacGetUserAssignment = (
+  data: RbacGetUserAssignmentData
+): CancelablePromise<RbacGetUserAssignmentResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/rbac/user-assignments/{assignment_id}",
+    path: {
+      assignment_id: data.assignmentId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update User Assignment
+ * Update a user role assignment (change role).
+ * @param data The data for the request.
+ * @param data.assignmentId
+ * @param data.requestBody
+ * @returns UserRoleAssignmentReadWithDetails Successful Response
+ * @throws ApiError
+ */
+export const rbacUpdateUserAssignment = (
+  data: RbacUpdateUserAssignmentData
+): CancelablePromise<RbacUpdateUserAssignmentResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/rbac/user-assignments/{assignment_id}",
+    path: {
+      assignment_id: data.assignmentId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete User Assignment
+ * Delete a user role assignment.
+ * @param data The data for the request.
+ * @param data.assignmentId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const rbacDeleteUserAssignment = (
+  data: RbacDeleteUserAssignmentData
+): CancelablePromise<RbacDeleteUserAssignmentResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/rbac/user-assignments/{assignment_id}",
+    path: {
+      assignment_id: data.assignmentId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * List Scopes
  * List scopes available to the organization.
  *
@@ -8800,45 +8962,6 @@ export const rbacDeleteScope = (
     path: {
       scope_id: data.scopeId,
     },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * List Roles
- * List roles for the organization.
- *
- * Requires: org:rbac:read scope
- * @returns RoleList Successful Response
- * @throws ApiError
- */
-export const rbacListRoles = (): CancelablePromise<RbacListRolesResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/rbac/roles",
-  })
-}
-
-/**
- * Create Role
- * Create a custom role.
- *
- * Requires: org:rbac:create scope
- * @param data The data for the request.
- * @param data.requestBody
- * @returns RoleReadWithScopes Successful Response
- * @throws ApiError
- */
-export const rbacCreateRole = (
-  data: RbacCreateRoleData
-): CancelablePromise<RbacCreateRoleResponse> => {
-  return __request(OpenAPI, {
-    method: "POST",
-    url: "/rbac/roles",
-    body: data.requestBody,
-    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },
@@ -9223,139 +9346,6 @@ export const rbacDeleteAssignment = (
   return __request(OpenAPI, {
     method: "DELETE",
     url: "/rbac/assignments/{assignment_id}",
-    path: {
-      assignment_id: data.assignmentId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * List User Assignments
- * List user role assignments for the organization.
- *
- * Requires: org:rbac:read scope
- * @param data The data for the request.
- * @param data.userId Filter by user ID
- * @param data.workspaceId Filter by workspace ID
- * @returns UserRoleAssignmentList Successful Response
- * @throws ApiError
- */
-export const rbacListUserAssignments = (
-  data: RbacListUserAssignmentsData = {}
-): CancelablePromise<RbacListUserAssignmentsResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/rbac/user-assignments",
-    query: {
-      user_id: data.userId,
-      workspace_id: data.workspaceId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Create User Assignment
- * Create a user role assignment.
- *
- * Assigns a role directly to a user. If workspace_id is None, creates an org-wide
- * assignment that applies to all workspaces. Each user can have at most
- * one assignment per workspace (or one org-wide assignment).
- *
- * Requires: org:rbac:create scope
- * @param data The data for the request.
- * @param data.requestBody
- * @returns UserRoleAssignmentReadWithDetails Successful Response
- * @throws ApiError
- */
-export const rbacCreateUserAssignment = (
-  data: RbacCreateUserAssignmentData
-): CancelablePromise<RbacCreateUserAssignmentResponse> => {
-  return __request(OpenAPI, {
-    method: "POST",
-    url: "/rbac/user-assignments",
-    body: data.requestBody,
-    mediaType: "application/json",
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Get User Assignment
- * Get a user role assignment by ID.
- *
- * Requires: org:rbac:read scope
- * @param data The data for the request.
- * @param data.assignmentId
- * @returns UserRoleAssignmentReadWithDetails Successful Response
- * @throws ApiError
- */
-export const rbacGetUserAssignment = (
-  data: RbacGetUserAssignmentData
-): CancelablePromise<RbacGetUserAssignmentResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/rbac/user-assignments/{assignment_id}",
-    path: {
-      assignment_id: data.assignmentId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Update User Assignment
- * Update a user role assignment (change role).
- *
- * Requires: org:rbac:update scope
- * @param data The data for the request.
- * @param data.assignmentId
- * @param data.requestBody
- * @returns UserRoleAssignmentReadWithDetails Successful Response
- * @throws ApiError
- */
-export const rbacUpdateUserAssignment = (
-  data: RbacUpdateUserAssignmentData
-): CancelablePromise<RbacUpdateUserAssignmentResponse> => {
-  return __request(OpenAPI, {
-    method: "PATCH",
-    url: "/rbac/user-assignments/{assignment_id}",
-    path: {
-      assignment_id: data.assignmentId,
-    },
-    body: data.requestBody,
-    mediaType: "application/json",
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Delete User Assignment
- * Delete a user role assignment.
- *
- * Requires: org:rbac:delete scope
- * @param data The data for the request.
- * @param data.assignmentId
- * @returns void Successful Response
- * @throws ApiError
- */
-export const rbacDeleteUserAssignment = (
-  data: RbacDeleteUserAssignmentData
-): CancelablePromise<RbacDeleteUserAssignmentResponse> => {
-  return __request(OpenAPI, {
-    method: "DELETE",
-    url: "/rbac/user-assignments/{assignment_id}",
     path: {
       assignment_id: data.assignmentId,
     },

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -8774,6 +8774,8 @@ export const rbacListUserAssignments = (
  * Assigns a role directly to a user. If workspace_id is None, creates an org-wide
  * assignment that applies to all workspaces. Each user can have at most
  * one assignment per workspace (or one org-wide assignment).
+ *
+ * Requires: org:rbac:create scope
  * @param data The data for the request.
  * @param data.requestBody
  * @returns UserRoleAssignmentReadWithDetails Successful Response
@@ -8819,6 +8821,8 @@ export const rbacGetUserAssignment = (
 /**
  * Update User Assignment
  * Update a user role assignment (change role).
+ *
+ * Requires: org:rbac:update scope
  * @param data The data for the request.
  * @param data.assignmentId
  * @param data.requestBody
@@ -8845,6 +8849,8 @@ export const rbacUpdateUserAssignment = (
 /**
  * Delete User Assignment
  * Delete a user role assignment.
+ *
+ * Requires: org:rbac:delete scope
  * @param data The data for the request.
  * @param data.assignmentId
  * @returns void Successful Response

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9351,6 +9351,52 @@ export type UsersGetMyScopesData = {
 
 export type UsersGetMyScopesResponse = UserScopesRead
 
+export type RbacListRolesResponse = RoleList
+
+export type RbacCreateRoleData = {
+  requestBody: RoleCreate
+}
+
+export type RbacCreateRoleResponse = RoleReadWithScopes
+
+export type RbacListUserAssignmentsData = {
+  /**
+   * Filter by user ID
+   */
+  userId?: string | null
+  /**
+   * Filter by workspace ID
+   */
+  workspaceId?: string | null
+}
+
+export type RbacListUserAssignmentsResponse = UserRoleAssignmentList
+
+export type RbacCreateUserAssignmentData = {
+  requestBody: UserRoleAssignmentCreate
+}
+
+export type RbacCreateUserAssignmentResponse = UserRoleAssignmentReadWithDetails
+
+export type RbacGetUserAssignmentData = {
+  assignmentId: string
+}
+
+export type RbacGetUserAssignmentResponse = UserRoleAssignmentReadWithDetails
+
+export type RbacUpdateUserAssignmentData = {
+  assignmentId: string
+  requestBody: UserRoleAssignmentUpdate
+}
+
+export type RbacUpdateUserAssignmentResponse = UserRoleAssignmentReadWithDetails
+
+export type RbacDeleteUserAssignmentData = {
+  assignmentId: string
+}
+
+export type RbacDeleteUserAssignmentResponse = void
+
 export type RbacListScopesData = {
   /**
    * Include system/registry scopes
@@ -9381,14 +9427,6 @@ export type RbacDeleteScopeData = {
 }
 
 export type RbacDeleteScopeResponse = void
-
-export type RbacListRolesResponse = RoleList
-
-export type RbacCreateRoleData = {
-  requestBody: RoleCreate
-}
-
-export type RbacCreateRoleResponse = RoleReadWithScopes
 
 export type RbacGetRoleData = {
   roleId: string
@@ -9489,44 +9527,6 @@ export type RbacDeleteAssignmentData = {
 }
 
 export type RbacDeleteAssignmentResponse = void
-
-export type RbacListUserAssignmentsData = {
-  /**
-   * Filter by user ID
-   */
-  userId?: string | null
-  /**
-   * Filter by workspace ID
-   */
-  workspaceId?: string | null
-}
-
-export type RbacListUserAssignmentsResponse = UserRoleAssignmentList
-
-export type RbacCreateUserAssignmentData = {
-  requestBody: UserRoleAssignmentCreate
-}
-
-export type RbacCreateUserAssignmentResponse = UserRoleAssignmentReadWithDetails
-
-export type RbacGetUserAssignmentData = {
-  assignmentId: string
-}
-
-export type RbacGetUserAssignmentResponse = UserRoleAssignmentReadWithDetails
-
-export type RbacUpdateUserAssignmentData = {
-  assignmentId: string
-  requestBody: UserRoleAssignmentUpdate
-}
-
-export type RbacUpdateUserAssignmentResponse = UserRoleAssignmentReadWithDetails
-
-export type RbacDeleteUserAssignmentData = {
-  assignmentId: string
-}
-
-export type RbacDeleteUserAssignmentResponse = void
 
 export type UsersUsersCurrentUserResponse = UserRead
 
@@ -13879,6 +13879,98 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/rbac/roles": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: RoleList
+      }
+    }
+    post: {
+      req: RbacCreateRoleData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: RoleReadWithScopes
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/rbac/user-assignments": {
+    get: {
+      req: RbacListUserAssignmentsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: UserRoleAssignmentList
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: RbacCreateUserAssignmentData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: UserRoleAssignmentReadWithDetails
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/rbac/user-assignments/{assignment_id}": {
+    get: {
+      req: RbacGetUserAssignmentData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: UserRoleAssignmentReadWithDetails
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: RbacUpdateUserAssignmentData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: UserRoleAssignmentReadWithDetails
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: RbacDeleteUserAssignmentData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
   "/rbac/scopes": {
     get: {
       req: RbacListScopesData
@@ -13928,29 +14020,6 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/rbac/roles": {
-    get: {
-      res: {
-        /**
-         * Successful Response
-         */
-        200: RoleList
-      }
-    }
-    post: {
-      req: RbacCreateRoleData
-      res: {
-        /**
-         * Successful Response
-         */
-        201: RoleReadWithScopes
         /**
          * Validation Error
          */
@@ -14152,75 +14221,6 @@ export type $OpenApiTs = {
     }
     delete: {
       req: RbacDeleteAssignmentData
-      res: {
-        /**
-         * Successful Response
-         */
-        204: void
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/rbac/user-assignments": {
-    get: {
-      req: RbacListUserAssignmentsData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: UserRoleAssignmentList
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-    post: {
-      req: RbacCreateUserAssignmentData
-      res: {
-        /**
-         * Successful Response
-         */
-        201: UserRoleAssignmentReadWithDetails
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/rbac/user-assignments/{assignment_id}": {
-    get: {
-      req: RbacGetUserAssignmentData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: UserRoleAssignmentReadWithDetails
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-    patch: {
-      req: RbacUpdateUserAssignmentData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: UserRoleAssignmentReadWithDetails
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-    delete: {
-      req: RbacDeleteUserAssignmentData
       res: {
         /**
          * Successful Response

--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -649,7 +649,6 @@ class RBACService(BaseOrgService):
             raise TracecatNotFoundError("User role assignment not found")
         return assignment
 
-    @require_scope("org:rbac:create")
     @audit_log(resource_type="rbac_user_assignment", action="create")
     async def create_user_assignment(
         self,
@@ -702,7 +701,6 @@ class RBACService(BaseOrgService):
         await self.session.refresh(assignment, ["user", "role", "workspace"])
         return assignment
 
-    @require_scope("org:rbac:update")
     @audit_log(
         resource_type="rbac_user_assignment",
         action="update",
@@ -725,7 +723,6 @@ class RBACService(BaseOrgService):
         await self.session.refresh(assignment, ["user", "role", "workspace"])
         return assignment
 
-    @require_scope("org:rbac:delete")
     @audit_log(
         resource_type="rbac_user_assignment",
         action="delete",

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -49,6 +49,10 @@ from tracecat.auth.users import (
     auth_backend,
     fastapi_users,
 )
+from tracecat.authz.rbac.router import roles_router as rbac_roles_read_router
+from tracecat.authz.rbac.router import (
+    user_assignments_router as rbac_user_assignments_router,
+)
 from tracecat.authz.rbac.router import user_scopes_router
 from tracecat.authz.seeding import seed_all_system_data
 from tracecat.cases.attachments.internal_router import (
@@ -436,8 +440,10 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(mcp_router)
     app.include_router(feature_flags_router)
     app.include_router(vcs_router)
-    # RBAC routers - user_scopes_router is always included (OSS)
+    # RBAC routers - user scopes + role listing + user role assignments are always included (OSS)
     app.include_router(user_scopes_router)
+    app.include_router(rbac_roles_read_router)
+    app.include_router(rbac_user_assignments_router)
 
     # EE-only RBAC management endpoints - gated by RBAC entitlement
     from tracecat_ee.rbac.router import (
@@ -452,15 +458,11 @@ def create_app(**kwargs) -> FastAPI:
     from tracecat_ee.rbac.router import (
         scopes_router as rbac_scopes_router,
     )
-    from tracecat_ee.rbac.router import (
-        user_assignments_router as rbac_user_assignments_router,
-    )
 
     app.include_router(rbac_scopes_router)
     app.include_router(rbac_roles_router)
     app.include_router(rbac_groups_router)
     app.include_router(rbac_assignments_router)
-    app.include_router(rbac_user_assignments_router)
     app.include_router(
         fastapi_users.get_users_router(UserRead, UserUpdate),
         prefix="/users",

--- a/tracecat/authz/rbac/router.py
+++ b/tracecat/authz/rbac/router.py
@@ -1,16 +1,34 @@
-"""RBAC API routers - user scopes endpoint (OSS).
+"""RBAC API routers - OSS endpoints.
 
-The RBAC management endpoints (scopes, roles, groups, assignments) are
-available in the Enterprise Edition (tracecat_ee.rbac.router).
+Read-only role listing is exposed here; write operations are in the Enterprise
+Edition RBAC router (`tracecat_ee.rbac.router`).
 """
 
 from typing import Annotated
+from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+from tracecat_ee.rbac.schemas import (
+    RoleList,
+    RoleReadWithScopes,
+    ScopeRead,
+    UserRoleAssignmentCreate,
+    UserRoleAssignmentList,
+    UserRoleAssignmentReadWithDetails,
+    UserRoleAssignmentUpdate,
+)
+from tracecat_ee.rbac.service import RBACService
 
 from tracecat.auth.credentials import RoleACL
+from tracecat.auth.dependencies import OrgUserRole
 from tracecat.auth.types import Role
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.db.models import Role as DBRole
+from tracecat.exceptions import TracecatNotFoundError
 
 # =============================================================================
 # User Scopes Schemas (kept here for OSS endpoint)
@@ -51,3 +69,216 @@ async def get_my_scopes(
     """
     current_scopes = role.scopes or frozenset()
     return UserScopesRead(scopes=sorted(current_scopes))
+
+
+# =============================================================================
+# Roles Router (Public read)
+# =============================================================================
+
+roles_router = APIRouter(prefix="/rbac/roles", tags=["rbac"])
+
+
+@roles_router.get("", response_model=RoleList)
+async def list_roles(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+) -> RoleList:
+    """List roles for the organization.
+
+    Requires: authenticated organization member.
+    """
+    if role.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization context",
+        )
+
+    stmt = (
+        select(DBRole)
+        .where(DBRole.organization_id == role.organization_id)
+        .options(selectinload(DBRole.scopes))
+        .order_by(DBRole.name)
+    )
+    result = await session.execute(stmt)
+    roles = result.scalars().all()
+
+    return RoleList(
+        items=[
+            RoleReadWithScopes(
+                id=r.id,
+                name=r.name,
+                slug=r.slug,
+                description=r.description,
+                organization_id=r.organization_id,
+                created_at=r.created_at,
+                updated_at=r.updated_at,
+                created_by=r.created_by,
+                scopes=ScopeRead.list_adapter().validate_python(r.scopes),
+            )
+            for r in roles
+        ],
+        total=len(roles),
+    )
+
+
+# =============================================================================
+# User Role Assignments Router (Public read/write for direct user-role assignment)
+# =============================================================================
+
+user_assignments_router = APIRouter(prefix="/rbac/user-assignments", tags=["rbac"])
+
+
+@user_assignments_router.get("", response_model=UserRoleAssignmentList)
+async def list_user_assignments(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    user_id: UUID | None = Query(None, description="Filter by user ID"),
+    workspace_id: UUID | None = Query(None, description="Filter by workspace ID"),
+) -> UserRoleAssignmentList:
+    """List user role assignments for the organization."""
+    service = RBACService(session, role=role)
+    assignments = await service.list_user_assignments(
+        user_id=user_id,
+        workspace_id=workspace_id,
+    )
+    return UserRoleAssignmentList(
+        items=[
+            UserRoleAssignmentReadWithDetails(
+                id=a.id,
+                organization_id=a.organization_id,
+                user_id=a.user_id,
+                workspace_id=a.workspace_id,
+                role_id=a.role_id,
+                assigned_at=a.assigned_at,
+                assigned_by=a.assigned_by,
+                user_email=a.user.email,
+                role_name=a.role.name,
+                workspace_name=a.workspace.name if a.workspace else None,
+            )
+            for a in assignments
+        ],
+        total=len(assignments),
+    )
+
+
+@user_assignments_router.get(
+    "/{assignment_id}", response_model=UserRoleAssignmentReadWithDetails
+)
+async def get_user_assignment(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    assignment_id: UUID,
+) -> UserRoleAssignmentReadWithDetails:
+    """Get a user role assignment by ID."""
+    service = RBACService(session, role=role)
+    try:
+        a = await service.get_user_assignment(assignment_id)
+        return UserRoleAssignmentReadWithDetails(
+            id=a.id,
+            organization_id=a.organization_id,
+            user_id=a.user_id,
+            workspace_id=a.workspace_id,
+            role_id=a.role_id,
+            assigned_at=a.assigned_at,
+            assigned_by=a.assigned_by,
+            user_email=a.user.email,
+            role_name=a.role.name,
+            workspace_name=a.workspace.name if a.workspace else None,
+        )
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@user_assignments_router.post(
+    "",
+    response_model=UserRoleAssignmentReadWithDetails,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_user_assignment(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    params: UserRoleAssignmentCreate,
+) -> UserRoleAssignmentReadWithDetails:
+    """Create a user role assignment.
+
+    Assigns a role directly to a user. If workspace_id is None, creates an org-wide
+    assignment that applies to all workspaces. Each user can have at most
+    one assignment per workspace (or one org-wide assignment).
+    """
+    service = RBACService(session, role=role)
+    try:
+        a = await service.create_user_assignment(
+            user_id=params.user_id,
+            role_id=params.role_id,
+            workspace_id=params.workspace_id,
+        )
+        return UserRoleAssignmentReadWithDetails(
+            id=a.id,
+            organization_id=a.organization_id,
+            user_id=a.user_id,
+            workspace_id=a.workspace_id,
+            role_id=a.role_id,
+            assigned_at=a.assigned_at,
+            assigned_by=a.assigned_by,
+            user_email=a.user.email,
+            role_name=a.role.name,
+            workspace_name=a.workspace.name if a.workspace else None,
+        )
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except IntegrityError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="User already has an assignment for this workspace",
+        ) from e
+
+
+@user_assignments_router.patch(
+    "/{assignment_id}", response_model=UserRoleAssignmentReadWithDetails
+)
+async def update_user_assignment(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    assignment_id: UUID,
+    params: UserRoleAssignmentUpdate,
+) -> UserRoleAssignmentReadWithDetails:
+    """Update a user role assignment (change role)."""
+    service = RBACService(session, role=role)
+    try:
+        a = await service.update_user_assignment(assignment_id, role_id=params.role_id)
+        return UserRoleAssignmentReadWithDetails(
+            id=a.id,
+            organization_id=a.organization_id,
+            user_id=a.user_id,
+            workspace_id=a.workspace_id,
+            role_id=a.role_id,
+            assigned_at=a.assigned_at,
+            assigned_by=a.assigned_by,
+            user_email=a.user.email,
+            role_name=a.role.name,
+            workspace_name=a.workspace.name if a.workspace else None,
+        )
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@user_assignments_router.delete(
+    "/{assignment_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_user_assignment(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    assignment_id: UUID,
+) -> None:
+    """Delete a user role assignment."""
+    service = RBACService(session, role=role)
+    try:
+        await service.delete_user_assignment(assignment_id)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose basic RBAC in OSS by moving role listing and user role assignments (CRUD) from EE to the core API. Keep advanced RBAC in EE; role listing is open to authenticated org members, while user assignment CRUD requires org:rbac scopes.

- New Features
  - /rbac/roles GET in OSS for org role listing (auth required).
  - /rbac/user-assignments CRUD in OSS; gated by org:rbac:* scopes.

- Refactors
  - Registered OSS routers in app; removed EE equivalents for role listing and user assignments.
  - RBACService now raises validation for duplicate assignments; OSS returns 409.
  - Regenerated frontend client/types for moved endpoints; no URL or payload changes.

<sup>Written for commit b397158516e23a393e203dd2aa9875c653b1a609. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

