### PR TITLE
fix(ui): Propagate task_id when triggering workflows from task UI

### DIFF
--- a/frontend/src/components/cases/task-workflow-trigger.tsx
+++ b/frontend/src/components/cases/task-workflow-trigger.tsx
@@ -42,6 +42,7 @@ export function TaskWorkflowTrigger({
         caseData={caseData}
         workflowId={workflowId}
         workflowTitle={workflowTitle}
+        taskId={task?.id}
         defaultTriggerValues={task?.default_trigger_values}
         open={isDialogOpen}
         onOpenChange={setIsDialogOpen}

--- a/frontend/src/components/cases/workflow-trigger-form.tsx
+++ b/frontend/src/components/cases/workflow-trigger-form.tsx
@@ -59,6 +59,7 @@ interface WorkflowTriggerFormProps {
   caseFields: Record<string, unknown>
   groupCaseFields: boolean
   defaultTriggerValues?: Record<string, unknown> | null
+  taskId?: string
   onSubmit: (values: TriggerFormValues) => Promise<void>
   isSubmitting: boolean
 }
@@ -180,6 +181,7 @@ export function WorkflowTriggerForm({
   caseFields,
   groupCaseFields,
   defaultTriggerValues,
+  taskId,
   onSubmit,
   isSubmitting,
 }: WorkflowTriggerFormProps) {
@@ -240,6 +242,11 @@ export function WorkflowTriggerForm({
         continue
       }
 
+      if (key === "task_id" && taskId) {
+        defaults[key] = taskId
+        continue
+      }
+
       if (groupCaseFields && key === "case_fields") {
         defaults[key] = caseFields
         continue
@@ -262,7 +269,14 @@ export function WorkflowTriggerForm({
     }
 
     return defaults
-  }, [schema, caseId, caseFields, groupCaseFields, defaultTriggerValues])
+  }, [
+    schema,
+    caseId,
+    caseFields,
+    groupCaseFields,
+    defaultTriggerValues,
+    taskId,
+  ])
 
   useEffect(() => {
     form.reset(computedDefaults)

--- a/frontend/src/hooks/use-workflow-trigger-inputs.ts
+++ b/frontend/src/hooks/use-workflow-trigger-inputs.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react"
 import type { CaseRead } from "@/client"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 
-export function useWorkflowTriggerInputs(caseData: CaseRead) {
+export function useWorkflowTriggerInputs(caseData: CaseRead, taskId?: string) {
   const [groupCaseFields, setGroupCaseFields] = useLocalStorage(
     "groupCaseFields",
     false
@@ -24,14 +24,16 @@ export function useWorkflowTriggerInputs(caseData: CaseRead) {
     if (groupCaseFields) {
       return {
         case_id: caseData.id,
+        ...(taskId ? { task_id: taskId } : {}),
         case_fields: caseFieldsRecord,
       }
     }
     return {
       case_id: caseData.id,
+      ...(taskId ? { task_id: taskId } : {}),
       ...caseFieldsRecord,
     }
-  }, [caseData.id, caseFieldsRecord, groupCaseFields])
+  }, [caseData.id, caseFieldsRecord, groupCaseFields, taskId])
 
   return {
     caseFieldsRecord,


### PR DESCRIPTION
### Motivation

- Ensure workflow executions triggered from a task include the task context so workflows can use `task_id` when run. 
- Pre-populate workflow trigger inputs with the task identifier where applicable so defaults and fallback payloads include `task_id`.
- Keep existing behavior for case-level triggers while adding task-scoped inputs for task-initiated triggers.

### Description

- Thread `taskId` from `TaskWorkflowTrigger` into `WorkflowTriggerDialog` and `WorkflowTriggerForm` by adding a `taskId` prop and passing it through the components. 
- Update `useWorkflowTriggerInputs` to accept an optional `taskId` and include `task_id` in `fallbackInputs` both when grouping case fields and when not grouping. 
- Add `withTaskContextInputs` wrapper in `WorkflowTriggerDialog` to inject `case_id` and conditional `task_id` into the payloads used for `createExecution`, and use it for both schema-based and fallback triggers. 
- Set `task_id` as a computed default in `WorkflowTriggerForm` so the form pre-fills the field when the schema includes `task_id`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20f69d16883338faf3e6ea5e06a39)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workflows triggered from the task UI now include task_id so executions run with task context. The trigger dialog and form prefill and send task_id alongside case_id for both schema-based and fallback triggers.

- **New Features**
  - Pass taskId from TaskWorkflowTrigger to WorkflowTriggerDialog and WorkflowTriggerForm.
  - useWorkflowTriggerInputs accepts taskId and adds task_id to fallback inputs (grouped and flat).
  - Inject case_id and task_id into createExecution inputs via withTaskContextInputs.
  - Form computes a default for task_id when the schema includes it.

<sup>Written for commit 6ff8b887d20a2643f076d6fa9eae16f5af2cef5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

