### PR TITLE
feat(api): Add dropdown support to case CRUD endpoints

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -85,6 +85,13 @@ async def create_case(
         dict[str, Any] | None,
         Doc("Payload for the case."),
     ] = None,
+    dropdown_values: Annotated[
+        list[types.CaseDropdownValueInput] | None,
+        Doc(
+            "Dropdown selections to set on the case. "
+            "Each item must include either definition_id or definition_ref, and either option_id or option_ref (or null to clear)."
+        ),
+    ] = None,
     tags: Annotated[
         list[str] | None,
         Doc("List of tag identifiers (IDs or refs) to add to the case."),
@@ -105,6 +112,8 @@ async def create_case(
         params["fields"] = fields
     if payload is not None:
         params["payload"] = payload
+    if dropdown_values is not None:
+        params["dropdown_values"] = dropdown_values
     if tags is not None:
         params["tags"] = tags
     return await get_context().cases.create_case_simple(**params)
@@ -149,6 +158,13 @@ async def update_case(
         dict[str, Any] | None,
         Doc("Updated payload for the case."),
     ] = None,
+    dropdown_values: Annotated[
+        list[types.CaseDropdownValueInput] | None,
+        Doc(
+            "Dropdown selections to set or clear. "
+            "Each item must include either definition_id or definition_ref, and either option_id or option_ref (or null to clear)."
+        ),
+    ] = None,
     tags: Annotated[
         list[str] | None,
         Doc(
@@ -180,6 +196,8 @@ async def update_case(
         client_params["fields"] = fields
     if payload is not None:
         client_params["payload"] = payload
+    if dropdown_values is not None:
+        client_params["dropdown_values"] = dropdown_values
     if tags is not None:
         client_params["tags"] = tags
     if append and description is not None:

--- a/packages/tracecat-registry/tracecat_registry/sdk/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/cases.py
@@ -40,6 +40,7 @@ class CasesClient:
         payload: dict[str, Any] | None | Unset = UNSET,
         tags: list[str] | None | Unset = UNSET,
         fields: dict[str, Any] | None | Unset = UNSET,
+        dropdown_values: list[types.CaseDropdownValueInput] | None | Unset = UNSET,
     ) -> types.CaseRead:
         """Create a new case.
 
@@ -53,6 +54,7 @@ class CasesClient:
             payload: Additional JSON payload.
             tags: List of tag names or IDs to attach.
             fields: Custom field values.
+            dropdown_values: Dropdown selections to set on the case.
 
         Returns:
             Created case data.
@@ -72,6 +74,8 @@ class CasesClient:
             data["tags"] = tags
         if is_set(fields):
             data["fields"] = fields
+        if is_set(dropdown_values):
+            data["dropdown_values"] = dropdown_values
 
         return await self._client.post("/cases", json=data)
 
@@ -99,6 +103,7 @@ class CasesClient:
         payload: dict[str, Any] | None | Unset = UNSET,
         fields: dict[str, Any] | None | Unset = UNSET,
         tags: list[str] | None | Unset = UNSET,
+        dropdown_values: list[types.CaseDropdownValueInput] | None | Unset = UNSET,
     ) -> types.CaseRead:
         """Update a case.
 
@@ -113,6 +118,7 @@ class CasesClient:
             payload: New payload (merged with existing). Pass None to clear.
             fields: Custom field values to update.
             tags: List of tag IDs or refs to set (replaces existing).
+            dropdown_values: Dropdown selections to set or clear.
 
         Returns:
             Updated case data.
@@ -136,6 +142,8 @@ class CasesClient:
             data["fields"] = fields
         if is_set(tags):
             data["tags"] = tags
+        if is_set(dropdown_values):
+            data["dropdown_values"] = dropdown_values
 
         return await self._client.patch(f"/cases/{case_id}", json=data)
 
@@ -573,6 +581,7 @@ class CasesClient:
         payload: dict[str, Any] | None | Unset = UNSET,
         tags: list[str] | None | Unset = UNSET,
         fields: dict[str, Any] | None | Unset = UNSET,
+        dropdown_values: list[types.CaseDropdownValueInput] | None | Unset = UNSET,
     ) -> types.Case:
         """Create a new case and return simple dict format.
 
@@ -588,6 +597,7 @@ class CasesClient:
             payload: Additional JSON payload.
             tags: List of tag names or IDs to attach.
             fields: Custom field values.
+            dropdown_values: Dropdown selections to set on the case.
 
         Returns:
             Created case data (CaseDict format).
@@ -607,6 +617,8 @@ class CasesClient:
             data["tags"] = tags
         if is_set(fields):
             data["fields"] = fields
+        if is_set(dropdown_values):
+            data["dropdown_values"] = dropdown_values
 
         return await self._client.post("/cases/simple", json=data)
 
@@ -623,6 +635,7 @@ class CasesClient:
         payload: dict[str, Any] | None | Unset = UNSET,
         fields: dict[str, Any] | None | Unset = UNSET,
         tags: list[str] | None | Unset = UNSET,
+        dropdown_values: list[types.CaseDropdownValueInput] | None | Unset = UNSET,
         append_description: bool = False,
     ) -> types.Case:
         """Update a case and return simple dict format.
@@ -640,6 +653,7 @@ class CasesClient:
             payload: New payload (merged with existing). Pass None to clear.
             fields: Custom field values to update.
             tags: List of tag IDs or refs to set (replaces existing).
+            dropdown_values: Dropdown selections to set or clear.
             append_description: If True, append description to existing.
 
         Returns:
@@ -664,6 +678,8 @@ class CasesClient:
             data["fields"] = fields
         if is_set(tags):
             data["tags"] = tags
+        if is_set(dropdown_values):
+            data["dropdown_values"] = dropdown_values
         if append_description:
             data["append_description"] = append_description
 

--- a/packages/tracecat-registry/tracecat_registry/sdk/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/cases.py
@@ -26,6 +26,22 @@ class CasesClient:
     def __init__(self, client: TracecatClient) -> None:
         self._client = client
 
+    @staticmethod
+    def _serialize_dropdown_values(
+        dropdown_values: list[types.CaseDropdownValueInput] | None,
+    ) -> list[dict[str, Any]] | None:
+        """Serialize dropdown UUID values to strings for JSON transport."""
+        if dropdown_values is None:
+            return None
+
+        serialized: list[dict[str, Any]] = []
+        for dropdown_value in dropdown_values:
+            item: dict[str, Any] = {}
+            for key, value in dropdown_value.items():
+                item[key] = str(value) if isinstance(value, UUID) else value
+            serialized.append(item)
+        return serialized
+
     # === Case CRUD === #
 
     async def create_case(
@@ -75,7 +91,7 @@ class CasesClient:
         if is_set(fields):
             data["fields"] = fields
         if is_set(dropdown_values):
-            data["dropdown_values"] = dropdown_values
+            data["dropdown_values"] = self._serialize_dropdown_values(dropdown_values)
 
         return await self._client.post("/cases", json=data)
 
@@ -143,7 +159,7 @@ class CasesClient:
         if is_set(tags):
             data["tags"] = tags
         if is_set(dropdown_values):
-            data["dropdown_values"] = dropdown_values
+            data["dropdown_values"] = self._serialize_dropdown_values(dropdown_values)
 
         return await self._client.patch(f"/cases/{case_id}", json=data)
 
@@ -618,7 +634,7 @@ class CasesClient:
         if is_set(fields):
             data["fields"] = fields
         if is_set(dropdown_values):
-            data["dropdown_values"] = dropdown_values
+            data["dropdown_values"] = self._serialize_dropdown_values(dropdown_values)
 
         return await self._client.post("/cases/simple", json=data)
 
@@ -679,7 +695,7 @@ class CasesClient:
         if is_set(tags):
             data["tags"] = tags
         if is_set(dropdown_values):
-            data["dropdown_values"] = dropdown_values
+            data["dropdown_values"] = self._serialize_dropdown_values(dropdown_values)
         if append_description:
             data["append_description"] = append_description
 

--- a/packages/tracecat-registry/tracecat_registry/types.py
+++ b/packages/tracecat-registry/tracecat_registry/types.py
@@ -69,6 +69,15 @@ class CaseDropdownValueRead(TypedDict):
     option_color: str | None
 
 
+class CaseDropdownValueInput(TypedDict):
+    """Dropdown selection payload for case create/update operations."""
+
+    definition_id: NotRequired[UUID]
+    definition_ref: NotRequired[str]
+    option_id: NotRequired[UUID | None]
+    option_ref: NotRequired[str | None]
+
+
 class Case(TypedDict):
     """Case information returned by create/update/assign operations.
 

--- a/tests/registry/test_cases_sdk.py
+++ b/tests/registry/test_cases_sdk.py
@@ -1,0 +1,81 @@
+"""Tests for the Cases SDK client."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from tracecat_registry.sdk.cases import CasesClient
+
+
+@pytest.fixture
+def mock_tracecat_client() -> MagicMock:
+    """Create a mock TracecatClient."""
+    client = MagicMock()
+    client.post = AsyncMock()
+    client.patch = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def cases_client(mock_tracecat_client: MagicMock) -> CasesClient:
+    """Create a CasesClient with mocked HTTP client."""
+    return CasesClient(mock_tracecat_client)
+
+
+@pytest.mark.anyio
+async def test_create_case_serializes_dropdown_uuid_values(
+    cases_client: CasesClient, mock_tracecat_client: MagicMock
+) -> None:
+    """UUID dropdown ids are serialized to strings for JSON transport."""
+    definition_id = uuid4()
+    option_id = uuid4()
+    mock_tracecat_client.post.return_value = {"id": "case-id"}
+
+    await cases_client.create_case(
+        summary="Case summary",
+        description="Case description",
+        dropdown_values=[
+            {"definition_id": definition_id, "option_id": option_id},
+            {"definition_ref": "environment", "option_ref": "prod"},
+        ],
+    )
+
+    mock_tracecat_client.post.assert_called_once_with(
+        "/cases",
+        json={
+            "summary": "Case summary",
+            "description": "Case description",
+            "status": "new",
+            "priority": "medium",
+            "severity": "medium",
+            "dropdown_values": [
+                {"definition_id": str(definition_id), "option_id": str(option_id)},
+                {"definition_ref": "environment", "option_ref": "prod"},
+            ],
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_update_case_simple_serializes_and_keeps_null_option(
+    cases_client: CasesClient, mock_tracecat_client: MagicMock
+) -> None:
+    """UUID dropdown ids are stringified while explicit null option_id is retained."""
+    definition_id = uuid4()
+    mock_tracecat_client.patch.return_value = {"id": "case-id"}
+
+    await cases_client.update_case_simple(
+        "case-id",
+        dropdown_values=[{"definition_id": definition_id, "option_id": None}],
+    )
+
+    mock_tracecat_client.patch.assert_called_once_with(
+        "/cases/case-id/simple",
+        json={
+            "dropdown_values": [
+                {"definition_id": str(definition_id), "option_id": None},
+            ]
+        },
+    )

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -203,6 +203,35 @@ class TestCoreCreate:
         )
         assert result == mock_case_dict
 
+    async def test_create_case_with_dropdown_values(
+        self, mock_cases_client: AsyncMock, mock_case_dict
+    ):
+        """Test creating a case with dropdown selections."""
+        mock_cases_client.create_case_simple.return_value = mock_case_dict
+
+        dropdown_values = [
+            {"definition_ref": "environment", "option_ref": "prod"},
+            {"definition_ref": "region", "option_ref": "us_west"},
+        ]
+        result = await create_case(
+            summary="Test Case",
+            description="Test Description",
+            priority="medium",
+            severity="medium",
+            status="new",
+            dropdown_values=dropdown_values,
+        )
+
+        mock_cases_client.create_case_simple.assert_called_once_with(
+            summary="Test Case",
+            description="Test Description",
+            priority="medium",
+            severity="medium",
+            status="new",
+            dropdown_values=dropdown_values,
+        )
+        assert result == mock_case_dict
+
 
 @pytest.mark.anyio
 class TestCoreUpdate:
@@ -322,6 +351,29 @@ class TestCoreUpdate:
         mock_cases_client.update_case_simple.assert_called_once_with(
             case_id,
             tags=["new-tag1", "new-tag2"],
+        )
+        assert result == updated_case
+
+    async def test_update_with_dropdown_values(
+        self, mock_cases_client: AsyncMock, mock_case_dict
+    ):
+        """Test updating case dropdown selections."""
+        updated_case = {**mock_case_dict}
+        mock_cases_client.update_case_simple.return_value = updated_case
+
+        case_id = mock_case_dict["id"]
+        dropdown_values = [
+            {"definition_ref": "environment", "option_ref": "staging"},
+            {"definition_ref": "region", "option_ref": None},
+        ]
+        result = await update_case(
+            case_id=case_id,
+            dropdown_values=dropdown_values,
+        )
+
+        mock_cases_client.update_case_simple.assert_called_once_with(
+            case_id,
+            dropdown_values=dropdown_values,
         )
         assert result == updated_case
 

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import tracecat_registry.core.cases as cases_core
+import tracecat_registry.types as registry_types
 from tracecat_registry.core.cases import (
     add_case_tag,
     assign_user,
@@ -209,7 +210,7 @@ class TestCoreCreate:
         """Test creating a case with dropdown selections."""
         mock_cases_client.create_case_simple.return_value = mock_case_dict
 
-        dropdown_values = [
+        dropdown_values: list[registry_types.CaseDropdownValueInput] = [
             {"definition_ref": "environment", "option_ref": "prod"},
             {"definition_ref": "region", "option_ref": "us_west"},
         ]
@@ -362,7 +363,7 @@ class TestCoreUpdate:
         mock_cases_client.update_case_simple.return_value = updated_case
 
         case_id = mock_case_dict["id"]
-        dropdown_values = [
+        dropdown_values: list[registry_types.CaseDropdownValueInput] = [
             {"definition_ref": "environment", "option_ref": "staging"},
             {"definition_ref": "region", "option_ref": None},
         ]

--- a/tracecat/cases/dropdowns/schemas.py
+++ b/tracecat/cases/dropdowns/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from tracecat.core.schemas import Schema
 
@@ -100,3 +100,35 @@ class CaseDropdownValueSet(Schema):
         default=None,
         description="The option ID to set. Pass null to clear the value.",
     )
+
+
+class CaseDropdownValueInput(Schema):
+    """Dropdown selection payload for case create/update operations."""
+
+    definition_id: uuid.UUID | None = Field(
+        default=None,
+        description="Dropdown definition ID.",
+    )
+    definition_ref: str | None = Field(
+        default=None,
+        description="Dropdown definition ref.",
+    )
+    option_id: uuid.UUID | None = Field(
+        default=None,
+        description="Dropdown option ID. Pass null to clear the value.",
+    )
+    option_ref: str | None = Field(
+        default=None,
+        description="Dropdown option ref. Pass null to clear the value.",
+    )
+
+    @model_validator(mode="after")
+    def validate_identifiers(self) -> CaseDropdownValueInput:
+        has_definition_id = self.definition_id is not None
+        has_definition_ref = self.definition_ref is not None
+        if has_definition_id == has_definition_ref:
+            raise ValueError("Provide exactly one of definition_id or definition_ref")
+
+        if self.option_id is not None and self.option_ref is not None:
+            raise ValueError("Provide only one of option_id or option_ref")
+        return self

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -1071,6 +1071,7 @@ async def create_case_simple(
                 severity=params.severity,
                 status=params.status,
                 fields=params.fields,
+                dropdown_values=params.dropdown_values,
                 assignee_id=params.assignee_id,
                 payload=params.payload,
             )
@@ -1135,6 +1136,8 @@ async def update_case_simple(
         update_params["status"] = params.status
     if params.fields is not None:
         update_params["fields"] = params.fields
+    if params.dropdown_values is not None:
+        update_params["dropdown_values"] = params.dropdown_values
     if params.assignee_id is not None:
         update_params["assignee_id"] = params.assignee_id
     if params.payload is not None:

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -9,7 +9,10 @@ from pydantic import ConfigDict, Field, RootModel, field_validator
 
 from tracecat.auth.schemas import UserRead
 from tracecat.cases.constants import RESERVED_CASE_FIELDS
-from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
+from tracecat.cases.dropdowns.schemas import (
+    CaseDropdownValueInput,
+    CaseDropdownValueRead,
+)
 from tracecat.cases.enums import (
     CaseEventType,
     CasePriority,
@@ -84,6 +87,7 @@ class CaseCreate(Schema):
     priority: CasePriority
     severity: CaseSeverity
     fields: dict[str, Any] | None = None
+    dropdown_values: list[CaseDropdownValueInput] | None = None
     assignee_id: uuid.UUID | None = None
     payload: dict[str, Any] | None = None
 
@@ -95,6 +99,7 @@ class CaseUpdate(Schema):
     priority: CasePriority | None = None
     severity: CaseSeverity | None = None
     fields: dict[str, Any] | None = None
+    dropdown_values: list[CaseDropdownValueInput] | None = None
     assignee_id: uuid.UUID | None = None
     payload: dict[str, Any] | None = None
 


### PR DESCRIPTION
Summary
- extend case create/update services, routers, and UDFs to honor dropdown inputs
- ensure dropdown handling is consistent across all CRUD layers for cases

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dropdown support to case create and update so you can set or clear selections by ID or ref. Works across API, SDK, registry, and service layers and applies changes in a single transaction with events.

- **New Features**
  - API and SDK: Accept dropdown_values on POST/PATCH /cases and simple endpoints; each item uses definition_id or definition_ref, and option_id or option_ref (null clears). SDK serializes UUIDs to strings and preserves explicit nulls.
  - Service: Added apply_values to set multiple selections in one transaction, resolve IDs/refs, prevent duplicate definitions, and log events; wired into CasesService create/update with single-commit flow.
  - Schemas/Types: Unified CaseDropdownValueInput across service and registry with validators enforcing exactly one of definition_id/ref and only one of option_id/ref.
  - Tests: Added coverage for create/update with dropdowns across API, registry core, service, and SDK UUID serialization.

- **Bug Fixes**
  - Fixed case CRUD dropdown typing by propagating CaseDropdownValueInput through CaseCreate/CaseUpdate and internal router, and normalizing inputs during update.

<sup>Written for commit 5fab828335afb3f02317dd3c4ed84a072db3bb61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

