### PR TITLE
feat(eks): scale MCP workloads and node group defaults

### DIFF
--- a/deployments/eks/README.md
+++ b/deployments/eks/README.md
@@ -27,11 +27,11 @@ Network hardening:
 
 ## Default deployment profile (~100 concurrent users)
 
-- Nodes: `10 x m7g.2xlarge` (`8` on-demand + `2` spot by default)
+- Nodes: `13 x m7g.2xlarge` (`10` on-demand + `3` spot by default)
 - Guardrail requirement (rollout peak + reserved headroom): `46.5 vCPU`, `95.5 GiB RAM`
-- Scheduled capacity (on-demand only): `64 vCPU`, `256 GiB RAM`
-- Scheduled capacity (on-demand + spot): `80 vCPU`, `320 GiB RAM`
-- Percent headroom (on-demand only): `~27% CPU`, `~63% RAM` (`17.5 vCPU`, `160.5 GiB RAM`)
+- Scheduled capacity (on-demand only): `80 vCPU`, `320 GiB RAM`
+- Scheduled capacity (on-demand + spot): `104 vCPU`, `416 GiB RAM`
+- Percent headroom (on-demand only): `~42% CPU`, `~70% RAM` (`33.5 vCPU`, `224.5 GiB RAM`)
 - Estimated cost: `$4500/month`
 
 Definitions used above:
@@ -59,18 +59,18 @@ agent_executor_memory_request_mib=8192
 ui_cpu_request_millicores=500
 ui_memory_request_mib=512
 
-# Node groups: 8 on-demand + 2 spot, all m7g.2xlarge
+# Node groups: 10 on-demand + 3 spot, all m7g.2xlarge
 node_instance_types='["m7g.2xlarge"]'
 node_architecture="arm64"
 node_ami_type="AL2023_ARM_64_STANDARD"
-node_min_size=8
-node_desired_size=8
-node_max_size=12
+node_min_size=10
+node_desired_size=10
+node_max_size=16
 spot_node_group_enabled=true
 spot_node_instance_types='["m7g.2xlarge"]'
-spot_node_min_size=2
-spot_node_desired_size=2
-spot_node_max_size=4
+spot_node_min_size=3
+spot_node_desired_size=3
+spot_node_max_size=6
 
 # Capacity guardrail inputs
 node_schedulable_cpu_millicores_per_node=8000

--- a/deployments/eks/modules/eks/helm.tf
+++ b/deployments/eks/modules/eks/helm.tf
@@ -373,6 +373,26 @@ resource "helm_release" "tracecat" {
     value = "${var.ui_memory_request_mib}Mi"
   }
 
