### PR TITLE
fix(terraform): enforce ALB TLS 1.2+ security policies

### DIFF
--- a/deployments/eks/modules/eks/helm.tf
+++ b/deployments/eks/modules/eks/helm.tf
@@ -54,6 +54,7 @@ locals {
       "alb.ingress.kubernetes.io/target-type"     = "ip"
       "alb.ingress.kubernetes.io/listen-ports"    = "[{\"HTTP\": 80}, {\"HTTPS\": 443}]"
       "alb.ingress.kubernetes.io/ssl-redirect"    = "443"
+      "alb.ingress.kubernetes.io/ssl-policy"      = var.alb_ssl_policy
       "alb.ingress.kubernetes.io/certificate-arn" = var.acm_certificate_arn
       "alb.ingress.kubernetes.io/group.name"      = local.alb_group_name
       "external-dns.alpha.kubernetes.io/hostname" = var.domain_name

--- a/deployments/eks/modules/eks/variables.tf
+++ b/deployments/eks/modules/eks/variables.tf
@@ -32,6 +32,12 @@ variable "acm_certificate_arn" {
   type        = string
 }
 
+variable "alb_ssl_policy" {
+  description = "ALB SSL security policy for HTTPS listeners"
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+}
+
 # Node Group Configuration
 variable "node_instance_types" {
   description = "Instance types for the EKS node group"

--- a/deployments/fargate/modules/ecs/alb.tf
+++ b/deployments/fargate/modules/ecs/alb.tf
@@ -39,7 +39,7 @@ resource "aws_alb_listener" "https" {
   port              = "443"
   protocol          = "HTTPS"
 
-  ssl_policy      = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+  ssl_policy      = var.alb_ssl_policy
   certificate_arn = var.acm_certificate_arn
 
   default_action {

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -69,6 +69,12 @@ variable "acm_certificate_arn" {
   description = "The ARN of the ACM certificate to use for Tracecat"
 }
 
+variable "alb_ssl_policy" {
+  type        = string
+  description = "The ALB SSL security policy for HTTPS listeners"
+  default     = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+}
+
 ### Security
 
 variable "auth_types" {


### PR DESCRIPTION
### Description
- Add a new `alb_ssl_policy` Terraform variable with a secure default (`ELBSecurityPolicy-TLS13-1-2-Res-2021-06`) to the EKS module in `deployments/eks/modules/eks/variables.tf` to make the ALB policy configurable.
- Inject `alb.ingress.kubernetes.io/ssl-policy = var.alb_ssl_policy` into the shared ingress annotations in `deployments/eks/modules/eks/helm.tf` so the ALB controller provisions HTTPS listeners with the configured policy.
- Replace the hardcoded `ssl_policy` in the Fargate ALB HTTPS listener with `var.alb_ssl_policy` and add the corresponding variable to `deployments/fargate/modules/ecs/variables.tf`, so both `deployments/fargate` and `deployments/eks` honor the same secure default.

### Testing
- Verified the repository diff with `git diff` to confirm the intended changes to `deployments/eks/modules/eks/helm.tf`, `deployments/eks/modules/eks/variables.tf`, `deployments/fargate/modules/ecs/alb.tf`, and `deployments/fargate/modules/ecs/variables.tf` succeeded.
- Committed the changes successfully with `git commit` (message: `fix(terraform): enforce ALB TLS 1.2+ security policies`).
- Attempted to run `terraform fmt` to validate formatting, but the Terraform CLI is not installed in the execution environment so formatting could not be run here (please run `terraform fmt` or CI checks before merging).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fdf3e8b48333abcf1e3565fffa49)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces TLS 1.2+ on all ALBs by making the SSL policy configurable with a secure default across EKS and Fargate. Resolves the weak cipher finding on platform.tracecat.com.

- **Bug Fixes**
  - Added alb_ssl_policy variable with default ELBSecurityPolicy-TLS13-1-2-Res-2021-06 in EKS and Fargate modules.
  - Applied ssl-policy via ALB Ingress annotation in EKS (aws-load-balancer-controller).
  - Switched Fargate HTTPS listener to use var.alb_ssl_policy instead of a hardcoded policy.

- **Migration**
  - No action needed unless you use a custom ALB policy.
  - To override, set alb_ssl_policy in your module inputs and run terraform plan/apply.

<sup>Written for commit 7b664c4c7bbba405a86d9a9b748ebe2d8c22d46d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

