### PR TITLE
fix: avoid /wait webhook crash on InlineObject workflow results

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -20022,65 +20022,10 @@ distinguish multiple files.`,
 export const $WaitResultOutput = {
   anyOf: [
     {
-      $ref: "#/components/schemas/WaitResultValue",
-    },
-    {
       $ref: "#/components/schemas/WebhookStoredObjectInlineResponse",
     },
     {
       $ref: "#/components/schemas/WebhookStoredObjectDownloadResponse",
-    },
-    {
-      items: {
-        $ref: "#/components/schemas/WaitResultOutput",
-      },
-      type: "array",
-    },
-    {
-      additionalProperties: {
-        $ref: "#/components/schemas/WaitResultOutput",
-      },
-      type: "object",
-    },
-  ],
-} as const
-
-export const $WaitResultScalar = {
-  anyOf: [
-    {
-      type: "string",
-    },
-    {
-      type: "integer",
-    },
-    {
-      type: "number",
-    },
-    {
-      type: "boolean",
-    },
-    {
-      type: "null",
-    },
-  ],
-} as const
-
-export const $WaitResultValue = {
-  anyOf: [
-    {
-      $ref: "#/components/schemas/WaitResultScalar",
-    },
-    {
-      items: {
-        $ref: "#/components/schemas/WaitResultValue",
-      },
-      type: "array",
-    },
-    {
-      additionalProperties: {
-        $ref: "#/components/schemas/WaitResultValue",
-      },
-      type: "object",
     },
   ],
 } as const
@@ -20317,7 +20262,7 @@ export const $WebhookStoredObjectInlineResponse = {
       title: "Kind",
     },
     value: {
-      $ref: "#/components/schemas/WaitResultValue",
+      title: "Value",
     },
   },
   type: "object",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -20019,6 +20019,72 @@ distinguish multiple files.`,
   description: "A URL to a video.",
 } as const
 
