### PR TITLE
release: 1.0.0-beta.19

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
 
-- Tracecat version (e.g. `1.0.0-beta.18`)
+- Tracecat version (e.g. `1.0.0-beta.19`)
 - OS (e.g. Ubuntu 20.03 on WSL2)
 - Where did you deploy Tracecat? (VM, AWS EC2, etc.)
 - CPU architecture

--- a/deployments/eks/modules/eks/variables.tf
+++ b/deployments/eks/modules/eks/variables.tf
@@ -140,7 +140,7 @@ variable "hosted_zone_id" {
 variable "tracecat_image_tag" {
   description = "Docker image tag for Tracecat services"
   type        = string
-  default     = "1.0.0-beta.18"
+  default     = "1.0.0-beta.19"
 }
 
 variable "tracecat_ingress_split" {

--- a/deployments/eks/variables.tf
+++ b/deployments/eks/variables.tf
@@ -156,7 +156,7 @@ variable "spot_node_max_size" {
 variable "tracecat_image_tag" {
   description = "Docker image tag for Tracecat services"
   type        = string
-  default     = "1.0.0-beta.18"
+  default     = "1.0.0-beta.19"
 }
 
 variable "tracecat_ingress_split" {

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -108,7 +108,7 @@ variable "tracecat_ui_image" {
 
 variable "tracecat_image_tag" {
   type    = string
-  default = "1.0.0-beta.18"
+  default = "1.0.0-beta.19"
 }
 
 variable "temporal_server_image" {

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -68,7 +68,7 @@ variable "tracecat_ui_image" {
 
 variable "tracecat_image_tag" {
   type    = string
-  default = "1.0.0-beta.18"
+  default = "1.0.0-beta.19"
 }
 
 variable "temporal_server_image" {

--- a/deployments/helm/tracecat/Chart.yaml
+++ b/deployments/helm/tracecat/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tracecat
 description: Tracecat is the AI automation platform for mission critical work.
 type: application
-version: 0.3.26
-appVersion: "1.0.0-beta.18"
+version: 0.3.27
+appVersion: "1.0.0-beta.19"
 home: https://tracecat.com
 maintainers:
   - email: founders@tracecat.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
 
   api:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.18}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.19}
     container_name: api
     restart: unless-stopped
     networks:
@@ -100,7 +100,7 @@ services:
       start_period: 10s
 
   worker:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.18}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.19}
     restart: unless-stopped
     networks:
       - core
@@ -158,7 +158,7 @@ services:
         condition: service_healthy
 
   executor:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.18}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.19}
     restart: unless-stopped
     networks:
       - core
@@ -233,7 +233,7 @@ services:
         condition: service_healthy
 
   agent-executor:
-      image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.18}
+      image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.19}
       restart: unless-stopped
       networks:
         - core
@@ -307,7 +307,7 @@ services:
         minio:
           condition: service_healthy
   ui:
-    image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-1.0.0-beta.18}
+    image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-1.0.0-beta.19}
     container_name: ui
     restart: unless-stopped
     networks:
@@ -343,7 +343,7 @@ services:
       start_period: 5s
 
   migrations:
-    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.18}
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.19}
     container_name: migrations
     restart: "no"
     networks:

--- a/docs/quickstart/install.mdx
+++ b/docs/quickstart/install.mdx
@@ -28,15 +28,15 @@ Deploy a local Tracecat stack using Docker Compose. View step-by-step instructio
 
 ```bash
 # 1. Setup .env configs and secrets (you'll be prompted for superadmin email)
-curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/env.sh
-curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/.env.example
+curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/env.sh
+curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/.env.example
 chmod +x env.sh && ./env.sh
 
 # 2. Download Caddyfile
-curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/Caddyfile
+curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/Caddyfile
 
 # 3. Download Docker Compose file
-curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/docker-compose.yml
 
 # Run Tracecat
 docker compose up -d
@@ -45,7 +45,7 @@ docker compose up -d
 <PublicUrlNote />
 
 Check out the generated `.env` file to better understand Tracecat's configurations.
-You can also view the template `.env.example` file [here](https://github.com/TracecatHQ/tracecat/blob/1.0.0-beta.18/.env.example).
+You can also view the template `.env.example` file [here](https://github.com/TracecatHQ/tracecat/blob/1.0.0-beta.19/.env.example).
 
 ### AWS Fargate
 

--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -57,10 +57,10 @@ Use the commands listed below to download the required configuration files
 
 ```bash
 # 1. Download the env.sh installation script
-curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/env.sh
+curl -o env.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/env.sh
 
 # 2. Download the .env.example template file (env.sh needs this to generate your .env file)
-curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/.env.example
+curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/.env.example
 
 # 3. Make the env.sh script executable and run it
 chmod +x env.sh && ./env.sh
@@ -101,13 +101,13 @@ Tracecat uses Caddy as a reverse proxy.
 You'll need to download the following `Caddyfile` to configure this service.
 
 ```bash
-curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/Caddyfile
+curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/Caddyfile
 ```
 
 ## Download Docker Compose File
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/docker-compose.yml
 ```
 
 ## Start Tracecat
@@ -195,4 +195,4 @@ Please check the following:
 
 - Log into Tracecat and build your first playbook. [View quickstart](/quickstart).
 - Tracecat comes with basic (email + password) authentication. Find out how to configure other authentication methods. [View docs](/self-hosting/authentication/overview).
-- Read inline comments in the generated `.env` file to better understand Tracecat's configurations. [View `.env.example` file](https://github.com/TracecatHQ/tracecat/blob/1.0.0-beta.18/.env.example).
+- Read inline comments in the generated `.env` file to better understand Tracecat's configurations. [View `.env.example` file](https://github.com/TracecatHQ/tracecat/blob/1.0.0-beta.19/.env.example).

--- a/docs/self-hosting/updating.mdx
+++ b/docs/self-hosting/updating.mdx
@@ -23,8 +23,8 @@ description: Learn how to safely update versions and run data migrations.
     version.
 
     ```
-    curl -o env-migration.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/env-migration.sh
-    curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/.env.example
+    curl -o env-migration.sh https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/env-migration.sh
+    curl -o .env.example https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/.env.example
     ```
 
   </Step>
@@ -41,14 +41,14 @@ description: Learn how to safely update versions and run data migrations.
     Download the latest Docker Compose file.
 
     ```
-    curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/docker-compose.yml
+    curl -o docker-compose.yml https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/docker-compose.yml
     ```
   </Step>
   <Step title="Update Caddyfile">
     Download the latest Caddyfile.
 
     ```
-    curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.18/Caddyfile
+    curl -o Caddyfile https://raw.githubusercontent.com/TracecatHQ/tracecat/1.0.0-beta.19/Caddyfile
     ```
   </Step>
   <Step title="Restart Tracecat">

--- a/packages/tracecat-registry/tracecat_registry/__init__.py
+++ b/packages/tracecat-registry/tracecat_registry/__init__.py
@@ -1,6 +1,6 @@
 """Tracecat managed actions and integrations registry."""
 
-__version__ = "1.0.0-beta.18"
+__version__ = "1.0.0-beta.19"
 
 
 from tracecat_registry import types

--- a/tracecat/__init__.py
+++ b/tracecat/__init__.py
@@ -1,3 +1,3 @@
 """Tracecat is open source AI automation platform for mission critical workflows."""
 
-__version__ = "1.0.0-beta.18"
+__version__ = "1.0.0-beta.19"


### PR DESCRIPTION
<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/tracecat/tracecat/editor/release%2F1.0.0-beta.19?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release 1.0.0-beta.19: bumps app and registry versions and updates all deployment configs (Docker Compose, Helm chart, Terraform defaults) and docs to use the new image tag.

- **Migration**
  - Docker Compose: set TRACECAT__IMAGE_TAG=1.0.0-beta.19 or re-download env.sh, .env.example, Caddyfile, and docker-compose.yml for 1.0.0-beta.19, then docker compose pull && up -d.
  - Helm: upgrade tracecat chart to 0.3.27 (appVersion 1.0.0-beta.19).
  - Terraform (EKS/Fargate): defaults now 1.0.0-beta.19; update tracecat_image_tag if you override it and apply.

<sup>Written for commit 0ed6e234e3dd5888775e5f595e4b9bf5396a6884. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

