### PR TITLE
chore: update cluster script for mcp service

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -24,9 +24,9 @@
 #
 # Port allocation (offset = (cluster_num - 1) * 100):
 #   Cluster numbers are GLOBAL across all worktrees to avoid port conflicts.
-#   Cluster 1: 80, 3000, 5432, 6379, 7233, 8000, 8081, 9000, 9001
-#   Cluster 2: 180, 3100, 5532, 6479, 7333, 8100, 8181, 9100, 9101
-#   Cluster 3: 280, 3200, 5632, 6579, 7433, 8200, 8281, 9200, 9201
+#   Cluster 1: 80, 3000, 5432, 6379, 7233, 8000, 8081, 9000, 9001, 8099
+#   Cluster 2: 180, 3100, 5532, 6479, 7333, 8100, 8181, 9100, 9101, 8199
+#   Cluster 3: 280, 3200, 5632, 6579, 7433, 8200, 8281, 9200, 9201, 8299
 #   ...
 
 set -euo pipefail
@@ -157,6 +157,7 @@ BASE_API_PORT=8000
 BASE_TEMPORAL_UI_PORT=8081
 BASE_MINIO_PORT=9000
 BASE_MINIO_CONSOLE_PORT=9001
+BASE_MCP_PORT=8099
 
 # Map profile to compose file
 get_compose_file() {
@@ -247,6 +248,7 @@ calculate_ports() {
     TEMPORAL_UI_PORT=$(( BASE_TEMPORAL_UI_PORT + offset ))
     MINIO_PORT=$(( BASE_MINIO_PORT + offset ))
     MINIO_CONSOLE_PORT=$(( BASE_MINIO_CONSOLE_PORT + offset ))
+    MCP_PORT=$(( BASE_MCP_PORT + offset ))
 }
 
 # Build environment variables for docker compose
@@ -254,9 +256,9 @@ build_env() {
     local cluster_num=$1
     calculate_ports "$cluster_num"
 
-    # URLs that depend on ports. Allow explicit env overrides (e.g. ngrok).
-    local PUBLIC_APP_URL="${PUBLIC_APP_URL:-http://localhost:${PUBLIC_APP_PORT}}"
-    local PUBLIC_API_URL="${PUBLIC_API_URL:-${PUBLIC_APP_URL%/}/api}"
+    # URLs that depend on ports
+    local PUBLIC_APP_URL="http://localhost:${PUBLIC_APP_PORT}"
+    local PUBLIC_API_URL="${PUBLIC_APP_URL}/api"
 
     # Export all variables (include worktree ID for isolation)
     export COMPOSE_PROJECT_NAME="tracecat-${WORKTREE_ID}-${cluster_num}"
@@ -271,12 +273,13 @@ build_env() {
     export TEMPORAL_UI_PORT
     export MINIO_PORT
     export MINIO_CONSOLE_PORT
+    export MCP_PORT
 
     # URL variables that reference the public port
     export TRACECAT__PUBLIC_APP_URL="${PUBLIC_APP_URL}"
     export TRACECAT__PUBLIC_API_URL="${PUBLIC_API_URL}"
     export NEXT_PUBLIC_APP_URL="${PUBLIC_APP_URL}"
-    export NEXT_PUBLIC_API_URL="${PUBLIC_API_URL}"
+    export NEXT_PUBLIC_API_URL="http://localhost:${PUBLIC_APP_PORT}/api"
 
     # Caddy configuration
     export BASE_DOMAIN=":${PUBLIC_APP_PORT}"
@@ -307,6 +310,7 @@ Cluster ${WORKTREE_ID}-${cluster_num} port mappings:
   Temporal UI:     http://localhost:${TEMPORAL_UI_PORT}
   MinIO:           localhost:${MINIO_PORT}
   MinIO Console:   http://localhost:${MINIO_CONSOLE_PORT}
+  MCP:             localhost:${MCP_PORT}
 EOF
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added MCP service port mapping to the cluster script so each dev cluster gets a unique MCP port and it appears in the port summary. Also simplified public URL env vars to consistently use local ports.

- **New Features**
  - Added BASE_MCP_PORT (8099) with per-cluster offset (e.g., 8099/8199/8299); calculated and exported MCP_PORT for Docker Compose.
  - Included MCP in the port table comments and cluster output.
  - Set PUBLIC_APP_URL/PUBLIC_API_URL to use localhost ports and defined NEXT_PUBLIC_API_URL explicitly.

<sup>Written for commit 0a32d2b6507210f4dbc929321346153bd3cf69ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