+export const $WaitResultOutput = {
+  anyOf: [
+    {
+      $ref: "#/components/schemas/WaitResultValue",
+    },
+    {
+      $ref: "#/components/schemas/WebhookStoredObjectInlineResponse",
+    },
+    {
+      $ref: "#/components/schemas/WebhookStoredObjectDownloadResponse",
+    },
+    {
+      items: {
+        $ref: "#/components/schemas/WaitResultOutput",
+      },
+      type: "array",
+    },
+    {
+      additionalProperties: {
+        $ref: "#/components/schemas/WaitResultOutput",
+      },
+      type: "object",
+    },
+  ],
+} as const
+
+export const $WaitResultScalar = {
+  anyOf: [
+    {
+      type: "string",
+    },
+    {
+      type: "integer",
+    },
+    {
+      type: "number",
+    },
+    {
+      type: "boolean",
+    },
+    {
+      type: "null",
+    },
+  ],
+} as const
+
+export const $WaitResultValue = {
+  anyOf: [
+    {
+      $ref: "#/components/schemas/WaitResultScalar",
+    },
+    {
+      items: {
+        $ref: "#/components/schemas/WaitResultValue",
+      },
+      type: "array",
+    },
+    {
+      additionalProperties: {
+        $ref: "#/components/schemas/WaitResultValue",
+      },
+      type: "object",
+    },
+  ],
+} as const
+
 export const $WaitStrategy = {
   type: "string",
   enum: ["wait", "detach"],
@@ -20206,6 +20272,57 @@ export const $WebhookRead = {
 export const $WebhookStatus = {
   type: "string",
   enum: ["online", "offline"],
+} as const
+
+export const $WebhookStoredObjectDownloadResponse = {
+  properties: {
+    kind: {
+      type: "string",
+      enum: ["download_file", "download_export"],
+      title: "Kind",
+    },
+    download_url: {
+      type: "string",
+      title: "Download Url",
+    },
+    expires_in_seconds: {
+      type: "integer",
+      title: "Expires In Seconds",
+    },
+    content_type: {
+      type: "string",
+      title: "Content Type",
+    },
+    size_bytes: {
+      type: "integer",
+      title: "Size Bytes",
+    },
+  },
+  type: "object",
+  required: [
+    "kind",
+    "download_url",
+    "expires_in_seconds",
+    "content_type",
+    "size_bytes",
+  ],
+  title: "WebhookStoredObjectDownloadResponse",
+} as const
+
+export const $WebhookStoredObjectInlineResponse = {
+  properties: {
+    kind: {
+      type: "string",
+      const: "value",
+      title: "Kind",
+    },
+    value: {
+      $ref: "#/components/schemas/WaitResultValue",
+    },
+  },
+  type: "object",
+  required: ["kind", "value"],
+  title: "WebhookStoredObjectInlineResponse",
 } as const
 
 export const $WebhookUpdate = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -773,7 +773,7 @@ export const publicIncomingWebhookGet = (
  * @param data.secret
  * @param data.workflowId
  * @param data.contentType
- * @returns unknown Successful Response
+ * @returns WaitResultOutput Successful Response
  * @throws ApiError
  */
 export const publicIncomingWebhookWait = (

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6262,6 +6262,24 @@ export type VideoUrl = {
   readonly identifier: string
 }
 
+export type WaitResultOutput =
+  | WaitResultValue
+  | WebhookStoredObjectInlineResponse
+  | WebhookStoredObjectDownloadResponse
+  | Array<WaitResultOutput>
+  | {
+      [key: string]: WaitResultOutput
+    }
+
+export type WaitResultScalar = string | number | boolean | null
+
+export type WaitResultValue =
+  | WaitResultScalar
+  | Array<WaitResultValue>
+  | {
+      [key: string]: WaitResultValue
+    }
+
 export type WaitStrategy = "wait" | "detach"
 
 export type WebhookApiKeyGenerateResponse = {
@@ -6309,6 +6327,21 @@ export type WebhookRead = {
 }
 
 export type WebhookStatus = "online" | "offline"
+
+export type WebhookStoredObjectDownloadResponse = {
+  kind: "download_file" | "download_export"
+  download_url: string
+  expires_in_seconds: number
+  content_type: string
+  size_bytes: number
+}
+
+export type kind = "download_file" | "download_export"
+
+export type WebhookStoredObjectInlineResponse = {
+  kind: "value"
+  value: WaitResultValue
+}
 
 export type WebhookUpdate = {
   status?: WebhookStatus | null
@@ -7218,7 +7251,7 @@ export type PublicIncomingWebhookWaitData = {
   workflowId: string
 }
 
-export type PublicIncomingWebhookWaitResponse = unknown
+export type PublicIncomingWebhookWaitResponse = WaitResultOutput
 
 export type PublicIncomingWebhookDraftData = {
   contentType?: string | null
@@ -9958,7 +9991,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: unknown
+        200: WaitResultOutput
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6263,22 +6263,8 @@ export type VideoUrl = {
 }
 
 export type WaitResultOutput =
-  | WaitResultValue
   | WebhookStoredObjectInlineResponse
   | WebhookStoredObjectDownloadResponse
-  | Array<WaitResultOutput>
-  | {
-      [key: string]: WaitResultOutput
-    }
-
-export type WaitResultScalar = string | number | boolean | null
-
-export type WaitResultValue =
-  | WaitResultScalar
-  | Array<WaitResultValue>
-  | {
-      [key: string]: WaitResultValue
-    }
 
 export type WaitStrategy = "wait" | "detach"
 
@@ -6340,7 +6326,7 @@ export type kind = "download_file" | "download_export"
 
 export type WebhookStoredObjectInlineResponse = {
   kind: "value"
-  value: WaitResultValue
+  value: unknown
 }
 
 export type WebhookUpdate = {

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -714,3 +714,26 @@ class TestWebhookDispatchWorkflowInvariants:
             pair for pair in search_attrs.search_attributes if pair.key == trigger_key
         ]
         assert found and found[0].value == "webhook"
+
+    @pytest.mark.anyio
+    async def test_dispatch_does_not_crash_for_inline_object_results(
+        self, service: WorkflowExecutionsService, mock_client: MagicMock
+    ):
+        """Regression: /wait dispatch must tolerate non-JSON-serializable results."""
+        inline_result = InlineObject(type="inline", data={"_": "result-ref"})
+        mock_client.execute_workflow.return_value = {
+            "status": "ok",
+            "result_ref": inline_result,
+        }
+        dsl = _dsl_input()
+
+        with patch.object(service, "_resolve_execution_timeout", return_value=None):
+            response = await service._dispatch_workflow(
+                dsl=dsl,
+                wf_id=_WF_ID,
+                wf_exec_id=f"{_WF_ID.short()}/exec_test",
+                trigger_inputs=None,
+                trigger_type=TriggerType.WEBHOOK,
+            )
+
+        assert response["result"]["result_ref"] == inline_result

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -862,12 +862,9 @@ class TestWebhookDispatchWorkflowInvariants:
     async def test_dispatch_does_not_crash_for_inline_object_results(
         self, service: WorkflowExecutionsService, mock_client: MagicMock
     ):
-        """Regression: /wait dispatch must tolerate non-JSON-serializable results."""
+        """Regression: /wait dispatch returns StoredObject results for inline values."""
         inline_result = InlineObject(type="inline", data={"_": "result-ref"})
-        mock_client.execute_workflow.return_value = {
-            "status": "ok",
-            "result_ref": inline_result,
-        }
+        mock_client.execute_workflow.return_value = inline_result
         dsl = _dsl_input()
 
         with patch.object(service, "_resolve_execution_timeout", return_value=None):
@@ -879,4 +876,4 @@ class TestWebhookDispatchWorkflowInvariants:
                 trigger_type=TriggerType.WEBHOOK,
             )
 
-        assert response["result"]["result_ref"] == inline_result
+        assert response["result"] == inline_result

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -26,7 +26,12 @@ from tracecat.db.models import WorkflowDefinition
 from tracecat.dsl.common import DSLInput, DSLRunArgs
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
-from tracecat.storage.object import InlineObject
+from tracecat.storage.object import (
+    CollectionObject,
+    ExternalObject,
+    InlineObject,
+    ObjectRef,
+)
 from tracecat.webhooks.router import _incoming_webhook, incoming_webhook_wait
 from tracecat.workflow.executions.enums import (
     ExecutionType,
@@ -617,11 +622,119 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["result_ref"] == inline_result
+        assert response["result_ref"] == {"_": "result-ref"}
         mock_service.create_workflow_execution.assert_awaited_once()
         call_kwargs = mock_service.create_workflow_execution.call_args.kwargs
         assert call_kwargs["trigger_type"] == TriggerType.WEBHOOK
         assert call_kwargs["payload"] == payload
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_returns_download_url_for_external_object(self):
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        external_result = ExternalObject(
+            type="external",
+            ref=ObjectRef(
+                backend="s3",
+                bucket="tracecat-workflow",
+                key="wf/test/return.json",
+                size_bytes=42,
+                sha256="abc123",
+                content_type="application/json",
+                encoding="json",
+            ),
+        )
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": {"result_ref": external_result},
+            }
+        )
+
+        with (
+            patch(
+                "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "tracecat.webhooks.router.blob.generate_presigned_download_url",
+                AsyncMock(return_value="https://example.com/presigned/external"),
+            ),
+        ):
+            response = await incoming_webhook_wait(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+            )
+
+        assert response["result_ref"]["kind"] == "external_ref"
+        assert (
+            response["result_ref"]["download_url"]
+            == "https://example.com/presigned/external"
+        )
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_returns_single_download_url_for_collection_object(self):
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        collection_result = CollectionObject(
+            type="collection",
+            manifest_ref=ObjectRef(
+                backend="s3",
+                bucket="tracecat-workflow",
+                key="wf/test/return/manifest.json",
+                size_bytes=128,
+                sha256="manifest-sha",
+                content_type="application/json",
+                encoding="json",
+            ),
+            count=3,
+            chunk_size=2,
+            element_kind="value",
+        )
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": {"result_ref": collection_result},
+            }
+        )
+        mock_storage = MagicMock()
+        mock_storage.retrieve = AsyncMock(
+            return_value=[{"id": 1}, {"id": 2}, {"id": 3}]
+        )
+
+        with (
+            patch(
+                "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "tracecat.webhooks.router.get_object_storage",
+                return_value=mock_storage,
+            ),
+            patch(
+                "tracecat.webhooks.router.blob.upload_file",
+                AsyncMock(),
+            ) as upload_file_mock,
+            patch(
+                "tracecat.webhooks.router.blob.generate_presigned_download_url",
+                AsyncMock(return_value="https://example.com/presigned/collection"),
+            ),
+        ):
+            response = await incoming_webhook_wait(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+            )
+
+        assert response["result_ref"]["kind"] == "collection_ref"
+        assert (
+            response["result_ref"]["download_url"]
+            == "https://example.com/presigned/collection"
+        )
+        upload_file_mock.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
+from hashlib import sha256
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -711,8 +712,8 @@ class TestWebhookRouterExecutionPath:
                 AsyncMock(return_value=mock_service),
             ),
             patch(
-                "tracecat.webhooks.router.get_object_storage",
-                return_value=mock_storage,
+                "tracecat.webhooks.router.get_collection_page",
+                AsyncMock(return_value=[{"id": 1}, {"id": 2}, {"id": 3}]),
             ),
             patch(
                 "tracecat.webhooks.router.blob.upload_file",
@@ -734,6 +735,87 @@ class TestWebhookRouterExecutionPath:
         assert (
             response_obj["download_url"] == "https://example.com/presigned/collection"
         )
+        upload_file_mock.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_materializes_collection_without_storage_backend(self):
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        external_payload = b'{"id":2}'
+        external_ref = ExternalObject(
+            type="external",
+            ref=ObjectRef(
+                backend="s3",
+                bucket="tracecat-workflow",
+                key="wf/test/chunks/0.json",
+                size_bytes=len(external_payload),
+                sha256=sha256(external_payload).hexdigest(),
+                content_type="application/json",
+                encoding="json",
+            ),
+        )
+        collection_result = CollectionObject(
+            type="collection",
+            manifest_ref=ObjectRef(
+                backend="s3",
+                bucket="tracecat-workflow",
+                key="wf/test/return/manifest.json",
+                size_bytes=128,
+                sha256="manifest-sha",
+                content_type="application/json",
+                encoding="json",
+            ),
+            count=2,
+            chunk_size=2,
+            element_kind="stored_object",
+        )
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": collection_result,
+            }
+        )
+
+        with (
+            patch(
+                "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "tracecat.webhooks.router.get_collection_page",
+                AsyncMock(
+                    return_value=[
+                        InlineObject(type="inline", data={"id": 1}).model_dump(),
+                        external_ref.model_dump(),
+                    ]
+                ),
+            ),
+            patch(
+                "tracecat.webhooks.router.cached_blob_download",
+                AsyncMock(return_value=external_payload),
+            ) as cached_download_mock,
+            patch(
+                "tracecat.webhooks.router.blob.upload_file",
+                AsyncMock(),
+            ) as upload_file_mock,
+            patch(
+                "tracecat.webhooks.router.blob.generate_presigned_download_url",
+                AsyncMock(return_value="https://example.com/presigned/collection"),
+            ),
+        ):
+            response = await incoming_webhook_wait(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+            )
+
+        assert response["kind"] == "download_export"
+        response_obj = cast(dict[str, Any], response)
+        assert (
+            response_obj["download_url"] == "https://example.com/presigned/collection"
+        )
+        cached_download_mock.assert_awaited_once()
         upload_file_mock.assert_awaited_once()
 
 

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -27,7 +27,7 @@ from tracecat.dsl.common import DSLInput, DSLRunArgs
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import InlineObject
-from tracecat.webhooks.router import _incoming_webhook
+from tracecat.webhooks.router import _incoming_webhook, incoming_webhook_wait
 from tracecat.workflow.executions.enums import (
     ExecutionType,
     TemporalSearchAttr,
@@ -592,6 +592,36 @@ class TestWebhookRouterExecutionPath:
         assert "wf_id" in response
         assert "wf_exec_id" in response
         assert response["wf_exec_id"] == expected_exec_id
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_returns_result_with_inline_object(self):
+        """The /wait router path must return workflow result payloads as-is."""
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        inline_result = InlineObject(type="inline", data={"_": "result-ref"})
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": {"status": "ok", "result_ref": inline_result},
+            }
+        )
+
+        with patch(
+            "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+            AsyncMock(return_value=mock_service),
+        ):
+            response = await incoming_webhook_wait(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+            )
+
+        assert response["result_ref"] == inline_result
+        mock_service.create_workflow_execution.assert_awaited_once()
+        call_kwargs = mock_service.create_workflow_execution.call_args.kwargs
+        assert call_kwargs["trigger_type"] == TriggerType.WEBHOOK
+        assert call_kwargs["payload"] == payload
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -33,6 +33,7 @@ from tracecat.storage.object import (
     InlineObject,
     ObjectRef,
 )
