### PR TITLE
feat(integrations): add slack pin and bookmark actions

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/bookmarks/add_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/bookmarks/add_bookmark.yml
@@ -1,0 +1,39 @@
+type: action
+definition:
+  title: Add bookmark
+  description: Add a bookmark to a Slack channel.
+  display_group: Slack
+  doc_url: https://api.slack.com/methods/bookmarks.add
+  namespace: tools.slack
+  name: add_bookmark
+  expects:
+    channel_id:
+      type: str
+      description: ID of the channel to add the bookmark to.
+    title:
+      type: str
+      description: Title for the bookmark.
+    type:
+      type: str
+      description: Type of the bookmark (e.g. "link").
+      default: "link"
+    link:
+      type: str | None
+      description: URL to bookmark.
+      default: null
+    emoji:
+      type: str | None
+      description: Emoji tag to apply to the bookmark.
+      default: null
+  steps:
+    - ref: add_bookmark
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: bookmarks_add
+        params:
+          channel_id: ${{ inputs.channel_id }}
+          title: ${{ inputs.title }}
+          type: ${{ inputs.type }}
+          link: ${{ inputs.link }}
+          emoji: ${{ inputs.emoji }}
+  returns: ${{ steps.add_bookmark.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/bookmarks/list_bookmarks.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/bookmarks/list_bookmarks.yml
@@ -1,0 +1,20 @@
+type: action
+definition:
+  title: List bookmarks
+  description: List bookmarks for a Slack channel.
+  display_group: Slack
+  doc_url: https://api.slack.com/methods/bookmarks.list
+  namespace: tools.slack
+  name: list_bookmarks
+  expects:
+    channel_id:
+      type: str
+      description: ID of the channel to list bookmarks for.
+  steps:
+    - ref: list_bookmarks
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: bookmarks_list
+        params:
+          channel_id: ${{ inputs.channel_id }}
+  returns: ${{ steps.list_bookmarks.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/bookmarks/remove_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/bookmarks/remove_bookmark.yml
@@ -1,0 +1,24 @@
+type: action
+definition:
+  title: Remove bookmark
+  description: Remove a bookmark from a Slack channel.
+  display_group: Slack
+  doc_url: https://api.slack.com/methods/bookmarks.remove
+  namespace: tools.slack
+  name: remove_bookmark
+  expects:
+    channel_id:
+      type: str
+      description: ID of the channel to remove the bookmark from.
+    bookmark_id:
+      type: str
+      description: ID of the bookmark to remove.
+  steps:
+    - ref: remove_bookmark
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: bookmarks_remove
+        params:
+          channel_id: ${{ inputs.channel_id }}
+          bookmark_id: ${{ inputs.bookmark_id }}
+  returns: ${{ steps.remove_bookmark.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/pins/add_pin.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/pins/add_pin.yml
@@ -1,0 +1,24 @@
+type: action
+definition:
+  title: Add pin
+  description: Pin a message in a Slack channel.
+  display_group: Slack
+  doc_url: https://api.slack.com/methods/pins.add
+  namespace: tools.slack
+  name: add_pin
+  expects:
+    channel:
+      type: str
+      description: ID of the channel containing the message to pin.
+    timestamp:
+      type: str
+      description: Timestamp of the message to pin.
+  steps:
+    - ref: add_pin
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: pins_add
+        params:
+          channel: ${{ inputs.channel }}
+          timestamp: ${{ inputs.timestamp }}
+  returns: ${{ steps.add_pin.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/pins/list_pins.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/pins/list_pins.yml
@@ -1,0 +1,20 @@
+type: action
+definition:
+  title: List pins
+  description: List pinned messages in a Slack channel.
+  display_group: Slack
+  doc_url: https://api.slack.com/methods/pins.list
+  namespace: tools.slack
+  name: list_pins
+  expects:
+    channel:
+      type: str
+      description: ID of the channel to list pins for.
+  steps:
+    - ref: list_pins
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: pins_list
+        params:
+          channel: ${{ inputs.channel }}
+  returns: ${{ steps.list_pins.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/pins/remove_pin.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/pins/remove_pin.yml
@@ -1,0 +1,24 @@
+type: action
+definition:
+  title: Remove pin
+  description: Remove a pinned message from a Slack channel.
+  display_group: Slack
+  doc_url: https://api.slack.com/methods/pins.remove
+  namespace: tools.slack
+  name: remove_pin
+  expects:
+    channel:
+      type: str
+      description: ID of the channel containing the pinned message.
+    timestamp:
+      type: str
+      description: Timestamp of the message to unpin.
+  steps:
+    - ref: remove_pin
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: pins_remove
+        params:
+          channel: ${{ inputs.channel }}
+          timestamp: ${{ inputs.timestamp }}
+  returns: ${{ steps.remove_pin.result }}


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Added slack integration actions for:
- pins
  - add_pin
  - list_pin
  - remove_pin
- bookmarks
  - add_bookmark
  - remove_bookmark
  - list_bookmarks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Slack actions to manage pins and bookmarks so workflows can pin/unpin messages and add/list/remove bookmarks directly via the Slack API.

- **New Features**
  - Pins: add_pin, list_pins, remove_pin (inputs: channel, timestamp)
  - Bookmarks: add_bookmark, list_bookmarks, remove_bookmark (inputs: channel_id, title, type, link, emoji, bookmark_id)

<sup>Written for commit 4eb7ab7da00559748e7a6eff33854dd7a6f89293. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

