### PR TITLE
feat(api): Return dropdown metadata in case responses

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5114,6 +5114,7 @@ export const $CaseRead = {
     "description",
     "fields",
     "payload",
+    "dropdown_values",
   ],
   title: "CaseRead",
 } as const
@@ -5197,6 +5198,7 @@ export const $CaseReadMinimal = {
     "status",
     "priority",
     "severity",
+    "dropdown_values",
   ],
   title: "CaseReadMinimal",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1440,7 +1440,7 @@ export type CaseRead = {
     [key: string]: unknown
   } | null
   tags?: Array<CaseTagRead>
-  dropdown_values?: Array<CaseDropdownValueRead>
+  dropdown_values: Array<CaseDropdownValueRead>
 }
 
 export type CaseReadMinimal = {
@@ -1454,7 +1454,7 @@ export type CaseReadMinimal = {
   severity: CaseSeverity
   assignee?: UserRead | null
   tags?: Array<CaseTagRead>
-  dropdown_values?: Array<CaseDropdownValueRead>
+  dropdown_values: Array<CaseDropdownValueRead>
   num_tasks_completed?: number
   num_tasks_total?: number
 }

--- a/packages/tracecat-registry/tracecat_registry/core/ee/durations.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ee/durations.py
@@ -36,6 +36,7 @@ async def get_case_metrics(
     - duration_slug: Slugified name for filtering (e.g., "time_to_resolve")
     - case_priority, case_severity, case_status: Dimensions for groupby
     - case_id, case_short_id: Identifiers for drill-down
+    - fields, tags, dropdown_values: Full case metadata snapshot for each metric row
     """
     if not case_ids:
         return []

--- a/packages/tracecat-registry/tracecat_registry/sdk/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/cases.py
@@ -18,7 +18,6 @@ from tracecat_registry.sdk.types import (
 
 if TYPE_CHECKING:
     from tracecat_registry.sdk.client import TracecatClient
-    from tracecat_ee.cases.types import CaseDurationMetric
 
 
 class CasesClient:
@@ -794,7 +793,7 @@ class CasesClient:
     async def get_case_metrics(
         self,
         case_ids: list[str],
-    ) -> list["CaseDurationMetric"]:
+    ) -> list[types.CaseDurationMetric]:
         """Get case metrics as time-series for the provided case IDs.
 
         Args:

--- a/packages/tracecat-registry/tracecat_registry/types.py
+++ b/packages/tracecat-registry/tracecat_registry/types.py
@@ -106,7 +106,7 @@ class CaseRead(TypedDict):
     payload: dict[str, Any] | None
     fields: list[CaseFieldRead]
     tags: list[CaseTagRead]
-    dropdown_values: NotRequired[list[CaseDropdownValueRead]]
+    dropdown_values: list[CaseDropdownValueRead]
     assignee: UserRead | None
     created_at: datetime
     updated_at: datetime
@@ -125,7 +125,7 @@ class CaseReadMinimal(TypedDict):
     severity: str
     status: str
     tags: list[CaseTagRead]
-    dropdown_values: NotRequired[list[CaseDropdownValueRead]]
+    dropdown_values: list[CaseDropdownValueRead]
     assignee: UserRead | None
     created_at: datetime
     updated_at: datetime
@@ -196,6 +196,9 @@ class CaseDurationMetric(TypedDict):
     case_status: str
     case_id: str
     case_short_id: str
+    fields: list[CaseFieldRead]
+    tags: list[CaseTagRead]
+    dropdown_values: list[CaseDropdownValueRead]
 
 
 class TagRead(TypedDict):

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -80,6 +80,7 @@ async def test_list_cases_success(
             severity=mock_case.severity,
             assignee=None,
             tags=[],
+            dropdown_values=[],
             num_tasks_completed=0,
             num_tasks_total=0,
         )
@@ -143,6 +144,7 @@ async def test_list_cases_with_filters(
             severity=mock_case.severity,
             assignee=None,
             tags=[],
+            dropdown_values=[],
             num_tasks_completed=0,
             num_tasks_total=0,
         )
@@ -543,6 +545,7 @@ async def test_search_cases_success(
             severity=mock_case.severity,
             assignee=None,
             tags=[],
+            dropdown_values=[],
             num_tasks_completed=0,
             num_tasks_total=0,
         )
@@ -596,6 +599,7 @@ async def test_search_cases_forwards_date_filters(
             severity=mock_case.severity,
             assignee=None,
             tags=[],
+            dropdown_values=[],
             num_tasks_completed=0,
             num_tasks_total=0,
         )

--- a/tracecat/cases/durations/schemas.py
+++ b/tracecat/cases/durations/schemas.py
@@ -9,7 +9,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
 from tracecat.cases.enums import CaseEventType
+from tracecat.cases.tags.schemas import CaseTagRead
 
 
 class CaseDurationAnchorSelection(StrEnum):
@@ -191,3 +193,17 @@ class CaseDurationMetric(BaseModel):
     # Case identifiers (high cardinality - for drill-down/lookups)
     case_id: str = Field(..., description="Case UUID for lookups")
     case_short_id: str = Field(..., description="Human-readable case identifier")
+
+    # Case details
+    fields: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Case custom fields and their values.",
+    )
+    tags: list[CaseTagRead] = Field(
+        default_factory=list,
+        description="Case tags.",
+    )
+    dropdown_values: list[CaseDropdownValueRead] = Field(
+        default_factory=list,
+        description="Case dropdown selections with definition and option info.",
+    )

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -20,6 +20,8 @@ from tracecat.auth.dependencies import ExecutorWorkspaceRole
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope
+from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
+from tracecat.cases.dropdowns.service import CaseDropdownValuesService
 from tracecat.cases.durations.schemas import CaseDurationMetric
 from tracecat.cases.durations.service import CaseDurationService
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
@@ -56,6 +58,7 @@ from tracecat.exceptions import TracecatNotFoundError
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
+from tracecat.tiers.enums import Entitlement
 
 router = APIRouter(
     prefix="/internal/cases", tags=["internal-cases"], include_in_schema=False
@@ -64,6 +67,18 @@ router = APIRouter(
 # Sub-routers for feature-gated routes (service-layer entitlement checks)
 task_router = APIRouter()
 duration_router = APIRouter()
+
+
+async def _list_case_dropdown_values(
+    *,
+    session: AsyncDBSession,
+    role: ExecutorWorkspaceRole,
+    case_id: uuid.UUID,
+) -> list[CaseDropdownValueRead]:
+    dropdown_service = CaseDropdownValuesService(session, role)
+    if not await dropdown_service.has_entitlement(Entitlement.CASE_ADDONS):
+        return []
+    return await dropdown_service.list_values_for_case(case_id)
 
 
 @router.get("")
@@ -291,6 +306,9 @@ async def get_case(
     tag_reads = [
         CaseTagRead.model_validate(tag, from_attributes=True) for tag in case.tags
     ]
+    dropdown_reads = await _list_case_dropdown_values(
+        session=session, role=role, case_id=case.id
+    )
 
     return CaseRead(
         id=case.id,
@@ -308,6 +326,7 @@ async def get_case(
         fields=final_fields,
         payload=case.payload,
         tags=tag_reads,
+        dropdown_values=dropdown_reads,
     )
 
 
@@ -350,6 +369,9 @@ async def create_case(
     tag_reads = [
         CaseTagRead.model_validate(tag, from_attributes=True) for tag in case.tags
     ]
+    dropdown_reads = await _list_case_dropdown_values(
+        session=session, role=role, case_id=case.id
+    )
 
     return CaseRead(
         id=case.id,
@@ -367,6 +389,7 @@ async def create_case(
         fields=final_fields,
         payload=case.payload,
         tags=tag_reads,
+        dropdown_values=dropdown_reads,
     )
 
 
@@ -423,6 +446,9 @@ async def update_case(
         CaseTagRead.model_validate(tag, from_attributes=True)
         for tag in updated_case.tags
     ]
+    dropdown_reads = await _list_case_dropdown_values(
+        session=session, role=role, case_id=updated_case.id
+    )
 
     return CaseRead(
         id=updated_case.id,
@@ -440,6 +466,7 @@ async def update_case(
         fields=final_fields,
         payload=updated_case.payload,
         tags=tag_reads,
+        dropdown_values=dropdown_reads,
     )
 
 
@@ -674,7 +701,17 @@ async def get_case_metrics(
     cases_service = CasesService(session, role)
     duration_service = CaseDurationService(session, role)
 
+    field_definitions = await cases_service.fields.list_fields()
+    field_schema = await cases_service.fields.get_field_schema()
+    field_templates = [
+        CaseFieldReadMinimal.from_sa(defn, field_schema=field_schema)
+        for defn in field_definitions
+    ]
+
     cases = []
+    case_context: dict[
+        str, tuple[list[CaseFieldRead], list[CaseTagRead], list[CaseDropdownValueRead]]
+    ] = {}
     for case_id in params.case_ids:
         case = await cases_service.get_case(case_id)
         if case is None:
@@ -682,9 +719,50 @@ async def get_case_metrics(
                 status_code=HTTP_404_NOT_FOUND,
                 detail=f"Case with ID {case_id} not found",
             )
+
+        fields = await cases_service.fields.get_fields(case) or {}
+        field_reads = [
+            CaseFieldRead(
+                id=f.id,
+                type=f.type,
+                description=f.description,
+                nullable=f.nullable,
+                default=f.default,
+                reserved=f.reserved,
+                options=f.options,
+                value=fields.get(f.id),
+            )
+            for f in field_templates
+        ]
+        tag_reads = [
+            CaseTagRead.model_validate(tag, from_attributes=True) for tag in case.tags
+        ]
+        dropdown_reads = await _list_case_dropdown_values(
+            session=session, role=role, case_id=case.id
+        )
+
+        case_context[str(case.id)] = (field_reads, tag_reads, dropdown_reads)
         cases.append(case)
 
-    return await duration_service.compute_time_series(cases)
+    metrics = await duration_service.compute_time_series(cases)
+    enriched_metrics: list[CaseDurationMetric] = []
+    for metric in metrics:
+        context = case_context.get(metric.case_id)
+        if context is None:
+            enriched_metrics.append(metric)
+            continue
+        fields, tags, dropdown_values = context
+        enriched_metrics.append(
+            metric.model_copy(
+                update={
+                    "fields": fields,
+                    "tags": tags,
+                    "dropdown_values": dropdown_values,
+                }
+            )
+        )
+
+    return enriched_metrics
 
 
 @task_router.get("/{case_id}/tasks", status_code=HTTP_200_OK)

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -710,7 +710,7 @@ async def get_case_metrics(
 
     cases = []
     case_context: dict[
-        str, tuple[list[CaseFieldRead], list[CaseTagRead], list[CaseDropdownValueRead]]
+        str, tuple[list[dict[str, Any]], list[CaseTagRead], list[CaseDropdownValueRead]]
     ] = {}
     for case_id in params.case_ids:
         case = await cases_service.get_case(case_id)
@@ -734,6 +734,7 @@ async def get_case_metrics(
             )
             for f in field_templates
         ]
+        field_dicts = [field.model_dump() for field in field_reads]
         tag_reads = [
             CaseTagRead.model_validate(tag, from_attributes=True) for tag in case.tags
         ]
@@ -741,7 +742,7 @@ async def get_case_metrics(
             session=session, role=role, case_id=case.id
         )
 
-        case_context[str(case.id)] = (field_reads, tag_reads, dropdown_reads)
+        case_context[str(case.id)] = (field_dicts, tag_reads, dropdown_reads)
         cases.append(case)
 
     metrics = await duration_service.compute_time_series(cases)

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -42,7 +42,7 @@ class CaseReadMinimal(Schema):
     severity: CaseSeverity
     assignee: UserRead | None = None
     tags: list[CaseTagRead] = Field(default_factory=list)
-    dropdown_values: list[CaseDropdownValueRead] = Field(default_factory=list)
+    dropdown_values: list[CaseDropdownValueRead]
     num_tasks_completed: int = Field(default=0)
     num_tasks_total: int = Field(default=0)
 
@@ -61,7 +61,7 @@ class CaseRead(Schema):
     assignee: UserRead | None = None
     payload: dict[str, Any] | None
     tags: list[CaseTagRead] = Field(default_factory=list)
-    dropdown_values: list[CaseDropdownValueRead] = Field(default_factory=list)
+    dropdown_values: list[CaseDropdownValueRead]
 
 
 class CaseCreate(Schema):


### PR DESCRIPTION
Summary:
- enforce `dropdown_values` on `CaseRead`/`CaseReadMinimal` and regenerate clients so every case payload always contains the dropdown selections
- hook `CaseDropdownValuesService` into `get_case`, list/search flows, and case creation/update so dropdowns are fetched with any entitlement and passed to responses
- enrich `get_case_metrics` output with case fields, tags, and dropdowns so metrics rows include the same metadata snapshot as the case endpoints

Testing:
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always return dropdown selections in case payloads and enrich case metrics with full case metadata to improve reporting across endpoints.

- **New Features**
  - dropdown_values is now required on CaseRead and CaseReadMinimal. Populated via CaseDropdownValuesService for get/create/update, and included on list/search (empty when not fetched).
  - Gated by CASE_ADDONS entitlement. Returns [] when not entitled.
  - CaseDurationMetric now includes fields (returned as plain dicts), tags, and dropdown_values. SDK get_case_metrics returns the enriched type.

- **Migration**
  - dropdown_values is required in API and generated clients. Update consumers to expect a list (may be empty).

<sup>Written for commit f9edc571e67b1a14edb89dd31b62158c8e4f9efc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