+from tracecat.storage.utils import deserialize_object
 from tracecat.webhooks.router import _incoming_webhook, incoming_webhook_wait
 from tracecat.workflow.executions.enums import (
     ExecutionType,
@@ -736,6 +737,67 @@ class TestWebhookRouterExecutionPath:
             response_obj["download_url"] == "https://example.com/presigned/collection"
         )
         upload_file_mock.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_materializes_only_indexed_collection_item(self):
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        collection_result = CollectionObject(
+            type="collection",
+            manifest_ref=ObjectRef(
+                backend="s3",
+                bucket="tracecat-workflow",
+                key="wf/test/return/manifest.json",
+                size_bytes=128,
+                sha256="manifest-sha",
+                content_type="application/json",
+                encoding="json",
+            ),
+            count=3,
+            chunk_size=2,
+            element_kind="value",
+            index=1,
+        )
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": collection_result,
+            }
+        )
+        get_page_mock = AsyncMock(return_value=[{"id": 2}])
+
+        with (
+            patch(
+                "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "tracecat.webhooks.router.get_collection_page",
+                get_page_mock,
+            ),
+            patch(
+                "tracecat.webhooks.router.blob.upload_file",
+                AsyncMock(),
+            ) as upload_file_mock,
+            patch(
+                "tracecat.webhooks.router.blob.generate_presigned_download_url",
+                AsyncMock(return_value="https://example.com/presigned/collection"),
+            ),
+        ):
+            response = await incoming_webhook_wait(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+            )
+
+        assert response["kind"] == "download_export"
+        get_page_mock.assert_awaited_once_with(collection_result, offset=1, limit=1)
+
+        await_args = upload_file_mock.await_args
+        assert await_args is not None
+        uploaded_content = await_args.kwargs["content"]
+        assert deserialize_object(uploaded_content) == {"id": 2}
 
     @pytest.mark.anyio
     async def test_wait_webhook_materializes_collection_without_storage_backend(self):

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -608,7 +608,7 @@ class TestWebhookRouterExecutionPath:
         mock_service.create_workflow_execution = AsyncMock(
             return_value={
                 "wf_id": workflow_id,
-                "result": {"status": "ok", "result_ref": inline_result},
+                "result": inline_result,
             }
         )
 
