### PR TITLE
fix(cases): separate closed and resolved aggregate counts

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5410,6 +5410,11 @@ export const $CaseStatusGroupCounts = {
       title: "Resolved",
       default: 0,
     },
+    closed: {
+      type: "integer",
+      title: "Closed",
+      default: 0,
+    },
     other: {
       type: "integer",
       title: "Other",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1536,6 +1536,7 @@ export type CaseStatusGroupCounts = {
   in_progress?: number
   on_hold?: number
   resolved?: number
+  closed?: number
   other?: number
 }
 

--- a/frontend/src/components/cases/cases-accordion.tsx
+++ b/frontend/src/components/cases/cases-accordion.tsx
@@ -77,6 +77,7 @@ const STATUS_GROUPS: Record<StatusGroup, StatusGroupConfig> = {
     icon: CheckCircleIcon,
     statuses: ["closed"],
     iconColor: "text-violet-600",
+    aggregateKey: "closed",
   },
   other: {
     label: "Other",

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -721,6 +721,7 @@ async def test_search_case_aggregates_success(
                 in_progress=8,
                 on_hold=4,
                 resolved=18,
+                closed=4,
                 other=2,
             ),
         )
@@ -744,4 +745,5 @@ async def test_search_case_aggregates_success(
         assert data["total"] == 42
         assert data["status_groups"]["new"] == 10
         assert data["status_groups"]["resolved"] == 18
+        assert data["status_groups"]["closed"] == 4
         mock_svc.get_search_case_aggregates.assert_called_once()

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -946,6 +946,7 @@ class TestCasesService:
         assert aggregates.status_groups.in_progress == 1
         assert aggregates.status_groups.on_hold == 0
         assert aggregates.status_groups.resolved == 1
+        assert aggregates.status_groups.closed == 0
         assert aggregates.status_groups.other == 0
 
     async def test_create_case_with_nonexistent_field(

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -57,6 +57,7 @@ class CaseStatusGroupCounts(Schema):
     in_progress: int = 0
     on_hold: int = 0
     resolved: int = 0
+    closed: int = 0
     other: int = 0
 
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -667,9 +667,7 @@ class CasesService(BaseWorkspaceService):
                 0,
             ).label("on_hold"),
             func.coalesce(
-                func.sum(
-                    sa.case((Case.status == CaseStatus.RESOLVED, 1), else_=0)
-                ),
+                func.sum(sa.case((Case.status == CaseStatus.RESOLVED, 1), else_=0)),
                 0,
             ).label("resolved"),
             func.coalesce(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -668,16 +668,14 @@ class CasesService(BaseWorkspaceService):
             ).label("on_hold"),
             func.coalesce(
                 func.sum(
-                    sa.case(
-                        (
-                            Case.status.in_([CaseStatus.RESOLVED, CaseStatus.CLOSED]),
-                            1,
-                        ),
-                        else_=0,
-                    )
+                    sa.case((Case.status == CaseStatus.RESOLVED, 1), else_=0)
                 ),
                 0,
             ).label("resolved"),
+            func.coalesce(
+                func.sum(sa.case((Case.status == CaseStatus.CLOSED, 1), else_=0)),
+                0,
+            ).label("closed"),
             func.coalesce(
                 func.sum(
                     sa.case(
@@ -704,6 +702,7 @@ class CasesService(BaseWorkspaceService):
                 in_progress=int(row.in_progress or 0),
                 on_hold=int(row.on_hold or 0),
                 resolved=int(row.resolved or 0),
+                closed=int(row.closed or 0),
                 other=int(row.other or 0),
             ),
         )


### PR DESCRIPTION
### Motivation
- The backend aggregation query lumped `closed` into the `resolved` bucket, causing the UI "Resolved" count to include closed cases and be misleading.
- The frontend accordion's `closed` group lacked an `aggregateKey`, so it could show local/paginated counts instead of the global aggregate and diverge from the API response.

### Description
- Split the aggregate query so `resolved` only counts `CaseStatus.RESOLVED` and added a distinct `closed` aggregate count for `CaseStatus.CLOSED` in `tracecat/cases/service.py`.
- Added `closed` to the response schema `CaseStatusGroupCounts` in `tracecat/cases/schemas.py` and propagated the new field to generated frontend client types and schemas (`frontend/src/client/types.gen.ts`, `frontend/src/client/schemas.gen.ts`).
- Wired the frontend accordion `closed` section to use the global aggregate by adding `aggregateKey: "closed"` in `frontend/src/components/cases/cases-accordion.tsx` so group headings show the server-provided counts when available.
- Updated unit tests that assert aggregate response shape/values to include the new `closed` field (`tests/unit/test_cases_service.py`, `tests/unit/api/test_api_cases.py`).

### Testing
- Ran frontend type checking with `pnpm -C frontend run typecheck` and it succeeded.
- Attempted targeted unit tests with `uv run pytest tests/unit/test_cases_service.py -k get_search_case_aggregates_applies_enum_filters` and `uv run pytest tests/unit/api/test_api_cases.py -k search_case_aggregates_success`, but both runs failed in this environment due to PostgreSQL not running (`Connection refused`), so assertions in CI/local with a running DB should verify behavior.
- Tried loading the UI for a visual check (Playwright) but the local UI server was not running, so no screenshot was produced; recommend verifying the accordion counts in a running dev cluster (`just cluster up -d`) or local frontend server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fd5c706883338609a6751706fd49)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated resolved and closed case aggregates so “Resolved” no longer counts closed cases, and the “Closed” group shows accurate global totals.

- **Bug Fixes**
  - Backend: count RESOLVED and CLOSED separately in aggregates.
  - API: added closed to CaseStatusGroupCounts; regenerated frontend types/schemas.
  - Frontend: set aggregateKey="closed" for the Closed accordion group.
  - Tests: updated assertions to include closed counts.

- **Refactors**
  - Applied ruff formatting to the aggregates query.

<sup>Written for commit 93427f507a769a60a3d92705de67f524038d0f31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

