### PR TITLE
feat(api): Delete user platform via admin settings

### DIFF
--- a/frontend/src/client/services.custom.ts
+++ b/frontend/src/client/services.custom.ts
@@ -143,6 +143,10 @@ export type AdminDeleteOrganizationWithConfirmationData = {
   confirm: string
 }
 
+export type AdminDeleteUserData = {
+  userId: string
+}
+
 export const adminDeleteOrganizationWithConfirmation = (
   data: AdminDeleteOrganizationWithConfirmationData
 ): CancelablePromise<void> =>
@@ -154,6 +158,22 @@ export const adminDeleteOrganizationWithConfirmation = (
     },
     query: {
       confirm: data.confirm,
+    },
+    errors: {
+      400: "Bad Request",
+      404: "Not Found",
+      422: "Validation Error",
+    },
+  })
+
+export const adminDeleteUser = (
+  data: AdminDeleteUserData
+): CancelablePromise<void> =>
+  request(OpenAPI, {
+    method: "DELETE",
+    url: "/admin/users/{user_id}",
+    path: {
+      user_id: data.userId,
     },
     errors: {
       400: "Bad Request",

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -60,6 +60,7 @@ import {
 } from "@/client"
 import {
   adminDeleteOrganizationWithConfirmation,
+  adminDeleteUser,
   adminListOrgTiers,
 } from "@/client/services.custom"
 
@@ -261,6 +262,16 @@ export function useAdminUsers() {
         queryClient.invalidateQueries({ queryKey: ["admin", "users"] }),
     })
 
+  const { mutateAsync: deleteUser, isPending: deletePending } = useMutation<
+    void,
+    Error,
+    string
+  >({
+    mutationFn: (userId) => adminDeleteUser({ userId }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["admin", "users"] }),
+  })
+
   return {
     users,
     isLoading,
@@ -271,6 +282,8 @@ export function useAdminUsers() {
     promotePending,
     demoteFromSuperuser,
     demotePending,
+    deleteUser,
+    deletePending,
   }
 }
 

--- a/packages/tracecat-ee/tracecat_ee/admin/users/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/router.py
@@ -108,3 +108,28 @@ async def demote_from_superuser(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
         ) from e
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user(
+    role: SuperuserRole,
+    session: AsyncDBSession,
+    user_id: uuid.UUID,
+) -> None:
+    """Delete a platform user."""
+    if role.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete user without authenticated user context",
+        )
+    service = AdminUserService(session, role)
+    try:
+        await service.delete_user(user_id, current_user_id=role.user_id)
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e

--- a/tests/unit/api/test_api_admin_users.py
+++ b/tests/unit/api/test_api_admin_users.py
@@ -302,3 +302,46 @@ async def test_demote_user_not_found(client: TestClient, test_admin_role: Role) 
         response = client.post(f"/admin/users/{user_id}/demote")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_delete_user_success(client: TestClient, test_admin_role: Role) -> None:
+    user_id = uuid.uuid4()
+
+    with patch.object(users_router, "AdminUserService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.delete_user.return_value = None
+        MockService.return_value = mock_svc
+
+        response = client.delete(f"/admin/users/{user_id}")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_delete_self_error(client: TestClient, test_admin_role: Role) -> None:
+    user_id = uuid.uuid4()
+
+    with patch.object(users_router, "AdminUserService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.delete_user.side_effect = ValueError("Cannot delete yourself")
+        MockService.return_value = mock_svc
+
+        response = client.delete(f"/admin/users/{user_id}")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Cannot delete yourself" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_delete_user_not_found(client: TestClient, test_admin_role: Role) -> None:
+    user_id = uuid.uuid4()
+
+    with patch.object(users_router, "AdminUserService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.delete_user.side_effect = ValueError(f"User {user_id} not found")
+        MockService.return_value = mock_svc
+
+        response = client.delete(f"/admin/users/{user_id}")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
### Motivation
- Provide platform administrators the ability to delete user accounts from the admin console while enforcing safety checks.
- Ensure deletion cleans up related `Membership` and `OrganizationMembership` records and removes the user from the user manager store.
- Record the deletion in the audit log and surface appropriate errors for self-deletes and not-found cases.

### Description
- Add a `DELETE /admin/users/{user_id}` router handler implemented in `admin/users/router.py` that calls `AdminUserService.delete_user` and maps `ValueError` cases to appropriate HTTP errors.
- Implement `AdminUserService.delete_user` in `admin/users/service.py` to prevent self-deletes, validate existence, remove `Membership` and `OrganizationMembership` rows, call the user manager `delete`, and create an audit event via `AuditService`.
- Add a client-side API entry in `frontend/src/client/services.custom.ts` (`adminDeleteUser`) and wire it into the admin hook `useAdminUsers` with a `deleteUser` mutation and `deletePending` status in `frontend/src/hooks/use-admin.ts`.
- Extend the admin users UI `AdminUsersTable` (`frontend/src/components/admin/admin-users-table.tsx`) to include a "Delete user" action, confirmation dialog text, destructive styling, and proper disabled/pending behavior.
- Add unit tests for the router and service (`tests/unit/api/test_api_admin_users.py` and `tests/unit/test_admin_users_service.py`) covering success, self-delete rejection, and not-found error cases.

### Testing
- Added and ran unit tests `tests/unit/test_admin_users_service.py::test_delete_user_removes_user` and `::test_delete_user_rejects_self`, which verify deletion behavior and self-delete rejection and succeeded. 
- Added and ran API unit tests in `tests/unit/api/test_api_admin_users.py` covering `DELETE /admin/users/{user_id}` success, self-delete error, and not-found error, and they succeeded.
- Ran the admin-related unit test subset with `pytest tests/unit -k admin_users` to validate the changes and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f740430c8333957363288dabe252)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe admin delete user flow across API, service, client, and UI. Admins can delete users with membership cleanup, audit logging, and clear error handling.

- **New Features**
  - API: DELETE /admin/users/{user_id} returns 204; maps self-delete to 400 and not-found to 404.
  - Service: prevents self-deletes, validates existence, removes Membership and OrganizationMembership, deletes user via user manager, writes audit event.
  - Client/Hook: adds adminDeleteUser and deleteUser mutation with deletePending; invalidates admin users list.
  - UI: adds “Delete user” action with confirmation and destructive styling; disabled for self or non-superuser; shows pending state.
  - Tests: unit coverage for success, self-delete rejection, and not-found cases.

<sup>Written for commit 5ad0a1531ff4076ca827e3b7fd9e92a30bf3c4d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

