### PR TITLE
feat(workflows): support target-branch publish and branch picker

### DIFF
--- a/alembic/versions/672fecea1d32_add_workflow_git_sync_branch.py
+++ b/alembic/versions/672fecea1d32_add_workflow_git_sync_branch.py
@@ -1,7 +1,7 @@
 """add workflow git sync branch
 
 Revision ID: 672fecea1d32
-Revises: 8bec3e244487
+Revises: 2410092f4ce4
 Create Date: 2026-02-20 22:39:21.867394
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "672fecea1d32"
-down_revision: str | None = "8bec3e244487"
+down_revision: str | None = "2410092f4ce4"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/672fecea1d32_add_workflow_git_sync_branch.py
+++ b/alembic/versions/672fecea1d32_add_workflow_git_sync_branch.py
@@ -1,0 +1,27 @@
+"""add workflow git sync branch
+
+Revision ID: 672fecea1d32
+Revises: 8bec3e244487
+Create Date: 2026-02-20 22:39:21.867394
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "672fecea1d32"
+down_revision: str | None = "8bec3e244487"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("workflow", sa.Column("git_sync_branch", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workflow", "git_sync_branch")

--- a/docs/quickstart/github-workflow-sync-setup.md
+++ b/docs/quickstart/github-workflow-sync-setup.md
@@ -1,0 +1,22 @@
+# GitHub workflow sync setup
+
+Use this checklist to configure GitHub workflow sync in Tracecat.
+
+1. In Tracecat, go to `Organization settings -> VCS -> GitHub` and click `Connect`.
+2. Configure app credentials:
+   - `Create new`: use the GitHub App manifest flow from Tracecat.
+   - `Use existing`: provide `App ID` and `Private key (PEM)` (optional: `Webhook secret`, `Client ID`).
+3. In GitHub, install the app under the **same owner (user/org) that owns the target repository**.
+4. In the GitHub app installation settings, grant repository access to the target repo (or all repos if intended).
+5. In Tracecat, go to `Workspace settings -> Git repository settings` and set:
+   - `Remote repository URL`: `git+ssh://git@github.com/<owner>/<repo>.git`
+6. Save settings and run sync operations:
+   - Publish: Tracecat -> GitHub
+   - Pull workflows: GitHub -> Tracecat
+
+## Common failure case
+
+If publish or pull fails, first verify:
+
+- the app is installed into the correct owner (org/user),
+- the installation has access to the target repository.

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8449,6 +8449,28 @@ export const $GetWorkflowDefinitionActivityInputs = {
   title: "GetWorkflowDefinitionActivityInputs",
 } as const
 
+export const $GitBranchInfo = {
+  properties: {
+    name: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Name",
+      description: "Branch name",
+    },
+    is_default: {
+      type: "boolean",
+      title: "Is Default",
+      description: "Whether this branch is the repository default branch",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["name"],
+  title: "GitBranchInfo",
+  description: "Git branch information for repository management.",
+} as const
+
 export const $GitCommitInfo = {
   properties: {
     sha: {
@@ -20008,9 +20030,99 @@ export const $WorkflowDslPublish = {
       ],
       title: "Message",
     },
+    branch: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Branch",
+    },
+    create_pr: {
+      type: "boolean",
+      title: "Create Pr",
+      default: false,
+    },
+    pr_base_branch: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Base Branch",
+    },
   },
   type: "object",
   title: "WorkflowDslPublish",
+} as const
+
+export const $WorkflowDslPublishResult = {
+  properties: {
+    status: {
+      type: "string",
+      enum: ["committed", "no_op"],
+      title: "Status",
+    },
+    commit_sha: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Commit Sha",
+    },
+    branch: {
+      type: "string",
+      title: "Branch",
+    },
+    base_branch: {
+      type: "string",
+      title: "Base Branch",
+    },
+    pr_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Url",
+    },
+    pr_number: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Number",
+    },
+    pr_reused: {
+      type: "boolean",
+      title: "Pr Reused",
+      default: false,
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+  },
+  type: "object",
+  required: ["status", "branch", "base_branch", "message"],
+  title: "WorkflowDslPublishResult",
 } as const
 
 export const $WorkflowEntrypointValidationRequest = {
@@ -21125,6 +21237,17 @@ export const $WorkflowRead = {
         },
       ],
       title: "Alias",
