### PR TITLE
feat(admin): allow platform superusers to delete users

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -30,6 +30,8 @@ import type {
   AdminDeleteOrganizationResponse,
   AdminDeleteTierData,
   AdminDeleteTierResponse,
+  AdminDeleteUserData,
+  AdminDeleteUserResponse,
   AdminDemoteFromSuperuserData,
   AdminDemoteFromSuperuserResponse,
   AdminGetOrganizationData,
@@ -4840,6 +4842,29 @@ export const adminGetUser = (
 ): CancelablePromise<AdminGetUserResponse> => {
   return __request(OpenAPI, {
     method: "GET",
+    url: "/admin/users/{user_id}",
+    path: {
+      user_id: data.userId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete User
+ * Delete a platform user.
+ * @param data The data for the request.
+ * @param data.userId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const adminDeleteUser = (
+  data: AdminDeleteUserData
+): CancelablePromise<AdminDeleteUserResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
     url: "/admin/users/{user_id}",
     path: {
       user_id: data.userId,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8283,6 +8283,12 @@ export type AdminGetUserData = {
 
 export type AdminGetUserResponse = AdminUserRead
 
+export type AdminDeleteUserData = {
+  userId: string
+}
+
+export type AdminDeleteUserResponse = void
+
 export type AdminPromoteToSuperuserData = {
   userId: string
 }
@@ -11996,6 +12002,19 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: AdminUserRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AdminDeleteUserData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
         /**
          * Validation Error
          */

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -21,6 +21,7 @@ import {
   adminCreateUser,
   adminDeleteOrganizationDomain,
   adminDeleteTier,
+  adminDeleteUser,
   adminDemoteFromSuperuser,
   adminGetOrganization,
   adminGetOrgTier,
@@ -261,6 +262,16 @@ export function useAdminUsers() {
         queryClient.invalidateQueries({ queryKey: ["admin", "users"] }),
     })
 
+  const { mutateAsync: deleteUser, isPending: deletePending } = useMutation<
+    void,
+    Error,
+    string
+  >({
+    mutationFn: (userId) => adminDeleteUser({ userId }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["admin", "users"] }),
+  })
+
   return {
     users,
     isLoading,
@@ -271,6 +282,8 @@ export function useAdminUsers() {
     promotePending,
     demoteFromSuperuser,
     demotePending,
+    deleteUser,
+    deletePending,
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide platform superusers a way to remove platform users from the admin UI while preserving safety guards.
- Ensure deletions are auditable and prevent destructive mistakes like deleting yourself or the last superuser.

### Description
- Add `AdminUserService.delete_user(user_id, current_user_id)` which enforces "no self-delete" and "cannot delete last superuser" and emits an audit event.
- Expose a new API route `DELETE /admin/users/{user_id}` with proper 400/404 error mapping for service errors at the admin router.
- Regenerate the frontend API client to add `adminDeleteUser`, wire it into `useAdminUsers`, and add a destructive "Delete user" action to `AdminUsersTable` with confirmation dialog and UI disable states for safety.
- Add unit tests for the admin users API covering delete success and common failure scenarios (`tests/unit/api/test_api_admin_users.py`).

### Testing
- Ran `pnpm -C frontend generate-client-ci`, `pnpm -C frontend check`, and `pnpm -C frontend run typecheck` which completed successfully.
- Ran linters/type checks: `uv run ruff check`, `uv run ruff format --check`, and `uv run basedpyright` which completed with no issues for the modified files.
- Added unit tests and attempted `uv run pytest tests/unit/api/test_api_admin_users.py`, but the test run failed in this environment because PostgreSQL at `localhost:5432` was not available, so HTTP-level tests could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f66f51748320bd67e0a23e8004ac)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user deletion to the admin UI for platform superusers, with safeguards and audit logging. Improves safety by preventing self-deletes and blocking deletion of the last superuser.

- **New Features**
  - Backend: AdminUserService.delete_user with self-delete and last-superuser checks; emits audit event.
  - API: DELETE /admin/users/{user_id} returning 204, with 400/404 error mapping.
  - Frontend: Generated adminDeleteUser client, added deleteUser to useAdminUsers, and a “Delete user” action with confirmation and disabled states for unsafe cases.
  - Tests: Added API unit tests for success, not found, self-delete, and last-superuser errors.

<sup>Written for commit 2ef2961e8d0320ba972e24f962a71eb9ba38d841. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

