### PR TITLE
fix(eks): exempt both MCP registration paths in WAF

### DIFF
--- a/deployments/eks/modules/eks/waf.tf
+++ b/deployments/eks/modules/eks/waf.tf
@@ -28,7 +28,7 @@ resource "aws_wafv2_regex_pattern_set" "mcp_register_endpoint" {
   scope       = "REGIONAL"
 
   regular_expression {
-    regex_string = "^/mcp/register$"
+    regex_string = "^/(mcp/)?register$"
   }
 
   tags = var.tags


### PR DESCRIPTION
### Motivation
- The WAF exemption previously matched only `^/mcp/register$` while the MCP dynamic client registration route exposed by ingress/virtualservice is `/register`, which caused legitimate local OAuth client registration requests with localhost redirect URIs to be blocked by the `EC2MetaDataSSRF_Body` rule.

### Description
- Update `deployments/eks/modules/eks/waf.tf` to change the MCP registration regex from `^/mcp/register$` to `^/(mcp/)?register$` so the WAF exemption covers both `/register` and `/mcp/register`.

### Testing
- Verified the diff for `deployments/eks/modules/eks/waf.tf` and attempted `terraform fmt deployments/eks/modules/eks/waf.tf`, which could not be run in this environment because `terraform` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49761388c8333a8cf534adb43ce70)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the WAF regex to exempt both MCP registration paths (/register and /mcp/register), so local OAuth client registration is not blocked by the EC2MetaDataSSRF_Body rule. This changes ^/mcp/register$ to ^/(mcp/)?register$.

<sup>Written for commit b1807b42272944324996b69cf9ba774692f7b44b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

