### PR TITLE
feat: Handle corrupted workspace secrets gracefully

### DIFF
--- a/frontend/src/components/workspaces/delete-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/delete-workspace-secret.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import type React from "react"
-import type { SecretReadMinimal } from "@/client"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,7 +12,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
-import { useWorkspaceSecrets } from "@/lib/hooks"
+import { useWorkspaceSecrets, type WorkspaceSecretListItem } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 export function DeleteSecretAlertDialog({
@@ -21,8 +20,8 @@ export function DeleteSecretAlertDialog({
   setSelectedSecret,
   children,
 }: React.PropsWithChildren<{
-  selectedSecret: SecretReadMinimal | null
-  setSelectedSecret: (selectedSecret: SecretReadMinimal | null) => void
+  selectedSecret: WorkspaceSecretListItem | null
+  setSelectedSecret: (selectedSecret: WorkspaceSecretListItem | null) => void
 }>) {
   const workspaceId = useWorkspaceId()
   const { deleteSecretById } = useWorkspaceSecrets(workspaceId)

--- a/frontend/src/components/workspaces/edit-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/edit-workspace-secret.tsx
@@ -69,6 +69,9 @@ function getEditableSecretKeys(secret: WorkspaceSecretListItem) {
   if (secret.type === "ssh-key") {
     return []
   }
+  if (secret.is_corrupted && secret.type === "custom") {
+    return [{ key: "", value: "" }]
+  }
   const keyNames =
     secret.keys.length > 0
       ? secret.keys
@@ -120,6 +123,23 @@ export function EditCredentialsDialog({
       // Remove unset values from the params object
       // We consider empty strings as unset values
       const submittedKeys = values.keys ?? []
+      if (
+        selectedSecret.is_corrupted &&
+        !isSshKey &&
+        submittedKeys.length === 0
+      ) {
+        methods.setError("keys", {
+          type: "manual",
+          message: "Add all key names and values to recover this secret.",
+        })
+        toast({
+          title: "Recovery requires all keys",
+          description:
+            "This secret is corrupted. Re-enter all key names and values before saving.",
+          variant: "destructive",
+        })
+        return
+      }
       const params = {
         name: values.name || undefined,
         description: values.description || undefined,

--- a/frontend/src/components/workspaces/edit-workspace-secret.tsx
+++ b/frontend/src/components/workspaces/edit-workspace-secret.tsx
@@ -2,11 +2,17 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import type { DialogProps } from "@radix-ui/react-dialog"
-import { PlusCircle, SaveIcon, Trash2Icon } from "lucide-react"
+import {
+  AlertTriangleIcon,
+  PlusCircle,
+  SaveIcon,
+  Trash2Icon,
+} from "lucide-react"
 import React, { type PropsWithChildren, useCallback } from "react"
 import { useFieldArray, useForm } from "react-hook-form"
 import { z } from "zod"
-import type { SecretReadMinimal, SecretUpdate } from "@/client"
+import type { SecretUpdate } from "@/client"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -29,15 +35,15 @@ import {
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
-import { useWorkspaceSecrets } from "@/lib/hooks"
+import { useWorkspaceSecrets, type WorkspaceSecretListItem } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 interface EditCredentialsDialogProps
   extends PropsWithChildren<
     DialogProps & React.HTMLAttributes<HTMLDivElement>
   > {
-  selectedSecret: SecretReadMinimal | null
-  setSelectedSecret: (selectedSecret: SecretReadMinimal | null) => void
+  selectedSecret: WorkspaceSecretListItem | null
+  setSelectedSecret: (selectedSecret: WorkspaceSecretListItem | null) => void
 }
 
 const updateSecretSchema = z.object({
@@ -51,6 +57,24 @@ const updateSecretSchema = z.object({
     })
   ),
 })
+
+const fixedSecretTypeKeyNames: Partial<
+  Record<WorkspaceSecretListItem["type"], string[]>
+> = {
+  mtls: ["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+  "ca-cert": ["CA_CERTIFICATE"],
+}
+
+function getEditableSecretKeys(secret: WorkspaceSecretListItem) {
+  if (secret.type === "ssh-key") {
+    return []
+  }
+  const keyNames =
+    secret.keys.length > 0
+      ? secret.keys
+      : (fixedSecretTypeKeyNames[secret.type] ?? [])
+  return keyNames.map((keyName) => ({ key: keyName, value: "" }))
+}
 
 export function EditCredentialsDialog({
   selectedSecret,
@@ -78,18 +102,11 @@ export function EditCredentialsDialog({
 
   React.useEffect(() => {
     if (selectedSecret) {
-      const secretKeys =
-        selectedSecret.type === "ssh-key"
-          ? []
-          : selectedSecret.keys.map((keyName) => ({
-              key: keyName,
-              value: "",
-            }))
       reset({
         name: "",
         description: "",
         environment: "",
-        keys: secretKeys,
+        keys: getEditableSecretKeys(selectedSecret),
       })
     }
   }, [selectedSecret, reset])
@@ -102,11 +119,13 @@ export function EditCredentialsDialog({
       }
       // Remove unset values from the params object
       // We consider empty strings as unset values
+      const submittedKeys = values.keys ?? []
       const params = {
         name: values.name || undefined,
         description: values.description || undefined,
         environment: values.environment || undefined,
-        keys: isSshKey ? undefined : values.keys,
+        keys:
+          isSshKey || submittedKeys.length === 0 ? undefined : submittedKeys,
       }
       console.log("Submitting edit secret", params)
       try {
@@ -120,7 +139,7 @@ export function EditCredentialsDialog({
       methods.reset()
       setSelectedSecret(null) // Only unset the selected secret after the form has been submitted
     },
-    [selectedSecret, setSelectedSecret]
+    [isSshKey, methods, selectedSecret, setSelectedSecret, updateSecretById]
   )
 
   const onValidationFailed = (errors: unknown) => {
@@ -164,6 +183,17 @@ export function EditCredentialsDialog({
         <Form {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit, onValidationFailed)}>
             <div className="space-y-4">
+              {selectedSecret?.is_corrupted && (
+                <Alert>
+                  <AlertTriangleIcon className="size-4 !text-amber-600" />
+                  <AlertTitle>Unable to decrypt current key data</AlertTitle>
+                  <AlertDescription>
+                    {isSshKey
+                      ? "This SSH key secret cannot be edited. Delete and recreate it with a new key."
+                      : "Stored key names and values could not be decrypted. Re-enter all key names and values before saving."}
+                  </AlertDescription>
+                </Alert>
+              )}
               <FormField
                 key="name"
                 control={control}

--- a/frontend/src/components/workspaces/workspace-secrets-table.tsx
+++ b/frontend/src/components/workspaces/workspace-secrets-table.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { AlertTriangleIcon } from "lucide-react"
 import { useState } from "react"
-import type { SecretReadMinimal } from "@/client"
 import {
   DataTable,
   DataTableColumnHeader,
@@ -10,6 +10,7 @@ import {
 } from "@/components/data-table"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -26,10 +27,10 @@ import {
   EditCredentialsDialog,
   EditCredentialsDialogTrigger,
 } from "@/components/workspaces/edit-workspace-secret"
-import { useWorkspaceSecrets } from "@/lib/hooks"
+import { useWorkspaceSecrets, type WorkspaceSecretListItem } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-const secretTypeLabels: Record<SecretReadMinimal["type"], string> = {
+const secretTypeLabels: Record<WorkspaceSecretListItem["type"], string> = {
   custom: "Custom",
   "ssh-key": "SSH key",
   mtls: "mTLS",
@@ -42,7 +43,7 @@ export function WorkspaceSecretsTable() {
   const { secrets, secretsIsLoading, secretsError } =
     useWorkspaceSecrets(workspaceId)
   const [selectedSecret, setSelectedSecret] =
-    useState<SecretReadMinimal | null>(null)
+    useState<WorkspaceSecretListItem | null>(null)
   if (secretsIsLoading) {
     return <CenteredSpinner />
   }
@@ -55,191 +56,232 @@ export function WorkspaceSecretsTable() {
     )
   }
 
+  const corruptedSecrets = secrets.filter((secret) => secret.is_corrupted)
+
   return (
-    <DeleteSecretAlertDialog
-      selectedSecret={selectedSecret}
-      setSelectedSecret={setSelectedSecret}
-    >
-      <EditCredentialsDialog
+    <>
+      {corruptedSecrets.length > 0 && (
+        <Alert>
+          <AlertTriangleIcon className="size-4 !text-amber-600" />
+          <AlertTitle>Some secrets could not be decrypted</AlertTitle>
+          <AlertDescription>
+            Failed to decrypt key names and values for{" "}
+            {corruptedSecrets.map((secret) => secret.name).join(", ")}. Secret
+            names are still available, but you must re-enter all key names and
+            values to recover these secrets. For SSH keys, delete and recreate
+            the secret.
+          </AlertDescription>
+        </Alert>
+      )}
+      <DeleteSecretAlertDialog
         selectedSecret={selectedSecret}
         setSelectedSecret={setSelectedSecret}
       >
-        <DataTable
-          data={secrets}
-          columns={[
-            {
-              accessorKey: "name",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Secret Name"
-                />
-              ),
-              cell: ({ row }) => (
-                <div className="font-mono text-xs">
-                  {row.getValue<SecretReadMinimal["name"]>("name")}
-                </div>
-              ),
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "type",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Secret Type"
-                />
-              ),
-              cell: ({ row }) => {
-                const type = row.getValue<SecretReadMinimal["type"]>("type")
-                const label = secretTypeLabels[type] ?? type
-                return (
-                  <Badge variant="secondary" className="text-xs">
-                    {label}
-                  </Badge>
-                )
-              },
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "description",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Description"
-                />
-              ),
-              cell: ({ row }) => (
-                <div className="text-xs">
-                  {row.getValue<SecretReadMinimal["description"]>(
-                    "description"
-                  ) || "-"}
-                </div>
-              ),
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "environment",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Environment"
-                />
-              ),
-              cell: ({ row }) => (
-                <div className="text-xs">
-                  {row.getValue<SecretReadMinimal["environment"]>(
-                    "environment"
-                  ) || "-"}
-                </div>
-              ),
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "keys",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Secret keys"
-                />
-              ),
-              cell: ({ row }) => {
-                const keys = row.getValue<SecretReadMinimal["keys"]>("keys")
-                if (!keys?.length) {
-                  return <div className="text-xs">-</div>
-                }
-                return (
-                  <div className="flex-auto space-x-4 text-xs">
-                    {keys.map((key, idx) => (
-                      <Badge
-                        variant="secondary"
-                        className="font-mono text-xs"
-                        key={idx}
-                      >
-                        {key}
-                      </Badge>
-                    ))}
+        <EditCredentialsDialog
+          selectedSecret={selectedSecret}
+          setSelectedSecret={setSelectedSecret}
+        >
+          <DataTable
+            data={secrets}
+            columns={[
+              {
+                accessorKey: "name",
+                header: ({ column }) => (
+                  <DataTableColumnHeader
+                    className="text-xs"
+                    column={column}
+                    title="Secret Name"
+                  />
+                ),
+                cell: ({ row }) => (
+                  <div className="flex items-center gap-2 font-mono text-xs">
+                    {row.original.is_corrupted ? (
+                      <span
+                        aria-label="Secret is corrupted"
+                        className="size-1.5 rounded-full bg-amber-500"
+                        title="Unable to decrypt this secret"
+                      />
+                    ) : null}
+                    <span>
+                      {row.getValue<WorkspaceSecretListItem["name"]>("name")}
+                    </span>
                   </div>
-                )
+                ),
+                enableSorting: true,
+                enableHiding: false,
               },
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              id: "actions",
-              enableHiding: false,
-              cell: ({ row }) => {
-                return (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" className="size-8 p-0">
-                        <span className="sr-only">Open menu</span>
-                        <DotsHorizontalIcon className="size-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent>
-                      <DropdownMenuItem
-                        onClick={() =>
-                          navigator.clipboard.writeText(row.original.id)
-                        }
-                      >
-                        Copy Secret ID
-                      </DropdownMenuItem>
-
-                      <EditCredentialsDialogTrigger asChild>
-                        <DropdownMenuItem
-                          onClick={() => {
-                            if (!row.original) {
-                              console.error("No secret to edit")
-                              return
-                            }
-                            setSelectedSecret(row.original)
-                            console.debug(
-                              "Selected secret to edit",
-                              row.original
-                            )
-                          }}
-                        >
-                          Edit
-                        </DropdownMenuItem>
-                      </EditCredentialsDialogTrigger>
-
-                      <DeleteSecretAlertDialogTrigger asChild>
-                        <DropdownMenuItem
-                          className="text-rose-500 focus:text-rose-600"
-                          onClick={() => {
-                            setSelectedSecret(row.original)
-                            console.debug(
-                              "Selected secret to delete",
-                              row.original
-                            )
-                          }}
-                        >
-                          Delete
-                        </DropdownMenuItem>
-                      </DeleteSecretAlertDialogTrigger>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )
+              {
+                accessorKey: "type",
+                header: ({ column }) => (
+                  <DataTableColumnHeader
+                    className="text-xs"
+                    column={column}
+                    title="Secret Type"
+                  />
+                ),
+                cell: ({ row }) => {
+                  const type =
+                    row.getValue<WorkspaceSecretListItem["type"]>("type")
+                  const label = secretTypeLabels[type] ?? type
+                  return (
+                    <Badge variant="secondary" className="text-xs">
+                      {label}
+                    </Badge>
+                  )
+                },
+                enableSorting: true,
+                enableHiding: false,
               },
-            },
-          ]}
-          toolbarProps={defaultToolbarProps}
-        />
-      </EditCredentialsDialog>
-    </DeleteSecretAlertDialog>
+              {
+                accessorKey: "description",
+                header: ({ column }) => (
+                  <DataTableColumnHeader
+                    className="text-xs"
+                    column={column}
+                    title="Description"
+                  />
+                ),
+                cell: ({ row }) => (
+                  <div className="text-xs">
+                    {row.getValue<WorkspaceSecretListItem["description"]>(
+                      "description"
+                    ) || "-"}
+                  </div>
+                ),
+                enableSorting: true,
+                enableHiding: false,
+              },
+              {
+                accessorKey: "environment",
+                header: ({ column }) => (
+                  <DataTableColumnHeader
+                    className="text-xs"
+                    column={column}
+                    title="Environment"
+                  />
+                ),
+                cell: ({ row }) => (
+                  <div className="text-xs">
+                    {row.getValue<WorkspaceSecretListItem["environment"]>(
+                      "environment"
+                    ) || "-"}
+                  </div>
+                ),
+                enableSorting: true,
+                enableHiding: false,
+              },
+              {
+                accessorKey: "keys",
+                header: ({ column }) => (
+                  <DataTableColumnHeader
+                    className="text-xs"
+                    column={column}
+                    title="Secret keys"
+                  />
+                ),
+                cell: ({ row }) => {
+                  if (row.original.is_corrupted) {
+                    return (
+                      <span className="text-xs">
+                        Unavailable (reconfigure required)
+                      </span>
+                    )
+                  }
+
+                  const keys =
+                    row.getValue<WorkspaceSecretListItem["keys"]>("keys")
+                  if (!keys?.length) {
+                    return <div className="text-xs">-</div>
+                  }
+                  return (
+                    <div className="flex-auto space-x-4 text-xs">
+                      {keys.map((key, idx) => (
+                        <Badge
+                          variant="secondary"
+                          className="font-mono text-xs"
+                          key={idx}
+                        >
+                          {key}
+                        </Badge>
+                      ))}
+                    </div>
+                  )
+                },
+                enableSorting: true,
+                enableHiding: false,
+              },
+              {
+                id: "actions",
+                enableHiding: false,
+                cell: ({ row }) => {
+                  const isCorruptedSshKey =
+                    row.original.is_corrupted && row.original.type === "ssh-key"
+                  return (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="size-8 p-0">
+                          <span className="sr-only">Open menu</span>
+                          <DotsHorizontalIcon className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        <DropdownMenuItem
+                          onClick={() =>
+                            navigator.clipboard.writeText(row.original.id)
+                          }
+                        >
+                          Copy Secret ID
+                        </DropdownMenuItem>
+
+                        <EditCredentialsDialogTrigger asChild>
+                          <DropdownMenuItem
+                            disabled={isCorruptedSshKey}
+                            onClick={() => {
+                              if (!row.original) {
+                                console.error("No secret to edit")
+                                return
+                              }
+                              setSelectedSecret(row.original)
+                              console.debug(
+                                "Selected secret to edit",
+                                row.original
+                              )
+                            }}
+                          >
+                            {isCorruptedSshKey
+                              ? "Edit (delete and recreate)"
+                              : "Edit"}
+                          </DropdownMenuItem>
+                        </EditCredentialsDialogTrigger>
+
+                        <DeleteSecretAlertDialogTrigger asChild>
+                          <DropdownMenuItem
+                            className="text-rose-500 focus:text-rose-600"
+                            onClick={() => {
+                              setSelectedSecret(row.original)
+                              console.debug(
+                                "Selected secret to delete",
+                                row.original
+                              )
+                            }}
+                          >
+                            Delete
+                          </DropdownMenuItem>
+                        </DeleteSecretAlertDialogTrigger>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )
+                },
+              },
+            ]}
+            toolbarProps={defaultToolbarProps}
+          />
+        </EditCredentialsDialog>
+      </DeleteSecretAlertDialog>
+    </>
   )
 }
-const defaultToolbarProps: DataTableToolbarProps<SecretReadMinimal> = {
+const defaultToolbarProps: DataTableToolbarProps<WorkspaceSecretListItem> = {
   filterProps: {
     placeholder: "Filter secrets by name...",
     column: "name",

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -374,6 +374,10 @@ interface AppInfo {
   ee_multi_tenant: boolean
 }
 
+export type WorkspaceSecretListItem = SecretReadMinimal & {
+  is_corrupted?: boolean
+}
+
 export function useAppInfo() {
   const {
     data: appInfo,
@@ -1312,7 +1316,7 @@ export function useWorkspaceSecrets(workspaceId: string) {
     data: secrets,
     isLoading: secretsIsLoading,
     error: secretsError,
-  } = useQuery<SecretReadMinimal[], ApiError>({
+  } = useQuery<WorkspaceSecretListItem[], ApiError>({
     queryKey: ["workspace-secrets", workspaceId],
     queryFn: async () =>
       await secretsListSecrets({
@@ -1404,7 +1408,7 @@ export function useWorkspaceSecrets(workspaceId: string) {
 
   // Delete secret
   const { mutateAsync: deleteSecretById } = useMutation({
-    mutationFn: async (secret: SecretReadMinimal) =>
+    mutationFn: async (secret: WorkspaceSecretListItem) =>
       await secretsDeleteSecretById({ workspaceId, secretId: secret.id }),
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/tracecat/secrets/schemas.py
+++ b/tracecat/secrets/schemas.py
@@ -289,6 +289,7 @@ class SecretReadMinimal(BaseModel):
     description: str | None = None
     keys: list[str]
     environment: str
+    is_corrupted: bool = False
 
 
 class SecretReadBase(BaseModel):

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from pydantic import SecretStr
+from cryptography.fernet import InvalidToken
+from pydantic import SecretStr, ValidationError
 from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -104,10 +105,25 @@ class SecretsService(BaseOrgService):
         set_fields = params.model_dump(exclude_unset=True)
         # Handle keys separately
         if keys := set_fields.pop("keys", None):
-            # Decrypt existing keys to a dictionary for easy lookup
-            existing_keys = {
-                kv.key: kv.value for kv in self.decrypt_keys(secret.encrypted_keys)
-            }
+            existing_keys: dict[str, SecretStr] = {}
+            try:
+                # Decrypt existing keys to a dictionary for easy lookup.
+                existing_keys = {
+                    kv.key: kv.value for kv in self.decrypt_keys(secret.encrypted_keys)
+                }
+            except (InvalidToken, ValidationError, ValueError) as e:
+                # Allow recovery from a corrupted encryption key by requiring callers
+                # to provide all key values, rather than preserving blanks.
+                if any(not kv["value"] for kv in keys):
+                    raise ValueError(
+                        "Stored secret values cannot be decrypted. Re-enter all key values to recover this secret."
+                    ) from e
+                self.logger.warning(
+                    "Failed to decrypt existing secret keys during update; proceeding with full key replacement",
+                    secret_id=str(secret.id),
+                    secret_name=secret.name,
+                    error=str(e),
+                )
 
             # Create new key-value pairs, preserving existing values when the new value is empty
             merged_keyvalues = []


### PR DESCRIPTION
Summary:
- Add error handling on the workspace credentials page so failures decrypting secrets render a warning similar to the org settings SSO page, allowing the user to reconfigure values instead of hitting a 500.
- Highlight corrupted secrets with a smaller yellow icon indicator without relying on borders or font color, and keep the underlying names/keys visible since they are not encrypted.
- Surface guidance when decryption fails (InvalidToken) so users know to re-enter the secrets rather than seeing an opaque error page.

Testing:
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle corrupted workspace and org secrets gracefully. When decryption fails, APIs return safe data with is_corrupted, and the UI guides users to recover instead of hitting a 500.

- **Bug Fixes**
  - Backend: List endpoints now tolerate decryption errors via a serializer helper and mark secrets as is_corrupted with keys=[] (workspace and org). Added is_corrupted to SecretReadMinimal. update_secret enforces recovery: require full key payload when ciphertext is unreadable, reject empty values, and force delete/recreate for SSH keys; logs warnings instead of failing.
  - Frontend: Secrets table shows a warning alert when any secret is corrupted, adds a small amber dot next to names, and displays “Unavailable (reconfigure required)” for keys. Edit dialog explains recovery, disables edit for corrupted SSH keys, and requires all key names/values for other types; updated types/hooks to include is_corrupted.
  - Tests: Added API tests for corrupted listing (workspace and org) and service tests covering recovery and error cases.

<sup>Written for commit 1250856504da86e6ef53299c325aef254096cc0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

