### PR TITLE
refactor(auth): remove unused SAML email policy helper

### DIFF
--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -319,33 +319,6 @@ async def get_org_saml_metadata_url(
     return value
 
 
-async def should_allow_email_for_org(
-    session: AsyncSession, organization_id: OrganizationID, email: str
-) -> bool:
-    """Check whether a SAML email satisfies domain policy for the org.
-
-    Policy:
-    - Multi-tenant: require active org domain allowlist match.
-    - Single-tenant:
-      - If active org domains exist, require active org domain match.
-      - Else if env allowed domains are configured, require env domain match.
-      - Else allow any valid email domain.
-    """
-    if "@" not in email:
-        return False
-    raw_domain = email.split("@", 1)[1].strip().lower()
-    try:
-        normalized_domain = normalize_domain(raw_domain).normalized_domain
-    except ValueError:
-        return False
-
-    active_domains = await _get_active_org_domains(session, organization_id)
-    return _is_normalized_domain_allowed_for_org(
-        normalized_domain=normalized_domain,
-        active_domains=active_domains,
-    )
-
-
 async def _get_active_org_domains(
     session: AsyncSession, organization_id: OrganizationID
 ) -> set[str]:


### PR DESCRIPTION
### Motivation
- The `should_allow_email_for_org` helper was left as dead production code after `_select_allowlisted_email` → `_select_authorized_email` refactor and no longer has production callers, creating misleading test coverage.
- Tests were exercising the obsolete public helper instead of the real runtime path which uses `_get_active_org_domains` + `_is_normalized_domain_allowed_for_org`.

### Description
- Remove the unused `should_allow_email_for_org` function from `tracecat/auth/saml.py` to eliminate dead production code.
- Update `tests/unit/test_saml_client_config.py` to assert behavior against the actual runtime helper ` _is_normalized_domain_allowed_for_org` instead of the removed public function.
- Preserve existing SAML domain-policy coverage (multi-tenant deny-by-default, single-tenant env-fallback, and active-domain matching) via the updated tests.
- Commit message: `refactor(auth): remove unused SAML email policy helper`.

### Testing
- Ran linters/formatters: `uv run ruff check tracecat/auth/saml.py tests/unit/test_saml_client_config.py` (passed) and `uv run ruff format --check tracecat/auth/saml.py tests/unit/test_saml_client_config.py` (passed).
- Ran `pytest` for the modified test file with `uv run pytest tests/unit/test_saml_client_config.py -q`, which failed in this environment because PostgreSQL at `localhost:5432` is not available and test DB setup could not connect; the failure is an environment issue, not caused by the code changes.
- All local style checks succeed and unit tests exercise the updated internal helper; CI should run full test matrix (including DB-backed tests) to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c5b649108333b4cca5030db1ae3e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused SAML email policy helper should_allow_email_for_org. Updated tests to target _is_normalized_domain_allowed_for_org and preserve domain-policy coverage (multi-tenant deny-by-default, single-tenant env fallback, active-domain matching).

<sup>Written for commit e1ff93b1bf78bc139cc19003bb02695afca55c2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

