### PR TITLE
fix(api): Allow platform superusers SAML org access

### DIFF
--- a/docs/quickstart/admin.mdx
+++ b/docs/quickstart/admin.mdx
@@ -31,7 +31,7 @@ Tracecat has a two-level permission system:
 
 ## Organization owner
 
-The first user who logs into Tracecat is automatically assigned both `superadmin` and an organization admin role.
+The first account created with the `TRACECAT__AUTH_SUPERADMIN_EMAIL` email is automatically assigned both `superadmin` and an organization admin role.
 **Important:** Only the email address you specified during the initial setup (via `env.sh`) can become the first superadmin.
 Currently, the `superadmin` role does not have any additional permissions beyond the organization admin role.
 

--- a/docs/self-hosting/authentication/overview.mdx
+++ b/docs/self-hosting/authentication/overview.mdx
@@ -6,7 +6,8 @@ icon: lock
 
 ## Owner
 
-The owner role is assigned to the first user who logs into Tracecat. This user has admin rights to every workspace in the Tracecat instance.
+The owner (platform superadmin) role is assigned to the first account created with the `TRACECAT__AUTH_SUPERADMIN_EMAIL` email address.
+This account has admin rights to every workspace in the Tracecat instance.
 
 ## Domain whitelist
 

--- a/docs/self-hosting/authentication/saml-sso.mdx
+++ b/docs/self-hosting/authentication/saml-sso.mdx
@@ -20,6 +20,22 @@ TRACECAT__AUTH_TYPES=saml
 SAML_IDP_METADATA_URL=https://<your-idp-metadata-url>
 ```
 
+## Access policy
+
+After SAML authentication succeeds, Tracecat allows organization access when at least one of the following is true:
+
+- The user already has membership in the organization.
+- The user has a pending invitation for the organization.
+- The user is the first-user superadmin bootstrap account in the default organization.
+- The user is a platform superadmin (owner).
+
+Tracecat only auto-provisions SAML user accounts for:
+
+- Pending organization invitations.
+- First-user superadmin bootstrap (default organization only).
+
+If this is a new deployment, make sure `TRACECAT__AUTH_SUPERADMIN_EMAIL` exactly matches the email claim sent by your IdP for the owner account.
+
 ## Instructions
 
 <Note>

--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -142,8 +142,8 @@ To access the Tracecat GUI, visit `http://localhost:${PUBLIC_APP_PORT}`.
   docs](/self-hosting/authentication/overview).
 </Note>
 
-For each new Tracecat deployment, the super admin role is assigned to the first user who logs into the Tracecat instance.
-This user owns the organization and has admin rights to every workspace in the Tracecat deployment.
+For each new Tracecat deployment, the super admin role is assigned to the first account created with `TRACECAT__AUTH_SUPERADMIN_EMAIL`.
+This account owns the organization and has admin rights to every workspace in the Tracecat deployment.
 
 **Important:** Only the email address you specified during the `env.sh` setup can become super admin.
 You must sign up using exactly that email address to gain super admin privileges.

--- a/tests/unit/test_saml_client_config.py
+++ b/tests/unit/test_saml_client_config.py
@@ -481,23 +481,33 @@ async def test_is_superadmin_saml_bootstrap_allowed_for_org_false_for_non_defaul
         "has_existing_membership",
         "has_pending_invitation",
         "is_first_superadmin_bootstrap",
+        "is_platform_superuser",
         "expected",
     ),
     [
-        (False, False, False, False),
-        (True, False, False, True),
-        (False, True, False, True),
-        (False, False, True, True),
-        (True, True, False, True),
-        (True, False, True, True),
-        (False, True, True, True),
-        (True, True, True, True),
+        (False, False, False, False, False),
+        (True, False, False, False, True),
+        (False, True, False, False, True),
+        (False, False, True, False, True),
+        (False, False, False, True, True),
+        (True, True, False, False, True),
+        (True, False, True, False, True),
+        (False, True, True, False, True),
+        (True, True, True, False, True),
+        (True, False, False, True, True),
+        (False, True, False, True, True),
+        (False, False, True, True, True),
+        (True, True, False, True, True),
+        (True, False, True, True, True),
+        (False, True, True, True, True),
+        (True, True, True, True, True),
     ],
 )
 def test_should_allow_saml_org_access_matrix(
     has_existing_membership: bool,
     has_pending_invitation: bool,
     is_first_superadmin_bootstrap: bool,
+    is_platform_superuser: bool,
     expected: bool,
 ) -> None:
     pending_invitation = (
@@ -511,6 +521,7 @@ def test_should_allow_saml_org_access_matrix(
             has_existing_membership=has_existing_membership,
             pending_invitation=pending_invitation,
             is_first_superadmin_bootstrap=is_first_superadmin_bootstrap,
+            is_platform_superuser=is_platform_superuser,
         )
         is expected
     )

--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -498,12 +498,14 @@ def should_allow_saml_org_access(
     has_existing_membership: bool,
     pending_invitation: OrganizationInvitation | None,
     is_first_superadmin_bootstrap: bool,
+    is_platform_superuser: bool,
 ) -> bool:
     """Allow org access after SAML auth when at least one trusted path exists."""
     return (
         has_existing_membership
         or pending_invitation is not None
         or is_first_superadmin_bootstrap
+        or is_platform_superuser
     )
 
 
@@ -915,6 +917,7 @@ async def sso_acs(
         has_existing_membership=has_existing_membership,
         pending_invitation=pending_invitation,
         is_first_superadmin_bootstrap=is_first_superadmin_bootstrap,
+        is_platform_superuser=bool(user.is_superuser),
     )
     if not can_access_org:
         logger.warning(


### PR DESCRIPTION
Summary
- let platform superusers bypass the SAML org membership check so they can authenticate without a pending invitation
- update the org access unit test matrix to cover the new `is_platform_superuser` flag

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow platform superusers (owner) to access SAML organizations without prior membership or a pending invite, unblocking owner login on new deployments.

- **Bug Fixes**
  - Add platform superuser bypass to the SAML org access check.
  - Extend the unit test matrix to cover the is_platform_superuser flag.

- **Docs**
  - Clarify owner/superadmin bootstrap via TRACECAT__AUTH_SUPERADMIN_EMAIL.
  - Document SAML access policy and auto-provision rules; update Docker Compose notes.

<sup>Written for commit 767662d334ca2f809cea30da23226af28b7962d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