@@ -622,11 +622,9 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
+        assert response["kind"] == "value"
         response_obj = cast(dict[str, Any], response)
-        assert response_obj["result_ref"] == {
-            "kind": "value",
-            "value": {"_": "result-ref"},
-        }
+        assert response_obj["value"] == {"_": "result-ref"}
         mock_service.create_workflow_execution.assert_awaited_once()
         call_kwargs = mock_service.create_workflow_execution.call_args.kwargs
         assert call_kwargs["trigger_type"] == TriggerType.WEBHOOK
@@ -652,7 +650,7 @@ class TestWebhookRouterExecutionPath:
         mock_service.create_workflow_execution = AsyncMock(
             return_value={
                 "wf_id": workflow_id,
-                "result": {"result_ref": external_result},
+                "result": external_result,
             }
         )
 
@@ -672,10 +670,9 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
+        assert response["kind"] == "download_file"
         response_obj = cast(dict[str, Any], response)
-        result_ref = cast(dict[str, Any], response_obj["result_ref"])
-        assert result_ref["kind"] == "download_file"
-        assert result_ref["download_url"] == "https://example.com/presigned/external"
+        assert response_obj["download_url"] == "https://example.com/presigned/external"
 
     @pytest.mark.anyio
     async def test_wait_webhook_returns_single_download_url_for_collection_object(self):
@@ -700,7 +697,7 @@ class TestWebhookRouterExecutionPath:
         mock_service.create_workflow_execution = AsyncMock(
             return_value={
                 "wf_id": workflow_id,
-                "result": {"result_ref": collection_result},
+                "result": collection_result,
             }
         )
         mock_storage = MagicMock()
@@ -732,10 +729,11 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
+        assert response["kind"] == "download_export"
         response_obj = cast(dict[str, Any], response)
-        result_ref = cast(dict[str, Any], response_obj["result_ref"])
-        assert result_ref["kind"] == "download_export"
-        assert result_ref["download_url"] == "https://example.com/presigned/collection"
+        assert (
+            response_obj["download_url"] == "https://example.com/presigned/collection"
+        )
         upload_file_mock.assert_awaited_once()
 
 

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -600,7 +600,7 @@ class TestWebhookRouterExecutionPath:
 
     @pytest.mark.anyio
     async def test_wait_webhook_returns_result_with_inline_object(self):
-        """The /wait router path must return workflow result payloads as-is."""
+        """The /wait router path wraps inline results in a value envelope."""
         workflow_id = WorkflowUUID.new_uuid4()
         payload = {"event": "test"}
         inline_result = InlineObject(type="inline", data={"_": "result-ref"})
@@ -622,7 +622,11 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["result_ref"] == {"_": "result-ref"}
+        response_obj = cast(dict[str, Any], response)
+        assert response_obj["result_ref"] == {
+            "kind": "value",
+            "value": {"_": "result-ref"},
+        }
         mock_service.create_workflow_execution.assert_awaited_once()
         call_kwargs = mock_service.create_workflow_execution.call_args.kwargs
         assert call_kwargs["trigger_type"] == TriggerType.WEBHOOK
@@ -668,11 +672,10 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["result_ref"]["kind"] == "external_ref"
-        assert (
-            response["result_ref"]["download_url"]
-            == "https://example.com/presigned/external"
-        )
+        response_obj = cast(dict[str, Any], response)
+        result_ref = cast(dict[str, Any], response_obj["result_ref"])
+        assert result_ref["kind"] == "download_file"
+        assert result_ref["download_url"] == "https://example.com/presigned/external"
 
     @pytest.mark.anyio
     async def test_wait_webhook_returns_single_download_url_for_collection_object(self):
@@ -729,11 +732,10 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["result_ref"]["kind"] == "collection_ref"
-        assert (
-            response["result_ref"]["download_url"]
-            == "https://example.com/presigned/collection"
-        )
+        response_obj = cast(dict[str, Any], response)
+        result_ref = cast(dict[str, Any], response_obj["result_ref"])
+        assert result_ref["kind"] == "download_export"
+        assert result_ref["download_url"] == "https://example.com/presigned/collection"
         upload_file_mock.assert_awaited_once()
 
 

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -175,7 +175,27 @@ async def _resolve_stored_object_value(stored: StoredObject) -> Any:
 
 async def _materialize_collection_values_for_wait(
     collection: CollectionObject,
-) -> list[Any]:
+) -> Any:
+    if collection.index is not None:
+        index = collection.index
+        if index < 0:
+            index += collection.count
+        if index < 0 or index >= collection.count:
+            raise IndexError(
+                f"Collection index {index} out of range [0, {collection.count})"
+            )
+
+        items = await get_collection_page(collection, offset=index, limit=1)
+        if not items:
+            raise IndexError(
+                f"Collection index {index} out of range [0, {collection.count})"
+            )
+        item = items[0]
+        if collection.element_kind == "value":
+            return item
+        stored = StoredObjectValidator.validate_python(item)
+        return await _resolve_stored_object_value(stored)
+
     items = await get_collection_page(collection)
     if collection.element_kind == "value":
         return items

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -1,6 +1,6 @@
 import uuid
 from itertools import batched
