### PR TITLE
feat(api): Unify case and table aggregation search contracts

### DIFF
--- a/alembic/versions/d6e1f2a0a1ec_add_case_aggregation_indexes.py
+++ b/alembic/versions/d6e1f2a0a1ec_add_case_aggregation_indexes.py
@@ -1,0 +1,40 @@
+"""add case aggregation indexes
+
+Revision ID: d6e1f2a0a1ec
+Revises: 8f4f1bd13e9c
+Create Date: 2026-03-02 16:35:53.844817
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d6e1f2a0a1ec"
+down_revision: str | None = "8f4f1bd13e9c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_case_tag_link_tag_case",
+        "case_tag_link",
+        ["tag_id", "case_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_case_dropdown_value_definition_option_case",
+        "case_dropdown_value",
+        ["definition_id", "option_id", "case_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_case_dropdown_value_definition_option_case",
+        table_name="case_dropdown_value",
+    )
+    op.drop_index("ix_case_tag_link_tag_case", table_name="case_tag_link")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5332,19 +5332,340 @@ export const $CaseReadMinimal = {
   title: "CaseReadMinimal",
 } as const
 
-export const $CaseSearchAggregateRead = {
+export const $CaseSearchRequest = {
   properties: {
-    total: {
+    limit: {
       type: "integer",
-      title: "Total",
+      maximum: 200,
+      minimum: 1,
+      title: "Limit",
+      default: 20,
     },
-    status_groups: {
-      $ref: "#/components/schemas/CaseStatusGroupCounts",
+    cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Cursor",
+    },
+    reverse: {
+      type: "boolean",
+      title: "Reverse",
+      default: false,
+    },
+    search_term: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Search Term",
+    },
+    short_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Short Id",
+    },
+    status: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/CaseStatus",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Status",
+    },
+    priority: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/CasePriority",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Priority",
+    },
+    severity: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/CaseSeverity",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Severity",
+    },
+    tags: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Tags",
+    },
+    dropdown: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Dropdown",
+    },
+    start_time: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Start Time",
+    },
+    end_time: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "End Time",
+    },
+    updated_after: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Updated After",
+    },
+    updated_before: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Updated Before",
+    },
+    assignee_id: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Assignee Id",
+    },
+    order_by: {
+      anyOf: [
+        {
+          type: "string",
+          enum: [
+            "created_at",
+            "updated_at",
+            "priority",
+            "severity",
+            "status",
+            "tasks",
+          ],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Order By",
+    },
+    sort: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["asc", "desc"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Sort",
+    },
+    include_rows: {
+      type: "boolean",
+      title: "Include Rows",
+      default: false,
+    },
+    group_by: {
+      anyOf: [
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Group By",
+    },
+    agg: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Agg",
+    },
+    agg_field: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Agg Field",
+    },
+    bucket_limit: {
+      type: "integer",
+      maximum: 1000,
+      minimum: 1,
+      title: "Bucket Limit",
+      default: 100,
     },
   },
   type: "object",
-  required: ["total", "status_groups"],
-  title: "CaseSearchAggregateRead",
+  title: "CaseSearchRequest",
+} as const
+
+export const $CaseSearchResponse = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/CaseReadMinimal",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+    aggregation: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/SearchAggregationResult",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CaseSearchResponse",
 } as const
 
 export const $CaseSeverity = {
@@ -5386,38 +5707,6 @@ export const $CaseStatus = {
   ],
   title: "CaseStatus",
   description: "Case status values aligned with OCSF Incident Finding status.",
-} as const
-
-export const $CaseStatusGroupCounts = {
-  properties: {
-    new: {
-      type: "integer",
-      title: "New",
-      default: 0,
-    },
-    in_progress: {
-      type: "integer",
-      title: "In Progress",
-      default: 0,
-    },
-    on_hold: {
-      type: "integer",
-      title: "On Hold",
-      default: 0,
-    },
-    resolved: {
-      type: "integer",
-      title: "Resolved",
-      default: 0,
-    },
-    other: {
-      type: "integer",
-      title: "Other",
-      default: 0,
-    },
-  },
-  type: "object",
-  title: "CaseStatusGroupCounts",
 } as const
 
 export const $CaseTableRowInsertCreate = {
@@ -15451,6 +15740,97 @@ export const $ScopeSource = {
   enum: ["platform", "custom"],
   title: "ScopeSource",
   description: "Source/ownership of a scope definition.",
+} as const
+
+export const $SearchAggFunction = {
+  type: "string",
+  enum: ["count", "sum", "min", "max", "mean", "median", "mode", "n_unique"],
+  title: "SearchAggFunction",
+} as const
+
+export const $SearchAggregationBucket = {
+  properties: {
+    key: {
+      additionalProperties: true,
+      type: "object",
+      title: "Key",
+    },
+    value: {
+      $ref: "#/components/schemas/SearchAggregationValue",
+    },
+  },
+  type: "object",
+  required: ["key", "value"],
+  title: "SearchAggregationBucket",
+} as const
+
+export const $SearchAggregationResult = {
+  properties: {
+    agg: {
+      $ref: "#/components/schemas/SearchAggFunction",
+    },
+    agg_field: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Agg Field",
+    },
+    group_by: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Group By",
+    },
+    value: {
+      $ref: "#/components/schemas/SearchAggregationValue",
+    },
+    buckets: {
+      items: {
+        $ref: "#/components/schemas/SearchAggregationBucket",
+      },
+      type: "array",
+      title: "Buckets",
+    },
+    bucket_limit: {
+      type: "integer",
+      title: "Bucket Limit",
+      default: 100,
+    },
+    truncated: {
+      type: "boolean",
+      title: "Truncated",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["agg", "value"],
+  title: "SearchAggregationResult",
+} as const
+
+export const $SearchAggregationValue = {
+  anyOf: [
+    {
+      type: "integer",
+    },
+    {
+      type: "number",
+    },
+    {
+      type: "string",
+    },
+    {
+      type: "boolean",
+    },
+    {
+      type: "null",
+    },
+  ],
 } as const
 
 export const $SecretCreate = {

--- a/frontend/src/client/services.custom.ts
+++ b/frontend/src/client/services.custom.ts
@@ -25,6 +25,28 @@ export type ProvidersCreateCustomProviderData = {
   requestBody: CustomOAuthProviderCreateRequest
 }
 
+export type OAuth2AuthorizeResponse = {
+  authorization_url: string
+}
+
+export type AuthOauthOidcDatabaseAuthorizeData = {
+  scopes?: string[]
+}
+
+export const authOauthOidcDatabaseAuthorize = (
+  data?: AuthOauthOidcDatabaseAuthorizeData
+): CancelablePromise<OAuth2AuthorizeResponse> =>
+  request(OpenAPI, {
+    method: "GET",
+    url: "/auth/oauth/authorize",
+    query: {
+      scopes: data?.scopes,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+
 export const providersCreateCustomProvider = (
   data: ProvidersCreateCustomProviderData
 ): CancelablePromise<ProviderReadMinimal> =>

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -240,8 +240,6 @@ import type {
   CasesListTasksResponse,
   CasesRemoveTagData,
   CasesRemoveTagResponse,
-  CasesSearchCaseAggregatesData,
-  CasesSearchCaseAggregatesResponse,
   CasesSearchCasesData,
   CasesSearchCasesResponse,
   CasesSetCaseDropdownValueData,
@@ -6520,99 +6518,21 @@ export const casesCreateCase = (
  * Search cases with cursor-based pagination, filtering, and sorting.
  * @param data The data for the request.
  * @param data.workspaceId
- * @param data.limit Maximum items per page
- * @param data.cursor Cursor for pagination
- * @param data.reverse Reverse pagination direction
- * @param data.searchTerm Text to search for in case summary, description, or short ID
- * @param data.shortId Search by exact case short ID (e.g. 42 or CASE-0042)
- * @param data.status Filter by case status
- * @param data.priority Filter by case priority
- * @param data.severity Filter by case severity
- * @param data.tags Filter by tag IDs or slugs (AND logic)
- * @param data.dropdown Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)
- * @param data.startTime Return cases created at or after this timestamp
- * @param data.endTime Return cases created at or before this timestamp
- * @param data.updatedAfter Return cases updated at or after this timestamp
- * @param data.updatedBefore Return cases updated at or before this timestamp
- * @param data.assigneeId Filter by assignee ID or 'unassigned'
- * @param data.orderBy Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at
- * @param data.sort Direction to sort (asc or desc)
- * @param data.includeRows Include linked table rows
- * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
+ * @param data.requestBody
+ * @returns CaseSearchResponse Successful Response
  * @throws ApiError
  */
 export const casesSearchCases = (
   data: CasesSearchCasesData
 ): CancelablePromise<CasesSearchCasesResponse> => {
   return __request(OpenAPI, {
-    method: "GET",
+    method: "POST",
     url: "/cases/search",
     query: {
-      limit: data.limit,
-      cursor: data.cursor,
-      reverse: data.reverse,
-      search_term: data.searchTerm,
-      short_id: data.shortId,
-      status: data.status,
-      priority: data.priority,
-      severity: data.severity,
-      tags: data.tags,
-      dropdown: data.dropdown,
-      start_time: data.startTime,
-      end_time: data.endTime,
-      updated_after: data.updatedAfter,
-      updated_before: data.updatedBefore,
-      assignee_id: data.assigneeId,
-      order_by: data.orderBy,
-      sort: data.sort,
-      include_rows: data.includeRows,
       workspace_id: data.workspaceId,
     },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
- * Search Case Aggregates
- * Return global case totals and per-stage counts for the current filters.
- * @param data The data for the request.
- * @param data.workspaceId
- * @param data.searchTerm Text to search for in case summary, description, or short ID
- * @param data.status Filter by case status
- * @param data.priority Filter by case priority
- * @param data.severity Filter by case severity
- * @param data.tags Filter by tag IDs or slugs (AND logic)
- * @param data.dropdown Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)
- * @param data.startTime Return cases created at or after this timestamp
- * @param data.endTime Return cases created at or before this timestamp
- * @param data.updatedAfter Return cases updated at or after this timestamp
- * @param data.updatedBefore Return cases updated at or before this timestamp
- * @param data.assigneeId Filter by assignee ID or 'unassigned'
- * @returns CaseSearchAggregateRead Successful Response
- * @throws ApiError
- */
-export const casesSearchCaseAggregates = (
-  data: CasesSearchCaseAggregatesData
-): CancelablePromise<CasesSearchCaseAggregatesResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/cases/search/aggregate",
-    query: {
-      search_term: data.searchTerm,
-      status: data.status,
-      priority: data.priority,
-      severity: data.severity,
-      tags: data.tags,
-      dropdown: data.dropdown,
-      start_time: data.startTime,
-      end_time: data.endTime,
-      updated_after: data.updatedAfter,
-      updated_before: data.updatedBefore,
-      assignee_id: data.assigneeId,
-      workspace_id: data.workspaceId,
-    },
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1491,9 +1491,61 @@ export type CaseReadMinimal = {
   num_tasks_total?: number
 }
 
-export type CaseSearchAggregateRead = {
-  total: number
-  status_groups: CaseStatusGroupCounts
+export type CaseSearchRequest = {
+  limit?: number
+  cursor?: string | null
+  reverse?: boolean
+  search_term?: string | null
+  short_id?: string | null
+  status?: Array<CaseStatus> | null
+  priority?: Array<CasePriority> | null
+  severity?: Array<CaseSeverity> | null
+  tags?: Array<string> | null
+  dropdown?: Array<string> | null
+  start_time?: string | null
+  end_time?: string | null
+  updated_after?: string | null
+  updated_before?: string | null
+  assignee_id?: Array<string> | null
+  order_by?:
+    | "created_at"
+    | "updated_at"
+    | "priority"
+    | "severity"
+    | "status"
+    | "tasks"
+    | null
+  sort?: "asc" | "desc" | null
+  include_rows?: boolean
+  group_by?: Array<string> | null
+  agg?: string | null
+  agg_field?: string | null
+  bucket_limit?: number
+}
+
+export type CaseSearchResponse = {
+  items: Array<CaseReadMinimal>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+  aggregation?: SearchAggregationResult | null
 }
 
 /**
@@ -1530,14 +1582,6 @@ export type CaseStatus =
   | "resolved"
   | "closed"
   | "other"
-
-export type CaseStatusGroupCounts = {
-  new?: number
-  in_progress?: number
-  on_hold?: number
-  resolved?: number
-  other?: number
-}
 
 export type CaseTableRowInsertCreate = {
   table_id: string
@@ -4865,6 +4909,35 @@ export type ScopeRead = {
  * Source/ownership of a scope definition.
  */
 export type ScopeSource = "platform" | "custom"
+
+export type SearchAggFunction =
+  | "count"
+  | "sum"
+  | "min"
+  | "max"
+  | "mean"
+  | "median"
+  | "mode"
+  | "n_unique"
+
+export type SearchAggregationBucket = {
+  key: {
+    [key: string]: unknown
+  }
+  value: SearchAggregationValue
+}
+
+export type SearchAggregationResult = {
+  agg: SearchAggFunction
+  agg_field?: string | null
+  group_by?: Array<string>
+  value: SearchAggregationValue
+  buckets?: Array<SearchAggregationBucket>
+  bucket_limit?: number
+  truncated?: boolean
+}
+
+export type SearchAggregationValue = number | string | boolean | null
 
 /**
  * Create a new secret.
@@ -8865,139 +8938,11 @@ export type CasesCreateCaseData = {
 export type CasesCreateCaseResponse = unknown
 
 export type CasesSearchCasesData = {
-  /**
-   * Filter by assignee ID or 'unassigned'
-   */
-  assigneeId?: Array<string> | null
-  /**
-   * Cursor for pagination
-   */
-  cursor?: string | null
-  /**
-   * Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)
-   */
-  dropdown?: Array<string> | null
-  /**
-   * Return cases created at or before this timestamp
-   */
-  endTime?: string | null
-  /**
-   * Include linked table rows
-   */
-  includeRows?: boolean
-  /**
-   * Maximum items per page
-   */
-  limit?: number
-  /**
-   * Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at
-   */
-  orderBy?:
-    | "created_at"
-    | "updated_at"
-    | "priority"
-    | "severity"
-    | "status"
-    | "tasks"
-    | null
-  /**
-   * Filter by case priority
-   */
-  priority?: Array<CasePriority> | null
-  /**
-   * Reverse pagination direction
-   */
-  reverse?: boolean
-  /**
-   * Text to search for in case summary, description, or short ID
-   */
-  searchTerm?: string | null
-  /**
-   * Filter by case severity
-   */
-  severity?: Array<CaseSeverity> | null
-  /**
-   * Search by exact case short ID (e.g. 42 or CASE-0042)
-   */
-  shortId?: string | null
-  /**
-   * Direction to sort (asc or desc)
-   */
-  sort?: "asc" | "desc" | null
-  /**
-   * Return cases created at or after this timestamp
-   */
-  startTime?: string | null
-  /**
-   * Filter by case status
-   */
-  status?: Array<CaseStatus> | null
-  /**
-   * Filter by tag IDs or slugs (AND logic)
-   */
-  tags?: Array<string> | null
-  /**
-   * Return cases updated at or after this timestamp
-   */
-  updatedAfter?: string | null
-  /**
-   * Return cases updated at or before this timestamp
-   */
-  updatedBefore?: string | null
+  requestBody: CaseSearchRequest
   workspaceId: string
 }
 
-export type CasesSearchCasesResponse = CursorPaginatedResponse_CaseReadMinimal_
-
-export type CasesSearchCaseAggregatesData = {
-  /**
-   * Filter by assignee ID or 'unassigned'
-   */
-  assigneeId?: Array<string> | null
-  /**
-   * Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)
-   */
-  dropdown?: Array<string> | null
-  /**
-   * Return cases created at or before this timestamp
-   */
-  endTime?: string | null
-  /**
-   * Filter by case priority
-   */
-  priority?: Array<CasePriority> | null
-  /**
-   * Text to search for in case summary, description, or short ID
-   */
-  searchTerm?: string | null
-  /**
-   * Filter by case severity
-   */
-  severity?: Array<CaseSeverity> | null
-  /**
-   * Return cases created at or after this timestamp
-   */
-  startTime?: string | null
-  /**
-   * Filter by case status
-   */
-  status?: Array<CaseStatus> | null
-  /**
-   * Filter by tag IDs or slugs (AND logic)
-   */
-  tags?: Array<string> | null
-  /**
-   * Return cases updated at or after this timestamp
-   */
-  updatedAfter?: string | null
-  /**
-   * Return cases updated at or before this timestamp
-   */
-  updatedBefore?: string | null
-  workspaceId: string
-}
-
-export type CasesSearchCaseAggregatesResponse = CaseSearchAggregateRead
+export type CasesSearchCasesResponse = CaseSearchResponse
 
 export type CasesGetCaseData = {
   caseId: string
@@ -13060,28 +13005,13 @@ export type $OpenApiTs = {
     }
   }
   "/cases/search": {
-    get: {
+    post: {
       req: CasesSearchCasesData
       res: {
         /**
          * Successful Response
          */
-        200: CursorPaginatedResponse_CaseReadMinimal_
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
-  "/cases/search/aggregate": {
-    get: {
-      req: CasesSearchCaseAggregatesData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: CaseSearchAggregateRead
+        200: CaseSearchResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { type ComponentPropsWithoutRef, useState } from "react"
-import { authOauthOidcDatabaseAuthorize } from "@/client"
+import { authOauthOidcDatabaseAuthorize } from "@/client/services.custom"
 import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import {

--- a/frontend/src/components/cases/cases-accordion.tsx
+++ b/frontend/src/components/cases/cases-accordion.tsx
@@ -17,13 +17,13 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type {
   CaseDropdownDefinitionRead,
   CaseReadMinimal,
-  CaseSearchAggregateRead,
   CaseStatus,
   CaseTagRead,
   WorkspaceMember,
 } from "@/client"
 import { CaseItem } from "@/components/cases/case-item"
 import type { FilterMode, SortDirection } from "@/components/cases/cases-header"
+import type { CaseStageCounts } from "@/hooks/use-cases"
 import { cn } from "@/lib/utils"
 
 type StatusGroup =
@@ -40,7 +40,7 @@ interface StatusGroupConfig {
   icon: ComponentType<{ className?: string }>
   statuses: CaseStatus[]
   iconColor: string
-  aggregateKey?: keyof CaseSearchAggregateRead["status_groups"]
+  aggregateKey?: keyof CaseStageCounts
 }
 
 const STATUS_GROUPS: Record<StatusGroup, StatusGroupConfig> = {
@@ -125,7 +125,7 @@ interface CasesAccordionProps {
   statusFilter?: CaseStatus[]
   statusMode?: FilterMode
   totalFilteredCaseEstimate?: number | null
-  stageCounts?: CaseSearchAggregateRead["status_groups"] | null
+  stageCounts?: CaseStageCounts | null
   isCountsLoading?: boolean
   isCountsFetching?: boolean
   hasNextPage?: boolean

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -6,7 +6,6 @@ import {
   type CaseDropdownDefinitionRead,
   type CasePriority,
   type CaseReadMinimal,
-  type CaseSearchAggregateRead,
   type CaseSeverity,
   type CaseStatus,
   type CaseTagRead,
@@ -26,7 +25,11 @@ import {
 import { DeleteCaseAlertDialog } from "@/components/cases/delete-case-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useToast } from "@/components/ui/use-toast"
-import type { CaseDateFilterValue, UseCasesFilters } from "@/hooks/use-cases"
+import type {
+  CaseDateFilterValue,
+  CaseStageCounts,
+  UseCasesFilters,
+} from "@/hooks/use-cases"
 import { useDeleteCase } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -60,7 +63,7 @@ interface CasesLayoutProps {
   onDropdownModeChange: (ref: string, mode: FilterMode) => void
   onDropdownSortDirectionChange: (ref: string, direction: SortDirection) => void
   totalFilteredCaseEstimate: number | null
-  stageCounts: CaseSearchAggregateRead["status_groups"] | null
+  stageCounts: CaseStageCounts | null
   isCountsLoading: boolean
   isCountsFetching: boolean
   hasNextPage: boolean

--- a/frontend/src/components/tables/table-link-rows-to-case-command.tsx
+++ b/frontend/src/components/tables/table-link-rows-to-case-command.tsx
@@ -43,13 +43,15 @@ export function TableLinkRowsToCaseCommand() {
   } = useQuery({
     queryKey: ["cases", "search", "short-id", workspaceId, normalizedShortId],
     queryFn: async () => {
-      const response = await apiClient.get<SearchCasesResponse>(
+      const response = await apiClient.post<SearchCasesResponse>(
         "/cases/search",
+        {
+          short_id: normalizedShortId,
+          limit: 20,
+        },
         {
           params: {
             workspace_id: workspaceId,
-            short_id: normalizedShortId,
-            limit: 20,
           },
         }
       )

--- a/frontend/src/hooks/pagination/use-cases-pagination.tsx
+++ b/frontend/src/hooks/pagination/use-cases-pagination.tsx
@@ -3,15 +3,36 @@
 import type {
   CasePriority,
   CaseReadMinimal,
+  CaseSearchRequest,
   CaseSeverity,
   CaseStatus,
-  CasesSearchCasesData,
 } from "@/client"
 import { casesSearchCases } from "@/client"
 import {
+  type CursorPaginationParams,
   type CursorPaginationResponse,
   useCursorPagination,
 } from "./use-cursor-pagination"
+
+const CASE_ORDER_BY_FIELDS = [
+  "created_at",
+  "updated_at",
+  "priority",
+  "severity",
+  "status",
+  "tasks",
+] as const satisfies ReadonlyArray<NonNullable<CaseSearchRequest["order_by"]>>
+
+function isCaseOrderByField(
+  value: string | null | undefined
+): value is NonNullable<CaseSearchRequest["order_by"]> {
+  if (!value) {
+    return false
+  }
+  return CASE_ORDER_BY_FIELDS.includes(
+    value as (typeof CASE_ORDER_BY_FIELDS)[number]
+  )
+}
 
 // Convenience hook for cases specifically
 export interface UseCasesPaginationParams {
@@ -37,16 +58,23 @@ export function useCasesPagination({
 }: UseCasesPaginationParams) {
   // Wrapper function to adapt the API response to our generic interface
   const adaptedCasesSearchCases = async (
-    params: CasesSearchCasesData
+    params: CursorPaginationParams
   ): Promise<CursorPaginationResponse<CaseReadMinimal>> => {
     const response = await casesSearchCases({
-      ...params,
-      searchTerm,
-      status: status && status.length ? status : null,
-      priority: priority && priority.length ? priority : null,
-      severity: severity && severity.length ? severity : null,
-      assigneeId: assigneeIds && assigneeIds.length ? assigneeIds : null,
-      tags,
+      workspaceId: params.workspaceId,
+      requestBody: {
+        limit: params.limit,
+        cursor: params.cursor,
+        reverse: params.reverse,
+        order_by: isCaseOrderByField(params.orderBy) ? params.orderBy : null,
+        sort: params.sort,
+        search_term: searchTerm,
+        status: status && status.length ? status : null,
+        priority: priority && priority.length ? priority : null,
+        severity: severity && severity.length ? severity : null,
+        assignee_id: assigneeIds && assigneeIds.length ? assigneeIds : null,
+        tags,
+      },
     })
     return {
       items: response.items,
@@ -58,7 +86,7 @@ export function useCasesPagination({
     }
   }
 
-  return useCursorPagination<CaseReadMinimal, CasesSearchCasesData>({
+  return useCursorPagination<CaseReadMinimal, CursorPaginationParams>({
     workspaceId,
     limit,
     queryKey: [

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -6,13 +6,11 @@ import type { DateRange } from "react-day-picker"
 import {
   type CasePriority,
   type CaseReadMinimal,
-  type CaseSearchAggregateRead,
   type CaseSeverity,
   type CaseStatus,
-  type CasesSearchCaseAggregatesResponse,
   type CasesSearchCasesResponse,
-  casesSearchCaseAggregates,
   casesSearchCases,
+  type SearchAggregationResult,
 } from "@/client"
 import {
   type CaseSortValue,
@@ -52,7 +50,15 @@ const ALL_CASE_SEVERITIES: ReadonlyArray<CaseSeverity> = [
   "fatal",
   "other",
 ]
-const EMPTY_STAGE_COUNTS: CaseSearchAggregateRead["status_groups"] = {
+export interface CaseStageCounts {
+  new: number
+  in_progress: number
+  on_hold: number
+  resolved: number
+  other: number
+}
+
+const EMPTY_STAGE_COUNTS: CaseStageCounts = {
   new: 0,
   in_progress: 0,
   on_hold: 0,
@@ -129,7 +135,7 @@ export interface UseCasesResult {
   setUpdatedAfter: (value: CaseDateFilterValue) => void
   setCreatedAfter: (value: CaseDateFilterValue) => void
   totalFilteredCaseEstimate: number | null
-  stageCounts: CaseSearchAggregateRead["status_groups"] | null
+  stageCounts: CaseStageCounts | null
   isCountsLoading: boolean
   isCountsFetching: boolean
   hasNextPage: boolean
@@ -206,6 +212,45 @@ function resolveEnumIncludeFilter<T extends string>(
     return { values: undefined, matchesNone: true }
   }
   return { values: complement, matchesNone: false }
+}
+
+function deriveStageCounts(
+  aggregation: SearchAggregationResult | null | undefined
+): CaseStageCounts | null {
+  if (!aggregation) {
+    return null
+  }
+  const counts: CaseStageCounts = { ...EMPTY_STAGE_COUNTS }
+  const buckets = aggregation.buckets ?? []
+  for (const bucket of buckets) {
+    const rawStatus = bucket.key["status"]
+    const value = typeof bucket.value === "number" ? bucket.value : 0
+    if (typeof rawStatus !== "string") {
+      continue
+    }
+    if (rawStatus === "new") {
+      counts.new += value
+      continue
+    }
+    if (rawStatus === "in_progress") {
+      counts.in_progress += value
+      continue
+    }
+    if (rawStatus === "on_hold") {
+      counts.on_hold += value
+      continue
+    }
+    // Stage mapping: UI "Resolved" includes both resolved + closed statuses.
+    if (rawStatus === "resolved" || rawStatus === "closed") {
+      counts.resolved += value
+      continue
+    }
+    // Stage mapping: UI "Other" includes both other + unknown statuses.
+    if (rawStatus === "other" || rawStatus === "unknown") {
+      counts.other += value
+    }
+  }
+  return counts
 }
 
 export function useCases(options: UseCasesOptions = {}): UseCasesResult {
@@ -366,23 +411,23 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
 
     return {
       apiQueryParams: {
-        searchTerm: normalizedSearch.length > 0 ? normalizedSearch : undefined,
+        search_term: normalizedSearch.length > 0 ? normalizedSearch : undefined,
         status: resolvedStatus.values,
         priority: resolvedPriority.values,
         severity: resolvedSeverity.values,
-        assigneeId:
+        assignee_id:
           assigneeFilter.length > 0 && assigneeMode === "include"
             ? assigneeFilter
             : undefined,
         tags:
           tagFilter.length > 0 && tagMode === "include" ? tagFilter : undefined,
         dropdown: dropdownIncludes.length > 0 ? dropdownIncludes : undefined,
-        startTime: createdBounds.start?.toISOString(),
-        endTime: createdBounds.end
+        start_time: createdBounds.start?.toISOString(),
+        end_time: createdBounds.end
           ? toEndOfDay(createdBounds.end).toISOString()
           : undefined,
-        updatedAfter: updatedBounds.start?.toISOString(),
-        updatedBefore: updatedBounds.end
+        updated_after: updatedBounds.start?.toISOString(),
+        updated_before: updatedBounds.end
           ? toEndOfDay(updatedBounds.end).toISOString()
           : undefined,
       },
@@ -465,11 +510,13 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     queryFn: ({ pageParam }) =>
       casesSearchCases({
         workspaceId,
-        ...apiQueryParams,
-        orderBy: serverSortParams.orderBy,
-        sort: serverSortParams.sort,
-        limit: CASES_PAGE_SIZE,
-        cursor: (pageParam as string | null) ?? undefined,
+        requestBody: {
+          ...apiQueryParams,
+          order_by: serverSortParams.orderBy,
+          sort: serverSortParams.sort,
+          limit: CASES_PAGE_SIZE,
+          cursor: (pageParam as string | null) ?? undefined,
+        },
       }),
     enabled: enabled && Boolean(workspaceId) && !hasImpossibleEnumFilter,
     initialPageParam: null,
@@ -490,12 +537,18 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     isLoading: isCountsLoading,
     isFetching: isCountsFetching,
     refetch: refetchCounts,
-  } = useQuery<CasesSearchCaseAggregatesResponse, TracecatApiError>({
+  } = useQuery<CasesSearchCasesResponse, TracecatApiError>({
     queryKey: ["cases", "aggregate", workspaceId, filtersKey],
     queryFn: () =>
-      casesSearchCaseAggregates({
+      casesSearchCases({
         workspaceId,
-        ...apiQueryParams,
+        requestBody: {
+          ...apiQueryParams,
+          limit: 1,
+          agg: "count",
+          group_by: ["status"],
+          bucket_limit: 1000,
+        },
       }),
     enabled: enabled && Boolean(workspaceId) && !hasImpossibleEnumFilter,
     retry: retryHandler,
@@ -548,9 +601,12 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
 
   const cases = hasImpossibleEnumFilter ? [] : sortedCases
 
+  const aggregateTotal = aggregateData?.aggregation?.value
   const totalFilteredCaseEstimate = hasImpossibleEnumFilter
     ? 0
-    : (aggregateData?.total ?? rowsData?.pages[0]?.total_estimate ?? null)
+    : typeof aggregateTotal === "number"
+      ? aggregateTotal
+      : (rowsData?.pages[0]?.total_estimate ?? null)
 
   const refetch = useCallback(() => {
     void refetchRows()
@@ -614,7 +670,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     totalFilteredCaseEstimate,
     stageCounts: hasImpossibleEnumFilter
       ? EMPTY_STAGE_COUNTS
-      : (aggregateData?.status_groups ?? null),
+      : deriveStageCounts(aggregateData?.aggregation),
     isCountsLoading: hasImpossibleEnumFilter ? false : isCountsLoading,
     isCountsFetching: hasImpossibleEnumFilter ? false : isCountsFetching,
     hasNextPage: hasImpossibleEnumFilter ? false : Boolean(hasNextPage),

--- a/frontend/tests/use-cases.test.tsx
+++ b/frontend/tests/use-cases.test.tsx
@@ -7,10 +7,9 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import type {
   CaseReadMinimal,
   CaseStatus,
-  CasesSearchCaseAggregatesResponse,
   CasesSearchCasesResponse,
 } from "@/client"
-import { casesSearchCaseAggregates, casesSearchCases } from "@/client"
+import { casesSearchCases } from "@/client"
 import { useCases } from "@/hooks/use-cases"
 
 jest.mock("@/providers/workspace-id", () => ({
@@ -19,16 +18,17 @@ jest.mock("@/providers/workspace-id", () => ({
 
 jest.mock("@/client", () => ({
   casesSearchCases: jest.fn(),
-  casesSearchCaseAggregates: jest.fn(),
 }))
 
 const mockSearchCases = casesSearchCases as jest.MockedFunction<
   typeof casesSearchCases
 >
-const mockSearchCaseAggregates =
-  casesSearchCaseAggregates as jest.MockedFunction<
-    typeof casesSearchCaseAggregates
-  >
+
+function asCancelableResponse(
+  response: CasesSearchCasesResponse
+): ReturnType<typeof casesSearchCases> {
+  return Promise.resolve(response) as ReturnType<typeof casesSearchCases>
+}
 
 function createCase(index: number): CaseReadMinimal {
   const id = `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`
@@ -145,19 +145,37 @@ describe("useCases", () => {
       total_estimate: 1000,
     }
 
-    const aggregate: CasesSearchCaseAggregatesResponse = {
-      total: 1000,
-      status_groups: {
-        new: 700,
-        in_progress: 200,
-        on_hold: 50,
-        resolved: 40,
-        other: 10,
+    const aggregate: CasesSearchCasesResponse = {
+      items: [],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      aggregation: {
+        agg: "count",
+        agg_field: null,
+        group_by: ["status"],
+        value: 1000,
+        buckets: [
+          { key: { status: "new" }, value: 700 },
+          { key: { status: "in_progress" }, value: 200 },
+          { key: { status: "on_hold" }, value: 50 },
+          { key: { status: "resolved" }, value: 30 },
+          { key: { status: "closed" }, value: 10 },
+          { key: { status: "other" }, value: 5 },
+          { key: { status: "unknown" }, value: 5 },
+        ],
+        bucket_limit: 1000,
+        truncated: false,
       },
     }
 
-    mockSearchCases.mockResolvedValue(firstPage)
-    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+    mockSearchCases.mockImplementation(({ requestBody }) => {
+      if (requestBody?.agg === "count") {
+        return asCancelableResponse(aggregate)
+      }
+      return asCancelableResponse(firstPage)
+    })
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -181,18 +199,23 @@ describe("useCases", () => {
     expect(screen.getByTestId("new-count")).toHaveTextContent("700")
 
     // Ensure the hook does not walk every cursor page by default.
-    expect(mockSearchCases).toHaveBeenCalledTimes(1)
+    expect(mockSearchCases).toHaveBeenCalledTimes(2)
     expect(mockSearchCases).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: "workspace-1",
-        limit: 100,
+        requestBody: expect.objectContaining({
+          limit: 100,
+        }),
       })
     )
 
-    expect(mockSearchCaseAggregates).toHaveBeenCalledTimes(1)
-    expect(mockSearchCaseAggregates).toHaveBeenCalledWith(
+    expect(mockSearchCases).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: "workspace-1",
+        requestBody: expect.objectContaining({
+          agg: "count",
+          group_by: ["status"],
+        }),
       })
     )
   })
@@ -207,19 +230,29 @@ describe("useCases", () => {
       total_estimate: 1,
     }
 
-    const aggregate: CasesSearchCaseAggregatesResponse = {
-      total: 1,
-      status_groups: {
-        new: 1,
-        in_progress: 0,
-        on_hold: 0,
-        resolved: 0,
-        other: 0,
+    const aggregate: CasesSearchCasesResponse = {
+      items: [],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      aggregation: {
+        agg: "count",
+        agg_field: null,
+        group_by: ["status"],
+        value: 1,
+        buckets: [{ key: { status: "new" }, value: 1 }],
+        bucket_limit: 1000,
+        truncated: false,
       },
     }
 
-    mockSearchCases.mockResolvedValue(firstPage)
-    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+    mockSearchCases.mockImplementation(({ requestBody }) => {
+      if (requestBody?.agg === "count") {
+        return asCancelableResponse(aggregate)
+      }
+      return asCancelableResponse(firstPage)
+    })
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -247,8 +280,7 @@ describe("useCases", () => {
 
     expect(screen.getByTestId("total")).toHaveTextContent("0")
     expect(screen.getByTestId("new-count")).toHaveTextContent("0")
-    expect(mockSearchCases).toHaveBeenCalledTimes(1)
-    expect(mockSearchCaseAggregates).toHaveBeenCalledTimes(1)
+    expect(mockSearchCases).toHaveBeenCalledTimes(2)
   })
 
   it("resets sortBy when clearing priority or severity sorting", async () => {
@@ -261,19 +293,29 @@ describe("useCases", () => {
       total_estimate: 1,
     }
 
-    const aggregate: CasesSearchCaseAggregatesResponse = {
-      total: 1,
-      status_groups: {
-        new: 1,
-        in_progress: 0,
-        on_hold: 0,
-        resolved: 0,
-        other: 0,
+    const aggregate: CasesSearchCasesResponse = {
+      items: [],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      aggregation: {
+        agg: "count",
+        agg_field: null,
+        group_by: ["status"],
+        value: 1,
+        buckets: [{ key: { status: "new" }, value: 1 }],
+        bucket_limit: 1000,
+        truncated: false,
       },
     }
 
-    mockSearchCases.mockResolvedValue(firstPage)
-    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+    mockSearchCases.mockImplementation(({ requestBody }) => {
+      if (requestBody?.agg === "count") {
+        return asCancelableResponse(aggregate)
+      }
+      return asCancelableResponse(firstPage)
+    })
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -399,6 +399,22 @@ async def search_cases(
         Literal["asc", "desc"] | None,
         Doc("The direction to order the cases by."),
     ] = None,
+    group_by: Annotated[
+        list[str] | None,
+        Doc("Optional group-by tokens for aggregation."),
+    ] = None,
+    agg: Annotated[
+        types.SearchAggFunction | Literal["avg", "value_counts"] | None,
+        Doc("Optional aggregation function."),
+    ] = None,
+    agg_field: Annotated[
+        str | None,
+        Doc("Field/token to aggregate over when agg is not count."),
+    ] = None,
+    bucket_limit: Annotated[
+        int | None,
+        Doc("Maximum grouped buckets to return when aggregation is requested."),
+    ] = None,
     paginate: Annotated[
         bool,
         Doc("If true, return cursor pagination metadata along with items."),
@@ -441,8 +457,23 @@ async def search_cases(
         params["order_by"] = order_by
     if sort is not None:
         params["sort"] = sort
+    if group_by is not None:
+        params["group_by"] = group_by
+    if agg is not None:
+        params["agg"] = agg
+    if agg_field is not None:
+        params["agg_field"] = agg_field
+    if bucket_limit is not None:
+        params["bucket_limit"] = bucket_limit
     response = await get_context().cases.search_cases(**params)
-    if paginate:
+    wants_structured = (
+        paginate
+        or agg is not None
+        or agg_field is not None
+        or group_by is not None
+        or bucket_limit is not None
+    )
+    if wants_structured:
         return response
     return response["items"]
 

--- a/packages/tracecat-registry/tracecat_registry/core/table.py
+++ b/packages/tracecat-registry/tracecat_registry/core/table.py
@@ -136,6 +136,22 @@ async def search_rows(
         int,
         Doc("The maximum number of rows to return."),
     ] = 100,
+    group_by: Annotated[
+        list[str] | None,
+        Doc("Optional columns to group by when aggregation is requested."),
+    ] = None,
+    agg: Annotated[
+        types.SearchAggFunction | Literal["avg", "value_counts"] | None,
+        Doc("Optional aggregation function."),
+    ] = None,
+    agg_field: Annotated[
+        str | None,
+        Doc("Column to aggregate over when agg is not count."),
+    ] = None,
+    bucket_limit: Annotated[
+        int | None,
+        Doc("Maximum grouped buckets to return when aggregation is requested."),
+    ] = None,
     paginate: Annotated[
         bool,
         Doc("If true, return cursor pagination metadata along with items."),
@@ -162,8 +178,23 @@ async def search_rows(
     if cursor is not None:
         params["cursor"] = cursor
     params["reverse"] = reverse
+    if group_by is not None:
+        params["group_by"] = group_by
+    if agg is not None:
+        params["agg"] = agg
+    if agg_field is not None:
+        params["agg_field"] = agg_field
+    if bucket_limit is not None:
+        params["bucket_limit"] = bucket_limit
     response = await get_context().tables.search_rows(**params)
-    if paginate:
+    wants_structured = (
+        paginate
+        or agg is not None
+        or agg_field is not None
+        or group_by is not None
+        or bucket_limit is not None
+    )
+    if wants_structured:
         return response
     if isinstance(response, dict):
         return response.get("items")

--- a/packages/tracecat-registry/tracecat_registry/sdk/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/cases.py
@@ -236,57 +236,71 @@ class CasesClient:
         updated_after: datetime | str | Unset = UNSET,
         updated_before: datetime | str | Unset = UNSET,
         include_rows: bool | Unset = UNSET,
+        group_by: list[str] | Unset = UNSET,
+        agg: str | Unset = UNSET,
+        agg_field: str | Unset = UNSET,
+        bucket_limit: int | Unset = UNSET,
     ) -> types.CaseListResponse:
         """Search cases with filtering and pagination."""
-        params: dict[str, Any] = {"limit": limit}
+        data: dict[str, Any] = {"limit": limit}
         if is_set(cursor):
-            params["cursor"] = cursor
+            data["cursor"] = cursor
         if is_set(reverse):
-            params["reverse"] = reverse
+            data["reverse"] = reverse
         if is_set(search_term):
-            params["search_term"] = search_term
+            data["search_term"] = search_term
         if is_set(status):
-            params["status"] = status
+            data["status"] = status
         if is_set(priority):
-            params["priority"] = priority
+            data["priority"] = priority
         if is_set(severity):
-            params["severity"] = severity
+            data["severity"] = severity
         if is_set(assignee_id):
-            params["assignee_id"] = assignee_id
+            data["assignee_id"] = assignee_id
         if is_set(tags):
-            params["tags"] = tags
+            data["tags"] = tags
         if is_set(dropdown):
-            # Search uses query param `dropdown` (not `dropdown_values`) because this
-            # is a filter expression list like "definition_ref:option_ref".
-            params["dropdown"] = dropdown
+            # Search uses `dropdown` (not `dropdown_values`) as a filter expression
+            # list like "definition_ref:option_ref".
+            data["dropdown"] = dropdown
         if is_set(order_by):
-            params["order_by"] = order_by
+            data["order_by"] = order_by
         if is_set(sort):
-            params["sort"] = sort
+            data["sort"] = sort
         if is_set(start_time):
-            params["start_time"] = (
+            data["start_time"] = (
                 start_time.isoformat()
                 if isinstance(start_time, datetime)
                 else start_time
             )
         if is_set(end_time):
-            params["end_time"] = (
+            data["end_time"] = (
                 end_time.isoformat() if isinstance(end_time, datetime) else end_time
             )
         if is_set(updated_after):
-            params["updated_after"] = (
+            data["updated_after"] = (
                 updated_after.isoformat()
                 if isinstance(updated_after, datetime)
                 else updated_after
             )
         if is_set(updated_before):
-            params["updated_before"] = (
+            data["updated_before"] = (
                 updated_before.isoformat()
                 if isinstance(updated_before, datetime)
                 else updated_before
             )
+        if is_set(include_rows):
+            data["include_rows"] = include_rows
+        if is_set(group_by):
+            data["group_by"] = group_by
+        if is_set(agg):
+            data["agg"] = agg
+        if is_set(agg_field):
+            data["agg_field"] = agg_field
+        if is_set(bucket_limit):
+            data["bucket_limit"] = bucket_limit
 
-        return await self._client.get("/cases/search", params=params)
+        return await self._client.post("/cases/search", json=data)
 
     # === Comments === #
 

--- a/packages/tracecat-registry/tracecat_registry/sdk/tables.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/tables.py
@@ -109,6 +109,10 @@ class TablesClient:
         cursor: str | Unset = UNSET,
         reverse: bool | Unset = UNSET,
         limit: int | Unset = UNSET,
+        group_by: list[str] | Unset = UNSET,
+        agg: str | Unset = UNSET,
+        agg_field: str | Unset = UNSET,
+        bucket_limit: int | Unset = UNSET,
     ) -> types.TableSearchResponse | list[dict[str, Any]]:
         """Search rows with optional filters."""
         data: dict[str, Any] = {}
@@ -142,6 +146,14 @@ class TablesClient:
             data["reverse"] = reverse
         if is_set(limit):
             data["limit"] = limit
+        if is_set(group_by):
+            data["group_by"] = group_by
+        if is_set(agg):
+            data["agg"] = agg
+        if is_set(agg_field):
+            data["agg_field"] = agg_field
+        if is_set(bucket_limit):
+            data["bucket_limit"] = bucket_limit
         response = await self._client.post(f"/tables/{table}/search", json=data)
         if isinstance(response, list):
             return cast(list[dict[str, Any]], response)

--- a/packages/tracecat-registry/tracecat_registry/types.py
+++ b/packages/tracecat-registry/tracecat_registry/types.py
@@ -7,7 +7,7 @@ and datetimes become ISO format strings.
 
 from uuid import UUID
 from datetime import datetime
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 # ============================================================================
@@ -32,6 +32,33 @@ class UserRead(TypedDict):
 # ============================================================================
 # Cases Types
 # ============================================================================
+
+
+SearchAggFunction = Literal[
+    "count",
+    "sum",
+    "min",
+    "max",
+    "mean",
+    "median",
+    "mode",
+    "n_unique",
+]
+
+
+class SearchAggregationBucket(TypedDict):
+    key: dict[str, Any]
+    value: int | float | str | bool | None
+
+
+class SearchAggregation(TypedDict):
+    agg: SearchAggFunction
+    agg_field: str | None
+    group_by: list[str]
+    value: int | float | str | bool | None
+    buckets: list[SearchAggregationBucket]
+    bucket_limit: int
+    truncated: bool
 
 
 class CaseTagRead(TypedDict):
@@ -165,6 +192,7 @@ class CaseListResponse(TypedDict):
     has_more: bool
     has_previous: bool
     total_estimate: int | None
+    aggregation: NotRequired[SearchAggregation | None]
 
 
 class CaseComment(TypedDict):
@@ -641,6 +669,7 @@ class TableSearchResponse(TypedDict):
     has_more: bool
     has_previous: bool
     total_estimate: NotRequired[int | None]
+    aggregation: NotRequired[SearchAggregation | None]
 
 
 # ============================================================================

--- a/tests/registry/test_cases_sdk.py
+++ b/tests/registry/test_cases_sdk.py
@@ -79,3 +79,45 @@ async def test_update_case_simple_serializes_and_keeps_null_option(
             ]
         },
     )
+
+
+@pytest.mark.anyio
+async def test_search_cases_uses_post_body_with_aggregation(
+    cases_client: CasesClient, mock_tracecat_client: MagicMock
+) -> None:
+    """Case search should use POST body and forward aggregation fields."""
+    mock_tracecat_client.post.return_value = {
+        "items": [],
+        "next_cursor": None,
+        "prev_cursor": None,
+        "has_more": False,
+        "has_previous": False,
+        "aggregation": {
+            "agg": "mean",
+            "agg_field": "field:duration_ms",
+            "group_by": ["status"],
+            "value": 12.5,
+            "buckets": [],
+            "bucket_limit": 100,
+            "truncated": False,
+        },
+    }
+
+    await cases_client.search_cases(
+        limit=5,
+        search_term="incident",
+        agg="avg",
+        agg_field="field:duration_ms",
+        group_by=["status"],
+    )
+
+    mock_tracecat_client.post.assert_called_once_with(
+        "/cases/search",
+        json={
+            "limit": 5,
+            "search_term": "incident",
+            "group_by": ["status"],
+            "agg": "avg",
+            "agg_field": "field:duration_ms",
+        },
+    )

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -627,6 +627,45 @@ class TestCoreSearchCases:
         assert result["items"] == [mock_case_dict]
         assert result["next_cursor"] == "cursor-1"
 
+    async def test_search_cases_returns_structured_shape_for_aggregation(
+        self, mock_cases_client: AsyncMock, mock_case_dict
+    ):
+        """Aggregation requests should return the full response object."""
+        mock_cases_client.search_cases.return_value = {
+            "items": [mock_case_dict],
+            "next_cursor": None,
+            "prev_cursor": None,
+            "has_more": False,
+            "has_previous": False,
+            "aggregation": {
+                "agg": "mean",
+                "agg_field": "field:duration_ms",
+                "group_by": ["status"],
+                "value": 12.5,
+                "buckets": [{"key": {"status": "new"}, "value": 12.5}],
+                "bucket_limit": 100,
+                "truncated": False,
+            },
+        }
+
+        result = await search_cases(
+            agg="avg",
+            agg_field="field:duration_ms",
+            group_by=["status"],
+            limit=5,
+        )
+
+        mock_cases_client.search_cases.assert_called_once_with(
+            agg="avg",
+            agg_field="field:duration_ms",
+            group_by=["status"],
+            limit=5,
+        )
+        assert isinstance(result, dict)
+        aggregation = result.get("aggregation")
+        assert aggregation is not None
+        assert aggregation["agg"] == "mean"
+
     async def test_search_cases_with_ordering(
         self, mock_cases_client: AsyncMock, mock_case_dict
     ):

--- a/tests/registry/test_core_table.py
+++ b/tests/registry/test_core_table.py
@@ -407,6 +407,46 @@ class TestCoreSearchRecords:
         assert result["items"][0] == mock_row
         assert result["next_cursor"] == "cursor-1"
 
+    async def test_search_rows_returns_structured_shape_for_aggregation(
+        self, mock_tables_client: AsyncMock, mock_row
+    ):
+        """Aggregation requests should return the full response object."""
+        mock_tables_client.search_rows.return_value = {
+            "items": [mock_row],
+            "next_cursor": None,
+            "prev_cursor": None,
+            "has_more": False,
+            "has_previous": False,
+            "aggregation": {
+                "agg": "count",
+                "agg_field": None,
+                "group_by": ["status"],
+                "value": 1,
+                "buckets": [{"key": {"status": "active"}, "value": 1}],
+                "bucket_limit": 100,
+                "truncated": False,
+            },
+        }
+
+        result = await search_rows(
+            table="test_table",
+            agg="count",
+            group_by=["status"],
+            limit=50,
+        )
+
+        mock_tables_client.search_rows.assert_called_once_with(
+            table="test_table",
+            agg="count",
+            group_by=["status"],
+            limit=50,
+            reverse=False,
+        )
+        assert isinstance(result, dict)
+        aggregation = result.get("aggregation")
+        assert aggregation is not None
+        assert aggregation["value"] == 1
+
     async def test_search_rows_legacy_list_response(
         self, mock_tables_client: AsyncMock
     ):

--- a/tests/registry/test_tables_sdk.py
+++ b/tests/registry/test_tables_sdk.py
@@ -63,3 +63,42 @@ async def test_search_rows_rejects_unexpected_dict_shape(
 
     with pytest.raises(ValueError, match="Unexpected search response"):
         await tables_client.search_rows(table="test_table")
+
+
+@pytest.mark.anyio
+async def test_search_rows_forwards_aggregation_fields(
+    tables_client: TablesClient, mock_tracecat_client: MagicMock
+) -> None:
+    """Aggregation args should be posted in the search body."""
+    mock_tracecat_client.post.return_value = {
+        "items": [],
+        "next_cursor": None,
+        "prev_cursor": None,
+        "has_more": False,
+        "has_previous": False,
+        "aggregation": {
+            "agg": "count",
+            "agg_field": None,
+            "group_by": ["status"],
+            "value": 0,
+            "buckets": [],
+            "bucket_limit": 100,
+            "truncated": False,
+        },
+    }
+
+    await tables_client.search_rows(
+        table="test_table",
+        agg="count",
+        group_by=["status"],
+        bucket_limit=25,
+    )
+
+    mock_tracecat_client.post.assert_called_once_with(
+        "/tables/test_table/search",
+        json={
+            "group_by": ["status"],
+            "agg": "count",
+            "bucket_limit": 25,
+        },
+    )

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -14,11 +14,15 @@ from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.schemas import (
     CaseReadMinimal,
-    CaseSearchAggregateRead,
-    CaseStatusGroupCounts,
+    CaseSearchResponse,
 )
 from tracecat.db.models import Case, CaseTag, Workspace
 from tracecat.pagination import CursorPaginatedResponse
+from tracecat.search.schemas import (
+    SearchAggFunction,
+    SearchAggregationBucket,
+    SearchAggregationResult,
+)
 
 
 @pytest.fixture
@@ -605,7 +609,7 @@ async def test_search_cases_success(
     test_admin_role: Role,
     mock_case: Case,
 ) -> None:
-    """Test GET /cases/search delegates to search_cases shape/response."""
+    """Test POST /cases/search delegates to search_cases shape/response."""
     with (
         patch.object(cases_router, "CasesService") as MockService,
     ):
@@ -636,12 +640,14 @@ async def test_search_cases_success(
         MockService.return_value = mock_svc
 
         # Make request
-        response = client.get(
+        response = client.post(
             "/cases/search",
-            params={
-                "workspace_id": str(test_admin_role.workspace_id),
+            json={
                 "search_term": "Test",
                 "limit": 10,
+            },
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
             },
         )
 
@@ -659,7 +665,7 @@ async def test_search_cases_forwards_date_filters(
     test_admin_role: Role,
     mock_case: Case,
 ) -> None:
-    """Test GET /cases/search forwards date filters to search_cases."""
+    """Test POST /cases/search forwards date filters to search_cases."""
     with (
         patch.object(cases_router, "CasesService") as MockService,
     ):
@@ -689,14 +695,16 @@ async def test_search_cases_forwards_date_filters(
         )
         MockService.return_value = mock_svc
 
-        response = client.get(
+        response = client.post(
             "/cases/search",
-            params={
-                "workspace_id": str(test_admin_role.workspace_id),
+            json={
                 "start_time": "2024-01-01T00:00:00Z",
                 "end_time": "2024-01-31T23:59:59Z",
                 "updated_after": "2024-01-15T00:00:00Z",
                 "updated_before": "2024-01-31T23:59:59Z",
+            },
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
             },
         )
 
@@ -705,43 +713,57 @@ async def test_search_cases_forwards_date_filters(
 
 
 @pytest.mark.anyio
-async def test_search_case_aggregates_success(
+async def test_search_cases_with_aggregation_success(
     client: TestClient,
     test_admin_role: Role,
 ) -> None:
-    """Test GET /cases/search/aggregate returns grouped global counts."""
+    """Test POST /cases/search returns unified aggregation in response."""
     with (
         patch.object(cases_router, "CasesService") as MockService,
     ):
         mock_svc = AsyncMock()
-        mock_svc.get_search_case_aggregates.return_value = CaseSearchAggregateRead(
-            total=42,
-            status_groups=CaseStatusGroupCounts(
-                new=10,
-                in_progress=8,
-                on_hold=4,
-                resolved=18,
-                other=2,
+        mock_svc.search_cases.return_value = CaseSearchResponse(
+            items=[],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+            total_estimate=42,
+            aggregation=SearchAggregationResult(
+                agg=SearchAggFunction.COUNT,
+                agg_field=None,
+                group_by=["status"],
+                value=42,
+                buckets=[
+                    SearchAggregationBucket(key={"status": "new"}, value=10),
+                    SearchAggregationBucket(key={"status": "resolved"}, value=18),
+                ],
+                bucket_limit=100,
+                truncated=False,
             ),
         )
         MockService.return_value = mock_svc
 
-        response = client.get(
-            "/cases/search/aggregate",
-            params={
-                "workspace_id": str(test_admin_role.workspace_id),
-                "status": "new",
-                "priority": "medium",
-                "severity": "high",
+        response = client.post(
+            "/cases/search",
+            json={
+                "status": ["new"],
+                "priority": ["medium"],
+                "severity": ["high"],
                 "search_term": "incident",
                 "start_time": "2024-01-01T00:00:00Z",
                 "updated_after": "2024-01-15T00:00:00Z",
+                "agg": "count",
+                "group_by": ["status"],
+            },
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
             },
         )
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data["total"] == 42
-        assert data["status_groups"]["new"] == 10
-        assert data["status_groups"]["resolved"] == 18
-        mock_svc.get_search_case_aggregates.assert_called_once()
+        assert data["aggregation"]["value"] == 42
+        assert data["aggregation"]["buckets"][0]["key"]["status"] == "new"
+        assert data["aggregation"]["buckets"][0]["value"] == 10
+        mock_svc.search_cases.assert_called_once()

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -26,9 +26,10 @@ from tracecat.cases.schemas import (
     CaseUpdate,
 )
 from tracecat.cases.service import CaseFieldsService, CasesService
-from tracecat.db.models import Case
+from tracecat.db.models import Case, CaseTag, CaseTagLink
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.pagination import CursorPaginationParams
+from tracecat.search.schemas import SearchRequestValidationError
 from tracecat.tables.enums import SqlType
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -874,10 +875,10 @@ class TestCasesService:
                 short_id="CASE-ABCD",
             )
 
-    async def test_get_search_case_aggregates_applies_enum_filters(
+    async def test_search_cases_aggregation_applies_enum_filters(
         self, cases_service: CasesService, session: AsyncSession
     ) -> None:
-        """Aggregate counts should respect include/exclude enum filters."""
+        """Aggregations should respect enum filter constraints."""
         now = datetime.now(UTC)
         session.add_all(
             [
@@ -935,18 +936,195 @@ class TestCasesService:
         )
         await session.commit()
 
-        aggregates = await cases_service.get_search_case_aggregates(
+        response = await cases_service.search_cases(
+            params=CursorPaginationParams(limit=20, cursor=None, reverse=False),
             status=[CaseStatus.IN_PROGRESS, CaseStatus.RESOLVED],
             priority=[CasePriority.HIGH, CasePriority.CRITICAL],
             severity=[CaseSeverity.MEDIUM, CaseSeverity.HIGH],
+            agg="count",
+            group_by=["status"],
         )
 
-        assert aggregates.total == 2
-        assert aggregates.status_groups.new == 0
-        assert aggregates.status_groups.in_progress == 1
-        assert aggregates.status_groups.on_hold == 0
-        assert aggregates.status_groups.resolved == 1
-        assert aggregates.status_groups.other == 0
+        assert response.aggregation is not None
+        assert response.aggregation.agg == "count"
+        assert response.aggregation.value == 2
+        buckets = {
+            bucket.key.get("status"): bucket.value
+            for bucket in response.aggregation.buckets
+        }
+        assert buckets["in_progress"] == 1
+        assert buckets["resolved"] == 1
+
+    async def test_search_cases_aggregation_normalizes_avg_alias(
+        self, cases_service: CasesService, session: AsyncSession
+    ) -> None:
+        """avg should normalize to mean in responses."""
+        await cases_service.fields.create_field(
+            CaseFieldCreate(
+                name="duration_ms",
+                type=SqlType.NUMERIC,
+            )
+        )
+
+        first_case = await cases_service.create_case(
+            CaseCreate(
+                summary="Case A",
+                description="A",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+                fields={"duration_ms": 10},
+            )
+        )
+        await cases_service.create_case(
+            CaseCreate(
+                summary="Case B",
+                description="B",
+                status=CaseStatus.RESOLVED,
+                priority=CasePriority.HIGH,
+                severity=CaseSeverity.MEDIUM,
+                fields={"duration_ms": 20},
+            )
+        )
+
+        response = await cases_service.search_cases(
+            params=CursorPaginationParams(limit=10, cursor=None, reverse=False),
+            agg="avg",
+            agg_field="field:duration_ms",
+            group_by=["status"],
+        )
+
+        assert response.aggregation is not None
+        assert response.aggregation.agg == "mean"
+        assert response.aggregation.value == 15
+        grouped = {
+            bucket.key.get("status"): bucket.value
+            for bucket in response.aggregation.buckets
+        }
+        assert grouped["new"] == 10
+        assert grouped["resolved"] == 20
+
+        # Ensure rows still return with no regression when aggregation is requested.
+        assert any(item.id == first_case.id for item in response.items)
+
+    async def test_search_cases_rejects_value_counts_aggregation(
+        self, cases_service: CasesService
+    ) -> None:
+        """value_counts is explicitly out of scope and should fail validation."""
+        with pytest.raises(SearchRequestValidationError) as exc_info:
+            await cases_service.search_cases(
+                params=CursorPaginationParams(limit=10, cursor=None, reverse=False),
+                agg="value_counts",
+                agg_field="status",
+            )
+        assert exc_info.value.detail["field"] == "agg"
+
+    async def test_search_cases_group_by_tag_uses_explode_semantics(
+        self, cases_service: CasesService, session: AsyncSession
+    ) -> None:
+        """Cases linked to multiple tags should contribute to multiple buckets."""
+        first_case = await cases_service.create_case(
+            CaseCreate(
+                summary="Case A",
+                description="A",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+        second_case = await cases_service.create_case(
+            CaseCreate(
+                summary="Case B",
+                description="B",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+
+        tag_alpha = CaseTag(
+            workspace_id=cases_service.workspace_id,
+            name="alpha",
+            ref="alpha",
+            color="#111111",
+        )
+        tag_bravo = CaseTag(
+            workspace_id=cases_service.workspace_id,
+            name="bravo",
+            ref="bravo",
+            color="#222222",
+        )
+        session.add_all([tag_alpha, tag_bravo])
+        await session.flush()
+        session.add_all(
+            [
+                CaseTagLink(case_id=first_case.id, tag_id=tag_alpha.id),
+                CaseTagLink(case_id=first_case.id, tag_id=tag_bravo.id),
+                CaseTagLink(case_id=second_case.id, tag_id=tag_alpha.id),
+            ]
+        )
+        await session.commit()
+
+        response = await cases_service.search_cases(
+            params=CursorPaginationParams(limit=20, cursor=None, reverse=False),
+            agg="count",
+            group_by=["tag"],
+        )
+
+        assert response.aggregation is not None
+        assert response.aggregation.value == 2
+        buckets = {
+            bucket.key.get("tag"): bucket.value
+            for bucket in response.aggregation.buckets
+        }
+        assert buckets["alpha"] == 2
+        assert buckets["bravo"] == 1
+
+    async def test_search_cases_group_by_multiselect_field_explodes_values(
+        self, cases_service: CasesService
+    ) -> None:
+        """MULTI_SELECT custom fields should explode into one bucket per option."""
+        await cases_service.fields.create_field(
+            CaseFieldCreate(
+                name="systems",
+                type=SqlType.MULTI_SELECT,
+                options=["db", "api", "cache"],
+            )
+        )
+        await cases_service.create_case(
+            CaseCreate(
+                summary="Case A",
+                description="A",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+                fields={"systems": ["db", "api"]},
+            )
+        )
+        await cases_service.create_case(
+            CaseCreate(
+                summary="Case B",
+                description="B",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+                fields={"systems": ["api"]},
+            )
+        )
+
+        response = await cases_service.search_cases(
+            params=CursorPaginationParams(limit=20, cursor=None, reverse=False),
+            agg="count",
+            group_by=["field:systems"],
+        )
+
+        assert response.aggregation is not None
+        buckets = {
+            bucket.key.get("field:systems"): bucket.value
+            for bucket in response.aggregation.buckets
+        }
+        assert buckets["db"] == 1
+        assert buckets["api"] == 2
 
     async def test_create_case_with_nonexistent_field(
         self, cases_service: CasesService

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -14,6 +14,7 @@ from tracecat.db.models import Table
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginationParams
+from tracecat.search.schemas import SearchRequestValidationError
 from tracecat.tables.common import parse_postgres_default
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import (
@@ -809,6 +810,69 @@ class TestTableRows:
         # - has_previous: there are no older rows before this reverse page
         assert reverse_page.has_more is True
         assert reverse_page.has_previous is False
+
+    async def test_list_rows_with_count_aggregation(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Table search should return scalar + grouped count aggregations."""
+        for data in [
+            {"name": "Alice", "age": 20},
+            {"name": "Alice", "age": 30},
+            {"name": "Bob", "age": 40},
+        ]:
+            await tables_service.insert_row(table, TableRowInsert(data=data))
+
+        response = await tables_service.list_rows(
+            table,
+            params=CursorPaginationParams(limit=20, cursor=None, reverse=False),
+            agg="count",
+            group_by=["name"],
+        )
+
+        assert response.aggregation is not None
+        assert response.aggregation.agg == "count"
+        assert response.aggregation.value == 3
+        grouped = {
+            bucket.key.get("name"): bucket.value
+            for bucket in response.aggregation.buckets
+        }
+        assert grouped["Alice"] == 2
+        assert grouped["Bob"] == 1
+
+    async def test_list_rows_normalizes_avg_alias(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """avg should canonicalize to mean for table aggregations."""
+        await tables_service.insert_row(
+            table, TableRowInsert(data={"name": "A", "age": 10})
+        )
+        await tables_service.insert_row(
+            table, TableRowInsert(data={"name": "B", "age": 20})
+        )
+
+        response = await tables_service.list_rows(
+            table,
+            params=CursorPaginationParams(limit=20, cursor=None, reverse=False),
+            agg="avg",
+            agg_field="age",
+        )
+
+        assert response.aggregation is not None
+        assert response.aggregation.agg == "mean"
+        assert response.aggregation.value == 15
+
+    async def test_list_rows_rejects_value_counts_aggregation(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """value_counts is intentionally unsupported for this release."""
+        with pytest.raises(SearchRequestValidationError) as exc_info:
+            await tables_service.list_rows(
+                table,
+                params=CursorPaginationParams(limit=20, cursor=None, reverse=False),
+                agg="value_counts",
+                agg_field="name",
+            )
+        assert exc_info.value.detail["field"] == "agg"
 
     async def test_table_editor_list_rows_reverse_pagination_flags(
         self, tables_service: TablesService, table: Table

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query
@@ -24,7 +23,6 @@ from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
 from tracecat.cases.durations.schemas import CaseDurationMetric
 from tracecat.cases.durations.service import CaseDurationService
-from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.rows.schemas import CaseTableRowRead
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
@@ -39,6 +37,8 @@ from tracecat.cases.schemas import (
     CaseFieldReadMinimal,
     CaseRead,
     CaseReadMinimal,
+    CaseSearchRequest,
+    CaseSearchResponse,
     CaseTaskCreate,
     CaseTaskRead,
     CaseTaskUpdate,
@@ -60,6 +60,7 @@ from tracecat.exceptions import TracecatNotFoundError
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
+from tracecat.search.schemas import SearchRequestValidationError
 from tracecat.tiers.enums import Entitlement
 
 router = APIRouter(
@@ -163,70 +164,20 @@ async def list_cases(
     return cases
 
 
-@router.get("/search")
+@router.post("/search")
+@require_scope("case:read")
 async def search_cases(
     *,
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
-    limit: int = Query(
-        config.TRACECAT__LIMIT_DEFAULT,
-        ge=config.TRACECAT__LIMIT_MIN,
-        le=config.TRACECAT__LIMIT_CURSOR_MAX,
-        description="Maximum items per page",
-    ),
-    cursor: str | None = Query(None, description="Cursor for pagination"),
-    reverse: bool = Query(False, description="Reverse pagination direction"),
-    search_term: str | None = Query(
-        None,
-        description="Text to search for in case summary, description, or short ID",
-    ),
-    status: list[CaseStatus] | None = Query(None, description="Filter by case status"),
-    priority: list[CasePriority] | None = Query(
-        None, description="Filter by case priority"
-    ),
-    severity: list[CaseSeverity] | None = Query(
-        None, description="Filter by case severity"
-    ),
-    assignee_id: list[str] | None = Query(
-        None, description="Filter by assignee ID or 'unassigned'"
-    ),
-    tags: list[str] | None = Query(
-        None, description="Filter by tag IDs or slugs (AND logic)"
-    ),
-    dropdown: list[str] | None = Query(
-        None,
-        description="Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)",
-    ),
-    start_time: datetime | None = Query(
-        None, description="Return cases created at or after this timestamp"
-    ),
-    end_time: datetime | None = Query(
-        None, description="Return cases created at or before this timestamp"
-    ),
-    updated_after: datetime | None = Query(
-        None, description="Return cases updated at or after this timestamp"
-    ),
-    updated_before: datetime | None = Query(
-        None, description="Return cases updated at or before this timestamp"
-    ),
-    order_by: Literal[
-        "created_at", "updated_at", "priority", "severity", "status", "tasks"
-    ]
-    | None = Query(
-        None,
-        description="Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at",
-    ),
-    sort: Literal["asc", "desc"] | None = Query(
-        None, description="Direction to sort (asc or desc)"
-    ),
-    include_rows: bool = Query(False, description="Include linked table rows"),
-) -> CursorPaginatedResponse[CaseReadMinimal]:
+    params: CaseSearchRequest,
+) -> CaseSearchResponse:
     service = CasesService(session, role)
 
     tag_ids: list[uuid.UUID] = []
-    if tags:
+    if params.tags:
         tags_service = CaseTagsService(session, role)
-        for tag_identifier in tags:
+        for tag_identifier in params.tags:
             try:
                 tag = await tags_service.get_tag_by_ref_or_id(tag_identifier)
                 tag_ids.append(tag.id)
@@ -234,15 +185,15 @@ async def search_cases(
                 continue
 
     pagination_params = CursorPaginationParams(
-        limit=limit,
-        cursor=cursor,
-        reverse=reverse,
+        limit=params.limit,
+        cursor=params.cursor,
+        reverse=params.reverse,
     )
 
     parsed_assignee_ids: list[uuid.UUID] = []
     include_unassigned = False
-    if assignee_id:
-        for identifier in assignee_id:
+    if params.assignee_id:
+        for identifier in params.assignee_id:
             if identifier == "unassigned":
                 include_unassigned = True
                 continue
@@ -255,9 +206,9 @@ async def search_cases(
                 ) from e
 
     parsed_dropdown_filters: dict[str, list[str]] | None = None
-    if dropdown:
+    if params.dropdown:
         parsed_dropdown_filters = {}
-        for entry in dropdown:
+        for entry in params.dropdown:
             if ":" not in entry:
                 raise HTTPException(
                     status_code=HTTP_400_BAD_REQUEST,
@@ -268,23 +219,28 @@ async def search_cases(
 
     try:
         cases = await service.search_cases(
-            pagination_params,
-            search_term=search_term,
-            status=status,
-            priority=priority,
-            severity=severity,
+            params=pagination_params,
+            search_term=params.search_term,
+            short_id=params.short_id,
+            status=params.status,
+            priority=params.priority,
+            severity=params.severity,
             assignee_ids=parsed_assignee_ids or None,
             include_unassigned=include_unassigned,
             tag_ids=tag_ids if tag_ids else None,
             dropdown_filters=parsed_dropdown_filters,
-            start_time=start_time,
-            end_time=end_time,
-            updated_after=updated_after,
-            updated_before=updated_before,
-            order_by=order_by,
-            sort=sort,
+            start_time=params.start_time,
+            end_time=params.end_time,
+            updated_after=params.updated_after,
+            updated_before=params.updated_before,
+            order_by=params.order_by,
+            sort=params.sort,
+            group_by=params.group_by,
+            agg=params.agg,
+            agg_field=params.agg_field,
+            bucket_limit=params.bucket_limit,
         )
-        if include_rows and cases.items:
+        if params.include_rows and cases.items:
             rows_service = CaseTableRowsService(session, role)
             rows_by_case = await rows_service.hydrate_case_rows(
                 case_ids=[item.id for item in cases.items],
@@ -296,6 +252,12 @@ async def search_cases(
             ]
         return cases
 
+    except SearchRequestValidationError as e:
+        logger.warning("Invalid request for search cases", detail=e.detail)
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=e.detail,
+        ) from e
     except ValueError as e:
         logger.warning(f"Invalid request for search cases: {e}")
         raise HTTPException(

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 from typing import Annotated, Literal, TypedDict
 
 from asyncpg import DuplicateColumnError
@@ -22,7 +21,6 @@ from tracecat.auth.types import Role
 from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
-from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
     AssigneeChangedEventRead,
@@ -38,7 +36,8 @@ from tracecat.cases.schemas import (
     CaseFieldUpdate,
     CaseRead,
     CaseReadMinimal,
-    CaseSearchAggregateRead,
+    CaseSearchRequest,
+    CaseSearchResponse,
     CaseTaskCreate,
     CaseTaskRead,
     CaseTaskUpdate,
@@ -61,6 +60,7 @@ from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
 )
+from tracecat.search.schemas import SearchRequestValidationError
 from tracecat.tiers.enums import Entitlement
 
 cases_router = APIRouter(prefix="/cases", tags=["cases"])
@@ -240,104 +240,59 @@ async def list_cases(
     return cases
 
 
-@cases_router.get("/search")
+@cases_router.post("/search")
 @require_scope("case:read")
 async def search_cases(
     *,
     role: WorkspaceUser,
     session: AsyncDBSession,
-    limit: int = Query(
-        config.TRACECAT__LIMIT_DEFAULT,
-        ge=config.TRACECAT__LIMIT_MIN,
-        le=config.TRACECAT__LIMIT_CURSOR_MAX,
-        description="Maximum items per page",
-    ),
-    cursor: str | None = Query(None, description="Cursor for pagination"),
-    reverse: bool = Query(False, description="Reverse pagination direction"),
-    search_term: str | None = Query(
-        None,
-        description="Text to search for in case summary, description, or short ID",
-    ),
-    short_id: str | None = Query(
-        None,
-        description="Search by exact case short ID (e.g. 42 or CASE-0042)",
-    ),
-    status: list[CaseStatus] | None = Query(None, description="Filter by case status"),
-    priority: list[CasePriority] | None = Query(
-        None, description="Filter by case priority"
-    ),
-    severity: list[CaseSeverity] | None = Query(
-        None, description="Filter by case severity"
-    ),
-    tags: list[str] | None = Query(
-        None, description="Filter by tag IDs or slugs (AND logic)"
-    ),
-    dropdown: list[str] | None = Query(
-        None,
-        description="Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)",
-    ),
-    start_time: datetime | None = Query(
-        None, description="Return cases created at or after this timestamp"
-    ),
-    end_time: datetime | None = Query(
-        None, description="Return cases created at or before this timestamp"
-    ),
-    updated_after: datetime | None = Query(
-        None, description="Return cases updated at or after this timestamp"
-    ),
-    updated_before: datetime | None = Query(
-        None, description="Return cases updated at or before this timestamp"
-    ),
-    assignee_id: list[str] | None = Query(
-        None, description="Filter by assignee ID or 'unassigned'"
-    ),
-    order_by: Literal[
-        "created_at", "updated_at", "priority", "severity", "status", "tasks"
-    ]
-    | None = Query(
-        None,
-        description="Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at",
-    ),
-    sort: Literal["asc", "desc"] | None = Query(
-        None, description="Direction to sort (asc or desc)"
-    ),
-    include_rows: bool = Query(False, description="Include linked table rows"),
-) -> CursorPaginatedResponse[CaseReadMinimal]:
+    params: CaseSearchRequest,
+) -> CaseSearchResponse:
     """Search cases with cursor-based pagination, filtering, and sorting."""
     service = CasesService(session, role)
 
-    pagination_params = CursorPaginationParams(
-        limit=limit,
-        cursor=cursor,
-        reverse=reverse,
-    )
     parsed_filters = await _parse_case_search_filters(
         role=role,
         session=session,
-        assignee_id=assignee_id,
-        tags=tags,
-        dropdown=dropdown,
+        assignee_id=params.assignee_id,
+        tags=params.tags,
+        dropdown=params.dropdown,
+    )
+    pagination_params = CursorPaginationParams(
+        limit=params.limit,
+        cursor=params.cursor,
+        reverse=params.reverse,
     )
 
     try:
         cases = await service.search_cases(
-            pagination_params,
-            search_term=search_term,
-            short_id=short_id,
-            status=status,
-            priority=priority,
-            severity=severity,
+            params=pagination_params,
+            search_term=params.search_term,
+            short_id=params.short_id,
+            status=params.status,
+            priority=params.priority,
+            severity=params.severity,
             assignee_ids=parsed_filters["assignee_ids"],
             include_unassigned=parsed_filters["include_unassigned"],
             tag_ids=parsed_filters["tag_ids"],
             dropdown_filters=parsed_filters["dropdown_filters"],
-            start_time=start_time,
-            end_time=end_time,
-            updated_after=updated_after,
-            updated_before=updated_before,
-            order_by=order_by,
-            sort=sort,
+            start_time=params.start_time,
+            end_time=params.end_time,
+            updated_after=params.updated_after,
+            updated_before=params.updated_before,
+            order_by=params.order_by,
+            sort=params.sort,
+            group_by=params.group_by,
+            agg=params.agg,
+            agg_field=params.agg_field,
+            bucket_limit=params.bucket_limit,
         )
+    except SearchRequestValidationError as e:
+        logger.warning("Invalid case search request", detail=e.detail)
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=e.detail,
+        ) from e
     except ValueError as e:
         logger.warning(f"Invalid request for search cases: {e}")
         raise HTTPException(
@@ -352,7 +307,7 @@ async def search_cases(
             status_code=HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve cases",
         ) from e
-    if include_rows and cases.items:
+    if params.include_rows and cases.items:
         try:
             rows_service = CaseTableRowsService(session, role)
             rows_by_case = await rows_service.hydrate_case_rows(
@@ -370,87 +325,6 @@ async def search_cases(
                 detail="Failed to hydrate linked rows",
             ) from e
     return cases
-
-
-@cases_router.get("/search/aggregate")
-@require_scope("case:read")
-async def search_case_aggregates(
-    *,
-    role: WorkspaceUser,
-    session: AsyncDBSession,
-    search_term: str | None = Query(
-        None,
-        description="Text to search for in case summary, description, or short ID",
-    ),
-    status: list[CaseStatus] | None = Query(None, description="Filter by case status"),
-    priority: list[CasePriority] | None = Query(
-        None, description="Filter by case priority"
-    ),
-    severity: list[CaseSeverity] | None = Query(
-        None, description="Filter by case severity"
-    ),
-    tags: list[str] | None = Query(
-        None, description="Filter by tag IDs or slugs (AND logic)"
-    ),
-    dropdown: list[str] | None = Query(
-        None,
-        description="Filter by dropdown values. Format: definition_ref:option_ref (AND across definitions, OR within)",
-    ),
-    start_time: datetime | None = Query(
-        None, description="Return cases created at or after this timestamp"
-    ),
-    end_time: datetime | None = Query(
-        None, description="Return cases created at or before this timestamp"
-    ),
-    updated_after: datetime | None = Query(
-        None, description="Return cases updated at or after this timestamp"
-    ),
-    updated_before: datetime | None = Query(
-        None, description="Return cases updated at or before this timestamp"
-    ),
-    assignee_id: list[str] | None = Query(
-        None, description="Filter by assignee ID or 'unassigned'"
-    ),
-) -> CaseSearchAggregateRead:
-    """Return global case totals and per-stage counts for the current filters."""
-    service = CasesService(session, role)
-    parsed_filters = await _parse_case_search_filters(
-        role=role,
-        session=session,
-        assignee_id=assignee_id,
-        tags=tags,
-        dropdown=dropdown,
-    )
-
-    try:
-        return await service.get_search_case_aggregates(
-            search_term=search_term,
-            status=status,
-            priority=priority,
-            severity=severity,
-            assignee_ids=parsed_filters["assignee_ids"],
-            include_unassigned=parsed_filters["include_unassigned"],
-            tag_ids=parsed_filters["tag_ids"],
-            dropdown_filters=parsed_filters["dropdown_filters"],
-            start_time=start_time,
-            end_time=end_time,
-            updated_after=updated_after,
-            updated_before=updated_before,
-        )
-    except ValueError as e:
-        logger.warning(f"Invalid request for case aggregate counts: {e}")
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        ) from e
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to fetch case aggregate counts: {e}")
-        raise HTTPException(
-            status_code=HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve case aggregate counts",
-        ) from e
 
 
 @cases_router.get("/{case_id}")

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, Literal
 import sqlalchemy as sa
 from pydantic import ConfigDict, Field, RootModel, field_validator
 
+from tracecat import config
 from tracecat.auth.schemas import UserRead
 from tracecat.cases.constants import RESERVED_CASE_FIELDS
 from tracecat.cases.dropdowns.schemas import (
@@ -33,6 +34,12 @@ from tracecat.identifiers.workflow import (
     WorkflowIDShort,
     WorkflowUUID,
 )
+from tracecat.pagination import CursorPaginatedResponse
+from tracecat.search.schemas import (
+    DEFAULT_BUCKET_LIMIT,
+    MAX_BUCKET_LIMIT,
+    SearchAggregationResult,
+)
 
 
 class CaseReadMinimal(Schema):
@@ -52,17 +59,44 @@ class CaseReadMinimal(Schema):
     num_tasks_total: int = Field(default=0)
 
 
-class CaseStatusGroupCounts(Schema):
-    new: int = 0
-    in_progress: int = 0
-    on_hold: int = 0
-    resolved: int = 0
-    other: int = 0
+class CaseSearchRequest(Schema):
+    limit: int = Field(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    )
+    cursor: str | None = Field(default=None)
+    reverse: bool = Field(default=False)
+    search_term: str | None = Field(default=None)
+    short_id: str | None = Field(default=None)
+    status: list[CaseStatus] | None = Field(default=None)
+    priority: list[CasePriority] | None = Field(default=None)
+    severity: list[CaseSeverity] | None = Field(default=None)
+    tags: list[str] | None = Field(default=None)
+    dropdown: list[str] | None = Field(default=None)
+    start_time: datetime | None = Field(default=None)
+    end_time: datetime | None = Field(default=None)
+    updated_after: datetime | None = Field(default=None)
+    updated_before: datetime | None = Field(default=None)
+    assignee_id: list[str] | None = Field(default=None)
+    order_by: (
+        Literal["created_at", "updated_at", "priority", "severity", "status", "tasks"]
+        | None
+    ) = Field(default=None)
+    sort: Literal["asc", "desc"] | None = Field(default=None)
+    include_rows: bool = Field(default=False)
+    group_by: list[str] | None = Field(default=None)
+    agg: str | None = Field(default=None)
+    agg_field: str | None = Field(default=None)
+    bucket_limit: int = Field(
+        default=DEFAULT_BUCKET_LIMIT,
+        ge=1,
+        le=MAX_BUCKET_LIMIT,
+    )
 
 
-class CaseSearchAggregateRead(Schema):
-    total: int
-    status_groups: CaseStatusGroupCounts
+class CaseSearchResponse(CursorPaginatedResponse[CaseReadMinimal]):
+    aggregation: SearchAggregationResult | None = None
 
 
 class CaseRead(Schema):

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1,6 +1,8 @@
+import decimal
 import re
 import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
@@ -11,7 +13,7 @@ from sqlalchemy import and_, cast, func, or_, select
 from sqlalchemy.dialects.postgresql import UUID, insert
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -40,8 +42,7 @@ from tracecat.cases.schemas import (
     CaseCreate,
     CaseEventVariant,
     CaseReadMinimal,
-    CaseSearchAggregateRead,
-    CaseStatusGroupCounts,
+    CaseSearchResponse,
     CaseTaskCreate,
     CaseTaskUpdate,
     CaseUpdate,
@@ -77,6 +78,7 @@ from tracecat.db.models import (
     CaseDropdownValue,
     CaseEvent,
     CaseFields,
+    CaseTag,
     CaseTagLink,
     CaseTask,
     User,
@@ -96,8 +98,16 @@ from tracecat.expressions.expectations import (
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.pagination import (
     BaseCursorPaginator,
-    CursorPaginatedResponse,
     CursorPaginationParams,
+)
+from tracecat.search.schemas import (
+    MAX_BUCKET_LIMIT,
+    SearchAggFunction,
+    SearchAggregationBucket,
+    SearchAggregationResult,
+    SearchAggregationValue,
+    SearchRequestValidationError,
+    normalize_agg_function,
 )
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tables.common import normalize_column_options
@@ -126,6 +136,23 @@ CASE_PRIORITY_SORT_ORDER = tuple(priority.value for priority in CasePriority)
 CASE_SEVERITY_SORT_ORDER = tuple(severity.value for severity in CaseSeverity)
 CASE_STATUS_SORT_ORDER = tuple(status.value for status in CaseStatus)
 SHORT_ID_PATTERN = re.compile(r"^(?:CASE-)?(\d{1,10})$", re.IGNORECASE)
+CASE_AGG_BASE_FIELDS: dict[str, Any] = {
+    "status": Case.status,
+    "priority": Case.priority,
+    "severity": Case.severity,
+    "assignee_id": Case.assignee_id,
+}
+CASE_NUMERIC_CUSTOM_FIELD_TYPES = {
+    SqlType.INTEGER.value,
+    SqlType.NUMERIC.value,
+}
+
+
+@dataclass(frozen=True)
+class ParsedCaseAggToken:
+    token: str
+    kind: Literal["base", "tag", "dropdown", "field"]
+    value: str | None = None
 
 
 def _enum_sort_expr(column: Any, ordered_values: Sequence[str]) -> ColumnElement[int]:
@@ -320,6 +347,444 @@ class CasesService(BaseWorkspaceService):
 
         return filters
 
+    @staticmethod
+    def _normalize_aggregation_value(value: Any) -> SearchAggregationValue:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int | float | str):
+            return value
+        if isinstance(value, decimal.Decimal):
+            exponent = value.as_tuple().exponent
+            if isinstance(exponent, int) and exponent >= 0:
+                return int(value)
+            return float(value)
+        if isinstance(value, uuid.UUID):
+            return str(value)
+        normalized_enum = getattr(value, "value", None)
+        if isinstance(normalized_enum, str):
+            return normalized_enum
+        return str(value)
+
+    @staticmethod
+    def _parse_case_agg_token(
+        token: str, *, field: Literal["group_by", "agg_field"]
+    ) -> ParsedCaseAggToken:
+        if token in CASE_AGG_BASE_FIELDS:
+            return ParsedCaseAggToken(token=token, kind="base")
+        if token == "tag":
+            return ParsedCaseAggToken(token=token, kind="tag")
+        if token.startswith("dropdown:"):
+            definition_ref = token.removeprefix("dropdown:").strip()
+            if not definition_ref:
+                raise SearchRequestValidationError(
+                    code="invalid_group_by_token",
+                    field=field,
+                    message="Dropdown group-by tokens must include a definition ref.",
+                    value=token,
+                )
+            return ParsedCaseAggToken(
+                token=token,
+                kind="dropdown",
+                value=definition_ref,
+            )
+        if token.startswith("field:"):
+            field_id = token.removeprefix("field:").strip()
+            if not field_id:
+                raise SearchRequestValidationError(
+                    code="invalid_group_by_token",
+                    field=field,
+                    message="Custom field group-by tokens must include a field id.",
+                    value=token,
+                )
+            return ParsedCaseAggToken(token=token, kind="field", value=field_id)
+        raise SearchRequestValidationError(
+            code="invalid_group_by_token",
+            field=field,
+            message=f"Unsupported {field} token: {token!r}.",
+            value=token,
+            detail={
+                "supported_tokens": [
+                    "status",
+                    "priority",
+                    "severity",
+                    "assignee_id",
+                    "tag",
+                    "dropdown:<definition_ref>",
+                    "field:<field_id>",
+                ]
+            },
+        )
+
+    @staticmethod
+    def _requires_numeric_agg_field(agg: SearchAggFunction) -> bool:
+        return agg in {
+            SearchAggFunction.SUM,
+            SearchAggFunction.MEAN,
+            SearchAggFunction.MEDIAN,
+        }
+
+    async def _build_case_aggregation_dataset(
+        self,
+        *,
+        parsed_tokens: list[ParsedCaseAggToken],
+    ) -> tuple[Any, dict[str, Any], dict[str, bool]]:
+        from_clause: Any = Case.__table__
+        token_exprs: dict[str, Any] = {}
+        token_is_numeric: dict[str, bool] = {}
+
+        dropdown_refs = sorted(
+            {
+                token.value
+                for token in parsed_tokens
+                if token.kind == "dropdown" and token.value is not None
+            }
+        )
+        dropdown_ids_by_ref: dict[str, uuid.UUID] = {}
+        if dropdown_refs:
+            definition_rows = (
+                await self.session.execute(
+                    select(CaseDropdownDefinition.ref, CaseDropdownDefinition.id).where(
+                        CaseDropdownDefinition.workspace_id == self.workspace_id,
+                        CaseDropdownDefinition.ref.in_(dropdown_refs),
+                    )
+                )
+            ).all()
+            dropdown_ids_by_ref = {row.ref: row.id for row in definition_rows}
+            missing_dropdown_refs = [
+                ref for ref in dropdown_refs if ref not in dropdown_ids_by_ref
+            ]
+            if missing_dropdown_refs:
+                raise SearchRequestValidationError(
+                    code="invalid_group_by_token",
+                    field="group_by",
+                    message="Unknown dropdown definition refs in group_by tokens.",
+                    detail={"missing_dropdown_refs": missing_dropdown_refs},
+                )
+
+        field_ids = sorted(
+            {
+                token.value
+                for token in parsed_tokens
+                if token.kind == "field" and token.value is not None
+            }
+        )
+        custom_field_type_by_id: dict[str, str] = {}
+        custom_field_table: Any | None = None
+        if field_ids:
+            await self.fields._ensure_schema_ready()
+            reflected_columns = await self.fields.list_fields()
+            reflected_names = {
+                str(col["name"])
+                for col in reflected_columns
+                if isinstance(col.get("name"), str)
+            }
+            missing_fields = [
+                field_id for field_id in field_ids if field_id not in reflected_names
+            ]
+            if missing_fields:
+                raise SearchRequestValidationError(
+                    code="invalid_group_by_token",
+                    field="group_by",
+                    message="Unknown custom field ids in group_by tokens.",
+                    detail={"missing_fields": missing_fields},
+                )
+            field_schema = await self.fields.get_field_schema()
+            custom_field_type_by_id = {
+                field_id: str(field_schema.get(field_id, {}).get("type", "")).upper()
+                for field_id in field_ids
+            }
+            custom_field_columns = [sa.column("case_id")]
+            custom_field_columns.extend(sa.column(field_id) for field_id in field_ids)
+            custom_field_table = sa.table(
+                self.fields.sanitized_table_name,
+                *custom_field_columns,
+                schema=self.fields.schema_name,
+            )
+            from_clause = from_clause.outerjoin(
+                custom_field_table, custom_field_table.c.case_id == Case.id
+            )
+
+        tag_join_added = False
+        for idx, token in enumerate(parsed_tokens):
+            if token.kind == "base":
+                token_exprs[token.token] = CASE_AGG_BASE_FIELDS[token.token]
+                token_is_numeric[token.token] = False
+                continue
+
+            if token.kind == "tag":
+                if not tag_join_added:
+                    from_clause = from_clause.outerjoin(
+                        CaseTagLink.__table__,
+                        CaseTagLink.case_id == Case.id,
+                    ).outerjoin(
+                        CaseTag.__table__,
+                        and_(
+                            CaseTag.id == CaseTagLink.tag_id,
+                            CaseTag.workspace_id == self.workspace_id,
+                        ),
+                    )
+                    tag_join_added = True
+                token_exprs[token.token] = CaseTag.ref
+                token_is_numeric[token.token] = False
+                continue
+
+            if token.kind == "dropdown":
+                assert token.value is not None
+                dropdown_id = dropdown_ids_by_ref[token.value]
+                dropdown_value_alias = aliased(
+                    CaseDropdownValue, name=f"case_dropdown_value_{idx}"
+                )
+                dropdown_option_alias = aliased(
+                    CaseDropdownOption, name=f"case_dropdown_option_{idx}"
+                )
+                from_clause = from_clause.outerjoin(
+                    dropdown_value_alias,
+                    and_(
+                        dropdown_value_alias.case_id == Case.id,
+                        dropdown_value_alias.definition_id == dropdown_id,
+                    ),
+                ).outerjoin(
+                    dropdown_option_alias,
+                    dropdown_option_alias.id == dropdown_value_alias.option_id,
+                )
+                token_exprs[token.token] = dropdown_option_alias.ref
+                token_is_numeric[token.token] = False
+                continue
+
+            if token.kind == "field":
+                assert custom_field_table is not None
+                assert token.value is not None
+                field_type = custom_field_type_by_id.get(token.value, "")
+                field_expr = custom_field_table.c[token.value]
+                if field_type == SqlType.MULTI_SELECT.value:
+                    json_values = sa.case(
+                        (
+                            sa.func.jsonb_typeof(field_expr) == "array",
+                            field_expr,
+                        ),
+                        else_=sa.text("'[]'::jsonb"),
+                    )
+                    values_alias = sa.func.jsonb_array_elements_text(
+                        json_values
+                    ).table_valued("value")
+                    lateral_values = sa.lateral(values_alias).alias(
+                        f"case_field_values_{idx}"
+                    )
+                    from_clause = from_clause.outerjoin(lateral_values, sa.true())
+                    token_exprs[token.token] = lateral_values.c.value
+                else:
+                    token_exprs[token.token] = field_expr
+                token_is_numeric[token.token] = (
+                    field_type in CASE_NUMERIC_CUSTOM_FIELD_TYPES
+                )
+                continue
+
+        return from_clause, token_exprs, token_is_numeric
+
+    def _build_case_agg_expression(
+        self,
+        *,
+        agg: SearchAggFunction,
+        value_expr: Any | None,
+    ) -> Any:
+        if agg is SearchAggFunction.COUNT:
+            return func.count()
+        if value_expr is None:
+            raise SearchRequestValidationError(
+                code="missing_agg_field",
+                field="agg_field",
+                message=f"Aggregation '{agg.value}' requires agg_field.",
+            )
+        if agg is SearchAggFunction.SUM:
+            return func.sum(value_expr)
+        if agg is SearchAggFunction.MIN:
+            return func.min(value_expr)
+        if agg is SearchAggFunction.MAX:
+            return func.max(value_expr)
+        if agg is SearchAggFunction.MEAN:
+            return func.avg(value_expr)
+        if agg is SearchAggFunction.MEDIAN:
+            return func.percentile_cont(0.5).within_group(value_expr)
+        if agg is SearchAggFunction.N_UNIQUE:
+            return func.count(sa.distinct(value_expr))
+        raise SearchRequestValidationError(
+            code="invalid_aggregation",
+            field="agg",
+            message=f"Unsupported aggregation function: {agg.value!r}.",
+            value=agg.value,
+        )
+
+    async def _compute_case_scalar_aggregation(
+        self,
+        *,
+        filters: list[Any],
+        agg: SearchAggFunction,
+        agg_token: ParsedCaseAggToken | None,
+        from_clause: Any,
+        token_exprs: dict[str, Any],
+        token_is_numeric: dict[str, bool],
+    ) -> SearchAggregationValue:
+        if agg is SearchAggFunction.COUNT:
+            count_stmt = select(func.count(Case.id)).where(*filters)
+            count_result = await self.session.scalar(count_stmt)
+            return int(count_result or 0)
+
+        if agg_token is None:
+            raise SearchRequestValidationError(
+                code="missing_agg_field",
+                field="agg_field",
+                message=f"Aggregation '{agg.value}' requires agg_field.",
+            )
+
+        value_expr = token_exprs[agg_token.token]
+        if self._requires_numeric_agg_field(agg) and not token_is_numeric.get(
+            agg_token.token, False
+        ):
+            raise SearchRequestValidationError(
+                code="invalid_agg_field_type",
+                field="agg_field",
+                message=f"Aggregation '{agg.value}' requires a numeric agg_field.",
+                value=agg_token.token,
+            )
+
+        if agg is SearchAggFunction.MODE:
+            mode_stmt = (
+                select(
+                    value_expr.label("value"),
+                    func.count().label("frequency"),
+                )
+                .select_from(from_clause)
+                .where(*filters, value_expr.is_not(None))
+                .group_by(value_expr)
+                .order_by(func.count().desc(), value_expr.asc())
+                .limit(1)
+            )
+            mode_row = (await self.session.execute(mode_stmt)).first()
+            return (
+                self._normalize_aggregation_value(mode_row.value) if mode_row else None
+            )
+
+        agg_expr = self._build_case_agg_expression(agg=agg, value_expr=value_expr)
+        agg_stmt = (
+            select(agg_expr.label("value")).select_from(from_clause).where(*filters)
+        )
+        row = (await self.session.execute(agg_stmt)).one()
+        return self._normalize_aggregation_value(row.value)
+
+    async def _compute_case_grouped_aggregation(
+        self,
+        *,
+        filters: list[Any],
+        agg: SearchAggFunction,
+        agg_token: ParsedCaseAggToken | None,
+        group_tokens: list[ParsedCaseAggToken],
+        bucket_limit: int,
+        from_clause: Any,
+        token_exprs: dict[str, Any],
+        token_is_numeric: dict[str, bool],
+    ) -> tuple[list[SearchAggregationBucket], bool]:
+        if not group_tokens:
+            return [], False
+
+        group_labels = [f"group_key_{idx}" for idx in range(len(group_tokens))]
+        group_columns = [
+            token_exprs[token.token].label(label)
+            for token, label in zip(group_tokens, group_labels, strict=True)
+        ]
+
+        if agg is SearchAggFunction.MODE:
+            if agg_token is None:
+                raise SearchRequestValidationError(
+                    code="missing_agg_field",
+                    field="agg_field",
+                    message=f"Aggregation '{agg.value}' requires agg_field.",
+                )
+            value_expr = token_exprs[agg_token.token]
+            mode_counts = (
+                select(
+                    *group_columns,
+                    value_expr.label("mode_value"),
+                    func.count().label("frequency"),
+                )
+                .select_from(from_clause)
+                .where(*filters, value_expr.is_not(None))
+                .group_by(*group_columns, value_expr)
+                .subquery("mode_counts")
+            )
+            partition_by = [mode_counts.c[label] for label in group_labels]
+            ranked_modes = select(
+                *partition_by,
+                mode_counts.c.mode_value.label("value"),
+                sa.func.row_number()
+                .over(
+                    partition_by=partition_by,
+                    order_by=(
+                        mode_counts.c.frequency.desc(),
+                        mode_counts.c.mode_value.asc(),
+                    ),
+                )
+                .label("mode_rank"),
+            ).subquery("ranked_modes")
+            grouped_stmt = (
+                select(
+                    *[ranked_modes.c[label] for label in group_labels],
+                    ranked_modes.c.value.label("value"),
+                )
+                .where(ranked_modes.c.mode_rank == 1)
+                .order_by(sa.desc(ranked_modes.c.value).nulls_last())
+            )
+        else:
+            value_expr = token_exprs[agg_token.token] if agg_token else None
+            if agg is not SearchAggFunction.COUNT and agg_token is None:
+                raise SearchRequestValidationError(
+                    code="missing_agg_field",
+                    field="agg_field",
+                    message=f"Aggregation '{agg.value}' requires agg_field.",
+                )
+            if (
+                agg_token is not None
+                and self._requires_numeric_agg_field(agg)
+                and not token_is_numeric.get(agg_token.token, False)
+            ):
+                raise SearchRequestValidationError(
+                    code="invalid_agg_field_type",
+                    field="agg_field",
+                    message=f"Aggregation '{agg.value}' requires a numeric agg_field.",
+                    value=agg_token.token,
+                )
+            grouped_value_expr = self._build_case_agg_expression(
+                agg=agg,
+                value_expr=value_expr,
+            )
+            grouped_stmt = (
+                select(*group_columns, grouped_value_expr.label("value"))
+                .select_from(from_clause)
+                .where(*filters)
+                .group_by(*group_columns)
+                .order_by(sa.desc(sa.column("value")).nulls_last())
+            )
+
+        grouped_stmt = grouped_stmt.limit(bucket_limit + 1)
+        rows = (await self.session.execute(grouped_stmt)).all()
+        truncated = len(rows) > bucket_limit
+        rows = rows[:bucket_limit]
+
+        buckets: list[SearchAggregationBucket] = []
+        for row in rows:
+            row_data = row._mapping
+            key: dict[str, Any] = {}
+            for token, label in zip(group_tokens, group_labels, strict=True):
+                key[token.token] = self._normalize_aggregation_value(row_data[label])
+            buckets.append(
+                SearchAggregationBucket(
+                    key=key,
+                    value=self._normalize_aggregation_value(row_data["value"]),
+                )
+            )
+        return buckets, truncated
+
     async def search_cases(
         self,
         params: CursorPaginationParams,
@@ -341,7 +806,11 @@ class CasesService(BaseWorkspaceService):
         ]
         | None = None,
         sort: Literal["asc", "desc"] | None = None,
-    ) -> CursorPaginatedResponse[CaseReadMinimal]:
+        group_by: Sequence[str] | None = None,
+        agg: str | SearchAggFunction | None = None,
+        agg_field: str | None = None,
+        bucket_limit: int = 100,
+    ) -> CaseSearchResponse:
         """Search cases with cursor-based pagination and filtering."""
         paginator = BaseCursorPaginator(self.session)
         filters = self._build_search_filters(
@@ -611,101 +1080,102 @@ class CasesService(BaseWorkspaceService):
                 )
             )
 
-        return CursorPaginatedResponse(
+        aggregation: SearchAggregationResult | None = None
+        if bucket_limit < 1 or bucket_limit > MAX_BUCKET_LIMIT:
+            raise SearchRequestValidationError(
+                code="invalid_bucket_limit",
+                field="bucket_limit",
+                message=(f"bucket_limit must be between 1 and {MAX_BUCKET_LIMIT}."),
+                value=bucket_limit,
+            )
+        normalized_agg = normalize_agg_function(agg)
+        has_group_by = bool(group_by)
+        if normalized_agg is None and (agg_field is not None or has_group_by):
+            raise SearchRequestValidationError(
+                code="missing_aggregation",
+                field="agg",
+                message="agg is required when group_by or agg_field is provided.",
+            )
+
+        if normalized_agg is not None:
+            if normalized_agg is SearchAggFunction.COUNT and agg_field is not None:
+                raise SearchRequestValidationError(
+                    code="invalid_agg_field",
+                    field="agg_field",
+                    message="agg_field is not used with count aggregation.",
+                    value=agg_field,
+                )
+
+            parsed_group_tokens = [
+                self._parse_case_agg_token(token, field="group_by")
+                for token in (group_by or [])
+            ]
+            parsed_agg_token = (
+                self._parse_case_agg_token(agg_field, field="agg_field")
+                if agg_field is not None
+                else None
+            )
+            if (
+                normalized_agg is not SearchAggFunction.COUNT
+                and parsed_agg_token is None
+            ):
+                raise SearchRequestValidationError(
+                    code="missing_agg_field",
+                    field="agg_field",
+                    message=f"Aggregation '{normalized_agg.value}' requires agg_field.",
+                )
+
+            parsed_tokens: list[ParsedCaseAggToken] = []
+            seen_tokens: set[str] = set()
+            for token in parsed_group_tokens + (
+                [parsed_agg_token] if parsed_agg_token is not None else []
+            ):
+                if token.token in seen_tokens:
+                    continue
+                seen_tokens.add(token.token)
+                parsed_tokens.append(token)
+
+            (
+                from_clause,
+                token_exprs,
+                token_is_numeric,
+            ) = await self._build_case_aggregation_dataset(parsed_tokens=parsed_tokens)
+            scalar_value = await self._compute_case_scalar_aggregation(
+                filters=filters,
+                agg=normalized_agg,
+                agg_token=parsed_agg_token,
+                from_clause=from_clause,
+                token_exprs=token_exprs,
+                token_is_numeric=token_is_numeric,
+            )
+            buckets, truncated = await self._compute_case_grouped_aggregation(
+                filters=filters,
+                agg=normalized_agg,
+                agg_token=parsed_agg_token,
+                group_tokens=parsed_group_tokens,
+                bucket_limit=bucket_limit,
+                from_clause=from_clause,
+                token_exprs=token_exprs,
+                token_is_numeric=token_is_numeric,
+            )
+            aggregation = SearchAggregationResult(
+                agg=normalized_agg,
+                agg_field=parsed_agg_token.token if parsed_agg_token else None,
+                group_by=[token.token for token in parsed_group_tokens],
+                value=scalar_value,
+                buckets=buckets,
+                bucket_limit=bucket_limit,
+                truncated=truncated,
+            )
+
+        return CaseSearchResponse(
             items=case_items,
             next_cursor=next_cursor,
             prev_cursor=prev_cursor,
             has_more=has_more,
             has_previous=has_previous,
             total_estimate=total_estimate,
-        )
-
-    async def get_search_case_aggregates(
-        self,
-        *,
-        search_term: str | None = None,
-        status: CaseStatus | Sequence[CaseStatus] | None = None,
-        priority: CasePriority | Sequence[CasePriority] | None = None,
-        severity: CaseSeverity | Sequence[CaseSeverity] | None = None,
-        assignee_ids: Sequence[uuid.UUID] | None = None,
-        include_unassigned: bool = False,
-        tag_ids: list[uuid.UUID] | None = None,
-        dropdown_filters: dict[str, list[str]] | None = None,
-        start_time: datetime | None = None,
-        end_time: datetime | None = None,
-        updated_before: datetime | None = None,
-        updated_after: datetime | None = None,
-    ) -> CaseSearchAggregateRead:
-        """Return global totals for the current case search filter set."""
-        filters = self._build_search_filters(
-            search_term=search_term,
-            status=status,
-            priority=priority,
-            severity=severity,
-            assignee_ids=assignee_ids,
-            include_unassigned=include_unassigned,
-            tag_ids=tag_ids,
-            dropdown_filters=dropdown_filters,
-            start_time=start_time,
-            end_time=end_time,
-            updated_before=updated_before,
-            updated_after=updated_after,
-        )
-
-        aggregate_stmt = select(
-            func.count(Case.id).label("total"),
-            func.coalesce(
-                func.sum(sa.case((Case.status == CaseStatus.NEW, 1), else_=0)),
-                0,
-            ).label("new"),
-            func.coalesce(
-                func.sum(sa.case((Case.status == CaseStatus.IN_PROGRESS, 1), else_=0)),
-                0,
-            ).label("in_progress"),
-            func.coalesce(
-                func.sum(sa.case((Case.status == CaseStatus.ON_HOLD, 1), else_=0)),
-                0,
-            ).label("on_hold"),
-            func.coalesce(
-                func.sum(
-                    sa.case(
-                        (
-                            Case.status.in_([CaseStatus.RESOLVED, CaseStatus.CLOSED]),
-                            1,
-                        ),
-                        else_=0,
-                    )
-                ),
-                0,
-            ).label("resolved"),
-            func.coalesce(
-                func.sum(
-                    sa.case(
-                        (
-                            Case.status.in_([CaseStatus.OTHER, CaseStatus.UNKNOWN]),
-                            1,
-                        ),
-                        else_=0,
-                    )
-                ),
-                0,
-            ).label("other"),
-        )
-
-        for clause in filters:
-            aggregate_stmt = aggregate_stmt.where(clause)
-
-        row = (await self.session.execute(aggregate_stmt)).one()
-
-        return CaseSearchAggregateRead(
-            total=int(row.total or 0),
-            status_groups=CaseStatusGroupCounts(
-                new=int(row.new or 0),
-                in_progress=int(row.in_progress or 0),
-                on_hold=int(row.on_hold or 0),
-                resolved=int(row.resolved or 0),
-                other=int(row.other or 0),
-            ),
+            aggregation=aggregation,
         )
 
     async def list_cases(
@@ -718,7 +1188,7 @@ class CasesService(BaseWorkspaceService):
         ]
         | None = None,
         sort: Literal["asc", "desc"] | None = None,
-    ) -> CursorPaginatedResponse[CaseReadMinimal]:
+    ) -> CaseSearchResponse:
         """List cases with a simplified default search query."""
         return await self.search_cases(
             params=CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -1670,6 +1670,7 @@ class CaseTagLink(Base):
     """Link table for cases and case tags."""
 
     __tablename__ = "case_tag_link"
+    __table_args__ = (Index("ix_case_tag_link_tag_case", "tag_id", "case_id"),)
 
     case_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
@@ -1810,6 +1811,12 @@ class CaseDropdownValue(Base):
             "case_id",
             "definition_id",
             name="uq_case_dropdown_value_case_definition",
+        ),
+        Index(
+            "ix_case_dropdown_value_definition_option_case",
+            "definition_id",
+            "option_id",
+            "case_id",
         ),
     )
 

--- a/tracecat/search/__init__.py
+++ b/tracecat/search/__init__.py
@@ -1,0 +1,1 @@
+"""Shared search contracts and helpers."""

--- a/tracecat/search/schemas.py
+++ b/tracecat/search/schemas.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import Field
+
+from tracecat.core.schemas import Schema
+
+DEFAULT_BUCKET_LIMIT = 100
+MAX_BUCKET_LIMIT = 1000
+
+
+class SearchAggFunction(StrEnum):
+    COUNT = "count"
+    SUM = "sum"
+    MIN = "min"
+    MAX = "max"
+    MEAN = "mean"
+    MEDIAN = "median"
+    MODE = "mode"
+    N_UNIQUE = "n_unique"
+
+
+type SearchAggregationValue = int | float | str | bool | None
+
+
+class SearchAggregationBucket(Schema):
+    key: dict[str, Any]
+    value: SearchAggregationValue
+
+
+class SearchAggregationResult(Schema):
+    agg: SearchAggFunction
+    agg_field: str | None = None
+    group_by: list[str] = Field(default_factory=list)
+    value: SearchAggregationValue
+    buckets: list[SearchAggregationBucket] = Field(default_factory=list)
+    bucket_limit: int = Field(default=DEFAULT_BUCKET_LIMIT)
+    truncated: bool = False
+
+
+class SearchRequestValidationError(ValueError):
+    def __init__(
+        self,
+        *,
+        code: str,
+        field: str,
+        message: str,
+        value: Any | None = None,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        full_detail: dict[str, Any] = {
+            "code": code,
+            "field": field,
+            "message": message,
+        }
+        if value is not None:
+            full_detail["value"] = value
+        if detail:
+            full_detail.update(detail)
+        self.detail = full_detail
+        super().__init__(message)
+
+
+def normalize_agg_function(
+    value: str | SearchAggFunction | None,
+) -> SearchAggFunction | None:
+    if value is None:
+        return None
+    if isinstance(value, SearchAggFunction):
+        return value
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized == "avg":
+        return SearchAggFunction.MEAN
+    if normalized == "value_counts":
+        raise SearchRequestValidationError(
+            code="unsupported_aggregation",
+            field="agg",
+            message="Aggregation function 'value_counts' is not supported in this release.",
+            value=value,
+        )
+    try:
+        return SearchAggFunction(normalized)
+    except ValueError as exc:
+        supported = [member.value for member in SearchAggFunction]
+        raise SearchRequestValidationError(
+            code="invalid_aggregation",
+            field="agg",
+            message=f"Unsupported aggregation function: {value!r}.",
+            value=value,
+            detail={"supported": supported + ["avg"]},
+        ) from exc

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
@@ -20,7 +19,8 @@ from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.expressions.functions import tabulate
 from tracecat.logger import logger
-from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
+from tracecat.pagination import CursorPaginationParams
+from tracecat.search.schemas import SearchRequestValidationError
 from tracecat.tables.common import coerce_optional_to_utc_datetime
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import (
@@ -30,6 +30,8 @@ from tracecat.tables.schemas import (
     TableRead,
     TableRowInsert,
     TableRowInsertBatch,
+    TableSearchRequest,
+    TableSearchResponse,
 )
 from tracecat.tables.service import TablesService
 
@@ -57,21 +59,6 @@ class TableLookupRequest(BaseModel):
 class TableExistsRequest(BaseModel):
     columns: list[str]
     values: list[Any]
-
-
-class TableSearchRequest(BaseModel):
-    search_term: str | None = None
-    start_time: datetime | None = None
-    end_time: datetime | None = None
-    updated_before: datetime | None = None
-    updated_after: datetime | None = None
-    cursor: str | None = None
-    reverse: bool = False
-    limit: int = Field(
-        default=config.TRACECAT__LIMIT_TABLE_SEARCH_DEFAULT,
-        ge=config.TRACECAT__LIMIT_MIN,
-        le=config.TRACECAT__LIMIT_CURSOR_MAX,
-    )
 
 
 class TableRowUpdate(BaseModel):
@@ -245,7 +232,7 @@ async def search_rows(
     session: AsyncDBSession,
     table_name: str,
     params: TableSearchRequest,
-) -> CursorPaginatedResponse[dict[str, Any]]:
+) -> TableSearchResponse:
     """Search rows in a table with optional filters."""
     service = TablesService(session, role=role)
     try:
@@ -269,7 +256,16 @@ async def search_rows(
             end_time=coerce_optional_to_utc_datetime(params.end_time),
             updated_before=coerce_optional_to_utc_datetime(params.updated_before),
             updated_after=coerce_optional_to_utc_datetime(params.updated_after),
+            group_by=params.group_by,
+            agg=params.agg,
+            agg_field=params.agg_field,
+            bucket_limit=params.bucket_limit,
         )
+    except SearchRequestValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=exc.detail,
+        ) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/tables/schemas.py
+++ b/tracecat/tables/schemas.py
@@ -5,8 +5,15 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from tracecat import config
 from tracecat.core.schemas import Schema
 from tracecat.identifiers import TableColumnID, TableID, TableRowID
+from tracecat.pagination import CursorPaginatedResponse
+from tracecat.search.schemas import (
+    DEFAULT_BUCKET_LIMIT,
+    MAX_BUCKET_LIMIT,
+    SearchAggregationResult,
+)
 from tracecat.tables.common import (
     coerce_multi_select_value,
     coerce_select_value,
@@ -263,3 +270,30 @@ class TableImportResponse(BaseModel):
     table: TableRead
     rows_inserted: int
     column_mapping: list[InferredColumn]
+
+
+class TableSearchRequest(Schema):
+    search_term: str | None = Field(default=None)
+    start_time: datetime | None = Field(default=None)
+    end_time: datetime | None = Field(default=None)
+    updated_before: datetime | None = Field(default=None)
+    updated_after: datetime | None = Field(default=None)
+    cursor: str | None = Field(default=None)
+    reverse: bool = Field(default=False)
+    limit: int = Field(
+        default=config.TRACECAT__LIMIT_TABLE_SEARCH_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    )
+    group_by: list[str] | None = Field(default=None)
+    agg: str | None = Field(default=None)
+    agg_field: str | None = Field(default=None)
+    bucket_limit: int = Field(
+        default=DEFAULT_BUCKET_LIMIT,
+        ge=1,
+        le=MAX_BUCKET_LIMIT,
+    )
+
+
+class TableSearchResponse(CursorPaginatedResponse[dict[str, Any]]):
+    aggregation: SearchAggregationResult | None = None

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -1,4 +1,5 @@
 import csv
+import decimal
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
@@ -13,7 +14,7 @@ from asyncpg.exceptions import (
     InvalidCachedStatementError,
     UndefinedTableError,
 )
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import JSONB, insert
 from sqlalchemy.exc import DBAPIError, IntegrityError, NoResultFound, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -41,6 +42,15 @@ from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
 )
+from tracecat.search.schemas import (
+    MAX_BUCKET_LIMIT,
+    SearchAggFunction,
+    SearchAggregationBucket,
+    SearchAggregationResult,
+    SearchAggregationValue,
+    SearchRequestValidationError,
+    normalize_agg_function,
+)
 from tracecat.service import BaseWorkspaceService
 from tracecat.tables.common import (
     coerce_multi_select_value,
@@ -64,6 +74,7 @@ from tracecat.tables.schemas import (
     TableColumnUpdate,
     TableCreate,
     TableRowInsert,
+    TableSearchResponse,
     TableUpdate,
 )
 
@@ -71,6 +82,7 @@ _RETRYABLE_DB_EXCEPTIONS = (
     InvalidCachedStatementError,
     InFailedSQLTransactionError,
 )
+TABLE_NUMERIC_TYPES = {SqlType.INTEGER.value, SqlType.NUMERIC.value}
 
 
 class BaseTablesService(BaseWorkspaceService):
@@ -1076,6 +1088,241 @@ class BaseTablesService(BaseWorkspaceService):
                 )
                 raise
 
+    @staticmethod
+    def _normalize_aggregation_value(value: Any) -> SearchAggregationValue:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int | float | str):
+            return value
+        if isinstance(value, decimal.Decimal):
+            exponent = value.as_tuple().exponent
+            if isinstance(exponent, int) and exponent >= 0:
+                return int(value)
+            return float(value)
+        normalized_enum = getattr(value, "value", None)
+        if isinstance(normalized_enum, str):
+            return normalized_enum
+        return str(value)
+
+    @staticmethod
+    def _requires_numeric_agg_field(agg: SearchAggFunction) -> bool:
+        return agg in {
+            SearchAggFunction.SUM,
+            SearchAggFunction.MEAN,
+            SearchAggFunction.MEDIAN,
+        }
+
+    def _build_table_agg_expression(
+        self,
+        *,
+        agg: SearchAggFunction,
+        value_expr: Any | None,
+    ) -> Any:
+        if agg is SearchAggFunction.COUNT:
+            return func.count()
+        if value_expr is None:
+            raise SearchRequestValidationError(
+                code="missing_agg_field",
+                field="agg_field",
+                message=f"Aggregation '{agg.value}' requires agg_field.",
+            )
+        if agg is SearchAggFunction.SUM:
+            return func.sum(value_expr)
+        if agg is SearchAggFunction.MIN:
+            return func.min(value_expr)
+        if agg is SearchAggFunction.MAX:
+            return func.max(value_expr)
+        if agg is SearchAggFunction.MEAN:
+            return func.avg(value_expr)
+        if agg is SearchAggFunction.MEDIAN:
+            return func.percentile_cont(0.5).within_group(value_expr)
+        if agg is SearchAggFunction.N_UNIQUE:
+            return func.count(sa.distinct(value_expr))
+        raise SearchRequestValidationError(
+            code="invalid_aggregation",
+            field="agg",
+            message=f"Unsupported aggregation function: {agg.value!r}.",
+            value=agg.value,
+        )
+
+    async def _compute_table_scalar_aggregation(
+        self,
+        *,
+        table_clause: Any,
+        where_conditions: list[Any],
+        agg: SearchAggFunction,
+        agg_field_expr: Any | None,
+        agg_field_name: str | None,
+        numeric_columns: set[str],
+    ) -> SearchAggregationValue:
+        if agg is SearchAggFunction.COUNT:
+            count_stmt = select(func.count()).select_from(table_clause)
+            if where_conditions:
+                count_stmt = count_stmt.where(sa.and_(*where_conditions))
+            count_result = await self.session.scalar(count_stmt)
+            return int(count_result or 0)
+
+        if agg_field_expr is None or agg_field_name is None:
+            raise SearchRequestValidationError(
+                code="missing_agg_field",
+                field="agg_field",
+                message=f"Aggregation '{agg.value}' requires agg_field.",
+            )
+        if (
+            self._requires_numeric_agg_field(agg)
+            and agg_field_name not in numeric_columns
+        ):
+            raise SearchRequestValidationError(
+                code="invalid_agg_field_type",
+                field="agg_field",
+                message=f"Aggregation '{agg.value}' requires a numeric agg_field.",
+                value=agg_field_name,
+            )
+
+        if agg is SearchAggFunction.MODE:
+            mode_stmt = (
+                select(
+                    agg_field_expr.label("value"),
+                    func.count().label("frequency"),
+                )
+                .select_from(table_clause)
+                .where(agg_field_expr.is_not(None))
+                .group_by(agg_field_expr)
+                .order_by(func.count().desc(), agg_field_expr.asc())
+                .limit(1)
+            )
+            if where_conditions:
+                mode_stmt = mode_stmt.where(sa.and_(*where_conditions))
+            mode_row = (await self.session.execute(mode_stmt)).first()
+            return (
+                self._normalize_aggregation_value(mode_row.value) if mode_row else None
+            )
+
+        agg_expr = self._build_table_agg_expression(agg=agg, value_expr=agg_field_expr)
+        agg_stmt = select(agg_expr.label("value")).select_from(table_clause)
+        if where_conditions:
+            agg_stmt = agg_stmt.where(sa.and_(*where_conditions))
+        row = (await self.session.execute(agg_stmt)).one()
+        return self._normalize_aggregation_value(row.value)
+
+    async def _compute_table_grouped_aggregation(
+        self,
+        *,
+        table_clause: Any,
+        where_conditions: list[Any],
+        agg: SearchAggFunction,
+        agg_field_expr: Any | None,
+        agg_field_name: str | None,
+        group_by: list[str],
+        bucket_limit: int,
+        numeric_columns: set[str],
+    ) -> tuple[list[SearchAggregationBucket], bool]:
+        if not group_by:
+            return [], False
+
+        group_labels = [f"group_key_{idx}" for idx in range(len(group_by))]
+        group_columns = [
+            sa.column(self._sanitize_identifier(column_name)).label(label)
+            for column_name, label in zip(group_by, group_labels, strict=True)
+        ]
+
+        if agg is SearchAggFunction.MODE:
+            if agg_field_expr is None or agg_field_name is None:
+                raise SearchRequestValidationError(
+                    code="missing_agg_field",
+                    field="agg_field",
+                    message=f"Aggregation '{agg.value}' requires agg_field.",
+                )
+            mode_counts = (
+                select(
+                    *group_columns,
+                    agg_field_expr.label("mode_value"),
+                    func.count().label("frequency"),
+                )
+                .select_from(table_clause)
+                .where(agg_field_expr.is_not(None))
+                .group_by(*group_columns, agg_field_expr)
+            )
+            if where_conditions:
+                mode_counts = mode_counts.where(sa.and_(*where_conditions))
+            mode_counts_subquery = mode_counts.subquery("mode_counts")
+            partition_by = [mode_counts_subquery.c[label] for label in group_labels]
+            ranked_modes = select(
+                *partition_by,
+                mode_counts_subquery.c.mode_value.label("value"),
+                sa.func.row_number()
+                .over(
+                    partition_by=partition_by,
+                    order_by=(
+                        mode_counts_subquery.c.frequency.desc(),
+                        mode_counts_subquery.c.mode_value.asc(),
+                    ),
+                )
+                .label("mode_rank"),
+            ).subquery("ranked_modes")
+            grouped_stmt = (
+                select(
+                    *[ranked_modes.c[label] for label in group_labels],
+                    ranked_modes.c.value.label("value"),
+                )
+                .where(ranked_modes.c.mode_rank == 1)
+                .order_by(sa.desc(ranked_modes.c.value).nulls_last())
+            )
+        else:
+            if agg is not SearchAggFunction.COUNT and (
+                agg_field_expr is None or agg_field_name is None
+            ):
+                raise SearchRequestValidationError(
+                    code="missing_agg_field",
+                    field="agg_field",
+                    message=f"Aggregation '{agg.value}' requires agg_field.",
+                )
+            if (
+                agg_field_name is not None
+                and self._requires_numeric_agg_field(agg)
+                and agg_field_name not in numeric_columns
+            ):
+                raise SearchRequestValidationError(
+                    code="invalid_agg_field_type",
+                    field="agg_field",
+                    message=f"Aggregation '{agg.value}' requires a numeric agg_field.",
+                    value=agg_field_name,
+                )
+            grouped_value_expr = self._build_table_agg_expression(
+                agg=agg,
+                value_expr=agg_field_expr,
+            )
+            grouped_stmt = (
+                select(*group_columns, grouped_value_expr.label("value"))
+                .select_from(table_clause)
+                .group_by(*group_columns)
+                .order_by(sa.desc(sa.column("value")).nulls_last())
+            )
+            if where_conditions:
+                grouped_stmt = grouped_stmt.where(sa.and_(*where_conditions))
+
+        grouped_stmt = grouped_stmt.limit(bucket_limit + 1)
+        rows = (await self.session.execute(grouped_stmt)).all()
+        truncated = len(rows) > bucket_limit
+        rows = rows[:bucket_limit]
+
+        buckets: list[SearchAggregationBucket] = []
+        for row in rows:
+            row_data = row._mapping
+            key = {
+                column_name: self._normalize_aggregation_value(row_data[label])
+                for column_name, label in zip(group_by, group_labels, strict=True)
+            }
+            buckets.append(
+                SearchAggregationBucket(
+                    key=key,
+                    value=self._normalize_aggregation_value(row_data["value"]),
+                )
+            )
+        return buckets, truncated
+
     async def search_rows(
         self,
         table: Table,
@@ -1090,7 +1337,11 @@ class BaseTablesService(BaseWorkspaceService):
         reverse: bool = False,
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
-    ) -> CursorPaginatedResponse[dict[str, Any]]:
+        group_by: list[str] | None = None,
+        agg: str | SearchAggFunction | None = None,
+        agg_field: str | None = None,
+        bucket_limit: int = 100,
+    ) -> TableSearchResponse:
         """Search rows in a table using cursor-based pagination."""
         page_limit = (
             limit if limit is not None else config.TRACECAT__LIMIT_TABLE_SEARCH_DEFAULT
@@ -1110,6 +1361,10 @@ class BaseTablesService(BaseWorkspaceService):
             updated_after=updated_after,
             order_by=order_by,
             sort=sort,
+            group_by=group_by,
+            agg=agg,
+            agg_field=agg_field,
+            bucket_limit=bucket_limit,
         )
 
     async def list_rows(
@@ -1123,7 +1378,11 @@ class BaseTablesService(BaseWorkspaceService):
         updated_after: datetime | None = None,
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
-    ) -> CursorPaginatedResponse[dict[str, Any]]:
+        group_by: list[str] | None = None,
+        agg: str | SearchAggFunction | None = None,
+        agg_field: str | None = None,
+        bucket_limit: int = 100,
+    ) -> TableSearchResponse:
         """List rows in a table with cursor-based pagination.
 
         Args:
@@ -1147,11 +1406,10 @@ class BaseTablesService(BaseWorkspaceService):
         schema_name = self._get_schema_name()
         sanitized_table_name = self._sanitize_identifier(table.name)
         conn = await self.session.connection()
+        table_clause = sa.table(sanitized_table_name, schema=schema_name)
 
         # Build the base query
-        stmt = sa.select(sa.text("*")).select_from(
-            sa.table(sanitized_table_name, schema=schema_name)
-        )
+        stmt = sa.select(sa.text("*")).select_from(table_clause)
 
         # Build WHERE conditions
         where_conditions = []
@@ -1230,12 +1488,85 @@ class BaseTablesService(BaseWorkspaceService):
         sort_direction = sort or "desc"
 
         # Validate the sort column exists in the table
-        valid_columns = {col.name for col in table.columns}
-        valid_columns.update(["id", "created_at", "updated_at"])  # Always available
+        valid_columns = {col.name: col.type for col in table.columns}
+        # System columns exist on every workspace table
+        valid_columns.update(
+            {
+                "id": SqlType.UUID.value,
+                "created_at": SqlType.TIMESTAMPTZ.value,
+                "updated_at": SqlType.TIMESTAMPTZ.value,
+            }
+        )
         if sort_column not in valid_columns:
             raise ValueError(f"Invalid order_by column: {sort_column}")
 
         sort_col = sa.column(self._sanitize_identifier(sort_column))
+        if bucket_limit < 1 or bucket_limit > MAX_BUCKET_LIMIT:
+            raise SearchRequestValidationError(
+                code="invalid_bucket_limit",
+                field="bucket_limit",
+                message=f"bucket_limit must be between 1 and {MAX_BUCKET_LIMIT}.",
+                value=bucket_limit,
+            )
+        normalized_agg = normalize_agg_function(agg)
+        has_group_by = bool(group_by)
+        if normalized_agg is None and (has_group_by or agg_field is not None):
+            raise SearchRequestValidationError(
+                code="missing_aggregation",
+                field="agg",
+                message="agg is required when group_by or agg_field is provided.",
+            )
+
+        validated_group_by = list(dict.fromkeys(group_by or []))
+        if validated_group_by:
+            invalid_group_by = [
+                column_name
+                for column_name in validated_group_by
+                if column_name not in valid_columns
+            ]
+            if invalid_group_by:
+                raise SearchRequestValidationError(
+                    code="invalid_group_by",
+                    field="group_by",
+                    message="group_by must reference existing table columns.",
+                    detail={"invalid_columns": invalid_group_by},
+                )
+
+        agg_field_expr: Any | None = None
+        if agg_field is not None:
+            if agg_field not in valid_columns:
+                raise SearchRequestValidationError(
+                    code="invalid_agg_field",
+                    field="agg_field",
+                    message="agg_field must reference an existing table column.",
+                    value=agg_field,
+                )
+            agg_field_expr = sa.column(self._sanitize_identifier(agg_field))
+
+        if normalized_agg is SearchAggFunction.COUNT and agg_field is not None:
+            raise SearchRequestValidationError(
+                code="invalid_agg_field",
+                field="agg_field",
+                message="agg_field is not used with count aggregation.",
+                value=agg_field,
+            )
+
+        if (
+            normalized_agg is not None
+            and normalized_agg is not SearchAggFunction.COUNT
+            and agg_field is None
+        ):
+            raise SearchRequestValidationError(
+                code="missing_agg_field",
+                field="agg_field",
+                message=f"Aggregation '{normalized_agg.value}' requires agg_field.",
+            )
+
+        numeric_columns = {
+            name
+            for name, column_type in valid_columns.items()
+            if column_type in TABLE_NUMERIC_TYPES
+        }
 
         # Apply cursor-based pagination with sort-column-aware filtering
         if params.cursor:
@@ -1379,12 +1710,43 @@ class BaseTablesService(BaseWorkspaceService):
             next_cursor, prev_cursor = prev_cursor, next_cursor
             has_more, has_previous = has_previous, has_more
 
-        return CursorPaginatedResponse(
+        aggregation: SearchAggregationResult | None = None
+        if normalized_agg is not None:
+            scalar_value = await self._compute_table_scalar_aggregation(
+                table_clause=table_clause,
+                where_conditions=where_conditions,
+                agg=normalized_agg,
+                agg_field_expr=agg_field_expr,
+                agg_field_name=agg_field,
+                numeric_columns=numeric_columns,
+            )
+            buckets, truncated = await self._compute_table_grouped_aggregation(
+                table_clause=table_clause,
+                where_conditions=where_conditions,
+                agg=normalized_agg,
+                agg_field_expr=agg_field_expr,
+                agg_field_name=agg_field,
+                group_by=validated_group_by,
+                bucket_limit=bucket_limit,
+                numeric_columns=numeric_columns,
+            )
+            aggregation = SearchAggregationResult(
+                agg=normalized_agg,
+                agg_field=agg_field,
+                group_by=validated_group_by,
+                value=scalar_value,
+                buckets=buckets,
+                bucket_limit=bucket_limit,
+                truncated=truncated,
+            )
+
+        return TableSearchResponse(
             items=rows,
             next_cursor=next_cursor,
             prev_cursor=prev_cursor,
             has_more=has_more,
             has_previous=has_previous,
+            aggregation=aggregation,
         )
 
     async def batch_insert_rows(


### PR DESCRIPTION
Summary
- replace the split case aggregation endpoints with a single POST search contract that returns scalar and grouped aggregation objects
- keep the internal table search path intact while extending schemas/services/SDKs to support the new aggregation response shape and functions
- normalize aggregation inputs (`avg` → `mean`), enforce validation (bucket limits, function/field allowlists), and update the frontend hooks/components to consume the shared response
Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies case and table search under a single POST contract with built-in aggregation. Replaces the legacy case aggregates endpoint and updates schemas, services, SDKs, and frontend to the new response shape.

- **New Features**
  - POST /cases/search returns items plus an aggregation result (scalar value and grouped buckets).
  - Shared search schema (tracecat/search) with standard agg functions (count, sum, min, max, mean, median, mode, n_unique) and bucket limits.
  - Tables now support the same aggregation options via POST /tables/{table}/search (group_by, agg, agg_field, bucket_limit).
  - Normalized agg inputs (avg → mean, value_counts → n_unique) and enforced validation (bucket limits, field/function allowlists, short_id format).
  - Added DB indexes on case_tag_link and case_dropdown_value for faster grouped queries.

- **Migration**
  - /cases/search is now POST with a JSON body (filters, pagination, group_by, agg, agg_field, bucket_limit). Update clients to send a body instead of query params.
  - Removed CasesSearchCaseAggregates. Use the aggregation in /cases/search.
  - SDK methods now post request bodies and accept aggregation fields; adopt normalized agg names.
  - Response includes aggregation under aggregation. Update frontend hooks/components to read this shape (stage counts via hooks, removed CaseSearchAggregateRead).

<sup>Written for commit 12b58aa136a76fe454370ef434e3a3e8c88a934e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

