### PR TITLE
feat(api+ui+ee): Link rows to case

### DIFF
--- a/alembic/versions/1224a945b9f7_add_case_table_row_links.py
+++ b/alembic/versions/1224a945b9f7_add_case_table_row_links.py
@@ -1,0 +1,84 @@
+"""add case table row links
+
+Revision ID: 1224a945b9f7
+Revises: c9e4f54f0a2b
+Create Date: 2026-02-27 23:08:20.288499
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1224a945b9f7"
+down_revision: str | None = "c9e4f54f0a2b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "case_table_row",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("case_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("table_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("row_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["case_id"],
+            ["case.id"],
+            name=op.f("fk_case_table_row_case_id_case"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["table_id"],
+            ["tables.id"],
+            name=op.f("fk_case_table_row_table_id_tables"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_case_table_row_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_case_table_row")),
+        sa.UniqueConstraint(
+            "case_id", "table_id", "row_id", name="uq_case_table_row_link"
+        ),
+    )
+    op.create_index(
+        "ix_case_table_row_case_id", "case_table_row", ["case_id"], unique=False
+    )
+    op.create_index(op.f("ix_case_table_row_id"), "case_table_row", ["id"], unique=True)
+    op.create_index(
+        "ix_case_table_row_row_id", "case_table_row", ["row_id"], unique=False
+    )
+    op.create_index(
+        "ix_case_table_row_table_id", "case_table_row", ["table_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_case_table_row_table_id", table_name="case_table_row")
+    op.drop_index("ix_case_table_row_row_id", table_name="case_table_row")
+    op.drop_index(op.f("ix_case_table_row_id"), table_name="case_table_row")
+    op.drop_index("ix_case_table_row_case_id", table_name="case_table_row")
+    op.drop_table("case_table_row")

--- a/alembic/versions/8f4f1bd13e9c_add_case_table_row_event_types.py
+++ b/alembic/versions/8f4f1bd13e9c_add_case_table_row_event_types.py
@@ -1,0 +1,128 @@
+"""add case table row event types
+
+Revision ID: 8f4f1bd13e9c
+Revises: 1224a945b9f7
+Create Date: 2026-03-01 10:02:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic_postgresql_enum import TableReference
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8f4f1bd13e9c"
+down_revision: str | None = "1224a945b9f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(  # type: ignore[attr-defined]
+        enum_schema="public",
+        enum_name="caseeventtype",
+        new_values=[
+            "CASE_CREATED",
+            "CASE_UPDATED",
+            "CASE_CLOSED",
+            "CASE_REOPENED",
+            "CASE_VIEWED",
+            "PRIORITY_CHANGED",
+            "SEVERITY_CHANGED",
+            "STATUS_CHANGED",
+            "FIELDS_CHANGED",
+            "ASSIGNEE_CHANGED",
+            "ATTACHMENT_CREATED",
+            "ATTACHMENT_DELETED",
+            "TAG_ADDED",
+            "TAG_REMOVED",
+            "PAYLOAD_CHANGED",
+            "TASK_CREATED",
+            "TASK_DELETED",
+            "TASK_STATUS_CHANGED",
+            "TASK_PRIORITY_CHANGED",
+            "TASK_WORKFLOW_CHANGED",
+            "TASK_ASSIGNEE_CHANGED",
+            "DROPDOWN_VALUE_CHANGED",
+            "TABLE_ROW_LINKED",
+            "TABLE_ROW_UNLINKED",
+        ],
+        affected_columns=[
+            TableReference(
+                table_schema="public",
+                table_name="case_duration_definition",
+                column_name="end_event_type",
+            ),
+            TableReference(
+                table_schema="public",
+                table_name="case_duration_definition",
+                column_name="start_event_type",
+            ),
+            TableReference(
+                table_schema="public",
+                table_name="case_event",
+                column_name="type",
+            ),
+        ],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM case_duration_definition "
+        "WHERE start_event_type IN ('TABLE_ROW_LINKED', 'TABLE_ROW_UNLINKED') "
+        "OR end_event_type IN ('TABLE_ROW_LINKED', 'TABLE_ROW_UNLINKED')"
+    )
+    op.execute(
+        "DELETE FROM case_event WHERE type IN ('TABLE_ROW_LINKED', 'TABLE_ROW_UNLINKED')"
+    )
+
+    op.sync_enum_values(  # type: ignore[attr-defined]
+        enum_schema="public",
+        enum_name="caseeventtype",
+        new_values=[
+            "CASE_CREATED",
+            "CASE_UPDATED",
+            "CASE_CLOSED",
+            "CASE_REOPENED",
+            "CASE_VIEWED",
+            "PRIORITY_CHANGED",
+            "SEVERITY_CHANGED",
+            "STATUS_CHANGED",
+            "FIELDS_CHANGED",
+            "ASSIGNEE_CHANGED",
+            "ATTACHMENT_CREATED",
+            "ATTACHMENT_DELETED",
+            "TAG_ADDED",
+            "TAG_REMOVED",
+            "PAYLOAD_CHANGED",
+            "TASK_CREATED",
+            "TASK_DELETED",
+            "TASK_STATUS_CHANGED",
+            "TASK_PRIORITY_CHANGED",
+            "TASK_WORKFLOW_CHANGED",
+            "TASK_ASSIGNEE_CHANGED",
+            "DROPDOWN_VALUE_CHANGED",
+        ],
+        affected_columns=[
+            TableReference(
+                table_schema="public",
+                table_name="case_duration_definition",
+                column_name="end_event_type",
+            ),
+            TableReference(
+                table_schema="public",
+                table_name="case_duration_definition",
+                column_name="start_event_type",
+            ),
+            TableReference(
+                table_schema="public",
+                table_name="case_event",
+                column_name="type",
+            ),
+        ],
+        enum_values_to_rename=[],
+    )

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4769,6 +4769,12 @@ export const $CaseEventRead = {
     {
       $ref: "#/components/schemas/DropdownValueChangedEventRead",
     },
+    {
+      $ref: "#/components/schemas/TableRowLinkedEventRead",
+    },
+    {
+      $ref: "#/components/schemas/TableRowUnlinkedEventRead",
+    },
   ],
   title: "CaseEventRead",
   description: "Base read model for all event types.",
