### PR TITLE
fix(ui): Increase case comment length limit

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3592,7 +3592,7 @@ export const $CaseCommentCreate = {
   properties: {
     content: {
       type: "string",
-      maxLength: 5000,
+      maxLength: 25000,
       minLength: 1,
       title: "Content",
     },
@@ -3681,7 +3681,7 @@ export const $CaseCommentUpdate = {
       anyOf: [
         {
           type: "string",
-          maxLength: 5000,
+          maxLength: 25000,
           minLength: 1,
         },
         {

--- a/frontend/src/components/cases/case-comments-section.tsx
+++ b/frontend/src/components/cases/case-comments-section.tsx
@@ -173,7 +173,7 @@ const commentFormSchema = z.object({
   content: z
     .string()
     .min(1, { message: "Comment cannot be empty" })
-    .max(5000, { message: "Comment cannot be longer than 5000 characters" }),
+    .max(25000, { message: "Comment cannot be longer than 25000 characters" }),
 })
 type CommentFormSchema = z.infer<typeof commentFormSchema>
 

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -160,12 +160,12 @@ class CaseCommentRead(Schema):
 
 
 class CaseCommentCreate(Schema):
-    content: str = Field(..., min_length=1, max_length=5_000)
+    content: str = Field(..., min_length=1, max_length=25_000)
     parent_id: uuid.UUID | None = Field(default=None)
 
 
 class CaseCommentUpdate(Schema):
-    content: str | None = Field(default=None, min_length=1, max_length=5_000)
+    content: str | None = Field(default=None, min_length=1, max_length=25_000)
     parent_id: uuid.UUID | None = Field(default=None)
 
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2065,7 +2065,7 @@ class CaseComment(WorkspaceModel):
         unique=True,
         index=True,
     )
-    content: Mapped[str] = mapped_column(String(5000), nullable=False)
+    content: Mapped[str] = mapped_column(String(25000), nullable=False)
     user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID,
         nullable=True,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the case comment limit from 5,000 to 25,000 characters across the app to support longer notes without validation errors. Updated frontend form validation, generated client schemas, API schemas, and the DB model to match the new limit.

<sup>Written for commit 4e84230f2cddd3e50ba880eba76fcc32988e2bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

