### PR TITLE
feat(deployments): add MCP support for EKS and Istio routing

### DIFF
--- a/deployments/eks/README.md
+++ b/deployments/eks/README.md
@@ -357,6 +357,23 @@ export TF_VAR_temporal_cluster_namespace="my-temporal-namespace"
 export TF_VAR_temporal_secret_arn="arn:aws:secretsmanager:us-east-1:123456789012:secret:tracecat/temporal-api-key-AbCdEf"
 ```
 
+## Enable Tracecat MCP on EKS
+
+The EKS Terraform stack can enable the MCP service and ALB routing for `/mcp` and OIDC endpoints.
+
+```bash
+export TF_VAR_tracecat_mcp_enabled=true
+export TF_VAR_tracecat_mcp_replicas=1
+
+# Required by Helm validation when MCP is enabled.
+export TF_VAR_auth_types="oidc"
+export TF_VAR_oidc_issuer="https://issuer.example.com"
+export TF_VAR_oidc_client_id="tracecat-mcp"
+export TF_VAR_oidc_client_secret="replace-me"
+```
+
+When enabled, the module sets `urls.publicMcp=https://<domain>/mcp`, enables the chart `mcp` workload, and configures ALB ingress annotations for MCP in split-ingress mode.
+
 ## Observability (Grafana Cloud)
 
 The stack includes an optional observability pipeline that deploys:

--- a/deployments/eks/main.tf
+++ b/deployments/eks/main.tf
@@ -44,6 +44,8 @@ module "eks" {
   hosted_zone_id         = var.hosted_zone_id
   tracecat_image_tag     = var.tracecat_image_tag
   tracecat_ingress_split = var.tracecat_ingress_split
+  tracecat_mcp_enabled   = var.tracecat_mcp_enabled
+  tracecat_mcp_replicas  = var.tracecat_mcp_replicas
   superadmin_email       = var.superadmin_email
 
   # Tracecat Secrets (AWS Secrets Manager ARN)

--- a/deployments/eks/modules/eks/helm.tf
+++ b/deployments/eks/modules/eks/helm.tf
@@ -117,10 +117,21 @@ resource "helm_release" "tracecat" {
             "alb.ingress.kubernetes.io/healthcheck-path" = "/api/health"
           }
         }
