### PR TITLE
feat(ui): Row integrations

### DIFF
--- a/frontend/src/components/integrations/integrations-header.tsx
+++ b/frontend/src/components/integrations/integrations-header.tsx
@@ -35,6 +35,7 @@ interface IntegrationsHeaderProps {
   onTypeFilterToggle: (filter: IntegrationTypeFilter) => void
   connectionFilter: ConnectionFilter
   onConnectionFilterChange: (filter: ConnectionFilter) => void
+  displayIntegrationCount?: number
 }
 
 const TYPE_FILTER_OPTIONS: Array<{
@@ -59,6 +60,7 @@ export function IntegrationsHeader({
   onTypeFilterToggle,
   connectionFilter,
   onConnectionFilterChange,
+  displayIntegrationCount = 0,
 }: IntegrationsHeaderProps) {
   return (
     <div className="w-full shrink-0 border-b">
@@ -82,6 +84,14 @@ export function IntegrationsHeader({
             )}
           />
         </div>
+
+        {displayIntegrationCount > 0 && (
+          <div className="ml-auto flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">
+              {displayIntegrationCount} integrations
+            </span>
+          </div>
+        )}
       </header>
 
       {/* Row 2: Filters */}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -4457,6 +4457,9 @@ export function useIntegrations(workspaceId: string) {
   } = useQuery<IntegrationReadMinimal[], TracecatApiError>({
     queryKey: ["integrations", workspaceId],
     queryFn: async () => await integrationsListIntegrations({ workspaceId }),
+    enabled: Boolean(workspaceId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   })
 
   // List providers
@@ -4467,6 +4470,9 @@ export function useIntegrations(workspaceId: string) {
   } = useQuery<ProviderReadMinimal[], TracecatApiError>({
     queryKey: ["providers", workspaceId],
     queryFn: async () => await providersListProviders({ workspaceId }),
+    enabled: Boolean(workspaceId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   })
 
   return {
@@ -4589,6 +4595,8 @@ export function useListMcpIntegrations(workspaceId: string) {
     queryFn: async () =>
       await mcpIntegrationsListMcpIntegrations({ workspaceId }),
     enabled: Boolean(workspaceId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   })
 
   return {
@@ -4614,6 +4622,8 @@ export function useGetMcpIntegration(
         mcpIntegrationId: mcpIntegrationId!,
       }),
     enabled: Boolean(workspaceId && mcpIntegrationId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   })
 
   return {
@@ -4746,6 +4756,9 @@ export function useIntegrationProvider({
         grantType,
       }),
     retry: retryHandler,
+    enabled: Boolean(providerId && workspaceId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   })
 
   // Get provider schema
@@ -4757,6 +4770,9 @@ export function useIntegrationProvider({
     queryKey: ["provider-schema", providerId, workspaceId, grantType],
     queryFn: async () =>
       await providersGetProvider({ providerId, workspaceId, grantType }),
+    enabled: Boolean(providerId && workspaceId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   })
 
   // Update


### PR DESCRIPTION
Summary
- group the integrations list into accordions by type, including the new “Custom OAuth” section, while keeping counts and total displayed in the header
- simplify the provider display logic and preserve the existing connect/disconnect behavior inside the new collapsibles
- ensure the feed keeps its cached hook usage so no additional API calls were introduced beyond the existing parameters

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Integrations page to group providers into collapsible sections by type (including Custom OAuth) and added a filtered count in the header. Preserved connect/configure/reconnect/disconnect flows and reduced redundant API calls with better caching.

- **New Features**
  - Group integrations into accordions: Built-in credentials, OAuth, Custom OAuth, MCP, Custom MCP.
  - Keep “Custom OAuth” visible even when empty; each section shows its item count.
  - Simplified item rendering and click behavior; configured state and environment badges are shown consistently.

- **Performance**
  - Added React Query caching (5-minute stale time, no refetch on focus) for integrations, providers, MCP list/get, and provider details/schema.
  - Maintains existing feed caching; no new API calls beyond current parameters.

<sup>Written for commit d326c939d3234ed68141c322a0624e934d61eb83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

