### PR TITLE
chore(config): drop google_oauth from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,8 +66,8 @@ TRACECAT__DB_URI=postgresql+psycopg://${TRACECAT__POSTGRES_USER}:${TRACECAT__POS
 # First user to promote to superadmin
 TRACECAT__AUTH_SUPERADMIN_EMAIL=
 
-# One or more comma-separated values from `basic`, `google_oauth`, `oidc`, `saml`
-TRACECAT__AUTH_TYPES=basic,google_oauth
+# One or more comma-separated values from `basic`, `oidc`, `saml`
+TRACECAT__AUTH_TYPES=basic
 # One or more comma-separated domains, e.g. `example.com,example.org`
 # Leave blank to allow all domains
 TRACECAT__AUTH_ALLOWED_DOMAINS=


### PR DESCRIPTION
### Motivation
- Remove `google_oauth` from the example environment to stop documenting it as a default auth option and to set the example `TRACECAT__AUTH_TYPES` to `basic` only.

### Description
- Updated `.env.example` to remove `google_oauth` from the documented `TRACECAT__AUTH_TYPES` options and set `TRACECAT__AUTH_TYPES=basic`.

### Testing
- No automated tests were required for this documentation/configuration-only change; the update was validated by inspecting the file with `rg` and `git diff` and committing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b5c5627483339bf4cff6cef5a9f3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed google_oauth from .env.example to avoid implying it’s a default auth option and set TRACECAT__AUTH_TYPES=basic. Updated the comment to list valid options: basic, oidc, saml.

<sup>Written for commit 422e3c69711df8d573bfd1a4f75179668a56954d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