+    },
+    git_sync_branch: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Git Sync Branch",
     },
     error_handler: {
       anyOf: [

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -622,6 +622,8 @@ import type {
   WorkflowsGetWorkflowResponse,
   WorkflowsListTagsData,
   WorkflowsListTagsResponse,
+  WorkflowsListWorkflowBranchesData,
+  WorkflowsListWorkflowBranchesResponse,
   WorkflowsListWorkflowCommitsData,
   WorkflowsListWorkflowCommitsResponse,
   WorkflowsListWorkflowDefinitionsData,
@@ -2400,7 +2402,7 @@ export const workflowsRemoveTag = (
  * @param data.workflowId
  * @param data.workspaceId
  * @param data.requestBody
- * @returns void Successful Response
+ * @returns WorkflowDslPublishResult Successful Response
  * @throws ApiError
  */
 export const workflowsPublishWorkflow = (
@@ -2444,6 +2446,31 @@ export const workflowsListWorkflowCommits = (
     url: "/workflows/sync/commits",
     query: {
       branch: data.branch,
+      limit: data.limit,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Workflow Branches
+ * Get branch list for workflow repository via GitHub App.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.limit Maximum number of branches to return
+ * @returns GitBranchInfo Successful Response
+ * @throws ApiError
+ */
+export const workflowsListWorkflowBranches = (
+  data: WorkflowsListWorkflowBranchesData
+): CancelablePromise<WorkflowsListWorkflowBranchesResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workflows/sync/branches",
+    query: {
       limit: data.limit,
       workspace_id: data.workspaceId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2584,6 +2584,20 @@ export type GetWorkflowDefinitionActivityInputs = {
 }
 
 /**
+ * Git branch information for repository management.
+ */
+export type GitBranchInfo = {
+  /**
+   * Branch name
+   */
+  name: string
+  /**
+   * Whether this branch is the repository default branch
+   */
+  is_default?: boolean
+}
+
+/**
  * Git commit information for repository management.
  */
 export type GitCommitInfo = {
@@ -6210,7 +6224,23 @@ export type WorkflowDirectoryItem = {
 
 export type WorkflowDslPublish = {
   message?: string | null
+  branch?: string | null
+  create_pr?: boolean
+  pr_base_branch?: string | null
 }
+
+export type WorkflowDslPublishResult = {
+  status: "committed" | "no_op"
+  commit_sha?: string | null
+  branch: string
+  base_branch: string
+  pr_url?: string | null
+  pr_number?: number | null
+  pr_reused?: boolean
+  message: string
+}
+
+export type status4 = "committed" | "no_op"
 
 export type WorkflowEntrypointValidationRequest = {
   expects?: {
@@ -6431,7 +6461,7 @@ export type WorkflowExecutionRead = {
   interactions?: Array<InteractionRead>
 }
 
-export type status4 =
+export type status5 =
   | "RUNNING"
   | "COMPLETED"
   | "FAILED"
@@ -6597,6 +6627,7 @@ export type WorkflowRead = {
   returns: unknown
   config: DSLConfig_Output | null
   alias?: string | null
+  git_sync_branch?: string | null
   error_handler?: string | null
   trigger_position_x?: number
   trigger_position_y?: number
@@ -7404,7 +7435,7 @@ export type WorkflowsPublishWorkflowData = {
   workspaceId: string
 }
 
-export type WorkflowsPublishWorkflowResponse = void
+export type WorkflowsPublishWorkflowResponse = WorkflowDslPublishResult
 
 export type WorkflowsListWorkflowCommitsData = {
   /**
@@ -7419,6 +7450,16 @@ export type WorkflowsListWorkflowCommitsData = {
 }
 
 export type WorkflowsListWorkflowCommitsResponse = Array<GitCommitInfo>
+
+export type WorkflowsListWorkflowBranchesData = {
+  /**
+   * Maximum number of branches to return
+   */
+  limit?: number
+  workspaceId: string
+}
+
+export type WorkflowsListWorkflowBranchesResponse = Array<GitBranchInfo>
 
 export type WorkflowsPullWorkflowsData = {
   requestBody: WorkflowSyncPullRequest
@@ -10394,7 +10435,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        204: void
+        200: WorkflowDslPublishResult
         /**
          * Validation Error
          */
@@ -10410,6 +10451,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: Array<GitCommitInfo>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workflows/sync/branches": {
+    get: {
+      req: WorkflowsListWorkflowBranchesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<GitBranchInfo>
         /**
          * Validation Error
          */

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -751,7 +751,7 @@ function WorkflowSaveActions({
                   className="flex flex-col"
                 >
                   <span className="mb-2 text-xs text-muted-foreground">
-                    Commit workflow
+                    Version control
                   </span>
                   <FormField
                     control={publishForm.control}

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -880,8 +880,7 @@ function WorkflowSaveActions({
                   />
                   {isDefaultBranchSelected && !createPrEnabled && (
                     <p className="mt-2 text-[11px] text-amber-700">
-                      Publishing to the default branch will create a direct
-                      commit.
+                      Pushing to the default branch will create a direct commit.
                     </p>
                   )}
                   <Button
@@ -892,12 +891,12 @@ function WorkflowSaveActions({
                     {isPublishing ? (
                       <>
                         <Spinner className="size-3" />
-                        Publishing changes...
+                        Pushing changes...
                       </>
                     ) : (
                       <>
                         <GitBranchIcon className="size-3" />
-                        Publish changes
+                        Push changes
                       </>
                     )}
                   </Button>

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -802,8 +802,17 @@ function WorkflowSaveActions({
                                     key={branch.name}
                                     value={branch.name}
                                   >
-                                    {branch.name}
-                                    {branch.is_default ? " (default)" : ""}
+                                    <div className="flex items-center gap-2">
+                                      <span>{branch.name}</span>
+                                      {branch.is_default && (
+                                        <Badge
+                                          variant="secondary"
+                                          className="h-4 rounded-sm px-1 text-[10px] font-normal"
+                                        >
+                                          default
+                                        </Badge>
+                                      )}
+                                    </div>
                                   </SelectItem>
                                 ))}
                               </>

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -1,0 +1,271 @@
+"""HTTP-level tests for workflow publish API endpoint."""
+
+import uuid
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatValidationError
+from tracecat.registry.repositories.schemas import GitBranchInfo
+from tracecat.vcs.github.app import GitHubAppError
+from tracecat.workflow.store.schemas import WorkflowDslPublishResult
+
+
+def _sample_dsl_content() -> dict[str, object]:
+    return {
+        "title": "Test workflow",
+        "description": "A test workflow",
+        "entrypoint": {"ref": "start", "expects": {}},
+        "actions": [
+            {
+                "ref": "start",
+                "action": "core.transform.passthrough",
+                "args": {"value": "test"},
+            }
+        ],
+    }
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/{workflow_id}/publish returns structured publish result."""
+    workflow_id = str(uuid.uuid4())
+    workflow = Mock()
+    workflow.id = uuid.UUID(workflow_id)
+
+    definition = Mock()
+    definition.content = _sample_dsl_content()
+    definition.workflow = workflow
+
+    with (
+        patch(
+            "tracecat.workflow.store.router.WorkflowDefinitionsService"
+        ) as mock_defn_cls,
+        patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls,
+    ):
+        mock_defn_svc = AsyncMock()
+        mock_defn_svc.get_definition_by_workflow_id.return_value = definition
+        mock_defn_cls.return_value = mock_defn_svc
+
+        mock_store_svc = AsyncMock()
+        mock_store_svc.publish_workflow_dsl.return_value = WorkflowDslPublishResult(
+            status="committed",
+            commit_sha="abc123",
+            branch="feature/shared-workflow",
+            base_branch="main",
+            pr_url="https://github.com/test-org/test-repo/pull/123",
+            pr_number=123,
+            pr_reused=False,
+            message="Committed workflow changes.",
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            f"/workflows/{workflow_id}/publish",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "message": "Update workflow",
+                "branch": "feature/shared-workflow",
+                "create_pr": True,
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["status"] == "committed"
+    assert payload["commit_sha"] == "abc123"
+    assert payload["branch"] == "feature/shared-workflow"
+    assert payload["base_branch"] == "main"
+    assert payload["pr_url"] == "https://github.com/test-org/test-repo/pull/123"
+    assert payload["pr_number"] == 123
+    assert payload["pr_reused"] is False
+
+    called_params = mock_store_svc.publish_workflow_dsl.call_args.kwargs["params"]
+    assert called_params.branch == "feature/shared-workflow"
+    assert called_params.create_pr is True
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_invalid_branch_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test branch validation errors from service return 400."""
+    workflow_id = str(uuid.uuid4())
+    workflow = Mock()
+    workflow.id = uuid.UUID(workflow_id)
+
+    definition = Mock()
+    definition.content = _sample_dsl_content()
+    definition.workflow = workflow
+
+    with (
+        patch(
+            "tracecat.workflow.store.router.WorkflowDefinitionsService"
+        ) as mock_defn_cls,
+        patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls,
+    ):
+        mock_defn_svc = AsyncMock()
+        mock_defn_svc.get_definition_by_workflow_id.return_value = definition
+        mock_defn_cls.return_value = mock_defn_svc
+
+        mock_store_svc = AsyncMock()
+        mock_store_svc.publish_workflow_dsl.side_effect = TracecatValidationError(
+            "branch must be a short branch name, not a full ref (refs/...)"
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            f"/workflows/{workflow_id}/publish",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "branch": "refs/heads/feature/shared-workflow",
+                "create_pr": False,
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "short branch name" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_definition_not_found_returns_404(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test publish returns 404 when workflow definition does not exist."""
+    workflow_id = str(uuid.uuid4())
+
+    with patch(
+        "tracecat.workflow.store.router.WorkflowDefinitionsService"
+    ) as mock_defn_cls:
+        mock_defn_svc = AsyncMock()
+        mock_defn_svc.get_definition_by_workflow_id.return_value = None
+        mock_defn_cls.return_value = mock_defn_svc
+
+        response = client.post(
+            f"/workflows/{workflow_id}/publish",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"branch": "feature/shared-workflow", "create_pr": False},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Workflow definition not found"
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_invalid_create_pr_type_returns_422(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test request validation rejects invalid create_pr type."""
+    workflow_id = str(uuid.uuid4())
+    response = client.post(
+        f"/workflows/{workflow_id}/publish",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={
+            "branch": "feature/shared-workflow",
+            "create_pr": {"invalid": True},
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+@pytest.mark.anyio
+async def test_list_workflow_branches_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workflows/sync/branches returns branch list."""
+    with (
+        patch("tracecat.workflow.store.router.WorkspaceService") as mock_workspace_cls,
+        patch("tracecat.workflow.store.router.WorkflowSyncService") as mock_sync_cls,
+    ):
+        mock_workspace_svc = AsyncMock()
+        mock_workspace = Mock()
+        mock_workspace.settings = {
+            "git_repo_url": "git+ssh://git@github.com/test-org/test-repo.git"
+        }
+        mock_workspace_svc.get_workspace.return_value = mock_workspace
+        mock_workspace_cls.return_value = mock_workspace_svc
+
+        mock_sync_svc = AsyncMock()
+        mock_sync_svc.list_branches.return_value = [
+            GitBranchInfo(name="main", is_default=True),
+            GitBranchInfo(name="feature/workflow-publish", is_default=False),
+        ]
+        mock_sync_cls.return_value = mock_sync_svc
+
+        response = client.get(
+            "/workflows/sync/branches",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload == [
+        {"name": "main", "is_default": True},
+        {"name": "feature/workflow-publish", "is_default": False},
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_workflow_branches_missing_repo_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workflows/sync/branches returns 400 when repo URL is missing."""
+    with patch("tracecat.workflow.store.router.WorkspaceService") as mock_workspace_cls:
+        mock_workspace_svc = AsyncMock()
+        mock_workspace = Mock()
+        mock_workspace.settings = {}
+        mock_workspace_svc.get_workspace.return_value = mock_workspace
+        mock_workspace_cls.return_value = mock_workspace_svc
+
+        response = client.get(
+            "/workflows/sync/branches",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Git repository URL not configured" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_list_workflow_branches_github_error_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workflows/sync/branches maps GitHub errors to 400."""
+    with (
+        patch("tracecat.workflow.store.router.WorkspaceService") as mock_workspace_cls,
+        patch("tracecat.workflow.store.router.WorkflowSyncService") as mock_sync_cls,
+    ):
+        mock_workspace_svc = AsyncMock()
+        mock_workspace = Mock()
+        mock_workspace.settings = {
+            "git_repo_url": "git+ssh://git@github.com/test-org/test-repo.git"
+        }
+        mock_workspace_svc.get_workspace.return_value = mock_workspace
+        mock_workspace_cls.return_value = mock_workspace_svc
+
+        mock_sync_svc = AsyncMock()
+        mock_sync_svc.list_branches.side_effect = GitHubAppError(
+            "Unable to access repository"
+        )
+        mock_sync_cls.return_value = mock_sync_svc
+
+        response = client.get(
+            "/workflows/sync/branches",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Unable to access repository" in response.json()["detail"]

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -1,9 +1,11 @@
 """Tests for WorkflowSyncService functionality."""
 
+import base64
 import uuid
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import yaml
 from github.GithubException import GithubException
 
 from tracecat.auth.types import Role
@@ -11,7 +13,7 @@ from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.dsl.common import DSLEntrypoint, DSLInput
 from tracecat.dsl.schemas import ActionStatement
 from tracecat.git.types import GitUrl
-from tracecat.sync import Author, PushObject, PushOptions
+from tracecat.sync import Author, PushObject, PushOptions, PushStatus
 from tracecat.workflow.store.import_service import WorkflowImportService
 from tracecat.workflow.store.schemas import RemoteWorkflowDefinition
 from tracecat.workflow.store.sync import WorkflowSyncService
@@ -171,6 +173,7 @@ class TestWorkflowSyncService:
                 objects=[push_obj], url=git_url, options=options
             )
 
+            assert result.status == PushStatus.COMMITTED
             assert result.sha == "abc123def"
             assert result.ref.startswith("tracecat-sync-")
 
@@ -228,6 +231,7 @@ class TestWorkflowSyncService:
                 objects=[push_item], url=git_url, options=options
             )
 
+            assert result.status == PushStatus.COMMITTED
             assert result.sha == "abc123def"
             assert result.ref.startswith("tracecat-sync-")
 
@@ -300,6 +304,7 @@ class TestWorkflowSyncService:
                 objects=[push_obj], url=git_url, options=options
             )
 
+            assert result.status == PushStatus.COMMITTED
             assert result.sha == "abc123def"
             assert result.ref.startswith("tracecat-sync-")
 
@@ -427,6 +432,407 @@ class TestWorkflowSyncService:
             call_args = mock_repo.create_file.call_args
             file_path = call_args.kwargs["path"]
             assert file_path == "workflows/my-test-workflow.yaml"
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_commits_to_existing_branch(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode commits directly to an existing branch."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo = Mock()
+        base_branch = Mock()
+        base_branch.commit.sha = "base123"
+        target_branch = Mock()
+        target_branch.commit.sha = "target123"
+        mock_repo.default_branch = "main"
+        mock_repo.get_branch.side_effect = lambda name: (
+            base_branch if name == "main" else target_branch
+        )
+        mock_repo.get_contents.side_effect = GithubException(
+            404, {"message": "Not Found"}, {}
+        )
+        mock_repo.create_file = Mock()
+        mock_repo.create_git_ref = Mock()
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            async def mock_to_thread_impl(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mock_to_thread.side_effect = mock_to_thread_impl
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == "target123"
+            assert result.ref == "feature/shared-workflow"
+            assert result.base_ref == "main"
+            assert result.pr_url is None
+            assert result.pr_number is None
+            assert result.pr_reused is False
+            mock_repo.create_git_ref.assert_not_called()
+            mock_repo.create_file.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_creates_missing_branch_from_base(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode creates target branch when it is missing."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/new-workflow",
+        )
+
+        mock_repo = Mock()
+        base_branch = Mock()
+        base_branch.commit.sha = "base123"
+        target_branch = Mock()
+        target_branch.commit.sha = "target123"
+        mock_repo.default_branch = "main"
+
+        target_branch_lookup_count = 0
+
+        def get_branch(name: str):
+            nonlocal target_branch_lookup_count
+            if name == "main":
+                return base_branch
+            if name == "feature/new-workflow":
+                target_branch_lookup_count += 1
+                if target_branch_lookup_count == 1:
+                    raise GithubException(404, {"message": "Not Found"}, {})
+                return target_branch
+            raise AssertionError(f"Unexpected branch lookup: {name}")
+
+        mock_repo.get_branch.side_effect = get_branch
+        mock_repo.get_contents.side_effect = GithubException(
+            404, {"message": "Not Found"}, {}
+        )
+        mock_repo.create_file = Mock()
+        mock_repo.create_git_ref = Mock()
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            async def mock_to_thread_impl(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mock_to_thread.side_effect = mock_to_thread_impl
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.ref == "feature/new-workflow"
+            assert result.base_ref == "main"
+            mock_repo.create_git_ref.assert_called_once_with(
+                ref="refs/heads/feature/new-workflow",
+                sha="base123",
+            )
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_noop_returns_no_op(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode returns no_op on identical file contents."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/shared-workflow",
+        )
+
+        expected_yaml = yaml.dump(
+            sample_remote_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+
+        mock_repo = Mock()
+        base_branch = Mock()
+        base_branch.commit.sha = "base123"
+        target_branch = Mock()
+        target_branch.commit.sha = "target123"
+        mock_repo.default_branch = "main"
+        mock_repo.get_branch.side_effect = lambda name: (
+            base_branch if name == "main" else target_branch
+        )
+
+        mock_contents = Mock()
+        mock_contents.path = "workflows/test-workflow.yml"
+        mock_contents.sha = "file123"
+        mock_contents.content = base64.b64encode(expected_yaml.encode("utf-8")).decode(
+            "utf-8"
+        )
+        mock_repo.get_contents.return_value = mock_contents
+        mock_repo.update_file = Mock()
+        mock_repo.create_file = Mock()
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            async def mock_to_thread_impl(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mock_to_thread.side_effect = mock_to_thread_impl
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.NO_OP
+            assert result.sha is None
+            assert result.ref == "feature/shared-workflow"
+            assert result.base_ref == "main"
+            mock_repo.update_file.assert_not_called()
+            mock_repo.create_file.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_create_pr_creates_new_pull_request(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode creates a PR when requested and none exists."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo = Mock()
+        base_branch = Mock()
+        base_branch.commit.sha = "base123"
+        target_branch = Mock()
+        target_branch.commit.sha = "target123"
+        mock_repo.default_branch = "main"
+        mock_repo.get_branch.side_effect = lambda name: (
+            base_branch if name == "main" else target_branch
+        )
+        mock_repo.get_contents.side_effect = GithubException(
+            404, {"message": "Not Found"}, {}
+        )
+        mock_repo.get_pulls.return_value = []
+        mock_repo.create_file = Mock()
+
+        mock_pr = Mock()
+        mock_pr.number = 456
+        mock_pr.html_url = "https://github.com/test-org/test-repo/pull/456"
+        mock_repo.create_pull.return_value = mock_pr
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+            patch(
+                "tracecat.workflow.store.sync.WorkspaceService"
+            ) as mock_ws_service_class,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_ws_service = AsyncMock()
+            mock_workspace = Mock()
+            mock_workspace.name = "Test Workspace"
+            mock_ws_service.get_workspace.return_value = mock_workspace
+            mock_ws_service_class.return_value = mock_ws_service
+
+            async def mock_to_thread_impl(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mock_to_thread.side_effect = mock_to_thread_impl
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.pr_reused is False
+            assert result.pr_number == 456
+            assert result.pr_url == "https://github.com/test-org/test-repo/pull/456"
+            mock_repo.create_pull.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_create_pr_reuses_existing_pull_request(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode reuses existing open PR for same head/base."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo = Mock()
+        base_branch = Mock()
+        base_branch.commit.sha = "base123"
+        target_branch = Mock()
+        target_branch.commit.sha = "target123"
+        mock_repo.default_branch = "main"
+        mock_repo.get_branch.side_effect = lambda name: (
+            base_branch if name == "main" else target_branch
+        )
+        mock_repo.get_contents.side_effect = GithubException(
+            404, {"message": "Not Found"}, {}
+        )
+        mock_repo.create_file = Mock()
+
+        existing_pr = Mock()
+        existing_pr.number = 789
+        existing_pr.html_url = "https://github.com/test-org/test-repo/pull/789"
+        mock_repo.get_pulls.return_value = [existing_pr]
+        mock_repo.create_pull = Mock()
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            async def mock_to_thread_impl(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mock_to_thread.side_effect = mock_to_thread_impl
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.pr_reused is True
+            assert result.pr_number == 789
+            assert result.pr_url == "https://github.com/test-org/test-repo/pull/789"
+            mock_repo.create_pull.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_list_branches_success(self, workflow_sync_service, git_url):
+        """Test branch listing from GitHub repository."""
+        mock_repo = Mock()
+        mock_repo.default_branch = "main"
+
+        main_branch = Mock()
+        main_branch.name = "main"
+        feature_branch = Mock()
+        feature_branch.name = "feature/workflow-sync"
+        mock_repo.get_branches.return_value = [main_branch, feature_branch]
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            async def mock_to_thread_impl(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mock_to_thread.side_effect = mock_to_thread_impl
+
+            branches = await workflow_sync_service.list_branches(url=git_url, limit=10)
+
+            assert len(branches) == 2
+            assert branches[0].name == "main"
+            assert branches[0].is_default is True
+            assert branches[1].name == "feature/workflow-sync"
+            assert branches[1].is_default is False
 
 
 class TestWorkflowImportServiceFolders:

--- a/tests/unit/test_workflows_store.py
+++ b/tests/unit/test_workflows_store.py
@@ -212,6 +212,7 @@ class TestWorkflowPublishBranchValidation:
             "feature/contains space",
             "feature/has@{token}",
             "feature/ends.lock",
+            "feature/foo.lock/bar",
         ],
     )
     def test_validate_short_branch_name_rejects_invalid_names(

--- a/tests/unit/test_workflows_store.py
+++ b/tests/unit/test_workflows_store.py
@@ -202,6 +202,7 @@ class TestWorkflowPublishBranchValidation:
     @pytest.mark.parametrize(
         ("branch_name"),
         [
+            "",
             "refs/heads/main",
             "feature//broken",
             "feature..broken",

--- a/tests/unit/test_workflows_store.py
+++ b/tests/unit/test_workflows_store.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 import pytest
 
 from tracecat.identifiers.workflow import WorkflowID
-from tracecat.workflow.store.schemas import WorkflowSource
+from tracecat.workflow.store.schemas import WorkflowSource, validate_short_branch_name
 
 
 class TestWorkflowSource:
@@ -178,3 +178,43 @@ actions:
         # Test fetch_yaml with invalid path/sha
         with pytest.raises(FileNotFoundError):
             await store.fetch_yaml("invalid.yml", "invalid")
+
+
+class TestWorkflowPublishBranchValidation:
+    """Test Git branch validation helpers for workflow publish."""
+
+    @pytest.mark.parametrize(
+        ("branch_name"),
+        [
+            "main",
+            "feature/shared-workflow",
+            "fix/workflow_publish",
+            "release/2026.02",
+        ],
+    )
+    def test_validate_short_branch_name_accepts_valid_names(
+        self, branch_name: str
+    ) -> None:
+        assert (
+            validate_short_branch_name(branch_name, field_name="branch") == branch_name
+        )
+
+    @pytest.mark.parametrize(
+        ("branch_name"),
+        [
+            "refs/heads/main",
+            "feature//broken",
+            "feature..broken",
+            "feature/.hidden",
+            "feature/trailing.",
+            "-leading-dash",
+            "feature/contains space",
+            "feature/has@{token}",
+            "feature/ends.lock",
+        ],
+    )
+    def test_validate_short_branch_name_rejects_invalid_names(
+        self, branch_name: str
+    ) -> None:
+        with pytest.raises(ValueError):
+            validate_short_branch_name(branch_name, field_name="branch")

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -853,6 +853,11 @@ class Workflow(WorkspaceModel):
     alias: Mapped[str | None] = mapped_column(
         String, nullable=True, index=True, doc="Alias for the workflow"
     )
+    git_sync_branch: Mapped[str | None] = mapped_column(
+        String,
+        nullable=True,
+        doc="Shared preferred branch for workflow publish operations",
+    )
     error_handler: Mapped[str | None] = mapped_column(
         String,
         nullable=True,

--- a/tracecat/registry/repositories/schemas.py
+++ b/tracecat/registry/repositories/schemas.py
@@ -122,6 +122,21 @@ class GitCommitInfo(BaseModel):
     )
 
 
+class GitBranchInfo(BaseModel):
+    """Git branch information for repository management."""
+
+    name: str = Field(
+        ...,
+        description="Branch name",
+        min_length=1,
+        max_length=255,
+    )
+    is_default: bool = Field(
+        default=False,
+        description="Whether this branch is the repository default branch",
+    )
+
+
 class RegistryRepositorySync(BaseModel):
     """Parameters for syncing a repository to a specific commit."""
 

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -323,6 +323,7 @@ async def get_workflow(
         webhook=WebhookRead.model_validate(workflow.webhook, from_attributes=True),
         schedules=ScheduleRead.list_adapter().validate_python(workflow.schedules),
         alias=workflow.alias,
+        git_sync_branch=workflow.git_sync_branch,
         error_handler=workflow.error_handler,
         trigger_position_x=workflow.trigger_position_x,
         trigger_position_y=workflow.trigger_position_y,

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -41,6 +41,7 @@ class WorkflowRead(Schema):
     returns: Any
     config: DSLConfig | None
     alias: str | None = None
+    git_sync_branch: str | None = None
     error_handler: str | None = None
     trigger_position_x: float = 0.0
     trigger_position_y: float = 0.0

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -165,8 +165,10 @@ async def list_workflow_commits(
             detail=f"Unable to access repository: {str(e)}",
         ) from e
     except Exception as e:
-        logger.exception(
-            f"Error fetching commits from repository: {repository_url}", exc_info=True
+        logger.error(
+            "Error fetching commits from repository",
+            repository_url=repository_url,
+            error=str(e),
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -233,9 +235,10 @@ async def list_workflow_branches(
             detail=f"Unable to access repository: {str(e)}",
         ) from e
     except Exception as e:
-        logger.exception(
-            f"Error fetching branches from repository: {repository_url}",
-            exc_info=True,
+        logger.error(
+            "Error fetching branches from repository",
+            repository_url=repository_url,
+            error=str(e),
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -38,8 +38,10 @@ def validate_short_branch_name(value: str, *, field_name: str) -> str:
         raise ValueError(f"{field_name} cannot start with '-'")
     if value.endswith("."):
         raise ValueError(f"{field_name} cannot end with '.'")
-    if value.endswith(".lock"):
-        raise ValueError(f"{field_name} cannot end with '.lock'")
+    if any(part.endswith(".lock") for part in value.split("/")):
+        raise ValueError(
+            f"{field_name} cannot contain path segments ending with '.lock'"
+        )
     if ".." in value:
         raise ValueError(f"{field_name} cannot contain '..'")
     if "//" in value:

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -24,6 +24,8 @@ _INVALID_GIT_REF_CHARS_RE = re.compile(r"[\x00-\x20\x7f~^:?*\[\\]")
 
 def validate_short_branch_name(value: str, *, field_name: str) -> str:
     """Validate Git-safe short branch names."""
+    if value == "":
+        raise ValueError(f"{field_name} cannot be empty")
     if value.startswith("refs/"):
         raise ValueError(
             f"{field_name} must be a short branch name, not a full ref (refs/...)"

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -1,7 +1,14 @@
+import re
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    model_validator,
+)
 
 from tracecat.cases.enums import CaseEventType
 from tracecat.dsl.common import DSLInput
@@ -12,8 +19,58 @@ from tracecat.store import Source
 WorkflowSource = Source[WorkflowID]
 
 
+_INVALID_GIT_REF_CHARS_RE = re.compile(r"[\x00-\x20\x7f~^:?*\[\\]")
+
+
+def validate_short_branch_name(value: str, *, field_name: str) -> str:
+    """Validate Git-safe short branch names."""
+    if value.startswith("refs/"):
+        raise ValueError(
+            f"{field_name} must be a short branch name, not a full ref (refs/...)"
+        )
+    if value in {".", "..", "@", "HEAD"}:
+        raise ValueError(f"{field_name} must be a valid branch name")
+    if value.startswith("/") or value.endswith("/"):
+        raise ValueError(f"{field_name} cannot start or end with '/'")
+    if value.startswith("-"):
+        raise ValueError(f"{field_name} cannot start with '-'")
+    if value.endswith("."):
+        raise ValueError(f"{field_name} cannot end with '.'")
+    if value.endswith(".lock"):
+        raise ValueError(f"{field_name} cannot end with '.lock'")
+    if ".." in value:
+        raise ValueError(f"{field_name} cannot contain '..'")
+    if "//" in value:
+        raise ValueError(f"{field_name} cannot contain '//'")
+    if "@{" in value:
+        raise ValueError(f"{field_name} cannot contain '@{{'")
+    if _INVALID_GIT_REF_CHARS_RE.search(value):
+        raise ValueError(
+            f"{field_name} contains invalid characters for a Git branch name"
+        )
+    if any(part.startswith(".") or part.endswith(".") for part in value.split("/")):
+        raise ValueError(
+            f"{field_name} contains invalid path segments for a Git branch name"
+        )
+    return value
+
+
 class WorkflowDslPublish(BaseModel):
     message: str | None = None
+    branch: str | None = None
+    create_pr: bool = False
+    pr_base_branch: str | None = None
+
+
+class WorkflowDslPublishResult(BaseModel):
+    status: Literal["committed", "no_op"]
+    commit_sha: str | None = None
+    branch: str
+    base_branch: str
+    pr_url: str | None = None
+    pr_number: int | None = None
+    pr_reused: bool = False
+    message: str
 
 
 class WorkflowSyncPullRequest(BaseModel):

--- a/tracecat/workflow/store/sync.py
+++ b/tracecat/workflow/store/sync.py
@@ -367,7 +367,7 @@ class WorkflowSyncService(BaseWorkspaceService):
         branch_name = options.branch
         if branch_name is None:
             raise ValueError("branch is required for target-branch push mode")
-        base_branch_name = options.pr_base_branch or repo.default_branch
+        base_branch_name = options.pr_base_branch or url.ref or repo.default_branch
         base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
 
         try:

--- a/tracecat/workflow/store/sync.py
+++ b/tracecat/workflow/store/sync.py
@@ -19,7 +19,7 @@ from tracecat.db.models import User
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.git.utils import GitUrl
 from tracecat.logger import logger
-from tracecat.registry.repositories.schemas import GitCommitInfo
+from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import (
     CommitInfo,
@@ -28,6 +28,7 @@ from tracecat.sync import (
     PullResult,
     PushObject,
     PushOptions,
+    PushStatus,
 )
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.workflow.store.import_service import WorkflowImportService
@@ -329,147 +330,19 @@ class WorkflowSyncService(BaseWorkspaceService):
         try:
             repo = await asyncio.to_thread(gh.get_repo, f"{url.org}/{url.repo}")
 
-            # Get base branch
-            base_branch_name = url.ref or repo.default_branch
-            base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
-
-            # Create feature branch
-            timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-            branch_name = f"tracecat-sync-{timestamp}"
-
-            logger.info(
-                "Creating branch via GitHub API",
-                branch=branch_name,
-                base_branch=base_branch_name,
-                repo=f"{url.org}/{url.repo}",
-            )
-
-            await asyncio.to_thread(
-                repo.create_git_ref,
-                ref=f"refs/heads/{branch_name}",
-                sha=base_branch.commit.sha,
-            )
-
-            # Create/update workflow files via API
-            file_path = obj.path_str
-
-            yaml_content = yaml.dump(
-                obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
-                sort_keys=False,
-            )
-
-            # NOTE: We intentionally omit author/committer parameters to enable
-            # GitHub's automatic commit signing for GitHub Apps. Per GitHub docs:
-            # "Signature verification for bots will only work if the request
-            # contains no custom author information, custom committer information"
-            # https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-
-            try:
-                # Try to get existing file to update it
-                contents = await asyncio.to_thread(
-                    repo.get_contents, file_path, ref=branch_name
+            if options.branch:
+                return await self._push_to_target_branch(
+                    repo=repo,
+                    url=url,
+                    obj=obj,
+                    options=options,
                 )
-                # get_contents returns ContentFile for files, or list for directories
-                if isinstance(contents, list):
-                    raise GithubException(404, {"message": "Not a file"}, {})
 
-                await asyncio.to_thread(
-                    repo.update_file,
-                    path=contents.path,
-                    message=options.message,
-                    content=yaml_content,
-                    sha=contents.sha,
-                    branch=branch_name,
-                )
-                logger.debug(
-                    "Updated workflow file via API",
-                    path=file_path,
-                    branch=branch_name,
-                )
-            except GithubException as e:
-                if e.status == 404:
-                    # File doesn't exist, create it
-                    await asyncio.to_thread(
-                        repo.create_file,
-                        path=file_path,
-                        message=options.message,
-                        content=yaml_content,
-                        branch=branch_name,
-                    )
-                    logger.debug(
-                        "Created workflow file via API",
-                        path=file_path,
-                        branch=branch_name,
-                    )
-
-            # Get the latest commit SHA from the branch
-            branch = await asyncio.to_thread(repo.get_branch, branch_name)
-            commit_sha = branch.commit.sha
-
-            # Create PR if requested
-            pr_url = None
-            if options.create_pr:
-                try:
-                    ws_svc = WorkspaceService(session=self.session, role=self.role)
-                    workspace = await ws_svc.get_workspace(self.workspace_id)
-                    if not workspace:
-                        raise TracecatNotFoundError("Workspace not found")
-
-                    try:
-                        title = obj.data.definition.title
-                        description = obj.data.definition.description
-                    except ValueError:
-                        title = "<An error occurred while determining the title>"
-                        description = (
-                            "<An error occurred while determining the description>"
-                        )
-
-                    try:
-                        current_user = await self.session.get(User, self.role.user_id)
-                    except Exception:
-                        current_user = None
-
-                    published_by = current_user.email if current_user else "<unknown>"
-
-                    pr = await asyncio.to_thread(
-                        repo.create_pull,
-                        title=options.message,
-                        body=(
-                            f"Automated workflow sync from Tracecat\n\n"
-                            f"**Workspace:** {workspace.name}\n"
-                            f"**Published by:** {published_by}\n"
-                            f"**Workflow Title:** {title}\n"
-                            f"**Workflow Description:** {description}"
-                        ),
-                        head=branch_name,
-                        base=base_branch_name,
-                    )
-                    pr_url = pr.html_url
-
-                    logger.info(
-                        "Created PR via GitHub API",
-                        pr_number=pr.number,
-                        pr_url=pr_url,
-                    )
-                except GithubException as e:
-                    logger.error(
-                        "Failed to create PR via GitHub API",
-                        error=str(e),
-                        branch=branch_name,
-                    )
-                    # Don't fail the entire operation if PR creation fails
-
-            logger.info(
-                "Successfully pushed workflows via GitHub API",
-                count=1,
-                branch=branch_name,
-                commit_sha=commit_sha,
-                pr_created=pr_url is not None,
-            )
-
-            return CommitInfo(
-                sha=commit_sha,
-                ref=branch_name,
+            return await self._push_legacy(
+                repo=repo,
+                url=url,
+                obj=obj,
+                options=options,
             )
 
         except GithubException as e:
@@ -482,6 +355,338 @@ class WorkflowSyncService(BaseWorkspaceService):
             raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
         finally:
             gh.close()
+
+    async def _push_to_target_branch(
+        self,
+        *,
+        repo: Any,
+        url: GitUrl,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+    ) -> CommitInfo:
+        branch_name = options.branch
+        if branch_name is None:
+            raise ValueError("branch is required for target-branch push mode")
+        base_branch_name = options.pr_base_branch or repo.default_branch
+        base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
+
+        try:
+            await asyncio.to_thread(repo.get_branch, branch_name)
+        except GithubException as e:
+            if e.status != 404:
+                raise
+            await asyncio.to_thread(
+                repo.create_git_ref,
+                ref=f"refs/heads/{branch_name}",
+                sha=base_branch.commit.sha,
+            )
+            logger.info(
+                "Created target branch via GitHub API",
+                branch=branch_name,
+                base_branch=base_branch_name,
+                repo=f"{url.org}/{url.repo}",
+            )
+
+        file_path = obj.path_str
+        yaml_content = yaml.dump(
+            obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
+            sort_keys=False,
+        )
+
+        pr_url: str | None = None
+        pr_number: int | None = None
+        pr_reused = False
+
+        try:
+            contents = await asyncio.to_thread(
+                repo.get_contents, file_path, ref=branch_name
+            )
+            if isinstance(contents, list):
+                raise GithubException(404, {"message": "Not a file"}, {})
+            existing_content = base64.b64decode(contents.content).decode("utf-8")
+            if existing_content == yaml_content:
+                if options.create_pr:
+                    pr_url, pr_number, pr_reused = await self._upsert_pull_request(
+                        repo=repo,
+                        url=url,
+                        obj=obj,
+                        options=options,
+                        branch_name=branch_name,
+                        base_branch_name=base_branch_name,
+                    )
+                return CommitInfo(
+                    status=PushStatus.NO_OP,
+                    sha=None,
+                    ref=branch_name,
+                    base_ref=base_branch_name,
+                    pr_url=pr_url,
+                    pr_number=pr_number,
+                    pr_reused=pr_reused,
+                    message="No changes detected; nothing to commit.",
+                )
+
+            await asyncio.to_thread(
+                repo.update_file,
+                path=contents.path,
+                message=options.message,
+                content=yaml_content,
+                sha=contents.sha,
+                branch=branch_name,
+            )
+            logger.debug(
+                "Updated workflow file via API",
+                path=file_path,
+                branch=branch_name,
+            )
+        except GithubException as e:
+            if e.status != 404:
+                raise
+            await asyncio.to_thread(
+                repo.create_file,
+                path=file_path,
+                message=options.message,
+                content=yaml_content,
+                branch=branch_name,
+            )
+            logger.debug(
+                "Created workflow file via API",
+                path=file_path,
+                branch=branch_name,
+            )
+
+        branch = await asyncio.to_thread(repo.get_branch, branch_name)
+        commit_sha = branch.commit.sha
+
+        if options.create_pr:
+            pr_url, pr_number, pr_reused = await self._upsert_pull_request(
+                repo=repo,
+                url=url,
+                obj=obj,
+                options=options,
+                branch_name=branch_name,
+                base_branch_name=base_branch_name,
+            )
+
+        logger.info(
+            "Successfully pushed workflow via GitHub API",
+            branch=branch_name,
+            base_branch=base_branch_name,
+            commit_sha=commit_sha,
+            pr_url=pr_url,
+            pr_number=pr_number,
+            pr_reused=pr_reused,
+        )
+
+        return CommitInfo(
+            status=PushStatus.COMMITTED,
+            sha=commit_sha,
+            ref=branch_name,
+            base_ref=base_branch_name,
+            pr_url=pr_url,
+            pr_number=pr_number,
+            pr_reused=pr_reused,
+            message="Committed workflow changes.",
+        )
+
+    async def _push_legacy(
+        self,
+        *,
+        repo: Any,
+        url: GitUrl,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+    ) -> CommitInfo:
+        base_branch_name = url.ref or repo.default_branch
+        base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
+
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        branch_name = f"tracecat-sync-{timestamp}"
+
+        logger.info(
+            "Creating legacy temp branch via GitHub API",
+            branch=branch_name,
+            base_branch=base_branch_name,
+            repo=f"{url.org}/{url.repo}",
+        )
+
+        await asyncio.to_thread(
+            repo.create_git_ref,
+            ref=f"refs/heads/{branch_name}",
+            sha=base_branch.commit.sha,
+        )
+
+        file_path = obj.path_str
+        yaml_content = yaml.dump(
+            obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
+            sort_keys=False,
+        )
+
+        try:
+            contents = await asyncio.to_thread(
+                repo.get_contents, file_path, ref=branch_name
+            )
+            if isinstance(contents, list):
+                raise GithubException(404, {"message": "Not a file"}, {})
+            await asyncio.to_thread(
+                repo.update_file,
+                path=contents.path,
+                message=options.message,
+                content=yaml_content,
+                sha=contents.sha,
+                branch=branch_name,
+            )
+            logger.debug(
+                "Updated workflow file via API (legacy)",
+                path=file_path,
+                branch=branch_name,
+            )
+        except GithubException as e:
+            if e.status != 404:
+                raise
+            await asyncio.to_thread(
+                repo.create_file,
+                path=file_path,
+                message=options.message,
+                content=yaml_content,
+                branch=branch_name,
+            )
+            logger.debug(
+                "Created workflow file via API (legacy)",
+                path=file_path,
+                branch=branch_name,
+            )
+
+        branch = await asyncio.to_thread(repo.get_branch, branch_name)
+        commit_sha = branch.commit.sha
+
+        pr_url: str | None = None
+        pr_number: int | None = None
+        if options.create_pr:
+            try:
+                pr_url, pr_number, _ = await self._create_pull_request(
+                    repo=repo,
+                    obj=obj,
+                    options=options,
+                    branch_name=branch_name,
+                    base_branch_name=base_branch_name,
+                )
+            except GithubException as e:
+                logger.error(
+                    "Failed to create PR via GitHub API (legacy)",
+                    error=str(e),
+                    branch=branch_name,
+                )
+
+        return CommitInfo(
+            status=PushStatus.COMMITTED,
+            sha=commit_sha,
+            ref=branch_name,
+            base_ref=base_branch_name,
+            pr_url=pr_url,
+            pr_number=pr_number,
+            pr_reused=False,
+            message="Committed workflow changes on a temporary legacy branch.",
+        )
+
+    async def _upsert_pull_request(
+        self,
+        *,
+        repo: Any,
+        url: GitUrl,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+        branch_name: str,
+        base_branch_name: str,
+    ) -> tuple[str | None, int | None, bool]:
+        def _first_open_pull_request() -> Any | None:
+            pulls = repo.get_pulls(
+                state="open",
+                head=f"{url.org}:{branch_name}",
+                base=base_branch_name,
+            )
+            return next(iter(pulls), None)
+
+        try:
+            existing_pr = await asyncio.to_thread(_first_open_pull_request)
+        except GithubException as e:
+            logger.error(
+                "Failed to search for open pull requests",
+                error=str(e),
+                branch=branch_name,
+                base_branch=base_branch_name,
+            )
+            existing_pr = None
+
+        if existing_pr is not None:
+            logger.info(
+                "Reused existing pull request",
+                pr_number=existing_pr.number,
+                pr_url=existing_pr.html_url,
+                branch=branch_name,
+                base_branch=base_branch_name,
+            )
+            return existing_pr.html_url, existing_pr.number, True
+
+        return await self._create_pull_request(
+            repo=repo,
+            obj=obj,
+            options=options,
+            branch_name=branch_name,
+            base_branch_name=base_branch_name,
+        )
+
+    async def _create_pull_request(
+        self,
+        *,
+        repo: Any,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+        branch_name: str,
+        base_branch_name: str,
+    ) -> tuple[str, int, bool]:
+        ws_svc = WorkspaceService(session=self.session, role=self.role)
+        workspace = await ws_svc.get_workspace(self.workspace_id)
+        if not workspace:
+            raise TracecatNotFoundError("Workspace not found")
+
+        try:
+            title = obj.data.definition.title
+            description = obj.data.definition.description
+        except ValueError:
+            title = "<An error occurred while determining the title>"
+            description = "<An error occurred while determining the description>"
+
+        current_user = None
+        if self.role.user_id is not None:
+            try:
+                current_user = await self.session.get(User, self.role.user_id)
+            except Exception:
+                current_user = None
+
+        published_by = current_user.email if current_user else "<unknown>"
+
+        pr = await asyncio.to_thread(
+            repo.create_pull,
+            title=options.message,
+            body=(
+                f"Automated workflow sync from Tracecat\n\n"
+                f"**Workspace:** {workspace.name}\n"
+                f"**Published by:** {published_by}\n"
+                f"**Workflow Title:** {title}\n"
+                f"**Workflow Description:** {description}"
+            ),
+            head=branch_name,
+            base=base_branch_name,
+        )
+
+        logger.info(
+            "Created PR via GitHub API",
+            pr_number=pr.number,
+            pr_url=pr.html_url,
+            branch=branch_name,
+            base_branch=base_branch_name,
+        )
+        return pr.html_url, pr.number, False
 
     async def list_commits(
         self,
@@ -567,5 +772,45 @@ class WorkflowSyncService(BaseWorkspaceService):
                 data=e.data,
                 repo=f"{url.org}/{url.repo}",
                 branch=branch,
+            )
+            raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
+
+    async def list_branches(
+        self,
+        *,
+        url: GitUrl,
+        limit: int = 100,
+    ) -> list[GitBranchInfo]:
+        """List branches from a Git repository using GitHub App API."""
+        try:
+            gh_svc = GitHubAppService(session=self.session, role=self.role)
+            gh = await gh_svc.get_github_client_for_repo(url)
+
+            try:
+                repo = await asyncio.to_thread(gh.get_repo, f"{url.org}/{url.repo}")
+                branches_paginated = await asyncio.to_thread(repo.get_branches)
+
+                branches: list[GitBranchInfo] = []
+                count = 0
+                for branch_obj in branches_paginated:
+                    if count >= limit:
+                        break
+                    branches.append(
+                        GitBranchInfo(
+                            name=branch_obj.name,
+                            is_default=branch_obj.name == repo.default_branch,
+                        )
+                    )
+                    count += 1
+
+                return branches
+            finally:
+                gh.close()
+        except GithubException as e:
+            logger.error(
+                "GitHub API error during branch listing",
+                status=e.status,
+                data=e.data,
+                repo=f"{url.org}/{url.repo}",
             )
             raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds branch-targeted workflow publish support and updates the builder publish UX to use repository branches directly.

Backend:
- Adds `branch`, `create_pr`, and `pr_base_branch` publish inputs and returns a structured publish result.
- Supports publishing directly to a target branch, creating missing branches from the default/base branch, detecting no-op commits, and optional PR creation/reuse.
- Adds a new `GET /workflows/sync/branches` endpoint for listing branches from the configured repo via GitHub App.
- Persists `workflow.git_sync_branch` and exposes it in workflow read APIs.
- Adds migration `672fecea1d32_add_workflow_git_sync_branch.py`.

Frontend:
- Publish dropdown now loads real branches from the repo.
- Branch picker supports both selecting existing branches and creating a new branch inline.
- `Create new branch...` appears first with a separator.
- Adds a collapsed-state loading skeleton in the branch selector while branch data is loading.
- Updates publish success copy from "Workflow published" to "Workflow committed" for commit-success outcomes.

Docs:
- Adds `docs/quickstart/github-workflow-sync-setup.md` with GitHub App workflow sync setup steps.

Tests:
- Adds/updates workflow sync service tests for target branch commit/create/no-op/PR create/reuse and branch listing.
- Adds workflow publish API tests including branch list endpoint success/error handling.

## Related Issues

N/A

## Screenshots / Recordings

<img width="1156" height="955" alt="image" src="https://github.com/user-attachments/assets/757b0bb0-fd35-4718-a870-cb685c4a0a3c" />


## Steps to QA

1. Run backend tests:
   - `PG_PORT=5532 REDIS_PORT=6479 MINIO_PORT=9100 TEMPORAL_PORT=7333 uv run pytest tests/unit/test_workflow_sync_service.py tests/unit/test_workflows_store.py tests/unit/api/test_api_workflow_store_publish.py`
2. Run Python checks on changed files:
   - `uv run ruff check tests/unit/test_workflow_sync_service.py tests/unit/test_workflows_store.py tracecat/db/models.py tracecat/registry/repositories/schemas.py tracecat/sync.py tracecat/workflow/management/router.py tracecat/workflow/management/schemas.py tracecat/workflow/store/router.py tracecat/workflow/store/schemas.py tracecat/workflow/store/service.py tracecat/workflow/store/sync.py`
   - `uv run basedpyright tests/unit/test_workflow_sync_service.py tests/unit/test_workflows_store.py tracecat/db/models.py tracecat/registry/repositories/schemas.py tracecat/sync.py tracecat/workflow/management/router.py tracecat/workflow/management/schemas.py tracecat/workflow/store/router.py tracecat/workflow/store/schemas.py tracecat/workflow/store/service.py tracecat/workflow/store/sync.py`
3. Run frontend checks:
   - `pnpm -C frontend exec biome check src/providers/workflow.tsx src/components/nav/builder-nav.tsx`
   - `pnpm -C frontend run typecheck`
4. Manual UI check:
   - Open builder publish dropdown.
   - Verify branch selector shows a skeleton while loading (collapsed trigger).
   - Verify `Create new branch...` is first, separated from existing branches.
   - Publish with existing branch and new branch; verify success toast title says `Workflow committed`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds branch-targeted workflow publishing with a branch picker, PR create/reuse, and a branch list API. Publish returns a structured result; we persist and expose the selected branch, use “Push changes” under “Version control,” warn on default-branch pushes, show a “default” badge in the picker, and harden branch publish error handling.

- **New Features**
  - Backend: publish inputs (branch, create_pr, pr_base_branch), branch auto-creation, no-op detection, PR create/reuse, branch validation, GET /workflows/sync/branches (with is_default), persist and expose workflow.git_sync_branch in read APIs, and structured publish result (status, commit, branch/base, PR info, message).
  - Frontend: branch picker with real branches and inline “Create new branch…”, loading skeleton, “Create pull request” toggle, shows persisted branch and default badge, copy changed to “Push changes,” header “Version control,” warns on default-branch pushes, success toasts include commit/PR/no-op states and a “View PR” action.
  - Docs/Tests: GitHub App setup guide; unit and HTTP tests for publish flows, branch listing, branch validation, API responses, hardened error handling; registry LDAP tests retry transient bind failures to reduce flakes.

- **Migration**
  - Run DB migrations to add workflow.git_sync_branch (revision reparented; run as normal).
  - Ensure the GitHub App and repository are configured; see docs/quickstart/github-workflow-sync-setup.md.

<sup>Written for commit f08c14d8c0b2751568e334a643b3d870d692d1f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



