### PR TITLE
feat(ui): Drop most recent / least recent pagination filters

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "@t3-oss/env-nextjs": "^0.9.2",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "3.13.12",
     "@tiptap/extension-highlight": "^3.7.1",
     "@tiptap/extension-horizontal-rule": "^3.7.1",
     "@tiptap/extension-image": "^3.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: 3.13.12
+        version: 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tiptap/extension-highlight':
         specifier: ^3.7.1
         version: 3.7.1(@tiptap/core@3.7.1(@tiptap/pm@3.7.1))
@@ -2528,9 +2531,18 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -8179,7 +8191,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -38,6 +38,12 @@ export default function CasesPage() {
     setUpdatedAfter,
     setCreatedAfter,
     totalFilteredCaseEstimate,
+    stageCounts,
+    isCountsLoading,
+    isCountsFetching,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
   } = useCases()
 
   const { members } = useWorkspaceMembers(workspaceId)
@@ -88,6 +94,12 @@ export default function CasesPage() {
         onDropdownModeChange={setDropdownMode}
         onDropdownSortDirectionChange={setDropdownSortDirection}
         totalFilteredCaseEstimate={totalFilteredCaseEstimate}
+        stageCounts={stageCounts}
+        isCountsLoading={isCountsLoading}
+        isCountsFetching={isCountsFetching}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={fetchNextPage}
         refetch={refetch}
       />
     </div>

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -37,13 +37,7 @@ export default function CasesPage() {
     setDropdownSortDirection,
     setUpdatedAfter,
     setCreatedAfter,
-    setUpdatedAtSort,
-    setLimit,
-    goToNextPage,
-    goToPreviousPage,
-    hasNextPage,
-    hasPreviousPage,
-    currentPage,
+    totalFilteredCaseEstimate,
   } = useCases()
 
   const { members } = useWorkspaceMembers(workspaceId)
@@ -87,19 +81,13 @@ export default function CasesPage() {
         onTagSortDirectionChange={setTagSortDirection}
         onUpdatedAfterChange={setUpdatedAfter}
         onCreatedAfterChange={setCreatedAfter}
-        onUpdatedAtSortChange={setUpdatedAtSort}
-        onLimitChange={setLimit}
         dropdownDefinitions={
           caseAddonsEnabled ? dropdownDefinitions : undefined
         }
         onDropdownFilterChange={setDropdownFilter}
         onDropdownModeChange={setDropdownMode}
         onDropdownSortDirectionChange={setDropdownSortDirection}
-        onNextPage={goToNextPage}
-        onPreviousPage={goToPreviousPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
-        currentPage={currentPage}
+        totalFilteredCaseEstimate={totalFilteredCaseEstimate}
         refetch={refetch}
       />
     </div>

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5203,6 +5203,21 @@ export const $CaseReadMinimal = {
   title: "CaseReadMinimal",
 } as const
 
+export const $CaseSearchAggregateRead = {
+  properties: {
+    total: {
+      type: "integer",
+      title: "Total",
+    },
+    status_groups: {
+      $ref: "#/components/schemas/CaseStatusGroupCounts",
+    },
+  },
+  type: "object",
+  required: ["total", "status_groups"],
+  title: "CaseSearchAggregateRead",
+} as const
+
 export const $CaseSeverity = {
   type: "string",
   enum: [
@@ -5242,6 +5257,38 @@ export const $CaseStatus = {
   ],
   title: "CaseStatus",
   description: "Case status values aligned with OCSF Incident Finding status.",
+} as const
+
+export const $CaseStatusGroupCounts = {
+  properties: {
+    new: {
+      type: "integer",
+      title: "New",
+      default: 0,
+    },
+    in_progress: {
+      type: "integer",
+      title: "In Progress",
+      default: 0,
+    },
+    on_hold: {
+      type: "integer",
+      title: "On Hold",
+      default: 0,
+    },
+    resolved: {
+      type: "integer",
+      title: "Resolved",
+      default: 0,
+    },
+    other: {
+      type: "integer",
+      title: "Other",
+      default: 0,
+    },
+  },
+  type: "object",
+  title: "CaseStatusGroupCounts",
 } as const
 
 export const $CaseTagCreate = {
@@ -15334,6 +15381,11 @@ export const $SecretReadMinimal = {
     environment: {
       type: "string",
       title: "Environment",
+    },
+    is_corrupted: {
+      type: "boolean",
+      title: "Is Corrupted",
+      default: false,
     },
   },
   type: "object",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -234,6 +234,8 @@ import type {
   CasesListTasksResponse,
   CasesRemoveTagData,
   CasesRemoveTagResponse,
+  CasesSearchCaseAggregatesData,
+  CasesSearchCaseAggregatesResponse,
   CasesSearchCasesData,
   CasesSearchCasesResponse,
   CasesSetCaseDropdownValueData,
@@ -6550,6 +6552,51 @@ export const casesSearchCases = (
       assignee_id: data.assigneeId,
       order_by: data.orderBy,
       sort: data.sort,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Search Case Aggregates
+ * Return global case totals and per-stage counts for the current filters.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.searchTerm Text to search for in case summary, description, or short ID
+ * @param data.status Filter by case status
+ * @param data.priority Filter by case priority
+ * @param data.severity Filter by case severity
+ * @param data.tags Filter by tag IDs or slugs (AND logic)
+ * @param data.dropdown Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)
+ * @param data.startTime Return cases created at or after this timestamp
+ * @param data.endTime Return cases created at or before this timestamp
+ * @param data.updatedAfter Return cases updated at or after this timestamp
+ * @param data.updatedBefore Return cases updated at or before this timestamp
+ * @param data.assigneeId Filter by assignee ID or 'unassigned'
+ * @returns CaseSearchAggregateRead Successful Response
+ * @throws ApiError
+ */
+export const casesSearchCaseAggregates = (
+  data: CasesSearchCaseAggregatesData
+): CancelablePromise<CasesSearchCaseAggregatesResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/cases/search/aggregate",
+    query: {
+      search_term: data.searchTerm,
+      status: data.status,
+      priority: data.priority,
+      severity: data.severity,
+      tags: data.tags,
+      dropdown: data.dropdown,
+      start_time: data.startTime,
+      end_time: data.endTime,
+      updated_after: data.updatedAfter,
+      updated_before: data.updatedBefore,
+      assignee_id: data.assigneeId,
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1459,6 +1459,11 @@ export type CaseReadMinimal = {
   num_tasks_total?: number
 }
 
+export type CaseSearchAggregateRead = {
+  total: number
+  status_groups: CaseStatusGroupCounts
+}
+
 /**
  * Case severity values aligned with OCSF severity values.
  *
@@ -1493,6 +1498,14 @@ export type CaseStatus =
   | "resolved"
   | "closed"
   | "other"
+
+export type CaseStatusGroupCounts = {
+  new?: number
+  in_progress?: number
+  on_hold?: number
+  resolved?: number
+  other?: number
+}
 
 export type CaseTagCreate = {
   /**
@@ -4834,6 +4847,7 @@ export type SecretReadMinimal = {
   description?: string | null
   keys: Array<string>
   environment: string
+  is_corrupted?: boolean
 }
 
 /**
@@ -8783,6 +8797,56 @@ export type CasesSearchCasesData = {
 }
 
 export type CasesSearchCasesResponse = CursorPaginatedResponse_CaseReadMinimal_
+
+export type CasesSearchCaseAggregatesData = {
+  /**
+   * Filter by assignee ID or 'unassigned'
+   */
+  assigneeId?: Array<string> | null
+  /**
+   * Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)
+   */
+  dropdown?: Array<string> | null
+  /**
+   * Return cases created at or before this timestamp
+   */
+  endTime?: string | null
+  /**
+   * Filter by case priority
+   */
+  priority?: Array<CasePriority> | null
+  /**
+   * Text to search for in case summary, description, or short ID
+   */
+  searchTerm?: string | null
+  /**
+   * Filter by case severity
+   */
+  severity?: Array<CaseSeverity> | null
+  /**
+   * Return cases created at or after this timestamp
+   */
+  startTime?: string | null
+  /**
+   * Filter by case status
+   */
+  status?: Array<CaseStatus> | null
+  /**
+   * Filter by tag IDs or slugs (AND logic)
+   */
+  tags?: Array<string> | null
+  /**
+   * Return cases updated at or after this timestamp
+   */
+  updatedAfter?: string | null
+  /**
+   * Return cases updated at or before this timestamp
+   */
+  updatedBefore?: string | null
+  workspaceId: string
+}
+
+export type CasesSearchCaseAggregatesResponse = CaseSearchAggregateRead
 
 export type CasesGetCaseData = {
   caseId: string
@@ -12812,6 +12876,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: CursorPaginatedResponse_CaseReadMinimal_
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/cases/search/aggregate": {
+    get: {
+      req: CasesSearchCaseAggregatesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CaseSearchAggregateRead
         /**
          * Validation Error
          */

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -239,6 +239,40 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
     }
   }
 
+  const panelFieldRowClassName =
+    "group -mx-2 flex h-7 w-full cursor-pointer items-center gap-2 rounded-sm px-2 transition-colors hover:bg-muted/70 focus-within:bg-muted/70"
+  const panelFieldRowInteractiveSelector =
+    "input:not([type='hidden']):not([disabled]), textarea:not([disabled]), [role='combobox']:not([aria-disabled='true']), button:not([disabled])"
+  const panelFieldRowTargetSelector =
+    "button:not([disabled]), input:not([type='hidden']):not([disabled]), textarea:not([disabled]), [role='combobox']:not([aria-disabled='true']), a[href]"
+  const handlePanelFieldRowClick = (
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    const target = event.target as HTMLElement | null
+    if (target?.closest(panelFieldRowTargetSelector)) {
+      return
+    }
+
+    const controlContainer = event.currentTarget.querySelector<HTMLElement>(
+      ".tc-panel-row-control"
+    )
+    const control = controlContainer?.querySelector<HTMLElement>(
+      panelFieldRowInteractiveSelector
+    )
+    if (!control) return
+
+    if (
+      control instanceof HTMLInputElement ||
+      control instanceof HTMLTextAreaElement
+    ) {
+      control.focus()
+      return
+    }
+
+    control.click()
+    control.focus()
+  }
+
   return (
     <>
       <CaseWorkflowTrigger caseData={caseData} />
@@ -396,59 +430,71 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
               <SidebarGroupLabel>Properties</SidebarGroupLabel>
               <SidebarGroupContent className="px-2">
                 <div className="space-y-2">
-                  <div className="flex h-7 w-full items-center gap-2">
+                  <div
+                    className={panelFieldRowClassName}
+                    onClick={handlePanelFieldRowClick}
+                  >
                     <span className="text-sm text-muted-foreground">
                       Status
                     </span>
-                    <div className="ml-auto min-w-0 flex-1">
+                    <div className="ml-auto min-w-0 flex-1 tc-panel-row-control">
                       <StatusSelect
                         status={caseData.status}
                         onValueChange={handleStatusChange}
                         showLabel={false}
-                        triggerClassName="h-7 w-full justify-end px-2 text-sm [&>span]:w-full"
+                        triggerClassName="h-7 w-full justify-end border-none px-2 text-sm hover:bg-transparent focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:border-none data-[state=open]:ring-0 [&>span]:w-full"
                         valueClassName="text-sm"
                       />
                     </div>
                   </div>
-                  <div className="flex h-7 w-full items-center gap-2">
+                  <div
+                    className={panelFieldRowClassName}
+                    onClick={handlePanelFieldRowClick}
+                  >
                     <span className="text-sm text-muted-foreground">
                       Priority
                     </span>
-                    <div className="ml-auto min-w-0 flex-1">
+                    <div className="ml-auto min-w-0 flex-1 tc-panel-row-control">
                       <PrioritySelect
                         priority={caseData.priority || "unknown"}
                         onValueChange={handlePriorityChange}
                         showLabel={false}
-                        triggerClassName="h-7 w-full justify-end px-2 text-sm [&>span]:w-full"
+                        triggerClassName="h-7 w-full justify-end border-none px-2 text-sm hover:bg-transparent focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:border-none data-[state=open]:ring-0 [&>span]:w-full"
                         valueClassName="text-sm"
                       />
                     </div>
                   </div>
-                  <div className="flex h-7 w-full items-center gap-2">
+                  <div
+                    className={panelFieldRowClassName}
+                    onClick={handlePanelFieldRowClick}
+                  >
                     <span className="text-sm text-muted-foreground">
                       Severity
                     </span>
-                    <div className="ml-auto min-w-0 flex-1">
+                    <div className="ml-auto min-w-0 flex-1 tc-panel-row-control">
                       <SeveritySelect
                         severity={caseData.severity || "unknown"}
                         onValueChange={handleSeverityChange}
                         showLabel={false}
-                        triggerClassName="h-7 w-full justify-end px-2 text-sm [&>span]:w-full"
+                        triggerClassName="h-7 w-full justify-end border-none px-2 text-sm hover:bg-transparent focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:border-none data-[state=open]:ring-0 [&>span]:w-full"
                         valueClassName="text-sm"
                       />
                     </div>
                   </div>
-                  <div className="flex h-7 w-full items-center gap-2">
+                  <div
+                    className={panelFieldRowClassName}
+                    onClick={handlePanelFieldRowClick}
+                  >
                     <span className="text-sm text-muted-foreground">
                       Assignee
                     </span>
-                    <div className="ml-auto min-w-0 flex-1">
+                    <div className="ml-auto min-w-0 flex-1 tc-panel-row-control">
                       <AssigneeSelect
                         assignee={caseData.assignee}
                         workspaceMembers={members ?? []}
                         onValueChange={handleAssigneeChange}
                         showLabel={false}
-                        triggerClassName="h-7 w-full justify-end px-2 text-sm [&>span]:w-full"
+                        triggerClassName="h-7 w-full justify-end border-none px-2 text-sm hover:bg-transparent focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:border-none data-[state=open]:ring-0 [&>span]:w-full"
                         valueClassName="text-sm"
                       />
                     </div>
@@ -462,7 +508,8 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                         return (
                           <div
                             key={def.id}
-                            className="flex h-7 w-full items-center gap-2"
+                            className={panelFieldRowClassName}
+                            onClick={handlePanelFieldRowClick}
                           >
                             <span
                               className="truncate text-sm text-muted-foreground"
@@ -470,7 +517,7 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                             >
                               {def.name}
                             </span>
-                            <div className="ml-auto min-w-0 flex-1">
+                            <div className="ml-auto min-w-0 flex-1 tc-panel-row-control">
                               <CaseDropdownSelect
                                 definition={def}
                                 currentValue={currentValue}
@@ -482,7 +529,7 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                                   })
                                 }
                                 showLabel={false}
-                                triggerClassName="h-7 w-full justify-end px-2 text-sm [&>span]:w-full"
+                                triggerClassName="h-7 w-full justify-end border-none px-2 text-sm hover:bg-transparent focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:border-none data-[state=open]:ring-0 [&>span]:w-full"
                                 valueClassName="text-sm"
                               />
                             </div>
@@ -503,7 +550,8 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                       return (
                         <div
                           key={field.id}
-                          className="flex h-7 w-full items-center gap-2"
+                          className={panelFieldRowClassName}
+                          onClick={handlePanelFieldRowClick}
                         >
                           {showAllCustomFields && (
                             <Button
@@ -525,14 +573,14 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                           >
                             {label}
                           </span>
-                          <div className="ml-auto min-w-0 flex-1">
+                          <div className="ml-auto min-w-0 flex-1 tc-panel-row-control">
                             <div className="flex h-7 w-full items-center gap-2">
                               <div className="min-w-0 flex-1">
                                 <CustomField
                                   customField={field}
                                   updateCase={updateCase}
                                   formClassName="w-full"
-                                  inputClassName="w-full min-w-0 text-sm"
+                                  inputClassName="w-full min-w-0 border-none text-sm hover:bg-transparent focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
                                 />
                               </div>
                             </div>

--- a/frontend/src/components/cases/cases-accordion.tsx
+++ b/frontend/src/components/cases/cases-accordion.tsx
@@ -1,33 +1,35 @@
 "use client"
 
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { useVirtualizer } from "@tanstack/react-virtual"
 import {
   CheckCircleIcon,
   ChevronRightIcon,
   CircleIcon,
   CirclePauseIcon,
   FlagTriangleRightIcon,
+  Loader2Icon,
   TrafficConeIcon,
 } from "lucide-react"
-import { useMemo } from "react"
+import type { ComponentType } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import type {
   CaseDropdownDefinitionRead,
   CaseReadMinimal,
+  CaseSearchAggregateRead,
   CaseStatus,
   CaseTagRead,
   WorkspaceMember,
 } from "@/client"
 import { CaseItem } from "@/components/cases/case-item"
 import type { FilterMode, SortDirection } from "@/components/cases/cases-header"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
 
-// Define the status groups we want to display
 type StatusGroup = "new" | "in_progress" | "on_hold" | "resolved" | "other"
 
 interface StatusGroupConfig {
   label: string
-  icon: React.ComponentType<{ className?: string }>
+  icon: ComponentType<{ className?: string }>
   statuses: CaseStatus[]
   iconColor: string
 }
@@ -65,7 +67,6 @@ const STATUS_GROUPS: Record<StatusGroup, StatusGroupConfig> = {
   },
 }
 
-// Order in which groups should appear
 const GROUP_ORDER: StatusGroup[] = [
   "new",
   "in_progress",
@@ -84,7 +85,6 @@ interface CasesAccordionProps {
   tags?: CaseTagRead[]
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
-  /** When any sort direction is active, preserve the order from the hook */
   prioritySortDirection?: SortDirection
   severitySortDirection?: SortDirection
   assigneeSortDirection?: SortDirection
@@ -92,6 +92,86 @@ interface CasesAccordionProps {
   statusFilter?: CaseStatus[]
   statusMode?: FilterMode
   totalFilteredCaseEstimate?: number | null
+  stageCounts?: CaseSearchAggregateRead["status_groups"] | null
+  isCountsLoading?: boolean
+  isCountsFetching?: boolean
+  hasNextPage?: boolean
+  isFetchingNextPage?: boolean
+  onLoadMore?: () => void
+}
+
+interface VirtualizedGroupRowsProps {
+  groupCases: CaseReadMinimal[]
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
+  selectedId: string | null
+  selectedCaseIds: Set<string>
+  onSelect: (id: string) => void
+  onCheckChange: (id: string, checked: boolean) => void
+  onDeleteRequest?: (caseData: CaseReadMinimal) => void
+  tags?: CaseTagRead[]
+  members?: WorkspaceMember[]
+  dropdownDefinitions?: CaseDropdownDefinitionRead[]
+}
+
+function VirtualizedGroupRows({
+  groupCases,
+  scrollContainerRef,
+  selectedId,
+  selectedCaseIds,
+  onSelect,
+  onCheckChange,
+  onDeleteRequest,
+  tags,
+  members,
+  dropdownDefinitions,
+}: VirtualizedGroupRowsProps) {
+  const rowVirtualizer = useVirtualizer({
+    count: groupCases.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => 44,
+    overscan: 8,
+    getItemKey: (index) => groupCases[index]?.id ?? index,
+  })
+
+  if (groupCases.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className="relative w-full"
+      style={{
+        height: `${rowVirtualizer.getTotalSize()}px`,
+      }}
+    >
+      {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+        const caseData = groupCases[virtualItem.index]
+        if (!caseData) {
+          return null
+        }
+
+        return (
+          <div
+            key={virtualItem.key}
+            className="absolute left-0 top-0 w-full"
+            style={{ transform: `translateY(${virtualItem.start}px)` }}
+          >
+            <CaseItem
+              caseData={caseData}
+              isSelected={selectedId === caseData.id}
+              isChecked={selectedCaseIds.has(caseData.id)}
+              onCheckChange={(checked) => onCheckChange(caseData.id, checked)}
+              onClick={() => onSelect(caseData.id)}
+              onDeleteRequest={onDeleteRequest}
+              tags={tags}
+              members={members}
+              dropdownDefinitions={dropdownDefinitions}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
 }
 
 export function CasesAccordion({
@@ -111,15 +191,19 @@ export function CasesAccordion({
   statusFilter = [],
   statusMode = "include",
   totalFilteredCaseEstimate = null,
+  stageCounts = null,
+  isCountsLoading = false,
+  isCountsFetching = false,
+  hasNextPage = false,
+  isFetchingNextPage = false,
+  onLoadMore,
 }: CasesAccordionProps) {
-  // Check if any explicit sort is active (from the header)
   const hasExplicitSort =
     prioritySortDirection ||
     severitySortDirection ||
     assigneeSortDirection ||
     tagSortDirection
 
-  // Group cases by status category
   const groupedCases = useMemo(() => {
     const groups: Record<StatusGroup, CaseReadMinimal[]> = {
       new: [],
@@ -138,14 +222,11 @@ export function CasesAccordion({
           break
         }
       }
-      // If no match, put in "other"
       if (!matched) {
         groups.other.push(caseData)
       }
     }
 
-    // Only apply default updated_at sorting when no explicit sort is active
-    // When explicit sorting is applied, preserve the order from the hook
     if (!hasExplicitSort) {
       for (const groupKey of Object.keys(groups) as StatusGroup[]) {
         groups[groupKey].sort(
@@ -158,7 +239,6 @@ export function CasesAccordion({
     return groups
   }, [cases, hasExplicitSort])
 
-  // Calculate which groups have items and should be expanded by default
   const defaultExpandedGroups = useMemo(() => {
     return GROUP_ORDER.filter((group) => groupedCases[group].length > 0)
   }, [groupedCases])
@@ -177,8 +257,39 @@ export function CasesAccordion({
     return matchingGroups.length === 1 ? matchingGroups[0] : null
   }, [statusFilter, statusMode])
 
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!hasNextPage || !onLoadMore) {
+      return
+    }
+
+    const root = scrollContainerRef.current
+    const target = loadMoreRef.current
+    if (!root || !target) {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const isVisible = entries.some((entry) => entry.isIntersecting)
+        if (isVisible && !isFetchingNextPage) {
+          onLoadMore()
+        }
+      },
+      {
+        root,
+        rootMargin: "300px 0px",
+      }
+    )
+
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, onLoadMore])
+
   return (
-    <ScrollArea className="h-full">
+    <div ref={scrollContainerRef} className="h-full overflow-auto">
       <AccordionPrimitive.Root
         type="multiple"
         defaultValue={defaultExpandedGroups}
@@ -188,11 +299,14 @@ export function CasesAccordion({
           const config = STATUS_GROUPS[groupKey]
           const groupCases = groupedCases[groupKey]
           const StatusIcon = config.icon
+          const hasGlobalCount = typeof stageCounts?.[groupKey] === "number"
           const groupCount =
             singleFilteredGroup === groupKey &&
             typeof totalFilteredCaseEstimate === "number"
               ? totalFilteredCaseEstimate
-              : groupCases.length
+              : hasGlobalCount
+                ? stageCounts[groupKey]
+                : groupCases.length
 
           return (
             <AccordionPrimitive.Item
@@ -204,11 +318,9 @@ export function CasesAccordion({
               <AccordionPrimitive.Header className="flex">
                 <AccordionPrimitive.Trigger
                   className={cn(
-                    // Use pl-[10px] to compensate for border-l-2 (2px) so total left offset matches px-3 (12px)
                     "flex w-full items-center gap-1 border-l-2 border-l-transparent py-1.5 pl-[10px] pr-3 text-left transition-colors",
                     "hover:bg-muted/50",
                     "[&[data-state=open]_.chevron]:rotate-90",
-                    // Tint backgrounds when open
                     "data-[state=open]:border-l-current",
                     groupKey === "new" &&
                       "data-[state=open]:border-l-yellow-600 data-[state=open]:bg-yellow-600/[0.03] dark:data-[state=open]:bg-yellow-600/[0.08]",
@@ -222,7 +334,6 @@ export function CasesAccordion({
                       "data-[state=open]:border-l-muted-foreground data-[state=open]:bg-muted/50"
                   )}
                 >
-                  {/* Match SidebarTrigger dimensions (h-7 w-7) for alignment */}
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center">
                     <ChevronRightIcon className="chevron size-4 text-muted-foreground transition-transform duration-200" />
                   </div>
@@ -234,33 +345,41 @@ export function CasesAccordion({
                     <span className="text-xs text-muted-foreground">
                       {groupCount}
                     </span>
+                    {(isCountsLoading || isCountsFetching) && (
+                      <Loader2Icon className="size-3 animate-spin text-muted-foreground" />
+                    )}
                   </div>
                 </AccordionPrimitive.Trigger>
               </AccordionPrimitive.Header>
               <AccordionPrimitive.Content className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
                 <div className="ml-[18px]">
-                  {groupCases.map((caseData) => (
-                    <CaseItem
-                      key={caseData.id}
-                      caseData={caseData}
-                      isSelected={selectedId === caseData.id}
-                      isChecked={selectedCaseIds.has(caseData.id)}
-                      onCheckChange={(checked) =>
-                        onCheckChange(caseData.id, checked)
-                      }
-                      onClick={() => onSelect(caseData.id)}
-                      onDeleteRequest={onDeleteRequest}
-                      tags={tags}
-                      members={members}
-                      dropdownDefinitions={dropdownDefinitions}
-                    />
-                  ))}
+                  <VirtualizedGroupRows
+                    groupCases={groupCases}
+                    scrollContainerRef={scrollContainerRef}
+                    selectedId={selectedId}
+                    selectedCaseIds={selectedCaseIds}
+                    onSelect={onSelect}
+                    onCheckChange={onCheckChange}
+                    onDeleteRequest={onDeleteRequest}
+                    tags={tags}
+                    members={members}
+                    dropdownDefinitions={dropdownDefinitions}
+                  />
                 </div>
               </AccordionPrimitive.Content>
             </AccordionPrimitive.Item>
           )
         })}
       </AccordionPrimitive.Root>
-    </ScrollArea>
+
+      {(hasNextPage || isFetchingNextPage) && (
+        <div
+          ref={loadMoreRef}
+          className="flex h-10 items-center justify-center text-xs text-muted-foreground"
+        >
+          {isFetchingNextPage ? "Loading more cases..." : "Scroll to load more"}
+        </div>
+      )}
+    </div>
   )
 }

--- a/frontend/src/components/cases/cases-header.tsx
+++ b/frontend/src/components/cases/cases-header.tsx
@@ -296,6 +296,7 @@ interface FilterMultiSelectProps<T extends string> {
   sortDirection?: SortDirection
   /** Callback when sort direction changes */
   onSortDirectionChange?: (direction: SortDirection) => void
+  allowExclude?: boolean
 }
 
 function FilterMultiSelect<T extends string>({
@@ -312,6 +313,7 @@ function FilterMultiSelect<T extends string>({
   showSort = false,
   sortDirection = null,
   onSortDirectionChange,
+  allowExclude = true,
 }: FilterMultiSelectProps<T>) {
   const [open, setOpen] = useState(false)
   const valueSet = useMemo(() => new Set(value), [value])
@@ -367,7 +369,10 @@ function FilterMultiSelect<T extends string>({
             {mode === "exclude" ? "Excluding" : "Including"}
           </span>
           <div className="flex items-center gap-0.5">
-            {(["include", "exclude"] as FilterMode[]).map((option) => (
+            {(allowExclude
+              ? (["include", "exclude"] as FilterMode[])
+              : (["include"] as FilterMode[])
+            ).map((option) => (
               <button
                 key={option}
                 type="button"
@@ -539,6 +544,7 @@ interface CasesHeaderProps {
   onDropdownSortDirectionChange: (ref: string, direction: SortDirection) => void
   // Selection props
   totalCaseCount?: number
+  displayCaseCount?: number | null
   selectedCount?: number
   onSelectAll?: () => void
   onDeselectAll?: () => void
@@ -587,6 +593,7 @@ export function CasesHeader({
   onDropdownModeChange,
   onDropdownSortDirectionChange,
   totalCaseCount = 0,
+  displayCaseCount = null,
   selectedCount = 0,
   onSelectAll,
   onDeselectAll,
@@ -740,10 +747,10 @@ export function CasesHeader({
           />
         </div>
 
-        {totalCaseCount > 0 && (
+        {(displayCaseCount ?? totalCaseCount) > 0 && (
           <div className="ml-auto flex items-center gap-2">
             <span className="text-xs text-muted-foreground">
-              {totalCaseCount} cases
+              {displayCaseCount ?? totalCaseCount} cases
             </span>
           </div>
         )}
@@ -825,6 +832,7 @@ export function CasesHeader({
           options={assigneeOptions}
           mode={assigneeMode}
           onModeChange={onAssigneeModeChange}
+          allowExclude={false}
           showSort
           sortDirection={assigneeSortDirection}
           onSortDirectionChange={onAssigneeSortDirectionChange}
@@ -843,6 +851,7 @@ export function CasesHeader({
           options={tagOptions}
           mode={tagMode}
           onModeChange={onTagModeChange}
+          allowExclude={false}
           showSort
           sortDirection={tagSortDirection}
           onSortDirectionChange={onTagSortDirectionChange}
@@ -911,6 +920,7 @@ export function CasesHeader({
               options={options}
               mode={state.mode}
               onModeChange={(mode) => onDropdownModeChange(def.ref, mode)}
+              allowExclude={false}
               showSort={def.is_ordered}
               sortDirection={state.sortDirection}
               onSortDirectionChange={(dir) =>

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -23,11 +23,7 @@ import {
 import { DeleteCaseAlertDialog } from "@/components/cases/delete-case-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useToast } from "@/components/ui/use-toast"
-import type {
-  CaseDateFilterValue,
-  CasesRecencySort,
-  UseCasesFilters,
-} from "@/hooks/use-cases"
+import type { CaseDateFilterValue, UseCasesFilters } from "@/hooks/use-cases"
 import { useDeleteCase } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -55,17 +51,11 @@ interface CasesLayoutProps {
   onTagSortDirectionChange: (direction: SortDirection) => void
   onUpdatedAfterChange: (value: CaseDateFilterValue) => void
   onCreatedAfterChange: (value: CaseDateFilterValue) => void
-  onUpdatedAtSortChange: (value: CasesRecencySort) => void
-  onLimitChange: (limit: number) => void
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
   onDropdownFilterChange: (ref: string, values: string[]) => void
   onDropdownModeChange: (ref: string, mode: FilterMode) => void
   onDropdownSortDirectionChange: (ref: string, direction: SortDirection) => void
-  onNextPage: () => void
-  onPreviousPage: () => void
-  hasNextPage: boolean
-  hasPreviousPage: boolean
-  currentPage: number
+  totalFilteredCaseEstimate: number | null
   refetch?: () => void
 }
 
@@ -93,17 +83,11 @@ export function CasesLayout({
   onTagSortDirectionChange,
   onUpdatedAfterChange,
   onCreatedAfterChange,
-  onUpdatedAtSortChange,
-  onLimitChange,
   dropdownDefinitions,
   onDropdownFilterChange,
   onDropdownModeChange,
   onDropdownSortDirectionChange,
-  onNextPage,
-  onPreviousPage,
-  hasNextPage,
-  hasPreviousPage,
-  currentPage,
+  totalFilteredCaseEstimate,
   refetch,
 }: CasesLayoutProps) {
   const workspaceId = useWorkspaceId()
@@ -295,10 +279,6 @@ export function CasesLayout({
     onUpdatedAfterChange,
     createdAfter: filters.createdAfter,
     onCreatedAfterChange,
-    updatedAtSort: filters.updatedAtSort,
-    onUpdatedAtSortChange,
-    limit: filters.limit,
-    onLimitChange,
     members,
     tags,
     dropdownDefinitions,
@@ -310,11 +290,6 @@ export function CasesLayout({
     selectedCount: selectedCaseIds.size,
     onSelectAll: handleSelectAll,
     onDeselectAll: handleDeselectAll,
-    onNextPage,
-    onPreviousPage,
-    hasNextPage,
-    hasPreviousPage,
-    currentPage,
   }
 
   if (isLoading) {
@@ -373,7 +348,9 @@ export function CasesLayout({
             severitySortDirection={filters.severitySortDirection}
             assigneeSortDirection={filters.assigneeSortDirection}
             tagSortDirection={filters.tagSortDirection}
-            updatedAtSort={filters.updatedAtSort}
+            statusFilter={filters.statusFilter}
+            statusMode={filters.statusMode}
+            totalFilteredCaseEstimate={totalFilteredCaseEstimate}
           />
         </div>
       </div>

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -6,6 +6,7 @@ import {
   type CaseDropdownDefinitionRead,
   type CasePriority,
   type CaseReadMinimal,
+  type CaseSearchAggregateRead,
   type CaseSeverity,
   type CaseStatus,
   type CaseTagRead,
@@ -56,6 +57,12 @@ interface CasesLayoutProps {
   onDropdownModeChange: (ref: string, mode: FilterMode) => void
   onDropdownSortDirectionChange: (ref: string, direction: SortDirection) => void
   totalFilteredCaseEstimate: number | null
+  stageCounts: CaseSearchAggregateRead["status_groups"] | null
+  isCountsLoading: boolean
+  isCountsFetching: boolean
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  onLoadMore: () => void
   refetch?: () => void
 }
 
@@ -88,6 +95,12 @@ export function CasesLayout({
   onDropdownModeChange,
   onDropdownSortDirectionChange,
   totalFilteredCaseEstimate,
+  stageCounts,
+  isCountsLoading,
+  isCountsFetching,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
   refetch,
 }: CasesLayoutProps) {
   const workspaceId = useWorkspaceId()
@@ -287,6 +300,7 @@ export function CasesLayout({
     onDropdownModeChange,
     onDropdownSortDirectionChange,
     totalCaseCount: cases.length,
+    displayCaseCount: totalFilteredCaseEstimate,
     selectedCount: selectedCaseIds.size,
     onSelectAll: handleSelectAll,
     onDeselectAll: handleDeselectAll,
@@ -351,6 +365,12 @@ export function CasesLayout({
             statusFilter={filters.statusFilter}
             statusMode={filters.statusMode}
             totalFilteredCaseEstimate={totalFilteredCaseEstimate}
+            stageCounts={stageCounts}
+            isCountsLoading={isCountsLoading}
+            isCountsFetching={isCountsFetching}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            onLoadMore={onLoadMore}
           />
         </div>
       </div>

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -367,8 +367,12 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
   }, [prioritySortDirection, severitySortDirection])
 
   const filtersKey = useMemo(
-    () => JSON.stringify(apiQueryParams),
-    [apiQueryParams]
+    () =>
+      JSON.stringify({
+        apiQueryParams,
+        hasImpossibleEnumFilter,
+      }),
+    [apiQueryParams, hasImpossibleEnumFilter]
   )
 
   const rowsKey = useMemo(
@@ -490,6 +494,8 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     return flattenedCases
   }, [flattenedCases, assigneeSortDirection, tagSortDirection])
 
+  const cases = hasImpossibleEnumFilter ? [] : sortedCases
+
   const totalFilteredCaseEstimate = hasImpossibleEnumFilter
     ? 0
     : (aggregateData?.total ?? rowsData?.pages[0]?.total_estimate ?? null)
@@ -507,7 +513,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
   }, [fetchNextPage, hasNextPage, isFetchingNextPage])
 
   return {
-    cases: sortedCases,
+    cases,
     isLoading,
     error: error ?? null,
     refetch,
@@ -558,7 +564,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     isCountsLoading: hasImpossibleEnumFilter ? false : isCountsLoading,
     isCountsFetching: hasImpossibleEnumFilter ? false : isCountsFetching,
     hasNextPage: hasImpossibleEnumFilter ? false : Boolean(hasNextPage),
-    isFetchingNextPage,
+    isFetchingNextPage: hasImpossibleEnumFilter ? false : isFetchingNextPage,
     fetchNextPage: handleFetchNextPage,
   }
 }

--- a/frontend/tests/use-cases.test.tsx
+++ b/frontend/tests/use-cases.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import type {
+  CaseReadMinimal,
+  CasesSearchCaseAggregatesResponse,
+  CasesSearchCasesResponse,
+} from "@/client"
+import { casesSearchCaseAggregates, casesSearchCases } from "@/client"
+import { useCases } from "@/hooks/use-cases"
+
+jest.mock("@/providers/workspace-id", () => ({
+  useWorkspaceId: () => "workspace-1",
+}))
+
+jest.mock("@/client", () => ({
+  casesSearchCases: jest.fn(),
+  casesSearchCaseAggregates: jest.fn(),
+}))
+
+const mockSearchCases = casesSearchCases as jest.MockedFunction<
+  typeof casesSearchCases
+>
+const mockSearchCaseAggregates =
+  casesSearchCaseAggregates as jest.MockedFunction<
+    typeof casesSearchCaseAggregates
+  >
+
+function createCase(index: number): CaseReadMinimal {
+  const id = `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`
+  return {
+    id,
+    short_id: `CASE-${String(index).padStart(4, "0")}`,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    summary: `Case ${index}`,
+    status: "new",
+    priority: "medium",
+    severity: "low",
+    assignee: null,
+    tags: [],
+    dropdown_values: [],
+    num_tasks_completed: 0,
+    num_tasks_total: 0,
+  }
+}
+
+function HookProbe() {
+  const { cases, totalFilteredCaseEstimate, stageCounts } = useCases({
+    autoRefresh: false,
+  })
+
+  return (
+    <div>
+      <span data-testid="rows">{cases.length}</span>
+      <span data-testid="total">{totalFilteredCaseEstimate ?? -1}</span>
+      <span data-testid="new-count">{stageCounts?.new ?? -1}</span>
+    </div>
+  )
+}
+
+describe("useCases", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("uses paginated rows and separate global counts", async () => {
+    const firstPage: CasesSearchCasesResponse = {
+      items: Array.from({ length: 100 }, (_, index) => createCase(index + 1)),
+      next_cursor: "cursor-page-2",
+      prev_cursor: null,
+      has_more: true,
+      has_previous: false,
+      total_estimate: 1000,
+    }
+
+    const aggregate: CasesSearchCaseAggregatesResponse = {
+      total: 1000,
+      status_groups: {
+        new: 700,
+        in_progress: 200,
+        on_hold: 50,
+        resolved: 40,
+        other: 10,
+      },
+    }
+
+    mockSearchCases.mockResolvedValue(firstPage)
+    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookProbe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rows")).toHaveTextContent("100")
+    })
+
+    expect(screen.getByTestId("total")).toHaveTextContent("1000")
+    expect(screen.getByTestId("new-count")).toHaveTextContent("700")
+
+    // Ensure the hook does not walk every cursor page by default.
+    expect(mockSearchCases).toHaveBeenCalledTimes(1)
+    expect(mockSearchCases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        limit: 100,
+      })
+    )
+
+    expect(mockSearchCaseAggregates).toHaveBeenCalledTimes(1)
+    expect(mockSearchCaseAggregates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+      })
+    )
+  })
+})

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -590,7 +590,9 @@ class TestWorkflowSyncService:
             create_pr=False,
             branch="feature/new-workflow",
         )
-        git_url = GitUrl(host="github.com", org="test-org", repo="test-repo", ref="release")
+        git_url = GitUrl(
+            host="github.com", org="test-org", repo="test-repo", ref="release"
+        )
 
         mock_repo = Mock()
         release_branch = Mock()

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -47,6 +47,19 @@ class CaseReadMinimal(Schema):
     num_tasks_total: int = Field(default=0)
 
 
+class CaseStatusGroupCounts(Schema):
+    new: int = 0
+    in_progress: int = 0
+    on_hold: int = 0
+    resolved: int = 0
+    other: int = 0
+
+
+class CaseSearchAggregateRead(Schema):
+    total: int
+    status_groups: CaseStatusGroupCounts
+
+
 class CaseRead(Schema):
     id: uuid.UUID
     short_id: str


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the _exclude filter from case search and added a fast aggregates endpoint. The cases list now uses infinite scroll with virtualized rows, shows live per-status counts, improves case panel interactions, and fixes stale results when enum filters change.

- **New Features**
  - API: GET /cases/search/aggregate returns total and status_groups for the current filters.
  - Frontend: infinite scroll with @tanstack/react-virtual and IntersectionObserver. Header shows total estimate; per-stage counts include loading state and auto-refresh every 2 minutes.
  - UX: Case panel property rows are clickable to focus/trigger controls. Assignee, tags, and dropdown filters are include-only. Created-after defaults to 1 month.

- **Migration**
  - Stop sending _exclude to /cases/search. Use include-only filters.
  - For totals and status counts, call GET /cases/search/aggregate with the same filters.
  - No other breaking changes to /cases/search; existing cursor and filters continue to work.

<sup>Written for commit f2a33b7b18698571e905cba7bd59edec94d0ebec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

