### PR TITLE
fix(dsl): use workflow-safe logging to avoid temporal deadlocks

### DIFF
--- a/scripts/temporal/repro_workflow_logging_deadlock.py
+++ b/scripts/temporal/repro_workflow_logging_deadlock.py
@@ -1,0 +1,184 @@
+"""Reproduce Temporal workflow deadlock caused by blocking process logger calls.
+
+This script runs two workflows in the Temporal local test environment:
+1) Legacy path: workflow code calls the process Loguru logger directly.
+2) Safe path: workflow code calls tracecat.dsl.workflow_logging.workflow_logger.
+
+A blocking Loguru sink is installed to emulate logger lock contention. The
+legacy path should fail with TMPRL1101 (workflow didn't yield), while the safe
+path should still complete.
+
+Run:
+    uv run python scripts/temporal/repro_workflow_logging_deadlock.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import time
+import uuid
+from enum import StrEnum
+
+from temporalio import workflow
+from temporalio.api.enums.v1 import EventType
+from temporalio.client import WorkflowFailureError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+with workflow.unsafe.imports_passed_through():
+    from tracecat.dsl.worker import new_sandbox_runner
+    from tracecat.dsl.workflow_logging import workflow_logger
+    from tracecat.logger import logger as process_logger
+
+
+class Mode(StrEnum):
+    LEGACY = "legacy"
+    SAFE = "safe"
+    BOTH = "both"
+
+
+DEADLOCK_MARKERS = ("TMPRL1101", "Potential deadlock", "didn't yield")
+
+
+@workflow.defn
+class LegacyProcessLoggerWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        process_logger.info("legacy process logger call from workflow")
+        await asyncio.sleep(0)
+        return "legacy-ok"
+
+
+@workflow.defn
+class SafeWorkflowLoggerWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        workflow_logger.info("workflow-safe logger call from workflow")
+        await asyncio.sleep(0)
+        return "safe-ok"
+
+
+class _BlockFirstSink:
+    def __init__(self, *, block_seconds: float, max_blocks: int = 1) -> None:
+        self._block_seconds = block_seconds
+        self._remaining_blocks = max_blocks
+
+    def __call__(self, _message: object) -> None:
+        if self._remaining_blocks <= 0:
+            return
+        self._remaining_blocks -= 1
+        time.sleep(self._block_seconds)
+
+
+async def _execute(
+    env: WorkflowEnvironment,
+    *,
+    task_queue: str,
+    workflow_cls: type[LegacyProcessLoggerWorkflow] | type[SafeWorkflowLoggerWorkflow],
+) -> tuple[str, bool]:
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        workflows=[workflow_cls],
+        workflow_runner=new_sandbox_runner(),
+    ):
+        handle = await env.client.start_workflow(
+            workflow_cls.run,
+            id=f"deadlock-repro-{workflow_cls.__name__}-{uuid.uuid4()}",
+            task_queue=task_queue,
+        )
+        result = await handle.result()
+        has_deadlock = False
+        async for event in handle.fetch_history_events():
+            if event.event_type != EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED:
+                continue
+            failure = event.workflow_task_failed_event_attributes.failure
+            msg = getattr(failure, "message", "")
+            stack = getattr(failure, "stack_trace", "")
+            failure_text = f"{msg}\n{stack}"
+            if any(marker in failure_text for marker in DEADLOCK_MARKERS):
+                has_deadlock = True
+                break
+        return result, has_deadlock
+
+
+async def run_repro(mode: Mode, block_seconds: float) -> int:
+    # Install a blocking sink to emulate logger contention in workflow threads.
+    blocking_sink = _BlockFirstSink(block_seconds=block_seconds, max_blocks=1)
+    sink_id = process_logger.add(
+        blocking_sink,
+        level="INFO",
+        format="{message}",
+        colorize=False,
+    )
+    try:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            if mode in (Mode.LEGACY, Mode.BOTH):
+                try:
+                    result, had_deadlock = await _execute(
+                        env,
+                        task_queue="deadlock-repro-legacy",
+                        workflow_cls=LegacyProcessLoggerWorkflow,
+                    )
+                except WorkflowFailureError as exc:
+                    print("LEGACY: workflow failed unexpectedly")
+                    print(str(exc))
+                    return 1
+                if not had_deadlock:
+                    print("LEGACY: workflow completed, but no TMPRL1101 was found")
+                    return 1
+                print(
+                    "LEGACY: completed and reproduced TMPRL1101 in task history",
+                    f"(result={result!r})",
+                )
+
+            if mode in (Mode.SAFE, Mode.BOTH):
+                try:
+                    result, had_deadlock = await _execute(
+                        env,
+                        task_queue="deadlock-repro-safe",
+                        workflow_cls=SafeWorkflowLoggerWorkflow,
+                    )
+                except WorkflowFailureError as exc:
+                    print("SAFE: workflow failed unexpectedly")
+                    print(str(exc))
+                    return 1
+                if had_deadlock:
+                    print("SAFE: workflow completed, but TMPRL1101 was still observed")
+                    return 1
+                print("SAFE: completed successfully with no TMPRL1101", f"(result={result!r})")
+    finally:
+        process_logger.remove(sink_id)
+
+    print("Repro complete.")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reproduce Temporal workflow logger deadlock behavior locally."
+    )
+    parser.add_argument(
+        "--mode",
+        type=Mode,
+        default=Mode.BOTH,
+        choices=list(Mode),
+        help="Which path to run: legacy, safe, or both (default).",
+    )
+    parser.add_argument(
+        "--block-seconds",
+        type=float,
+        default=3.0,
+        help="How long to block each process logger emission (default: 3.0).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return asyncio.run(run_repro(mode=args.mode, block_seconds=args.block_seconds))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_dsl_workflow_logging.py
+++ b/tests/unit/test_dsl_workflow_logging.py
@@ -84,10 +84,11 @@ def test_log_uses_process_logger_outside_workflow_context(
 
     process_logger.opt.assert_called_once_with(lazy=True)
     process_logger.log.assert_called_once()
-    [level, fmt, message, suffix], _ = process_logger.log.call_args
+    [level, fmt, message_factory, suffix], _ = process_logger.log.call_args
     assert level == "INFO"
     assert fmt == "{}{}"
-    assert message == "Hello"
+    assert callable(message_factory)
+    assert message_factory() == "Hello"
     assert callable(suffix)
     formatted_suffix = suffix()
     assert isinstance(formatted_suffix, str)

--- a/tests/unit/test_dsl_workflow_logging.py
+++ b/tests/unit/test_dsl_workflow_logging.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracecat.dsl import workflow_logging
+
+
+def test_in_workflow_context_true_in_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        workflow_logging.workflow.unsafe,
+        "in_sandbox",
+        lambda: True,
+    )
+
+    assert workflow_logging._in_workflow_context() is True
+
+
+def test_in_workflow_context_true_with_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        workflow_logging.workflow.unsafe,
+        "in_sandbox",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        workflow_logging.workflow,
+        "_Runtime",
+        SimpleNamespace(maybe_current=lambda: object()),
+    )
+
+    assert workflow_logging._in_workflow_context() is True
+
+
+def test_in_workflow_context_false_without_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workflow_logging.workflow.unsafe,
+        "in_sandbox",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        workflow_logging.workflow,
+        "_Runtime",
+        SimpleNamespace(maybe_current=lambda: None),
+    )
+
+    assert workflow_logging._in_workflow_context() is False
+
+
+def test_in_workflow_context_false_on_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workflow_logging.workflow.unsafe,
+        "in_sandbox",
+        lambda: False,
+    )
+
+    def _raise() -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        workflow_logging.workflow,
+        "_Runtime",
+        SimpleNamespace(maybe_current=_raise),
+    )
+
+    assert workflow_logging._in_workflow_context() is False
+
+
+def test_log_uses_process_logger_outside_workflow_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process_logger = MagicMock()
+    monkeypatch.setattr(workflow_logging, "_in_workflow_context", lambda: False)
+    monkeypatch.setattr(workflow_logging, "process_logger", process_logger)
+
+    logger = workflow_logging.get_workflow_logger(service="dsl")
+    logger.info("Hello", run_id="abc")
+
+    process_logger.info.assert_called_once()
+    [message], _ = process_logger.info.call_args
+    assert message.startswith("Hello | ")
+    # Keys are sorted for deterministic output.
+    assert "run_id='abc'" in message
+    assert "service='dsl'" in message
+
+
+def test_log_uses_temporal_logger_in_workflow_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temporal_logger = MagicMock()
+    monkeypatch.setattr(workflow_logging, "_in_workflow_context", lambda: True)
+    monkeypatch.setattr(workflow_logging.workflow, "logger", temporal_logger)
+
+    logger = workflow_logging.get_workflow_logger(workflow_id="wf-123")
+    logger.warning("Failure", attempt=2)
+
+    temporal_logger.warning.assert_called_once()
+    [message], _ = temporal_logger.warning.call_args
+    assert message.startswith("Failure | ")
+    assert "attempt=2" in message
+    assert "workflow_id='wf-123'" in message
+
+
+def test_trace_maps_to_temporal_debug(monkeypatch: pytest.MonkeyPatch) -> None:
+    temporal_logger = MagicMock()
+    monkeypatch.setattr(workflow_logging, "_in_workflow_context", lambda: True)
+    monkeypatch.setattr(workflow_logging.workflow, "logger", temporal_logger)
+
+    logger = workflow_logging.get_workflow_logger()
+    logger.trace("Trace message")
+
+    temporal_logger.debug.assert_called_once_with("Trace message")
+
+
+def test_safe_repr_handles_broken_repr() -> None:
+    class BrokenRepr:
+        def __repr__(self) -> str:
+            raise ValueError("broken")
+
+    output = workflow_logging._format_fields({"bad": BrokenRepr()})
+    assert output.startswith(" | ")
+    assert "bad=<unrepresentable BrokenRepr>" in output

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -461,7 +461,9 @@ class DSLScheduler:
         try:
             # 1) Skip propagation (force-skip) takes highest precedence over everything else
             if self._skip_should_propagate(task, stmt):
-                self.logger.debug("Task should be force-skipped, propagating", task=task)
+                self.logger.debug(
+                    "Task should be force-skipped, propagating", task=task
+                )
                 return await self._handle_skip_path(task, stmt)
 
             # 2) Then we check if the task is reachable

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -745,7 +745,9 @@ class DSLWorkflow:
         2. Decide whether we're running a child workflow or not
         """
         stream_id = ctx_stream_id.get()
