### PR TITLE
fix(editor): remove experimental pill decorations setting

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2280,10 +2280,6 @@ export const $AppSettingsRead = {
       type: "boolean",
       title: "App Create Workspace On Register",
     },
-    app_editor_pill_decorations_enabled: {
-      type: "boolean",
-      title: "App Editor Pill Decorations Enabled",
-    },
     app_action_form_mode_enabled: {
       type: "boolean",
       title: "App Action Form Mode Enabled",
@@ -2296,7 +2292,6 @@ export const $AppSettingsRead = {
     "app_interactions_enabled",
     "app_workflow_export_enabled",
     "app_create_workspace_on_register",
-    "app_editor_pill_decorations_enabled",
     "app_action_form_mode_enabled",
   ],
   title: "AppSettingsRead",
@@ -2335,13 +2330,6 @@ export const $AppSettingsUpdate = {
       title: "App Create Workspace On Register",
       description:
         "Whether to automatically create a workspace when a user signs up.",
-      default: false,
-    },
-    app_editor_pill_decorations_enabled: {
-      type: "boolean",
-      title: "App Editor Pill Decorations Enabled",
-      description:
-        "Whether to show template expression pills with decorations. When disabled, expressions show as plain text with simple highlighting.",
       default: false,
     },
     app_action_form_mode_enabled: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -535,7 +535,6 @@ export type AppSettingsRead = {
   app_interactions_enabled: boolean
   app_workflow_export_enabled: boolean
   app_create_workspace_on_register: boolean
-  app_editor_pill_decorations_enabled: boolean
   app_action_form_mode_enabled: boolean
 }
 
@@ -563,10 +562,6 @@ export type AppSettingsUpdate = {
    * Whether to automatically create a workspace when a user signs up.
    */
   app_create_workspace_on_register?: boolean
-  /**
-   * Whether to show template expression pills with decorations. When disabled, expressions show as plain text with simple highlighting.
-   */
-  app_editor_pill_decorations_enabled?: boolean
   /**
    * Whether to enable form mode for action inputs. When disabled, only YAML mode is available, preserving raw YAML formatting.
    */

--- a/frontend/src/components/editor/codemirror/yaml-editor.tsx
+++ b/frontend/src/components/editor/codemirror/yaml-editor.tsx
@@ -26,24 +26,14 @@ import React, { useCallback, useMemo, useRef, useState } from "react"
 import { type Control, type FieldValues, useController } from "react-hook-form"
 import YAML from "yaml"
 import type { ActionRead } from "@/client"
-import { useOrgAppSettings } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 import {
-  createAtKeyCompletion,
   createAutocomplete,
-  createBlurHandler,
   createCoreKeymap,
-  createExitEditModeKeyHandler,
-  createExpressionNodeHover,
-  createPillClickHandler,
-  createPillDeleteKeymap,
-  createTemplatePillPlugin,
   EDITOR_STYLE,
-  editingRangeField,
-  pillKeybinds,
   templatePillTheme,
 } from "./common"
 import { createSimpleTemplatePlugin } from "./highlight-plugin"
@@ -77,7 +67,6 @@ export const YamlStyledEditor = React.forwardRef<
   })
   const workspaceId = useWorkspaceId()
   const { workflow } = useWorkflow()
-  const { appSettings } = useOrgAppSettings()
   const [hasErrors, setHasErrors] = useState(false)
   const [saveState, setSaveState] = useState<SaveState>(SaveState.IDLE)
   const [validationErrors, setValidationErrors] = useState<string[]>([])
