### PR TITLE
fix(mcp): fail fast in missing creds

### DIFF
--- a/tests/unit/test_mcp_main.py
+++ b/tests/unit/test_mcp_main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tracecat.mcp import __main__ as mcp_main
+from tracecat.mcp.exceptions import MCPNonRetryableStartupError
 
 
 def test_main_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -11,7 +12,7 @@ def test_main_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
     def _run_mcp_server() -> None:
         attempts.append(1)
         if len(attempts) < 3:
-            raise ValueError("missing oidc config")
+            raise RuntimeError("temporary startup failure")
 
     monkeypatch.setattr(mcp_main, "_run_mcp_server", _run_mcp_server)
     monkeypatch.setattr(mcp_main, "TRACECAT_MCP__STARTUP_MAX_ATTEMPTS", 3)
@@ -52,5 +53,23 @@ def test_main_stops_on_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(mcp_main, "TRACECAT_MCP__STARTUP_MAX_ATTEMPTS", 3)
 
     mcp_main.main()
+
+    assert len(attempts) == 1
+
+
+def test_main_exits_immediately_for_non_retryable_startup_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    def _run_mcp_server() -> None:
+        attempts.append(1)
+        raise MCPNonRetryableStartupError("OIDC_ISSUER must be configured")
+
+    monkeypatch.setattr(mcp_main, "_run_mcp_server", _run_mcp_server)
+    monkeypatch.setattr(mcp_main, "TRACECAT_MCP__STARTUP_MAX_ATTEMPTS", 3)
+
+    with pytest.raises(SystemExit, match="1"):
+        mcp_main.main()
 
     assert len(attempts) == 1

--- a/tracecat/mcp/__main__.py
+++ b/tracecat/mcp/__main__.py
@@ -43,7 +43,7 @@ def main() -> None:
             logger.info("MCP server interrupted; shutting down")
             return
         except MCPNonRetryableStartupError:
-            logger.exception(
+            logger.error(
                 "MCP server startup failed due to non-retryable configuration error"
             )
             raise SystemExit(1) from None

--- a/tracecat/mcp/__main__.py
+++ b/tracecat/mcp/__main__.py
@@ -46,7 +46,7 @@ def main() -> None:
             logger.error(
                 "MCP server startup failed due to non-retryable configuration error"
             )
-            raise SystemExit(1) from None
+            raise SystemExit(0) from None
         except Exception as e:
             should_retry = attempt < max_attempts
             error = str(e)

--- a/tracecat/mcp/__main__.py
+++ b/tracecat/mcp/__main__.py
@@ -17,6 +17,7 @@ from tracecat.mcp.config import (
     TRACECAT_MCP__STARTUP_MAX_ATTEMPTS,
     TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS,
 )
+from tracecat.mcp.exceptions import MCPNonRetryableStartupError
 
 
 def _run_mcp_server() -> None:
@@ -41,6 +42,11 @@ def main() -> None:
         except KeyboardInterrupt:
             logger.info("MCP server interrupted; shutting down")
             return
+        except MCPNonRetryableStartupError:
+            logger.exception(
+                "MCP server startup failed due to non-retryable configuration error"
+            )
+            raise SystemExit(1) from None
         except Exception as e:
             should_retry = attempt < max_attempts
             error = str(e)

--- a/tracecat/mcp/exceptions.py
+++ b/tracecat/mcp/exceptions.py
@@ -1,0 +1,7 @@
+"""MCP-specific exception types."""
+
+from __future__ import annotations
+
+
+class MCPNonRetryableStartupError(RuntimeError):
+    """Raised when MCP startup fails due to invalid static configuration."""

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -72,6 +72,7 @@ from tracecat.mcp.config import (
     TRACECAT_MCP__RATE_LIMIT_BURST,
     TRACECAT_MCP__RATE_LIMIT_RPS,
 )
+from tracecat.mcp.exceptions import MCPNonRetryableStartupError
 from tracecat.mcp.middleware import (
     MCPInputSizeLimitMiddleware,
     MCPTimeoutMiddleware,
@@ -668,7 +669,15 @@ async def _apply_case_trigger_payload(
         )
 
 
-auth = create_mcp_auth()
+def _create_mcp_auth_or_raise() -> Any:
+    """Create MCP auth provider and surface config errors as non-retryable."""
+    try:
+        return create_mcp_auth()
+    except ValueError as exc:
+        raise MCPNonRetryableStartupError(str(exc)) from exc
+
+
+auth = _create_mcp_auth_or_raise()
 
 # ---------------------------------------------------------------------------
 # Server instructions — sent to every MCP client on connection


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fail fast on MCP startup when required config (e.g., OIDC creds) is missing by exiting immediately with code 0 to prevent retries. Transient errors still retry.

- **Bug Fixes**
  - Added MCPNonRetryableStartupError; map auth config ValueError to it during server init.
  - main catches it, logs with logger.error, and exits with code 0.
  - Tests updated: added immediate-exit test (expects code 0); retry test uses transient RuntimeError.

<sup>Written for commit 7c1fd83a0e1477d349ad9bf32ae9919cc3a35ca6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