-from typing import Annotated, Any, Literal, TypedDict
+from typing import Annotated, Literal, TypedDict, cast
 
 from fastapi import (
     APIRouter,
@@ -63,12 +63,38 @@ class OktaVerificationResponse(TypedDict):
     verification: str
 
 
+type WaitResultScalar = str | int | float | bool | None
+type WaitResultValue = (
+    WaitResultScalar | list["WaitResultValue"] | dict[str, "WaitResultValue"]
+)
+
+
+class WebhookStoredObjectInlineResponse(TypedDict):
+    kind: Literal["value"]
+    value: WaitResultValue
+
+
 class WebhookStoredObjectDownloadResponse(TypedDict):
-    kind: Literal["external_ref", "collection_ref"]
+    kind: Literal["download_file", "download_export"]
     download_url: str
     expires_in_seconds: int
     content_type: str
     size_bytes: int
+
+
+type WaitResultInput = (
+    StoredObject
+    | WaitResultValue
+    | list["WaitResultInput"]
+    | dict[str, "WaitResultInput"]
+)
+type WaitResultOutput = (
+    WaitResultValue
+    | WebhookStoredObjectInlineResponse
+    | WebhookStoredObjectDownloadResponse
+    | list["WaitResultOutput"]
+    | dict[str, "WaitResultOutput"]
+)
 
 
 type WebhookResponse = (
@@ -76,7 +102,7 @@ type WebhookResponse = (
 )
 
 
-def _try_parse_stored_object(value: Any) -> StoredObject | None:
+def _try_parse_stored_object(value: object) -> StoredObject | None:
     if isinstance(value, (InlineObject, ExternalObject, CollectionObject)):
         return value
     if isinstance(value, dict) and value.get("type") in {
@@ -104,7 +130,7 @@ async def _to_external_download_response(
         override_content_type="application/octet-stream",
     )
     return WebhookStoredObjectDownloadResponse(
-        kind="external_ref",
+        kind="download_file",
         download_url=download_url,
         expires_in_seconds=expiry,
         content_type=ref.content_type,
@@ -138,7 +164,7 @@ async def _to_collection_download_response(
     )
 
     return WebhookStoredObjectDownloadResponse(
-        kind="collection_ref",
+        kind="download_export",
         download_url=download_url,
         expires_in_seconds=expiry,
         content_type="application/json",
@@ -146,17 +172,28 @@ async def _to_collection_download_response(
     )
 
 
-async def _normalize_wait_result(value: Any) -> Any:
+async def _normalize_wait_result(value: WaitResultInput) -> WaitResultOutput:
     """Normalize /wait response values for StoredObject variants.
 
-    - InlineObject: returns raw data
-    - ExternalObject: returns presigned download response
-    - CollectionObject: materializes and returns presigned download response
+    - InlineObject: returns value envelope
+    - ExternalObject: returns download envelope
+    - CollectionObject: materializes and returns download envelope
     """
+    if isinstance(value, InlineObject):
+        return WebhookStoredObjectInlineResponse(
+            kind="value", value=cast(WaitResultValue, value.data)
+        )
+    if isinstance(value, ExternalObject):
+        return await _to_external_download_response(value)
+    if isinstance(value, CollectionObject):
+        return await _to_collection_download_response(value)
+
     if stored := _try_parse_stored_object(value):
         match stored:
             case InlineObject(data=data):
-                return await _normalize_wait_result(data)
+                return WebhookStoredObjectInlineResponse(
+                    kind="value", value=cast(WaitResultValue, data)
+                )
             case ExternalObject() as external:
                 return await _to_external_download_response(external)
             case CollectionObject() as collection:
@@ -166,7 +203,7 @@ async def _normalize_wait_result(value: Any) -> Any:
         return {k: await _normalize_wait_result(v) for k, v in value.items()}
     if isinstance(value, list):
         return [await _normalize_wait_result(item) for item in value]
-    return value
+    return cast(WaitResultValue, value)
 
 
 # NOTE: Need to set response_model to None to avoid FastAPI trying to parse the response as JSON
@@ -329,7 +366,7 @@ async def incoming_webhook_wait(
     workflow_id: AnyWorkflowIDPath,
     defn: ValidWorkflowDefinitionDep,
     payload: PayloadDep,
-) -> Any:
+) -> WaitResultOutput:
     """Webhook endpoint to trigger a workflow.
 
     This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
@@ -351,7 +388,7 @@ async def incoming_webhook_wait(
         else None,
     )
 
-    return await _normalize_wait_result(response["result"])
+    return await _normalize_wait_result(cast(WaitResultInput, response["result"]))
 
 
 @router.post("/draft", response_model=None)

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -1,6 +1,6 @@
 import uuid
 from itertools import batched
-from typing import Annotated, Literal, TypedDict, cast
+from typing import Annotated, Any, Literal, TypedDict
 
 from fastapi import (
     APIRouter,
@@ -63,15 +63,9 @@ class OktaVerificationResponse(TypedDict):
     verification: str
 
 
-type WaitResultScalar = str | int | float | bool | None
-type WaitResultValue = (
-    WaitResultScalar | list["WaitResultValue"] | dict[str, "WaitResultValue"]
-)
-
-
 class WebhookStoredObjectInlineResponse(TypedDict):
     kind: Literal["value"]
-    value: WaitResultValue
+    value: Any
 
 
 class WebhookStoredObjectDownloadResponse(TypedDict):
@@ -82,18 +76,8 @@ class WebhookStoredObjectDownloadResponse(TypedDict):
     size_bytes: int
 
 
-type WaitResultInput = (
-    StoredObject
-    | WaitResultValue
-    | list["WaitResultInput"]
-    | dict[str, "WaitResultInput"]
-)
 type WaitResultOutput = (
-    WaitResultValue
-    | WebhookStoredObjectInlineResponse
-    | WebhookStoredObjectDownloadResponse
-    | list["WaitResultOutput"]
-    | dict[str, "WaitResultOutput"]
+    WebhookStoredObjectInlineResponse | WebhookStoredObjectDownloadResponse
 )
 
 
@@ -172,38 +156,48 @@ async def _to_collection_download_response(
     )
 
 
-async def _normalize_wait_result(value: WaitResultInput) -> WaitResultOutput:
-    """Normalize /wait response values for StoredObject variants.
-
-    - InlineObject: returns value envelope
-    - ExternalObject: returns download envelope
-    - CollectionObject: materializes and returns download envelope
-    """
-    if isinstance(value, InlineObject):
-        return WebhookStoredObjectInlineResponse(
-            kind="value", value=cast(WaitResultValue, value.data)
-        )
-    if isinstance(value, ExternalObject):
-        return await _to_external_download_response(value)
-    if isinstance(value, CollectionObject):
-        return await _to_collection_download_response(value)
-
+async def _normalize_nested_stored_objects(value: object) -> Any:
     if stored := _try_parse_stored_object(value):
         match stored:
             case InlineObject(data=data):
-                return WebhookStoredObjectInlineResponse(
-                    kind="value", value=cast(WaitResultValue, data)
-                )
+                return await _normalize_nested_stored_objects(data)
             case ExternalObject() as external:
                 return await _to_external_download_response(external)
             case CollectionObject() as collection:
                 return await _to_collection_download_response(collection)
 
     if isinstance(value, dict):
-        return {k: await _normalize_wait_result(v) for k, v in value.items()}
+        return {
+            key: await _normalize_nested_stored_objects(item)
+            for key, item in value.items()
+        }
     if isinstance(value, list):
-        return [await _normalize_wait_result(item) for item in value]
-    return cast(WaitResultValue, value)
+        return [await _normalize_nested_stored_objects(item) for item in value]
+    return value
+
+
+async def _normalize_wait_result(value: object) -> WaitResultOutput:
+    """Normalize /wait response values for StoredObject variants.
+
+    - InlineObject: returns value envelope
+    - ExternalObject: returns download envelope
+    - CollectionObject: materializes and returns download envelope
+    """
+    if stored := _try_parse_stored_object(value):
+        match stored:
+            case InlineObject(data=data):
+                return WebhookStoredObjectInlineResponse(
+                    kind="value",
+                    value=await _normalize_nested_stored_objects(data),
+                )
+            case ExternalObject() as external:
+                return await _to_external_download_response(external)
+            case CollectionObject() as collection:
+                return await _to_collection_download_response(collection)
+    return WebhookStoredObjectInlineResponse(
+        kind="value",
+        value=await _normalize_nested_stored_objects(value),
+    )
 
 
 # NOTE: Need to set response_model to None to avoid FastAPI trying to parse the response as JSON
@@ -388,7 +382,7 @@ async def incoming_webhook_wait(
         else None,
     )
 
-    return await _normalize_wait_result(cast(WaitResultInput, response["result"]))
+    return await _normalize_wait_result(response["result"])
 
 
 @router.post("/draft", response_model=None)

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -1,5 +1,6 @@
+import uuid
 from itertools import batched
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, Any, Literal, TypedDict
 
 from fastapi import (
     APIRouter,
@@ -11,8 +12,10 @@ from fastapi import (
     Response,
     status,
 )
+from pydantic import ValidationError
 from temporalio.service import RPCError
 
+from tracecat import config
 from tracecat.concurrency import cooperative
 from tracecat.contexts import ctx_role
 from tracecat.dsl.client import get_temporal_client
@@ -23,6 +26,16 @@ from tracecat.ee.interactions.schemas import InteractionInput
 from tracecat.identifiers.workflow import AnyWorkflowIDPath, generate_exec_id
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.storage import blob
+from tracecat.storage.object import (
+    CollectionObject,
+    ExternalObject,
+    InlineObject,
+    StoredObject,
+    StoredObjectValidator,
+    get_object_storage,
+)
+from tracecat.storage.utils import serialize_object
 from tracecat.webhooks.dependencies import (
     DraftWorkflowDep,
     PayloadDep,
@@ -50,9 +63,110 @@ class OktaVerificationResponse(TypedDict):
     verification: str
 
 
+class WebhookStoredObjectDownloadResponse(TypedDict):
+    kind: Literal["external_ref", "collection_ref"]
+    download_url: str
+    expires_in_seconds: int
+    content_type: str
+    size_bytes: int
+
+
 type WebhookResponse = (
     WorkflowExecutionCreateResponse | OktaVerificationResponse | Response
 )
+
+
+def _try_parse_stored_object(value: Any) -> StoredObject | None:
+    if isinstance(value, (InlineObject, ExternalObject, CollectionObject)):
+        return value
+    if isinstance(value, dict) and value.get("type") in {
+        "inline",
+        "external",
+        "collection",
+    }:
+        try:
+            return StoredObjectValidator.validate_python(value)
+        except ValidationError:
+            return None
+    return None
+
+
+async def _to_external_download_response(
+    external: ExternalObject,
+) -> WebhookStoredObjectDownloadResponse:
+    ref = external.ref
+    expiry = config.TRACECAT__BLOB_STORAGE_PRESIGNED_URL_EXPIRY
+    download_url = await blob.generate_presigned_download_url(
+        key=ref.key,
+        bucket=ref.bucket,
+        expiry=expiry,
+        force_download=True,
+        override_content_type="application/octet-stream",
+    )
+    return WebhookStoredObjectDownloadResponse(
+        kind="external_ref",
+        download_url=download_url,
+        expires_in_seconds=expiry,
+        content_type=ref.content_type,
+        size_bytes=ref.size_bytes,
+    )
+
+
+async def _to_collection_download_response(
+    collection: CollectionObject,
+) -> WebhookStoredObjectDownloadResponse:
+    storage = get_object_storage()
+    materialized = await storage.retrieve(collection)
+    serialized = serialize_object(materialized)
+    prefix = collection.manifest_ref.key.removesuffix("/manifest.json")
+    export_key = f"{prefix}/downloads/{uuid.uuid4().hex}.json"
+
+    await blob.upload_file(
+        content=serialized,
+        key=export_key,
+        bucket=collection.manifest_ref.bucket,
+        content_type="application/json",
+    )
+
+    expiry = config.TRACECAT__BLOB_STORAGE_PRESIGNED_URL_EXPIRY
+    download_url = await blob.generate_presigned_download_url(
+        key=export_key,
+        bucket=collection.manifest_ref.bucket,
+        expiry=expiry,
+        force_download=True,
+        override_content_type="application/json",
+    )
+
+    return WebhookStoredObjectDownloadResponse(
+        kind="collection_ref",
+        download_url=download_url,
+        expires_in_seconds=expiry,
+        content_type="application/json",
+        size_bytes=len(serialized),
+    )
+
+
+async def _normalize_wait_result(value: Any) -> Any:
+    """Normalize /wait response values for StoredObject variants.
+
+    - InlineObject: returns raw data
+    - ExternalObject: returns presigned download response
+    - CollectionObject: materializes and returns presigned download response
+    """
+    if stored := _try_parse_stored_object(value):
+        match stored:
+            case InlineObject(data=data):
+                return await _normalize_wait_result(data)
+            case ExternalObject() as external:
+                return await _to_external_download_response(external)
+            case CollectionObject() as collection:
+                return await _to_collection_download_response(collection)
+
+    if isinstance(value, dict):
+        return {k: await _normalize_wait_result(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [await _normalize_wait_result(item) for item in value]
+    return value
 
 
 # NOTE: Need to set response_model to None to avoid FastAPI trying to parse the response as JSON
@@ -237,7 +351,7 @@ async def incoming_webhook_wait(
         else None,
     )
 
-    return response["result"]
+    return await _normalize_wait_result(response["result"])
 
 
 @router.post("/draft", response_model=None)

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -12,7 +12,6 @@ from fastapi import (
     Response,
     status,
 )
-from pydantic import ValidationError
 from temporalio.service import RPCError
 
 from tracecat import config
@@ -32,7 +31,6 @@ from tracecat.storage.object import (
     ExternalObject,
     InlineObject,
     StoredObject,
-    StoredObjectValidator,
     get_object_storage,
 )
 from tracecat.storage.utils import serialize_object
@@ -84,21 +82,6 @@ type WaitResultOutput = (
 type WebhookResponse = (
     WorkflowExecutionCreateResponse | OktaVerificationResponse | Response
 )
-
-
-def _try_parse_stored_object(value: object) -> StoredObject | None:
-    if isinstance(value, (InlineObject, ExternalObject, CollectionObject)):
-        return value
-    if isinstance(value, dict) and value.get("type") in {
-        "inline",
-        "external",
-        "collection",
-    }:
-        try:
-            return StoredObjectValidator.validate_python(value)
-        except ValidationError:
-            return None
-    return None
 
 
 async def _to_external_download_response(
@@ -156,48 +139,25 @@ async def _to_collection_download_response(
     )
 
 
-async def _normalize_nested_stored_objects(value: object) -> Any:
-    if stored := _try_parse_stored_object(value):
-        match stored:
-            case InlineObject(data=data):
-                return await _normalize_nested_stored_objects(data)
-            case ExternalObject() as external:
-                return await _to_external_download_response(external)
-            case CollectionObject() as collection:
-                return await _to_collection_download_response(collection)
-
-    if isinstance(value, dict):
-        return {
-            key: await _normalize_nested_stored_objects(item)
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [await _normalize_nested_stored_objects(item) for item in value]
-    return value
-
-
-async def _normalize_wait_result(value: object) -> WaitResultOutput:
+async def _normalize_wait_result(value: StoredObject) -> WaitResultOutput:
     """Normalize /wait response values for StoredObject variants.
 
     - InlineObject: returns value envelope
     - ExternalObject: returns download envelope
     - CollectionObject: materializes and returns download envelope
     """
-    if stored := _try_parse_stored_object(value):
-        match stored:
-            case InlineObject(data=data):
-                return WebhookStoredObjectInlineResponse(
-                    kind="value",
-                    value=await _normalize_nested_stored_objects(data),
-                )
-            case ExternalObject() as external:
-                return await _to_external_download_response(external)
-            case CollectionObject() as collection:
-                return await _to_collection_download_response(collection)
-    return WebhookStoredObjectInlineResponse(
-        kind="value",
-        value=await _normalize_nested_stored_objects(value),
-    )
+    match value:
+        case InlineObject(data=data):
+            return WebhookStoredObjectInlineResponse(
+                kind="value",
+                value=data,
+            )
+        case ExternalObject() as external:
+            return await _to_external_download_response(external)
+        case CollectionObject() as collection:
+            return await _to_collection_download_response(collection)
+        case _:
+            raise ValueError(f"Expected StoredObject, got {type(value).__name__}")
 
 
 # NOTE: Need to set response_model to None to avoid FastAPI trying to parse the response as JSON

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -26,14 +26,20 @@ from tracecat.identifiers.workflow import AnyWorkflowIDPath, generate_exec_id
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage import blob
+from tracecat.storage.collection import get_collection_page
 from tracecat.storage.object import (
     CollectionObject,
     ExternalObject,
     InlineObject,
     StoredObject,
-    get_object_storage,
+    StoredObjectValidator,
 )
-from tracecat.storage.utils import serialize_object
+from tracecat.storage.utils import (
+    cached_blob_download,
+    compute_sha256,
+    deserialize_object,
+    serialize_object,
+)
 from tracecat.webhooks.dependencies import (
     DraftWorkflowDep,
     PayloadDep,
@@ -108,8 +114,7 @@ async def _to_external_download_response(
 async def _to_collection_download_response(
     collection: CollectionObject,
 ) -> WebhookStoredObjectDownloadResponse:
-    storage = get_object_storage()
-    materialized = await storage.retrieve(collection)
+    materialized = await _materialize_collection_values_for_wait(collection)
     serialized = serialize_object(materialized)
     prefix = collection.manifest_ref.key.removesuffix("/manifest.json")
     export_key = f"{prefix}/downloads/{uuid.uuid4().hex}.json"
@@ -137,6 +142,49 @@ async def _to_collection_download_response(
         content_type="application/json",
         size_bytes=len(serialized),
     )
+
+
+async def _retrieve_external_value(external: ExternalObject) -> Any:
+    ref = external.ref
+    content = await cached_blob_download(
+        sha256=ref.sha256,
+        bucket=ref.bucket,
+        key=ref.key,
+    )
+
+    actual_sha256 = compute_sha256(content)
+    if actual_sha256 != ref.sha256:
+        raise ValueError(
+            f"Integrity check failed for {ref.key}: "
+            f"expected {ref.sha256}, got {actual_sha256}"
+        )
+    return deserialize_object(content)
+
+
+async def _resolve_stored_object_value(stored: StoredObject) -> Any:
+    match stored:
+        case InlineObject(data=data):
+            return data
+        case ExternalObject() as external:
+            return await _retrieve_external_value(external)
+        case CollectionObject() as collection:
+            return await _materialize_collection_values_for_wait(collection)
+        case _:
+            raise TypeError(f"Expected StoredObject, got {type(stored).__name__}")
+
+
+async def _materialize_collection_values_for_wait(
+    collection: CollectionObject,
+) -> list[Any]:
+    items = await get_collection_page(collection)
+    if collection.element_kind == "value":
+        return items
+
+    values: list[Any] = []
+    for item in items:
+        stored = StoredObjectValidator.validate_python(item)
+        values.append(await _resolve_stored_object_value(stored))
+    return values
 
 
 async def _normalize_wait_result(value: StoredObject) -> WaitResultOutput:

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -818,7 +818,7 @@ class WorkflowExecutionCreateResponse(TypedDict):
 
 class WorkflowDispatchResponse(TypedDict):
     wf_id: WorkflowID
-    result: Any
+    result: StoredObject
 
 
 class WorkflowExecutionTerminate(BaseModel):

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -48,6 +48,7 @@ from tracecat.storage.collection import (
 from tracecat.storage.object import (
     CollectionObject,
     ExternalObject,
+    InlineObject,
     StoredObject,
     StoredObjectValidator,
     get_object_storage,
@@ -1256,10 +1257,13 @@ class WorkflowExecutionsService:
                 # Don't re-raise for expected terminations
                 return WorkflowDispatchResponse(
                     wf_id=wf_id,
-                    result={
-                        "status": "terminated",
-                        "message": "Workflow execution terminated by user",
-                    },
+                    result=InlineObject(
+                        type="inline",
+                        data={
+                            "status": "terminated",
+                            "message": "Workflow execution terminated by user",
+                        },
+                    ),
                 )
             else:
                 cause_message = self.format_failure_cause(e.cause)

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-import json
 from collections import OrderedDict
 from collections.abc import AsyncGenerator, Awaitable, Sequence
 from typing import Any
@@ -1286,7 +1285,9 @@ class WorkflowExecutionsService:
                 "Unexpected workflow error", role=self.role, wf_exec_id=wf_exec_id, e=e
             )
             raise e
-        self.logger.debug(f"Workflow result:\n{json.dumps(result, indent=2)}")
+        # Workflow results can include rich objects (e.g., StoredObject variants)
+        # that are not guaranteed to be JSON serializable.
+        self.logger.debug("Workflow result", result=result)
         return WorkflowDispatchResponse(wf_id=wf_id, result=result)
 
     async def _start_workflow(


### PR DESCRIPTION
## Summary
- fix `/webhooks/{workflow_id}/{secret}/wait` regression where debug logging raised `TypeError` when workflow results included non-JSON-serializable objects (for example `InlineObject`)
- replace `json.dumps(result)` in `_dispatch_workflow` with structured logger field output
- add `_dispatch_workflow` regression test to assert dispatch returns successfully when workflow result contains an `InlineObject`
- add router-level `/wait` handler test to assert `incoming_webhook_wait` returns `response["result"]` unchanged and forwards `TriggerType.WEBHOOK`

## Root cause
`WorkflowExecutionsService._dispatch_workflow` was logging workflow results with:

```py
json.dumps(result, indent=2)
```

When Temporal returned a result containing `InlineObject`, `json.dumps` raised `TypeError: Object of type InlineObject is not JSON serializable`, which bubbled up and caused the webhook `/wait` request to return HTTP 500.

## Example
```
~/dev/org/trees/tracecat/fix-webhook-wait-regression fix/webhook-wait-regression *162                                                           26s 15:12:50
> curl -X POST "http://localhost:380/api/webhooks/wf_702uqaTiUW94FX1QVZ5Qau/503bbd3fc9052d41de93b186c5477c6a7a4d3904ca072deea55059de4630e1b6/wait"
{"kind":"value","value":1}%
```

## Testing
- `PG_PORT=5732 TEMPORAL_PORT=7533 MINIO_PORT=9300 REDIS_PORT=6679 TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_webhook_execution_path.py -x`
- `uv run ruff check tracecat/workflow/executions/service.py tests/unit/test_webhook_execution_path.py`
- `uv run pyright tracecat/workflow/executions/service.py tests/unit/test_webhook_execution_path.py`
