### PR TITLE
refactor(workspaces): move workspace org resolution activity

### DIFF
--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -34,6 +34,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.workflow.management.management import WorkflowsManagementService
     from tracecat.workflow.schedules.service import WorkflowSchedulesService
+    from tracecat.workspaces.activities import get_workspace_organization_id_activity
 
 
 # Due to known issues with Pydantic's use of issubclass and our inability to
@@ -84,6 +85,7 @@ def get_activities() -> list[Callable]:
         *CollectionActivities.get_activities(),
         get_workflow_definition_activity,
         resolve_registry_lock_activity,
+        get_workspace_organization_id_activity,
         *WorkflowSchedulesService.get_activities(),
         resolve_time_anchor_activity,
         *WorkflowsManagementService.get_activities(),

--- a/tracecat/workspaces/activities.py
+++ b/tracecat/workspaces/activities.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import Workspace
+from tracecat.identifiers import OrganizationID, WorkspaceID
+
+
+@activity.defn
+async def get_workspace_organization_id_activity(
+    workspace_id: WorkspaceID,
+) -> OrganizationID:
+    """Resolve organization_id for a workspace."""
+    async with get_async_session_context_manager() as session:
+        stmt = select(Workspace.organization_id).where(Workspace.id == workspace_id)
+        result = await session.execute(stmt)
+        org_id = result.scalar_one_or_none()
+    if org_id is None:
+        raise ApplicationError(
+            f"Workspace {workspace_id} not found or has no organization",
+            non_retryable=True,
+        )
+    return org_id


### PR DESCRIPTION
## Summary
- move `get_workspace_organization_id_activity` out of `WorkflowSchedulesService` into a shared module: `tracecat/workspaces/activities.py`
- update `DSLWorkflow` to call the shared workspace activity for organization resolution
- register the shared activity in the DSL worker activity list
- remove the schedule-owned workspace/org activity from schedules service
- rename unit test module from `test_schedule_role_healing.py` to `test_workspace_org_resolution.py`

## Testing
- `uv run ruff check tracecat/workspaces/activities.py tracecat/workflow/schedules/service.py tracecat/dsl/workflow.py tracecat/dsl/worker.py tests/unit/test_workspace_org_resolution.py`
- `uv run basedpyright tracecat/workspaces/activities.py tracecat/workflow/schedules/service.py tracecat/dsl/workflow.py tracecat/dsl/worker.py tests/unit/test_workspace_org_resolution.py`
- `TRACECAT__SERVICE_KEY=test AWS_ACCESS_KEY_ID=minio AWS_SECRET_ACCESS_KEY=password uv run pytest tests/unit/test_workspace_org_resolution.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized workspace organization resolution into a shared activity and updated DSL workflows to fail fast when workspace or organization cannot be resolved.

- **Refactors**
  - Moved get_workspace_organization_id_activity to tracecat/workspaces/activities.py and made it raise ApplicationError when not found.
  - DSLWorkflow validates workspace_id on init and resolves organization_id via the shared activity.
  - Registered the shared activity in the DSL worker and removed the schedules service version.
  - Renamed and updated unit tests to reflect the new fail-fast behavior.

<sup>Written for commit 87ebb93f9234a80b408ba8a534fa213c54b4bb52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

