### PR TITLE
refactor(frontend): remove SAFE_ markdown prefix terminology

### DIFF
--- a/frontend/src/components/ai-elements/response.tsx
+++ b/frontend/src/components/ai-elements/response.tsx
@@ -3,9 +3,9 @@
 import { type ComponentProps, memo } from "react"
 import { Streamdown } from "streamdown"
 import {
+  ALLOWED_MARKDOWN_IMAGE_PREFIXES,
+  ALLOWED_MARKDOWN_LINK_PREFIXES,
   getStreamdownRehypePlugins,
-  SAFE_MARKDOWN_IMAGE_PREFIXES,
-  SAFE_MARKDOWN_LINK_PREFIXES,
 } from "@/lib/sanitize-markdown"
 import { cn } from "@/lib/utils"
 
@@ -23,8 +23,8 @@ export const Response = memo(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className
       )}
-      allowedImagePrefixes={SAFE_MARKDOWN_IMAGE_PREFIXES}
-      allowedLinkPrefixes={SAFE_MARKDOWN_LINK_PREFIXES}
+      allowedImagePrefixes={ALLOWED_MARKDOWN_IMAGE_PREFIXES}
+      allowedLinkPrefixes={ALLOWED_MARKDOWN_LINK_PREFIXES}
       rehypePlugins={responseRehypePlugins}
     >
       {children}

--- a/frontend/src/components/chat/messages.tsx
+++ b/frontend/src/components/chat/messages.tsx
@@ -10,9 +10,9 @@ import { Streamdown } from "streamdown"
 import { Dots } from "@/components/loading/dots"
 import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 import {
+  ALLOWED_MARKDOWN_IMAGE_PREFIXES,
+  ALLOWED_MARKDOWN_LINK_PREFIXES,
   getStreamdownRehypePlugins,
-  SAFE_MARKDOWN_IMAGE_PREFIXES,
-  SAFE_MARKDOWN_LINK_PREFIXES,
 } from "@/lib/sanitize-markdown"
 
 /**
@@ -208,8 +208,8 @@ export function Messages({
         >
           <Image src={TracecatIcon} alt="Tracecat" className="size-4 mt-1" />
           <Streamdown
-            allowedImagePrefixes={SAFE_MARKDOWN_IMAGE_PREFIXES}
-            allowedLinkPrefixes={SAFE_MARKDOWN_LINK_PREFIXES}
+            allowedImagePrefixes={ALLOWED_MARKDOWN_IMAGE_PREFIXES}
+            allowedLinkPrefixes={ALLOWED_MARKDOWN_LINK_PREFIXES}
             rehypePlugins={chatMessageRehypePlugins}
             className={`${assistantMarkdownStyle} flex-1`}
             parseIncompleteMarkdown
@@ -274,8 +274,8 @@ function AgentChatMessage({ message }: { message: ModelResponse }) {
       <div className="flex flex-1 flex-col gap-3 text-sm text-foreground">
         {textContent && (
           <Streamdown
-            allowedImagePrefixes={SAFE_MARKDOWN_IMAGE_PREFIXES}
-            allowedLinkPrefixes={SAFE_MARKDOWN_LINK_PREFIXES}
+            allowedImagePrefixes={ALLOWED_MARKDOWN_IMAGE_PREFIXES}
+            allowedLinkPrefixes={ALLOWED_MARKDOWN_LINK_PREFIXES}
             rehypePlugins={chatMessageRehypePlugins}
             className={assistantMarkdownStyle}
           >

--- a/frontend/src/lib/sanitize-markdown.ts
+++ b/frontend/src/lib/sanitize-markdown.ts
@@ -16,7 +16,7 @@ const sanitizeSchema = {
   },
 }
 
-export const SAFE_MARKDOWN_LINK_PREFIXES = [
+export const ALLOWED_MARKDOWN_LINK_PREFIXES = [
   "http://",
   "https://",
   "mailto:",
@@ -25,7 +25,7 @@ export const SAFE_MARKDOWN_LINK_PREFIXES = [
   "#",
 ]
 
-export const SAFE_MARKDOWN_IMAGE_PREFIXES = [
+export const ALLOWED_MARKDOWN_IMAGE_PREFIXES = [
   "http://",
   "https://",
   "data:image/",


### PR DESCRIPTION
### Motivation
- Remove the `SAFE_` prefix from markdown allowlists to avoid implying absolute security guarantees while keeping existing sanitization behavior.
- Ensure the markdown rendering path still defends against script/event-handler injection and unsafe URL schemes used in user-provided markdown content.

### Description
- Renamed `SAFE_MARKDOWN_LINK_PREFIXES` to `ALLOWED_MARKDOWN_LINK_PREFIXES` in `frontend/src/lib/sanitize-markdown.ts` and preserved the same prefixes (`http://`, `https://`, `mailto:`, `tel:`, `/`, `#`).
- Renamed `SAFE_MARKDOWN_IMAGE_PREFIXES` to `ALLOWED_MARKDOWN_IMAGE_PREFIXES` in `frontend/src/lib/sanitize-markdown.ts` and preserved the same prefixes (`http://`, `https://`, `data:image/`, `/`).
- Updated Streamdown consumers to use the new names in `frontend/src/components/chat/messages.tsx` and `frontend/src/components/ai-elements/response.tsx` without changing runtime behavior.
- Confirmed that `rehype-sanitize` is still applied via `getStreamdownRehypePlugins()` and that Streamdown `allowedLinkPrefixes`/`allowedImagePrefixes` continue to constrain URL schemes.

### Testing
- Ran `pnpm -C frontend check` and it completed successfully (auto-fixed formatting where applicable).
- Ran `pnpm -C frontend install` and `pnpm -C frontend run typecheck` and the TypeScript checks passed.
- Verified no remaining references to the old names with `rg -n "SAFE_MARKDOWN_(LINK|IMAGE)_PREFIXES" frontend/src` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a666480b148333b8e2a5db49556bfb)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed SAFE_ markdown prefix constants to ALLOWED_ to avoid implying absolute security while keeping the same sanitization and URL allowlists.

- **Refactors**
  - Renamed SAFE_MARKDOWN_LINK_PREFIXES to ALLOWED_MARKDOWN_LINK_PREFIXES and SAFE_MARKDOWN_IMAGE_PREFIXES to ALLOWED_MARKDOWN_IMAGE_PREFIXES.
  - Updated usages in frontend/src/components/ai-elements/response.tsx and frontend/src/components/chat/messages.tsx.

- **Migration**
  - Replace imports of SAFE_* constants with ALLOWED_* equivalents.

<sup>Written for commit 3ecc3b88bc79b7535718560c45a900a262718d53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