@@ -209,29 +198,17 @@ export const YamlStyledEditor = React.forwardRef<
 
   // Custom blur handler that commits YAML to form (stable function using refs)
   const yamlBlurHandler = useCallback(() => {
-    return (event: FocusEvent, view: EditorView): boolean => {
-      // Call the original blur handler for template pills, but only if the
-      // necessary state field is present to avoid a crash.
-      const originalResult = view.state.field(editingRangeField, false)
-        ? createBlurHandler()(event, view)
-        : false
-
-      // Commit to form on blur if there are unsaved changes
+    return (): boolean => {
       if (saveStateRef.current === SaveState.UNSAVED) {
-        // Call the commitToForm function to commit the changes to the form
         commitToFormRef.current()
         setSaveStateRef.current(SaveState.IDLE)
       }
 
-      return originalResult
+      return false
     }
   }, []) // No dependencies - stable function
 
   const extensions = useMemo(() => {
-    const pillsEnabled = Boolean(
-      appSettings?.app_editor_pill_decorations_enabled
-    )
-
     const errorMonitorPlugin = ViewPlugin.fromClass(
       class {
         constructor(view: EditorView) {
@@ -259,9 +236,7 @@ export const YamlStyledEditor = React.forwardRef<
       }
     )
 
-    const templatePlugin = pillsEnabled
-      ? createTemplatePillPlugin(workspaceId)
-      : createSimpleTemplatePlugin(workspaceId)
+    const templatePlugin = createSimpleTemplatePlugin(workspaceId)
 
     const baseExtensions = [
       lintGutter(),
@@ -287,29 +262,13 @@ export const YamlStyledEditor = React.forwardRef<
       yamlLiteralHighlighter,
     ]
 
-    if (pillsEnabled) {
-      return [
-        createPillDeleteKeymap(), // This must be first to ensure that the delete key is handled before the core keymap
-        createCoreKeymap(...pillKeybinds),
-        createAtKeyCompletion(),
-        createExitEditModeKeyHandler(),
-        ...baseExtensions,
-        editingRangeField,
-        createExpressionNodeHover(workspaceId),
-        EditorView.domEventHandlers({
-          mousedown: createPillClickHandler(),
-          blur: yamlBlurHandler(),
-        }),
-      ]
-    }
-
     return baseExtensions.concat([
       createCoreKeymap(),
       EditorView.domEventHandlers({
         blur: yamlBlurHandler(),
       }),
     ])
-  }, [workspaceId, actions, yamlBlurHandler, appSettings, forEachExpressions]) // Only stable dependencies
+  }, [workspaceId, actions, yamlBlurHandler, forEachExpressions]) // Only stable dependencies
 
   // Save-related keybindings (separate from core extensions to avoid recreation)
   const saveKeymap = useMemo(() => {
@@ -807,7 +766,6 @@ export function YamlViewOnlyEditor({
   className?: string
 }) {
   const workspaceId = useWorkspaceId()
-  const { appSettings } = useOrgAppSettings()
 
   const textValue = React.useMemo(() => {
     if (value == null) return ""
@@ -822,13 +780,7 @@ export function YamlViewOnlyEditor({
   }, [value])
 
   const extensions = useMemo(() => {
-    const pillsEnabled = Boolean(
-      appSettings?.app_editor_pill_decorations_enabled
-    )
-
-    const templatePlugin = pillsEnabled
-      ? createTemplatePillPlugin(workspaceId)
-      : createSimpleTemplatePlugin(workspaceId)
+    const templatePlugin = createSimpleTemplatePlugin(workspaceId)
 
     const baseExtensions = [
       // Core language support with proper indentation
@@ -850,12 +802,8 @@ export function YamlViewOnlyEditor({
       yamlLiteralHighlighter,
     ]
 
-    if (pillsEnabled) {
-      return baseExtensions.concat([editingRangeField])
-    }
-
     return baseExtensions
-  }, [workspaceId, appSettings])
+  }, [workspaceId])
 
   return (
     <div className="relative">

--- a/frontend/src/components/editor/expression-input.tsx
+++ b/frontend/src/components/editor/expression-input.tsx
@@ -15,24 +15,15 @@ import { useCallback, useMemo } from "react"
 import { useFormContext } from "react-hook-form"
 import type { ActionRead } from "@/client"
 import {
-  createAtKeyCompletion,
   createAutocomplete,
-  createBlurHandler,
   createCoreKeymap,
-  createExitEditModeKeyHandler,
-  createExpressionNodeHover,
-  createPillClickHandler,
-  createPillDeleteKeymap,
-  createTemplatePillPlugin,
   EDITOR_STYLE,
-  editingRangeField,
   templatePillTheme,
 } from "@/components/editor/codemirror/common"
 import { createSimpleTemplatePlugin } from "@/components/editor/codemirror/highlight-plugin"
 import { ExpressionErrorBoundary } from "@/components/error-boundaries"
 import { Input } from "@/components/ui/input"
 import { createTemplateRegex } from "@/lib/expressions"
-import { useOrgAppSettings } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
@@ -124,7 +115,6 @@ function ExpressionInputCore({
   const workspaceId = useWorkspaceId()
   const { workflow } = useWorkflow()
   const methods = useFormContext()
-  const { appSettings } = useOrgAppSettings()
   const actions = workflow?.actions || ({} as Record<string, ActionRead>)
   const forEach = useMemo(() => methods.watch("for_each"), [methods])
 
@@ -171,14 +161,7 @@ function ExpressionInputCore({
   }, [value])
 
   const extensions = useMemo(() => {
-    const pillsEnabled = Boolean(
-      appSettings?.app_editor_pill_decorations_enabled
-    )
-
-    // Choose between pill plugin and simple highlighting
-    const templatePlugin = pillsEnabled
-      ? createTemplatePillPlugin(workspaceId)
-      : createSimpleTemplatePlugin(workspaceId)
+    const templatePlugin = createSimpleTemplatePlugin(workspaceId)
 
     const editorVisualTheme = EditorView.theme({
       // Input-specific styling to match shadcn Input
@@ -260,64 +243,21 @@ function ExpressionInputCore({
     })
 
     const baseExtensions = [
-      // Core setup
       history(),
       EditorState.allowMultipleSelections.of(true),
       indentUnit.of("  "),
-
-      // Linting
       linter(expressionLinter),
-
-      // Features
       bracketMatching(),
       closeBrackets(),
-      createAutocomplete({
-        workspaceId,
-        actions,
-        forEach,
-      }),
-
-      // Placeholder
+      createAutocomplete({ workspaceId, actions, forEach }),
       placeholder(placeholderText),
-
-      // Template expression plugin
       templatePlugin,
       templatePillTheme,
       editorVisualTheme,
     ]
 
-    // Add pill-specific extensions only when pills are enabled
-    if (pillsEnabled) {
-      return [
-        // Keymaps (pill-specific)
-        createPillDeleteKeymap(), // This must be first to ensure that the delete key is handled before the core keymap
-        createCoreKeymap(),
-        createAtKeyCompletion(),
-        createExitEditModeKeyHandler(),
-
-        ...baseExtensions,
-
-        // Pill-specific plugins
-        editingRangeField,
-        createExpressionNodeHover(workspaceId),
-
-        // Event handlers (pill-specific)
-        EditorView.domEventHandlers({
-          mousedown: createPillClickHandler(),
-          blur: createBlurHandler(),
-        }),
-      ]
-    }
-
     return baseExtensions.concat([createCoreKeymap()])
-  }, [
-    workspaceId,
-    actions,
-    placeholderText,
-    forEach,
-    defaultHeight,
-    appSettings,
-  ])
+  }, [workspaceId, actions, placeholderText, forEach, defaultHeight])
 
   const handleChange = useCallback(
     (val: string) => {

--- a/frontend/src/components/organization/org-settings-app.tsx
+++ b/frontend/src/components/organization/org-settings-app.tsx
@@ -24,7 +24,6 @@ const appFormSchema = z.object({
   app_interactions_enabled: z.boolean(),
   app_workflow_export_enabled: z.boolean(),
   app_create_workspace_on_register: z.boolean(),
-  app_editor_pill_decorations_enabled: z.boolean(),
   app_action_form_mode_enabled: z.boolean(),
 })
 
@@ -51,9 +50,6 @@ export function OrgSettingsAppForm() {
         appSettings?.app_workflow_export_enabled ?? true,
       app_create_workspace_on_register:
         appSettings?.app_create_workspace_on_register ?? false,
-      app_editor_pill_decorations_enabled: Boolean(
-        appSettings?.app_editor_pill_decorations_enabled
-      ),
       app_action_form_mode_enabled:
         appSettings?.app_action_form_mode_enabled ?? true,
     },
@@ -69,8 +65,6 @@ export function OrgSettingsAppForm() {
           app_workflow_export_enabled: data.app_workflow_export_enabled,
           app_create_workspace_on_register:
             data.app_create_workspace_on_register,
-          app_editor_pill_decorations_enabled:
-            data.app_editor_pill_decorations_enabled,
           app_action_form_mode_enabled: data.app_action_form_mode_enabled,
         },
       })
@@ -191,32 +185,6 @@ export function OrgSettingsAppForm() {
                 <FormDescription>
                   Automatically create a workspace for new users when they sign
                   up.
-                </FormDescription>
-              </div>
-              <FormControl>
-                <Switch
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="app_editor_pill_decorations_enabled"
-          render={({ field }) => (
-            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-              <div className="space-y-0.5">
-                <FormLabel>
-                  Enable editor pill decorations (experimental)
-                </FormLabel>
-                <FormDescription>
-                  Show template expression pills with decorations. When
-                  disabled, expressions display as plain text with simple
-                  highlighting. This is an experimental feature that may contain
-                  bugs.
                 </FormDescription>
               </div>
               <FormControl>

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -87,7 +87,6 @@ class AppSettingsRead(BaseSettingsGroup):
     app_interactions_enabled: bool
     app_workflow_export_enabled: bool
     app_create_workspace_on_register: bool
-    app_editor_pill_decorations_enabled: bool
     app_action_form_mode_enabled: bool
 
 
@@ -112,10 +111,6 @@ class AppSettingsUpdate(BaseSettingsGroup):
     app_create_workspace_on_register: bool = Field(
         default=False,
         description="Whether to automatically create a workspace when a user signs up.",
-    )
-    app_editor_pill_decorations_enabled: bool = Field(
-        default=False,
-        description="Whether to show template expression pills with decorations. When disabled, expressions show as plain text with simple highlighting.",
     )
     app_action_form_mode_enabled: bool = Field(
         default=True,


### PR DESCRIPTION
### Motivation
- The editor "pill decorations" feature is experimental, produces buggy UX, and should be removed from configurable settings and code paths to simplify and stabilize the editor experience.
- Removing the toggle avoids shipping a broken configuration surface and ensures editors use the stable highlighting implementation by default.

### Description
- Removed the "Enable editor pill decorations (experimental)" form field and its value handling from the org App settings UI and update payload in `frontend/src/components/organization/org-settings-app.tsx`.
- Dropped `app_editor_pill_decorations_enabled` from backend settings schemas (`AppSettingsRead` / `AppSettingsUpdate`) in `tracecat/settings/schemas.py` and regenerated frontend client artifacts to reflect the schema change (`frontend/src/client/types.gen.ts`, `frontend/src/client/schemas.gen.ts`).
- Updated editor implementations to always use the stable simple template plugin (`createSimpleTemplatePlugin`) and removed the conditional pill-specific code paths and event handlers from `frontend/src/components/editor/expression-input.tsx` and `frontend/src/components/editor/codemirror/yaml-editor.tsx`.
- Cleaned up imports/usages tied to the removed setting (removed `useOrgAppSettings` usage where it was only driving the experimental toggle) and simplified blur/extension logic accordingly.

### Testing
- Ran client generation with `pnpm -C frontend run generate-client-ci` which succeeded and regenerated `frontend/src/client` artifacts.
- Ran frontend lint/format check with `pnpm -C frontend check` which completed and `biome` fixed a few files automatically.
- Ran TypeScript type checking with `pnpm -C frontend run typecheck` which passed without errors.
- Ran Python linting on the changed schema with `uv run ruff check tracecat/settings/schemas.py` which passed.
- Attempted a Playwright screenshot of the running frontend, but navigation to `http://localhost:3000` failed with `ERR_EMPTY_RESPONSE` because no local frontend server was running; this does not affect static checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7006fcb648320a1cfc6d2bfbd2f36)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the experimental “editor pill decorations” setting and standardized all editors on the simple template highlighting to improve stability and reduce complexity.

- **Refactors**
  - Removed the toggle from org App settings UI and update payload.
  - Dropped app_editor_pill_decorations_enabled from AppSettingsRead/Update; regenerated frontend client types/schemas.
  - Removed pill-specific plugins, keymaps, and handlers in yaml-editor.tsx and expression-input.tsx; simplified blur and core keymap logic.
  - Cleaned up imports and removed useOrgAppSettings where only used for the toggle.

- **Migration**
  - No action needed. Existing configs for the removed setting are ignored.

<sup>Written for commit 535f516cc77119231f0efa7b152914f659529383. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

