### PR TITLE
feat(mcp): extend approvals/allowlisting for all MCP tools

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -12125,6 +12125,10 @@ export const $MCPHttpServerConfig = {
       type: "string",
       title: "Name",
     },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
     url: {
       type: "string",
       title: "Url",
@@ -12549,6 +12553,10 @@ export const $MCPStdioServerConfig = {
     name: {
       type: "string",
       title: "Name",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
     },
     command: {
       type: "string",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8922,6 +8922,48 @@ export const $DataUIPart = {
   description: "A custom data part, where type matches 'data-...'.",
 } as const
 
+export const $DiscoverMCPToolsRequest = {
+  properties: {
+    mcp_integration_ids: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      minItems: 1,
+      title: "Mcp Integration Ids",
+      description: "List of MCP integration IDs to discover tools from",
+    },
+  },
+  type: "object",
+  required: ["mcp_integration_ids"],
+  title: "DiscoverMCPToolsRequest",
+  description: "Request body for discovering MCP tools from integrations.",
+} as const
+
+export const $DiscoveredMCPTool = {
+  properties: {
+    name: {
+      type: "string",
+      title: "Name",
+      description: "Canonical tool name (e.g. mcp.Linear.list_issues)",
+    },
+    description: {
+      type: "string",
+      title: "Description",
+      description: "Tool description",
+    },
+    server_name: {
+      type: "string",
+      title: "Server Name",
+      description: "MCP server name",
+    },
+  },
+  type: "object",
+  required: ["name", "description", "server_name"],
+  title: "DiscoveredMCPTool",
+  description: "A discovered MCP tool with its canonical name.",
+} as const
+
 export const $DocumentUrl = {
   properties: {
     url: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -112,6 +112,8 @@ import type {
   AgentPresetsCreateAgentPresetResponse,
   AgentPresetsDeleteAgentPresetData,
   AgentPresetsDeleteAgentPresetResponse,
+  AgentPresetsDiscoverMcpToolsData,
+  AgentPresetsDiscoverMcpToolsResponse,
   AgentPresetsGetAgentPresetBySlugData,
   AgentPresetsGetAgentPresetBySlugResponse,
   AgentPresetsGetAgentPresetData,
@@ -4221,6 +4223,32 @@ export const agentPresetsCreateAgentPreset = (
   return __request(OpenAPI, {
     method: "POST",
     url: "/agent/presets",
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Discover Mcp Tools
+ * Discover tools from MCP integrations for the approval selector.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns DiscoveredMCPTool Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsDiscoverMcpTools = (
+  data: AgentPresetsDiscoverMcpToolsData
+): CancelablePromise<AgentPresetsDiscoverMcpToolsResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/agent/presets/discover-mcp-tools",
     query: {
       workspace_id: data.workspaceId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2658,6 +2658,34 @@ export type DataUIPart = {
 }
 
 /**
+ * Request body for discovering MCP tools from integrations.
+ */
+export type DiscoverMCPToolsRequest = {
+  /**
+   * List of MCP integration IDs to discover tools from
+   */
+  mcp_integration_ids: Array<string>
+}
+
+/**
+ * A discovered MCP tool with its canonical name.
+ */
+export type DiscoveredMCPTool = {
+  /**
+   * Canonical tool name (e.g. mcp.Linear.list_issues)
+   */
+  name: string
+  /**
+   * Tool description
+   */
+  description: string
+  /**
+   * MCP server name
+   */
+  server_name: string
+}
+
+/**
  * The URL of the document.
  */
 export type DocumentUrl = {
@@ -8865,6 +8893,13 @@ export type AgentPresetsCreateAgentPresetData = {
 
 export type AgentPresetsCreateAgentPresetResponse = AgentPresetRead
 
+export type AgentPresetsDiscoverMcpToolsData = {
+  requestBody: DiscoverMCPToolsRequest
+  workspaceId: string
+}
+
+export type AgentPresetsDiscoverMcpToolsResponse = Array<DiscoveredMCPTool>
+
 export type AgentPresetsGetAgentPresetData = {
   presetId: string
   workspaceId: string
@@ -12653,6 +12688,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         201: AgentPresetRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/agent/presets/discover-mcp-tools": {
+    post: {
+      req: AgentPresetsDiscoverMcpToolsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<DiscoveredMCPTool>
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3855,6 +3855,7 @@ export type MCPHttpIntegrationCreate = {
 export type MCPHttpServerConfig = {
   type?: "http"
   name: string
+  display_name?: string
   url: string
   headers?: {
     [key: string]: string
@@ -3964,6 +3965,7 @@ export type MCPStdioIntegrationCreate = {
 export type MCPStdioServerConfig = {
   type: "stdio"
   name: string
+  display_name?: string
   command: string
   args?: Array<string>
   env?: {

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -324,6 +324,7 @@ export function AgentPresetsBuilder({
       .map((integration) => ({
         id: integration.id,
         name: integration.name,
+        slug: integration.slug,
         description: integration.description,
         providerId: getMcpProviderId(integration.slug),
       }))
@@ -880,8 +881,46 @@ type AgentPresetSideTab =
 type McpIntegrationOption = {
   id: string
   name: string
+  slug: string
   description?: string | null
   providerId?: string
+}
+
+function parseCanonicalMcpToolName(
+  value: string
+): { serverSlug: string; toolName: string } | null {
+  const match = value.match(/^mcp\.([^.]+)\.(.+)$/)
+  if (!match?.[1] || !match[2]) {
+    return null
+  }
+  return {
+    serverSlug: match[1],
+    toolName: match[2],
+  }
+}
+
+function normalizeLegacyMcpToolValue(
+  value: string,
+  integrations: McpIntegrationOption[]
+): string {
+  if (!value.startsWith("mcp.")) {
+    return value
+  }
+
+  for (const integration of [...integrations].sort(
+    (left, right) => right.name.length - left.name.length
+  )) {
+    const legacyPrefix = `mcp.${integration.name}.`
+    if (
+      integration.slug !== integration.name &&
+      value.startsWith(legacyPrefix) &&
+      value.length > legacyPrefix.length
+    ) {
+      return `mcp.${integration.slug}.${value.slice(legacyPrefix.length)}`
+    }
+  }
+
+  return value
 }
 
 function getAgentPresetErrorTab(
@@ -994,6 +1033,7 @@ function AgentPresetForm({
   const watchedName = form.watch("name")
   const providerValue = form.watch("model_provider")
   const modelNameValue = form.watch("model_name")
+  const watchedMcpIntegrationIds = form.watch("mcpIntegrations")
   const modelOptions = modelOptionsByProvider[providerValue] ?? []
 
   useEffect(() => {
@@ -1002,6 +1042,36 @@ function AgentPresetForm({
       form.setValue("slug", nextSlug, { shouldDirty: false })
     }
   }, [form, watchedName])
+
+  useEffect(() => {
+    const selectedIntegrations = mcpIntegrations.filter((integration) =>
+      watchedMcpIntegrationIds.includes(integration.id)
+    )
+    if (selectedIntegrations.length === 0) {
+      return
+    }
+
+    const currentActions = form.getValues("actions")
+    const normalizedActions = currentActions.map((action) =>
+      normalizeLegacyMcpToolValue(action, selectedIntegrations)
+    )
+    if (JSON.stringify(currentActions) !== JSON.stringify(normalizedActions)) {
+      form.setValue("actions", normalizedActions, { shouldDirty: false })
+    }
+
+    const currentApprovals = form.getValues("toolApprovals")
+    const normalizedApprovals = currentApprovals.map((approval) => ({
+      ...approval,
+      tool: normalizeLegacyMcpToolValue(approval.tool, selectedIntegrations),
+    }))
+    if (
+      JSON.stringify(currentApprovals) !== JSON.stringify(normalizedApprovals)
+    ) {
+      form.setValue("toolApprovals", normalizedApprovals, {
+        shouldDirty: false,
+      })
+    }
+  }, [form, mcpIntegrations, watchedMcpIntegrationIds])
 
   useEffect(() => {
     if (
@@ -1501,6 +1571,8 @@ function AgentPresetConfigurationPanel({
   const internetAccessEnabled = form.watch("enableInternetAccess")
   const modelOptions = modelOptionsByProvider[providerValue] ?? []
   const watchedMcpIntegrations = form.watch("mcpIntegrations")
+  const watchedActions = form.watch("actions")
+  const watchedToolApprovals = form.watch("toolApprovals")
   const workspaceId = useWorkspaceId()
 
   // Discover MCP tools when integrations are selected (for approval selector)
@@ -1514,40 +1586,95 @@ function AgentPresetConfigurationPanel({
     enabled: watchedMcpIntegrations.length > 0,
   })
 
-  // Build server name → provider ID lookup for MCP tool icons
-  const mcpProviderByName = useMemo(() => {
-    const map = new Map<string, string | undefined>()
+  // Build MCP integration metadata keyed by slug for tool labels and icons.
+  const selectedMcpIntegrationsBySlug = useMemo(() => {
+    const map = new Map<
+      string,
+      { label: string; providerId: string | undefined }
+    >()
     for (const integration of mcpIntegrations) {
-      map.set(integration.name, integration.providerId)
+      if (watchedMcpIntegrations.includes(integration.id)) {
+        map.set(integration.slug, {
+          label: integration.name,
+          providerId: integration.providerId,
+        })
+      }
     }
     return map
-  }, [mcpIntegrations])
+  }, [mcpIntegrations, watchedMcpIntegrations])
+
+  const fallbackMcpSuggestions = useMemo(() => {
+    const seen = new Set<string>()
+    return [
+      ...watchedActions,
+      ...watchedToolApprovals.map((item) => item.tool),
+    ].flatMap((value) => {
+      if (seen.has(value)) {
+        return []
+      }
+      seen.add(value)
+
+      const parsed = parseCanonicalMcpToolName(value)
+      if (!parsed) {
+        return []
+      }
+      const integration = selectedMcpIntegrationsBySlug.get(parsed.serverSlug)
+      if (!integration) {
+        return []
+      }
+      return [
+        {
+          id: value,
+          label: parsed.toolName,
+          value,
+          group: integration.label,
+          icon: (
+            <ProviderIcon
+              providerId={integration.providerId || "custom"}
+              className="size-6 border-[0.5px] p-[3px]"
+            />
+          ),
+        } satisfies Suggestion,
+      ]
+    })
+  }, [selectedMcpIntegrationsBySlug, watchedActions, watchedToolApprovals])
 
   // Merge registry action suggestions with MCP tool suggestions for the approval selector
   const approvalSuggestions: Suggestion[] = useMemo(() => {
-    const suggestions = [...actionSuggestions]
+    const suggestionsByValue = new Map<string, Suggestion>(
+      actionSuggestions.map((suggestion) => [suggestion.value, suggestion])
+    )
+    for (const suggestion of fallbackMcpSuggestions) {
+      suggestionsByValue.set(suggestion.value, suggestion)
+    }
     if (mcpToolSuggestions) {
       for (const tool of mcpToolSuggestions) {
-        // Strip "mcp.ServerName." prefix for a clean display label
-        const toolName = tool.name.replace(/^mcp\.[^.]+\./, "")
-        const providerId = mcpProviderByName.get(tool.server_name)
-        suggestions.push({
+        const parsed = parseCanonicalMcpToolName(tool.name)
+        const integration = parsed
+          ? selectedMcpIntegrationsBySlug.get(parsed.serverSlug)
+          : undefined
+        suggestionsByValue.set(tool.name, {
           id: tool.name,
-          label: toolName,
+          label: parsed?.toolName ?? tool.name,
           value: tool.name,
           description: tool.description,
           group: tool.server_name,
           icon: (
             <ProviderIcon
-              providerId={providerId || "custom"}
+              providerId={integration?.providerId || "custom"}
               className="size-6 p-[3px] border-[0.5px]"
             />
           ),
         })
       }
     }
-    return suggestions
-  }, [actionSuggestions, mcpToolSuggestions, mcpProviderByName])
+    return [...suggestionsByValue.values()]
+  }, [
+    actionSuggestions,
+    fallbackMcpSuggestions,
+    mcpToolSuggestions,
+    selectedMcpIntegrationsBySlug,
+  ])
 
   return (
     <ScrollArea className="h-full">

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useQuery } from "@tanstack/react-query"
 import {
   AlertCircle,
   Box,
@@ -40,6 +41,7 @@ import type {
   AgentPresetRead,
   AgentPresetUpdate,
 } from "@/client"
+import { agentPresetsDiscoverMcpTools } from "@/client"
 import { AgentPresetDeleteDialog } from "@/components/agents/agent-preset-delete-dialog"
 import { AgentPresetVersionSelect } from "@/components/agents/agent-preset-version-select"
 import { AgentPresetVersionsPanel } from "@/components/agents/agent-preset-versions-panel"
@@ -147,17 +149,25 @@ const DEFAULT_RETRIES = 3
  * This handles both built-in MCP providers and custom integrations.
  */
 function getMcpProviderId(slug: string): string | undefined {
-  // Map common slugs to provider IDs
+  // Map common slugs to provider IDs.
+  // Slugs from built-in providers already equal the provider ID (e.g. "linear_mcp"),
+  // so we include both short names and the full provider IDs as keys.
   const slugMap: Record<string, string> = {
     "github-copilot": "github_mcp",
     github: "github_mcp",
+    github_mcp: "github_mcp",
     sentry: "sentry_mcp",
+    sentry_mcp: "sentry_mcp",
     notion: "notion_mcp",
+    notion_mcp: "notion_mcp",
     linear: "linear_mcp",
     jira: "jira_mcp",
+    linear_mcp: "linear_mcp",
     runreveal: "runreveal_mcp",
+    runreveal_mcp: "runreveal_mcp",
     "secure-annex": "secureannex_mcp",
     secureannex: "secureannex_mcp",
+    secureannex_mcp: "secureannex_mcp",
     wiz: "wiz_mcp",
   }
 
@@ -1490,6 +1500,54 @@ function AgentPresetConfigurationPanel({
   const providerValue = form.watch("model_provider")
   const internetAccessEnabled = form.watch("enableInternetAccess")
   const modelOptions = modelOptionsByProvider[providerValue] ?? []
+  const watchedMcpIntegrations = form.watch("mcpIntegrations")
+  const workspaceId = useWorkspaceId()
+
+  // Discover MCP tools when integrations are selected (for approval selector)
+  const { data: mcpToolSuggestions } = useQuery({
+    queryKey: ["mcp-tools", workspaceId, watchedMcpIntegrations],
+    queryFn: () =>
+      agentPresetsDiscoverMcpTools({
+        workspaceId,
+        requestBody: { mcp_integration_ids: watchedMcpIntegrations },
+      }),
+    enabled: watchedMcpIntegrations.length > 0,
+  })
+
+  // Build server name → provider ID lookup for MCP tool icons
+  const mcpProviderByName = useMemo(() => {
+    const map = new Map<string, string | undefined>()
+    for (const integration of mcpIntegrations) {
+      map.set(integration.name, integration.providerId)
+    }
+    return map
+  }, [mcpIntegrations])
+
+  // Merge registry action suggestions with MCP tool suggestions for the approval selector
+  const approvalSuggestions: Suggestion[] = useMemo(() => {
+    const suggestions = [...actionSuggestions]
+    if (mcpToolSuggestions) {
+      for (const tool of mcpToolSuggestions) {
+        // Strip "mcp.ServerName." prefix for a clean display label
+        const toolName = tool.name.replace(/^mcp\.[^.]+\./, "")
+        const providerId = mcpProviderByName.get(tool.server_name)
+        suggestions.push({
+          id: tool.name,
+          label: toolName,
+          value: tool.name,
+          description: tool.description,
+          group: tool.server_name,
+          icon: (
+            <ProviderIcon
+              providerId={providerId || "custom"}
+              className="size-6 p-[3px] border-[0.5px]"
+            />
+          ),
+        })
+      }
+    }
+    return suggestions
+  }, [actionSuggestions, mcpToolSuggestions, mcpProviderByName])
 
   return (
     <ScrollArea className="h-full">
@@ -1639,7 +1697,7 @@ function AgentPresetConfigurationPanel({
                   <MultiTagCommandInput
                     value={field.value}
                     onChange={field.onChange}
-                    suggestions={actionSuggestions}
+                    suggestions={approvalSuggestions}
                     placeholder="+ Add tool"
                     searchKeys={["label", "value", "description", "group"]}
                     allowCustomTags
@@ -1755,7 +1813,7 @@ function AgentPresetConfigurationPanel({
                             <FormControl>
                               <ActionSelect
                                 field={field}
-                                suggestions={[...actionSuggestions]}
+                                suggestions={[...approvalSuggestions]}
                                 searchKeys={[
                                   "label",
                                   "value",

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -19,7 +19,7 @@ from tracecat.agent.mcp.internal_tools import (
     BUILDER_INTERNAL_TOOL_NAMES,
     get_builder_internal_tool_definitions,
 )
-from tracecat.agent.mcp.user_client import UserMCPClient
+from tracecat.agent.mcp.user_client import UserMCPClient, discover_user_mcp_tools
 from tracecat.agent.mcp.utils import is_http_server, mcp_tool_name_to_canonical
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.tokens import InternalToolContext, UserMCPServerClaim
@@ -116,9 +116,7 @@ class AgentActivities:
 
         # For builder sessions, add bundled actions to the tool filters
         actions_to_build = [
-            action.strip()
-            for action in (args.tool_filters.actions or [])
-            if action.strip()
+            s for action in (args.tool_filters.actions or []) if (s := action.strip())
         ]
         selected_mcp_action_names = {
             mcp_tool_name_to_canonical(action)
@@ -172,8 +170,6 @@ class AgentActivities:
                 f"{sorted(selected_mcp_action_names)}"
             )
         if args.mcp_servers:
-            from tracecat.agent.mcp.user_client import discover_user_mcp_tools
-
             http_servers = [
                 cfg for cfg in args.mcp_servers if is_http_server(cfg)
             ]

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable
-from typing import Any, TypeGuard
+from typing import Any
 
 from pydantic import (
     UUID4,
@@ -11,7 +11,6 @@ from pydantic import (
 from temporalio import activity
 
 from tracecat.agent.common.types import (
-    MCPHttpServerConfig,
     MCPServerConfig,
     MCPToolDefinition,
 )
@@ -20,6 +19,7 @@ from tracecat.agent.mcp.internal_tools import (
     BUILDER_INTERNAL_TOOL_NAMES,
     get_builder_internal_tool_definitions,
 )
+from tracecat.agent.mcp.utils import is_http_server
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.tokens import InternalToolContext, UserMCPServerClaim
 from tracecat.agent.tools import build_agent_tools
@@ -81,10 +81,6 @@ class ApplyApprovalResultsActivityInputs(BaseModel):
 
 class AgentActivities:
     """Activities for agent execution."""
-
-    @staticmethod
-    def _is_http_server(config: MCPServerConfig) -> TypeGuard[MCPHttpServerConfig]:
-        return config.get("type", "http") == "http"
 
     def get_activities(self) -> list[Callable[..., Any]]:
         return all_activities(self)
@@ -158,7 +154,7 @@ class AgentActivities:
             from tracecat.agent.mcp.user_client import discover_user_mcp_tools
 
             http_servers = [
-                cfg for cfg in args.mcp_servers if self._is_http_server(cfg)
+                cfg for cfg in args.mcp_servers if is_http_server(cfg)
             ]
             if not http_servers:
                 logger.info("No HTTP MCP servers configured for discovery")

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -123,6 +123,11 @@ class AgentActivities:
             for action in actions_to_build
             if UserMCPClient.parse_user_mcp_tool_name(action)
         }
+        approved_mcp_action_names = {
+            mcp_tool_name_to_canonical(tool_name)
+            for tool_name in (args.tool_approvals or {})
+            if UserMCPClient.parse_user_mcp_tool_name(tool_name)
+        }
         registry_actions = [
             action
             for action in actions_to_build
@@ -170,12 +175,50 @@ class AgentActivities:
                 f"{sorted(selected_mcp_action_names)}"
             )
         if args.mcp_servers:
-            http_servers = [
-                cfg for cfg in args.mcp_servers if is_http_server(cfg)
-            ]
-            if not http_servers:
-                logger.info("No HTTP MCP servers configured for discovery")
-                http_servers = []
+            http_servers = [cfg for cfg in args.mcp_servers if is_http_server(cfg)]
+            known_server_names = {cfg["name"] for cfg in args.mcp_servers}
+            stdio_server_names = {
+                cfg["name"] for cfg in args.mcp_servers if not is_http_server(cfg)
+            }
+            if selected_mcp_action_names:
+                selected_stdio_tools = {
+                    name
+                    for name in selected_mcp_action_names
+                    if (
+                        parsed := UserMCPClient.parse_user_mcp_tool_name(
+                            name,
+                            known_server_names=known_server_names,
+                        )
+                    )
+                    and parsed[0] in stdio_server_names
+                }
+                if selected_stdio_tools:
+                    raise TracecatValidationError(
+                        "Stdio MCP tools cannot be allowlisted individually in the "
+                        "Claude runtime because stdio integrations are mounted as "
+                        "whole servers: "
+                        f"{sorted(selected_stdio_tools)}"
+                    )
+
+            if args.tool_approvals:
+                stdio_approval_tools = {
+                    tool_name
+                    for tool_name in args.tool_approvals
+                    if (
+                        parsed := UserMCPClient.parse_user_mcp_tool_name(
+                            tool_name,
+                            known_server_names=known_server_names,
+                        )
+                    )
+                    and parsed[0] in stdio_server_names
+                }
+                if stdio_approval_tools:
+                    raise TracecatValidationError(
+                        "Stdio MCP tool approvals are not supported in the Claude "
+                        "runtime because approved stdio calls cannot be replayed "
+                        "through the executor: "
+                        f"{sorted(stdio_approval_tools)}"
+                    )
 
             try:
                 user_mcp_tools = await discover_user_mcp_tools(http_servers)
@@ -199,7 +242,20 @@ class AgentActivities:
                         if mcp_tool_name_to_canonical(tool_name)
                         in selected_mcp_action_names
                     }
+                else:
+                    canonical_mcp_names = {
+                        mcp_tool_name_to_canonical(tool_name)
+                        for tool_name in user_mcp_tools
+                    }
 
+                missing_mcp_approval_tools = (
+                    approved_mcp_action_names - canonical_mcp_names
+                )
+                if missing_mcp_approval_tools:
+                    raise TracecatValidationError(
+                        "Some MCP tool approvals did not match configured integrations: "
+                        f"{sorted(missing_mcp_approval_tools)}"
+                    )
 
                 # Add user MCP tools to definitions
                 for tool_name, tool_def in user_mcp_tools.items():

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -19,13 +19,15 @@ from tracecat.agent.mcp.internal_tools import (
     BUILDER_INTERNAL_TOOL_NAMES,
     get_builder_internal_tool_definitions,
 )
-from tracecat.agent.mcp.utils import is_http_server
+from tracecat.agent.mcp.user_client import UserMCPClient
+from tracecat.agent.mcp.utils import is_http_server, mcp_tool_name_to_canonical
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.tokens import InternalToolContext, UserMCPServerClaim
 from tracecat.agent.tools import build_agent_tools
 from tracecat.auth.types import Role
 from tracecat.common import all_activities
 from tracecat.contexts import ctx_role
+from tracecat.exceptions import TracecatValidationError
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
@@ -113,16 +115,30 @@ class AgentActivities:
         )
 
         # For builder sessions, add bundled actions to the tool filters
-        actions_to_build = list(args.tool_filters.actions or [])
+        actions_to_build = [
+            action.strip()
+            for action in (args.tool_filters.actions or [])
+            if action.strip()
+        ]
+        selected_mcp_action_names = {
+            mcp_tool_name_to_canonical(action)
+            for action in actions_to_build
+            if UserMCPClient.parse_user_mcp_tool_name(action)
+        }
+        registry_actions = [
+            action
+            for action in actions_to_build
+            if not UserMCPClient.parse_user_mcp_tool_name(action)
+        ]
         if is_builder:
             # Add bundled registry actions for builder (core.table.*, tools.exa.*)
             for action in BUILDER_BUNDLED_ACTIONS:
-                if action not in actions_to_build:
-                    actions_to_build.append(action)
+                if action not in registry_actions:
+                    registry_actions.append(action)
 
         result = await build_agent_tools(
             namespaces=args.tool_filters.namespaces,
-            actions=actions_to_build if actions_to_build else None,
+            actions=registry_actions if registry_actions else None,
             tool_approvals=args.tool_approvals,
         )
         # Convert to dict[str, MCPToolDefinition] keyed by canonical action name
@@ -150,6 +166,11 @@ class AgentActivities:
 
         # Discover user MCP tools if configured
         user_mcp_claims: list[UserMCPServerClaim] | None = None
+        if selected_mcp_action_names and not args.mcp_servers:
+            raise TracecatValidationError(
+                "MCP tools were selected, but no MCP servers are configured: "
+                f"{sorted(selected_mcp_action_names)}"
+            )
         if args.mcp_servers:
             from tracecat.agent.mcp.user_client import discover_user_mcp_tools
 
@@ -162,6 +183,28 @@ class AgentActivities:
 
             try:
                 user_mcp_tools = await discover_user_mcp_tools(http_servers)
+
+                # If specific MCP tools were selected, only include those.
+                # Otherwise include all discovered MCP tools for backward compatibility.
+                if selected_mcp_action_names:
+                    canonical_mcp_names = {
+                        mcp_tool_name_to_canonical(tool_name)
+                        for tool_name in user_mcp_tools
+                    }
+                    missing_mcp_tools = selected_mcp_action_names - canonical_mcp_names
+                    if missing_mcp_tools:
+                        raise TracecatValidationError(
+                            "Some MCP tools were not found in configured integrations: "
+                            f"{sorted(missing_mcp_tools)}"
+                        )
+                    user_mcp_tools = {
+                        tool_name: tool_def
+                        for tool_name, tool_def in user_mcp_tools.items()
+                        if mcp_tool_name_to_canonical(tool_name)
+                        in selected_mcp_action_names
+                    }
+
+
                 # Add user MCP tools to definitions
                 for tool_name, tool_def in user_mcp_tools.items():
                     defs[tool_name] = tool_def
@@ -183,6 +226,8 @@ class AgentActivities:
                     tool_count=len(user_mcp_tools),
                     server_count=len(http_servers),
                 )
+            except TracecatValidationError:
+                raise
             except Exception as e:
                 logger.error(
                     "Failed to discover user MCP tools",

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -15,16 +15,17 @@ with workflow.unsafe.imports_passed_through():
 
     from tracecat import config
     from tracecat.agent.common.stream_types import HarnessType
+    from tracecat.agent.common.types import MCPHttpServerConfig, MCPServerConfig
     from tracecat.agent.executor.activity import (
         AgentExecutorInput,
         ApprovedToolCall,
         DeniedToolCall,
+        ExecuteApprovedToolsInput,
+        execute_approved_tools_activity,
         run_agent_activity,
     )
     from tracecat.agent.mcp.executor import (
-        AGENT_TOOL_PRIORITY,
         build_run_input,
-        build_tracecat_mcp_role,
     )
     from tracecat.agent.mcp.utils import normalize_mcp_tool_name
     from tracecat.agent.parsers import try_parse_json
@@ -36,11 +37,8 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.session.activities import (
         CreateSessionInput,
         LoadSessionInput,
-        PendingToolResult,
-        ReconcileToolResultsInput,
         create_session_activity,
         load_session_activity,
-        reconcile_tool_results_activity,
     )
     from tracecat.agent.session.types import AgentSessionEntity
     from tracecat.agent.tokens import (
@@ -53,7 +51,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.auth.types import Role
     from tracecat.contexts import ctx_role
     from tracecat.dsl.common import RETRY_POLICIES
-    from tracecat.executor.activities import ExecutorActivities
     from tracecat.logger import logger
     from tracecat.registry.lock.types import RegistryLock
     from tracecat.workflow.executions.correlation import (
@@ -522,10 +519,43 @@ class DurableAgentWorkflow:
 
                 tool_results = None
                 if approved_tools or denied_tools:
-                    tool_results = await self._execute_and_reconcile_approved_tools(
-                        approved_tools=approved_tools,
-                        denied_tools=denied_tools,
+                    if self._registry_lock is None:
+                        raise ApplicationError(
+                            "Registry lock not initialized",
+                            non_retryable=True,
+                        )
+                    # Convert user MCP claims to configs for tool execution
+                    user_mcp_configs: list[MCPServerConfig] | None = (
+                        [
+                            MCPHttpServerConfig(
+                                name=claim.name,
+                                url=claim.url,
+                                transport=claim.transport,
+                                headers=claim.headers,
+                            )
+                            for claim in user_mcp_claims
+                        ]
+                        if user_mcp_claims
+                        else None
                     )
+
+                    tool_exec_result = await workflow.execute_activity(
+                        execute_approved_tools_activity,
+                        ExecuteApprovedToolsInput(
+                            session_id=self.session_id,
+                            workspace_id=self.workspace_id,
+                            role=self.role,
+                            approved_tools=approved_tools,
+                            denied_tools=denied_tools,
+                            allowed_actions=list(allowed_actions.keys()),
+                            registry_lock=self._registry_lock,
+                            user_mcp_configs=user_mcp_configs,
+                        ),
+                        start_to_close_timeout=timedelta(seconds=300),
+                        heartbeat_timeout=timedelta(seconds=60),
+                        retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                    )
+                    tool_results = tool_exec_result.results
                     logger.info(
                         "Tool execution completed",
                         result_count=len(tool_results),
@@ -651,84 +681,3 @@ class DurableAgentWorkflow:
         )
 
         return approved, denied
-
-    async def _execute_and_reconcile_approved_tools(
-        self,
-        *,
-        approved_tools: list[ApprovedToolCall],
-        denied_tools: list[DeniedToolCall],
-    ) -> list:
-        if self._registry_lock is None:
-            raise ApplicationError(
-                "Registry lock not initialized",
-                non_retryable=True,
-            )
-
-        logical_time = workflow.now()
-        service_role = build_tracecat_mcp_role(
-            workspace_id=self.role.workspace_id,
-            organization_id=self.role.organization_id,
-            user_id=self.role.user_id,
-        )
-        pending_results: list[PendingToolResult] = []
-        for tool_call in approved_tools:
-            try:
-                stored = await workflow.execute_activity(
-                    ExecutorActivities.execute_action_activity,
-                    args=[
-                        _build_approved_tool_run_input(
-                            tool_call=tool_call,
-                            registry_lock=self._registry_lock,
-                            workflow_id=workflow.uuid4(),
-                            run_id=workflow.uuid4(),
-                            execution_id=workflow.uuid4(),
-                            logical_time=logical_time,
-                        ),
-                        service_role,
-                    ],
-                    task_queue=config.TRACECAT__EXECUTOR_QUEUE,
-                    start_to_close_timeout=timedelta(
-                        seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
-                    ),
-                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                    priority=AGENT_TOOL_PRIORITY,
-                )
-                pending_results.append(
-                    PendingToolResult(
-                        tool_call_id=tool_call.tool_call_id,
-                        tool_name=tool_call.tool_name,
-                        stored_result=stored,
-                    )
-                )
-            except ActivityError as e:
-                pending_results.append(
-                    PendingToolResult(
-                        tool_call_id=tool_call.tool_call_id,
-                        tool_name=tool_call.tool_name,
-                        raw_result=f"Tool execution failed: {_activity_error_message(e)}",
-                        is_error=True,
-                    )
-                )
-
-        for denied_tool in denied_tools:
-            pending_results.append(
-                PendingToolResult(
-                    tool_call_id=denied_tool.tool_call_id,
-                    tool_name=denied_tool.tool_name,
-                    raw_result=f"Tool denied by user: {denied_tool.reason}",
-                    is_error=True,
-                )
-            )
-
-        reconcile = await workflow.execute_activity(
-            reconcile_tool_results_activity,
-            ReconcileToolResultsInput(
-                session_id=self.session_id,
-                workspace_id=self.workspace_id,
-                role=self.role,
-                pending_results=pending_results,
-            ),
-            start_to_close_timeout=timedelta(seconds=300),
-            retry_policy=RETRY_POLICIES["activity:fail_fast"],
-        )
-        return reconcile.results

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import TypedSearchAttributes
-from temporalio.exceptions import ActivityError, ApplicationError
+from temporalio.exceptions import ApplicationError
 
 with workflow.unsafe.imports_passed_through():
     from pydantic_ai.messages import ToolCallPart
@@ -24,10 +24,6 @@ with workflow.unsafe.imports_passed_through():
         execute_approved_tools_activity,
         run_agent_activity,
     )
-    from tracecat.agent.mcp.executor import (
-        build_run_input,
-    )
-    from tracecat.agent.mcp.utils import normalize_mcp_tool_name
     from tracecat.agent.parsers import try_parse_json
     from tracecat.agent.preset.activities import (
         ResolveAgentPresetConfigActivityInput,
@@ -69,33 +65,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat_ee.agent.context import AgentContext
     from tracecat_ee.agent.types import AgentWorkflowID
 
-
-def _activity_error_message(error: ActivityError) -> str:
-    cause = error.cause
-    if cause is not None:
-        return str(cause)
-    return str(error)
-
-
-def _build_approved_tool_run_input(
-    *,
-    tool_call: ApprovedToolCall,
-    registry_lock: RegistryLock,
-    workflow_id: uuid.UUID,
-    run_id: uuid.UUID,
-    execution_id: uuid.UUID,
-    logical_time: datetime,
-):
-    action_name = normalize_mcp_tool_name(tool_call.tool_name)
-    return build_run_input(
-        action_name=action_name,
-        args=tool_call.args,
-        registry_lock=registry_lock,
-        workflow_id=workflow_id,
-        run_id=run_id,
-        execution_id=execution_id,
-        logical_time=logical_time,
-    )
 
 
 class AgentWorkflowArgs(BaseModel):

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 from temporalio import workflow
 from temporalio.common import TypedSearchAttributes
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ActivityError, ApplicationError
 
 with workflow.unsafe.imports_passed_through():
     from pydantic_ai.messages import ToolCallPart
@@ -24,6 +24,13 @@ with workflow.unsafe.imports_passed_through():
         execute_approved_tools_activity,
         run_agent_activity,
     )
+    from tracecat.agent.mcp.executor import (
+        AGENT_TOOL_PRIORITY,
+        build_run_input,
+        build_tracecat_mcp_role,
+    )
+    from tracecat.agent.mcp.user_client import UserMCPClient
+    from tracecat.agent.mcp.utils import normalize_mcp_tool_name
     from tracecat.agent.parsers import try_parse_json
     from tracecat.agent.preset.activities import (
         ResolveAgentPresetConfigActivityInput,
@@ -33,12 +40,16 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.session.activities import (
         CreateSessionInput,
         LoadSessionInput,
+        PendingToolResult,
+        ReconcileToolResultsInput,
         create_session_activity,
         load_session_activity,
+        reconcile_tool_results_activity,
     )
     from tracecat.agent.session.types import AgentSessionEntity
     from tracecat.agent.tokens import (
         InternalToolContext,
+        UserMCPServerClaim,
         mint_llm_token,
         mint_mcp_token,
     )
@@ -47,6 +58,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.auth.types import Role
     from tracecat.contexts import ctx_role
     from tracecat.dsl.common import RETRY_POLICIES
+    from tracecat.executor.activities import ExecutorActivities
     from tracecat.logger import logger
     from tracecat.registry.lock.types import RegistryLock
     from tracecat.workflow.executions.correlation import (
@@ -64,7 +76,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat_ee.agent.approvals.service import ApprovalManager, ApprovalMap
     from tracecat_ee.agent.context import AgentContext
     from tracecat_ee.agent.types import AgentWorkflowID
-
 
 
 class AgentWorkflowArgs(BaseModel):
@@ -112,6 +123,34 @@ def _resolve_agent_output(
 UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH = (
     "durable-agent-upsert-tracecat-search-attributes-v1"
 )
+
+
+def _activity_error_message(error: ActivityError) -> str:
+    cause = error.cause
+    if cause is not None:
+        return str(cause)
+    return str(error)
+
+
+def _build_approved_tool_run_input(
+    *,
+    tool_call: ApprovedToolCall,
+    registry_lock: RegistryLock,
+    workflow_id: uuid.UUID,
+    run_id: uuid.UUID,
+    execution_id: uuid.UUID,
+    logical_time: datetime,
+):
+    action_name = normalize_mcp_tool_name(tool_call.tool_name)
+    return build_run_input(
+        action_name=action_name,
+        args=tool_call.args,
+        registry_lock=registry_lock,
+        workflow_id=workflow_id,
+        run_id=run_id,
+        execution_id=execution_id,
+        logical_time=logical_time,
+    )
 
 
 @workflow.defn
@@ -488,43 +527,12 @@ class DurableAgentWorkflow:
 
                 tool_results = None
                 if approved_tools or denied_tools:
-                    if self._registry_lock is None:
-                        raise ApplicationError(
-                            "Registry lock not initialized",
-                            non_retryable=True,
-                        )
-                    # Convert user MCP claims to configs for tool execution
-                    user_mcp_configs: list[MCPServerConfig] | None = (
-                        [
-                            MCPHttpServerConfig(
-                                name=claim.name,
-                                url=claim.url,
-                                transport=claim.transport,
-                                headers=claim.headers,
-                            )
-                            for claim in user_mcp_claims
-                        ]
-                        if user_mcp_claims
-                        else None
+                    tool_results = await self._execute_approved_tools(
+                        approved_tools=approved_tools,
+                        denied_tools=denied_tools,
+                        allowed_actions=list(allowed_actions.keys()),
+                        user_mcp_claims=user_mcp_claims,
                     )
-
-                    tool_exec_result = await workflow.execute_activity(
-                        execute_approved_tools_activity,
-                        ExecuteApprovedToolsInput(
-                            session_id=self.session_id,
-                            workspace_id=self.workspace_id,
-                            role=self.role,
-                            approved_tools=approved_tools,
-                            denied_tools=denied_tools,
-                            allowed_actions=list(allowed_actions.keys()),
-                            registry_lock=self._registry_lock,
-                            user_mcp_configs=user_mcp_configs,
-                        ),
-                        start_to_close_timeout=timedelta(seconds=300),
-                        heartbeat_timeout=timedelta(seconds=60),
-                        retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                    )
-                    tool_results = tool_exec_result.results
                     logger.info(
                         "Tool execution completed",
                         result_count=len(tool_results),
@@ -650,3 +658,148 @@ class DurableAgentWorkflow:
         )
 
         return approved, denied
+
+    async def _execute_approved_tools(
+        self,
+        *,
+        approved_tools: list[ApprovedToolCall],
+        denied_tools: list[DeniedToolCall],
+        allowed_actions: list[str],
+        user_mcp_claims: list[UserMCPServerClaim] | None,
+    ) -> list[Any]:
+        """Execute approved tools and reconcile results into session history."""
+        if self._registry_lock is None:
+            raise ApplicationError(
+                "Registry lock not initialized",
+                non_retryable=True,
+            )
+
+        user_mcp_configs: list[MCPServerConfig] | None = None
+        known_mcp_server_names: set[str] | None = None
+        if user_mcp_claims:
+            mcp_cfgs: list[MCPServerConfig] = []
+            for claim in user_mcp_claims:
+                mcp_cfg = MCPHttpServerConfig(
+                    name=claim.name,
+                    url=claim.url,
+                    transport=claim.transport,
+                    headers=claim.headers,
+                )
+                if claim.timeout is not None:
+                    mcp_cfg["timeout"] = claim.timeout
+                mcp_cfgs.append(mcp_cfg)
+            user_mcp_configs = mcp_cfgs
+            known_mcp_server_names = {claim.name for claim in user_mcp_claims}
+
+        logical_time = workflow.now()
+        service_role = build_tracecat_mcp_role(
+            workspace_id=self.role.workspace_id,
+            organization_id=self.role.organization_id,
+            user_id=self.role.user_id,
+        )
+        pending_results_by_id: dict[str, PendingToolResult] = {}
+
+        mcp_approved_tools = [
+            tool_call
+            for tool_call in approved_tools
+            if known_mcp_server_names
+            and UserMCPClient.parse_user_mcp_tool_name(
+                tool_call.tool_name,
+                known_server_names=known_mcp_server_names,
+            )
+            is not None
+        ]
+
+        if mcp_approved_tools:
+            tool_exec_result = await workflow.execute_activity(
+                execute_approved_tools_activity,
+                ExecuteApprovedToolsInput(
+                    session_id=self.session_id,
+                    workspace_id=self.workspace_id,
+                    role=self.role,
+                    approved_tools=mcp_approved_tools,
+                    denied_tools=[],
+                    allowed_actions=allowed_actions,
+                    registry_lock=self._registry_lock,
+                    user_mcp_configs=user_mcp_configs,
+                ),
+                task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
+                start_to_close_timeout=timedelta(seconds=300),
+                heartbeat_timeout=timedelta(seconds=60),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+            pending_results_by_id.update(
+                {
+                    result.tool_call_id: PendingToolResult(
+                        tool_call_id=result.tool_call_id,
+                        tool_name=result.tool_name,
+                        raw_result=result.result,
+                        is_error=result.is_error,
+                    )
+                    for result in tool_exec_result.results
+                }
+            )
+
+        for tool_call in approved_tools:
+            if tool_call.tool_call_id in pending_results_by_id:
+                continue
+            try:
+                stored = await workflow.execute_activity(
+                    ExecutorActivities.execute_action_activity,
+                    args=[
+                        _build_approved_tool_run_input(
+                            tool_call=tool_call,
+                            registry_lock=self._registry_lock,
+                            workflow_id=workflow.uuid4(),
+                            run_id=workflow.uuid4(),
+                            execution_id=workflow.uuid4(),
+                            logical_time=logical_time,
+                        ),
+                        service_role,
+                    ],
+                    task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+                    start_to_close_timeout=timedelta(
+                        seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
+                    ),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                    priority=AGENT_TOOL_PRIORITY,
+                )
+                pending_results_by_id[tool_call.tool_call_id] = PendingToolResult(
+                    tool_call_id=tool_call.tool_call_id,
+                    tool_name=tool_call.tool_name,
+                    stored_result=stored,
+                )
+            except ActivityError as e:
+                pending_results_by_id[tool_call.tool_call_id] = PendingToolResult(
+                    tool_call_id=tool_call.tool_call_id,
+                    tool_name=tool_call.tool_name,
+                    raw_result=f"Tool execution failed: {_activity_error_message(e)}",
+                    is_error=True,
+                )
+
+        pending_results = [
+            pending_results_by_id[tool_call.tool_call_id]
+            for tool_call in approved_tools
+        ]
+        pending_results.extend(
+            PendingToolResult(
+                tool_call_id=denied_tool.tool_call_id,
+                tool_name=denied_tool.tool_name,
+                raw_result=f"Tool denied by user: {denied_tool.reason}",
+                is_error=True,
+            )
+            for denied_tool in denied_tools
+        )
+
+        reconcile = await workflow.execute_activity(
+            reconcile_tool_results_activity,
+            ReconcileToolResultsInput(
+                session_id=self.session_id,
+                workspace_id=self.workspace_id,
+                role=self.role,
+                pending_results=pending_results,
+            ),
+            start_to_close_timeout=timedelta(seconds=300),
+            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        )
+        return reconcile.results

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -66,6 +66,7 @@ from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import AgentSessionHistory, User
 from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.dsl.schemas import RunActionInput
+from tracecat.executor.activities import ExecutorActivities
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import InlineObject
 from tracecat.tiers import defaults as tier_defaults
@@ -183,17 +184,19 @@ def create_mock_execute_action_activity(
     response_callback: Callable[[RunActionInput], InlineObject[dict[str, str]]]
     | None = None,
 ) -> Callable[..., Any]:
-    """Create a mock executor activity for approved registry UDFs."""
+    """Create a mock registry action executor activity."""
 
-    @activity.defn(name="execute_action_activity")
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
     async def mock_execute_action_activity(
         input: RunActionInput,
         role: Role,
     ) -> InlineObject[dict[str, str]]:
         del role
-        if response_callback:
-            return response_callback(input)
-        return InlineObject(data={"status": "success"})
+        return (
+            response_callback(input)
+            if response_callback
+            else InlineObject(data={"status": "success"})
+        )
 
     return mock_execute_action_activity
 
@@ -697,7 +700,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
     async def mock_apply_approval_decisions(input: Any) -> None:
         del input
 
-    @activity.defn(name="execute_action_activity")
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
     async def mock_execute_action_activity(
         input: RunActionInput,
         role: Role,
@@ -783,7 +786,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
     assert resumed_after_approval.is_set()
     assert len(captured_run_inputs) == 1
     assert len(captured_executor_roles) == 1
-    assert captured_run_inputs[0].task.action == "core__http_request"
+    assert captured_run_inputs[0].task.action == "core.http_request"
     assert captured_executor_roles[0].type == "service"
     assert captured_executor_roles[0].service_id == "tracecat-mcp"
     assert captured_executor_roles[0].workspace_id == svc_role.workspace_id
@@ -1010,7 +1013,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
     async def mock_apply_approval_decisions(input: Any) -> None:
         del input
 
-    @activity.defn(name="execute_action_activity")
+    @activity.defn(name=ExecutorActivities.execute_action_activity.__name__)
     async def mock_execute_action_activity(
         input: RunActionInput,
         role: Role,
@@ -1019,7 +1022,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         nonlocal executor_attempts
         executor_attempts += 1
         if executor_attempts == 1:
-            raise ApplicationError("transient tool failure")
+            raise ApplicationError("transient tool failure", non_retryable=True)
         return InlineObject(data={"status": "success"})
 
     workflow_args = AgentWorkflowArgs(

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -17,9 +17,12 @@ from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
+    ExecuteApprovedToolsInput,
     _execute_user_mcp_tool_with_heartbeat,
+    execute_approved_tools_activity,
     run_agent_activity,
 )
+from tracecat.agent.executor.schemas import ApprovedToolCall
 from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
@@ -33,6 +36,7 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.registry.lock.types import RegistryLock
 
 
 @pytest.fixture
@@ -488,3 +492,50 @@ class TestApprovedToolExecutionHeartbeat:
                 for call in mock_activity.heartbeat.call_args_list
                 if call.args
             )
+
+    @pytest.mark.anyio
+    async def test_approved_mcp_results_match_auto_approved_encoding(
+        self, mock_role: Role
+    ) -> None:
+        """Replay should preserve plain string MCP tool output."""
+        input = ExecuteApprovedToolsInput(
+            session_id=uuid.uuid4(),
+            workspace_id=mock_role.workspace_id or uuid.uuid4(),
+            role=mock_role,
+            approved_tools=[
+                ApprovedToolCall(
+                    tool_call_id="toolu_123",
+                    tool_name="mcp.Linear.list_issues",
+                    args={"limit": 10},
+                )
+            ],
+            denied_tools=[],
+            allowed_actions=[],
+            registry_lock=RegistryLock(origins={}, actions={}),
+            user_mcp_configs=[
+                {
+                    "type": "http",
+                    "name": "Linear",
+                    "display_name": "Linear",
+                    "url": "https://mcp.example.com",
+                }
+            ],
+        )
+
+        with (
+            patch(
+                "tracecat.agent.executor.activity._execute_user_mcp_tool_with_heartbeat",
+                new=AsyncMock(return_value='{"items":[]}'),
+            ),
+            patch("tracecat.agent.executor.activity.activity") as mock_activity,
+        ):
+            mock_activity.heartbeat = MagicMock()
+
+            result = await execute_approved_tools_activity(input)
+
+        assert result.success is True
+        assert len(result.results) == 1
+        assert result.results[0].tool_call_id == "toolu_123"
+        assert result.results[0].tool_name == "mcp.Linear.list_issues"
+        assert result.results[0].result == '{"items":[]}'
+        assert result.results[0].is_error is False

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -7,6 +7,7 @@ These tests cover:
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +17,7 @@ from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
+    _execute_user_mcp_tool_with_heartbeat,
     run_agent_activity,
 )
 from tracecat.agent.session.activities import (
@@ -440,3 +442,49 @@ class TestRunAgentActivity:
 
             # Should send heartbeat at start and end
             assert mock_activity.heartbeat.call_count >= 2
+
+
+class TestApprovedToolExecutionHeartbeat:
+    """Tests for heartbeat behavior while executing approved tools."""
+
+    @pytest.mark.anyio
+    async def test_user_mcp_execution_sends_periodic_heartbeats(self) -> None:
+        """Send heartbeats while waiting on a long-running user MCP call."""
+
+        async def slow_call_user_mcp_tool(
+            *,
+            configs,
+            server_name,
+            tool_name,
+            args,
+        ):
+            del configs, server_name, tool_name, args
+            await asyncio.sleep(0.03)
+            return {"ok": True}
+
+        with (
+            patch(
+                "tracecat.agent.executor.activity.call_user_mcp_tool",
+                side_effect=slow_call_user_mcp_tool,
+            ) as mock_call_user_mcp_tool,
+            patch("tracecat.agent.executor.activity.activity") as mock_activity,
+            patch("tracecat.agent.executor.activity.HEARTBEAT_INTERVAL", 0.01),
+        ):
+            mock_activity.heartbeat = MagicMock()
+
+            result = await _execute_user_mcp_tool_with_heartbeat(
+                configs=[{"name": "Linear", "url": "https://mcp.example.com"}],
+                server_name="Linear",
+                tool_name="issues.list",
+                args={"limit": 10},
+                original_tool_name="mcp.Linear.issues.list",
+            )
+
+            assert result == {"ok": True}
+            mock_call_user_mcp_tool.assert_awaited_once()
+            assert mock_activity.heartbeat.call_count >= 1
+            assert any(
+                "Executing tool mcp.Linear.issues.list" in call.args[0]
+                for call in mock_activity.heartbeat.call_args_list
+                if call.args
+            )

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -1,33 +1,33 @@
 from __future__ import annotations
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPStdioServerConfig
-from tracecat.agent.factory import _is_http_server
+from tracecat.agent.mcp.utils import is_http_server
 
 
-def test_is_http_server_accepts_legacy_untyped_http_config() -> None:
+def testis_http_server_accepts_legacy_untyped_http_config() -> None:
     legacy_http_config: MCPHttpServerConfig = {
         "name": "legacy",
         "url": "http://localhost:8080",
     }
 
-    assert _is_http_server(legacy_http_config) is True
+    assert is_http_server(legacy_http_config) is True
 
 
-def test_is_http_server_accepts_explicit_http_type() -> None:
+def testis_http_server_accepts_explicit_http_type() -> None:
     typed_http_config: MCPHttpServerConfig = {
         "type": "http",
         "name": "typed",
         "url": "http://localhost:8080",
     }
 
-    assert _is_http_server(typed_http_config) is True
+    assert is_http_server(typed_http_config) is True
 
 
-def test_is_http_server_rejects_stdio_type() -> None:
+def testis_http_server_rejects_stdio_type() -> None:
     stdio_config: MCPStdioServerConfig = {
         "type": "stdio",
         "name": "local-tools",
         "command": "npx",
     }
 
-    assert _is_http_server(stdio_config) is False
+    assert is_http_server(stdio_config) is False

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPStdioServerConfig
+from tracecat.agent.factory import build_agent
 from tracecat.agent.mcp.utils import is_http_server
+from tracecat.agent.types import AgentConfig
 
 
 def testis_http_server_accepts_legacy_untyped_http_config() -> None:
@@ -31,3 +39,249 @@ def testis_http_server_rejects_stdio_type() -> None:
     }
 
     assert is_http_server(stdio_config) is False
+
+
+@pytest.mark.anyio
+async def test_build_agent_routes_mcp_actions_to_filtered_toolsets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_agent_tools_mock = AsyncMock(
+        return_value=SimpleNamespace(tools=[], collected_secrets=set())
+    )
+    captured_http_servers: list[dict[str, object]] = []
+
+    class FakeHTTPToolset:
+        def __init__(
+            self,
+            *,
+            url: str,
+            headers: dict[str, str],
+            allowed_tool_names: set[str] | None = None,
+            timeout: float | None = None,
+        ) -> None:
+            captured_http_servers.append(
+                {
+                    "url": url,
+                    "headers": headers,
+                    "allowed_tool_names": allowed_tool_names,
+                    "timeout": timeout,
+                }
+            )
+
+    class FakeAgent:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(
+        "tracecat.agent.factory.build_agent_tools", build_agent_tools_mock
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.factory._FilteredMCPServerStreamableHTTP",
+        FakeHTTPToolset,
+    )
+    monkeypatch.setattr("tracecat.agent.factory.Agent", FakeAgent)
+    monkeypatch.setattr("tracecat.agent.factory.get_model", lambda *args: "model")
+    monkeypatch.setattr("tracecat.agent.factory.parse_output_type", lambda value: str)
+
+    config = AgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        actions=["core.http_request", "mcp.Linear.list_issues"],
+        mcp_servers=[
+            {
+                "type": "http",
+                "name": "Linear",
+                "url": "https://mcp.linear.app/mcp",
+                "headers": {"Authorization": "Bearer token"},
+            }
+        ],
+        instructions="test",
+    )
+
+    fake_agent = cast(FakeAgent, await build_agent(config))
+
+    build_agent_tools_mock.assert_awaited_once()
+    assert build_agent_tools_mock.await_args is not None
+    assert build_agent_tools_mock.await_args.kwargs["actions"] == ["core.http_request"]
+    assert captured_http_servers == [
+        {
+            "url": "https://mcp.linear.app/mcp",
+            "headers": {"Authorization": "Bearer token"},
+            "allowed_tool_names": {"list_issues"},
+            "timeout": None,
+        }
+    ]
+    assert fake_agent.kwargs["toolsets"] is not None
+
+
+@pytest.mark.anyio
+async def test_build_agent_preserves_dotted_mcp_tool_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_agent_tools_mock = AsyncMock(
+        return_value=SimpleNamespace(tools=[], collected_secrets=set())
+    )
+    captured_http_servers: list[dict[str, object]] = []
+
+    class FakeHTTPToolset:
+        def __init__(
+            self,
+            *,
+            url: str,
+            headers: dict[str, str],
+            allowed_tool_names: set[str] | None = None,
+            timeout: float | None = None,
+        ) -> None:
+            captured_http_servers.append(
+                {
+                    "url": url,
+                    "headers": headers,
+                    "allowed_tool_names": allowed_tool_names,
+                    "timeout": timeout,
+                }
+            )
+
+    class FakeAgent:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(
+        "tracecat.agent.factory.build_agent_tools", build_agent_tools_mock
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.factory._FilteredMCPServerStreamableHTTP",
+        FakeHTTPToolset,
+    )
+    monkeypatch.setattr("tracecat.agent.factory.Agent", FakeAgent)
+    monkeypatch.setattr("tracecat.agent.factory.get_model", lambda *args: "model")
+    monkeypatch.setattr("tracecat.agent.factory.parse_output_type", lambda value: str)
+
+    config = AgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        actions=["mcp.linear.foo.bar"],
+        mcp_servers=[
+            {
+                "type": "http",
+                "name": "linear",
+                "url": "https://mcp.linear.app/mcp",
+                "headers": {"Authorization": "Bearer token"},
+            }
+        ],
+        instructions="test",
+    )
+
+    await build_agent(config)
+
+    assert captured_http_servers == [
+        {
+            "url": "https://mcp.linear.app/mcp",
+            "headers": {"Authorization": "Bearer token"},
+            "allowed_tool_names": {"foo.bar"},
+            "timeout": None,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_build_agent_rejects_mcp_tool_approvals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.agent.factory.get_model",
+        lambda *args: "model",
+    )
+    monkeypatch.setattr("tracecat.agent.factory.parse_output_type", lambda value: str)
+
+    config = AgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        actions=["mcp.Linear.list_issues"],
+        tool_approvals={"mcp.Linear.list_issues": True},
+        mcp_servers=[
+            {
+                "type": "http",
+                "name": "Linear",
+                "url": "https://mcp.linear.app/mcp",
+            }
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="MCP tool approvals are not supported in the PydanticAI runtime",
+    ):
+        await build_agent(config)
+
+
+@pytest.mark.anyio
+async def test_build_agent_rejects_stdio_mcp_servers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.agent.factory.get_model",
+        lambda *args: "model",
+    )
+    monkeypatch.setattr("tracecat.agent.factory.parse_output_type", lambda value: str)
+
+    config = AgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        actions=["mcp.acme.com.list_issues"],
+        mcp_servers=[
+            {
+                "type": "stdio",
+                "name": "acme.com",
+                "command": "acme-mcp",
+            }
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Stdio MCP servers are not supported in the PydanticAI runtime",
+    ):
+        await build_agent(config)
+
+
+@pytest.mark.anyio
+async def test_build_agent_ignores_unused_stdio_mcp_servers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_agent_tools_mock = AsyncMock(
+        return_value=SimpleNamespace(tools=[], collected_secrets=set())
+    )
+
+    class FakeAgent:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(
+        "tracecat.agent.factory.build_agent_tools", build_agent_tools_mock
+    )
+    monkeypatch.setattr("tracecat.agent.factory.Agent", FakeAgent)
+    monkeypatch.setattr("tracecat.agent.factory.get_model", lambda *args: "model")
+    monkeypatch.setattr("tracecat.agent.factory.parse_output_type", lambda value: str)
+
+    config = AgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        actions=["core.http_request"],
+        mcp_servers=[
+            {
+                "type": "stdio",
+                "name": "acme.com",
+                "command": "acme-mcp",
+            }
+        ],
+    )
+
+    fake_agent = cast(FakeAgent, await build_agent(config))
+
+    build_agent_tools_mock.assert_awaited_once()
+    assert build_agent_tools_mock.await_args is not None
+    assert build_agent_tools_mock.await_args.kwargs["actions"] == ["core.http_request"]
+    assert fake_agent.kwargs["toolsets"] is None

--- a/tests/unit/test_agent_mcp_utils.py
+++ b/tests/unit/test_agent_mcp_utils.py
@@ -42,6 +42,22 @@ def test_parse_user_mcp_tool_name_canonical_splits_on_first_dot() -> None:
     assert parsed == ("Linear", "issues.list")
 
 
+def test_parse_user_mcp_tool_name_canonical_preserves_dotted_server_name() -> None:
+    parsed = UserMCPClient.parse_user_mcp_tool_name(
+        "mcp.acme.com.list_issues",
+        known_server_names={"acme.com"},
+    )
+    assert parsed == ("acme.com", "list_issues")
+
+
+def test_parse_user_mcp_tool_name_prefers_longest_server_match() -> None:
+    parsed = UserMCPClient.parse_user_mcp_tool_name(
+        "mcp.acme.com.issues.list",
+        known_server_names={"acme", "acme.com"},
+    )
+    assert parsed == ("acme.com", "issues.list")
+
+
 def test_parse_user_mcp_tool_name_rejects_registry_tools() -> None:
     assert (
         UserMCPClient.parse_user_mcp_tool_name(
@@ -68,3 +84,18 @@ def test_canonical_matches_runtime_wrapped_normalization() -> None:
     assert mcp_tool_name_to_canonical(discovered_name) == normalize_mcp_tool_name(
         wrapped_name
     )
+
+
+def test_normalize_mcp_tool_name_preserves_canonical_user_mcp_name() -> None:
+    assert normalize_mcp_tool_name("mcp.Linear.list_issues") == "mcp.Linear.list_issues"
+
+
+def test_normalize_mcp_tool_name_preserves_dotted_server_name() -> None:
+    assert (
+        normalize_mcp_tool_name("mcp.acme.com.list_issues")
+        == "mcp.acme.com.list_issues"
+    )
+
+
+def test_normalize_mcp_tool_name_denormalizes_registry_runtime_name() -> None:
+    assert normalize_mcp_tool_name("core__http_request") == "core.http_request"

--- a/tests/unit/test_agent_mcp_utils.py
+++ b/tests/unit/test_agent_mcp_utils.py
@@ -1,6 +1,12 @@
+"""Tests for MCP tool naming utilities."""
+
 from __future__ import annotations
 
-from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.mcp.user_client import UserMCPClient
+from tracecat.agent.mcp.utils import (
+    mcp_tool_name_to_canonical,
+    normalize_mcp_tool_name,
+)
 
 
 def test_normalize_mcp_tool_name_canonical_registry_prefix() -> None:
@@ -28,4 +34,37 @@ def test_normalize_mcp_tool_name_legacy_registry_user_mcp_prefix() -> None:
     assert (
         normalize_mcp_tool_name("mcp__tracecat_registry__mcp__Linear__list_issues")
         == "mcp.Linear.list_issues"
+    )
+
+
+def test_parse_user_mcp_tool_name_canonical_splits_on_first_dot() -> None:
+    parsed = UserMCPClient.parse_user_mcp_tool_name("mcp.Linear.issues.list")
+    assert parsed == ("Linear", "issues.list")
+
+
+def test_parse_user_mcp_tool_name_rejects_registry_tools() -> None:
+    assert (
+        UserMCPClient.parse_user_mcp_tool_name(
+            "mcp.tracecat-registry.core.cases.list_cases"
+        )
+        is None
+    )
+    assert (
+        UserMCPClient.parse_user_mcp_tool_name(
+            "mcp__tracecat-registry__core__cases__list_cases"
+        )
+        is None
+    )
+
+
+def test_mcp_tool_name_to_canonical_converts_tool_separators() -> None:
+    canonical = mcp_tool_name_to_canonical("mcp__Linear__issues__list")
+    assert canonical == "mcp.Linear.issues.list"
+
+
+def test_canonical_matches_runtime_wrapped_normalization() -> None:
+    discovered_name = "mcp__Linear__issues__list"
+    wrapped_name = f"mcp__tracecat-registry__{discovered_name}"
+    assert mcp_tool_name_to_canonical(discovered_name) == normalize_mcp_tool_name(
+        wrapped_name
     )

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1090,6 +1090,80 @@ class TestAgentPresetService:
         ]
         commit_mock.assert_not_awaited()
 
+    async def test_create_preset_canonicalizes_legacy_display_name_mcp_tools(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        agent_preset_create_params.actions = ["mcp.Linear.list_issues"]
+        agent_preset_create_params.mcp_integrations = ["linear-integration"]
+        agent_preset_create_params.tool_approvals = {"mcp.Linear.list_issues": True}
+
+        async def _resolve_mcp_integration_identities(
+            _mcp_integration_ids: list[str] | None,
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "type": "http",
+                    "name": "linear",
+                    "display_name": "Linear",
+                }
+            ]
+
+        async def _resolve_mcp_integrations(
+            _mcp_integration_ids: list[str] | None,
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "type": "http",
+                    "name": "linear",
+                    "display_name": "Linear",
+                    "url": "https://linear.example.com/mcp",
+                    "headers": {},
+                }
+            ]
+
+        async def _discover_user_mcp_tools(
+            _mcp_servers: list[dict[str, object]],
+        ) -> dict[str, object]:
+            return {
+                "mcp__linear__list_issues": type(
+                    "_ToolDef", (), {"description": "List issues"}
+                )()
+            }
+
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_validate_mcp_integrations",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_resolve_mcp_integration_identities",
+            _resolve_mcp_integration_identities,
+        )
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_resolve_mcp_integrations",
+            _resolve_mcp_integrations,
+        )
+        monkeypatch.setattr(
+            preset_service_module,
+            "discover_user_mcp_tools",
+            _discover_user_mcp_tools,
+        )
+
+        preset = await agent_preset_service.create_preset(agent_preset_create_params)
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=preset.id
+        )
+
+        assert preset.actions == ["mcp.linear.list_issues"]
+        assert preset.tool_approvals == {"mcp.linear.list_issues": True}
+        assert config.actions == ["mcp.linear.list_issues"]
+        assert config.tool_approvals == {"mcp.linear.list_issues": True}
+
     async def test_update_preset_rejects_mcp_integration_change_breaking_approval_rules(
         self,
         agent_preset_service: AgentPresetService,
@@ -1163,6 +1237,64 @@ class TestAgentPresetService:
                 preset,
                 AgentPresetUpdate(mcp_integrations=["github-integration"]),
             )
+
+    async def test_update_preset_allows_clearing_mcp_integrations_and_approvals_together(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        agent_preset_create_params.mcp_integrations = ["linear-integration"]
+        agent_preset_create_params.tool_approvals = {
+            "mcp.custom_linear.list_issues": True
+        }
+
+        async def _resolve_mcp_integrations(
+            _mcp_integration_ids: list[str] | None,
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "name": "custom_linear",
+                    "display_name": "Linear",
+                    "url": "https://linear.example.com/mcp",
+                    "headers": {},
+                }
+            ]
+
+        async def _discover_user_mcp_tools(
+            _mcp_servers: list[dict[str, object]],
+        ) -> dict[str, object]:
+            return {
+                "mcp__custom_linear__list_issues": type(
+                    "_ToolDef", (), {"description": "List issues"}
+                )()
+            }
+
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_validate_mcp_integrations",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_resolve_mcp_integrations",
+            _resolve_mcp_integrations,
+        )
+        monkeypatch.setattr(
+            preset_service_module,
+            "discover_user_mcp_tools",
+            _discover_user_mcp_tools,
+        )
+
+        preset = await agent_preset_service.create_preset(agent_preset_create_params)
+
+        updated_preset = await agent_preset_service.update_preset(
+            preset,
+            AgentPresetUpdate(mcp_integrations=None, tool_approvals=None),
+        )
+
+        assert updated_preset.mcp_integrations is None
+        assert updated_preset.tool_approvals is None
 
     async def test_create_preset_rejects_selected_stdio_mcp_tools(
         self,

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1052,12 +1052,19 @@ class TestAgentPresetService:
         async def _resolve_mcp_integrations(
             _mcp_integration_ids: list[str],
         ) -> list[dict[str, object]]:
-            return [{"name": "Linear", "url": "https://mcp.example.com", "headers": {}}]
+            return [
+                {
+                    "name": "custom_linear",
+                    "display_name": "Linear",
+                    "url": "https://mcp.example.com",
+                    "headers": {},
+                }
+            ]
 
         async def _discover_user_mcp_tools(
             _mcp_servers: list[dict[str, object]],
         ) -> dict[str, _ToolDef]:
-            return {"mcp__Linear__issues__list": _ToolDef()}
+            return {"mcp__custom_linear__issues__list": _ToolDef()}
 
         commit_mock = AsyncMock()
         monkeypatch.setattr(
@@ -1076,9 +1083,147 @@ class TestAgentPresetService:
 
         assert discovered == [
             preset_service_module.DiscoveredMCPTool(
-                name="mcp.Linear.issues.list",
+                name="mcp.custom_linear.issues.list",
                 description="List issues",
                 server_name="Linear",
             )
         ]
         commit_mock.assert_not_awaited()
+
+    async def test_update_preset_rejects_mcp_integration_change_breaking_approval_rules(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        agent_preset_create_params.mcp_integrations = ["linear-integration"]
+        agent_preset_create_params.tool_approvals = {
+            "mcp.custom_linear.list_issues": True
+        }
+
+        async def _resolve_mcp_integrations(
+            mcp_integration_ids: list[str] | None,
+        ) -> list[dict[str, object]]:
+            if mcp_integration_ids == ["linear-integration"]:
+                return [
+                    {
+                        "name": "custom_linear",
+                        "display_name": "Linear",
+                        "url": "https://linear.example.com/mcp",
+                        "headers": {},
+                    }
+                ]
+            return [
+                {
+                    "name": "custom_github",
+                    "display_name": "GitHub",
+                    "url": "https://github.example.com/mcp",
+                    "headers": {},
+                }
+            ]
+
+        async def _discover_user_mcp_tools(
+            mcp_servers: list[dict[str, object]],
+        ) -> dict[str, object]:
+            if mcp_servers[0]["name"] == "custom_linear":
+                return {
+                    "mcp__custom_linear__list_issues": type(
+                        "_ToolDef", (), {"description": "List issues"}
+                    )()
+                }
+            return {
+                "mcp__custom_github__list_pull_requests": type(
+                    "_ToolDef", (), {"description": "List pull requests"}
+                )()
+            }
+
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_validate_mcp_integrations",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_resolve_mcp_integrations",
+            _resolve_mcp_integrations,
+        )
+        monkeypatch.setattr(
+            preset_service_module,
+            "discover_user_mcp_tools",
+            _discover_user_mcp_tools,
+        )
+
+        preset = await agent_preset_service.create_preset(agent_preset_create_params)
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="Some MCP tools were not found in configured integrations",
+        ):
+            await agent_preset_service.update_preset(
+                preset,
+                AgentPresetUpdate(mcp_integrations=["github-integration"]),
+            )
+
+    async def test_create_preset_rejects_selected_stdio_mcp_tools(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        agent_preset_create_params.actions = ["mcp.acme.com.list_issues"]
+        agent_preset_create_params.mcp_integrations = ["stdio-integration"]
+
+        async def _resolve_mcp_integrations(
+            _mcp_integration_ids: list[str],
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "type": "stdio",
+                    "name": "acme.com",
+                    "command": "acme-mcp",
+                }
+            ]
+
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_resolve_mcp_integrations",
+            _resolve_mcp_integrations,
+        )
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="Stdio MCP tools cannot be allowlisted individually",
+        ):
+            await agent_preset_service.create_preset(agent_preset_create_params)
+
+    async def test_create_preset_rejects_stdio_mcp_tool_approvals(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        agent_preset_create_params.mcp_integrations = ["stdio-integration"]
+        agent_preset_create_params.tool_approvals = {"mcp.acme.com.list_issues": True}
+
+        async def _resolve_mcp_integrations(
+            _mcp_integration_ids: list[str],
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "type": "stdio",
+                    "name": "acme.com",
+                    "command": "acme-mcp",
+                }
+            ]
+
+        monkeypatch.setattr(
+            agent_preset_service,
+            "_resolve_mcp_integrations",
+            _resolve_mcp_integrations,
+        )
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="Stdio MCP tool approvals are not supported",
+        ):
+            await agent_preset_service.create_preset(agent_preset_create_params)

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -3,12 +3,14 @@
 import asyncio
 import uuid
 from typing import cast
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from tests.database import TEST_DB_CONFIG
+from tracecat.agent.preset import service as preset_service_module
 from tracecat.agent.preset.schemas import AgentPresetCreate, AgentPresetUpdate
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.types import AgentConfig
@@ -1036,3 +1038,47 @@ class TestAgentPresetService:
         update_params = AgentPresetUpdate(tool_approvals=None)
         updated_preset = await agent_preset_service.update_preset(preset, update_params)
         assert updated_preset.tool_approvals is None
+
+    async def test_discover_mcp_tools_is_read_only(
+        self,
+        agent_preset_service: AgentPresetService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Discovering MCP tools should not write or commit DB state."""
+
+        class _ToolDef:
+            description = "List issues"
+
+        async def _resolve_mcp_integrations(
+            _mcp_integration_ids: list[str],
+        ) -> list[dict[str, object]]:
+            return [{"name": "Linear", "url": "https://mcp.example.com", "headers": {}}]
+
+        async def _discover_user_mcp_tools(
+            _mcp_servers: list[dict[str, object]],
+        ) -> dict[str, _ToolDef]:
+            return {"mcp__Linear__issues__list": _ToolDef()}
+
+        commit_mock = AsyncMock()
+        monkeypatch.setattr(
+            agent_preset_service, "_resolve_mcp_integrations", _resolve_mcp_integrations
+        )
+        monkeypatch.setattr(
+            preset_service_module,
+            "discover_user_mcp_tools",
+            _discover_user_mcp_tools,
+        )
+        monkeypatch.setattr(agent_preset_service.session, "commit", commit_mock)
+
+        discovered = await agent_preset_service.discover_mcp_tools(
+            ["40f31ce3-a0c7-4b0a-bf26-2d8dc6a0ea16"]
+        )
+
+        assert discovered == [
+            preset_service_module.DiscoveredMCPTool(
+                name="mcp.Linear.issues.list",
+                description="List issues",
+                server_name="Linear",
+            )
+        ]
+        commit_mock.assert_not_awaited()

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -322,6 +322,10 @@ class TestClaudeAgentRuntimeRun:
 
         assert os.environ["CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK"] == "existing"
 
+
+class TestClaudeAgentRuntimeRunContinued:
+    """Additional tests for ClaudeAgentRuntime.run()."""
+
     @pytest.mark.anyio
     async def test_sends_error_on_exception(
         self,

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
@@ -14,18 +13,14 @@ from tracecat_ee.agent.workflows.durable import (
     UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,
     AgentWorkflowArgs,
     DurableAgentWorkflow,
-    _build_approved_tool_run_input,
 )
 
-from tracecat.agent.executor.schemas import ApprovedToolCall
 from tracecat.agent.preset.activities import ResolveAgentPresetConfigActivityInput
 from tracecat.agent.schemas import AgentOutput, RunAgentArgs
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.auth.types import Role
-from tracecat.identifiers.workflow import ExecutionUUID, WorkflowUUID
-from tracecat.registry.lock.types import RegistryLock
 from tracecat.workflow.executions.correlation import build_agent_session_correlation_id
 from tracecat.workflow.executions.enums import (
     ExecutionType,
@@ -235,38 +230,3 @@ async def test_build_config_prefers_pinned_preset_version_id() -> None:
     assert cfg.model_provider == pinned_config.model_provider
     assert cfg.actions == ["core.http_request"]
     assert cfg.instructions == "base instructions\nappend this"
-
-
-def test_build_approved_tool_run_input_is_deterministic() -> None:
-    workflow_id = uuid.UUID("00000000-0000-4000-8000-000000000123")
-    run_id = uuid.UUID("00000000-0000-4000-8000-000000000456")
-    execution_id = uuid.UUID("00000000-0000-4000-8000-000000000789")
-    logical_time = datetime(2026, 3, 17, tzinfo=UTC)
-    registry_lock = RegistryLock(
-        origins={"tracecat_registry": "test-version"},
-        actions={"core.http_request": "tracecat_registry"},
-    )
-    tool_call = ApprovedToolCall(
-        tool_call_id="toolu_123",
-        tool_name="mcp__tracecat__core_http_request",
-        args={"url": "https://example.com"},
-    )
-
-    result = _build_approved_tool_run_input(
-        tool_call=tool_call,
-        registry_lock=registry_lock,
-        workflow_id=workflow_id,
-        run_id=run_id,
-        execution_id=execution_id,
-        logical_time=logical_time,
-    )
-
-    assert result.task.action == "core_http_request"
-    assert result.task.args == {"url": "https://example.com"}
-    assert result.run_context.wf_id == WorkflowUUID.from_uuid(workflow_id)
-    assert result.run_context.wf_run_id == run_id
-    assert (
-        result.run_context.wf_exec_id
-        == f"{WorkflowUUID.from_uuid(workflow_id).short()}/{ExecutionUUID.from_uuid(execution_id).short()}"
-    )
-    assert result.run_context.logical_time == logical_time

--- a/tests/unit/test_ee_agent_activities.py
+++ b/tests/unit/test_ee_agent_activities.py
@@ -1,0 +1,48 @@
+"""Tests for EE agent activities MCP selection validation."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from tracecat_ee.agent.activities import AgentActivities, BuildToolDefsArgs
+
+from tracecat.agent.schemas import ToolFilters
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatValidationError
+
+
+@pytest.fixture
+def role() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-agent-executor",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset(),
+    )
+
+
+@pytest.mark.anyio
+async def test_build_tool_definitions_raises_when_mcp_selected_without_servers(
+    role: Role,
+) -> None:
+    activity = AgentActivities()
+    args = BuildToolDefsArgs(
+        role=role,
+        tool_filters=ToolFilters(actions=["mcp.Linear.list_issues"]),
+        mcp_servers=None,
+    )
+
+    with patch(
+        "tracecat_ee.agent.activities.build_agent_tools",
+        new=AsyncMock(return_value=SimpleNamespace(tools=[])),
+    ):
+        with pytest.raises(
+            TracecatValidationError,
+            match="no MCP servers are configured",
+        ):
+            await activity.build_tool_definitions(args)

--- a/tests/unit/test_ee_agent_activities.py
+++ b/tests/unit/test_ee_agent_activities.py
@@ -12,6 +12,7 @@ from tracecat_ee.agent.activities import AgentActivities, BuildToolDefsArgs
 from tracecat.agent.schemas import ToolFilters
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
+from tracecat.registry.lock.types import RegistryLock
 
 
 @pytest.fixture
@@ -44,5 +45,151 @@ async def test_build_tool_definitions_raises_when_mcp_selected_without_servers(
         with pytest.raises(
             TracecatValidationError,
             match="no MCP servers are configured",
+        ):
+            await activity.build_tool_definitions(args)
+
+
+@pytest.mark.anyio
+async def test_build_tool_definitions_rejects_selected_stdio_tools_with_dotted_server_name(
+    role: Role,
+) -> None:
+    activity = AgentActivities()
+    args = BuildToolDefsArgs(
+        role=role,
+        tool_filters=ToolFilters(actions=["mcp.acme.com.list_issues"]),
+        mcp_servers=[
+            {
+                "type": "stdio",
+                "name": "acme.com",
+                "command": "acme-mcp",
+            }
+        ],
+    )
+
+    mock_lock_service = AsyncMock()
+    mock_lock_service.resolve_lock_with_bindings.return_value = RegistryLock(
+        origins={},
+        actions={},
+    )
+    mock_lock_ctx = AsyncMock()
+    mock_lock_ctx.__aenter__.return_value = mock_lock_service
+
+    with (
+        patch(
+            "tracecat_ee.agent.activities.build_agent_tools",
+            new=AsyncMock(return_value=SimpleNamespace(tools=[])),
+        ),
+        patch(
+            "tracecat_ee.agent.activities.discover_user_mcp_tools",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "tracecat_ee.agent.activities.RegistryLockService.with_session",
+            return_value=mock_lock_ctx,
+        ),
+    ):
+        with pytest.raises(
+            TracecatValidationError,
+            match="Stdio MCP tools cannot be allowlisted individually",
+        ):
+            await activity.build_tool_definitions(args)
+
+
+@pytest.mark.anyio
+async def test_build_tool_definitions_rejects_stdio_tool_approvals(
+    role: Role,
+) -> None:
+    activity = AgentActivities()
+    args = BuildToolDefsArgs(
+        role=role,
+        tool_filters=ToolFilters(actions=None),
+        tool_approvals={"mcp.acme.com.list_issues": True},
+        mcp_servers=[
+            {
+                "type": "stdio",
+                "name": "acme.com",
+                "command": "acme-mcp",
+            }
+        ],
+    )
+
+    mock_lock_service = AsyncMock()
+    mock_lock_service.resolve_lock_with_bindings.return_value = RegistryLock(
+        origins={},
+        actions={},
+    )
+    mock_lock_ctx = AsyncMock()
+    mock_lock_ctx.__aenter__.return_value = mock_lock_service
+
+    with (
+        patch(
+            "tracecat_ee.agent.activities.build_agent_tools",
+            new=AsyncMock(return_value=SimpleNamespace(tools=[])),
+        ),
+        patch(
+            "tracecat_ee.agent.activities.discover_user_mcp_tools",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "tracecat_ee.agent.activities.RegistryLockService.with_session",
+            return_value=mock_lock_ctx,
+        ),
+    ):
+        with pytest.raises(
+            TracecatValidationError,
+            match="Stdio MCP tool approvals are not supported",
+        ):
+            await activity.build_tool_definitions(args)
+
+
+@pytest.mark.anyio
+async def test_build_tool_definitions_rejects_missing_http_mcp_tool_approvals(
+    role: Role,
+) -> None:
+    activity = AgentActivities()
+    args = BuildToolDefsArgs(
+        role=role,
+        tool_filters=ToolFilters(actions=None),
+        tool_approvals={"mcp.custom_linear.list_issues": True},
+        mcp_servers=[
+            {
+                "type": "http",
+                "name": "custom_linear",
+                "url": "https://linear.example.com/mcp",
+            }
+        ],
+    )
+
+    mock_lock_service = AsyncMock()
+    mock_lock_service.resolve_lock_with_bindings.return_value = RegistryLock(
+        origins={},
+        actions={},
+    )
+    mock_lock_ctx = AsyncMock()
+    mock_lock_ctx.__aenter__.return_value = mock_lock_service
+
+    with (
+        patch(
+            "tracecat_ee.agent.activities.build_agent_tools",
+            new=AsyncMock(return_value=SimpleNamespace(tools=[])),
+        ),
+        patch(
+            "tracecat_ee.agent.activities.discover_user_mcp_tools",
+            new=AsyncMock(
+                return_value={
+                    "mcp__custom_linear__list_projects": SimpleNamespace(
+                        description="List projects"
+                    )
+                }
+            ),
+        ),
+        patch(
+            "tracecat_ee.agent.activities.RegistryLockService.with_session",
+            return_value=mock_lock_ctx,
+        ),
+    ):
+        with pytest.raises(
+            TracecatValidationError,
+            match="Some MCP tool approvals did not match configured integrations",
         ):
             await activity.build_tool_definitions(args)

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -225,6 +225,30 @@ class TestMCPIntegrationCRUD:
         assert headers.get("Authorization") == "Bearer test_access_token"
         assert headers.get("X-Wiz-Tenant") == "tenant-a"
 
+    async def test_resolve_http_mcp_uses_slug_as_server_identifier(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """HTTP MCP configs should use the integration slug as the server ID."""
+        params = MCPHttpIntegrationCreate(
+            name="Linear",
+            server_uri="https://api.example.com/mcp",
+            auth_type=MCPAuthType.NONE,
+        )
+        created = await integration_service.create_mcp_integration(params=params)
+
+        preset_service = AgentPresetService(
+            session=integration_service.session,
+            role=integration_service.role,
+        )
+        resolved = await preset_service._resolve_mcp_integrations([str(created.id)])
+
+        assert resolved is not None
+        assert len(resolved) == 1
+        assert resolved[0]["name"] == "linear"
+        assert resolved[0].get("display_name") == "Linear"
+        assert created.slug == "linear"
+
     async def test_resolve_oauth2_mcp_filters_authorization_header_variants(
         self,
         integration_service: IntegrationService,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -346,7 +346,7 @@ class TestMCPIntegrationCRUD:
         assert updated is not None
         assert updated.name == "Updated MCP"
         assert updated.description == "Updated description"
-        assert updated.slug == "updated-mcp"  # Slug regenerated when name changes
+        assert updated.slug == created.slug  # Slug remains stable when name changes
         assert updated.server_uri == created.server_uri  # Unchanged
 
     async def test_update_mcp_integration_partial(
@@ -1029,6 +1029,29 @@ class TestMCPIntegrationValidation:
             mcp_integration_id=non_existent_id, params=update_params
         )
         assert result is None
+
+    async def test_rename_preserves_existing_slug(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Renaming an MCP integration should not change its stable slug."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Linear MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+
+        original_slug = created.slug
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(name="Renamed MCP"),
+        )
+
+        assert updated is not None
+        assert updated.name == "Renamed MCP"
+        assert updated.slug == original_slug
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_worker_activity_registration.py
+++ b/tests/unit/test_worker_activity_registration.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from tracecat.agent.executor.activity import run_agent_activity
+from tracecat.agent.executor.activity import (
+    execute_approved_tools_activity,
+    run_agent_activity,
+)
 from tracecat.agent.executor_worker import (
     get_activities as get_agent_executor_activities,
 )
@@ -47,9 +50,12 @@ def test_agent_worker_registers_preset_resolution_activities() -> None:
     assert _activity_name(resolve_agent_preset_version_ref_activity) in names
 
 
-def test_agent_executor_worker_registers_only_runtime_execution_activity() -> None:
+def test_agent_executor_worker_registers_runtime_execution_activities() -> None:
     names = _activity_names(get_agent_executor_activities())
-    assert names == {_activity_name(run_agent_activity)}
+    assert names == {
+        _activity_name(run_agent_activity),
+        _activity_name(execute_approved_tools_activity),
+    }
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -31,6 +31,9 @@ class MCPHttpServerConfig(TypedDict):
     name: str
     """Required: Unique identifier for the server. Tools will be prefixed with mcp__{name}__."""
 
+    display_name: NotRequired[str]
+    """Optional human-readable label for UI display."""
+
     url: str
     """Required: HTTP/SSE endpoint URL for the MCP server."""
 
@@ -49,6 +52,7 @@ class MCPStdioServerConfig(TypedDict):
 
     type: Literal["stdio"]
     name: str
+    display_name: NotRequired[str]
     command: str
     args: NotRequired[list[str]]
     env: NotRequired[dict[str, str]]

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -19,19 +19,25 @@ from tracecat.agent.common.config import (
     TRACECAT__DISABLE_NSJAIL,
 )
 from tracecat.agent.common.exceptions import AgentSandboxExecutionError
-from tracecat.agent.common.stream_types import ToolCallContent
-from tracecat.agent.common.types import MCPToolDefinition
+from tracecat.agent.common.stream_types import ToolCallContent, UnifiedStreamEvent
+from tracecat.agent.common.types import MCPServerConfig, MCPToolDefinition
 from tracecat.agent.executor.loopback import (
     LoopbackHandler,
     LoopbackInput,
     LoopbackResult,
 )
+from tracecat.agent.mcp.executor import ActionExecutionError, execute_action
+from tracecat.agent.mcp.user_client import UserMCPClient, call_user_mcp_tool
+from tracecat.agent.mcp.utils import is_http_server, normalize_mcp_tool_name
 from tracecat.agent.sandbox.llm_proxy import LLM_SOCKET_NAME, LLMSocketProxy
 from tracecat.agent.sandbox.nsjail import spawn_jailed_runtime
 from tracecat.agent.session.service import AgentSessionService
+from tracecat.agent.stream.connector import AgentStream
+from tracecat.agent.tokens import MCPTokenClaims
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
+from tracecat.executor import registry_resolver
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 
@@ -86,7 +92,7 @@ class AgentExecutorResult(BaseModel):
 
 
 class ExecuteApprovedToolsInput(BaseModel):
-    """Deprecated compatibility input for approval-path tool execution."""
+    """Input for the execute_approved_tools_activity."""
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -97,10 +103,12 @@ class ExecuteApprovedToolsInput(BaseModel):
     denied_tools: list[DeniedToolCall]
     allowed_actions: list[str]
     registry_lock: RegistryLock
+    # User MCP server configs for executing approved MCP tools
+    user_mcp_configs: list[MCPServerConfig] | None = None
 
 
 class ExecuteApprovedToolsResult(BaseModel):
-    """Deprecated compatibility result for approval-path tool execution."""
+    """Result from execute_approved_tools_activity."""
 
     results: list[ToolExecutionResult]
     success: bool = True
@@ -573,3 +581,273 @@ async def run_agent_activity(
         activity.heartbeat(f"Agent execution failed: {result.error}")
 
     return result
+
+
+# --- Approved Tools Execution Activity ---
+
+
+HEARTBEAT_INTERVAL = 30  # seconds - must be less than heartbeat_timeout (60s)
+
+
+async def _execute_action_with_heartbeat(
+    action_name: str,
+    args: dict[str, Any],
+    claims: MCPTokenClaims,
+    registry_lock: RegistryLock,
+    tool_name: str,
+) -> Any:
+    """Execute an action with periodic heartbeats to Temporal.
+
+    Wraps execute_action in a polling loop that sends heartbeats every
+    HEARTBEAT_INTERVAL seconds to prevent Temporal from timing out the
+    activity during long-running tool executions.
+
+    Args:
+        action_name: The normalized action name to execute.
+        args: Arguments to pass to the action.
+        claims: MCP token claims for authorization.
+        registry_lock: Registry lock for action resolution.
+        tool_name: Original tool name for heartbeat messages.
+
+    Returns:
+        The result from execute_action.
+
+    Raises:
+        ActionExecutionError: If the action execution fails.
+        Exception: Any other error from the action.
+    """
+    # Create a task for the action execution
+    action_task = asyncio.create_task(
+        execute_action(
+            action_name=action_name,
+            args=args,
+            claims=claims,
+            registry_lock=registry_lock,
+        )
+    )
+
+    elapsed = 0
+    try:
+        while True:
+            try:
+                # Wait for completion with heartbeat interval timeout
+                result = await asyncio.wait_for(
+                    asyncio.shield(action_task),
+                    timeout=HEARTBEAT_INTERVAL,
+                )
+                return result
+            except TimeoutError:
+                # Action still running - send heartbeat and continue waiting
+                elapsed += HEARTBEAT_INTERVAL
+                activity.heartbeat(f"Executing tool {tool_name}: {elapsed}s elapsed")
+                logger.debug(
+                    "Heartbeat sent while executing tool",
+                    tool_name=tool_name,
+                    elapsed=elapsed,
+                )
+    finally:
+        if not action_task.done():
+            action_task.cancel()
+
+
+@activity.defn
+async def execute_approved_tools_activity(
+    input: ExecuteApprovedToolsInput,
+) -> ExecuteApprovedToolsResult:
+    """Execute approved tools via MCP executor after approval.
+
+    This activity:
+    1. Mints a fresh JWT token (original may have expired during approval wait)
+    2. Executes each approved tool via the MCP executor
+    3. Returns results for approved tools and denial messages for denied tools
+
+    The results are used by the workflow to construct a continuation message
+    that includes tool results, allowing the agent to continue its response.
+
+    Args:
+        input: Contains approved/denied tools and context for execution.
+
+    Returns:
+        ExecuteApprovedToolsResult with tool execution results.
+    """
+    activity.heartbeat(f"Executing approved tools for session: {input.session_id}")
+
+    results: list[ToolExecutionResult] = []
+
+    # Ensure organization_id is set (agent sessions are always org-scoped)
+    if input.role.organization_id is None:
+        raise ValueError("organization_id is required for agent tool execution")
+
+    # Build claims for execute_action calls
+    claims = MCPTokenClaims(
+        workspace_id=input.workspace_id,
+        user_id=input.role.user_id,
+        organization_id=input.role.organization_id,
+        allowed_actions=input.allowed_actions,
+        session_id=input.session_id,
+    )
+
+    logger.info(
+        "Executing approved tools",
+        session_id=str(input.session_id),
+        approved_count=len(input.approved_tools),
+        denied_count=len(input.denied_tools),
+    )
+
+    # Prefetch registry manifests into agent worker's cache for O(1) action resolution
+    await registry_resolver.prefetch_lock(
+        input.registry_lock, input.role.organization_id
+    )
+
+    # Initialize stream for emitting tool results to frontend
+    stream = await AgentStream.new(
+        session_id=input.session_id,
+        workspace_id=input.workspace_id,
+    )
+
+    # Execute approved tools
+    for tool_call in input.approved_tools:
+        activity.heartbeat(f"Executing tool: {tool_call.tool_name}")
+
+        try:
+            # Normalize tool name (MCP format -> action name)
+            action_name = normalize_mcp_tool_name(tool_call.tool_name)
+
+            # Check if this is a user MCP tool (not a registry action)
+            parsed_mcp = UserMCPClient.parse_user_mcp_tool_name(tool_call.tool_name)
+
+            logger.info(
+                "Executing approved tool",
+                tool_call_id=tool_call.tool_call_id,
+                tool_name=tool_call.tool_name,
+                action_name=action_name,
+                is_mcp_tool=parsed_mcp is not None,
+            )
+
+            if parsed_mcp and input.user_mcp_configs:
+                # Route to user MCP server
+                server_name, original_tool_name = parsed_mcp
+                http_configs = [c for c in input.user_mcp_configs if is_http_server(c)]
+                result = await call_user_mcp_tool(
+                    configs=http_configs,
+                    server_name=server_name,
+                    tool_name=original_tool_name,
+                    args=tool_call.args,
+                )
+            else:
+                # Execute the action via MCP executor with heartbeating
+                result = await _execute_action_with_heartbeat(
+                    action_name=action_name,
+                    args=tool_call.args,
+                    claims=claims,
+                    registry_lock=input.registry_lock,
+                    tool_name=tool_call.tool_name,
+                )
+
+            tool_result = ToolExecutionResult(
+                tool_call_id=tool_call.tool_call_id,
+                tool_name=tool_call.tool_name,
+                result=result,
+                is_error=False,
+            )
+            results.append(tool_result)
+
+            # Emit tool result to stream for frontend UI update
+            await stream.append(
+                UnifiedStreamEvent.tool_result_event(
+                    tool_call_id=tool_result.tool_call_id,
+                    tool_name=tool_result.tool_name,
+                    output=tool_result.result,
+                    is_error=tool_result.is_error,
+                )
+            )
+
+            logger.info(
+                "Tool executed successfully",
+                tool_call_id=tool_call.tool_call_id,
+                tool_name=tool_call.tool_name,
+            )
+
+        except ActionExecutionError as e:
+            logger.error(
+                "Tool execution failed",
+                tool_call_id=tool_call.tool_call_id,
+                tool_name=tool_call.tool_name,
+                error=str(e),
+            )
+            tool_result = ToolExecutionResult(
+                tool_call_id=tool_call.tool_call_id,
+                tool_name=tool_call.tool_name,
+                result=f"Tool execution failed: {e}",
+                is_error=True,
+            )
+            results.append(tool_result)
+
+            # Emit error result to stream
+            await stream.append(
+                UnifiedStreamEvent.tool_result_event(
+                    tool_call_id=tool_result.tool_call_id,
+                    tool_name=tool_result.tool_name,
+                    output=tool_result.result,
+                    is_error=tool_result.is_error,
+                )
+            )
+
+        except Exception as e:
+            logger.exception(
+                "Unexpected error executing tool",
+                tool_call_id=tool_call.tool_call_id,
+                tool_name=tool_call.tool_name,
+                error=str(e),
+            )
+            tool_result = ToolExecutionResult(
+                tool_call_id=tool_call.tool_call_id,
+                tool_name=tool_call.tool_name,
+                result=f"Unexpected error: {e}",
+                is_error=True,
+            )
+            results.append(tool_result)
+
+            # Emit error result to stream
+            await stream.append(
+                UnifiedStreamEvent.tool_result_event(
+                    tool_call_id=tool_result.tool_call_id,
+                    tool_name=tool_result.tool_name,
+                    output=tool_result.result,
+                    is_error=tool_result.is_error,
+                )
+            )
+
+    # Add denial results for rejected tools
+    for denied_tool in input.denied_tools:
+        tool_result = ToolExecutionResult(
+            tool_call_id=denied_tool.tool_call_id,
+            tool_name=denied_tool.tool_name,
+            result=f"Tool denied by user: {denied_tool.reason}",
+            is_error=True,
+        )
+        results.append(tool_result)
+
+        # Emit denial result to stream
+        await stream.append(
+            UnifiedStreamEvent.tool_result_event(
+                tool_call_id=tool_result.tool_call_id,
+                tool_name=tool_result.tool_name,
+                output=tool_result.result,
+                is_error=tool_result.is_error,
+            )
+        )
+
+    activity.heartbeat(f"Completed tool execution: {len(results)} results")
+
+    # Replace interrupt entries with proper tool_result (atomic with tool execution)
+    if results:
+        async with AgentSessionService.with_session(role=input.role) as session_service:
+            await session_service.replace_interrupt_with_tool_results(
+                input.session_id,
+                results,
+            )
+
+        activity.heartbeat("Replaced interrupt entries with tool results")
+
+    return ExecuteApprovedToolsResult(results=results)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import tempfile
 import uuid
@@ -636,6 +637,13 @@ async def _execute_user_mcp_tool_with_heartbeat(
     return await _await_with_heartbeat(mcp_task, tool_name=original_tool_name)
 
 
+def _encode_approved_mcp_result(result: Any) -> str:
+    """Preserve plain text tool output while stringifying structured values."""
+    if isinstance(result, str):
+        return result
+    return json.dumps(result, default=str)
+
+
 @activity.defn
 async def execute_approved_tools_activity(
     input: ExecuteApprovedToolsInput,
@@ -698,7 +706,7 @@ async def execute_approved_tools_activity(
             tool_result = ToolExecutionResult(
                 tool_call_id=tool_call.tool_call_id,
                 tool_name=tool_call.tool_name,
-                result=result,
+                result=_encode_approved_mcp_result(result),
                 is_error=False,
             )
             results.append(tool_result)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -19,25 +19,25 @@ from tracecat.agent.common.config import (
     TRACECAT__DISABLE_NSJAIL,
 )
 from tracecat.agent.common.exceptions import AgentSandboxExecutionError
-from tracecat.agent.common.stream_types import ToolCallContent, UnifiedStreamEvent
-from tracecat.agent.common.types import MCPServerConfig, MCPToolDefinition
+from tracecat.agent.common.stream_types import ToolCallContent
+from tracecat.agent.common.types import (
+    MCPHttpServerConfig,
+    MCPServerConfig,
+    MCPToolDefinition,
+)
 from tracecat.agent.executor.loopback import (
     LoopbackHandler,
     LoopbackInput,
     LoopbackResult,
 )
-from tracecat.agent.mcp.executor import ActionExecutionError, execute_action
 from tracecat.agent.mcp.user_client import UserMCPClient, call_user_mcp_tool
 from tracecat.agent.mcp.utils import is_http_server, normalize_mcp_tool_name
 from tracecat.agent.sandbox.llm_proxy import LLM_SOCKET_NAME, LLMSocketProxy
 from tracecat.agent.sandbox.nsjail import spawn_jailed_runtime
 from tracecat.agent.session.service import AgentSessionService
-from tracecat.agent.stream.connector import AgentStream
-from tracecat.agent.tokens import MCPTokenClaims
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
-from tracecat.executor import registry_resolver
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 
@@ -589,55 +589,21 @@ async def run_agent_activity(
 HEARTBEAT_INTERVAL = 30  # seconds - must be less than heartbeat_timeout (60s)
 
 
-async def _execute_action_with_heartbeat(
-    action_name: str,
-    args: dict[str, Any],
-    claims: MCPTokenClaims,
-    registry_lock: RegistryLock,
+async def _await_with_heartbeat(
+    task: asyncio.Task[Any],
+    *,
     tool_name: str,
 ) -> Any:
-    """Execute an action with periodic heartbeats to Temporal.
-
-    Wraps execute_action in a polling loop that sends heartbeats every
-    HEARTBEAT_INTERVAL seconds to prevent Temporal from timing out the
-    activity during long-running tool executions.
-
-    Args:
-        action_name: The normalized action name to execute.
-        args: Arguments to pass to the action.
-        claims: MCP token claims for authorization.
-        registry_lock: Registry lock for action resolution.
-        tool_name: Original tool name for heartbeat messages.
-
-    Returns:
-        The result from execute_action.
-
-    Raises:
-        ActionExecutionError: If the action execution fails.
-        Exception: Any other error from the action.
-    """
-    # Create a task for the action execution
-    action_task = asyncio.create_task(
-        execute_action(
-            action_name=action_name,
-            args=args,
-            claims=claims,
-            registry_lock=registry_lock,
-        )
-    )
-
+    """Await a task while sending periodic Temporal heartbeats."""
     elapsed = 0
     try:
         while True:
             try:
-                # Wait for completion with heartbeat interval timeout
-                result = await asyncio.wait_for(
-                    asyncio.shield(action_task),
+                return await asyncio.wait_for(
+                    asyncio.shield(task),
                     timeout=HEARTBEAT_INTERVAL,
                 )
-                return result
             except TimeoutError:
-                # Action still running - send heartbeat and continue waiting
                 elapsed += HEARTBEAT_INTERVAL
                 activity.heartbeat(f"Executing tool {tool_name}: {elapsed}s elapsed")
                 logger.debug(
@@ -646,106 +612,88 @@ async def _execute_action_with_heartbeat(
                     elapsed=elapsed,
                 )
     finally:
-        if not action_task.done():
-            action_task.cancel()
+        if not task.done():
+            task.cancel()
+
+
+async def _execute_user_mcp_tool_with_heartbeat(
+    configs: list[MCPHttpServerConfig],
+    server_name: str,
+    tool_name: str,
+    args: dict[str, Any],
+    *,
+    original_tool_name: str,
+) -> Any:
+    """Execute a user MCP tool with periodic Temporal heartbeats."""
+    mcp_task = asyncio.create_task(
+        call_user_mcp_tool(
+            configs=configs,
+            server_name=server_name,
+            tool_name=tool_name,
+            args=args,
+        )
+    )
+    return await _await_with_heartbeat(mcp_task, tool_name=original_tool_name)
 
 
 @activity.defn
 async def execute_approved_tools_activity(
     input: ExecuteApprovedToolsInput,
 ) -> ExecuteApprovedToolsResult:
-    """Execute approved tools via MCP executor after approval.
-
-    This activity:
-    1. Mints a fresh JWT token (original may have expired during approval wait)
-    2. Executes each approved tool via the MCP executor
-    3. Returns results for approved tools and denial messages for denied tools
-
-    The results are used by the workflow to construct a continuation message
-    that includes tool results, allowing the agent to continue its response.
-
-    Args:
-        input: Contains approved/denied tools and context for execution.
-
-    Returns:
-        ExecuteApprovedToolsResult with tool execution results.
-    """
+    """Execute approved HTTP MCP tools after approval."""
     activity.heartbeat(f"Executing approved tools for session: {input.session_id}")
 
     results: list[ToolExecutionResult] = []
-
-    # Ensure organization_id is set (agent sessions are always org-scoped)
-    if input.role.organization_id is None:
-        raise ValueError("organization_id is required for agent tool execution")
-
-    # Build claims for execute_action calls
-    claims = MCPTokenClaims(
-        workspace_id=input.workspace_id,
-        user_id=input.role.user_id,
-        organization_id=input.role.organization_id,
-        allowed_actions=input.allowed_actions,
-        session_id=input.session_id,
-    )
+    if input.denied_tools:
+        raise ValueError(
+            "Denied tools must be reconciled by the workflow, not the agent executor"
+        )
+    if not input.user_mcp_configs:
+        raise ValueError("HTTP MCP configs are required for approved MCP execution")
 
     logger.info(
         "Executing approved tools",
         session_id=str(input.session_id),
         approved_count=len(input.approved_tools),
-        denied_count=len(input.denied_tools),
+        denied_count=0,
     )
-
-    # Prefetch registry manifests into agent worker's cache for O(1) action resolution
-    await registry_resolver.prefetch_lock(
-        input.registry_lock, input.role.organization_id
-    )
-
-    # Initialize stream for emitting tool results to frontend
-    stream = await AgentStream.new(
-        session_id=input.session_id,
-        workspace_id=input.workspace_id,
-    )
+    known_mcp_server_names = {cfg["name"] for cfg in input.user_mcp_configs}
+    http_configs = [cfg for cfg in input.user_mcp_configs if is_http_server(cfg)]
 
     # Execute approved tools
     for tool_call in input.approved_tools:
         activity.heartbeat(f"Executing tool: {tool_call.tool_name}")
 
         try:
-            # Normalize tool name (MCP format -> action name)
-            action_name = normalize_mcp_tool_name(tool_call.tool_name)
-
-            # Check if this is a user MCP tool (not a registry action)
-            parsed_mcp = UserMCPClient.parse_user_mcp_tool_name(tool_call.tool_name)
+            parsed_mcp = UserMCPClient.parse_user_mcp_tool_name(
+                tool_call.tool_name,
+                known_server_names=known_mcp_server_names,
+            )
             if parsed_mcp is None:
-                # Fall back to already-normalized name (helps with canonical MCP names)
-                parsed_mcp = UserMCPClient.parse_user_mcp_tool_name(action_name)
+                parsed_mcp = UserMCPClient.parse_user_mcp_tool_name(
+                    normalize_mcp_tool_name(tool_call.tool_name),
+                    known_server_names=known_mcp_server_names,
+                )
+            if parsed_mcp is None:
+                raise ValueError(
+                    f"Approved tool is not a configured HTTP MCP tool: {tool_call.tool_name}"
+                )
 
             logger.info(
                 "Executing approved tool",
                 tool_call_id=tool_call.tool_call_id,
                 tool_name=tool_call.tool_name,
-                action_name=action_name,
-                is_mcp_tool=parsed_mcp is not None,
+                is_mcp_tool=True,
             )
 
-            if parsed_mcp and input.user_mcp_configs:
-                # Route to user MCP server
-                server_name, original_tool_name = parsed_mcp
-                http_configs = [c for c in input.user_mcp_configs if is_http_server(c)]
-                result = await call_user_mcp_tool(
-                    configs=http_configs,
-                    server_name=server_name,
-                    tool_name=original_tool_name,
-                    args=tool_call.args,
-                )
-            else:
-                # Execute the action via MCP executor with heartbeating
-                result = await _execute_action_with_heartbeat(
-                    action_name=action_name,
-                    args=tool_call.args,
-                    claims=claims,
-                    registry_lock=input.registry_lock,
-                    tool_name=tool_call.tool_name,
-                )
+            server_name, original_tool_name = parsed_mcp
+            result = await _execute_user_mcp_tool_with_heartbeat(
+                configs=http_configs,
+                server_name=server_name,
+                tool_name=original_tool_name,
+                args=tool_call.args,
+                original_tool_name=tool_call.tool_name,
+            )
 
             tool_result = ToolExecutionResult(
                 tool_call_id=tool_call.tool_call_id,
@@ -755,25 +703,15 @@ async def execute_approved_tools_activity(
             )
             results.append(tool_result)
 
-            # Emit tool result to stream for frontend UI update
-            await stream.append(
-                UnifiedStreamEvent.tool_result_event(
-                    tool_call_id=tool_result.tool_call_id,
-                    tool_name=tool_result.tool_name,
-                    output=tool_result.result,
-                    is_error=tool_result.is_error,
-                )
-            )
-
             logger.info(
                 "Tool executed successfully",
                 tool_call_id=tool_call.tool_call_id,
                 tool_name=tool_call.tool_name,
             )
 
-        except ActionExecutionError as e:
-            logger.error(
-                "Tool execution failed",
+        except Exception as e:
+            logger.exception(
+                "Approved MCP tool execution failed",
                 tool_call_id=tool_call.tool_call_id,
                 tool_name=tool_call.tool_name,
                 error=str(e),
@@ -786,71 +724,6 @@ async def execute_approved_tools_activity(
             )
             results.append(tool_result)
 
-            # Emit error result to stream
-            await stream.append(
-                UnifiedStreamEvent.tool_result_event(
-                    tool_call_id=tool_result.tool_call_id,
-                    tool_name=tool_result.tool_name,
-                    output=tool_result.result,
-                    is_error=tool_result.is_error,
-                )
-            )
-
-        except Exception as e:
-            logger.exception(
-                "Unexpected error executing tool",
-                tool_call_id=tool_call.tool_call_id,
-                tool_name=tool_call.tool_name,
-                error=str(e),
-            )
-            tool_result = ToolExecutionResult(
-                tool_call_id=tool_call.tool_call_id,
-                tool_name=tool_call.tool_name,
-                result=f"Unexpected error: {e}",
-                is_error=True,
-            )
-            results.append(tool_result)
-
-            # Emit error result to stream
-            await stream.append(
-                UnifiedStreamEvent.tool_result_event(
-                    tool_call_id=tool_result.tool_call_id,
-                    tool_name=tool_result.tool_name,
-                    output=tool_result.result,
-                    is_error=tool_result.is_error,
-                )
-            )
-
-    # Add denial results for rejected tools
-    for denied_tool in input.denied_tools:
-        tool_result = ToolExecutionResult(
-            tool_call_id=denied_tool.tool_call_id,
-            tool_name=denied_tool.tool_name,
-            result=f"Tool denied by user: {denied_tool.reason}",
-            is_error=True,
-        )
-        results.append(tool_result)
-
-        # Emit denial result to stream
-        await stream.append(
-            UnifiedStreamEvent.tool_result_event(
-                tool_call_id=tool_result.tool_call_id,
-                tool_name=tool_result.tool_name,
-                output=tool_result.result,
-                is_error=tool_result.is_error,
-            )
-        )
-
     activity.heartbeat(f"Completed tool execution: {len(results)} results")
-
-    # Replace interrupt entries with proper tool_result (atomic with tool execution)
-    if results:
-        async with AgentSessionService.with_session(role=input.role) as session_service:
-            await session_service.replace_interrupt_with_tool_results(
-                input.session_id,
-                results,
-            )
-
-        activity.heartbeat("Replaced interrupt entries with tool results")
 
     return ExecuteApprovedToolsResult(results=results)

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -715,6 +715,9 @@ async def execute_approved_tools_activity(
 
             # Check if this is a user MCP tool (not a registry action)
             parsed_mcp = UserMCPClient.parse_user_mcp_tool_name(tool_call.tool_name)
+            if parsed_mcp is None:
+                # Fall back to already-normalized name (helps with canonical MCP names)
+                parsed_mcp = UserMCPClient.parse_user_mcp_tool_name(action_name)
 
             logger.info(
                 "Executing approved tool",

--- a/tracecat/agent/executor_worker.py
+++ b/tracecat/agent/executor_worker.py
@@ -1,4 +1,4 @@
-"""AgentExecutorWorker - Temporal worker for `run_agent_activity` execution."""
+"""AgentExecutorWorker for agent runtime and approved HTTP MCP replay."""
 
 from __future__ import annotations
 
@@ -12,7 +12,10 @@ import uvloop
 from temporalio.worker import Worker
 
 from tracecat import config
-from tracecat.agent.executor.activity import run_agent_activity
+from tracecat.agent.executor.activity import (
+    execute_approved_tools_activity,
+    run_agent_activity,
+)
 from tracecat.agent.runtime_services import (
     start_litellm_proxy,
     start_mcp_server,
@@ -31,7 +34,7 @@ interrupt_event = asyncio.Event()
 
 def get_activities() -> list:
     """Load runtime activities registered by the agent-executor worker."""
-    return [run_agent_activity]
+    return [run_agent_activity, execute_approved_tools_activity]
 
 
 async def _start_runtime_services() -> Client:

--- a/tracecat/agent/factory.py
+++ b/tracecat/agent/factory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, Protocol, cast
 
 from pydantic_ai import Agent, ModelSettings
 from pydantic_ai.agent import AbstractAgent
@@ -9,6 +9,7 @@ from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.tools import DeferredToolRequests
 from pydantic_ai.tools import Tool as PATool
 
+from tracecat.agent.mcp.user_client import UserMCPClient
 from tracecat.agent.mcp.utils import is_http_server
 from tracecat.agent.parsers import parse_output_type
 from tracecat.agent.prompts import ToolCallPrompt, VerbosityPrompt
@@ -16,28 +17,177 @@ from tracecat.agent.providers import get_model
 from tracecat.agent.runtime.pydantic_ai.adapter import to_pydantic_ai_tools
 from tracecat.agent.tools import build_agent_tools
 from tracecat.agent.types import AgentConfig
-from tracecat.logger import logger
 
 type AgentFactory = Callable[[AgentConfig], Awaitable[AbstractAgent[Any, Any]]]
+
+
+class _ToolsetWithGetTools(Protocol):
+    async def get_tools(self, ctx: Any) -> dict[str, Any]: ...
+
+
+class _FilteredMCPToolsetMixin:
+    """Filter MCP tool exposure to an allowlisted subset when configured."""
+
+    def __init__(
+        self,
+        *args: Any,
+        allowed_tool_names: set[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._allowed_tool_names = (
+            frozenset(allowed_tool_names) if allowed_tool_names else None
+        )
+        super().__init__(*args, **kwargs)
+
+    async def get_tools(self, ctx: Any) -> dict[str, Any]:
+        toolset = cast(_ToolsetWithGetTools, super())
+        tools = await toolset.get_tools(ctx)
+        if self._allowed_tool_names is None:
+            return tools
+        return {
+            tool_name: tool
+            for tool_name, tool in tools.items()
+            if tool_name in self._allowed_tool_names
+        }
+
+
+class _FilteredMCPServerStreamableHTTP(
+    _FilteredMCPToolsetMixin, MCPServerStreamableHTTP
+):
+    """HTTP MCP server with optional per-tool filtering."""
+
+
+def _partition_actions(
+    config: AgentConfig,
+) -> tuple[list[str], dict[str, set[str]]]:
+    """Split configured actions into registry actions and MCP tool allowlists."""
+    registry_actions: list[str] = []
+    selected_mcp_tools_by_server: dict[str, set[str]] = {}
+    known_server_names = (
+        {server["name"] for server in config.mcp_servers}
+        if config.mcp_servers
+        else None
+    )
+
+    for action_name in config.actions or []:
+        if not (normalized_action := action_name.strip()):
+            continue
+
+        parsed = UserMCPClient.parse_user_mcp_tool_name(
+            normalized_action,
+            known_server_names=known_server_names,
+        )
+        if parsed is None:
+            registry_actions.append(normalized_action)
+            continue
+
+        server_name, original_tool_name = parsed
+        selected_mcp_tools_by_server.setdefault(server_name, set()).add(
+            original_tool_name
+        )
+
+    return registry_actions, selected_mcp_tools_by_server
+
+
+def _has_mcp_tool_approvals(config: AgentConfig) -> bool:
+    """Return True when tool approvals target user MCP tools."""
+    if not config.tool_approvals:
+        return False
+
+    known_server_names = (
+        {server["name"] for server in config.mcp_servers}
+        if config.mcp_servers
+        else None
+    )
+    return any(
+        UserMCPClient.parse_user_mcp_tool_name(
+            tool_name,
+            known_server_names=known_server_names,
+        )
+        is not None
+        for tool_name in config.tool_approvals
+    )
+
+
+def _build_mcp_toolsets(
+    config: AgentConfig,
+    *,
+    selected_mcp_tools_by_server: dict[str, set[str]],
+) -> list[Any] | None:
+    """Build MCP toolsets, optionally restricting each server to selected tools."""
+    if not config.mcp_servers:
+        return None
+
+    toolsets: list[Any] = []
+    selected_servers = (
+        set(selected_mcp_tools_by_server) if selected_mcp_tools_by_server else None
+    )
+    seen_servers: set[str] = set()
+
+    for server in config.mcp_servers:
+        server_name = server["name"]
+        if selected_servers is not None and server_name not in selected_servers:
+            continue
+
+        seen_servers.add(server_name)
+        allowed_tool_names = selected_mcp_tools_by_server.get(server_name)
+
+        if not is_http_server(server):
+            if allowed_tool_names:
+                raise ValueError(
+                    "Stdio MCP servers are not supported in the PydanticAI runtime"
+                )
+            continue
+
+        server_timeout = server.get("timeout")
+        if server_timeout is None:
+            toolsets.append(
+                _FilteredMCPServerStreamableHTTP(
+                    url=server["url"],
+                    headers=server.get("headers", {}),
+                    allowed_tool_names=allowed_tool_names,
+                )
+            )
+        else:
+            toolsets.append(
+                _FilteredMCPServerStreamableHTTP(
+                    url=server["url"],
+                    headers=server.get("headers", {}),
+                    timeout=float(server_timeout),
+                    allowed_tool_names=allowed_tool_names,
+                )
+            )
+
+    if selected_servers and (missing_servers := selected_servers - seen_servers):
+        raise ValueError(
+            "Requested MCP tools reference servers that are not configured: "
+            f"{sorted(missing_servers)}"
+        )
+
+    return toolsets or None
 
 
 async def build_agent(config: AgentConfig) -> Agent[Any, Any]:
     """The default factory for building an agent."""
 
-    if config.tool_approvals and any(
-        k.startswith("mcp.") for k in config.tool_approvals
-    ):
-        logger.warning(
-            "MCP tool approvals are only supported in Claude Code runtime; "
-            "approvals for MCP tools will be ignored in PydanticAI runtime"
+    registry_actions, selected_mcp_tools_by_server = _partition_actions(config)
+    if selected_mcp_tools_by_server and not config.mcp_servers:
+        raise ValueError(
+            "MCP tools were selected, but no MCP servers are configured: "
+            f"{sorted(selected_mcp_tools_by_server)}"
+        )
+
+    if _has_mcp_tool_approvals(config):
+        raise ValueError(
+            "MCP tool approvals are not supported in the PydanticAI runtime"
         )
 
     agent_tools: list[PATool] = []
     tool_prompt_tools: list[PATool] = []
-    if config.actions:
+    if registry_actions:
         tools_result = await build_agent_tools(
             namespaces=config.namespaces,
-            actions=config.actions,
+            actions=registry_actions,
             tool_approvals=config.tool_approvals,
         )
         # Convert Tracecat Tools to pydantic-ai Tools
@@ -64,29 +214,10 @@ async def build_agent(config: AgentConfig) -> Agent[Any, Any]:
         instruction_parts = [instructions, tool_calling_prompt.prompt]
         instructions = "\n".join(part for part in instruction_parts if part)
 
-    toolsets = None
-    if config.mcp_servers:
-        http_servers = [
-            server for server in config.mcp_servers if is_http_server(server)
-        ]
-        toolsets = []
-        for server in http_servers:
-            server_timeout = server.get("timeout")
-            if server_timeout is None:
-                toolsets.append(
-                    MCPServerStreamableHTTP(
-                        url=server["url"],
-                        headers=server.get("headers", {}),
-                    )
-                )
-            else:
-                toolsets.append(
-                    MCPServerStreamableHTTP(
-                        url=server["url"],
-                        headers=server.get("headers", {}),
-                        timeout=float(server_timeout),
-                    )
-                )
+    toolsets = _build_mcp_toolsets(
+        config,
+        selected_mcp_tools_by_server=selected_mcp_tools_by_server,
+    )
 
     output_type_for_agent: type[Any] | list[type[Any]]
     # If any tool requires approval, include DeferredToolRequests in output types

--- a/tracecat/agent/factory.py
+++ b/tracecat/agent/factory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeGuard
+from typing import Any
 
 from pydantic_ai import Agent, ModelSettings
 from pydantic_ai.agent import AbstractAgent
@@ -9,24 +9,28 @@ from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.tools import DeferredToolRequests
 from pydantic_ai.tools import Tool as PATool
 
-from tracecat.agent.common.types import MCPHttpServerConfig, MCPServerConfig
+from tracecat.agent.mcp.utils import is_http_server
 from tracecat.agent.parsers import parse_output_type
 from tracecat.agent.prompts import ToolCallPrompt, VerbosityPrompt
 from tracecat.agent.providers import get_model
 from tracecat.agent.runtime.pydantic_ai.adapter import to_pydantic_ai_tools
 from tracecat.agent.tools import build_agent_tools
 from tracecat.agent.types import AgentConfig
+from tracecat.logger import logger
 
 type AgentFactory = Callable[[AgentConfig], Awaitable[AbstractAgent[Any, Any]]]
 
 
-def _is_http_server(config: MCPServerConfig) -> TypeGuard[MCPHttpServerConfig]:
-    # Legacy HTTP configs may omit "type"; treat missing as HTTP for compatibility.
-    return config.get("type", "http") == "http"
-
-
 async def build_agent(config: AgentConfig) -> Agent[Any, Any]:
     """The default factory for building an agent."""
+
+    if config.tool_approvals and any(
+        k.startswith("mcp.") for k in config.tool_approvals
+    ):
+        logger.warning(
+            "MCP tool approvals are only supported in Claude Code runtime; "
+            "approvals for MCP tools will be ignored in PydanticAI runtime"
+        )
 
     agent_tools: list[PATool] = []
     tool_prompt_tools: list[PATool] = []
@@ -63,7 +67,7 @@ async def build_agent(config: AgentConfig) -> Agent[Any, Any]:
     toolsets = None
     if config.mcp_servers:
         http_servers = [
-            server for server in config.mcp_servers if _is_http_server(server)
+            server for server in config.mcp_servers if is_http_server(server)
         ]
         toolsets = []
         for server in http_servers:

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -189,9 +189,6 @@ class UserMCPClient:
 
         Args:
             tool_name: Full tool name to parse.
-            known_server_names: Optional configured server names used to
-                disambiguate canonical names when server names may contain dots.
-
         Returns:
             Tuple of (server_name, original_tool_name), or None if not a user MCP tool.
 
@@ -212,9 +209,6 @@ class UserMCPClient:
         #   mcp.{server_name}.{tool_name}
         if tool_name.startswith("mcp."):
             canonical_name = tool_name.removeprefix("mcp.")
-
-            # When server names are known, prefer the longest matching prefix.
-            # This preserves full server names that contain dots.
             if known_server_names:
                 matched_server_name = max(
                     (
@@ -229,8 +223,6 @@ class UserMCPClient:
                     original_tool_name = canonical_name[len(matched_server_name) + 1 :]
                     if original_tool_name:
                         return (matched_server_name, original_tool_name)
-
-            # Legacy fallback when no configured names are available.
             parts = canonical_name.split(".", 1)
             if len(parts) == 2 and parts[0] and parts[1]:
                 return (parts[0], parts[1])

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -178,13 +178,19 @@ class UserMCPClient:
             return ""
 
     @staticmethod
-    def parse_user_mcp_tool_name(tool_name: str) -> tuple[str, str] | None:
+    def parse_user_mcp_tool_name(
+        tool_name: str,
+        *,
+        known_server_names: set[str] | None = None,
+    ) -> tuple[str, str] | None:
         """Parse a user MCP tool name into (server_name, tool_name).
 
         User MCP tools follow the pattern: mcp__{server_name}__{tool_name}
 
         Args:
             tool_name: Full tool name to parse.
+            known_server_names: Optional configured server names used to
+                disambiguate canonical names when server names may contain dots.
 
         Returns:
             Tuple of (server_name, original_tool_name), or None if not a user MCP tool.
@@ -206,7 +212,25 @@ class UserMCPClient:
         #   mcp.{server_name}.{tool_name}
         if tool_name.startswith("mcp."):
             canonical_name = tool_name.removeprefix("mcp.")
-            # Split on the first separator so tool names can contain dots.
+
+            # When server names are known, prefer the longest matching prefix.
+            # This preserves full server names that contain dots.
+            if known_server_names:
+                matched_server_name = max(
+                    (
+                        server_name
+                        for server_name in known_server_names
+                        if canonical_name.startswith(f"{server_name}.")
+                    ),
+                    key=len,
+                    default=None,
+                )
+                if matched_server_name:
+                    original_tool_name = canonical_name[len(matched_server_name) + 1 :]
+                    if original_tool_name:
+                        return (matched_server_name, original_tool_name)
+
+            # Legacy fallback when no configured names are available.
             parts = canonical_name.split(".", 1)
             if len(parts) == 2 and parts[0] and parts[1]:
                 return (parts[0], parts[1])

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -206,7 +206,8 @@ class UserMCPClient:
         #   mcp.{server_name}.{tool_name}
         if tool_name.startswith("mcp."):
             canonical_name = tool_name.removeprefix("mcp.")
-            parts = canonical_name.rsplit(".", 1)
+            # Split on the first separator so tool names can contain dots.
+            parts = canonical_name.split(".", 1)
             if len(parts) == 2 and parts[0] and parts[1]:
                 return (parts[0], parts[1])
 

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -190,12 +190,25 @@ class UserMCPClient:
             Tuple of (server_name, original_tool_name), or None if not a user MCP tool.
 
         """
+        tool_name = tool_name.strip()
+        # Legacy or wrapped registry names are not user-defined MCP tools.
+        if tool_name.startswith("mcp.tracecat-registry."):
+            return None
+
         # Skip tracecat registry-reserved prefixes (handled separately).
         # Support both alias forms.
         if tool_name.startswith("mcp__tracecat-registry__") or tool_name.startswith(
             "mcp__tracecat_registry__"
         ):
             return None
+
+        # Canonical user MCP format:
+        #   mcp.{server_name}.{tool_name}
+        if tool_name.startswith("mcp."):
+            canonical_name = tool_name.removeprefix("mcp.")
+            parts = canonical_name.rsplit(".", 1)
+            if len(parts) == 2 and parts[0] and parts[1]:
+                return (parts[0], parts[1])
 
         # Check for user MCP pattern
         if not tool_name.startswith("mcp__"):

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -118,8 +118,8 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
     if mcp_tool_name.startswith("mcp__"):
         parts = mcp_tool_name.split("__", 2)
         if len(parts) >= 3:
-            # Return everything after mcp__{server-name}__ with underscores -> dots
-            return mcp_tool_name_to_action_name(parts[2])
+            # Return user MCP tool as canonical form: mcp.{server}.{tool_name}
+            return f"mcp.{parts[1]}.{mcp_tool_name_to_action_name(parts[2])}"
 
     # Other tool names returned as-is
     return mcp_tool_name

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -24,6 +24,8 @@ def is_http_server(config: MCPServerConfig) -> TypeGuard[MCPHttpServerConfig]:
     Legacy HTTP configs may omit "type"; treat missing as HTTP for compatibility.
     """
     return config.get("type", "http") == "http"
+
+
 LEGACY_REGISTRY_MCP_SERVER_NAME = "tracecat_registry"
 
 
@@ -60,7 +62,7 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
     - mcp.tracecat-registry.mcp.Linear.list_issues -> mcp.Linear.list_issues
     - mcp.tracecat_registry.mcp.Linear.list_issues -> mcp.Linear.list_issues
 
-    Other MCP tool names are returned as-is.
+    Other canonical user MCP names are returned as-is.
 
     Args:
         mcp_tool_name: The MCP tool name to normalize
@@ -106,13 +108,10 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
         ).replace(f"mcp__{LEGACY_REGISTRY_MCP_SERVER_NAME}__", "")
         return mcp_tool_name_to_action_name(tool_part)
 
-    # Generic MCP prefix stripping for any other servers
-    # Handle pattern: mcp.{server-name}.{tool_name}
+    # Canonical user MCP names are already normalized. Keep the server segment
+    # so approval/history flows remain unambiguous across integrations.
     if mcp_tool_name.startswith("mcp."):
-        parts = mcp_tool_name.split(".", 2)
-        if len(parts) >= 3:
-            # Return everything after mcp.{server-name}.
-            return parts[2]
+        return mcp_tool_name
 
     # Handle pattern: mcp__{server-name}__{tool_name}
     if mcp_tool_name.startswith("mcp__"):
@@ -120,6 +119,10 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
         if len(parts) >= 3:
             # Return user MCP tool as canonical form: mcp.{server}.{tool_name}
             return f"mcp.{parts[1]}.{mcp_tool_name_to_action_name(parts[2])}"
+
+    # Handle runtime registry/internal tool names (e.g. core__http_request)
+    if "__" in mcp_tool_name:
+        return mcp_tool_name_to_action_name(mcp_tool_name)
 
     # Other tool names returned as-is
     return mcp_tool_name

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -45,7 +45,28 @@ def mcp_tool_name_to_action_name(tool_name: str) -> str:
     return tool_name.replace("__", ".")
 
 
-def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
+def _resolve_canonical_user_mcp_name(
+    canonical_tool_name: str,
+    *,
+    known_server_names: set[str] | None = None,
+) -> str:
+    """Preserve full configured MCP server names when they contain dots."""
+    if not canonical_tool_name.startswith("mcp.") or not known_server_names:
+        return canonical_tool_name
+
+    canonical_name = canonical_tool_name.removeprefix("mcp.")
+    for known_server_name in sorted(known_server_names, key=len, reverse=True):
+        if canonical_name.startswith(f"{known_server_name}."):
+            return canonical_tool_name
+
+    return canonical_tool_name
+
+
+def normalize_mcp_tool_name(
+    mcp_tool_name: str,
+    *,
+    known_server_names: set[str] | None = None,
+) -> str:
     """Convert MCP tool name to readable action name for display.
 
     MCP tool naming convention: mcp__{server_name}__{tool_name}
@@ -76,8 +97,12 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
         f"mcp.{REGISTRY_MCP_SERVER_NAME}.mcp."
     ) or mcp_tool_name.startswith(f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}.mcp."):
         # Extract mcp.{server}.{tool} part
-        return mcp_tool_name.replace(f"mcp.{REGISTRY_MCP_SERVER_NAME}.", "", 1).replace(
-            f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}.", "", 1
+        canonical_name = mcp_tool_name.replace(
+            f"mcp.{REGISTRY_MCP_SERVER_NAME}.", "", 1
+        ).replace(f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}.", "", 1)
+        return _resolve_canonical_user_mcp_name(
+            canonical_name,
+            known_server_names=known_server_names,
         )
 
     # Handle user MCP tools routed through proxy (underscore-separated, runtime)
@@ -89,7 +114,11 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
         tool_part = mcp_tool_name.replace(
             f"mcp__{REGISTRY_MCP_SERVER_NAME}__", ""
         ).replace(f"mcp__{LEGACY_REGISTRY_MCP_SERVER_NAME}__", "")
-        return mcp_tool_name_to_action_name(tool_part)
+        canonical_name = mcp_tool_name_to_action_name(tool_part)
+        return _resolve_canonical_user_mcp_name(
+            canonical_name,
+            known_server_names=known_server_names,
+        )
 
     # Handle dot-separated format (persisted messages) for registry tools
     if mcp_tool_name.startswith(
@@ -111,7 +140,10 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
     # Canonical user MCP names are already normalized. Keep the server segment
     # so approval/history flows remain unambiguous across integrations.
     if mcp_tool_name.startswith("mcp."):
-        return mcp_tool_name
+        return _resolve_canonical_user_mcp_name(
+            mcp_tool_name,
+            known_server_names=known_server_names,
+        )
 
     # Handle pattern: mcp__{server-name}__{tool_name}
     if mcp_tool_name.startswith("mcp__"):

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -142,7 +142,7 @@ def mcp_tool_name_to_canonical(discovered_name: str) -> str:
     if discovered_name.startswith("mcp__"):
         parts = discovered_name.split("__", 2)
         if len(parts) >= 3:
-            return f"mcp.{parts[1]}.{parts[2]}"
+            return f"mcp.{parts[1]}.{mcp_tool_name_to_action_name(parts[2])}"
     return discovered_name
 
 

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -8,9 +8,22 @@ The fetch_tool_definitions() function requires DB access and uses lazy imports.
 
 from __future__ import annotations
 
-from tracecat.agent.common.types import MCPToolDefinition
+from typing import TYPE_CHECKING, TypeGuard
+
+from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
+
+if TYPE_CHECKING:
+    from tracecat.agent.common.types import MCPServerConfig
 
 REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
+
+
+def is_http_server(config: MCPServerConfig) -> TypeGuard[MCPHttpServerConfig]:
+    """Return True if the MCP server config is an HTTP/SSE server.
+
+    Legacy HTTP configs may omit "type"; treat missing as HTTP for compatibility.
+    """
+    return config.get("type", "http") == "http"
 LEGACY_REGISTRY_MCP_SERVER_NAME = "tracecat_registry"
 
 
@@ -110,6 +123,27 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
 
     # Other tool names returned as-is
     return mcp_tool_name
+
+
+def mcp_tool_name_to_canonical(discovered_name: str) -> str:
+    """Convert discovered MCP tool name to canonical dot format.
+
+    Discovered names follow the pattern ``mcp__{server}__{tool}``.
+    The canonical format is ``mcp.{server}.{tool}``.
+
+    This must produce the same result as :func:`normalize_mcp_tool_name`
+    when given the runtime-wrapped version
+    ``mcp__tracecat-registry__mcp__{server}__{tool}``.
+
+    Examples:
+        mcp__Linear__list_issues  -> mcp.Linear.list_issues
+        mcp__Sentry__get_issue    -> mcp.Sentry.get_issue
+    """
+    if discovered_name.startswith("mcp__"):
+        parts = discovered_name.split("__", 2)
+        if len(parts) >= 3:
+            return f"mcp.{parts[1]}.{parts[2]}"
+    return discovered_name
 
 
 async def fetch_tool_definitions(

--- a/tracecat/agent/preset/router.py
+++ b/tracecat/agent/preset/router.py
@@ -12,6 +12,8 @@ from tracecat.agent.preset.schemas import (
     AgentPresetVersionDiff,
     AgentPresetVersionRead,
     AgentPresetVersionReadMinimal,
+    DiscoveredMCPTool,
+    DiscoverMCPToolsRequest,
 )
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.auth.credentials import RoleACL
@@ -63,6 +65,25 @@ async def create_agent_preset(
     try:
         preset = await service.create_preset(params)
         return AgentPresetRead.model_validate(preset)
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.post("/discover-mcp-tools", response_model=list[DiscoveredMCPTool])
+@require_scope("agent:read")
+async def discover_mcp_tools(
+    *,
+    params: DiscoverMCPToolsRequest,
+    role: WorkspaceEditorRole,
+    session: AsyncDBSession,
+) -> list[DiscoveredMCPTool]:
+    """Discover tools from MCP integrations for the approval selector."""
+    service = AgentPresetService(session, role=role)
+    try:
+        return await service.discover_mcp_tools(params.mcp_integration_ids)
     except TracecatValidationError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -138,6 +138,26 @@ class AgentPresetRead(AgentPresetExecutionConfig):
         )
 
 
+class DiscoverMCPToolsRequest(BaseModel):
+    """Request body for discovering MCP tools from integrations."""
+
+    mcp_integration_ids: list[str] = Field(
+        ...,
+        min_length=1,
+        description="List of MCP integration IDs to discover tools from",
+    )
+
+
+class DiscoveredMCPTool(BaseModel):
+    """A discovered MCP tool with its canonical name."""
+
+    name: str = Field(
+        ..., description="Canonical tool name (e.g. mcp.Linear.list_issues)"
+    )
+    description: str = Field(..., description="Tool description")
+    server_name: str = Field(..., description="MCP server name")
+
+
 class AgentPresetWithConfig(AgentPresetRead):
     """Agent preset with the resolved configuration attached."""
 

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -13,10 +13,13 @@ from sqlalchemy import select
 
 from tracecat import config
 from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.mcp.user_client import discover_user_mcp_tools
+from tracecat.agent.mcp.utils import is_http_server, mcp_tool_name_to_canonical
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetUpdate,
     AgentPresetVersionDiff,
+    DiscoveredMCPTool,
     ScalarFieldChange,
     StringListFieldChange,
     ToolApprovalFieldChange,
@@ -144,16 +147,23 @@ class AgentPresetService(BaseWorkspaceService):
         return preset
 
     async def _validate_actions(self, actions: list[str]) -> None:
-        """Validate that all actions are in the registry index."""
-        actions_set = set(actions)
+        """Validate that all actions are in the registry index.
+
+        MCP tool keys (``mcp.*``) are skipped — they are discovered
+        dynamically from user MCP servers, not stored in the registry.
+        """
+        # Separate MCP tools from registry actions
+        registry_actions = {a for a in actions if not a.startswith("mcp.")}
+        if not registry_actions:
+            return
         registry_service = RegistryActionsService(self.session, role=self.role)
         index_entries = await registry_service.list_actions_from_index(
-            include_keys=actions_set
+            include_keys=registry_actions
         )
         available_identifiers = {
             f"{entry.namespace}.{entry.name}" for entry, _ in index_entries
         }
-        if missing_actions := actions_set - available_identifiers:
+        if missing_actions := registry_actions - available_identifiers:
             raise TracecatValidationError(
                 f"{len(missing_actions)} actions were not found in the registry: {sorted(missing_actions)}"
             )
@@ -1111,3 +1121,53 @@ class AgentPresetService(BaseWorkspaceService):
         preset.mcp_integrations = version.mcp_integrations
         preset.retries = version.retries
         preset.enable_internet_access = version.enable_internet_access
+
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def discover_mcp_tools(
+        self, mcp_integration_ids: list[str]
+    ) -> list[DiscoveredMCPTool]:
+        """Discover tools from MCP integrations for the approval selector.
+
+        Also seeds RBAC scopes for discovered MCP tools so they appear
+        in the role scope assignment UI.
+        """
+        mcp_servers = await self._resolve_mcp_integrations(mcp_integration_ids)
+        if not mcp_servers:
+            return []
+
+        http_servers = [cfg for cfg in mcp_servers if is_http_server(cfg)]
+        tools = await discover_user_mcp_tools(http_servers)
+        if not tools:
+            return []
+
+        # Seed RBAC scopes for discovered MCP tools
+        mcp_action_keys = [mcp_tool_name_to_canonical(name) for name in tools]
+        await self._seed_mcp_tool_scopes(mcp_action_keys)
+
+        return [
+            DiscoveredMCPTool(
+                name=mcp_tool_name_to_canonical(name),
+                description=defn.description,
+                server_name=name.split("__")[1] if "__" in name else "unknown",
+            )
+            for name, defn in tools.items()
+        ]
+
+    async def _seed_mcp_tool_scopes(self, mcp_action_keys: list[str]) -> None:
+        """Seed RBAC scopes for MCP tools using existing registry scope infra."""
+        if not mcp_action_keys:
+            return
+
+        from tracecat.authz.seeding import seed_registry_scopes
+
+        try:
+            await seed_registry_scopes(self.session, mcp_action_keys)
+            await self.session.commit()
+            logger.info(
+                "Seeded MCP tool scopes",
+                tool_count=len(mcp_action_keys),
+                tools=mcp_action_keys,
+            )
+        except Exception:
+            logger.exception("Failed to seed MCP tool scopes")
+            await self.session.rollback()

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 
 from tracecat import config
 from tracecat.agent.common.types import MCPHttpServerConfig
-from tracecat.agent.mcp.user_client import discover_user_mcp_tools
+from tracecat.agent.mcp.user_client import UserMCPClient, discover_user_mcp_tools
 from tracecat.agent.mcp.utils import is_http_server, mcp_tool_name_to_canonical
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
@@ -149,11 +149,16 @@ class AgentPresetService(BaseWorkspaceService):
     async def _validate_actions(self, actions: list[str]) -> None:
         """Validate that all actions are in the registry index.
 
-        MCP tool keys (``mcp.*``) are skipped — they are discovered
-        dynamically from user MCP servers, not stored in the registry.
+        MCP tool keys (``mcp.*``) are validated separately against MCP
+        integrations and may be mixed with registry actions.
         """
+        normalized_actions = {action.strip() for action in actions if action.strip()}
         # Separate MCP tools from registry actions
-        registry_actions = {a for a in actions if not a.startswith("mcp.")}
+        registry_actions = {
+            action
+            for action in normalized_actions
+            if not UserMCPClient.parse_user_mcp_tool_name(action)
+        }
         if not registry_actions:
             return
         registry_service = RegistryActionsService(self.session, role=self.role)

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -34,6 +34,7 @@ from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentPreset,
     AgentPresetVersion,
+    MCPIntegration,
     OAuthIntegration,
 )
 from tracecat.dsl.common import create_default_execution_context
@@ -77,6 +78,106 @@ class AgentPresetService(BaseWorkspaceService):
         "enable_internet_access",
     }
 
+    @staticmethod
+    def _canonicalize_mcp_tool_name(
+        tool_name: str,
+        *,
+        mcp_servers: Sequence[MCPServerConfig] | None = None,
+    ) -> str:
+        """Normalize legacy display-name MCP tool IDs to slug-based IDs."""
+        if not tool_name.startswith("mcp.") or not mcp_servers:
+            return tool_name
+
+        canonical_name = tool_name.removeprefix("mcp.")
+        servers_by_display_length = sorted(
+            mcp_servers,
+            key=lambda cfg: len(str(cfg.get("display_name", cfg["name"]))),
+            reverse=True,
+        )
+
+        for server in servers_by_display_length:
+            server_slug = server["name"]
+            display_name = server.get("display_name", server_slug)
+
+            if canonical_name.startswith(f"{server_slug}."):
+                return tool_name
+
+            if display_name != server_slug and canonical_name.startswith(
+                f"{display_name}."
+            ):
+                original_tool_name = canonical_name[len(display_name) + 1 :]
+                if original_tool_name:
+                    return f"mcp.{server_slug}.{original_tool_name}"
+
+        return tool_name
+
+    @classmethod
+    def _canonicalize_mcp_actions(
+        cls,
+        actions: list[str] | None,
+        *,
+        mcp_servers: Sequence[MCPServerConfig] | None = None,
+    ) -> list[str] | None:
+        """Normalize MCP action IDs while preserving registry actions."""
+        if not actions:
+            return actions
+        return [
+            cls._canonicalize_mcp_tool_name(action, mcp_servers=mcp_servers)
+            for action in actions
+        ]
+
+    @classmethod
+    def _canonicalize_mcp_tool_approvals(
+        cls,
+        tool_approvals: dict[str, bool] | None,
+        *,
+        mcp_servers: Sequence[MCPServerConfig] | None = None,
+    ) -> dict[str, bool] | None:
+        """Normalize MCP approval keys while preserving approval semantics."""
+        if not tool_approvals:
+            return tool_approvals
+        return {
+            cls._canonicalize_mcp_tool_name(tool_name, mcp_servers=mcp_servers): allow
+            for tool_name, allow in tool_approvals.items()
+        }
+
+    async def _resolve_mcp_integration_identities(
+        self, mcp_integration_ids: list[str] | None
+    ) -> list[MCPServerConfig]:
+        """Resolve MCP integration slugs and display names without auth details."""
+        if not mcp_integration_ids:
+            return []
+
+        try:
+            integration_ids = [uuid.UUID(mcp_id) for mcp_id in mcp_integration_ids]
+        except ValueError:
+            return []
+        stmt = select(MCPIntegration).where(
+            MCPIntegration.workspace_id == self.workspace_id,
+            MCPIntegration.id.in_(integration_ids),
+        )
+        result = await self.session.execute(stmt)
+        integrations = result.scalars().all()
+        servers: list[MCPServerConfig] = []
+        for integration in integrations:
+            server: MCPServerConfig
+            if integration.stdio_command:
+                server = {
+                    "type": "stdio",
+                    "name": integration.slug,
+                    "display_name": integration.name,
+                    "command": integration.stdio_command,
+                }
+            else:
+                server = {
+                    "type": "http",
+                    "name": integration.slug,
+                    "display_name": integration.name,
+                    "url": integration.server_uri or "",
+                }
+            servers.append(server)
+        return servers
+
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_presets(self) -> Sequence[AgentPreset]:
         """Return all agent presets for the current workspace ordered by recency."""
@@ -98,6 +199,17 @@ class AgentPresetService(BaseWorkspaceService):
         slug = await self._normalize_and_validate_slug(
             proposed_slug=params.slug,
             fallback_name=params.name,
+        )
+        canonical_mcp_servers = await self._resolve_mcp_integration_identities(
+            params.mcp_integrations
+        )
+        canonical_actions = self._canonicalize_mcp_actions(
+            params.actions,
+            mcp_servers=canonical_mcp_servers,
+        )
+        canonical_tool_approvals = self._canonicalize_mcp_tool_approvals(
+            params.tool_approvals,
+            mcp_servers=canonical_mcp_servers,
         )
         if params.actions:
             await self._validate_actions(
@@ -126,9 +238,9 @@ class AgentPresetService(BaseWorkspaceService):
             model_provider=params.model_provider,
             base_url=params.base_url,
             output_type=params.output_type,
-            actions=params.actions,
+            actions=canonical_actions,
             namespaces=params.namespaces,
-            tool_approvals=params.tool_approvals,
+            tool_approvals=canonical_tool_approvals,
             mcp_integrations=params.mcp_integrations,
             enable_internet_access=params.enable_internet_access,
             retries=params.retries,
@@ -144,9 +256,9 @@ class AgentPresetService(BaseWorkspaceService):
             model_provider=preset.model_provider,
             base_url=preset.base_url,
             output_type=preset.output_type,
-            actions=preset.actions,
+            actions=canonical_actions,
             namespaces=preset.namespaces,
-            tool_approvals=preset.tool_approvals,
+            tool_approvals=canonical_tool_approvals,
             mcp_integrations=preset.mcp_integrations,
             retries=preset.retries,
             enable_internet_access=preset.enable_internet_access,
@@ -229,6 +341,13 @@ class AgentPresetService(BaseWorkspaceService):
                 "No matching MCP integrations found for this preset in the workspace"
             )
 
+        canonical_mcp_action_names = {
+            self._canonicalize_mcp_tool_name(
+                action_name,
+                mcp_servers=mcp_servers,
+            )
+            for action_name in mcp_action_names
+        }
         known_server_names = {cfg["name"] for cfg in mcp_servers}
         stdio_server_names = {
             cfg["name"] for cfg in mcp_servers if not is_http_server(cfg)
@@ -236,7 +355,7 @@ class AgentPresetService(BaseWorkspaceService):
         http_servers = [cfg for cfg in mcp_servers if is_http_server(cfg)]
         unsupported_stdio_tools = {
             action_name
-            for action_name in mcp_action_names
+            for action_name in canonical_mcp_action_names
             if (
                 parsed := UserMCPClient.parse_user_mcp_tool_name(
                     action_name,
@@ -264,7 +383,7 @@ class AgentPresetService(BaseWorkspaceService):
         available_mcp_tool_names = {
             mcp_tool_name_to_canonical(tool_name) for tool_name in discovered_mcp_tools
         }
-        if missing_mcp_tools := mcp_action_names - available_mcp_tool_names:
+        if missing_mcp_tools := canonical_mcp_action_names - available_mcp_tool_names:
             raise TracecatValidationError(
                 "Some MCP tools were not found in configured integrations: "
                 f"{sorted(missing_mcp_tools)}"
@@ -301,6 +420,13 @@ class AgentPresetService(BaseWorkspaceService):
                     "mcp_integrations", preset.mcp_integrations
                 )
                 await self._validate_actions(actions, mcp_integrations=effective_mcp)
+                canonical_mcp_servers = await self._resolve_mcp_integration_identities(
+                    effective_mcp
+                )
+                actions = self._canonicalize_mcp_actions(
+                    actions,
+                    mcp_servers=canonical_mcp_servers,
+                )
             # If we reach this point, all actions are valid or was empty
             if preset.actions != actions:
                 preset.actions = actions
@@ -328,11 +454,13 @@ class AgentPresetService(BaseWorkspaceService):
                     mcp_integrations=mcp_integrations,
                     mode="actions",
                 )
-            existing_tool_approvals = preset.tool_approvals or {}
-            if existing_tool_approvals:
+            effective_tool_approvals = (
+                set_fields.get("tool_approvals", preset.tool_approvals) or {}
+            )
+            if effective_tool_approvals:
                 mcp_approval_tools = {
                     tool_name
-                    for tool_name in existing_tool_approvals
+                    for tool_name in effective_tool_approvals
                     if UserMCPClient.parse_user_mcp_tool_name(tool_name)
                 }
                 await self._validate_mcp_tool_configuration(
@@ -359,6 +487,13 @@ class AgentPresetService(BaseWorkspaceService):
                     mcp_action_names=mcp_approval_tools,
                     mcp_integrations=effective_mcp,
                     mode="tool_approvals",
+                )
+                canonical_mcp_servers = await self._resolve_mcp_integration_identities(
+                    effective_mcp
+                )
+                set_fields["tool_approvals"] = self._canonicalize_mcp_tool_approvals(
+                    tool_approvals,
+                    mcp_servers=canonical_mcp_servers,
                 )
 
         # Update remaining fields
@@ -1213,9 +1348,15 @@ class AgentPresetService(BaseWorkspaceService):
             base_url=version.base_url,
             instructions=version.instructions,
             output_type=cast(OutputType | None, version.output_type),
-            actions=version.actions,
+            actions=self._canonicalize_mcp_actions(
+                version.actions,
+                mcp_servers=mcp_servers,
+            ),
             namespaces=version.namespaces,
-            tool_approvals=version.tool_approvals,
+            tool_approvals=self._canonicalize_mcp_tool_approvals(
+                version.tool_approvals,
+                mcp_servers=mcp_servers,
+            ),
             mcp_servers=mcp_servers,
             retries=version.retries,
             model_settings=model_settings,

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -147,12 +147,13 @@ class AgentPresetService(BaseWorkspaceService):
         return preset
 
     async def _validate_actions(self, actions: list[str]) -> None:
-        """Validate that all actions are in the registry index.
+        """Validate registry actions in ``actions`` against the registry index.
 
-        MCP tool keys (``mcp.*``) are validated separately against MCP
-        integrations and may be mixed with registry actions.
+        User MCP actions (for example ``mcp.Linear.list_issues``) are filtered
+        out here and are not validated at preset-save time. They are resolved
+        when MCP integrations are discovered/used at execution time.
         """
-        normalized_actions = {action.strip() for action in actions if action.strip()}
+        normalized_actions = {s for action in actions if (s := action.strip())}
         # Separate MCP tools from registry actions
         registry_actions = {
             action
@@ -1131,11 +1132,7 @@ class AgentPresetService(BaseWorkspaceService):
     async def discover_mcp_tools(
         self, mcp_integration_ids: list[str]
     ) -> list[DiscoveredMCPTool]:
-        """Discover tools from MCP integrations for the approval selector.
-
-        Also seeds RBAC scopes for discovered MCP tools so they appear
-        in the role scope assignment UI.
-        """
+        """Discover tools from MCP integrations for the approval selector."""
         mcp_servers = await self._resolve_mcp_integrations(mcp_integration_ids)
         if not mcp_servers:
             return []
@@ -1145,10 +1142,6 @@ class AgentPresetService(BaseWorkspaceService):
         if not tools:
             return []
 
-        # Seed RBAC scopes for discovered MCP tools
-        mcp_action_keys = [mcp_tool_name_to_canonical(name) for name in tools]
-        await self._seed_mcp_tool_scopes(mcp_action_keys)
-
         return [
             DiscoveredMCPTool(
                 name=mcp_tool_name_to_canonical(name),
@@ -1157,22 +1150,3 @@ class AgentPresetService(BaseWorkspaceService):
             )
             for name, defn in tools.items()
         ]
-
-    async def _seed_mcp_tool_scopes(self, mcp_action_keys: list[str]) -> None:
-        """Seed RBAC scopes for MCP tools using existing registry scope infra."""
-        if not mcp_action_keys:
-            return
-
-        from tracecat.authz.seeding import seed_registry_scopes
-
-        try:
-            await seed_registry_scopes(self.session, mcp_action_keys)
-            await self.session.commit()
-            logger.info(
-                "Seeded MCP tool scopes",
-                tool_count=len(mcp_action_keys),
-                tools=mcp_action_keys,
-            )
-        except Exception:
-            logger.exception("Failed to seed MCP tool scopes")
-            await self.session.rollback()

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -100,7 +100,20 @@ class AgentPresetService(BaseWorkspaceService):
             fallback_name=params.name,
         )
         if params.actions:
-            await self._validate_actions(params.actions)
+            await self._validate_actions(
+                params.actions, mcp_integrations=params.mcp_integrations
+            )
+        if params.tool_approvals:
+            mcp_approval_tools = {
+                tool_name
+                for tool_name in params.tool_approvals
+                if UserMCPClient.parse_user_mcp_tool_name(tool_name)
+            }
+            await self._validate_mcp_tool_configuration(
+                mcp_action_names=mcp_approval_tools,
+                mcp_integrations=params.mcp_integrations,
+                mode="tool_approvals",
+            )
         if params.mcp_integrations:
             await self._validate_mcp_integrations(params.mcp_integrations)
         preset = AgentPreset(
@@ -146,20 +159,40 @@ class AgentPresetService(BaseWorkspaceService):
         await self.session.refresh(preset)
         return preset
 
-    async def _validate_actions(self, actions: list[str]) -> None:
+    async def _validate_actions(
+        self,
+        actions: list[str],
+        *,
+        mcp_integrations: list[str] | None = None,
+    ) -> None:
         """Validate registry actions in ``actions`` against the registry index.
 
-        User MCP actions (for example ``mcp.Linear.list_issues``) are filtered
-        out here and are not validated at preset-save time. They are resolved
-        when MCP integrations are discovered/used at execution time.
+        User MCP actions (for example ``mcp.Linear.list_issues``) are validated
+        to ensure at least one MCP integration is configured.  The exact tool
+        name is resolved at execution time via ``build_tool_definitions()``.
         """
         normalized_actions = {s for action in actions if (s := action.strip())}
         # Separate MCP tools from registry actions
-        registry_actions = {
+        mcp_actions = {
             action
             for action in normalized_actions
-            if not UserMCPClient.parse_user_mcp_tool_name(action)
+            if UserMCPClient.parse_user_mcp_tool_name(action)
         }
+        registry_actions = normalized_actions - mcp_actions
+
+        # Cross-check: MCP tool actions require at least one MCP integration
+        if mcp_actions and not mcp_integrations:
+            raise TracecatValidationError(
+                "Actions reference MCP tools but no MCP integrations are configured: "
+                f"{sorted(mcp_actions)}"
+            )
+        if mcp_actions:
+            await self._validate_mcp_tool_configuration(
+                mcp_action_names=mcp_actions,
+                mcp_integrations=mcp_integrations,
+                mode="actions",
+            )
+
         if not registry_actions:
             return
         registry_service = RegistryActionsService(self.session, role=self.role)
@@ -172,6 +205,69 @@ class AgentPresetService(BaseWorkspaceService):
         if missing_actions := registry_actions - available_identifiers:
             raise TracecatValidationError(
                 f"{len(missing_actions)} actions were not found in the registry: {sorted(missing_actions)}"
+            )
+
+    async def _validate_mcp_tool_configuration(
+        self,
+        *,
+        mcp_action_names: set[str],
+        mcp_integrations: list[str] | None,
+        mode: str,
+    ) -> None:
+        """Reject MCP configs the current runtimes cannot enforce safely."""
+        if not mcp_action_names:
+            return
+        if not mcp_integrations:
+            raise TracecatValidationError(
+                "MCP tools were referenced but no MCP integrations are configured: "
+                f"{sorted(mcp_action_names)}"
+            )
+
+        mcp_servers = await self._resolve_mcp_integrations(mcp_integrations)
+        if not mcp_servers:
+            raise TracecatValidationError(
+                "No matching MCP integrations found for this preset in the workspace"
+            )
+
+        known_server_names = {cfg["name"] for cfg in mcp_servers}
+        stdio_server_names = {
+            cfg["name"] for cfg in mcp_servers if not is_http_server(cfg)
+        }
+        http_servers = [cfg for cfg in mcp_servers if is_http_server(cfg)]
+        unsupported_stdio_tools = {
+            action_name
+            for action_name in mcp_action_names
+            if (
+                parsed := UserMCPClient.parse_user_mcp_tool_name(
+                    action_name,
+                    known_server_names=known_server_names,
+                )
+            )
+            and parsed[0] in stdio_server_names
+        }
+        if unsupported_stdio_tools:
+            if mode == "actions":
+                raise TracecatValidationError(
+                    "Stdio MCP tools cannot be allowlisted individually because the "
+                    "Claude runtime mounts stdio integrations as whole servers: "
+                    f"{sorted(unsupported_stdio_tools)}"
+                )
+            if mode == "tool_approvals":
+                raise TracecatValidationError(
+                    "Stdio MCP tool approvals are not supported because approved "
+                    "stdio calls cannot be replayed through the executor: "
+                    f"{sorted(unsupported_stdio_tools)}"
+                )
+            raise ValueError(f"Unknown MCP validation mode: {mode}")
+
+        discovered_mcp_tools = await discover_user_mcp_tools(http_servers)
+        available_mcp_tool_names = {
+            mcp_tool_name_to_canonical(tool_name) for tool_name in discovered_mcp_tools
+        }
+        if missing_mcp_tools := mcp_action_names - available_mcp_tool_names:
+            raise TracecatValidationError(
+                "Some MCP tools were not found in configured integrations: "
+                f"{sorted(missing_mcp_tools)}"
             )
 
     @require_scope("agent:update")
@@ -200,7 +296,11 @@ class AgentPresetService(BaseWorkspaceService):
         if "actions" in set_fields:
             # Select in RegistryAction actions that are in the list of actions
             if actions := set_fields.pop("actions"):
-                await self._validate_actions(actions)
+                # Use the effective mcp_integrations (update value or existing)
+                effective_mcp = set_fields.get(
+                    "mcp_integrations", preset.mcp_integrations
+                )
+                await self._validate_actions(actions, mcp_integrations=effective_mcp)
             # If we reach this point, all actions are valid or was empty
             if preset.actions != actions:
                 preset.actions = actions
@@ -209,9 +309,57 @@ class AgentPresetService(BaseWorkspaceService):
         if "mcp_integrations" in set_fields:
             if mcp_integrations := set_fields.pop("mcp_integrations"):
                 await self._validate_mcp_integrations(mcp_integrations)
+            # Re-validate existing actions against the new mcp_integrations
+            # to prevent removing integrations that are still referenced.
+            effective_actions = preset.actions
+            if effective_actions:
+                mcp_actions = [
+                    a
+                    for a in effective_actions
+                    if UserMCPClient.parse_user_mcp_tool_name(a)
+                ]
+                if mcp_actions and not mcp_integrations:
+                    raise TracecatValidationError(
+                        "Cannot remove MCP integrations while actions still "
+                        f"reference MCP tools: {sorted(mcp_actions)}"
+                    )
+                await self._validate_mcp_tool_configuration(
+                    mcp_action_names=set(mcp_actions),
+                    mcp_integrations=mcp_integrations,
+                    mode="actions",
+                )
+            existing_tool_approvals = preset.tool_approvals or {}
+            if existing_tool_approvals:
+                mcp_approval_tools = {
+                    tool_name
+                    for tool_name in existing_tool_approvals
+                    if UserMCPClient.parse_user_mcp_tool_name(tool_name)
+                }
+                await self._validate_mcp_tool_configuration(
+                    mcp_action_names=mcp_approval_tools,
+                    mcp_integrations=mcp_integrations,
+                    mode="tool_approvals",
+                )
             if preset.mcp_integrations != mcp_integrations:
                 preset.mcp_integrations = mcp_integrations
                 execution_changed = True
+
+        if "tool_approvals" in set_fields:
+            tool_approvals = set_fields["tool_approvals"]
+            if tool_approvals:
+                effective_mcp = set_fields.get(
+                    "mcp_integrations", preset.mcp_integrations
+                )
+                mcp_approval_tools = {
+                    tool_name
+                    for tool_name in tool_approvals
+                    if UserMCPClient.parse_user_mcp_tool_name(tool_name)
+                }
+                await self._validate_mcp_tool_configuration(
+                    mcp_action_names=mcp_approval_tools,
+                    mcp_integrations=effective_mcp,
+                    mode="tool_approvals",
+                )
 
         # Update remaining fields
         for field, value in set_fields.items():
@@ -529,6 +677,7 @@ class AgentPresetService(BaseWorkspaceService):
                 command_config: MCPServerConfig = {
                     "type": "stdio",
                     "name": mcp_integration.slug,
+                    "display_name": mcp_integration.name,
                     "command": mcp_integration.stdio_command,
                 }
                 if mcp_integration.stdio_args:
@@ -685,7 +834,8 @@ class AgentPresetService(BaseWorkspaceService):
             # Build MCP server config
             http_config: MCPHttpServerConfig = {
                 "type": "http",
-                "name": mcp_integration.name,
+                "name": mcp_integration.slug,
+                "display_name": mcp_integration.name,
                 "url": mcp_integration.server_uri,
                 "headers": headers,
             }
@@ -1141,12 +1291,18 @@ class AgentPresetService(BaseWorkspaceService):
         tools = await discover_user_mcp_tools(http_servers)
         if not tools:
             return []
+        display_names_by_server = {
+            cfg["name"]: cfg.get("display_name", cfg["name"]) for cfg in http_servers
+        }
 
         return [
             DiscoveredMCPTool(
                 name=mcp_tool_name_to_canonical(name),
                 description=defn.description,
-                server_name=name.split("__")[1] if "__" in name else "unknown",
+                server_name=display_names_by_server.get(
+                    name.split("__")[1] if "__" in name else "",
+                    "unknown",
+                ),
             )
             for name, defn in tools.items()
         ]

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -419,7 +419,8 @@ class ClaudeAgentRuntime:
         - Auto-approved (tool_approvals[action] is False or not set)
         - Require approval (tool_approvals[action] is True) -> trigger approval request
 
-        User MCP servers are auto-approved.
+        Both registry actions and user MCP tools are checked against tool_approvals
+        using their canonical names (e.g. ``mcp.Linear.list_issues``).
         """
 
         tool_name: str = input_data.get("tool_name", "")

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -637,8 +637,9 @@ TRACECAT__AGENT_EXECUTOR_QUEUE = os.environ.get(
 )
 """Task queue for the AgentExecutorWorker.
 
-This queue is reserved for `run_agent_activity` so agent runtime capacity can be
-provisioned independently from agent workflow/control-plane work."""
+This queue is reserved for agent runtime execution activities such as
+`run_agent_activity` and approved HTTP MCP tool replay so that runtime capacity
+can be provisioned independently from agent workflow/control-plane work."""
 
 # === Rate Limiting === #
 TRACECAT__RATE_LIMIT_ENABLED = (

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1276,9 +1276,6 @@ class IntegrationService(BaseWorkspaceService):
         if params.name is not None:
             if params.name.strip() != mcp_integration.name:
                 mcp_integration.name = params.name.strip()
-                mcp_integration.slug = await self._generate_mcp_integration_slug(
-                    name=params.name
-                )
         if params.description is not None:
             mcp_integration.description = (
                 params.description.strip() if params.description else None


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extends canonical approvals/allowlisting to all MCP tools and adds MCP tool discovery in the presets builder. Replays approved user HTTP MCP tools via a new executor activity with heartbeats and stable encoding for smoother, reliable long-running tool UX.

- **New Features**
  - Canonical approvals for all MCP tools (e.g., `mcp.Linear.list_issues`) enforced in the runtime; both registry and user MCP tools are checked using canonical names.
  - Presets builder: new POST `/agent/presets/discover-mcp-tools` returns canonical tool names with descriptions and server names; UI uses `@tanstack/react-query` to merge suggestions into the approval selector and show provider icons.
  - Execution: `execute_approved_tools_activity` replays approved user MCP (HTTP) tools, streams results, and is registered on the agent-executor worker alongside `run_agent_activity`.
  - Validation: require MCP integrations when actions/approvals include MCP tools; ensure selected tools exist on configured HTTP servers; block removing MCP integrations while actions still reference MCP tools; reject per-tool allowlisting for stdio MCP servers.
  - Normalization: consistent canonicalization across discovery, approvals, and execution; support `mcp__Server__tool` and `mcp.Server.tool`, dotted server names, and normalize runtime names like `core__http_request` to `core.http_request`; MCP server configs support optional `display_name` for the UI.

- **Bug Fixes**
  - Send periodic heartbeats during long-running user MCP tool calls, including during approved tool replay, to avoid activity timeouts.
  - Preserve MCP tool identifiers and use stable JSON encoding during approved tool replay to prevent mismatches.
  - MCP integration slugs remain stable when the integration name changes.
  - Removed seeding of RBAC scopes for MCP tools.

<sup>Written for commit 224e3a415286bc76277a58e6cebecbf4b0a81829. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