+        mcp = {
+          annotations = {
+            "alb.ingress.kubernetes.io/group.order"      = "15"
+            "alb.ingress.kubernetes.io/healthcheck-path" = "/mcp"
+          }
+        }
       }
       urls = {
         publicApp = "https://${var.domain_name}"
         publicApi = "https://${var.domain_name}/api"
+        publicMcp = "https://${var.domain_name}/mcp"
+      }
+      mcp = {
+        enabled  = var.tracecat_mcp_enabled
+        replicas = var.tracecat_mcp_replicas
       }
       scheduling = local.tracecat_scheduling
       tracecat = {

--- a/deployments/eks/modules/eks/variables.tf
+++ b/deployments/eks/modules/eks/variables.tf
@@ -149,6 +149,18 @@ variable "tracecat_ingress_split" {
   default     = true
 }
 
+variable "tracecat_mcp_enabled" {
+  description = "Enable the Tracecat MCP server deployment and /mcp ingress routing."
+  type        = bool
+  default     = false
+}
+
+variable "tracecat_mcp_replicas" {
+  description = "Replica count for the Tracecat MCP deployment when enabled."
+  type        = number
+  default     = 1
+}
+
 variable "superadmin_email" {
   description = "Email address for the Tracecat superadmin"
   type        = string

--- a/deployments/eks/variables.tf
+++ b/deployments/eks/variables.tf
@@ -165,6 +165,18 @@ variable "tracecat_ingress_split" {
   default     = true
 }
 
+variable "tracecat_mcp_enabled" {
+  description = "Enable the Tracecat MCP server deployment and /mcp ingress routing."
+  type        = bool
+  default     = false
+}
+
+variable "tracecat_mcp_replicas" {
+  description = "Replica count for the Tracecat MCP deployment when enabled."
+  type        = number
+  default     = 1
+}
+
 variable "superadmin_email" {
   description = "Email address for the Tracecat superadmin"
   type        = string

--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -77,6 +77,11 @@ helm install tracecat ./tracecat \
   --set ingress.enabled=false \
   --set urls.publicApp=https://tracecat.example.com \
   --set urls.publicApi=https://tracecat.example.com/api \
+  --set urls.publicMcp=https://tracecat.example.com/mcp \
+  --set mcp.enabled=true \
+  --set tracecat.oidc.issuer=https://issuer.example.com \
+  --set tracecat.oidc.clientId=tracecat-mcp \
+  --set tracecat.oidc.clientSecret=replace-me \
   --set secrets.existingSecret=tracecat-secrets \
   --set externalPostgres.host=your-db-host.example.com \
   --set externalPostgres.auth.existingSecret=tracecat-postgres-credentials \
@@ -184,7 +189,7 @@ Use this when ingress is disabled and traffic is managed by Istio gateways.
 |-----------|---------|-------------|
 | `virtualService.enabled` | `false` | Enable VirtualService rendering |
 | `virtualService.apiVersion` | `networking.istio.io/v1beta1` | Istio API version |
-| `virtualService.tracecat.enabled` | `true` | Render Tracecat UI/API VirtualServices |
+| `virtualService.tracecat.enabled` | `true` | Render Tracecat API/UI VirtualServices (and MCP routes when `mcp.enabled=true`) |
 | `virtualService.tracecat.configs` | `[]` | Required list of `{name, hosts, gateways}` entries |
 | `virtualService.webhooks.enabled` | `false` | Render webhook-only VirtualServices |
 | `virtualService.webhooks.timeout` | `5s` | Timeout for webhook routes |
@@ -224,6 +229,20 @@ virtualService:
           - temporal.example.com
         gateways:
           - istio-system/private-gateway
+
+mcp:
+  enabled: true
+
+tracecat:
+  oidc:
+    issuer: https://issuer.example.com
+    clientId: tracecat-mcp
+    clientSecret: replace-me
+
+urls:
+  publicApp: https://tracecat.example.com
+  publicApi: https://tracecat.example.com/api
+  publicMcp: https://tracecat.example.com/mcp
 ```
 
 ### Public URLs

--- a/deployments/helm/tracecat/templates/virtualservice.yaml
+++ b/deployments/helm/tracecat/templates/virtualservice.yaml
@@ -50,6 +50,30 @@ spec:
             host: {{ include "tracecat.fullname" $ }}-api
             port:
               number: 8000
+    {{- if $.Values.mcp.enabled }}
+    - match:
+        - uri:
+            prefix: /mcp
+        - uri:
+            exact: /.well-known/oauth-authorization-server
+        - uri:
+            exact: /.well-known/oauth-protected-resource
+        - uri:
+            prefix: /authorize
+        - uri:
+            exact: /token
+        - uri:
+            exact: /register
+        - uri:
+            prefix: /consent
+        - uri:
+            prefix: /auth/callback
+      route:
+        - destination:
+            host: {{ include "tracecat.fullname" $ }}-mcp
+            port:
+              number: {{ $.Values.mcp.port }}
+    {{- end }}
     - match:
         - uri:
             prefix: /


### PR DESCRIPTION
### Motivation
- Make Tracecat MCP (MCP/OIDC endpoints) enable-able for EKS Terraform deployments and ensure MCP is routed correctly under both ALB ingress (split-ingress) and Istio VirtualService networking.
- Prevent MCP from falling through to the UI (fix missing VirtualService routes) and ensure `publicMcp` is set when TLS is terminated at ALB so OIDC callbacks work.

### Description
- Added Terraform inputs `tracecat_mcp_enabled` and `tracecat_mcp_replicas` to both the root `deployments/eks/variables.tf` and module `deployments/eks/modules/eks/variables.tf` and passed them through in `deployments/eks/main.tf`.
- Wired Helm values in `deployments/eks/modules/eks/helm.tf` to set `mcp.enabled`, `mcp.replicas`, and explicit `urls.publicMcp`, and added ALB split-ingress annotations for MCP (`alb.ingress.kubernetes.io/group.order` and `alb.ingress.kubernetes.io/healthcheck-path`).
- Extended Helm `virtualservice.yaml` (`deployments/helm/tracecat/templates/virtualservice.yaml`) to render Istio `VirtualService` HTTP matches that route `/mcp`, OIDC discovery endpoints and auth routes (`/.well-known/*`, `/authorize`, `/token`, `/register`, `/consent`, `/auth/callback`) to the MCP service when `mcp.enabled=true`.
- Updated docs with examples and guidance: `deployments/eks/README.md` (how to enable via `TF_VAR_*`), and `deployments/helm/README.md` (values and VirtualService notes for MCP/OIDC).
- Commit message: `feat(deployments): add MCP support for EKS and Istio routing`.

### Testing
- Ran `git diff --check` and it succeeded with no whitespace errors. (passed)
- Attempted `terraform fmt -recursive deployments/eks` but Terraform CLI is not available in this environment, so formatting could not be validated here. (not run)
- Attempted `helm template ...` to validate chart rendering with `mcp.enabled=true`, but Helm CLI is not available in this environment, so template rendering could not be validated here. (not run)
- Verified repository changes were committed successfully (`git commit`). (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c57068dc8333bb07c1937ea21ede)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP support to EKS deployments and routes MCP/OIDC endpoints correctly via ALB and Istio, fixing misrouting to the UI. Enables toggling MCP via Terraform and sets publicMcp so OIDC callbacks work under ALB.

- **New Features**
  - Added Terraform inputs tracecat_mcp_enabled and tracecat_mcp_replicas; passed through to the EKS module.
  - Wired Helm values mcp.enabled, mcp.replicas, urls.publicMcp; added ALB split-ingress annotations for MCP.
  - Added Istio VirtualService matches for /mcp and OIDC endpoints to route to the MCP service when enabled.
  - Updated EKS and Helm docs with enablement examples and notes.

- **Bug Fixes**
  - Prevented MCP requests from falling through to the UI by adding missing VirtualService routes.
  - Set publicMcp when ALB terminates TLS to ensure OIDC callbacks resolve correctly.

<sup>Written for commit 5ce67593e625becb378b178eaa6d83295f7e08e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

