### PR TITLE
fix(ui): Add scroll area for large input / results in execution viewer

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/workflows/[workflowId]/executions/[executionId]/page.tsx
@@ -60,12 +60,12 @@ export default function ExecutionPage() {
     >
       {/* Panel 2: Events */}
       <ResizablePanel defaultSize={defaultLayout[1]} minSize={18}>
-        <div className="flex h-full flex-col overflow-hidden">
+        <div className="flex h-full min-h-0 flex-col overflow-hidden">
           <SectionHead
             text="Events"
             icon={<CalendarSearchIcon className="size-4" strokeWidth={2} />}
           />
-          <div className="flex-1 overflow-auto">
+          <div className="min-h-0 flex-1 overflow-auto">
             {fullExecutionId ? (
               <WorkflowExecutionEventHistory
                 executionId={fullExecutionId}
@@ -87,8 +87,8 @@ export default function ExecutionPage() {
         minSize={25}
         className="grow"
       >
-        <div className="flex h-full flex-col overflow-hidden">
-          <div className="flex-1 overflow-auto">
+        <div className="flex h-full min-h-0 flex-col overflow-hidden">
+          <div className="min-h-0 flex-1 overflow-auto">
             {selectedEvent ? (
               <WorkflowExecutionEventDetailView
                 event={selectedEvent}

--- a/frontend/src/components/executions/collection-object-result.tsx
+++ b/frontend/src/components/executions/collection-object-result.tsx
@@ -223,14 +223,14 @@ export function CollectionObjectResult({
                     <div className="rounded-sm border border-dashed p-2">
                       <JsonViewWithControls
                         src={item.stored.data}
-                        defaultExpanded={false}
+                        defaultExpanded={true}
                       />
                     </div>
                   ) : (
                     <div className="rounded-sm border border-dashed p-2">
                       <JsonViewWithControls
                         src={item.stored}
-                        defaultExpanded={false}
+                        defaultExpanded={true}
                       />
                     </div>
                   )

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -56,8 +56,8 @@ export function WorkflowExecutionEventDetailView({
   }, [event.source_event_id, initialTab])
 
   return (
-    <div className="size-full overflow-hidden">
-      <div className="flex h-full flex-col">
+    <div className="size-full min-h-0 overflow-hidden">
+      <div className="flex h-full min-h-0 flex-col">
         {hasFailure && (
           <div className="border-b">
             <div className="flex h-8 items-center border-b px-3 text-[11px] font-semibold text-muted-foreground">
@@ -100,12 +100,18 @@ export function WorkflowExecutionEventDetailView({
               </TabsList>
             </div>
             {hasInput && (
-              <TabsContent value="input" className="m-0 flex-1 overflow-auto">
+              <TabsContent
+                value="input"
+                className="m-0 flex-1 overflow-auto data-[state=active]:overflow-auto"
+              >
                 <JsonViewContent src={event.action_input} />
               </TabsContent>
             )}
             {hasResult && (
-              <TabsContent value="result" className="m-0 flex-1 overflow-auto">
+              <TabsContent
+                value="result"
+                className="m-0 flex-1 overflow-auto data-[state=active]:overflow-auto"
+              >
                 {isExternalStoredObject(event.action_result) ? (
                   <ExternalObjectResult
                     executionId={executionId}
@@ -141,7 +147,7 @@ export function WorkflowExecutionEventDetailView({
 function JsonViewContent({ src }: { src: unknown }): JSX.Element {
   return (
     <div className="p-3">
-      <JsonViewWithControls src={src} defaultExpanded={false} />
+      <JsonViewWithControls src={src} defaultExpanded={true} />
     </div>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds proper scroll areas in the execution viewer so large inputs and results are viewable without clipping. Expands JSON views by default to make event details and collection objects easier to inspect.

- **Bug Fixes**
  - Enabled scrolling in events and details panels by adding min-h-0 and overflow-auto.
  - Preserved scroll behavior in active tabs for input/result views.
  - Default-expanded JSON in event details and collection object result views.

<sup>Written for commit 3621ebaab166ec0058a8c0f2cb5d5b64d3ff4546. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