+  set {
+    name  = "mcp.resources.requests.cpu"
+    value = "4000m"
+  }
+
+  set {
+    name  = "mcp.resources.requests.memory"
+    value = "4096Mi"
+  }
+
+  set {
+    name  = "mcp.resources.limits.cpu"
+    value = "4000m"
+  }
+
+  set {
+    name  = "mcp.resources.limits.memory"
+    value = "4096Mi"
+  }
+
   # External PostgreSQL (RDS)
   set {
     name  = "externalPostgres.host"

--- a/deployments/eks/modules/eks/helm.tf
+++ b/deployments/eks/modules/eks/helm.tf
@@ -375,22 +375,22 @@ resource "helm_release" "tracecat" {
 
   set {
     name  = "mcp.resources.requests.cpu"
-    value = "4000m"
+    value = "1000m"
   }
 
   set {
     name  = "mcp.resources.requests.memory"
-    value = "4096Mi"
+    value = "1024Mi"
   }
 
   set {
     name  = "mcp.resources.limits.cpu"
-    value = "4000m"
+    value = "1000m"
   }
 
   set {
     name  = "mcp.resources.limits.memory"
-    value = "4096Mi"
+    value = "1024Mi"
   }
 
   # External PostgreSQL (RDS)

--- a/deployments/eks/modules/eks/variables.tf
+++ b/deployments/eks/modules/eks/variables.tf
@@ -75,19 +75,19 @@ variable "node_ami_type" {
 variable "node_desired_size" {
   description = "Desired number of nodes in the node group"
   type        = number
-  default     = 8
+  default     = 10
 }
 
 variable "node_min_size" {
   description = "Minimum number of nodes in the node group"
   type        = number
-  default     = 8
+  default     = 10
 }
 
 variable "node_max_size" {
   description = "Maximum number of nodes in the node group"
   type        = number
-  default     = 12
+  default     = 16
 }
 
 variable "node_disk_size" {
@@ -111,19 +111,19 @@ variable "spot_node_instance_types" {
 variable "spot_node_desired_size" {
   description = "Desired number of nodes in the spot managed node group."
   type        = number
-  default     = 2
+  default     = 3
 }
 
 variable "spot_node_min_size" {
   description = "Minimum number of nodes in the spot managed node group."
   type        = number
-  default     = 2
+  default     = 3
 }
 
 variable "spot_node_max_size" {
   description = "Maximum number of nodes in the spot managed node group."
   type        = number
-  default     = 4
+  default     = 6
 }
 
 # Tracecat Configuration
@@ -158,7 +158,7 @@ variable "tracecat_mcp_enabled" {
 variable "tracecat_mcp_replicas" {
   description = "Replica count for the Tracecat MCP deployment when enabled."
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "superadmin_email" {

--- a/deployments/eks/variables.tf
+++ b/deployments/eks/variables.tf
@@ -101,19 +101,19 @@ variable "node_ami_type" {
 variable "node_desired_size" {
   description = "Desired number of nodes in the node group"
   type        = number
-  default     = 8
+  default     = 10
 }
 
 variable "node_min_size" {
   description = "Minimum number of nodes in the node group"
   type        = number
-  default     = 8
+  default     = 10
 }
 
 variable "node_max_size" {
   description = "Maximum number of nodes in the node group"
   type        = number
-  default     = 12
+  default     = 16
 }
 
 variable "node_disk_size" {
@@ -137,19 +137,19 @@ variable "spot_node_instance_types" {
 variable "spot_node_desired_size" {
   description = "Desired number of nodes in the spot managed node group."
   type        = number
-  default     = 2
+  default     = 3
 }
 
 variable "spot_node_min_size" {
   description = "Minimum number of nodes in the spot managed node group."
   type        = number
-  default     = 2
+  default     = 3
 }
 
 variable "spot_node_max_size" {
   description = "Maximum number of nodes in the spot managed node group."
   type        = number
-  default     = 4
+  default     = 6
 }
 
 # Tracecat Configuration
@@ -174,7 +174,7 @@ variable "tracecat_mcp_enabled" {
 variable "tracecat_mcp_replicas" {
   description = "Replica count for the Tracecat MCP deployment when enabled."
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "superadmin_email" {

--- a/deployments/helm/tracecat/values.yaml
+++ b/deployments/helm/tracecat/values.yaml
@@ -316,15 +316,15 @@ agentExecutor:
 
 mcp:
   enabled: false
-  replicas: 1
+  replicas: 2
   port: 8099
   resources:
     requests:
-      cpu: "500m"
-      memory: "256Mi"
+      cpu: "4000m"
+      memory: "4096Mi"
     limits:
-      cpu: "1000m"
-      memory: "512Mi"
+      cpu: "4000m"
+      memory: "4096Mi"
 
 temporal:
   enabled: true

--- a/deployments/helm/tracecat/values.yaml
+++ b/deployments/helm/tracecat/values.yaml
@@ -320,11 +320,11 @@ mcp:
   port: 8099
   resources:
     requests:
-      cpu: "4000m"
-      memory: "4096Mi"
+      cpu: "1000m"
+      memory: "1024Mi"
     limits:
-      cpu: "4000m"
-      memory: "4096Mi"
+      cpu: "1000m"
+      memory: "1024Mi"
 
 temporal:
   enabled: true


### PR DESCRIPTION
### Motivation
- Provide a larger baseline capacity for the Tracecat MCP service by increasing replica count and per-pod CPU/memory so MCP can handle heavier loads. 
- Ensure cluster autoscaling/default capacity is sufficient for the increased MCP footprint by raising on-demand and spot node group size defaults.

### Description
- Increased MCP replica default from `1` to `2` in Terraform variables at `deployments/eks/variables.tf` and `deployments/eks/modules/eks/variables.tf` (variable `tracecat_mcp_replicas`).
- Raised on-demand node group defaults to desired/min/max = `10/10/16` via `deployments/eks/variables.tf` and `deployments/eks/modules/eks/variables.tf` (`node_desired_size`, `node_min_size`, `node_max_size`).
- Raised spot node group defaults to desired/min/max = `3/3/6` via `deployments/eks/variables.tf` and `deployments/eks/modules/eks/variables.tf` (`spot_node_desired_size`, `spot_node_min_size`, `spot_node_max_size`).
- Added Helm overrides in `deployments/eks/modules/eks/helm.tf` to set MCP pod resource requests/limits to `4000m` CPU and `4096Mi` memory, and aligned the Helm chart default `deployments/helm/tracecat/values.yaml` so MCP also shows `replicas: 2` and the updated resource values.

### Testing
- Ran `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('deployments/helm/tracecat/values.yaml').read_text())"` to validate the modified Helm `values.yaml`, which succeeded.
- Ran `git diff --check` to ensure no trailing whitespace/conflicts, which returned clean.
- Attempted `terraform fmt` on modified Terraform files but the `terraform` CLI was not available in this environment, so formatting could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d0cc04788333887591d6cfc323a6)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaled the Tracecat MCP service by setting replicas to 2 and setting pod resources to 1000m CPU and 1024Mi memory. Increased EKS capacity defaults to 10/10/16 (on-demand) and 3/3/6 (spot), and updated the README default profile to match.

<sup>Written for commit f1eee896066ac1dec6437df148281eb086f276cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

