### PR TITLE
ci: add frontend client sync check

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -63,9 +63,8 @@ jobs:
       - name: Check frontend client is up to date
         run: |
           pnpm -C frontend generate-client-ci
-          pnpm -C frontend check
-          uv run ruff check . --fix
-          uv run ruff format .
+          # openapi-ts output style doesn't match repo formatting; normalize generated client only
+          pnpm -C frontend exec biome check --write src/client
           git diff --exit-code frontend/src/client/
 
       - name: Run TypeScript type check


### PR DESCRIPTION
## Summary
- Add a "Check frontend client is up to date" step to the frontend CI workflow that runs `generate-client-ci` and fails if the committed client differs from what the backend generates
- Expand workflow trigger paths to include `tracecat/**` and `packages/**` so the check runs when backend schemas change
- Add uv/Python setup to support OpenAPI spec generation

## Test plan
- [ ] Verify CI passes on a branch with up-to-date client
- [ ] Verify CI fails when backend schemas change without regenerating the client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI check to keep the frontend API client in sync with the backend OpenAPI schema. The job now formats only the generated client before diffing and runs on backend changes to prevent drift.

- **New Features**
  - Verifies client sync by generating the client, normalizing formatting for frontend/src/client with Biome, then diffing that directory.
  - Expands workflow triggers to include tracecat/** and packages/** so backend schema changes run the check.
  - Sets up uv and Python dependencies for OpenAPI spec generation.

<sup>Written for commit 7030430e1331391ee5fef0cdbea7535703d6f99e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

