### PR TITLE
feat(integrations): add Jira MCP OAuth2.1 integration

### DIFF
--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -152,7 +152,16 @@ function getMcpProviderId(slug: string): string | undefined {
     secureannex: "secureannex_mcp",
   }
 
-  return slugMap[slug.toLowerCase()]
+  const normalized = slug.toLowerCase()
+  if (slugMap[normalized]) {
+    return slugMap[normalized]
+  }
+
+  if (normalized.endsWith("_mcp")) {
+    return normalized
+  }
+
+  return undefined
 }
 
 const agentPresetSchema = z

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -146,6 +146,7 @@ function getMcpProviderId(slug: string): string | undefined {
     sentry: "sentry_mcp",
     notion: "notion_mcp",
     linear: "linear_mcp",
+    jira: "jira_mcp",
     runreveal: "runreveal_mcp",
     "secure-annex": "secureannex_mcp",
     secureannex: "secureannex_mcp",

--- a/frontend/src/components/agents/agents-table.tsx
+++ b/frontend/src/components/agents/agents-table.tsx
@@ -67,6 +67,7 @@ function getMcpProviderId(slug: string): string | undefined {
     sentry: "sentry_mcp",
     notion: "notion_mcp",
     linear: "linear_mcp",
+    jira: "jira_mcp",
     runreveal: "runreveal_mcp",
     "secure-annex": "secureannex_mcp",
     secureannex: "secureannex_mcp",

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -542,6 +542,7 @@ export const providerIcons: Record<
   sentry_mcp: (props) => <SentryIcon {...props} />,
   notion_mcp: (props) => <NotionIcon {...props} />,
   linear_mcp: (props) => <LinearIcon {...props} />,
+  jira_mcp: (props) => <JiraIcon {...props} />,
   runreveal_mcp: (props) => <RunRevealIcon {...props} />,
   secureannex_mcp: (props) => <SecureAnnexIcon {...props} />,
   github_mcp: ({ className, ...rest }) => (

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
@@ -1,0 +1,58 @@
+from typing import Annotated
+
+from typing_extensions import Doc
+
+from tracecat_registry import RegistryOAuthSecret, registry, secrets
+from tracecat_registry.context import get_context
+from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
+from tracecat_registry.types import AgentOutputRead
+
+jira_mcp_oauth_secret = RegistryOAuthSecret(
+    provider_id="jira_mcp",
+    grant_type="authorization_code",
+)
+"""Jira MCP OAuth2.1 credentials (Authorization Code grant).
+
+- name: `jira_mcp`
+- provider_id: `jira_mcp`
+- token_name: `JIRA_MCP_USER_TOKEN`
+"""
+
+
+@registry.register(
+    default_title="Jira MCP",
+    description="Use AI to interact with Jira via Atlassian MCP.",
+    display_group="Jira MCP",
+    doc_url=(
+        "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/"
+        "getting-started-with-the-atlassian-remote-mcp-server/"
+    ),
+    namespace="tools.jira",
+    secrets=[jira_mcp_oauth_secret, *PYDANTIC_AI_REGISTRY_SECRETS],
+)
+async def mcp(
+    user_prompt: Annotated[str, Doc("User prompt to the agent.")],
+    instructions: Annotated[str, Doc("Instructions for the agent.")],
+    model_name: Annotated[str, Doc("Name of the model to use.")],
+    model_provider: Annotated[str, Doc("Provider of the model to use.")],
+) -> AgentOutputRead:
+    """Use AI to interact with Jira through Atlassian's remote MCP server."""
+    token = secrets.get(jira_mcp_oauth_secret.token_name)
+    ctx = get_context()
+    result = await ctx.agents.run(
+        user_prompt=user_prompt,
+        config=AgentConfig(
+            model_name=model_name,
+            model_provider=model_provider,
+            instructions=instructions,
+            mcp_servers=[
+                MCPServerConfig(
+                    name="jira",
+                    url="https://mcp.atlassian.com/v1/mcp",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+            ],
+        ),
+    )
+    return result

--- a/tracecat/integrations/providers/__init__.py
+++ b/tracecat/integrations/providers/__init__.py
@@ -10,6 +10,7 @@ from tracecat.integrations.providers.google import (
 )
 from tracecat.integrations.providers.google.drive import GoogleDriveACProvider
 from tracecat.integrations.providers.google.gmail import GoogleGmailACProvider
+from tracecat.integrations.providers.jira.mcp import JiraMCPProvider
 from tracecat.integrations.providers.linear.mcp import LinearMCPProvider
 from tracecat.integrations.providers.microsoft import (
     AzureLogAnalyticsACProvider,
@@ -45,6 +46,7 @@ _PROVIDER_CLASSES: list[type[BaseOAuthProvider]] = [
     GoogleGmailACProvider,
     GoogleServiceAccountOAuthProvider,
     GoogleSheetsOAuthProvider,
+    JiraMCPProvider,
     LinearMCPProvider,
     NotionMCPProvider,
     RunRevealMCPProvider,

--- a/tracecat/integrations/providers/jira/mcp.py
+++ b/tracecat/integrations/providers/jira/mcp.py
@@ -1,0 +1,44 @@
+"""Jira MCP OAuth integration using Model Context Protocol."""
+
+from typing import ClassVar
+
+from tracecat.integrations.providers.base import MCPAuthProvider
+from tracecat.integrations.schemas import ProviderMetadata, ProviderScopes
+
+
+class JiraMCPProvider(MCPAuthProvider):
+    """Jira OAuth 2.1 provider for Model Context Protocol integration.
+
+    This provider enables integration with Atlassian's remote MCP server for:
+    - Querying and updating Jira issues and projects
+    - Accessing contextual Atlassian cloud data from MCP-compatible agents
+    - Running the browser-based OAuth 2.1 authorization flow
+
+    OAuth endpoints are automatically discovered from the server.
+    """
+
+    id: ClassVar[str] = "jira_mcp"
+
+    # Atlassian remote MCP endpoint - OAuth endpoints discovered automatically.
+    mcp_server_uri: ClassVar[str] = "https://mcp.atlassian.com/v1/mcp"
+
+    # No default scopes - authorization server determines based on user permissions.
+    scopes: ClassVar[ProviderScopes] = ProviderScopes(default=[])
+
+    # Provider metadata
+    metadata: ClassVar[ProviderMetadata] = ProviderMetadata(
+        id="jira_mcp",
+        name="Jira MCP",
+        description="Jira MCP provider for Atlassian cloud issue and project access",
+        enabled=True,
+        requires_config=False,
+        setup_instructions=(
+            "Connect to Jira MCP to authorize browser-based OAuth 2.1 access to your "
+            "Atlassian cloud data. Permissions are automatically determined based on "
+            "your Jira and Atlassian account access."
+        ),
+        api_docs_url=(
+            "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/"
+            "getting-started-with-the-atlassian-remote-mcp-server/"
+        ),
+    )


### PR DESCRIPTION
### Motivation
- Add Atlassian Jira as an MCP (Model Context Protocol) provider so agents can use the Atlassian remote MCP server and perform browser-based OAuth 2.1 authorization to access Jira/Atlassian cloud context.
- Mirror the existing MCP pattern (e.g., `linear_mcp`) so the platform can auto-create MCP integrations and expose a registry action for Jira tooling.

### Description
- Added a new MCP provider implementation `JiraMCPProvider` with `mcp_server_uri` set to `https://mcp.atlassian.com/v1/mcp` and provider metadata. (`tracecat/integrations/providers/jira/mcp.py`).
- Registered `JiraMCPProvider` in the provider registry so it is discoverable by the integrations service (`tracecat/integrations/providers/__init__.py`).
- Added a tracecat-registry action/entry for Jira MCP that exposes a `jira_mcp` OAuth secret and wires an `tools.jira` registry agent to the Atlassian MCP server (`packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py`).
- Updated frontend mappings so `jira_mcp` uses the Jira logo: added `jira_mcp` to `providerIcons` and mapped `jira` slug -> `jira_mcp` in agent UIs (`frontend/src/components/icons.tsx`, `frontend/src/components/agents/agent-presets-builder.tsx`, `frontend/src/components/agents/agents-table.tsx`).

### Testing
- Ran Python lint/type checks: `uv run ruff check tracecat/integrations/providers/jira/mcp.py tracecat/integrations/providers/__init__.py packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py` — passed.
- Ran frontend checks: `pnpm -C frontend exec biome check src/components/icons.tsx src/components/agents/agent-presets-builder.tsx src/components/agents/agents-table.tsx` — passed.
- Attempted to boot the frontend dev server and capture a UI screenshot (Playwright); dev server started but page render failed due to missing required env vars (`NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_API_URL`), so the screenshot captures the environment error state (not a runtime integration failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fee929208333b8df34135f039f2c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Jira as an MCP OAuth2.1 integration so agents can use Atlassian’s remote MCP server with browser-based auth to interact with Jira. Also fixes slug handling so Jira resolves correctly in agent views and shows the right icon.

- **New Features**
  - Added JiraMCPProvider with server URL https://mcp.atlassian.com/v1/mcp; registered in the provider registry. Added tools.jira registry action with a jira_mcp OAuth secret and Bearer token wiring.
  - Updated UI to show the Jira icon for jira_mcp.

- **Bug Fixes**
  - Normalized agent slug resolution to map jira -> jira_mcp and accept *_mcp IDs, fixing provider ID and icon mapping in presets and the agents table.

<sup>Written for commit 2e84f3db35e7da38147d4ec38160a38b949afe41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

