### PR TITLE
fix: show Workflow sync as gated in org settings

### DIFF
--- a/frontend/src/app/organization/vcs/page.tsx
+++ b/frontend/src/app/organization/vcs/page.tsx
@@ -1,30 +1,18 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
+import { ArrowUpRight } from "lucide-react"
 
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { OrgVCSSettings } from "@/components/organization/org-vcs-settings"
+import { Button } from "@/components/ui/button"
 import { useEntitlements } from "@/hooks/use-entitlements"
 
 export default function VCSSettingsPage() {
-  const router = useRouter()
   const { hasEntitlement, isLoading } = useEntitlements()
-
-  useEffect(() => {
-    if (!isLoading && !hasEntitlement("git_sync")) {
-      // Use replace to avoid adding a history entry and prevent back navigation to this page
-      router.replace("/not-found")
-    }
-  }, [isLoading, hasEntitlement, router])
 
   // Show loading while feature flags are being fetched
   if (isLoading) {
-    return <CenteredSpinner />
-  }
-
-  // Don't render content if feature is disabled (redirect is happening in useEffect)
-  if (!hasEntitlement("git_sync")) {
     return <CenteredSpinner />
   }
 
@@ -42,7 +30,31 @@ export default function VCSSettingsPage() {
           </div>
         </div>
 
-        <OrgVCSSettings />
+        {hasEntitlement("git_sync") ? (
+          <OrgVCSSettings />
+        ) : (
+          <div className="flex flex-1 items-center justify-center pb-8">
+            <EntitlementRequiredEmptyState
+              title="Upgrade required"
+              description="Workflow sync is unavailable on your current plan."
+            >
+              <Button
+                variant="link"
+                asChild
+                className="text-muted-foreground"
+                size="sm"
+              >
+                <a
+                  href="https://tracecat.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn more <ArrowUpRight className="size-4" />
+                </a>
+              </Button>
+            </EntitlementRequiredEmptyState>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -39,6 +39,7 @@ export function OrganizationSidebar({
   const pathname = usePathname()
   const { hasEntitlement } = useEntitlements()
   const customRegistryEnabled = hasEntitlement("custom_registry")
+  const gitSyncEnabled = hasEntitlement("git_sync")
 
   // Fetch workspaces for the sidebar
   const { workspaces } = useWorkspaceManager()
@@ -96,18 +97,14 @@ export function OrganizationSidebar({
       visible: canViewSettings === true,
       locked: false,
     },
-    ...(hasEntitlement("git_sync")
-      ? [
-          {
-            title: "Workflow sync",
-            url: "/organization/vcs",
-            icon: GitBranchIcon,
-            isActive: pathname?.includes("/organization/vcs"),
-            visible: canViewSettings === true,
-            locked: false,
-          },
-        ]
-      : []),
+    {
+      title: "Workflow sync",
+      url: "/organization/vcs",
+      icon: GitBranchIcon,
+      isActive: pathname?.includes("/organization/vcs"),
+      visible: canViewSettings === true,
+      locked: !gitSyncEnabled,
+    },
   ]
 
   const navSecrets = [


### PR DESCRIPTION
## Summary
- keep the `Workflow sync` item visible in the organization settings sidebar even when `git_sync` is disabled
- show the lock badge for `Workflow sync` when `git_sync` is unavailable, matching gated behavior like `Git repository`
- replace the `/organization/vcs` not-found redirect with an entitlement-gated empty state and upgrade CTA

## Testing
- `pnpm -C frontend exec biome check src/app/organization/vcs/page.tsx src/components/sidebar/organization-sidebar.tsx`
- `uv run ruff check .`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Workflow sync visible in org settings and gate the page with an upgrade CTA when git_sync is unavailable. Revert the builtin registry tarball build to use the venv-from-source path and add uncompressed size metrics.

- **Bug Fixes**
  - Sidebar: Workflow sync is always shown; displays a lock when git_sync is disabled.
  - VCS page: Replaced not-found redirect with an entitlement-gated empty state and “Learn more” upgrade CTA.

- **Refactors**
  - Builtin registry tarball now always builds from the source path venv; removed the installed-site-packages path, its config flag, and related tests.
  - Added uncompressed size calculation and logging; included in TarballVenvBuildResult and upload logs.

<sup>Written for commit 32bac65b9d8f8887279c1b7a899f5d7ad03ffa06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

