### PR TITLE
fix(dsl): exclude disconnected action islands from execution

### DIFF
--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -418,10 +418,18 @@ function toDslApiErrorResult(message: string): ValidationResult {
 function normalizeRunValidationErrors(
   detail: unknown
 ): ValidationResult[] | null {
-  if (Array.isArray(detail) && detail.every(isValidationResult)) {
+  if (
+    Array.isArray(detail) &&
+    detail.length > 0 &&
+    detail.every(isValidationResult)
+  ) {
     return detail
   }
-  if (Array.isArray(detail) && detail.every(isValidationDetail)) {
+  if (
+    Array.isArray(detail) &&
+    detail.length > 0 &&
+    detail.every(isValidationDetail)
+  ) {
     return [
       {
         type: "dsl",
@@ -451,10 +459,18 @@ function normalizeRunValidationErrors(
     }
   }
 
-  if (Array.isArray(nestedDetail) && nestedDetail.every(isValidationResult)) {
+  if (
+    Array.isArray(nestedDetail) &&
+    nestedDetail.length > 0 &&
+    nestedDetail.every(isValidationResult)
+  ) {
     return nestedDetail
   }
-  if (Array.isArray(nestedDetail) && nestedDetail.every(isValidationDetail)) {
+  if (
+    Array.isArray(nestedDetail) &&
+    nestedDetail.length > 0 &&
+    nestedDetail.every(isValidationDetail)
+  ) {
     return [
       {
         type: "dsl",
@@ -530,7 +546,7 @@ function WorkflowManualTrigger({
         const validationErrors = normalizeRunValidationErrors(
           tracecatError.body.detail
         )
-        if (validationErrors) {
+        if (validationErrors && validationErrors.length > 0) {
           setManualTriggerErrors(validationErrors)
         } else {
           setManualTriggerErrors([

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -828,14 +828,19 @@ def build_action_statements_from_actions(
         for action in actions:
             for edge_data in action.upstream_edges:
                 edge = UpstreamEdgeDataValidator.validate_python(edge_data)
-                source_type = edge.get("source_type", "udf")
+                source_type = edge.get("source_type")
                 source_id_str = edge.get("source_id")
                 if not source_id_str:
                     continue
 
-                if source_type == "trigger":
+                # Legacy edge format omitted source_type for trigger roots.
+                if source_type == "trigger" or (
+                    source_type is None and source_id_str.startswith("trigger-")
+                ):
                     trigger_roots.add(action.id)
                     continue
+                if source_type is None:
+                    source_type = "udf"
                 if source_type != "udf":
                     continue
 


### PR DESCRIPTION
## Summary
This PR fixes two workflow execution consistency issues:
1. Prevents disconnected action islands from being executed.
2. Makes draft execution run the same tiered DSL validation used at commit/publish time.

## Screens
Equivalent validation format in draft

<img width="1728" height="1117" alt="Screenshot 2026-02-25 at 17 41 47" src="https://github.com/user-attachments/assets/729e45e8-7e1b-47e0-94e1-d12b88330bce" />

Can put other nodes on canvas

<img width="1728" height="1117" alt="Screenshot 2026-02-25 at 17 42 34" src="https://github.com/user-attachments/assets/f52bf3ee-c47f-42c9-a05d-57af9aa9ae98" />



## Problem
### 1) Disconnected islands could run
`build_action_statements_from_actions()` ignored trigger connectivity and could schedule zero-dependency actions that were not part of the trigger-connected DAG.

### 2) Draft validation differed from publish path
Draft execution (`POST /workflow-executions/draft`) only did structural DSL construction checks, while published workflows rely on commit-time tiered validation.

## Changes
### Trigger-connected execution filtering
- Updated `build_action_statements_from_actions()` to:
  - compute trigger-connected reachable actions
  - only emit statements for reachable actions
  - only keep dependencies whose source is reachable
- Added unit tests for:
  - disconnected island filtering
  - legacy fallback behavior when no trigger edges exist

### Draft validation parity
- Updated draft execution route to run `validate_dsl(...)` before dispatch.
- Draft execution now returns `400` with validation details when tiered DSL validation fails.
- Added API test asserting draft execution fails fast on DSL validation errors and does not dispatch.

## Validation
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_view.py -k "build_action_statements" -q`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/api/test_api_workflow_execution_path_ids.py -q`
- `uv run ruff check tracecat/dsl/common.py tracecat/workflow/executions/router.py tests/unit/test_view.py tests/unit/api/test_api_workflow_execution_path_ids.py`
- `uv run basedpyright tracecat/dsl/common.py tracecat/workflow/executions/router.py tests/unit/test_view.py tests/unit/api/test_api_workflow_execution_path_ids.py`

## Notes
During commit, the repository pre-commit `gen-client` hook regenerated frontend client artifacts:
- `frontend/src/client/schemas.gen.ts`
- `frontend/src/client/types.gen.ts`
