### PR TITLE
fix(org): add passive_deletes to User relationships for member removal

### DIFF
--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -517,23 +517,27 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         "AccessToken",
         back_populates="user",
         lazy="select",
+        passive_deletes=True,
     )
     chats: Mapped[list[Chat]] = relationship(
         "Chat",
         back_populates="user",
         lazy="select",
+        passive_deletes=True,
     )
     role_assignments: Mapped[list[UserRoleAssignment]] = relationship(
         "UserRoleAssignment",
         back_populates="user",
         foreign_keys="UserRoleAssignment.user_id",
         lazy="select",
+        passive_deletes=True,
     )
     organizations: Mapped[list[Organization]] = relationship(
         "Organization",
         secondary=OrganizationMembership.__table__,
         back_populates="members",
         lazy="select",
+        passive_deletes=True,
     )
 
 


### PR DESCRIPTION
## Summary                                                                                                                     
  - Deleting a user via `OrgService.delete_member()` failed with a `NOT NULL` constraint violation on `access_token.user_id` (and
   other child FKs like `user_role_assignment.user_id`)                                                                          
  - SQLAlchemy's default behavior when deleting a parent row is to `SET NULL` on child foreign keys to de-associate them — but
  these columns are non-nullable, causing the error
  - Added `passive_deletes=True` to User relationships (`access_tokens`, `chats`, `role_assignments`, `organizations`) so
  SQLAlchemy defers to the existing database-level `ON DELETE CASCADE` constraints instead of attempting to nullify the foreign
  keys

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set passive_deletes=True on User relationships (AccessToken, Chat, UserRoleAssignment, and Organization memberships) to rely on DB cascades during deletion and membership removal. Prevents foreign key violations and unnecessary ORM deletes when removing a user from an organization.

<sup>Written for commit 2ea185971b69b54a20bab1f2d1d3aac7e1d6088a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