-        self.logger.debug("Begin task execution", task_ref=task.ref, stream_id=stream_id)
+        self.logger.debug(
+            "Begin task execution", task_ref=task.ref, stream_id=stream_id
+        )
         task_result = TaskResult.from_result(None)
 
         try:
@@ -1885,7 +1887,9 @@ class DSLWorkflow:
         url = None
         if match := re.match(identifiers.workflow.WF_EXEC_ID_PATTERN, orig_wf_exec_id):
             if self.role.workspace_id is None:
-                self.logger.warning("Workspace ID is required to create error handler URL")
+                self.logger.warning(
+                    "Workspace ID is required to create error handler URL"
+                )
             else:
                 try:
                     workflow_id = identifiers.workflow.WorkflowUUID.new(

--- a/tracecat/dsl/workflow_logging.py
+++ b/tracecat/dsl/workflow_logging.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from temporalio import workflow
+
+from tracecat.logger import logger as process_logger
+
+
+def _in_workflow_context() -> bool:
+    """Return whether we're currently running in a Temporal workflow context."""
+    if workflow.unsafe.in_sandbox():
+        return True
+
+    runtime_cls = getattr(workflow, "_Runtime", None)
+    maybe_current = getattr(runtime_cls, "maybe_current", None)
+    if maybe_current is None:
+        return False
+
+    try:
+        return maybe_current() is not None
+    except Exception:
+        return False
+
+
+def _safe_repr(value: Any) -> str:
+    try:
+        return repr(value)
+    except Exception:
+        return f"<unrepresentable {type(value).__name__}>"
+
+
+def _format_fields(fields: dict[str, Any]) -> str:
+    if not fields:
+        return ""
+    serialized = ", ".join(
+        f"{key}={_safe_repr(value)}" for key, value in sorted(fields.items())
+    )
+    return f" | {serialized}"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRuntimeLogger:
+    """Logger adapter for workflow code paths.
+
+    Uses Temporal's workflow logger when running in workflow context to avoid
+    process-wide Loguru sink lock contention from workflow activation threads.
+    Falls back to process logger outside workflow runtime (e.g. unit tests).
+    """
+
+    _bound_fields: dict[str, Any] = field(default_factory=dict)
+
+    def bind(self, **fields: Any) -> WorkflowRuntimeLogger:
+        return WorkflowRuntimeLogger({**self._bound_fields, **fields})
+
+    def trace(self, message: str, **fields: Any) -> None:
+        self._log("trace", message, **fields)
+
+    def debug(self, message: str, **fields: Any) -> None:
+        self._log("debug", message, **fields)
+
+    def info(self, message: str, **fields: Any) -> None:
+        self._log("info", message, **fields)
+
+    def warning(self, message: str, **fields: Any) -> None:
+        self._log("warning", message, **fields)
+
+    def error(self, message: str, **fields: Any) -> None:
+        self._log("error", message, **fields)
+
+    def _log(self, level: str, message: str, **fields: Any) -> None:
+        merged_fields = {**self._bound_fields, **fields}
+        formatted_message = f"{message}{_format_fields(merged_fields)}"
+
+        if _in_workflow_context():
+            temporal_level = "debug" if level == "trace" else level
+            getattr(workflow.logger, temporal_level)(formatted_message)
+            return
+
+        getattr(process_logger, level)(formatted_message)
+
+
+workflow_logger = WorkflowRuntimeLogger()
+
+
+def get_workflow_logger(**fields: Any) -> WorkflowRuntimeLogger:
+    return workflow_logger.bind(**fields)

--- a/tracecat/dsl/workflow_logging.py
+++ b/tracecat/dsl/workflow_logging.py
@@ -112,7 +112,7 @@ class WorkflowRuntimeLogger:
         process_logger.opt(lazy=True).log(
             _LOGURU_LEVEL_BY_NAME[level],
             "{}{}",
-            message,
+            lambda: message,
             lambda: _format_fields({**bound_fields, **dynamic_fields}),
         )
 


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes `TMPRL1101` workflow deadlock risk caused by using process Loguru logger inside Temporal workflow threads.

Changes:
- Add `WorkflowRuntimeLogger` adapter in `tracecat/dsl/workflow_logging.py`.
- Route DSL workflow/scheduler logs through Temporal workflow logger when in workflow context.
- Keep process logger fallback for non-workflow contexts (unit tests/local usage).
- Reduce high-frequency workflow/scheduler log volume (`info` -> `debug`) in hot paths.
- Add unit tests for workflow logging adapter behavior.
- Add deterministic local repro harness: `scripts/temporal/repro_workflow_logging_deadlock.py`.
- Remove unused workflow-side `ctx_logger`/`process_logger` wiring from `DSLWorkflow`.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Run targeted checks:
   - `uv run ruff check tracecat/dsl/workflow.py tracecat/dsl/scheduler.py tracecat/dsl/workflow_logging.py tests/unit/test_dsl_workflow_logging.py scripts/temporal/repro_workflow_logging_deadlock.py`
   - `uv run basedpyright tracecat/dsl/workflow.py tracecat/dsl/scheduler.py tracecat/dsl/workflow_logging.py tests/unit/test_dsl_workflow_logging.py scripts/temporal/repro_workflow_logging_deadlock.py`
2. Run unit tests:
   - `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/test_dsl_workflow_logging.py`
   - `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/test_schedule_role_healing.py`
   - `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/test_dsl_scheduler_determinism.py`
3. Run deadlock repro harness:
   - `uv run python scripts/temporal/repro_workflow_logging_deadlock.py --mode both --block-seconds 2.5`
4. Verify expected repro output:
   - Legacy path reports `TMPRL1101` in workflow task history.
   - Safe path completes with no `TMPRL1101`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Temporal workflow deadlocks (TMPRL1101) by switching DSL logs to a workflow‑safe logger, deferring formatting with lazy callables, and gating formatting behind level checks to prevent blocking in workflow threads. Adds tests and a hardened local repro script to reliably reproduce and validate the fix.

- **Bug Fixes**
  - Added WorkflowRuntimeLogger and get_workflow_logger to use Temporal’s logger in workflow context with a process logger fallback; maps trace to debug, skips field formatting when the level is disabled, and uses Loguru lazy callables to defer message/field formatting.
  - Routed DSL workflow and Scheduler logs through the workflow‑safe logger; added optional logger injection; lowered hot‑path info logs to debug and adjusted warnings where appropriate.
  - Hardened repro harness: checks workflow history for TMPRL1101, installs/removes a blocking sink safely, supports mode/block‑seconds flags; expanded tests for context detection, trace mapping, safe repr, disabled‑level gating, and lazy callables.

- **Refactors**
  - Removed installed site‑packages tarball build; always build the venv tarball from the builtin source path, and deleted the TRACECAT__REGISTRY_SYNC_BUILTIN_USE_INSTALLED_SITE_PACKAGES flag.
  - Removed unused ctx_logger wiring from DSLWorkflow and routed logging through the new workflow‑safe adapter.

<sup>Written for commit b04e23d6a7ce927bda592ca525d29a508baf1c62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

