### PR TITLE
fix(agents): base url override patch

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -310,6 +310,7 @@ class DurableAgentWorkflow:
             session_id=self.session_id,
             model=cfg.model_name,
             provider=cfg.model_provider,
+            base_url=cfg.base_url,
             model_settings=cfg.model_settings,
             use_workspace_credentials=args.agent_args.use_workspace_credentials,
         )

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -238,6 +238,10 @@ class LLMTokenClaims(BaseModel):
     provider: str = Field(
         ..., description="The provider for the model (e.g., openai, anthropic, bedrock)"
     )
+    base_url: str | None = Field(
+        default=None,
+        description="Optional provider base URL override from the agent config/preset",
+    )
 
     # Model settings - passed through to LLM provider as-is
     # Supports: temperature, max_tokens, reasoning_effort, etc.
@@ -260,6 +264,7 @@ def mint_llm_token(
     session_id: uuid.UUID,
     model: str,
     provider: str,
+    base_url: str | None = None,
     model_settings: dict[str, Any] | None = None,
     use_workspace_credentials: bool = False,
     ttl_seconds: int | None = None,
@@ -275,6 +280,7 @@ def mint_llm_token(
         session_id: The agent session UUID
         model: The model to use for this run
         provider: The provider for the model (e.g., openai, anthropic, bedrock)
+        base_url: Optional provider base URL override from the agent config/preset
         model_settings: Model-specific settings (temperature, max_tokens,
             reasoning_effort, etc.) passed through to LLM provider
         use_workspace_credentials: Whether to use workspace-level creds
@@ -303,6 +309,7 @@ def mint_llm_token(
         # Model configuration
         "model": model,
         "provider": provider,
+        "base_url": base_url,
         "model_settings": model_settings or {},
         # Credential scope
         "use_workspace_credentials": use_workspace_credentials,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes base URL overrides for agent LLM calls. Preset/preset-configured base_url now reliably overrides workspace credential base URLs, with optional base URLs supported for OpenAI and Anthropic.

- **Bug Fixes**
  - Propagate base_url through LLM tokens and gateway metadata; durable workflow passes cfg.base_url to mint_llm_token.
  - Inject api_base from OPENAI_BASE_URL/ANTHROPIC_BASE_URL when present, then prefer token/preset base_url for openai, anthropic, and custom-model-provider.
  - Added unit tests for injection and override precedence.

<sup>Written for commit b5de519599d3e8a93d2a9ae2b6cbb7e77d89ecce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

