### PR TITLE
fix(registry): align Exa research templates with current API behavior

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_research.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_research.yml
@@ -1,7 +1,7 @@
 type: action
 definition:
   title: Get research task
-  description: Retrieve the status and results of a research task by its research_id. Automatically polls until the task is completed and returns the final results.
+  description: Retrieve the current status and results of a research task by its research_id.
   display_group: Exa
   doc_url: https://docs.exa.ai/reference/research/get-a-task
   namespace: tools.exa
@@ -17,7 +17,7 @@ definition:
     - ref: get_research
       action: core.http_request
       args:
-        url: https://api.exa.ai/research/v1/${{ inputs.research_id }}
+        url: https://api.exa.ai/research/v1/${{ FN.url_encode(inputs.research_id) }}
         method: GET
         headers:
           x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/list_research.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/list_research.yml
@@ -20,6 +20,20 @@ definition:
       description: Cursor token from previous response for pagination.
       optional: true
   steps:
+    - ref: build_params
+      action: core.script.run_python
+      args:
+        inputs:
+          limit: ${{ inputs.limit }}
+          cursor: ${{ inputs.cursor }}
+        script: |
+          def main(limit=None, cursor=None):
+              params = {}
+              if limit is not None:
+                  params["limit"] = limit
+              if cursor is not None:
+                  params["cursor"] = cursor
+              return params
     - ref: list_research
       action: core.http_request
       args:
@@ -27,7 +41,5 @@ definition:
         method: GET
         headers:
           x-api-key: ${{ SECRETS.exa.EXA_API_KEY }}
-        params:
-          limit: ${{ inputs.limit }}
-          cursor: ${{ inputs.cursor }}
+        params: ${{ steps.build_params.result }}
   returns: ${{ steps.list_research.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/exa/research.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/exa/research.yml
@@ -16,7 +16,7 @@ definition:
     model:
       type: enum["exa-research-fast", "exa-research", "exa-research-pro"]
       description: The model to use for research.
-      default: exa-research
+      default: exa-research-fast
   steps:
     - ref: create_research
       action: core.http_request


### PR DESCRIPTION
### Motivation

- The Exa research templates had drifted from the current Exa API/SDK semantics and could send incorrect defaults or unsafe request data (unencoded IDs and unset query params).

### Description

- Changed the `research` template default model from `exa-research` to `exa-research-fast` to match the current Exa client default in `packages/tracecat-registry/tracecat_registry/templates/tools/exa/research.yml`.
- Updated `get_research` to reflect single-fetch semantics (removed wording about automatic polling) and URL-encode the `research_id` in the path using `FN.url_encode` in `packages/tracecat-registry/tracecat_registry/templates/tools/exa/get_research.yml`.
- Modified `list_research` to dynamically build the `params` object via a `core.script.run_python` step so optional `limit`/`cursor` values are omitted when unset in `packages/tracecat-registry/tracecat_registry/templates/tools/exa/list_research.yml`.

### Testing

- Parsed all Exa template YAML files successfully using a small script (`python -c "import yaml; ..."`) which returned `ok`.
- Ran the targeted registry test command `uv run pytest tests/registry -k exa -q`, which could not complete in this environment because PostgreSQL is not available on `localhost:5432`, causing test setup to fail before template assertions.
- Verified the updated YAML files load and that template changes align with the current `exa-py` client behavior inspected from the official SDK sources (used for API semantics reference).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a079d889e48333b76a6c2e1bb89dc4)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Exa research templates with current API behavior to prevent incorrect defaults and unsafe requests. Updates the default model, request encoding, and pagination params to match the latest SDK.

- **Bug Fixes**
  - Set the research template default model to exa-research-fast to match the Exa client.
  - get_research: clarify single-fetch behavior and URL-encode research_id in the path using FN.url_encode.
  - list_research: build params dynamically so limit/cursor are omitted when unset.

<sup>Written for commit dc53db419a0bb8c0533ac2793b52ce485c4a0a40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

