### PR TITLE
fix(mcp): use Redis-backed storage for OAuth state

### DIFF
--- a/deployments/helm/tracecat/templates/_helpers.tpl
+++ b/deployments/helm/tracecat/templates/_helpers.tpl
@@ -791,6 +791,7 @@ Merges: common + temporal + postgres + mcp-specific
 {{ include "tracecat.env.common" . }}
 {{ include "tracecat.env.temporal" . }}
 {{ include "tracecat.env.postgres" . }}
+{{ include "tracecat.env.redis" . }}
 - name: TRACECAT_MCP__HOST
   value: "0.0.0.0"
 - name: TRACECAT_MCP__PORT

--- a/deployments/helm/tracecat/templates/mcp-deployment.yaml
+++ b/deployments/helm/tracecat/templates/mcp-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- include "tracecat.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: mcp
         tracecat.com/access-postgres: "true"
+        tracecat.com/access-redis: "true"
       {{- if .Values.reloader.enabled }}
       annotations:
         reloader.stakater.com/auto: "true"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -323,6 +323,8 @@ services:
       TRACECAT_MCP__BASE_URL: ${TRACECAT_MCP__BASE_URL:-http://localhost:${MCP_PORT:-8099}}
       TRACECAT_MCP__STARTUP_MAX_ATTEMPTS: ${TRACECAT_MCP__STARTUP_MAX_ATTEMPTS:-3}
       TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS: ${TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS:-2}
+      # Redis (OAuth state storage)
+      REDIS_URL: ${REDIS_URL}
       # Temporal
       TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
       TEMPORAL__CLUSTER_QUEUE: ${TEMPORAL__CLUSTER_QUEUE}
@@ -336,6 +338,8 @@ services:
       migrations:
         condition: service_completed_successfully
       temporal:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   ui:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -343,6 +343,7 @@ services:
       TRACECAT_MCP__BASE_URL: ${TRACECAT_MCP__BASE_URL:-http://localhost:${MCP_PORT:-8099}}
       TRACECAT_MCP__STARTUP_MAX_ATTEMPTS: ${TRACECAT_MCP__STARTUP_MAX_ATTEMPTS:-3}
       TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS: ${TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS:-2}
+      REDIS_URL: ${REDIS_URL}
       TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
       TEMPORAL__CLUSTER_QUEUE: ${TEMPORAL__CLUSTER_QUEUE}
       TEMPORAL__CLUSTER_NAMESPACE: ${TEMPORAL__CLUSTER_NAMESPACE}
@@ -352,6 +353,8 @@ services:
       migrations:
         condition: service_completed_successfully
       temporal:
+        condition: service_healthy
+      redis:
         condition: service_healthy
   ui:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -333,6 +333,7 @@ services:
       TRACECAT_MCP__BASE_URL: ${TRACECAT_MCP__BASE_URL:-http://localhost:${MCP_PORT:-8099}}
       TRACECAT_MCP__STARTUP_MAX_ATTEMPTS: ${TRACECAT_MCP__STARTUP_MAX_ATTEMPTS:-3}
       TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS: ${TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS:-2}
+      REDIS_URL: ${REDIS_URL}
       TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
       TEMPORAL__CLUSTER_QUEUE: ${TEMPORAL__CLUSTER_QUEUE}
       TEMPORAL__CLUSTER_NAMESPACE: ${TEMPORAL__CLUSTER_NAMESPACE}
@@ -342,6 +343,8 @@ services:
       migrations:
         condition: service_completed_successfully
       temporal:
+        condition: service_healthy
+      redis:
         condition: service_healthy
   ui:
     image: ghcr.io/tracecathq/tracecat-ui:${TRACECAT__IMAGE_TAG:-1.0.0-beta.23}

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -9,9 +9,13 @@ import uuid
 from base64 import urlsafe_b64decode
 from typing import Any
 
+from cryptography.fernet import Fernet
 from fastmcp.server.auth import AuthProvider
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.dependencies import get_access_token
+from key_value.aio.stores.redis import RedisStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+from key_value.aio.wrappers.prefix_collections import PrefixCollectionsWrapper
 from mcp.server.auth.provider import TokenError
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -22,6 +26,7 @@ from tracecat.auth.credentials import compute_effective_scopes
 from tracecat.auth.oidc import get_platform_oidc_config
 from tracecat.auth.types import Role
 from tracecat.authz.enums import OrgRole, WorkspaceRole
+from tracecat.config import REDIS_URL, TRACECAT__DB_ENCRYPTION_KEY
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import (
@@ -484,12 +489,29 @@ def create_mcp_auth() -> AuthProvider:
             response.headers["content-length"] = str(len(response.body))
             return response
 
+    # Build Redis-backed storage for OAuth state (client registrations,
+    # auth codes, tokens, transactions) so state survives restarts and
+    # is shared across MCP replicas.
+    redis_store = RedisStore(url=REDIS_URL)
+    prefixed_store = PrefixCollectionsWrapper(redis_store, prefix="mcp")
+    if TRACECAT__DB_ENCRYPTION_KEY:
+        client_storage = FernetEncryptionWrapper(
+            prefixed_store, fernet=Fernet(TRACECAT__DB_ENCRYPTION_KEY)
+        )
+    else:
+        logger.warning(
+            "TRACECAT__DB_ENCRYPTION_KEY is not set; "
+            "MCP OAuth state will be stored unencrypted in Redis"
+        )
+        client_storage = prefixed_store
+
     config_url = f"{oidc_config.issuer}/.well-known/openid-configuration"
     return TracecatOIDCProxy(
         config_url=config_url,
         client_id=oidc_config.client_id,
         client_secret=oidc_config.client_secret,
         base_url=base_url,
+        client_storage=client_storage,
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Store MCP OAuth state in Redis (with optional encryption) so logins persist across restarts and work across replicas. Helm and docker-compose now wire REDIS_URL and allow MCP to access Redis.

- **Migration**
  - Set REDIS_URL for MCP.
  - Optional: set TRACECAT__DB_ENCRYPTION_KEY to encrypt stored state.

<sup>Written for commit f7ffada43564b0cb390c51e1557ab67dfef62a3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

