### PR TITLE
feat(agents): rbac for agents

### DIFF
--- a/alembic/versions/d21b9ee6a5d1_add_agent_preset_rbac_fields.py
+++ b/alembic/versions/d21b9ee6a5d1_add_agent_preset_rbac_fields.py
@@ -1,0 +1,170 @@
+"""add agent preset rbac fields
+
+Revision ID: d21b9ee6a5d1
+Revises: c9e4f54f0a2b
+Create Date: 2026-02-27 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d21b9ee6a5d1"
+down_revision: str | None = "c9e4f54f0a2b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    op.add_column(
+        "agent_preset",
+        sa.Column(
+            "is_system",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "agent_preset",
+        sa.Column("assigned_role_id", sa.UUID(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_agent_preset_assigned_role_id"),
+        "agent_preset",
+        ["assigned_role_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "agent_preset_assigned_role_id_fkey",
+        "agent_preset",
+        "role",
+        ["assigned_role_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    bind.exec_driver_sql(
+        """
+        INSERT INTO scope (
+            id,
+            name,
+            resource,
+            action,
+            description,
+            source,
+            source_ref,
+            organization_id
+        )
+        VALUES
+            (
+                gen_random_uuid(),
+                'agent:preset:*:read',
+                'agent:preset',
+                'read',
+                'View all agent presets',
+                'PLATFORM'::scopesource,
+                'agent_preset:wildcard',
+                NULL
+            ),
+            (
+                gen_random_uuid(),
+                'agent:preset:*:execute',
+                'agent:preset',
+                'execute',
+                'Execute all agent presets',
+                'PLATFORM'::scopesource,
+                'agent_preset:wildcard',
+                NULL
+            ),
+            (
+                gen_random_uuid(),
+                'agent:preset:*:update',
+                'agent:preset',
+                'update',
+                'Update all agent presets',
+                'PLATFORM'::scopesource,
+                'agent_preset:wildcard',
+                NULL
+            ),
+            (
+                gen_random_uuid(),
+                'agent:preset:*:delete',
+                'agent:preset',
+                'delete',
+                'Delete all agent presets',
+                'PLATFORM'::scopesource,
+                'agent_preset:wildcard',
+                NULL
+            )
+        ON CONFLICT (name)
+        WHERE organization_id IS NULL
+        DO NOTHING
+        """
+    )
+
+    bind.exec_driver_sql(
+        """
+        INSERT INTO scope (
+            id,
+            name,
+            resource,
+            action,
+            description,
+            source,
+            source_ref,
+            organization_id
+        )
+        SELECT
+            gen_random_uuid(),
+            format('agent:preset:%s:%s', p.slug, action_map.action),
+            'agent:preset',
+            action_map.action,
+            format('Allow %s access to agent preset ''%s''', action_map.action, p.slug),
+            'PLATFORM'::scopesource,
+            format('agent_preset:%s', p.slug),
+            NULL
+        FROM (
+            SELECT DISTINCT slug
+            FROM agent_preset
+            WHERE slug IS NOT NULL
+        ) AS p
+        CROSS JOIN (
+            VALUES
+                ('read'),
+                ('execute'),
+                ('update'),
+                ('delete')
+        ) AS action_map(action)
+        ON CONFLICT (name)
+        WHERE organization_id IS NULL
+        DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    op.drop_constraint(
+        "agent_preset_assigned_role_id_fkey",
+        "agent_preset",
+        type_="foreignkey",
+    )
+    op.drop_index(op.f("ix_agent_preset_assigned_role_id"), table_name="agent_preset")
+    op.drop_column("agent_preset", "assigned_role_id")
+    op.drop_column("agent_preset", "is_system")
+
+    bind.exec_driver_sql(
+        """
+        DELETE FROM scope
+        WHERE organization_id IS NULL
+          AND resource = 'agent:preset'
+        """
+    )

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1148,6 +1148,18 @@ export const $AgentPresetCreate = {
       title: "Enable Internet Access",
       default: false,
     },
+    assigned_role_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Assigned Role Id",
+    },
     name: {
       type: "string",
       maxLength: 120,
@@ -1300,6 +1312,18 @@ export const $AgentPresetRead = {
       title: "Enable Internet Access",
       default: false,
     },
+    assigned_role_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Assigned Role Id",
+    },
     id: {
       type: "string",
       format: "uuid",
@@ -1317,6 +1341,11 @@ export const $AgentPresetRead = {
     slug: {
       type: "string",
       title: "Slug",
+    },
+    is_system: {
+      type: "boolean",
+      title: "Is System",
+      default: false,
     },
     created_at: {
       type: "string",
@@ -1374,6 +1403,11 @@ export const $AgentPresetReadMinimal = {
         },
       ],
       title: "Description",
+    },
+    is_system: {
+      type: "boolean",
+      title: "Is System",
+      default: false,
     },
     created_at: {
       type: "string",
@@ -1577,6 +1611,18 @@ export const $AgentPresetUpdate = {
         },
       ],
       title: "Enable Internet Access",
+    },
+    assigned_role_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Assigned Role Id",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -281,6 +281,7 @@ export type AgentPresetCreate = {
   mcp_integrations?: Array<string> | null
   retries?: number
   enable_internet_access?: boolean
