### PR TITLE
fix(workflow): preserve root-cause errors in Temporal failures

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -7931,6 +7931,17 @@ export const $EventFailure = {
       ],
       title: "Cause",
     },
+    root_cause_message: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Root Cause Message",
+    },
   },
   type: "object",
   required: ["message"],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2430,6 +2430,7 @@ export type EventFailure = {
   cause?: {
     [key: string]: unknown
   } | null
+  root_cause_message?: string | null
 }
 
 export type EventGroup_TypeVar_ = {

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -775,7 +775,9 @@ function ActionSessionShell({
 function ErrorEvent({ failure }: { failure: EventFailure }) {
   return (
     <div className="flex flex-col space-y-8 text-xs">
-      <CodeBlock title="Error Message">{failure.message}</CodeBlock>
+      <CodeBlock title="Error Message">
+        {failure.root_cause_message ?? failure.message}
+      </CodeBlock>
     </div>
   )
 }

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -70,7 +70,9 @@ export function WorkflowExecutionEventDetailView({
             <div className="p-3">
               <CodeBlock title="Message">
                 <span className="text-xs">
-                  {event.action_error?.message ?? "No error message"}
+                  {event.action_error?.root_cause_message ??
+                    event.action_error?.message ??
+                    "No error message"}
                 </span>
               </CodeBlock>
             </div>

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -3250,7 +3250,7 @@ async def test_workflow_error_handler_success(
         ),
         pytest.param(
             "invalid_error_handler",
-            "RuntimeError: Couldn't find matching workflow for alias 'invalid_error_handler'",
+            "WorkflowAliasResolutionError: Couldn't find matching workflow for alias 'invalid_error_handler'",
             id="alias-no-match",
         ),
     ],
@@ -3297,6 +3297,10 @@ async def test_workflow_error_handler_invalid_handler_fail_no_match(
     cause1 = cause0.cause
     assert isinstance(cause1, ApplicationError)
     assert str(cause1) == expected_err_msg
+    if id_or_alias == "invalid_error_handler":
+        err = str(cause1)
+        assert "Activity task failed" not in err
+        assert "timed out" not in err.lower()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_dsl_workflow_error_unwrap.py
+++ b/tests/unit/test_dsl_workflow_error_unwrap.py
@@ -1,0 +1,41 @@
+from tracecat.dsl.workflow import DSLWorkflow
+
+
+class CauseError(Exception):
+    def __init__(self, message: str, cause: BaseException | None = None) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+def test_unwrap_temporal_failure_cause_returns_deepest_nested_exception() -> None:
+    root = CauseError("Workflow alias 'invalid' not found")
+    activity_wrapper = CauseError("Activity task failed", cause=root)
+    workflow_wrapper = CauseError("Workflow execution failed", cause=activity_wrapper)
+
+    deepest_error, message = DSLWorkflow._unwrap_temporal_failure_cause(
+        workflow_wrapper
+    )
+
+    assert deepest_error is root
+    assert message == "Workflow alias 'invalid' not found"
+
+
+def test_unwrap_temporal_failure_cause_falls_back_to_outer_message() -> None:
+    root = CauseError("")
+    wrapper = CauseError("Activity task failed", cause=root)
+
+    deepest_error, message = DSLWorkflow._unwrap_temporal_failure_cause(wrapper)
+
+    assert deepest_error is root
+    assert message == "Activity task failed"
+
+
+def test_unwrap_temporal_failure_cause_handles_cyclic_causes() -> None:
+    first = CauseError("first")
+    second = CauseError("second", cause=first)
+    first.cause = second
+
+    deepest_error, message = DSLWorkflow._unwrap_temporal_failure_cause(first)
+
+    assert deepest_error is first
+    assert message == "first"

--- a/tests/unit/test_search_attributes.py
+++ b/tests/unit/test_search_attributes.py
@@ -366,9 +366,12 @@ class TestSearchAttributeQueries:
             workflow_id=test_workflow_id,
             trigger_types={TriggerType.MANUAL},
             triggered_by_user_id=mock_role_with_workspace.user_id,
+            workspace_id=str(mock_role_with_workspace.workspace_id),
         )
 
-        # Verify query includes trigger type and user ID
+        # Verify query includes workspace, trigger type, and user ID
+        assert TemporalSearchAttr.WORKSPACE_ID.value in query
+        assert str(mock_role_with_workspace.workspace_id) in query
         assert TemporalSearchAttr.TRIGGER_TYPE.value in query
         assert TemporalSearchAttr.TRIGGERED_BY_USER_ID.value in query
         assert str(mock_role_with_workspace.user_id) in query

--- a/tests/unit/test_workflow_execution_workspace_scoping.py
+++ b/tests/unit/test_workflow_execution_workspace_scoping.py
@@ -1,0 +1,115 @@
+"""Unit tests for workflow execution workspace scoping."""
+
+import uuid
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from temporalio.client import Client, WorkflowHandle
+from temporalio.common import TypedSearchAttributes
+
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.executions.enums import TemporalSearchAttr
+from tracecat.workflow.executions.service import WorkflowExecutionsService
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+def mock_client() -> Mock:
+    return Mock(spec=Client)
+
+
+@pytest.fixture
+def mock_role(svc_workspace) -> Role:
+    return Role(
+        type="service",
+        workspace_id=svc_workspace.id,
+        user_id=None,
+        service_id="tracecat-service",
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-service"],
+    )
+
+
+@pytest.mark.anyio
+class TestWorkflowExecutionWorkspaceFiltering:
+    async def test_get_execution_returns_none_for_workspace_mismatch(
+        self,
+        mock_client: Mock,
+        mock_role: Role,
+    ) -> None:
+        service = WorkflowExecutionsService(client=mock_client, role=mock_role)
+        execution = Mock()
+        execution.id = "wf_abc/exec_abc"
+        execution.typed_search_attributes = TypedSearchAttributes(
+            search_attributes=[
+                TemporalSearchAttr.WORKSPACE_ID.create_pair(str(uuid.uuid4()))
+            ]
+        )
+        handle = Mock(spec=WorkflowHandle)
+        handle.describe = AsyncMock(return_value=execution)
+        mock_client.get_workflow_handle_for = Mock(return_value=handle)
+
+        result = await service.get_execution("wf_abc/exec_abc")
+
+        assert result is None
+
+    async def test_get_execution_returns_execution_for_workspace_match(
+        self,
+        mock_client: Mock,
+        mock_role: Role,
+    ) -> None:
+        service = WorkflowExecutionsService(client=mock_client, role=mock_role)
+        execution = Mock()
+        execution.id = "wf_abc/exec_abc"
+        execution.typed_search_attributes = TypedSearchAttributes(
+            search_attributes=[
+                TemporalSearchAttr.WORKSPACE_ID.create_pair(str(mock_role.workspace_id))
+            ]
+        )
+        handle = Mock(spec=WorkflowHandle)
+        handle.describe = AsyncMock(return_value=execution)
+        mock_client.get_workflow_handle_for = Mock(return_value=handle)
+
+        result = await service.get_execution("wf_abc/exec_abc")
+
+        assert result is execution
+
+    async def test_list_executions_includes_workspace_filter(
+        self,
+        mock_client: Mock,
+        mock_role: Role,
+    ) -> None:
+        service = WorkflowExecutionsService(client=mock_client, role=mock_role)
+        with patch.object(
+            service, "query_executions", AsyncMock(return_value=[])
+        ) as mock_q:
+            await service.list_executions()
+
+        mock_q.assert_awaited_once()
+        await_args = mock_q.await_args
+        assert await_args is not None
+        query = await_args.kwargs["query"]
+        assert TemporalSearchAttr.WORKSPACE_ID.value in query
+        assert str(mock_role.workspace_id) in query
+
+    async def test_list_executions_by_workflow_id_includes_workspace_filter(
+        self,
+        mock_client: Mock,
+        mock_role: Role,
+    ) -> None:
+        service = WorkflowExecutionsService(client=mock_client, role=mock_role)
+        wf_id = WorkflowUUID.new("wf_4itKqkgCZrLhgYiq5L211X")
+        with patch.object(
+            service, "query_executions", AsyncMock(return_value=[])
+        ) as mock_q:
+            await service.list_executions_by_workflow_id(wf_id)
+
+        mock_q.assert_awaited_once()
+        await_args = mock_q.await_args
+        assert await_args is not None
+        query = await_args.kwargs["query"]
+        assert TemporalSearchAttr.WORKSPACE_ID.value in query
+        assert str(mock_role.workspace_id) in query
+        assert wf_id.short() in query

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -731,6 +731,11 @@ class DSLWorkflow:
         """Return the deepest nested Temporal cause and best-effort message."""
         current = error
         seen: set[int] = set()
+        # Termination argument:
+        # - Each non-breaking iteration adds one new exception object id to `seen`.
+        # - If a cause object repeats, we break on the `seen` check (cycle guard).
+        # - If `cause` is missing or not an exception, we break.
+        # Therefore this traversal cannot loop indefinitely.
         while True:
             current_id = id(current)
             if current_id in seen:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -724,6 +724,32 @@ class DSLWorkflow:
                 break
         return result
 
+    @staticmethod
+    def _unwrap_temporal_failure_cause(
+        error: BaseException,
+    ) -> tuple[BaseException, str]:
+        """Return the deepest nested Temporal cause and best-effort message."""
+        current = error
+        seen: set[int] = set()
+        while True:
+            current_id = id(current)
+            if current_id in seen:
+                break
+            seen.add(current_id)
+
+            nested = getattr(current, "cause", None)
+            if not isinstance(nested, BaseException):
+                break
+            current = nested
+
+        message = str(current)
+        if message:
+            return current, message
+        outer_message = str(error)
+        if outer_message:
+            return current, outer_message
+        return current, current.__class__.__name__
+
     @maybe_interactive
     async def _execute_task(self, task: ActionStatement) -> TaskResult:
         """Purely execute a task and manage the results.
@@ -1016,20 +1042,43 @@ class DSLWorkflow:
             # These are deterministic and expected errors that
             err_type = e.__class__.__name__
             msg = self.ERROR_TYPE_TO_MESSAGE[err_type]
-            self.logger.warning(msg, role=self.role, e=e, cause=e.cause, type=err_type)
-            match cause := e.cause:
+            cause = e.cause
+            root_error, root_message = self._unwrap_temporal_failure_cause(
+                cause if isinstance(cause, BaseException) else e
+            )
+            self.logger.warning(
+                msg,
+                role=self.role,
+                e=e,
+                cause=cause,
+                root_cause=root_error,
+                root_message=root_message,
+                type=err_type,
+            )
+            match cause:
                 case ApplicationError(details=details) if details:
                     err_info = details[0]
                     err_type = cause.type or err_type
                     task_result = task_result.with_error(err_info, err_type)
                     # Reraise the cause, as it's wrapped by the ApplicationError
                     raise cause from e
+                case ApplicationError() as app_err:
+                    err_type = app_err.type or err_type
+                    err_message = app_err.message or root_message
+                    task_result = task_result.with_error(err_message, err_type)
+                    raise app_err from e
                 case _:
-                    self.logger.warning("Unexpected error cause", cause=cause)
-                    task_result = task_result.with_error(e.message, err_type)
+                    resolved_type = root_error.__class__.__name__
+                    self.logger.warning(
+                        "Unexpected error cause",
+                        cause=cause,
+                        root_cause=root_error,
+                        root_message=root_message,
+                    )
+                    task_result = task_result.with_error(root_message, resolved_type)
                     raise ApplicationError(
-                        e.message, non_retryable=True, type=err_type
-                    ) from cause
+                        root_message, non_retryable=True, type=resolved_type
+                    ) from e
 
         except TracecatExpressionError as e:
             err_type = e.__class__.__name__

--- a/tracecat/workflow/executions/common.py
+++ b/tracecat/workflow/executions/common.py
@@ -273,9 +273,12 @@ def build_query(
     workflow_id: WorkflowID | None = None,
     trigger_types: set[TriggerType] | None = None,
     triggered_by_user_id: UserID | None = None,
+    workspace_id: str | None = None,
     _include_legacy: bool = True,
 ) -> str:
     query = []
+    if workspace_id:
+        query.append(f"{TemporalSearchAttr.WORKSPACE_ID.value} = '{workspace_id}'")
     if workflow_id:
         short_id = workflow_id.short()
         wf_id_query = f"WorkflowId STARTS_WITH '{short_id}'"

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -488,7 +488,7 @@ class EventFailure(BaseModel):
             case _:
                 raise ValueError("Event type not supported for failure extraction.")
 
-        cause = MessageToDict(failure.cause) if failure.cause is not None else None
+        cause = MessageToDict(failure.cause) if failure.HasField("cause") else None
         return EventFailure(
             message=failure.message,
             cause=cause,

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -455,6 +455,11 @@ class EventFailure(BaseModel):
         root_message: str | None = None
         current: dict[str, Any] | None = cause
         seen: set[int] = set()
+        # Termination argument:
+        # - Each non-breaking iteration adds a new object id to `seen`.
+        # - If a dict repeats (cycle), we break on the `seen` check.
+        # - If `cause` is missing or not a dict, we break.
+        # Therefore the loop cannot run indefinitely.
         while current is not None:
             current_id = id(current)
             if current_id in seen:

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -444,6 +444,33 @@ class EventGroup[T: EventInput](BaseModel):
 class EventFailure(BaseModel):
     message: str
     cause: dict[str, Any] | None = None
+    root_cause_message: str | None = None
+
+    @staticmethod
+    def extract_root_cause_message(cause: dict[str, Any] | None) -> str | None:
+        """Extract the deepest non-empty message from nested Temporal failure causes."""
+        if not cause:
+            return None
+
+        root_message: str | None = None
+        current: dict[str, Any] | None = cause
+        seen: set[int] = set()
+        while current is not None:
+            current_id = id(current)
+            if current_id in seen:
+                break
+            seen.add(current_id)
+
+            message = current.get("message")
+            if isinstance(message, str) and message.strip():
+                root_message = message
+
+            nested_cause = current.get("cause")
+            if not isinstance(nested_cause, dict):
+                break
+            current = nested_cause
+
+        return root_message
 
     @staticmethod
     def from_history_event(
@@ -461,9 +488,11 @@ class EventFailure(BaseModel):
             case _:
                 raise ValueError("Event type not supported for failure extraction.")
 
+        cause = MessageToDict(failure.cause) if failure.cause is not None else None
         return EventFailure(
             message=failure.message,
-            cause=MessageToDict(failure.cause) if failure.cause is not None else None,
+            cause=cause,
+            root_cause_message=EventFailure.extract_root_cause_message(cause),
         )
 
 

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from sqlalchemy import and_, select
 from sqlalchemy.orm import selectinload
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from tracecat.audit.logger import audit_log
 from tracecat.authz.controls import require_scope
@@ -900,7 +901,9 @@ class WorkflowsManagementService(BaseWorkspaceService):
                     id_or_alias, use_committed=use_committed
                 )
             if not handler_wf_id:
-                raise RuntimeError(
-                    f"Couldn't find matching workflow for alias {id_or_alias!r}"
+                raise ApplicationError(
+                    f"Couldn't find matching workflow for alias {id_or_alias!r}",
+                    non_retryable=True,
+                    type="WorkflowAliasResolutionError",
                 )
         return handler_wf_id


### PR DESCRIPTION
## Summary
- preserve deepest root-cause messages when Temporal wraps failures in `ActivityError` / `ChildWorkflowError` / `FailureError`
- mark error-handler alias resolution misses as non-retryable `ApplicationError` (`WorkflowAliasResolutionError`)
- add `EventFailure.root_cause_message` as an additive API field and regenerate frontend client types
- render root cause first in execution/builder error panels (`root_cause_message ?? message`)
- harden failure payload exposure by sanitizing sensitive substrings in failure messages
- enforce workspace-scoped execution reads/queries and hide raw nested failure `cause` by default

## Screens
### Before

<img width="1278" height="711" alt="Screenshot 2026-02-25 at 15 26 05" src="https://github.com/user-attachments/assets/f534a53a-135c-480e-93b4-cecc7fd1df51" />

### After

<img width="1314" height="776" alt="Screenshot 2026-02-25 at 15 26 50" src="https://github.com/user-attachments/assets/09fa5d39-ab52-486e-8bec-b29820f27ebb" />


## Changes
- backend
  - add `DSLWorkflow._unwrap_temporal_failure_cause` and use it in `_execute_task`
  - preserve structured `ApplicationError(details=...)` handling while avoiding wrapper message masking for all other nested causes
  - keep retry resilience for handler lookup (`activity:fail_slow`) while still failing fast for deterministic alias misses via `non_retryable=True`
  - add `EventFailure.extract_root_cause_message` and populate `root_cause_message` from nested failure `cause`
  - clarify scope: this root-cause traversal runs in `EventFailure.from_history_event` when mapping Temporal history failures for API responses, not inside `DSLWorkflow` runtime task execution
  - sanitize sensitive patterns in `EventFailure.message` and `root_cause_message` (Authorization/Bearer tokens, query-param secrets, URL credentials), and truncate oversized messages
  - default `EventFailure.from_history_event` to `include_raw_cause=False` so raw nested `cause` is not exposed unless explicitly requested
  - enforce workspace visibility in `get_execution` by checking `TracecatWorkspaceId` and denying cross-workspace/missing-attr reads
  - inject workspace filter in execution list queries (`build_query`, `list_executions`, `list_executions_by_workflow_id`)
- tests
  - add unit tests for generic cause unwrapping
  - add unit tests for root cause extraction/cycle handling in `EventFailure`
  - update temporal invalid-handler expectation from `RuntimeError` to `WorkflowAliasResolutionError` and assert no generic wrapper message leakage
  - add unit tests for failure-message sanitization and raw-cause opt-in behavior
  - add unit tests for workspace-scoped execution access and query filtering
- frontend
  - update event error rendering to prefer `root_cause_message`
  - regenerate `frontend/src/client/*.gen.ts`

## Validation
- `uv run ruff check tracecat/dsl/workflow.py tracecat/workflow/executions/schemas.py tracecat/workflow/management/management.py tests/unit/test_workflow_executions.py tests/unit/test_dsl_workflow_error_unwrap.py tests/temporal/test_workflows.py`
- `uv run pyright tracecat/workflow/executions/schemas.py tracecat/workflow/management/management.py tests/unit/test_workflow_executions.py tests/unit/test_dsl_workflow_error_unwrap.py tests/temporal/test_workflows.py`
- `uv run pyright tracecat/dsl/workflow.py` *(fails with pre-existing AgentConfig call-signature issues unrelated to this change)*
- `TRACECAT__SERVICE_KEY=test uv run pytest tests/unit/test_dsl_workflow_error_unwrap.py tests/unit/test_workflow_executions.py -k "root_cause or unwrap_temporal_failure_cause"`
- `TRACECAT__SERVICE_KEY=test uv run pytest tests/temporal/test_workflows.py -k "error_handler_invalid_handler_fail_no_match" -m integration` *(selected tests skipped in this environment)*
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- `uv run ruff check tracecat/workflow/executions/schemas.py tracecat/workflow/executions/common.py tracecat/workflow/executions/service.py tests/unit/test_workflow_executions.py tests/unit/test_workflow_execution_workspace_scoping.py tests/unit/test_search_attributes.py`
- `uv run pyright tracecat/workflow/executions/schemas.py tracecat/workflow/executions/common.py tracecat/workflow/executions/service.py tests/unit/test_workflow_executions.py tests/unit/test_workflow_execution_workspace_scoping.py tests/unit/test_search_attributes.py`
- `uv run pytest tests/unit/test_workflow_executions.py tests/unit/test_workflow_execution_workspace_scoping.py tests/unit/test_search_attributes.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the deepest root-cause message for Temporal failures so users see the real error in the UI and logs. Makes invalid error-handler aliases non-retryable.

- **Bug Fixes**
  - Unwrap nested Temporal failures to surface the deepest cause and type; cycle-safe traversal with fallback to a useful outer message; use in DSL runtime and EventFailure; add EventFailure.root_cause_message and update builder/execution views to prefer it.
  - Treat error-handler alias misses as non-retryable ApplicationError (WorkflowAliasResolutionError); ensure alias details appear and wrapper messages don’t leak; add tests for missing child workflow alias.
  - Sanitize/truncate failure messages and hide raw nested causes by default; enforce workspace-scoped execution access and queries; use protobuf HasField for cause presence; add unit tests and relax time-anchor assertions to avoid flakiness.

<sup>Written for commit 9d78c5dfbb860ce712e201e0ad8c34306b6ccca0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