@@ -4790,6 +4796,8 @@ export const $CaseEventRead = {
       priority_changed: "#/components/schemas/PriorityChangedEventRead",
       severity_changed: "#/components/schemas/SeverityChangedEventRead",
       status_changed: "#/components/schemas/StatusChangedEventRead",
+      table_row_linked: "#/components/schemas/TableRowLinkedEventRead",
+      table_row_unlinked: "#/components/schemas/TableRowUnlinkedEventRead",
       tag_added: "#/components/schemas/TagAddedEventRead",
       tag_removed: "#/components/schemas/TagRemovedEventRead",
       task_assignee_changed:
@@ -4830,6 +4838,8 @@ export const $CaseEventType = {
     "task_workflow_changed",
     "task_assignee_changed",
     "dropdown_value_changed",
+    "table_row_linked",
+    "table_row_unlinked",
   ],
   title: "CaseEventType",
   description: "Case activity type values.",
@@ -5205,6 +5215,13 @@ export const $CaseRead = {
       type: "array",
       title: "Dropdown Values",
     },
+    rows: {
+      items: {
+        $ref: "#/components/schemas/CaseTableRowRead",
+      },
+      type: "array",
+      title: "Rows",
+    },
   },
   type: "object",
   required: [
@@ -5281,6 +5298,13 @@ export const $CaseReadMinimal = {
       },
       type: "array",
       title: "Dropdown Values",
+    },
+    rows: {
+      items: {
+        $ref: "#/components/schemas/CaseTableRowRead",
+      },
+      type: "array",
+      title: "Rows",
     },
     num_tasks_completed: {
       type: "integer",
@@ -5394,6 +5418,106 @@ export const $CaseStatusGroupCounts = {
   },
   type: "object",
   title: "CaseStatusGroupCounts",
+} as const
+
+export const $CaseTableRowInsertCreate = {
+  properties: {
+    table_id: {
+      type: "string",
+      format: "uuid",
+      title: "Table Id",
+    },
+    row: {
+      $ref: "#/components/schemas/TableRowInsert",
+    },
+  },
+  type: "object",
+  required: ["table_id", "row"],
+  title: "CaseTableRowInsertCreate",
+} as const
+
+export const $CaseTableRowLinkCreate = {
+  properties: {
+    table_id: {
+      type: "string",
+      format: "uuid",
+      title: "Table Id",
+    },
+    row_id: {
+      type: "string",
+      format: "uuid",
+      title: "Row Id",
+    },
+  },
+  type: "object",
+  required: ["table_id", "row_id"],
+  title: "CaseTableRowLinkCreate",
+} as const
+
+export const $CaseTableRowRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    case_id: {
+      type: "string",
+      format: "uuid",
+      title: "Case Id",
+    },
+    table_id: {
+      type: "string",
+      format: "uuid",
+      title: "Table Id",
+    },
+    table_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Table Name",
+    },
+    row_id: {
+      type: "string",
+      format: "uuid",
+      title: "Row Id",
+    },
+    row_data: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Row Data",
+    },
+    is_row_available: {
+      type: "boolean",
+      title: "Is Row Available",
+      default: true,
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: ["id", "case_id", "table_id", "row_id", "created_at", "updated_at"],
+  title: "CaseTableRowRead",
 } as const
 
 export const $CaseTagCreate = {
@@ -6625,6 +6749,69 @@ export const $CursorPaginatedResponse_CaseReadMinimal_ = {
   type: "object",
   required: ["items"],
   title: "CursorPaginatedResponse[CaseReadMinimal]",
+} as const
+
+export const $CursorPaginatedResponse_CaseTableRowRead_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/CaseTableRowRead",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[CaseTableRowRead]",
 } as const
 
 export const $CursorPaginatedResponse_InboxItemRead_ = {
@@ -16474,6 +16661,73 @@ export const $TableRowInsertBatchResponse = {
   description: "Response for batch insert operation.",
 } as const
 
+export const $TableRowLinkedEventRead = {
+  properties: {
+    wf_exec_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Wf Exec Id",
+      description: "The execution ID of the workflow that triggered the event.",
+    },
+    type: {
+      type: "string",
+      const: "table_row_linked",
+      title: "Type",
+      default: "table_row_linked",
+    },
+    table_id: {
+      type: "string",
+      format: "uuid",
+      title: "Table Id",
+    },
+    table_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Table Name",
+    },
+    row_id: {
+      type: "string",
+      format: "uuid",
+      title: "Row Id",
+    },
+    user_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "User Id",
+      description: "The user who performed the action.",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+      description: "The timestamp of the event.",
+    },
+  },
+  type: "object",
+  required: ["table_id", "row_id", "created_at"],
+  title: "TableRowLinkedEventRead",
+  description: "Event for when a table row is linked to a case.",
+} as const
+
 export const $TableRowRead = {
   properties: {
     id: {
@@ -16497,6 +16751,73 @@ export const $TableRowRead = {
   required: ["id", "created_at", "updated_at"],
   title: "TableRowRead",
   description: "Read model for a table row.",
+} as const
+
+export const $TableRowUnlinkedEventRead = {
+  properties: {
+    wf_exec_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Wf Exec Id",
+      description: "The execution ID of the workflow that triggered the event.",
+    },
+    type: {
+      type: "string",
+      const: "table_row_unlinked",
+      title: "Type",
+      default: "table_row_unlinked",
+    },
+    table_id: {
+      type: "string",
+      format: "uuid",
+      title: "Table Id",
+    },
+    table_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Table Name",
+    },
+    row_id: {
+      type: "string",
+      format: "uuid",
+      title: "Row Id",
+    },
+    user_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "User Id",
+      description: "The user who performed the action.",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+      description: "The timestamp of the event.",
+    },
+  },
+  type: "object",
+  required: ["table_id", "row_id", "created_at"],
+  title: "TableRowUnlinkedEventRead",
+  description: "Event for when a table row is unlinked from a case.",
 } as const
 
 export const $TableRowUpdate = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -218,8 +218,14 @@ import type {
   CasesDeleteTaskResponse,
   CasesGetCaseData,
   CasesGetCaseResponse,
+  CasesInsertCaseRowData,
+  CasesInsertCaseRowResponse,
+  CasesLinkCaseRowData,
+  CasesLinkCaseRowResponse,
   CasesListCaseDropdownValuesData,
   CasesListCaseDropdownValuesResponse,
+  CasesListCaseRowsData,
+  CasesListCaseRowsResponse,
   CasesListCasesData,
   CasesListCasesResponse,
   CasesListCommentsData,
@@ -240,6 +246,8 @@ import type {
   CasesSearchCasesResponse,
   CasesSetCaseDropdownValueData,
   CasesSetCaseDropdownValueResponse,
+  CasesUnlinkCaseRowData,
+  CasesUnlinkCaseRowResponse,
   CasesUpdateCaseData,
   CasesUpdateCaseResponse,
   CasesUpdateCommentData,
@@ -6456,6 +6464,7 @@ export const tablesImportCsv = (
  * @param data.reverse Reverse pagination direction
  * @param data.orderBy Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at
  * @param data.sort Direction to sort (asc or desc)
+ * @param data.includeRows Include linked table rows
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -6471,6 +6480,7 @@ export const casesListCases = (
       reverse: data.reverse,
       order_by: data.orderBy,
       sort: data.sort,
+      include_rows: data.includeRows,
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -6514,6 +6524,7 @@ export const casesCreateCase = (
  * @param data.cursor Cursor for pagination
  * @param data.reverse Reverse pagination direction
  * @param data.searchTerm Text to search for in case summary, description, or short ID
+ * @param data.shortId Search by case short ID fragment only (contains match, e.g. 42 or CASE-0042)
  * @param data.status Filter by case status
  * @param data.priority Filter by case priority
  * @param data.severity Filter by case severity
@@ -6526,6 +6537,7 @@ export const casesCreateCase = (
  * @param data.assigneeId Filter by assignee ID or 'unassigned'
  * @param data.orderBy Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at
  * @param data.sort Direction to sort (asc or desc)
+ * @param data.includeRows Include linked table rows
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -6540,6 +6552,7 @@ export const casesSearchCases = (
       cursor: data.cursor,
       reverse: data.reverse,
       search_term: data.searchTerm,
+      short_id: data.shortId,
       status: data.status,
       priority: data.priority,
       severity: data.severity,
@@ -6552,6 +6565,7 @@ export const casesSearchCases = (
       assignee_id: data.assigneeId,
       order_by: data.orderBy,
       sort: data.sort,
+      include_rows: data.includeRows,
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -6611,6 +6625,7 @@ export const casesSearchCaseAggregates = (
  * @param data The data for the request.
  * @param data.caseId
  * @param data.workspaceId
+ * @param data.includeRows Include linked table rows
  * @returns CaseRead Successful Response
  * @throws ApiError
  */
@@ -6624,6 +6639,7 @@ export const casesGetCase = (
       case_id: data.caseId,
     },
     query: {
+      include_rows: data.includeRows,
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -6942,6 +6958,126 @@ export const casesDeleteTask = (
     path: {
       case_id: data.caseId,
       task_id: data.taskId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Case Rows
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.workspaceId
+ * @param data.limit
+ * @param data.cursor
+ * @param data.reverse
+ * @returns CursorPaginatedResponse_CaseTableRowRead_ Successful Response
+ * @throws ApiError
+ */
+export const casesListCaseRows = (
+  data: CasesListCaseRowsData
+): CancelablePromise<CasesListCaseRowsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/cases/{case_id}/rows",
+    path: {
+      case_id: data.caseId,
+    },
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      reverse: data.reverse,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Link Case Row
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns CaseTableRowRead Successful Response
+ * @throws ApiError
+ */
+export const casesLinkCaseRow = (
+  data: CasesLinkCaseRowData
+): CancelablePromise<CasesLinkCaseRowResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/cases/{case_id}/rows",
+    path: {
+      case_id: data.caseId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Insert Case Row
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns CaseTableRowRead Successful Response
+ * @throws ApiError
+ */
+export const casesInsertCaseRow = (
+  data: CasesInsertCaseRowData
+): CancelablePromise<CasesInsertCaseRowResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/cases/{case_id}/rows/insert",
+    path: {
+      case_id: data.caseId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Unlink Case Row
+ * @param data The data for the request.
+ * @param data.caseId
+ * @param data.tableId
+ * @param data.rowId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const casesUnlinkCaseRow = (
+  data: CasesUnlinkCaseRowData
+): CancelablePromise<CasesUnlinkCaseRowResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/cases/{case_id}/rows/{table_id}/{row_id}",
+    path: {
+      case_id: data.caseId,
+      table_id: data.tableId,
+      row_id: data.rowId,
     },
     query: {
       workspace_id: data.workspaceId,

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -6524,7 +6524,7 @@ export const casesCreateCase = (
  * @param data.cursor Cursor for pagination
  * @param data.reverse Reverse pagination direction
  * @param data.searchTerm Text to search for in case summary, description, or short ID
- * @param data.shortId Search by case short ID fragment only (contains match, e.g. 42 or CASE-0042)
+ * @param data.shortId Search by exact case short ID (e.g. 42 or CASE-0042)
  * @param data.status Filter by case status
  * @param data.priority Filter by case priority
  * @param data.severity Filter by case severity

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8917,7 +8917,7 @@ export type CasesSearchCasesData = {
    */
   severity?: Array<CaseSeverity> | null
   /**
-   * Search by case short ID fragment only (contains match, e.g. 42 or CASE-0042)
+   * Search by exact case short ID (e.g. 42 or CASE-0042)
    */
   shortId?: string | null
   /**

--- a/frontend/src/components/cases/case-linked-rows-section.tsx
+++ b/frontend/src/components/cases/case-linked-rows-section.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Trash2 } from "lucide-react"
+import { useMemo } from "react"
+import type { CaseRead, CaseTableRowRead } from "@/client"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { client as apiClient } from "@/lib/api"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+export function CaseLinkedRowsSection({ caseData }: { caseData: CaseRead }) {
+  const workspaceId = useWorkspaceId()
+  const queryClient = useQueryClient()
+  const rows = (
+    (caseData as CaseRead & { rows?: CaseTableRowRead[] }).rows ?? []
+  ).filter((row) => row.row_data)
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, CaseTableRowRead[]>()
+    for (const row of rows) {
+      const key = `${row.table_id}:${row.table_name ?? "Table"}`
+      const current = map.get(key) ?? []
+      current.push(row)
+      map.set(key, current)
+    }
+    return Array.from(map.entries())
+  }, [rows])
+
+  const unlinkMutation = useMutation({
+    mutationFn: async (row: CaseTableRowRead) => {
+      await apiClient.delete(
+        `/cases/${caseData.id}/rows/${row.table_id}/${row.row_id}`,
+        {
+          params: {
+            workspace_id: workspaceId,
+          },
+        }
+      )
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["case", caseData.id] })
+    },
+  })
+
+  if (grouped.length === 0) {
+    return (
+      <p className="p-2 text-sm text-muted-foreground">No linked table rows</p>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {grouped.map(([key, tableRows]) => {
+        const [, tableName] = key.split(":")
+        const columns = Array.from(
+          new Set(
+            tableRows.flatMap((row) =>
+              Object.keys((row.row_data as Record<string, unknown>) ?? {})
+            )
+          )
+        )
+
+        return (
+          <div key={key} className="space-y-2">
+            <p className="text-sm font-medium">{tableName}</p>
+            <div className="w-full max-w-[760px] overflow-hidden rounded-md border">
+              <ScrollArea className="w-full">
+                <div className="max-h-72 overflow-auto">
+                  <table className="w-[900px] table-fixed text-sm">
+                    <thead>
+                      <tr className="border-b bg-muted/50 text-left">
+                        {columns.map((column) => (
+                          <th key={column} className="px-3 py-2 font-medium">
+                            {column}
+                          </th>
+                        ))}
+                        <th className="w-16 px-3 py-2" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {tableRows.map((row) => (
+                        <tr key={row.id} className="border-b align-top">
+                          {columns.map((column) => (
+                            <td
+                              key={`${row.id}-${column}`}
+                              className="truncate px-3 py-2"
+                            >
+                              {String(
+                                (row.row_data as Record<string, unknown>)?.[
+                                  column
+                                ] ?? ""
+                              )}
+                            </td>
+                          ))}
+                          <td className="px-2 py-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => unlinkMutation.mutate(row)}
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </ScrollArea>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/cases/case-linked-rows-section.tsx
+++ b/frontend/src/components/cases/case-linked-rows-section.tsx
@@ -1,47 +1,40 @@
 "use client"
 
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Trash2 } from "lucide-react"
 import { useMemo } from "react"
-import type { CaseRead, CaseTableRowRead } from "@/client"
-import { Button } from "@/components/ui/button"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import { client as apiClient } from "@/lib/api"
+import type { CaseRead, CaseTableRowRead, TableRowRead } from "@/client"
+import { Spinner } from "@/components/loading/spinner"
+import { AgGridTable } from "@/components/tables/ag-grid-table"
+import { useGetTable } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 export function CaseLinkedRowsSection({ caseData }: { caseData: CaseRead }) {
   const workspaceId = useWorkspaceId()
-  const queryClient = useQueryClient()
   const rows = (
     (caseData as CaseRead & { rows?: CaseTableRowRead[] }).rows ?? []
   ).filter((row) => row.row_data)
 
   const grouped = useMemo(() => {
-    const map = new Map<string, CaseTableRowRead[]>()
+    const map = new Map<
+      string,
+      { tableName: string; rows: CaseTableRowRead[] }
+    >()
     for (const row of rows) {
-      const key = `${row.table_id}:${row.table_name ?? "Table"}`
-      const current = map.get(key) ?? []
-      current.push(row)
-      map.set(key, current)
+      const existing = map.get(row.table_id)
+      if (existing) {
+        existing.rows.push(row)
+        continue
+      }
+      map.set(row.table_id, {
+        tableName: row.table_name ?? "Table",
+        rows: [row],
+      })
     }
-    return Array.from(map.entries())
+    return Array.from(map.entries()).map(([tableId, value]) => ({
+      tableId,
+      tableName: value.tableName,
+      rows: value.rows,
+    }))
   }, [rows])
-
-  const unlinkMutation = useMutation({
-    mutationFn: async (row: CaseTableRowRead) => {
-      await apiClient.delete(
-        `/cases/${caseData.id}/rows/${row.table_id}/${row.row_id}`,
-        {
-          params: {
-            workspace_id: workspaceId,
-          },
-        }
-      )
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["case", caseData.id] })
-    },
-  })
 
   if (grouped.length === 0) {
     return (
@@ -51,67 +44,76 @@ export function CaseLinkedRowsSection({ caseData }: { caseData: CaseRead }) {
 
   return (
     <div className="space-y-4">
-      {grouped.map(([key, tableRows]) => {
-        const [, tableName] = key.split(":")
-        const columns = Array.from(
-          new Set(
-            tableRows.flatMap((row) =>
-              Object.keys((row.row_data as Record<string, unknown>) ?? {})
-            )
-          )
-        )
+      {grouped.map((group) => (
+        <LinkedTableGrid
+          key={group.tableId}
+          tableId={group.tableId}
+          tableName={group.tableName}
+          linkedRows={group.rows}
+          workspaceId={workspaceId}
+        />
+      ))}
+    </div>
+  )
+}
 
-        return (
-          <div key={key} className="space-y-2">
-            <p className="text-sm font-medium">{tableName}</p>
-            <div className="w-full max-w-[760px] overflow-hidden rounded-md border">
-              <ScrollArea className="w-full">
-                <div className="max-h-72 overflow-auto">
-                  <table className="w-[900px] table-fixed text-sm">
-                    <thead>
-                      <tr className="border-b bg-muted/50 text-left">
-                        {columns.map((column) => (
-                          <th key={column} className="px-3 py-2 font-medium">
-                            {column}
-                          </th>
-                        ))}
-                        <th className="w-16 px-3 py-2" />
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {tableRows.map((row) => (
-                        <tr key={row.id} className="border-b align-top">
-                          {columns.map((column) => (
-                            <td
-                              key={`${row.id}-${column}`}
-                              className="truncate px-3 py-2"
-                            >
-                              {String(
-                                (row.row_data as Record<string, unknown>)?.[
-                                  column
-                                ] ?? ""
-                              )}
-                            </td>
-                          ))}
-                          <td className="px-2 py-1">
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => unlinkMutation.mutate(row)}
-                            >
-                              <Trash2 className="size-4" />
-                            </Button>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </ScrollArea>
+function LinkedTableGrid({
+  tableId,
+  tableName,
+  linkedRows,
+  workspaceId,
+}: {
+  tableId: string
+  tableName: string
+  linkedRows: CaseTableRowRead[]
+  workspaceId: string
+}) {
+  const { table, tableIsLoading, tableError } = useGetTable({
+    tableId,
+    workspaceId,
+  })
+
+  const rowData = useMemo<TableRowRead[]>(() => {
+    return linkedRows.map((row) => {
+      const payload =
+        row.row_data && typeof row.row_data === "object" ? row.row_data : {}
+      return {
+        ...(payload as Record<string, unknown>),
+        id: row.row_id,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      }
+    })
+  }, [linkedRows])
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">{tableName}</p>
+        <span className="text-xs text-muted-foreground">
+          {rowData.length} linked row{rowData.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      <div className="overflow-x-auto rounded-md border">
+        <div className="min-w-[1200px]">
+          {tableIsLoading ? (
+            <div className="flex h-20 items-center justify-center">
+              <Spinner className="size-4" />
             </div>
-          </div>
-        )
-      })}
+          ) : tableError || !table ? (
+            <div className="p-3 text-sm text-destructive">
+              Failed to load table schema.
+            </div>
+          ) : (
+            <AgGridTable
+              table={table}
+              rowsOverride={rowData}
+              readOnly={true}
+              hidePagination={true}
+            />
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@/client"
 import { CaseAttachmentsSection } from "@/components/cases/case-attachments-section"
 import { CommentSection } from "@/components/cases/case-comments-section"
+import { CaseLinkedRowsSection } from "@/components/cases/case-linked-rows-section"
 import { CustomField } from "@/components/cases/case-panel-custom-fields"
 import { CasePanelDescription } from "@/components/cases/case-panel-description"
 import {
@@ -71,7 +72,7 @@ import {
 import { undoSlugify } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-type CasePanelTab = "comments" | "activity" | "attachments" | "payload"
+type CasePanelTab = "comments" | "activity" | "attachments" | "rows" | "payload"
 
 function isCustomFieldValueEmpty(value: unknown): boolean {
   if (value === null || value === undefined) return true
@@ -149,7 +150,7 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
   // Get active tab from URL query params, default to "comments"
   const activeTab = (
     searchParams &&
-    ["comments", "activity", "attachments", "payload"].includes(
+    ["comments", "activity", "attachments", "rows", "payload"].includes(
       searchParams.get("tab") || ""
     )
       ? (searchParams.get("tab") ?? "comments")
@@ -390,6 +391,12 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                   </TabsTrigger>
                   <TabsTrigger
                     className="ml-6 flex h-full items-center justify-center rounded-none py-0 text-xs font-medium data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    value="rows"
+                  >
+                    Tables
+                  </TabsTrigger>
+                  <TabsTrigger
+                    className="ml-6 flex h-full items-center justify-center rounded-none py-0 text-xs font-medium data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="payload"
                   >
                     <Braces className="mr-1.5 h-3.5 w-3.5" />
@@ -411,6 +418,10 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                     caseId={caseId}
                     workspaceId={workspaceId}
                   />
+                </TabsContent>
+
+                <TabsContent value="rows" className="mt-4">
+                  <CaseLinkedRowsSection caseData={caseData} />
                 </TabsContent>
 
                 <TabsContent value="payload" className="mt-4">

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -6,6 +6,7 @@ import {
   MessageSquare,
   MoreHorizontal,
   Paperclip,
+  Table2,
   X,
 } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
@@ -393,6 +394,7 @@ export function CasePanelView({ caseId }: CasePanelContentProps) {
                     className="ml-6 flex h-full items-center justify-center rounded-none py-0 text-xs font-medium data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="rows"
                   >
+                    <Table2 className="mr-1.5 h-3.5 w-3.5" />
                     Tables
                   </TabsTrigger>
                   <TabsTrigger

--- a/frontend/src/components/cases/cases-feed.tsx
+++ b/frontend/src/components/cases/cases-feed.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { AlertCircle, Clock, ExternalLinkIcon, PlusIcon } from "lucide-react"
+import {
+  AlertCircle,
+  Clock,
+  ExternalLinkIcon,
+  Link2,
+  PlusIcon,
+  Unlink2,
+} from "lucide-react"
 import Link from "next/link"
 import { useMemo } from "react"
 import type { CaseEventRead } from "@/client"
@@ -151,6 +158,26 @@ function CaseFeedEvent({
 
         {event.type === "dropdown_value_changed" && (
           <DropdownValueChangedEvent event={event} actor={actor} />
+        )}
+
+        {(event.type as string) === "table_row_linked" && (
+          <div className="flex items-center space-x-2 text-xs">
+            <EventIcon icon={Link2} />
+            <span>
+              <EventActor user={actor} /> linked a row from{" "}
+              {(event as { table_name?: string }).table_name || "a table"}
+            </span>
+          </div>
+        )}
+
+        {(event.type as string) === "table_row_unlinked" && (
+          <div className="flex items-center space-x-2 text-xs">
+            <EventIcon icon={Unlink2} />
+            <span>
+              <EventActor user={actor} /> unlinked a row from{" "}
+              {(event as { table_name?: string }).table_name || "a table"}
+            </span>
+          </div>
         )}
         {/* Add a dot separator */}
         <InlineDotSeparator />

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -66,6 +66,7 @@ import { TableSelectionActionsBar } from "@/components/tables/ag-grid-bulk-actio
 import { CreateTableDialog } from "@/components/tables/table-create-dialog"
 import { TableImportTableDialog } from "@/components/tables/table-import-table-dialog"
 import { TableInsertButton } from "@/components/tables/table-insert-button"
+import { TableLinkRowsToCaseCommand } from "@/components/tables/table-link-rows-to-case-command"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1094,6 +1095,7 @@ function TableDetailsActions() {
   return (
     <>
       <TableSelectionActionsBar />
+      <TableLinkRowsToCaseCommand />
       <TableInsertButton />
     </>
   )

--- a/frontend/src/components/tables/ag-grid-table.tsx
+++ b/frontend/src/components/tables/ag-grid-table.tsx
@@ -13,7 +13,7 @@ import type {
 } from "ag-grid-community"
 import { AgGridReact } from "ag-grid-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import type { TableRead, TableRowRead } from "@/client"
+import type { TableColumnRead, TableRead, TableRowRead } from "@/client"
 import { AgGridCellEditor } from "@/components/tables/ag-grid-cell-editor"
 import { AgGridCellRenderer } from "@/components/tables/ag-grid-cell-renderer"
 import { handleGridKeyDown } from "@/components/tables/ag-grid-clipboard"
@@ -21,6 +21,7 @@ import { AgGridColumnHeader } from "@/components/tables/ag-grid-column-header"
 import { AgGridContextMenu } from "@/components/tables/ag-grid-context-menu"
 import { AgGridPagination } from "@/components/tables/ag-grid-pagination"
 import { tracecatTheme } from "@/components/tables/ag-grid-theme"
+import { CellDisplay } from "@/components/tables/cell-display"
 import { useTableSelection } from "@/components/tables/table-selection-context"
 import { useTablesPagination } from "@/hooks/pagination/use-tables-pagination"
 import { useUpdateRow } from "@/lib/hooks"
@@ -99,11 +100,34 @@ function getColumnWidthPx(rawType?: string): number {
   return 288
 }
 
+function ReadOnlyCellRenderer({
+  value,
+  tableColumn,
+}: {
+  value: unknown
+  tableColumn: TableColumnRead
+}) {
+  return (
+    <div className="flex h-full w-full items-center overflow-hidden">
+      <div className="min-w-0 flex-1 overflow-hidden">
+        <CellDisplay value={value} column={tableColumn} />
+      </div>
+    </div>
+  )
+}
+
 export function AgGridTable({
   table: { id, name, columns },
+  rowsOverride,
+  readOnly = false,
+  hidePagination = false,
 }: {
   table: TableRead
+  rowsOverride?: TableRowRead[]
+  readOnly?: boolean
+  hidePagination?: boolean
 }) {
+  const isReadOnly = readOnly || rowsOverride !== undefined
   const workspaceId = useWorkspaceId()
   const [pageSize, setPageSize] = useState(20)
   const [gridApi, setGridApi] = useState<GridApi | null>(null)
@@ -127,25 +151,35 @@ export function AgGridTable({
     tableId: id,
     workspaceId,
     limit: pageSize,
+    enabled: rowsOverride === undefined,
   })
+  const rowData = rowsOverride ?? rows ?? []
+  const isLoading = rowsOverride === undefined ? rowsIsLoading : false
+  const error = rowsOverride === undefined ? rowsError : null
 
   useEffect(() => {
-    if (id) {
+    if (id && rowsOverride === undefined) {
       document.title = `Tables | ${name}`
     }
-  }, [id, name])
+  }, [id, name, rowsOverride])
 
   const handlePageSizeChange = useCallback(
     (newPageSize: number) => {
+      if (rowsOverride !== undefined) {
+        return
+      }
       setPageSize(newPageSize)
       goToFirstPage()
     },
-    [goToFirstPage]
+    [goToFirstPage, rowsOverride]
   )
 
   const handleGridReady = useCallback(
     (event: GridReadyEvent) => {
       setGridApi(event.api)
+      if (isReadOnly) {
+        return
+      }
       updateSelection({
         gridApi: event.api,
         tableId: id,
@@ -154,11 +188,14 @@ export function AgGridTable({
         selectedRowIds: [],
       })
     },
-    [updateSelection, id, columns]
+    [updateSelection, id, columns, isReadOnly]
   )
 
   // Keep selection context in sync when table id or columns change after grid init
   useEffect(() => {
+    if (isReadOnly) {
+      return
+    }
     if (gridApi) {
       updateSelection({
         tableId: id,
@@ -168,21 +205,27 @@ export function AgGridTable({
       })
       gridApi.deselectAll()
     }
-  }, [id, columns, gridApi, updateSelection])
+  }, [id, columns, gridApi, updateSelection, isReadOnly])
 
   const handleSelectionChanged = useCallback(
     (event: SelectionChangedEvent) => {
+      if (isReadOnly) {
+        return
+      }
       const selectedRows = event.api.getSelectedRows() as TableRowRead[]
       updateSelection({
         selectedCount: selectedRows.length,
         selectedRowIds: selectedRows.map((r) => r.id),
       })
     },
-    [updateSelection]
+    [updateSelection, isReadOnly]
   )
 
   const handleCellValueChanged = useCallback(
     (event: CellValueChangedEvent) => {
+      if (isReadOnly) {
+        return
+      }
       if (event.oldValue !== event.newValue && event.colDef.field) {
         const rowData = event.data as TableRowRead
         updateRow({
@@ -195,7 +238,7 @@ export function AgGridTable({
         })
       }
     },
-    [id, workspaceId, updateRow]
+    [id, workspaceId, updateRow, isReadOnly]
   )
 
   const columnDefs: ColDef[] = useMemo(() => {
@@ -203,12 +246,30 @@ export function AgGridTable({
       ...columns.map((column): ColDef => {
         const normalizedType = normalizeSqlType(column.type)
         const isPopupEditor = POPUP_EDITOR_TYPES.has(normalizedType)
-
         const isNumeric = NUMERIC_TYPES.has(normalizedType)
-
-        return {
+        const baseDef: ColDef = {
           field: column.name,
           headerName: column.name,
+          sortable: true,
+          resizable: true,
+          width: getColumnWidthPx(column.type),
+          minWidth: 100,
+          ...(isNumeric && { valueFormatter: numericValueFormatter }),
+        }
+
+        if (isReadOnly) {
+          return {
+            ...baseDef,
+            cellRenderer: ReadOnlyCellRenderer,
+            cellRendererParams: {
+              tableColumn: column,
+            },
+            editable: false,
+          }
+        }
+
+        return {
+          ...baseDef,
           headerComponent: AgGridColumnHeader,
           headerComponentParams: {
             tableColumn: column,
@@ -224,18 +285,13 @@ export function AgGridTable({
           cellEditorPopup: isPopupEditor,
           suppressKeyboardEvent: suppressEditorKeys,
           editable: true,
-          sortable: true,
-          resizable: true,
-          width: getColumnWidthPx(column.type),
-          minWidth: 100,
-          ...(isNumeric && { valueFormatter: numericValueFormatter }),
         }
       }),
     ]
     return defs
-  }, [columns])
+  }, [columns, isReadOnly])
 
-  if (rowsError) {
+  if (error) {
     return (
       <div className="flex h-full items-center justify-center p-8">
         <p className="text-sm text-destructive">
@@ -247,50 +303,70 @@ export function AgGridTable({
 
   return (
     <div className="flex h-full flex-col gap-2">
-      <AgGridContextMenu gridApi={gridApi} columns={columns}>
+      {isReadOnly ? (
         <div onKeyDown={(e) => handleGridKeyDown(e, gridApi)}>
           <AgGridReact
             theme={tracecatTheme}
             domLayout="autoHeight"
-            rowData={rows ?? []}
+            rowData={rowData}
             columnDefs={columnDefs}
             getRowId={(params) => params.data.id}
             onGridReady={handleGridReady}
-            onCellValueChanged={handleCellValueChanged}
-            onSelectionChanged={handleSelectionChanged}
-            selectionColumnDef={{
-              cellClass: "ag-selection-col-aligned",
-              headerClass: "ag-selection-col-aligned",
-            }}
-            rowSelection={{
-              mode: "multiRow",
-              enableClickSelection: false,
-              headerCheckbox: true,
-              checkboxes: true,
-            }}
-            suppressClickEdit
             suppressContextMenu
             headerHeight={36}
             rowHeight={36}
             animateRows={false}
-            loading={rowsIsLoading}
+            loading={isLoading}
           />
         </div>
-      </AgGridContextMenu>
-      <AgGridPagination
-        currentPage={currentPage}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
-        pageSize={pageSize}
-        totalEstimate={totalEstimate}
-        startItem={startItem}
-        endItem={endItem}
-        onNextPage={goToNextPage}
-        onPreviousPage={goToPreviousPage}
-        onFirstPage={goToFirstPage}
-        onPageSizeChange={handlePageSizeChange}
-        isLoading={rowsIsLoading}
-      />
+      ) : (
+        <AgGridContextMenu gridApi={gridApi} columns={columns}>
+          <div onKeyDown={(e) => handleGridKeyDown(e, gridApi)}>
+            <AgGridReact
+              theme={tracecatTheme}
+              domLayout="autoHeight"
+              rowData={rowData}
+              columnDefs={columnDefs}
+              getRowId={(params) => params.data.id}
+              onGridReady={handleGridReady}
+              onCellValueChanged={handleCellValueChanged}
+              onSelectionChanged={handleSelectionChanged}
+              selectionColumnDef={{
+                cellClass: "ag-selection-col-aligned",
+                headerClass: "ag-selection-col-aligned",
+              }}
+              rowSelection={{
+                mode: "multiRow",
+                enableClickSelection: false,
+                headerCheckbox: true,
+                checkboxes: true,
+              }}
+              suppressClickEdit
+              suppressContextMenu
+              headerHeight={36}
+              rowHeight={36}
+              animateRows={false}
+              loading={isLoading}
+            />
+          </div>
+        </AgGridContextMenu>
+      )}
+      {!hidePagination && rowsOverride === undefined && (
+        <AgGridPagination
+          currentPage={currentPage}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
+          pageSize={pageSize}
+          totalEstimate={totalEstimate}
+          startItem={startItem}
+          endItem={endItem}
+          onNextPage={goToNextPage}
+          onPreviousPage={goToPreviousPage}
+          onFirstPage={goToFirstPage}
+          onPageSizeChange={handlePageSizeChange}
+          isLoading={isLoading}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/tables/table-link-rows-to-case-command.tsx
+++ b/frontend/src/components/tables/table-link-rows-to-case-command.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { CheckIcon, LinkIcon } from "lucide-react"
+import { useMemo, useState } from "react"
+import type { CaseReadMinimal } from "@/client"
+import { Spinner } from "@/components/loading/spinner"
+import { useTableSelection } from "@/components/tables/table-selection-context"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { toast } from "@/components/ui/use-toast"
+import { useDebounce } from "@/hooks"
+import { client as apiClient } from "@/lib/api"
+import { cn } from "@/lib/utils"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+type SearchCasesResponse = {
+  items: CaseReadMinimal[]
+}
+
+export function TableLinkRowsToCaseCommand() {
+  const workspaceId = useWorkspaceId()
+  const { selectedCount, selectedRowIds, tableId, gridApi } =
+    useTableSelection()
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+  const [selectedCaseIds, setSelectedCaseIds] = useState<Set<string>>(new Set())
+  const [debouncedSearch] = useDebounce(search, 300)
+
+  const normalizedShortId = debouncedSearch.trim().toUpperCase()
+
+  const {
+    data: cases = [],
+    isLoading: casesIsLoading,
+    isFetching: casesIsFetching,
+  } = useQuery({
+    queryKey: ["cases", "search", "short-id", workspaceId, normalizedShortId],
+    queryFn: async () => {
+      const response = await apiClient.get<SearchCasesResponse>(
+        "/cases/search",
+        {
+          params: {
+            workspace_id: workspaceId,
+            short_id: normalizedShortId,
+            limit: 20,
+          },
+        }
+      )
+      return response.data.items
+    },
+    enabled: open && normalizedShortId.length > 0,
+  })
+
+  const { mutateAsync: linkRowsToCases, isPending: isLinking } = useMutation({
+    mutationFn: async () => {
+      const caseIds = Array.from(selectedCaseIds)
+      if (caseIds.length === 0 || selectedRowIds.length === 0) {
+        return
+      }
+
+      await Promise.all(
+        caseIds.flatMap((caseId) =>
+          selectedRowIds.map((rowId) =>
+            apiClient.post(
+              `/cases/${caseId}/rows`,
+              {
+                table_id: tableId,
+                row_id: rowId,
+              },
+              {
+                params: {
+                  workspace_id: workspaceId,
+                },
+              }
+            )
+          )
+        )
+      )
+    },
+    onSuccess: () => {
+      const caseCount = selectedCaseIds.size
+      toast({
+        title: "Rows linked",
+        description: `Linked ${selectedCount} row${selectedCount === 1 ? "" : "s"} to ${caseCount} case${caseCount === 1 ? "" : "s"}.`,
+      })
+      gridApi?.deselectAll()
+      setOpen(false)
+      setSearch("")
+      setSelectedCaseIds(new Set())
+    },
+    onError: (error) => {
+      toast({
+        title: "Could not link rows",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      })
+    },
+  })
+
+  const commandHint = useMemo(() => {
+    if (!normalizedShortId) {
+      return "Search case ID contains (e.g. 42 or CASE-0042)"
+    }
+    return "No case found with that ID fragment"
+  }, [normalizedShortId])
+
+  if (selectedCount === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 px-2 text-xs text-muted-foreground"
+        onClick={() => setOpen(true)}
+      >
+        <LinkIcon className="mr-1 size-3" />
+        Link to case
+      </Button>
+
+      <CommandDialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen)
+          if (!nextOpen) {
+            setSearch("")
+            setSelectedCaseIds(new Set())
+          }
+        }}
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search by case ID fragment..."
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            {!casesIsLoading && !casesIsFetching && (
+              <CommandEmpty>{commandHint}</CommandEmpty>
+            )}
+            {cases.map((caseItem) => {
+              const isSelected = selectedCaseIds.has(caseItem.id)
+              return (
+                <CommandItem
+                  key={caseItem.id}
+                  value={caseItem.short_id}
+                  onSelect={() => {
+                    setSelectedCaseIds((prev) => {
+                      const next = new Set(prev)
+                      if (next.has(caseItem.id)) {
+                        next.delete(caseItem.id)
+                      } else {
+                        next.add(caseItem.id)
+                      }
+                      return next
+                    })
+                  }}
+                >
+                  <CheckIcon
+                    className={cn(
+                      "size-4",
+                      isSelected ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  <div className="flex min-w-0 flex-col">
+                    <span className="text-sm font-medium">
+                      {caseItem.short_id}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {caseItem.summary}
+                    </span>
+                  </div>
+                </CommandItem>
+              )
+            })}
+          </CommandList>
+        </Command>
+        <div className="flex items-center justify-between border-t px-4 py-3">
+          <span className="text-xs text-muted-foreground">
+            {selectedCaseIds.size} case{selectedCaseIds.size === 1 ? "" : "s"}{" "}
+            selected
+          </span>
+          <Button
+            size="sm"
+            onClick={() => linkRowsToCases()}
+            disabled={selectedCaseIds.size === 0 || isLinking}
+          >
+            {isLinking ? (
+              <span className="flex items-center gap-2">
+                <Spinner className="size-3" />
+                Linking...
+              </span>
+            ) : (
+              "Link selected rows"
+            )}
+          </Button>
+        </div>
+      </CommandDialog>
+    </>
+  )
+}

--- a/frontend/src/hooks/pagination/use-tables-pagination.tsx
+++ b/frontend/src/hooks/pagination/use-tables-pagination.tsx
@@ -12,12 +12,14 @@ export interface UseTablesPaginationParams {
   tableId: string
   workspaceId: string
   limit?: number
+  enabled?: boolean
 }
 
 export function useTablesPagination({
   tableId,
   workspaceId,
   limit = 50,
+  enabled = true,
 }: UseTablesPaginationParams) {
   // Wrapper function to adapt the API response to our generic interface
   const adaptedTablesListRows = async (
@@ -40,5 +42,6 @@ export function useTablesPagination({
     queryKey: ["rows", "paginated", tableId, workspaceId],
     queryFn: adaptedTablesListRows,
     additionalParams: { tableId },
+    enabled,
   })
 }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -85,7 +85,6 @@ import {
   casesDeleteCase,
   casesDeleteComment,
   casesDeleteTask,
-  casesGetCase,
   casesListComments,
   casesListEventsWithUsers,
   casesListFields,
@@ -3580,7 +3579,12 @@ export function useGetCase(
     error: caseDataError,
   } = useQuery<CaseRead, TracecatApiError>({
     queryKey: ["case", caseId],
-    queryFn: async () => await casesGetCase({ caseId, workspaceId }),
+    queryFn: async () => {
+      const response = await apiClient.get<CaseRead>(`/cases/${caseId}`, {
+        params: { workspace_id: workspaceId, include_rows: true },
+      })
+      return response.data
+    },
     enabled: options?.enabled,
   })
 

--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -869,3 +869,57 @@ async def get_attachment_download_url(
         attachment_uuid,
         expiry=expiry,
     )
+
+
+@registry.register(
+    default_title="Link case row",
+    display_group="Cases",
+    description="Link an existing table row to a case.",
+    namespace="core.cases",
+)
+async def link_row(
+    case_id: Annotated[str, Doc("Case ID")],
+    table_id: Annotated[str, Doc("Table ID")],
+    row_id: Annotated[str, Doc("Row ID")],
+) -> types.CaseTableRowRead:
+    return await get_context().cases.link_case_row(
+        case_id,
+        table_id=table_id,
+        row_id=row_id,
+    )
+
+
+@registry.register(
+    default_title="Unlink case row",
+    display_group="Cases",
+    description="Remove a linked table row from a case.",
+    namespace="core.cases",
+)
+async def unlink_row(
+    case_id: Annotated[str, Doc("Case ID")],
+    table_id: Annotated[str, Doc("Table ID")],
+    row_id: Annotated[str, Doc("Row ID")],
+) -> None:
+    await get_context().cases.unlink_case_row(
+        case_id,
+        table_id=table_id,
+        row_id=row_id,
+    )
+
+
+@registry.register(
+    default_title="Insert case row",
+    display_group="Cases",
+    description="Insert a row into a table and link it to a case.",
+    namespace="core.cases",
+)
+async def insert_row(
+    case_id: Annotated[str, Doc("Case ID")],
+    table_id: Annotated[str, Doc("Table ID")],
+    row: Annotated[dict[str, Any], Doc("Row values")],
+) -> types.CaseTableRowRead:
+    return await get_context().cases.insert_case_row(
+        case_id,
+        table_id=table_id,
+        row=row,
+    )

--- a/packages/tracecat-registry/tracecat_registry/types.py
+++ b/packages/tracecat-registry/tracecat_registry/types.py
@@ -98,6 +98,18 @@ class Case(TypedDict):
     updated_at: datetime
 
 
+class CaseTableRowRead(TypedDict):
+    id: UUID
+    case_id: UUID
+    table_id: UUID
+    table_name: str | None
+    row_id: UUID
+    row_data: dict[str, Any] | None
+    is_row_available: bool
+    created_at: datetime
+    updated_at: datetime
+
+
 class CaseRead(TypedDict):
     """Case information returned by get_case.
 
@@ -117,6 +129,7 @@ class CaseRead(TypedDict):
     tags: list[CaseTagRead]
     dropdown_values: list[CaseDropdownValueRead]
     assignee: UserRead | None
+    rows: list[CaseTableRowRead]
     created_at: datetime
     updated_at: datetime
 
@@ -136,6 +149,7 @@ class CaseReadMinimal(TypedDict):
     tags: list[CaseTagRead]
     dropdown_values: list[CaseDropdownValueRead]
     assignee: UserRead | None
+    rows: list[CaseTableRowRead]
     created_at: datetime
     updated_at: datetime
     num_tasks_completed: int
@@ -485,6 +499,26 @@ class DropdownValueChangedEvent(TypedDict, total=False):
     new_option_label: str | None
 
 
+class TableRowLinkedEvent(TypedDict, total=False):
+    user_id: UUID | None
+    created_at: str
+    wf_exec_id: str | None
+    type: str
+    table_id: UUID
+    table_name: str | None
+    row_id: UUID
+
+
+class TableRowUnlinkedEvent(TypedDict, total=False):
+    user_id: UUID | None
+    created_at: str
+    wf_exec_id: str | None
+    type: str
+    table_id: UUID
+    table_name: str | None
+    row_id: UUID
+
+
 # Union type for all case events
 type CaseEvent = (
     CreatedEvent
@@ -509,6 +543,8 @@ type CaseEvent = (
     | TaskPriorityChangedEvent
     | TaskWorkflowChangedEvent
     | DropdownValueChangedEvent
+    | TableRowLinkedEvent
+    | TableRowUnlinkedEvent
 )
 
 

--- a/tests/unit/api/test_api_case_rows.py
+++ b/tests/unit/api/test_api_case_rows.py
@@ -1,0 +1,152 @@
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.cases import router as cases_router
+from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.rows import internal_router as internal_case_rows_router
+from tracecat.cases.rows import router as case_rows_router
+from tracecat.cases.rows.schemas import CaseTableRowLinkCreate
+from tracecat.cases.schemas import CaseReadMinimal
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import CursorPaginatedResponse
+
+
+def _build_case_read(case_id: uuid.UUID) -> CaseReadMinimal:
+    return CaseReadMinimal(
+        id=case_id,
+        short_id="CASE-0001",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        summary="Case",
+        status=CaseStatus.NEW,
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+        assignee=None,
+        tags=[],
+        dropdown_values=[],
+        num_tasks_completed=0,
+        num_tasks_total=0,
+    )
+
+
+@pytest.mark.anyio
+async def test_list_cases_include_rows_hydration_error_is_sanitized(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    case_id = uuid.uuid4()
+    with (
+        patch.object(cases_router, "CasesService") as mock_cases_service_cls,
+        patch.object(cases_router, "CaseTableRowsService") as mock_rows_service_cls,
+    ):
+        mock_cases_service = AsyncMock()
+        mock_cases_service.list_cases.return_value = CursorPaginatedResponse(
+            items=[_build_case_read(case_id)],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_cases_service_cls.return_value = mock_cases_service
+
+        mock_rows_service = AsyncMock()
+        mock_rows_service.hydrate_case_rows.side_effect = RuntimeError(
+            "sensitive error details"
+        )
+        mock_rows_service_cls.return_value = mock_rows_service
+
+        response = client.get(
+            "/cases",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "include_rows": "true",
+            },
+        )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json()["detail"] == "Failed to hydrate linked rows"
+
+
+@pytest.mark.anyio
+async def test_link_case_row_returns_400_for_value_error(
+    test_admin_role: Role,
+) -> None:
+    case_id = uuid.uuid4()
+    table_id = uuid.uuid4()
+    row_id = uuid.uuid4()
+    with patch.object(case_rows_router, "CaseTableRowsService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case_or_raise.return_value = MagicMock()
+        mock_service.link_row.side_effect = ValueError(
+            "A case can have at most 200 linked rows"
+        )
+        mock_service_cls.return_value = mock_service
+
+        with pytest.raises(HTTPException) as exc_info:
+            await case_rows_router.link_case_row(
+                role=test_admin_role,
+                session=AsyncMock(),
+                case_id=case_id,
+                params=CaseTableRowLinkCreate(table_id=table_id, row_id=row_id),
+            )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail == "A case can have at most 200 linked rows"
+
+
+@pytest.mark.anyio
+async def test_internal_link_case_row_returns_404_for_missing_case(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    case_id = uuid.uuid4()
+    table_id = uuid.uuid4()
+    row_id = uuid.uuid4()
+    with patch.object(
+        internal_case_rows_router, "CaseTableRowsService"
+    ) as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case_or_raise.side_effect = TracecatNotFoundError(
+            "Case not found"
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            f"/internal/cases/{case_id}/rows",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"table_id": str(table_id), "row_id": str(row_id)},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Case not found"
+
+
+@pytest.mark.anyio
+async def test_internal_link_case_row_returns_400_for_value_error(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    case_id = uuid.uuid4()
+    table_id = uuid.uuid4()
+    row_id = uuid.uuid4()
+    with patch.object(
+        internal_case_rows_router, "CaseTableRowsService"
+    ) as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case_or_raise.return_value = MagicMock()
+        mock_service.link_row.side_effect = ValueError(
+            "A case can link rows from at most 10 tables"
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            f"/internal/cases/{case_id}/rows",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"table_id": str(table_id), "row_id": str(row_id)},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "A case can link rows from at most 10 tables"

--- a/tests/unit/api/test_api_internal_cases.py
+++ b/tests/unit/api/test_api_internal_cases.py
@@ -1,0 +1,134 @@
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.cases import internal_router as internal_cases_router
+from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.rows.schemas import CaseTableRowRead
+from tracecat.db.models import Case, Workspace
+
+
+@pytest.fixture
+def mock_internal_case(test_workspace: Workspace) -> Case:
+    case = Case(
+        workspace_id=test_workspace.id,
+        summary="Internal case summary",
+        description="Internal case description",
+        priority=CasePriority.MEDIUM,
+        severity=CaseSeverity.LOW,
+        status=CaseStatus.NEW,
+        payload={"source": "test"},
+        assignee_id=None,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    case.id = uuid.uuid4()
+    case.case_number = 1
+    case.tags = []
+    case.assignee = None
+    case.dropdown_values = []
+    return case
+
+
+def _build_case_row(case_id: uuid.UUID) -> CaseTableRowRead:
+    return CaseTableRowRead(
+        id=uuid.uuid4(),
+        case_id=case_id,
+        table_id=uuid.uuid4(),
+        table_name="table_name",
+        row_id=uuid.uuid4(),
+        row_data={"value": "row data"},
+        is_row_available=True,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+@pytest.mark.anyio
+async def test_internal_get_case_include_rows_hydrates_rows(
+    client: TestClient, test_admin_role: Role, mock_internal_case: Case
+) -> None:
+    row = _build_case_row(mock_internal_case.id)
+    with (
+        patch.object(internal_cases_router, "CasesService") as mock_service_cls,
+        patch.object(
+            internal_cases_router,
+            "_list_case_dropdown_values",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            internal_cases_router,
+            "_list_case_rows",
+            new=AsyncMock(return_value=[row]),
+        ) as mock_list_rows,
+    ):
+        mock_service = AsyncMock()
+        mock_service.get_case.return_value = mock_internal_case
+        mock_service.fields = AsyncMock()
+        mock_service.fields.get_fields.return_value = {}
+        mock_service.fields.list_fields.return_value = []
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            f"/internal/cases/{mock_internal_case.id}",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "include_rows": "true",
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data["rows"]) == 1
+    assert data["rows"][0]["id"] == str(row.id)
+    assert mock_list_rows.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_internal_update_case_include_rows_hydrates_rows(
+    client: TestClient, test_admin_role: Role, mock_internal_case: Case
+) -> None:
+    row = _build_case_row(mock_internal_case.id)
+    with (
+        patch.object(internal_cases_router, "CasesService") as mock_service_cls,
+        patch.object(
+            internal_cases_router,
+            "_list_case_dropdown_values",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            internal_cases_router,
+            "_list_case_rows",
+            new=AsyncMock(return_value=[row]),
+        ) as mock_list_rows,
+    ):
+        mock_service = AsyncMock()
+        mock_service.get_case.return_value = mock_internal_case
+        updated_case = mock_internal_case
+        updated_case.summary = "Updated summary"
+        mock_service.update_case.return_value = updated_case
+        mock_service.fields = AsyncMock()
+        mock_service.fields.get_fields.return_value = {}
+        mock_service.fields.list_fields.return_value = []
+        mock_service_cls.return_value = mock_service
+
+        response = client.patch(
+            f"/internal/cases/{mock_internal_case.id}",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "include_rows": "true",
+            },
+            json={"summary": "Updated summary"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["summary"] == "Updated summary"
+    assert len(data["rows"]) == 1
+    assert data["rows"][0]["id"] == str(row.id)
+    assert mock_list_rows.await_count == 1

--- a/tests/unit/test_case_table_rows_service.py
+++ b/tests/unit/test_case_table_rows_service.py
@@ -1,0 +1,214 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.rows.schemas import CaseTableRowLinkCreate
+from tracecat.cases.rows.service import (
+    MAX_TABLES_PER_CASE,
+    CaseTableRowsService,
+)
+from tracecat.cases.schemas import CaseCreate
+from tracecat.cases.service import CasesService
+from tracecat.db.models import CaseTableRow
+from tracecat.pagination import BaseCursorPaginator
+from tracecat.tables.enums import SqlType
+from tracecat.tables.schemas import TableColumnCreate, TableCreate, TableRowInsert
+from tracecat.tables.service import TablesService
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def cases_service(session: AsyncSession, svc_role: Role) -> CasesService:
+    return CasesService(session=session, role=svc_role)
+
+
+@pytest.fixture
+async def case_rows_service(
+    session: AsyncSession, svc_role: Role
+) -> CaseTableRowsService:
+    return CaseTableRowsService(session=session, role=svc_role)
+
+
+@pytest.fixture
+async def tables_service(session: AsyncSession, svc_role: Role) -> TablesService:
+    return TablesService(session=session, role=svc_role)
+
+
+async def _create_case(cases_service: CasesService):
+    return await cases_service.create_case(
+        CaseCreate(
+            summary="Case rows test",
+            description="Case rows pagination and linking test",
+            status=CaseStatus.NEW,
+            priority=CasePriority.MEDIUM,
+            severity=CaseSeverity.LOW,
+        )
+    )
+
+
+async def _create_table_with_row(
+    tables_service: TablesService,
+    *,
+    name: str,
+    value: str,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    table = await tables_service.create_table(
+        TableCreate(
+            name=name,
+            columns=[
+                TableColumnCreate(
+                    name="value",
+                    type=SqlType.TEXT,
+                    nullable=True,
+                    default=None,
+                )
+            ],
+        )
+    )
+    row = await tables_service.insert_row(
+        table,
+        TableRowInsert(data={"value": value}),
+    )
+    row_id = row.get("id")
+    assert isinstance(row_id, uuid.UUID)
+    return table.id, row_id
+
+
+@pytest.mark.anyio
+async def test_link_row_allows_existing_table_when_table_limit_reached(
+    cases_service: CasesService,
+    case_rows_service: CaseTableRowsService,
+    tables_service: TablesService,
+) -> None:
+    case = await _create_case(cases_service)
+
+    first_table_id: uuid.UUID | None = None
+    for idx in range(MAX_TABLES_PER_CASE):
+        table_id, row_id = await _create_table_with_row(
+            tables_service,
+            name=f"case_rows_cap_{idx}_{uuid.uuid4().hex[:8]}",
+            value=f"value-{idx}",
+        )
+        if first_table_id is None:
+            first_table_id = table_id
+        await case_rows_service.link_row(
+            case=case,
+            params=CaseTableRowLinkCreate(table_id=table_id, row_id=row_id),
+        )
+
+    assert first_table_id is not None
+    first_table = await tables_service.get_table(first_table_id)
+    extra_row = await tables_service.insert_row(
+        first_table,
+        TableRowInsert(data={"value": "extra"}),
+    )
+    extra_row_id = extra_row.get("id")
+    assert isinstance(extra_row_id, uuid.UUID)
+
+    link = await case_rows_service.link_row(
+        case=case,
+        params=CaseTableRowLinkCreate(table_id=first_table_id, row_id=extra_row_id),
+    )
+
+    assert link.case_id == case.id
+    assert link.table_id == first_table_id
+    assert link.row_id == extra_row_id
+
+
+@pytest.mark.anyio
+async def test_list_rows_cursor_uses_created_at_and_id_order(
+    session: AsyncSession,
+    cases_service: CasesService,
+    case_rows_service: CaseTableRowsService,
+    tables_service: TablesService,
+) -> None:
+    case = await _create_case(cases_service)
+    table_id, _ = await _create_table_with_row(
+        tables_service,
+        name=f"case_rows_cursor_{uuid.uuid4().hex[:8]}",
+        value="seed",
+    )
+
+    newest_small_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    middle_large_id = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+    older_small_id = uuid.UUID("00000000-0000-0000-0000-000000000002")
+    oldest_small_id = uuid.UUID("00000000-0000-0000-0000-000000000003")
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+
+    links = [
+        CaseTableRow(
+            id=newest_small_id,
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=uuid.uuid4(),
+            created_at=base_time + timedelta(minutes=3),
+            updated_at=base_time + timedelta(minutes=3),
+        ),
+        CaseTableRow(
+            id=middle_large_id,
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=uuid.uuid4(),
+            created_at=base_time + timedelta(minutes=2),
+            updated_at=base_time + timedelta(minutes=2),
+        ),
+        CaseTableRow(
+            id=older_small_id,
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=uuid.uuid4(),
+            created_at=base_time + timedelta(minutes=1),
+            updated_at=base_time + timedelta(minutes=1),
+        ),
+        CaseTableRow(
+            id=oldest_small_id,
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=uuid.uuid4(),
+            created_at=base_time,
+            updated_at=base_time,
+        ),
+    ]
+    session.add_all(links)
+    await session.commit()
+
+    page1 = await case_rows_service.list_rows(
+        case_id=case.id,
+        limit=2,
+        include_row_data=False,
+    )
+    assert [item.id for item in page1.items] == [newest_small_id, middle_large_id]
+    assert page1.next_cursor is not None
+
+    page2 = await case_rows_service.list_rows(
+        case_id=case.id,
+        limit=2,
+        cursor=page1.next_cursor,
+        include_row_data=False,
+    )
+    assert [item.id for item in page2.items] == [older_small_id, oldest_small_id]
+    combined_ids = [item.id for item in page1.items] + [item.id for item in page2.items]
+    assert combined_ids == [
+        newest_small_id,
+        middle_large_id,
+        older_small_id,
+        oldest_small_id,
+    ]
+
+    legacy_cursor = BaseCursorPaginator.encode_cursor(middle_large_id)
+    legacy_page = await case_rows_service.list_rows(
+        case_id=case.id,
+        limit=2,
+        cursor=legacy_cursor,
+        include_row_data=False,
+    )
+    assert [item.id for item in legacy_page.items] == [older_small_id, oldest_small_id]

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -810,10 +810,10 @@ class TestCasesService:
 
         assert search_response.model_dump() == list_response.model_dump()
 
-    async def test_search_cases_short_id_contains_match(
+    async def test_search_cases_short_id_exact_match(
         self, cases_service: CasesService
     ) -> None:
-        """short_id filtering should support contains matching on case short IDs."""
+        """short_id filtering should match the exact case short ID only."""
         target_case = await cases_service.create_case(
             CaseCreate(
                 summary="Target case",
@@ -834,23 +834,10 @@ class TestCasesService:
             )
         )
 
-        target_digits = target_case.short_id.split("-", 1)[1]
-        other_digits = other_case.short_id.split("-", 1)[1]
-        fragment: str | None = None
-        for length in range(1, len(target_digits)):
-            for start in range(0, len(target_digits) - length + 1):
-                candidate = target_digits[start : start + length]
-                if candidate and candidate not in other_digits:
-                    fragment = candidate
-                    break
-            if fragment is not None:
-                break
-
-        assert fragment is not None
         params = CursorPaginationParams(limit=20, cursor=None, reverse=False)
         response = await cases_service.search_cases(
             params=params,
-            short_id=fragment,
+            short_id=target_case.short_id,
             order_by="created_at",
             sort="asc",
         )
@@ -858,6 +845,21 @@ class TestCasesService:
         result_ids = {item.id for item in response.items}
         assert target_case.id in result_ids
         assert other_case.id not in result_ids
+
+        # Partial strings should not match case short IDs.
+        non_exact_short_id = (
+            str(target_case.case_number * 10)
+            if target_case.case_number < 10
+            else str(target_case.case_number)[:-1]
+        )
+        non_exact_response = await cases_service.search_cases(
+            params=params,
+            short_id=non_exact_short_id,
+            order_by="created_at",
+            sort="asc",
+        )
+        non_exact_ids = {item.id for item in non_exact_response.items}
+        assert target_case.id not in non_exact_ids
 
     async def test_search_cases_short_id_rejects_invalid_value(
         self, cases_service: CasesService

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -69,6 +69,10 @@ from tracecat.cases.internal_router import (
 )
 from tracecat.cases.router import case_fields_router as case_fields_router
 from tracecat.cases.router import cases_router as cases_router
+from tracecat.cases.rows.internal_router import (
+    router as internal_case_rows_router,
+)
+from tracecat.cases.rows.router import router as case_rows_router
 from tracecat.cases.tag_definitions.internal_router import (
     router as internal_case_tag_definitions_router,
 )
@@ -426,6 +430,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(org_secrets_router)
     app.include_router(tables_router)
     app.include_router(cases_router)
+    app.include_router(case_rows_router)
     app.include_router(case_fields_router)
     app.include_router(case_tags_router)
     app.include_router(case_tag_definitions_router)
@@ -473,6 +478,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(internal_agent_preset_router)
     app.include_router(internal_case_attachments_router)
     app.include_router(internal_cases_router)
+    app.include_router(internal_case_rows_router)
     app.include_router(internal_comments_router)
     app.include_router(internal_case_tags_router)
     app.include_router(internal_case_tag_definitions_router)

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -82,6 +82,8 @@ class CaseEventType(StrEnum):
     TASK_WORKFLOW_CHANGED = "task_workflow_changed"
     TASK_ASSIGNEE_CHANGED = "task_assignee_changed"
     DROPDOWN_VALUE_CHANGED = "dropdown_value_changed"
+    TABLE_ROW_LINKED = "table_row_linked"
+    TABLE_ROW_UNLINKED = "table_row_unlinked"
 
 
 class CaseTaskStatus(StrEnum):

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -25,6 +25,7 @@ from tracecat.cases.dropdowns.service import CaseDropdownValuesService
 from tracecat.cases.durations.schemas import CaseDurationMetric
 from tracecat.cases.durations.service import CaseDurationService
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.rows.schemas import CaseTableRowRead
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
     AssigneeChangedEventRead,
@@ -80,6 +81,23 @@ async def _list_case_dropdown_values(
     if not await dropdown_service.has_entitlement(Entitlement.CASE_ADDONS):
         return []
     return await dropdown_service.list_values_for_case(case_id)
+
+
+async def _list_case_rows(
+    *,
+    session: AsyncDBSession,
+    role: ExecutorWorkspaceRole,
+    case_id: uuid.UUID,
+    include_rows: bool,
+) -> list[CaseTableRowRead]:
+    if not include_rows:
+        return []
+    rows_service = CaseTableRowsService(session, role)
+    rows_by_case = await rows_service.hydrate_case_rows(
+        case_ids=[case_id],
+        include_row_data=True,
+    )
+    return rows_by_case.get(case_id, [])
 
 
 @router.get("")
@@ -335,6 +353,12 @@ async def get_case(
     dropdown_reads = await _list_case_dropdown_values(
         session=session, role=role, case_id=case.id
     )
+    rows = await _list_case_rows(
+        session=session,
+        role=role,
+        case_id=case.id,
+        include_rows=include_rows,
+    )
 
     return CaseRead(
         id=case.id,
@@ -353,6 +377,7 @@ async def get_case(
         payload=case.payload,
         tags=tag_reads,
         dropdown_values=dropdown_reads,
+        rows=rows,
     )
 
 
@@ -476,6 +501,12 @@ async def update_case(
     dropdown_reads = await _list_case_dropdown_values(
         session=session, role=role, case_id=updated_case.id
     )
+    rows = await _list_case_rows(
+        session=session,
+        role=role,
+        case_id=updated_case.id,
+        include_rows=include_rows,
+    )
 
     return CaseRead(
         id=updated_case.id,
@@ -494,6 +525,7 @@ async def update_case(
         payload=updated_case.payload,
         tags=tag_reads,
         dropdown_values=dropdown_reads,
+        rows=rows,
     )
 
 

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -221,15 +221,22 @@ async def list_cases(
             detail="Failed to retrieve cases",
         ) from e
     if include_rows and cases.items:
-        rows_service = CaseTableRowsService(session, role)
-        rows_by_case = await rows_service.hydrate_case_rows(
-            case_ids=[item.id for item in cases.items],
-            include_row_data=True,
-        )
-        cases.items = [
-            item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
-            for item in cases.items
-        ]
+        try:
+            rows_service = CaseTableRowsService(session, role)
+            rows_by_case = await rows_service.hydrate_case_rows(
+                case_ids=[item.id for item in cases.items],
+                include_row_data=True,
+            )
+            cases.items = [
+                item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
+                for item in cases.items
+            ]
+        except Exception as e:
+            logger.error(f"Failed to hydrate case rows: {e}")
+            raise HTTPException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to hydrate linked rows",
+            ) from e
     return cases
 
 
@@ -253,7 +260,7 @@ async def search_cases(
     ),
     short_id: str | None = Query(
         None,
-        description="Search by case short ID fragment only (contains match, e.g. 42 or CASE-0042)",
+        description="Search by exact case short ID (e.g. 42 or CASE-0042)",
     ),
     status: list[CaseStatus] | None = Query(None, description="Filter by case status"),
     priority: list[CasePriority] | None = Query(
@@ -346,15 +353,22 @@ async def search_cases(
             detail="Failed to retrieve cases",
         ) from e
     if include_rows and cases.items:
-        rows_service = CaseTableRowsService(session, role)
-        rows_by_case = await rows_service.hydrate_case_rows(
-            case_ids=[item.id for item in cases.items],
-            include_row_data=True,
-        )
-        cases.items = [
-            item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
-            for item in cases.items
-        ]
+        try:
+            rows_service = CaseTableRowsService(session, role)
+            rows_by_case = await rows_service.hydrate_case_rows(
+                case_ids=[item.id for item in cases.items],
+                include_row_data=True,
+            )
+            cases.items = [
+                item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
+                for item in cases.items
+            ]
+        except Exception as e:
+            logger.error(f"Failed to hydrate case rows: {e}")
+            raise HTTPException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to hydrate linked rows",
+            ) from e
     return cases
 
 

--- a/tracecat/cases/rows/internal_router.py
+++ b/tracecat/cases/rows/internal_router.py
@@ -1,0 +1,101 @@
+import uuid
+
+from fastapi import APIRouter, HTTPException, Query
+from starlette.status import HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND
+
+from tracecat import config
+from tracecat.auth.dependencies import ExecutorWorkspaceRole
+from tracecat.authz.controls import require_scope
+from tracecat.cases.rows.schemas import (
+    CaseTableRowInsertCreate,
+    CaseTableRowLinkCreate,
+    CaseTableRowRead,
+)
+from tracecat.cases.rows.service import CaseTableRowsService
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import CursorPaginatedResponse
+
+router = APIRouter(
+    prefix="/internal/cases", tags=["internal-cases"], include_in_schema=False
+)
+
+
+@router.get("/{case_id}/rows")
+@require_scope("case:read")
+async def list_case_rows(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    limit: int = Query(
+        config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[CaseTableRowRead]:
+    service = CaseTableRowsService(session, role)
+    try:
+        await service.get_case_or_raise(case_id)
+        return await service.list_rows(
+            case_id=case_id,
+            limit=limit,
+            cursor=cursor,
+            reverse=reverse,
+            include_row_data=True,
+        )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.post("/{case_id}/rows", status_code=HTTP_201_CREATED)
+@require_scope("case:update")
+async def link_case_row(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    params: CaseTableRowLinkCreate,
+) -> CaseTableRowRead:
+    service = CaseTableRowsService(session, role)
+    case = await service.get_case_or_raise(case_id)
+    link = await service.link_row(case=case, params=params)
+    hydrated = await service._hydrate_links([link], include_row_data=True)
+    return hydrated[0]
+
+
+@router.post("/{case_id}/rows/insert", status_code=HTTP_201_CREATED)
+@require_scope("case:update")
+async def insert_case_row(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    params: CaseTableRowInsertCreate,
+) -> CaseTableRowRead:
+    service = CaseTableRowsService(session, role)
+    case = await service.get_case_or_raise(case_id)
+    link = await service.insert_row_to_case(case=case, params=params)
+    hydrated = await service._hydrate_links([link], include_row_data=True)
+    return hydrated[0]
+
+
+@router.delete("/{case_id}/rows/{table_id}/{row_id}", status_code=HTTP_204_NO_CONTENT)
+@require_scope("case:update")
+async def unlink_case_row(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    table_id: uuid.UUID,
+    row_id: uuid.UUID,
+) -> None:
+    service = CaseTableRowsService(session, role)
+    case = await service.get_case_or_raise(case_id)
+    deleted = await service.unlink_row(case=case, table_id=table_id, row_id=row_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND, detail="Linked row not found"
+        )

--- a/tracecat/cases/rows/internal_router.py
+++ b/tracecat/cases/rows/internal_router.py
@@ -1,7 +1,12 @@
 import uuid
 
 from fastapi import APIRouter, HTTPException, Query
-from starlette.status import HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND
+from starlette.status import (
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+    HTTP_404_NOT_FOUND,
+)
 
 from tracecat import config
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
@@ -48,6 +53,8 @@ async def list_case_rows(
         )
     except TracecatNotFoundError as exc:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.post("/{case_id}/rows", status_code=HTTP_201_CREATED)
@@ -60,10 +67,15 @@ async def link_case_row(
     params: CaseTableRowLinkCreate,
 ) -> CaseTableRowRead:
     service = CaseTableRowsService(session, role)
-    case = await service.get_case_or_raise(case_id)
-    link = await service.link_row(case=case, params=params)
-    hydrated = await service._hydrate_links([link], include_row_data=True)
-    return hydrated[0]
+    try:
+        case = await service.get_case_or_raise(case_id)
+        link = await service.link_row(case=case, params=params)
+        hydrated = await service._hydrate_links([link], include_row_data=True)
+        return hydrated[0]
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.post("/{case_id}/rows/insert", status_code=HTTP_201_CREATED)
@@ -76,10 +88,15 @@ async def insert_case_row(
     params: CaseTableRowInsertCreate,
 ) -> CaseTableRowRead:
     service = CaseTableRowsService(session, role)
-    case = await service.get_case_or_raise(case_id)
-    link = await service.insert_row_to_case(case=case, params=params)
-    hydrated = await service._hydrate_links([link], include_row_data=True)
-    return hydrated[0]
+    try:
+        case = await service.get_case_or_raise(case_id)
+        link = await service.insert_row_to_case(case=case, params=params)
+        hydrated = await service._hydrate_links([link], include_row_data=True)
+        return hydrated[0]
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.delete("/{case_id}/rows/{table_id}/{row_id}", status_code=HTTP_204_NO_CONTENT)
@@ -93,9 +110,12 @@ async def unlink_case_row(
     row_id: uuid.UUID,
 ) -> None:
     service = CaseTableRowsService(session, role)
-    case = await service.get_case_or_raise(case_id)
-    deleted = await service.unlink_row(case=case, table_id=table_id, row_id=row_id)
-    if not deleted:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND, detail="Linked row not found"
-        )
+    try:
+        case = await service.get_case_or_raise(case_id)
+        deleted = await service.unlink_row(case=case, table_id=table_id, row_id=row_id)
+        if not deleted:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Linked row not found"
+            )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/tracecat/cases/rows/router.py
+++ b/tracecat/cases/rows/router.py
@@ -1,0 +1,113 @@
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query
+from starlette.status import HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND
+
+from tracecat import config
+from tracecat.auth.credentials import RoleACL
+from tracecat.auth.types import Role
+from tracecat.authz.controls import require_scope
+from tracecat.cases.rows.schemas import (
+    CaseTableRowInsertCreate,
+    CaseTableRowLinkCreate,
+    CaseTableRowRead,
+)
+from tracecat.cases.rows.service import CaseTableRowsService
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import CursorPaginatedResponse
+
+router = APIRouter(prefix="/cases", tags=["cases"])
+
+WorkspaceUser = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=False,
+        require_workspace="yes",
+    ),
+]
+
+
+@router.get("/{case_id}/rows")
+@require_scope("case:read")
+async def list_case_rows(
+    *,
+    role: WorkspaceUser,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    limit: int = Query(
+        config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[CaseTableRowRead]:
+    service = CaseTableRowsService(session, role)
+    try:
+        await service.get_case_or_raise(case_id)
+        return await service.list_rows(
+            case_id=case_id,
+            limit=limit,
+            cursor=cursor,
+            reverse=reverse,
+            include_row_data=True,
+        )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.post("/{case_id}/rows", status_code=HTTP_201_CREATED)
+@require_scope("case:update")
+async def link_case_row(
+    *,
+    role: WorkspaceUser,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    params: CaseTableRowLinkCreate,
+) -> CaseTableRowRead:
+    service = CaseTableRowsService(session, role)
+    try:
+        case = await service.get_case_or_raise(case_id)
+        link = await service.link_row(case=case, params=params)
+        hydrated = await service._hydrate_links([link], include_row_data=True)
+        return hydrated[0]
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.post("/{case_id}/rows/insert", status_code=HTTP_201_CREATED)
+@require_scope("case:update")
+async def insert_case_row(
+    *,
+    role: WorkspaceUser,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    params: CaseTableRowInsertCreate,
+) -> CaseTableRowRead:
+    service = CaseTableRowsService(session, role)
+    case = await service.get_case_or_raise(case_id)
+    link = await service.insert_row_to_case(case=case, params=params)
+    hydrated = await service._hydrate_links([link], include_row_data=True)
+    return hydrated[0]
+
+
+@router.delete("/{case_id}/rows/{table_id}/{row_id}", status_code=HTTP_204_NO_CONTENT)
+@require_scope("case:update")
+async def unlink_case_row(
+    *,
+    role: WorkspaceUser,
+    session: AsyncDBSession,
+    case_id: uuid.UUID,
+    table_id: uuid.UUID,
+    row_id: uuid.UUID,
+) -> None:
+    service = CaseTableRowsService(session, role)
+    case = await service.get_case_or_raise(case_id)
+    deleted = await service.unlink_row(case=case, table_id=table_id, row_id=row_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND, detail="Linked row not found"
+        )

--- a/tracecat/cases/rows/router.py
+++ b/tracecat/cases/rows/router.py
@@ -2,7 +2,12 @@ import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
-from starlette.status import HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND
+from starlette.status import (
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+    HTTP_404_NOT_FOUND,
+)
 
 from tracecat import config
 from tracecat.auth.credentials import RoleACL
@@ -57,6 +62,8 @@ async def list_case_rows(
         )
     except TracecatNotFoundError as exc:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.post("/{case_id}/rows", status_code=HTTP_201_CREATED)
@@ -76,6 +83,8 @@ async def link_case_row(
         return hydrated[0]
     except TracecatNotFoundError as exc:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.post("/{case_id}/rows/insert", status_code=HTTP_201_CREATED)
@@ -88,10 +97,15 @@ async def insert_case_row(
     params: CaseTableRowInsertCreate,
 ) -> CaseTableRowRead:
     service = CaseTableRowsService(session, role)
-    case = await service.get_case_or_raise(case_id)
-    link = await service.insert_row_to_case(case=case, params=params)
-    hydrated = await service._hydrate_links([link], include_row_data=True)
-    return hydrated[0]
+    try:
+        case = await service.get_case_or_raise(case_id)
+        link = await service.insert_row_to_case(case=case, params=params)
+        hydrated = await service._hydrate_links([link], include_row_data=True)
+        return hydrated[0]
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.delete("/{case_id}/rows/{table_id}/{row_id}", status_code=HTTP_204_NO_CONTENT)
@@ -105,9 +119,12 @@ async def unlink_case_row(
     row_id: uuid.UUID,
 ) -> None:
     service = CaseTableRowsService(session, role)
-    case = await service.get_case_or_raise(case_id)
-    deleted = await service.unlink_row(case=case, table_id=table_id, row_id=row_id)
-    if not deleted:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND, detail="Linked row not found"
-        )
+    try:
+        case = await service.get_case_or_raise(case_id)
+        deleted = await service.unlink_row(case=case, table_id=table_id, row_id=row_id)
+        if not deleted:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND, detail="Linked row not found"
+            )
+    except TracecatNotFoundError as exc:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/tracecat/cases/rows/schemas.py
+++ b/tracecat/cases/rows/schemas.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import Field
+
+from tracecat.core.schemas import Schema
+from tracecat.tables.schemas import TableRowInsert
+
+
+class CaseTableRowRead(Schema):
+    id: uuid.UUID
+    case_id: uuid.UUID
+    table_id: uuid.UUID
+    table_name: str | None = None
+    row_id: uuid.UUID
+    row_data: dict[str, Any] | None = None
+    is_row_available: bool = True
+    created_at: datetime
+    updated_at: datetime
+
+
+class CaseTableRowLinkCreate(Schema):
+    table_id: uuid.UUID
+    row_id: uuid.UUID
+
+
+class CaseTableRowUnlink(Schema):
+    table_id: uuid.UUID
+    row_id: uuid.UUID
+
+
+class CaseTableRowInsertCreate(Schema):
+    table_id: uuid.UUID
+    row: TableRowInsert
+
+
+class CaseTableRowsHydrateOptions(Schema):
+    include_row_data: bool = Field(default=True)

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from asyncpg.exceptions import UndefinedTableError
+from sqlalchemy import exc as sa_exc
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from tracecat.auth.types import Role
+from tracecat.cases.rows.schemas import (
+    CaseTableRowInsertCreate,
+    CaseTableRowLinkCreate,
+    CaseTableRowRead,
+)
+from tracecat.cases.schemas import TableRowLinkedEvent, TableRowUnlinkedEvent
+from tracecat.cases.service import CaseEventsService
+from tracecat.db.models import Case, CaseTableRow, Table
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.pagination import BaseCursorPaginator, CursorPaginatedResponse
+from tracecat.service import BaseWorkspaceService
+from tracecat.tables.service import TablesService
+
+MAX_LINKED_ROWS_PER_CASE = 200
+MAX_TABLES_PER_CASE = 10
+
+
+class CaseTableRowsService(BaseWorkspaceService):
+    service_name = "case_table_rows"
+
+    def __init__(self, session: AsyncSession, role: Role | None = None):
+        super().__init__(session, role)
+        self.tables = TablesService(session=self.session, role=self.role)
+
+    async def list_rows(
+        self,
+        *,
+        case_id: uuid.UUID,
+        limit: int,
+        cursor: str | None = None,
+        reverse: bool = False,
+        include_row_data: bool = True,
+    ) -> CursorPaginatedResponse[CaseTableRowRead]:
+        paginator = BaseCursorPaginator(self.session)
+        stmt = (
+            select(CaseTableRow)
+            .where(
+                CaseTableRow.workspace_id == self.workspace_id,
+                CaseTableRow.case_id == case_id,
+            )
+            .options(selectinload(CaseTableRow.case))
+            .order_by(CaseTableRow.created_at.desc(), CaseTableRow.id.desc())
+        )
+
+        if cursor:
+            cursor_data = paginator.decode_cursor(cursor)
+            cursor_id = uuid.UUID(cursor_data.id)
+            if reverse:
+                stmt = stmt.where(CaseTableRow.id > cursor_id)
+                stmt = stmt.order_by(CaseTableRow.id.asc())
+            else:
+                stmt = stmt.where(CaseTableRow.id < cursor_id)
+
+        stmt = stmt.limit(limit + 1)
+        result = await self.session.execute(stmt)
+        links = result.scalars().all()
+
+        has_more = len(links) > limit
+        items = links[:limit] if has_more else links
+        has_previous = cursor is not None
+
+        if reverse:
+            items = list(reversed(items))
+
+        hydrated = await self._hydrate_links(items, include_row_data=include_row_data)
+
+        next_cursor = None
+        prev_cursor = None
+        if items and has_more:
+            next_cursor = paginator.encode_cursor(items[-1].id)
+        if items and cursor:
+            prev_cursor = paginator.encode_cursor(items[0].id)
+
+        if reverse:
+            next_cursor, prev_cursor = prev_cursor, next_cursor
+            has_more, has_previous = has_previous, has_more
+
+        return CursorPaginatedResponse(
+            items=hydrated,
+            next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
+            has_more=has_more,
+            has_previous=has_previous,
+        )
+
+    async def link_row(
+        self, *, case: Case, params: CaseTableRowLinkCreate
+    ) -> CaseTableRow:
+        table = await self.tables.get_table(params.table_id)
+        await self.tables.get_row(table, params.row_id)
+
+        dedupe_stmt = select(CaseTableRow).where(
+            CaseTableRow.workspace_id == self.workspace_id,
+            CaseTableRow.case_id == case.id,
+            CaseTableRow.table_id == params.table_id,
+            CaseTableRow.row_id == params.row_id,
+        )
+        existing = (await self.session.execute(dedupe_stmt)).scalars().first()
+        if existing is not None:
+            return existing
+
+        total_links_stmt = (
+            select(func.count())
+            .select_from(CaseTableRow)
+            .where(
+                CaseTableRow.workspace_id == self.workspace_id,
+                CaseTableRow.case_id == case.id,
+            )
+        )
+        total_links = int((await self.session.scalar(total_links_stmt)) or 0)
+        if total_links >= MAX_LINKED_ROWS_PER_CASE:
+            raise ValueError(
+                f"A case can have at most {MAX_LINKED_ROWS_PER_CASE} linked rows"
+            )
+
+        distinct_tables_stmt = select(
+            func.count(sa.distinct(CaseTableRow.table_id))
+        ).where(
+            CaseTableRow.workspace_id == self.workspace_id,
+            CaseTableRow.case_id == case.id,
+        )
+        distinct_tables = int((await self.session.scalar(distinct_tables_stmt)) or 0)
+        if distinct_tables >= MAX_TABLES_PER_CASE:
+            raise ValueError(
+                f"A case can link rows from at most {MAX_TABLES_PER_CASE} tables"
+            )
+
+        link = CaseTableRow(
+            workspace_id=self.workspace_id,
+            case_id=case.id,
+            table_id=table.id,
+            row_id=params.row_id,
+        )
+        self.session.add(link)
+
+        await CaseEventsService(self.session, self.role).create_event(
+            case,
+            TableRowLinkedEvent(
+                table_id=table.id, table_name=table.name, row_id=params.row_id
+            ),
+        )
+        await self.session.commit()
+        await self.session.refresh(link)
+        return link
+
+    async def unlink_row(
+        self, *, case: Case, table_id: uuid.UUID, row_id: uuid.UUID
+    ) -> bool:
+        stmt = select(CaseTableRow).where(
+            CaseTableRow.workspace_id == self.workspace_id,
+            CaseTableRow.case_id == case.id,
+            CaseTableRow.table_id == table_id,
+            CaseTableRow.row_id == row_id,
+        )
+        link = (await self.session.execute(stmt)).scalars().first()
+        if link is None:
+            return False
+
+        table_name = None
+        table_stmt = select(Table).where(
+            Table.workspace_id == self.workspace_id,
+            Table.id == table_id,
+        )
+        table = (await self.session.execute(table_stmt)).scalars().first()
+        if table is not None:
+            table_name = table.name
+
+        await self.session.delete(link)
+
+        await CaseEventsService(self.session, self.role).create_event(
+            case,
+            TableRowUnlinkedEvent(
+                table_id=table_id, table_name=table_name, row_id=row_id
+            ),
+        )
+        await self.session.commit()
+        return True
+
+    async def insert_row_to_case(
+        self,
+        *,
+        case: Case,
+        params: CaseTableRowInsertCreate,
+    ) -> CaseTableRow:
+        table = await self.tables.get_table(params.table_id)
+        row = await self.tables.insert_row(table, params.row)
+        row_id = row.get("id")
+        if not isinstance(row_id, uuid.UUID):
+            raise ValueError("Inserted row ID is invalid")
+        return await self.link_row(
+            case=case,
+            params=CaseTableRowLinkCreate(table_id=params.table_id, row_id=row_id),
+        )
+
+    async def hydrate_case_rows(
+        self,
+        *,
+        case_ids: list[uuid.UUID],
+        include_row_data: bool,
+    ) -> dict[uuid.UUID, list[CaseTableRowRead]]:
+        if not case_ids:
+            return {}
+        stmt = (
+            select(CaseTableRow)
+            .where(
+                CaseTableRow.workspace_id == self.workspace_id,
+                CaseTableRow.case_id.in_(case_ids),
+            )
+            .order_by(CaseTableRow.created_at.desc(), CaseTableRow.id.desc())
+        )
+        links = (await self.session.execute(stmt)).scalars().all()
+        hydrated = await self._hydrate_links(links, include_row_data=include_row_data)
+        grouped: dict[uuid.UUID, list[CaseTableRowRead]] = defaultdict(list)
+        for row in hydrated:
+            grouped[row.case_id].append(row)
+        return grouped
+
+    async def _hydrate_links(
+        self,
+        links: Sequence[CaseTableRow],
+        *,
+        include_row_data: bool,
+    ) -> list[CaseTableRowRead]:
+        tables_by_id = await self._get_tables_by_id([link.table_id for link in links])
+        hydrated: list[CaseTableRowRead] = []
+
+        for link in links:
+            table = tables_by_id.get(link.table_id)
+            row_data: dict[str, Any] | None = None
+            is_available = False
+            if include_row_data and table is not None:
+                try:
+                    row_data = await self.tables.get_row(table, link.row_id)
+                    is_available = True
+                except TracecatNotFoundError:
+                    is_available = False
+                except sa_exc.DBAPIError as exc:
+                    if not isinstance(exc.orig, UndefinedTableError):
+                        raise
+                    is_available = False
+            elif not include_row_data:
+                is_available = True
+
+            hydrated.append(
+                CaseTableRowRead(
+                    id=link.id,
+                    case_id=link.case_id,
+                    table_id=link.table_id,
+                    table_name=table.name if table else None,
+                    row_id=link.row_id,
+                    row_data=row_data,
+                    is_row_available=is_available,
+                    created_at=link.created_at,
+                    updated_at=link.updated_at,
+                )
+            )
+
+        return hydrated
+
+    async def _get_tables_by_id(
+        self, table_ids: list[uuid.UUID]
+    ) -> dict[uuid.UUID, Table]:
+        if not table_ids:
+            return {}
+        stmt = select(Table).where(
+            Table.workspace_id == self.workspace_id,
+            Table.id.in_(set(table_ids)),
+        )
+        tables = (await self.session.execute(stmt)).scalars().all()
+        return {table.id: table for table in tables}
+
+    async def get_case_or_raise(self, case_id: uuid.UUID) -> Case:
+        stmt = select(Case).where(
+            Case.workspace_id == self.workspace_id,
+            Case.id == case_id,
+        )
+        case = (await self.session.execute(stmt)).scalars().first()
+        if case is None:
+            raise TracecatNotFoundError(f"Case {case_id} not found")
+        return case

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Any
 
 import sqlalchemy as sa
 from asyncpg.exceptions import UndefinedTableError
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy import exc as sa_exc
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -60,11 +61,44 @@ class CaseTableRowsService(BaseWorkspaceService):
         if cursor:
             cursor_data = paginator.decode_cursor(cursor)
             cursor_id = uuid.UUID(cursor_data.id)
+            cursor_created_at: datetime | None = None
+            if cursor_data.sort_column == "created_at" and isinstance(
+                cursor_data.sort_value, datetime
+            ):
+                cursor_created_at = cursor_data.sort_value
+            if cursor_created_at is None:
+                cursor_created_at = await self.session.scalar(
+                    select(CaseTableRow.created_at).where(
+                        CaseTableRow.workspace_id == self.workspace_id,
+                        CaseTableRow.case_id == case_id,
+                        CaseTableRow.id == cursor_id,
+                    )
+                )
+            if cursor_created_at is None:
+                raise ValueError("Invalid cursor for case rows")
             if reverse:
-                stmt = stmt.where(CaseTableRow.id > cursor_id)
-                stmt = stmt.order_by(CaseTableRow.id.asc())
+                stmt = stmt.where(
+                    or_(
+                        CaseTableRow.created_at > cursor_created_at,
+                        and_(
+                            CaseTableRow.created_at == cursor_created_at,
+                            CaseTableRow.id > cursor_id,
+                        ),
+                    )
+                )
+                stmt = stmt.order_by(
+                    CaseTableRow.created_at.asc(), CaseTableRow.id.asc()
+                )
             else:
-                stmt = stmt.where(CaseTableRow.id < cursor_id)
+                stmt = stmt.where(
+                    or_(
+                        CaseTableRow.created_at < cursor_created_at,
+                        and_(
+                            CaseTableRow.created_at == cursor_created_at,
+                            CaseTableRow.id < cursor_id,
+                        ),
+                    )
+                )
 
         stmt = stmt.limit(limit + 1)
         result = await self.session.execute(stmt)
@@ -82,9 +116,17 @@ class CaseTableRowsService(BaseWorkspaceService):
         next_cursor = None
         prev_cursor = None
         if items and has_more:
-            next_cursor = paginator.encode_cursor(items[-1].id)
+            next_cursor = paginator.encode_cursor(
+                items[-1].id,
+                sort_column="created_at",
+                sort_value=items[-1].created_at,
+            )
         if items and cursor:
-            prev_cursor = paginator.encode_cursor(items[0].id)
+            prev_cursor = paginator.encode_cursor(
+                items[0].id,
+                sort_column="created_at",
+                sort_value=items[0].created_at,
+            )
 
         if reverse:
             next_cursor, prev_cursor = prev_cursor, next_cursor
@@ -128,17 +170,28 @@ class CaseTableRowsService(BaseWorkspaceService):
                 f"A case can have at most {MAX_LINKED_ROWS_PER_CASE} linked rows"
             )
 
-        distinct_tables_stmt = select(
-            func.count(sa.distinct(CaseTableRow.table_id))
-        ).where(
+        table_linked_stmt = select(CaseTableRow.id).where(
             CaseTableRow.workspace_id == self.workspace_id,
             CaseTableRow.case_id == case.id,
+            CaseTableRow.table_id == params.table_id,
         )
-        distinct_tables = int((await self.session.scalar(distinct_tables_stmt)) or 0)
-        if distinct_tables >= MAX_TABLES_PER_CASE:
-            raise ValueError(
-                f"A case can link rows from at most {MAX_TABLES_PER_CASE} tables"
+        table_already_linked = (
+            await self.session.execute(table_linked_stmt)
+        ).scalars().first() is not None
+        if not table_already_linked:
+            distinct_tables_stmt = select(
+                func.count(sa.distinct(CaseTableRow.table_id))
+            ).where(
+                CaseTableRow.workspace_id == self.workspace_id,
+                CaseTableRow.case_id == case.id,
             )
+            distinct_tables = int(
+                (await self.session.scalar(distinct_tables_stmt)) or 0
+            )
+            if distinct_tables >= MAX_TABLES_PER_CASE:
+                raise ValueError(
+                    f"A case can link rows from at most {MAX_TABLES_PER_CASE} tables"
+                )
 
         link = CaseTableRow(
             workspace_id=self.workspace_id,

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -246,12 +246,8 @@ class CasesService(BaseWorkspaceService):
             if not match:
                 raise ValueError("Short ID must match CASE-<number> or <number>")
 
-            short_id_fragment = match.group(1)
-            short_id_expr = func.concat(
-                "CASE-", func.lpad(cast(Case.case_number, sa.String), 4, "0")
-            )
-            short_id_pattern = func.concat("%", short_id_fragment, "%")
-            filters.append(short_id_expr.ilike(short_id_pattern))
+            short_id_number = int(match.group(1))
+            filters.append(Case.case_number == short_id_number)
 
         normalized_statuses = _normalize_filter_values(status)
         if normalized_statuses:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add linking/unlinking table rows to cases across API, UI, and events, plus a new “Tables” tab in the case panel. Adds exact short ID search (CASE-123 or 123) and optional row hydration via include_rows on case list/get/search, with improved error handling for link/insert.

- New Features
  - API: List/link/insert/unlink case rows (/cases/{case_id}/rows[...]); include_rows on case list/get/search; emits TABLE_ROW_LINKED/UNLINKED events; clearer HTTP errors on validation failures.
  - DB: New case_table_row table; added TABLE_ROW_LINKED/UNLINKED to caseeventtype enum.
  - UI: New “Tables” tab showing linked rows (read-only). Link selected table rows to cases via command palette using exact short ID. Activity feed shows link/unlink events.
  - Client/SDK: Generated types/services for row endpoints; include_rows param support on get/list.
  - Service: Row hydration on cases; deduped links; limits (200 rows per case, 10 tables per case).

- Migration
  - Run Alembic to create case_table_row and sync enum values.
  - No breaking changes; endpoints are additive.

<sup>Written for commit c09f2e67b758cf8a171d475b34d155b9e6e0af75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