+  assigned_role_id?: string | null
   name: string
   slug?: string | null
 }
@@ -303,10 +304,12 @@ export type AgentPresetRead = {
   mcp_integrations?: Array<string> | null
   retries?: number
   enable_internet_access?: boolean
+  assigned_role_id?: string | null
   id: string
   workspace_id: string
   name: string
   slug: string
+  is_system?: boolean
   created_at: string
   updated_at: string
 }
@@ -320,6 +323,7 @@ export type AgentPresetReadMinimal = {
   name: string
   slug: string
   description: string | null
+  is_system?: boolean
   created_at: string
   updated_at: string
 }
@@ -344,6 +348,7 @@ export type AgentPresetUpdate = {
   mcp_integrations?: Array<string> | null
   retries?: number | null
   enable_internet_access?: boolean | null
+  assigned_role_id?: string | null
 }
 
 /**

--- a/frontend/src/components/rbac/scope-category-row.tsx
+++ b/frontend/src/components/rbac/scope-category-row.tsx
@@ -38,6 +38,17 @@ function parseNamespaceValue(value: string): string | null {
   return value.slice(ACTION_SCOPE_NAMESPACE_PREFIX.length)
 }
 
+function getResourceGroupLabel(resource: string): string {
+  if (resource === "agent:preset:*") {
+    return "Agent presets (all)"
+  }
+  if (resource.startsWith("agent:preset:")) {
+    const presetSlug = resource.slice("agent:preset:".length)
+    return `Agent preset: ${presetSlug}`
+  }
+  return resource
+}
+
 export interface ScopeCategoryRowProps {
   categoryKey: string
   category: { label: string; description: string; resources: string[] }
@@ -265,7 +276,7 @@ export const ScopeCategoryRow = memo(function ScopeCategoryRow({
             ([resource, resourceScopes]) => (
               <div key={resource} className="space-y-1">
                 <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
-                  {resource}
+                  {getResourceGroupLabel(resource)}
                 </div>
                 <div className="flex flex-wrap gap-x-3 gap-y-1">
                   {resourceScopes.map((scope) => (

--- a/frontend/src/components/workspaces/workspace-members-table.tsx
+++ b/frontend/src/components/workspaces/workspace-members-table.tsx
@@ -2,15 +2,10 @@
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import { useQueryClient } from "@tanstack/react-query"
-import { BotIcon } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import type { WorkspaceMember, WorkspaceRead } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
-import {
-  DataTable,
-  DataTableColumnHeader,
-  type DataTableToolbarProps,
-} from "@/components/data-table"
+import { DataTable, DataTableColumnHeader } from "@/components/data-table"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,6 +17,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -86,6 +82,7 @@ export function WorkspaceMembersTable({
   const { members, membersLoading, membersError } = useWorkspaceMembers(
     workspace.id
   )
+  const memberRows = members ?? []
   const {
     userAssignments,
     isLoading: userAssignmentsIsLoading,
@@ -108,7 +105,7 @@ export function WorkspaceMembersTable({
           })
         }
         const selectedIsAgentPreset = isAgentPresetMember(selectedUser)
-        if (!roleId) {
+        if (!selectedIsAgentPreset && !roleId) {
           return toast({
             title: "No role selected",
             description: "Please select a role before continuing.",
@@ -124,7 +121,9 @@ export function WorkspaceMembersTable({
           await updateAgentPreset({
             presetId: selectedUser.user_id,
             assigned_role_id:
-              roleId === DEFAULT_PRESET_ROLE_VALUE ? null : roleId,
+              roleId === DEFAULT_PRESET_ROLE_VALUE || roleId === ""
+                ? null
+                : roleId,
           })
         } else {
           // Find the existing RBAC assignment for this user in this workspace
@@ -184,6 +183,9 @@ export function WorkspaceMembersTable({
       if (canUpdateAnyAgentPreset === true) {
         return true
       }
+      if (!isAgentPresetMember(member)) {
+        return false
+      }
       const presetSlug = getAgentPresetSlug(member)
       if (!presetSlug) {
         return false
@@ -203,10 +205,29 @@ export function WorkspaceMembersTable({
         }}
       >
         <DataTable
-          data={members}
+          data={memberRows}
           isLoading={membersLoading}
           error={membersError}
           columns={[
+            {
+              id: "type",
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  className="text-xs"
+                  column={column}
+                  title="Type"
+                />
+              ),
+              accessorFn: (row) =>
+                isAgentPresetMember(row) ? "Agent" : "Member",
+              cell: ({ row }) => (
+                <Badge variant="outline" className="text-[10px]">
+                  {isAgentPresetMember(row.original) ? "Agent" : "Member"}
+                </Badge>
+              ),
+              enableSorting: true,
+              enableHiding: false,
+            },
             {
               accessorKey: "email",
               header: ({ column }) => (
@@ -219,7 +240,7 @@ export function WorkspaceMembersTable({
               cell: ({ row }) => (
                 <div className="text-xs">
                   {isAgentPresetMember(row.original)
-                    ? "-"
+                    ? "Preset account"
                     : row.getValue<WorkspaceMember["email"]>("email")}
                 </div>
               ),
@@ -244,10 +265,7 @@ export function WorkspaceMembersTable({
                       .filter(Boolean)
                       .join(" ")
                 return (
-                  <div className="flex items-center gap-2 text-xs">
-                    {isAgentPreset && (
-                      <BotIcon className="size-3.5 text-muted-foreground" />
-                    )}
+                  <div className="text-xs">
                     <span>{name || "-"}</span>
                   </div>
                 )
@@ -266,7 +284,9 @@ export function WorkspaceMembersTable({
               ),
               cell: ({ row }) => (
                 <div className="text-xs capitalize">
-                  {row.getValue<string>("role_name")}
+                  {row.getValue<string>("role_name") === "Default preset role"
+                    ? ""
+                    : row.getValue<string>("role_name")}
                 </div>
               ),
               enableSorting: true,
@@ -331,7 +351,6 @@ export function WorkspaceMembersTable({
               },
             },
           ]}
-          toolbarProps={defaultToolbarProps}
         />
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -407,19 +426,7 @@ function ChangeUserRoleDialog({
     () => roles.filter((r) => !r.slug || r.slug.startsWith("workspace-")),
     [roles]
   )
-  const roleOptions = useMemo(
-    () =>
-      isAgentPresetMember
-        ? [
-            {
-              id: DEFAULT_PRESET_ROLE_VALUE,
-              name: "Default preset role",
-            },
-            ...workspaceRoles,
-          ]
-        : workspaceRoles,
-    [isAgentPresetMember, workspaceRoles]
-  )
+  const roleOptions = useMemo(() => [...workspaceRoles], [workspaceRoles])
   const [selectedRoleId, setSelectedRoleId] = useState<string>("")
 
   useEffect(() => {
@@ -427,15 +434,22 @@ function ChangeUserRoleDialog({
       setSelectedRoleId("")
       return
     }
+    if (!isAgentPresetMember) {
+      const match = workspaceRoles.find(
+        (r) => r.name === selectedUser?.role_name
+      )
+      setSelectedRoleId(match?.id ?? "")
+      return
+    }
     if (
-      isAgentPresetMember &&
-      selectedUser?.role_name === "Default preset role"
+      selectedUser?.role_name === "Default preset role" ||
+      !selectedUser?.role_name
     ) {
       setSelectedRoleId(DEFAULT_PRESET_ROLE_VALUE)
       return
     }
     const match = workspaceRoles.find((r) => r.name === selectedUser?.role_name)
-    setSelectedRoleId(match?.id ?? "")
+    setSelectedRoleId(match?.id ?? DEFAULT_PRESET_ROLE_VALUE)
   }, [isAgentPresetMember, open, selectedUser, workspaceRoles])
 
   return (
@@ -473,7 +487,11 @@ function ChangeUserRoleDialog({
           Cancel
         </Button>
         <Button
-          disabled={!selectedRoleId || rolesIsLoading || isSubmitting}
+          disabled={
+            (!isAgentPresetMember && !selectedRoleId) ||
+            rolesIsLoading ||
+            isSubmitting
+          }
           onClick={() => onConfirm(selectedRoleId)}
         >
           Change role
@@ -481,11 +499,4 @@ function ChangeUserRoleDialog({
       </DialogFooter>
     </DialogContent>
   )
-}
-
-const defaultToolbarProps: DataTableToolbarProps<WorkspaceMember> = {
-  filterProps: {
-    placeholder: "Filter members by email...",
-    column: "email",
-  },
 }

--- a/tests/unit/test_agent_session_default_presets.py
+++ b/tests/unit/test_agent_session_default_presets.py
@@ -1,0 +1,68 @@
+"""Tests for default system preset selection in AgentSessionService."""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tracecat.agent.preset.service import SYSTEM_PRESET_SLUG_WORKSPACE_COPILOT
+from tracecat.agent.session.schemas import AgentSessionCreate
+from tracecat.agent.session.service import AgentSessionService
+from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.auth.types import Role
+from tracecat.chat.tools import get_default_tools
+
+
+@pytest.fixture
+def role() -> Role:
+    return Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+
+@pytest.mark.anyio
+async def test_create_session_uses_default_system_preset_for_copilot(
+    role: Role,
+) -> None:
+    session = AsyncMock()
+    preset_id = uuid.uuid4()
+    session.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: preset_id)
+
+    service = AgentSessionService(session, role)
+    created = await service.create_session(
+        AgentSessionCreate(
+            title="Copilot chat",
+            entity_type=AgentSessionEntity.COPILOT,
+            entity_id=uuid.uuid4(),
+        )
+    )
+
+    assert created.agent_preset_id == preset_id
+    assert created.tools is None
+    stmt = session.execute.await_args.args[0]
+    assert SYSTEM_PRESET_SLUG_WORKSPACE_COPILOT in str(stmt)
+
+
+@pytest.mark.anyio
+async def test_create_session_falls_back_to_legacy_tools_when_default_missing(
+    role: Role,
+) -> None:
+    session = AsyncMock()
+    session.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: None)
+
+    service = AgentSessionService(session, role)
+    created = await service.create_session(
+        AgentSessionCreate(
+            title="Case chat",
+            entity_type=AgentSessionEntity.CASE,
+            entity_id=uuid.uuid4(),
+        )
+    )
+
+    assert created.agent_preset_id is None
+    assert created.tools == get_default_tools(AgentSessionEntity.CASE.value)

--- a/tests/unit/test_agent_session_default_presets.py
+++ b/tests/unit/test_agent_session_default_presets.py
@@ -45,7 +45,7 @@ async def test_create_session_uses_default_system_preset_for_copilot(
     assert created.agent_preset_id == preset_id
     assert created.tools is None
     stmt = session.execute.await_args.args[0]
-    assert SYSTEM_PRESET_SLUG_WORKSPACE_COPILOT in str(stmt)
+    assert SYSTEM_PRESET_SLUG_WORKSPACE_COPILOT in stmt.compile().params.values()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -181,6 +181,11 @@ class TestHasScope:
         assert has_scope(scopes, "case:read") is True
         assert has_scope(scopes, "case:create") is False
 
+    def test_has_scope_with_wildcard_required(self):
+        scopes = frozenset({"agent:preset:incident-bot:update"})
+        assert has_scope(scopes, "agent:preset:*:update") is True
+        assert has_scope(scopes, "agent:preset:*:delete") is False
+
     def test_has_scope_global_wildcard(self):
         scopes = frozenset({"*"})
         assert has_scope(scopes, "workflow:read") is True
@@ -308,6 +313,15 @@ class TestRequireScopeDecorator:
         _set_role_with_scopes(frozenset({"workflow:*"}))
 
         @require_scope("workflow:read")
+        def protected_func():
+            return "success"
+
+        assert protected_func() == "success"
+
+    def test_require_scope_passes_with_wildcard_required(self):
+        _set_role_with_scopes(frozenset({"agent:preset:incident-bot:update"}))
+
+        @require_scope("agent:preset:*:update")
         def protected_func():
             return "success"
 

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -186,6 +186,14 @@ class TestHasScope:
         assert has_scope(scopes, "agent:preset:*:update") is True
         assert has_scope(scopes, "agent:preset:*:delete") is False
 
+    def test_has_scope_with_wildcard_required_via_implication(self):
+        scopes = frozenset({"agent:preset:incident-bot:update"})
+        assert has_scope(scopes, "agent:preset:*:read") is True
+
+    def test_has_scope_with_wildcard_required_via_implication_is_resource_scoped(self):
+        scopes = frozenset({"workflow:update"})
+        assert has_scope(scopes, "agent:preset:*:read") is False
+
     def test_has_scope_global_wildcard(self):
         scopes = frozenset({"*"})
         assert has_scope(scopes, "workflow:read") is True

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -76,12 +76,12 @@ async def test_registry_repository_scope_guards(
 @pytest.mark.parametrize(
     ("endpoint", "required_scope"),
     [
-        (agent_preset_router.list_agent_presets, "agent:read"),
-        (agent_preset_router.get_agent_preset, "agent:read"),
-        (agent_preset_router.get_agent_preset_by_slug, "agent:read"),
+        (agent_preset_router.list_agent_presets, "agent:preset:*:read"),
+        (agent_preset_router.get_agent_preset, "agent:preset:*:read"),
+        (agent_preset_router.get_agent_preset_by_slug, "agent:preset:*:read"),
         (agent_preset_router.create_agent_preset, "agent:create"),
-        (agent_preset_router.update_agent_preset, "agent:update"),
-        (agent_preset_router.delete_agent_preset, "agent:delete"),
+        (agent_preset_router.update_agent_preset, "agent:preset:*:update"),
+        (agent_preset_router.delete_agent_preset, "agent:preset:*:delete"),
     ],
 )
 async def test_agent_preset_scope_guards(

--- a/tracecat/agent/preset/router.py
+++ b/tracecat/agent/preset/router.py
@@ -29,7 +29,7 @@ WorkspaceEditorRole = Annotated[
 
 
 @router.get("", response_model=list[AgentPresetReadMinimal])
-@require_scope("agent:read")
+@require_scope("agent:preset:*:read")
 async def list_agent_presets(
     *,
     role: WorkspaceEditorRole,
@@ -66,7 +66,7 @@ async def create_agent_preset(
 
 
 @router.get("/{preset_id}", response_model=AgentPresetRead)
-@require_scope("agent:read")
+@require_scope("agent:preset:*:read")
 async def get_agent_preset(
     *,
     preset_id: uuid.UUID,
@@ -84,7 +84,7 @@ async def get_agent_preset(
 
 
 @router.get("/by-slug/{slug}", response_model=AgentPresetRead)
-@require_scope("agent:read")
+@require_scope("agent:preset:*:read")
 async def get_agent_preset_by_slug(
     *,
     slug: str,
@@ -102,7 +102,7 @@ async def get_agent_preset_by_slug(
 
 
 @router.patch("/{preset_id}", response_model=AgentPresetRead)
-@require_scope("agent:update")
+@require_scope("agent:preset:*:update")
 async def update_agent_preset(
     *,
     preset_id: uuid.UUID,
@@ -112,7 +112,7 @@ async def update_agent_preset(
 ) -> AgentPresetRead:
     """Update an existing agent preset."""
     service = AgentPresetService(session, role=role)
-    if not (preset := await service.get_preset(preset_id)):
+    if not (preset := await service.get_preset(preset_id, required_action="update")):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Agent preset {preset_id} not found",
@@ -122,7 +122,7 @@ async def update_agent_preset(
 
 
 @router.delete("/{preset_id}", status_code=status.HTTP_204_NO_CONTENT)
-@require_scope("agent:delete")
+@require_scope("agent:preset:*:delete")
 async def delete_agent_preset(
     *,
     preset_id: uuid.UUID,
@@ -131,7 +131,7 @@ async def delete_agent_preset(
 ) -> None:
     """Delete an agent preset."""
     service = AgentPresetService(session, role=role)
-    if not (preset := await service.get_preset(preset_id)):
+    if not (preset := await service.get_preset(preset_id, required_action="delete")):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Agent preset {preset_id} not found",

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -27,6 +27,7 @@ class AgentPresetBase(Schema):
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int = Field(default=3, ge=0)
     enable_internet_access: bool = Field(default=False)
+    assigned_role_id: uuid.UUID | None = Field(default=None)
 
 
 class AgentPresetCreate(AgentPresetBase):
@@ -53,6 +54,7 @@ class AgentPresetUpdate(BaseModel):
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int | None = Field(default=None, ge=0)
     enable_internet_access: bool | None = Field(default=None)
+    assigned_role_id: uuid.UUID | None = Field(default=None)
 
 
 class AgentPresetReadMinimal(Schema):
@@ -63,6 +65,7 @@ class AgentPresetReadMinimal(Schema):
     name: str
     slug: str
     description: str | None
+    is_system: bool = False
     created_at: datetime
     updated_at: datetime
 
@@ -74,6 +77,7 @@ class AgentPresetRead(AgentPresetBase):
     workspace_id: WorkspaceID
     name: str
     slug: str
+    is_system: bool = False
     created_at: datetime
     updated_at: datetime
 

--- a/tracecat/agent/preset/scopes.py
+++ b/tracecat/agent/preset/scopes.py
@@ -1,0 +1,62 @@
+"""Scope helpers for agent presets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.authz.enums import ScopeSource
+from tracecat.db.models import Scope
+
+type PresetScopeAction = Literal["read", "execute", "update", "delete"]
+
+PRESET_SCOPE_ACTIONS: tuple[PresetScopeAction, ...] = (
+    "read",
+    "execute",
+    "update",
+    "delete",
+)
+
+
+def preset_scope_name(slug: str, action: PresetScopeAction) -> str:
+    """Build canonical scope name for an agent preset."""
+    return f"agent:preset:{slug}:{action}"
+
+
+def preset_scope_names(slug: str) -> dict[PresetScopeAction, str]:
+    """Return all canonical scope names for an agent preset."""
+    return {action: preset_scope_name(slug, action) for action in PRESET_SCOPE_ACTIONS}
+
+
+def wildcard_preset_scope_name(action: PresetScopeAction) -> str:
+    """Build wildcard preset scope name."""
+    return f"agent:preset:*:{action}"
+
+
+async def ensure_preset_scopes(session: AsyncSession, slugs: Iterable[str]) -> None:
+    """Ensure platform preset scopes exist for all provided slugs."""
+    values = []
+    for slug in set(slugs):
+        for action, scope_name in preset_scope_names(slug).items():
+            values.append(
+                {
+                    "name": scope_name,
+                    "resource": "agent:preset",
+                    "action": action,
+                    "description": f"Allow {action} access to agent preset '{slug}'",
+                    "source": ScopeSource.PLATFORM,
+                    "source_ref": f"agent_preset:{slug}",
+                    "organization_id": None,
+                }
+            )
+    if not values:
+        return
+
+    stmt = pg_insert(Scope).values(values)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["name"], index_where=Scope.organization_id.is_(None)
+    )
+    await session.execute(stmt)

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import cast
 
 from slugify import slugify
 from sqlalchemy import select
@@ -14,7 +14,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.agent.preset.schemas import AgentPresetCreate, AgentPresetUpdate
-from tracecat.agent.preset.scopes import ensure_preset_scopes, preset_scope_name
+from tracecat.agent.preset.scopes import (
+    PresetScopeAction,
+    ensure_preset_scopes,
+    preset_scope_name,
+)
 from tracecat.agent.types import AgentConfig, MCPServerConfig, OutputType
 from tracecat.audit.logger import audit_log
 from tracecat.authz.controls import has_scope, require_scope
@@ -120,8 +124,6 @@ SYSTEM_PRESET_DEFINITIONS: tuple[SystemPresetDefinition, ...] = (
         ),
     ),
 )
-
-type PresetScopeAction = Literal["read", "execute", "update", "delete"]
 
 
 async def seed_system_presets_for_workspace(

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -156,6 +156,7 @@ class AgentConfig:
     # MCP
     model_settings: dict[str, Any] | None = None
     mcp_servers: list[MCPServerConfig] | None = None
+    tool_execution_scopes: list[str] | None = None
     retries: int = TRACECAT__AGENT_MAX_RETRIES
     deps_type: type[Any] | None = None
     custom_tools: CustomToolList | None = None

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -22,6 +22,7 @@ from tracecat.agent.preset.internal_router import (
     router as internal_agent_preset_router,
 )
 from tracecat.agent.preset.router import router as agent_preset_router
+from tracecat.agent.preset.service import seed_system_presets_for_all_workspaces
 from tracecat.agent.router import router as agent_router
 from tracecat.agent.session.router import router as agent_session_router
 from tracecat.api.common import (
@@ -250,6 +251,9 @@ async def setup_rbac_defaults(session: AsyncSession):
     """Seed system scopes and roles for RBAC."""
     try:
         result = await seed_all_system_data(session)
+        workspaces_seeded = await seed_system_presets_for_all_workspaces(session)
+        await session.commit()
+        result["system_preset_workspaces_processed"] = workspaces_seeded
         logger.info("RBAC defaults seeded", **result)
     except Exception as e:
         logger.warning("Failed to seed RBAC defaults", error=str(e))

--- a/tracecat/authz/controls.py
+++ b/tracecat/authz/controls.py
@@ -115,9 +115,17 @@ def has_scope(user_scopes: frozenset[str], required_scope: str) -> bool:
         required_scope: The scope required for the operation
 
     Returns:
-        True if any granted scope matches the required scope
+        True if any granted scope matches the required scope.
+
+        If `required_scope` contains a wildcard, a specific granted scope that
+        matches that wildcard also satisfies the check.
     """
-    return any(scope_matches(granted, required_scope) for granted in user_scopes)
+    if "*" not in required_scope:
+        return any(scope_matches(granted, required_scope) for granted in user_scopes)
+    return any(
+        scope_matches(granted, required_scope) or scope_matches(required_scope, granted)
+        for granted in user_scopes
+    )
 
 
 def has_all_scopes(user_scopes: frozenset[str], required_scopes: set[str]) -> bool:

--- a/tracecat/authz/controls.py
+++ b/tracecat/authz/controls.py
@@ -122,10 +122,18 @@ def has_scope(user_scopes: frozenset[str], required_scope: str) -> bool:
     """
     if "*" not in required_scope:
         return any(scope_matches(granted, required_scope) for granted in user_scopes)
-    return any(
-        scope_matches(granted, required_scope) or scope_matches(required_scope, granted)
-        for granted in user_scopes
-    )
+
+    for granted in user_scopes:
+        if scope_matches(granted, required_scope) or scope_matches(
+            required_scope, granted
+        ):
+            return True
+        for implied in _implied_scopes(granted):
+            if scope_matches(implied, required_scope) or scope_matches(
+                required_scope, implied
+            ):
+                return True
+    return False
 
 
 def has_all_scopes(user_scopes: frozenset[str], required_scopes: set[str]) -> bool:

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -40,6 +40,7 @@ VIEWER_SCOPES: frozenset[str] = frozenset(
         "variable:read",
         "workspace:read",
         "workspace:member:read",
+        "agent:preset:*:read",
     }
 )
 
@@ -65,6 +66,7 @@ EDITOR_SCOPES: frozenset[str] = VIEWER_SCOPES | frozenset(
         "variable:create",
         "variable:update",
         "action:*:execute",
+        "agent:preset:*:execute",
     }
 )
 
@@ -89,6 +91,8 @@ ADMIN_SCOPES: frozenset[str] = EDITOR_SCOPES | frozenset(
         # Workspace RBAC (delegated admin)
         "workspace:rbac:read",
         "workspace:rbac:manage",
+        "agent:preset:*:update",
+        "agent:preset:*:delete",
         # Full action execution
         "action:*:execute",
     }
@@ -182,6 +186,10 @@ ORG_OWNER_SCOPES: frozenset[str] = frozenset(
         "agent:update",
         "agent:delete",
         "agent:execute",
+        "agent:preset:*:read",
+        "agent:preset:*:execute",
+        "agent:preset:*:update",
+        "agent:preset:*:delete",
         "secret:read",
         "secret:create",
         "secret:update",
@@ -273,6 +281,10 @@ ORG_ADMIN_SCOPES: frozenset[str] = frozenset(
         "agent:update",
         "agent:delete",
         "agent:execute",
+        "agent:preset:*:read",
+        "agent:preset:*:execute",
+        "agent:preset:*:update",
+        "agent:preset:*:delete",
         "secret:read",
         "secret:create",
         "secret:update",
@@ -361,6 +373,10 @@ WORKSPACE_OPERATIONAL_SCOPES: frozenset[str] = frozenset(
         "workspace:create",
         "workspace:delete",
         "workspace:member:read",
+        "agent:preset:*:read",
+        "agent:preset:*:execute",
+        "agent:preset:*:update",
+        "agent:preset:*:delete",
         "action:*:execute",
         "org:secret:read",
     }

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -82,7 +82,7 @@ class MembershipService(BaseService):
             .where(Membership.workspace_id == workspace_id)
             .order_by(asc(User.email))
         )
-        user_rows = (await self.session.execute(user_statement)).all()
+        user_rows = (await self.session.execute(user_statement)).tuples().all()
         members = [
             WorkspaceMember(
                 user_id=user.id,
@@ -107,7 +107,7 @@ class MembershipService(BaseService):
             .where(AgentPreset.workspace_id == workspace_id)
             .order_by(asc(AgentPreset.name))
         )
-        preset_rows = (await self.session.execute(preset_statement)).all()
+        preset_rows = (await self.session.execute(preset_statement)).tuples().all()
         members.extend(
             WorkspaceMember(
                 user_id=preset_id,

--- a/tracecat/cases/prompts.py
+++ b/tracecat/cases/prompts.py
@@ -5,6 +5,16 @@ from pydantic import BaseModel
 
 from tracecat.db.models import Case
 
+CASE_COPILOT_BASE_INSTRUCTIONS = textwrap.dedent("""
+    You are a helpful case management assistant that helps analysts in security and IT operations resolve cases / tickets efficiently and accurately.
+
+    IMPORTANT: Do not execute any actions or tools that are not explicitly requested by the user. You are an assistant, not a replacement for the analyst.
+    IMPORTANT: If you have suggestions or recommendations based on the case, you must ask the user for explicit permission before proceeding.
+    IMPORTANT: Assist with defensive security tasks only. Refuse to create, modify, or improve code that may be used maliciously. Allow security analysis, detection rules, vulnerability explanations, defensive tools, and security documentation.
+    IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
+    IMPORTANT: When using tools or APIs that require the case ID, ALWAYS supply the canonical UUID found in the <Case> "id" field. The "short_id" field is for human-readable display only and must NOT be used as an identifier in tool calls.
+""").strip()
+
 
 class CaseCopilotPrompts(BaseModel):
     """Prompts for the case copilot chat assistant."""
@@ -16,20 +26,17 @@ class CaseCopilotPrompts(BaseModel):
         """Build the instructions for the case copilot."""
         updated_at = self.case.updated_at.isoformat()
         case_data = yaml.dump(self.case.to_dict(), indent=2)
-        return textwrap.dedent(f"""
-            You are a helpful case management assistant that helps analysts in security and IT operations resolve cases / tickets efficiently and accurately. You will be given a case with a summary, description, and payload inside the <Case> tag.
-
-            IMPORTANT: Do not execute any actions or tools that are not explicitly requested by the user. You are an assistant, not a replacement for the analyst.
-            IMPORTANT: If you have suggestions or recommendations based on the case, you must ask the user for explicit permission before proceeding.
-            IMPORTANT: Assist with defensive security tasks only. Refuse to create, modify, or improve code that may be used maliciously. Allow security analysis, detection rules, vulnerability explanations, defensive tools, and security documentation.
-            IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
-            IMPORTANT: When using tools or APIs that require the case ID, ALWAYS supply the canonical UUID found in the <Case> "id" field. The "short_id" field is for human-readable display only and must NOT be used as an identifier in tool calls.
+        return textwrap.dedent(
+            f"""
+            {CASE_COPILOT_BASE_INSTRUCTIONS}
+            You will be given a case with a summary, description, and payload inside the <Case> tag.
 
             <CaseId description="This is the ID to use in case management CRUD APIs">{self.case.id}</CaseId>
             <Case description="This is the case you are working on with the summary, description, and payload. It was last updated at {updated_at}.">
             {case_data}
             </Case>
-        """)
+            """
+        ).strip()
 
     @property
     def user_prompt(self) -> str:

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2568,6 +2568,20 @@ class AgentPreset(WorkspaceModel):
         nullable=False,
         doc="Whether to enable direct internet access in the agent sandbox",
     )
+    is_system: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=text("false"),
+        nullable=False,
+        doc="Whether this is a platform-seeded system preset",
+    )
+    assigned_role_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("role.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        doc="Optional RBAC role used as the tool execution upper-bound",
+    )
 
     workspace: Mapped[Workspace] = relationship(back_populates="agent_presets")
     chats: Mapped[list[Chat]] = relationship(

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -357,7 +357,7 @@ async def list_org_members(
         .where(Workspace.organization_id == role.organization_id)
         .order_by(Workspace.name.asc(), AgentPreset.name.asc())
     )
-    agent_rows = (await session.execute(agent_stmt)).all()
+    agent_rows = (await session.execute(agent_stmt)).tuples().all()
     for (
         preset_id,
         preset_name,

--- a/tracecat/workspaces/prompts.py
+++ b/tracecat/workspaces/prompts.py
@@ -4,6 +4,25 @@ import textwrap
 
 from pydantic import BaseModel
 
+WORKSPACE_COPILOT_BASE_INSTRUCTIONS = textwrap.dedent("""
+    You are a helpful workspace assistant that helps users with security and IT automation operations in Tracecat. You can assist with workflows, cases, agents, lookup tables, and general workspace operations.
+
+    <IMPORTANT>
+    - Do not execute any actions or tools that are not explicitly requested by the user. You are an assistant, not a replacement for the user.
+    - If you have suggestions or recommendations based on the workspace, you must ask the user for explicit permission before proceeding.
+    - Assist with defensive security tasks only. Refuse to create, modify, or improve code that may be used maliciously. Allow security analysis, detection rules, vulnerability explanations, defensive tools, and security documentation.
+    - You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
+    </IMPORTANT>
+
+    You have access to various tools to help users manage their workspace:
+    - Case management: List, view, update, and manage security cases
+    - Workflow operations: Query and understand automation workflows
+    - Lookup tables: Access and query data tables
+    - General workspace queries and operations
+
+    Always be helpful, accurate, concise, and ask for clarification when needed.
+""").strip()
+
 
 class WorkspaceCopilotPrompts(BaseModel):
     """Prompts for the workspace copilot chat assistant."""
@@ -11,24 +30,7 @@ class WorkspaceCopilotPrompts(BaseModel):
     @property
     def instructions(self) -> str:
         """Build the instructions for the workspace copilot."""
-        return textwrap.dedent("""
-            You are a helpful workspace assistant that helps users with security and IT automation operations in Tracecat. You can assist with workflows, cases, agents, lookup tables, and general workspace operations.
-
-            <IMPORTANT>
-            - Do not execute any actions or tools that are not explicitly requested by the user. You are an assistant, not a replacement for the user.
-            - If you have suggestions or recommendations based on the workspace, you must ask the user for explicit permission before proceeding.
-            - Assist with defensive security tasks only. Refuse to create, modify, or improve code that may be used maliciously. Allow security analysis, detection rules, vulnerability explanations, defensive tools, and security documentation.
-            - You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
-            </IMPORTANT>
-
-            You have access to various tools to help users manage their workspace:
-            - Case management: List, view, update, and manage security cases
-            - Workflow operations: Query and understand automation workflows
-            - Lookup tables: Access and query data tables
-            - General workspace queries and operations
-
-            Always be helpful, accurate, concise, and ask for clarification when needed.
-        """)
+        return WORKSPACE_COPILOT_BASE_INSTRUCTIONS
 
     @property
     def user_prompt(self) -> str:

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -10,6 +10,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import load_only, noload, selectinload
 
+from tracecat.agent.preset.service import seed_system_presets_for_workspace
 from tracecat.audit.logger import audit_log
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
@@ -139,6 +140,10 @@ class WorkspaceService(BaseOrgService):
             session=self.session, role=bootstrap_role
         )
         await case_fields_service.initialize_workspace_schema()
+        await seed_system_presets_for_workspace(
+            session=self.session,
+            workspace_id=workspace.id,
+        )
 
         await self.session.commit()
         await self.session.refresh(workspace)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds RBAC to agent presets with preset-level scopes and runtime tool filtering, and seeds default system presets in every workspace. Agents now appear in org/workspace member lists.

- **New Features**
  - Added agent:preset:* scopes (read, execute, update, delete), per-preset scope seeding, and wildcard-aware scope checks.
  - Presets can have an assigned role; tools are filtered at runtime to that role’s execute scopes.
  - Seeded system presets (Workspace Copilot, Case Copilot) per workspace and use them as defaults; presets flagged via is_system.
  - Switched API guards to agent:preset:*; assigned_role_id supported on create/update/read. UI lists agent presets as members and groups preset scopes clearly.

- **Migration**
  - Run Alembic migration to add is_system and assigned_role_id on agent_preset.
  - Seed system and per-preset scopes; seed system presets for all existing workspaces.

<sup>Written for commit c3a3d8139caf6fdbcce339d05c44e7b12ee8c4b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

