### PR TITLE
fix(cases): use OR matching for multi-tag case filters

### DIFF
--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -25,7 +25,9 @@ from tracecat.cases.schemas import (
     CaseReadMinimal,
     CaseUpdate,
 )
+from tracecat.tags.schemas import TagCreate
 from tracecat.cases.service import CaseFieldsService, CasesService
+from tracecat.cases.tags.service import CaseTagsService
 from tracecat.db.models import Case
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.pagination import CursorPaginationParams
@@ -809,6 +811,65 @@ class TestCasesService:
         )
 
         assert search_response.model_dump() == list_response.model_dump()
+
+    async def test_search_cases_tag_filter_uses_or_logic(
+        self, cases_service: CasesService
+    ) -> None:
+        """Multiple tag filters should match cases that have any selected tag."""
+        tags_service = CaseTagsService(
+            session=cases_service.session,
+            role=cases_service.role,
+        )
+        tag_one = await tags_service.create_tag(
+            TagCreate(name="Tag One", color="#111111")
+        )
+        tag_two = await tags_service.create_tag(
+            TagCreate(name="Tag Two", color="#222222")
+        )
+
+        case_with_first_tag = await cases_service.create_case(
+            CaseCreate(
+                summary="Case with first tag",
+                description="Case linked to first tag",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+        case_with_second_tag = await cases_service.create_case(
+            CaseCreate(
+                summary="Case with second tag",
+                description="Case linked to second tag",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+        unrelated_case = await cases_service.create_case(
+            CaseCreate(
+                summary="Untagged case",
+                description="Case without matching tags",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+
+        await tags_service.add_tag_to_case(case_with_first_tag.id, tag_one.id)
+        await tags_service.add_tag_to_case(case_with_second_tag.id, tag_two.id)
+
+        params = CursorPaginationParams(limit=20, cursor=None, reverse=False)
+        response = await cases_service.search_cases(
+            params=params,
+            tag_ids=[tag_one.id, tag_two.id],
+            order_by="created_at",
+            sort="asc",
+        )
+
+        result_ids = {item.id for item in response.items}
+        assert case_with_first_tag.id in result_ids
+        assert case_with_second_tag.id in result_ids
+        assert unrelated_case.id not in result_ids
 
     async def test_search_cases_short_id_exact_match(
         self, cases_service: CasesService

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -855,8 +855,8 @@ class TestCasesService:
             )
         )
 
-        await tags_service.add_tag_to_case(case_with_first_tag.id, tag_one.id)
-        await tags_service.add_tag_to_case(case_with_second_tag.id, tag_two.id)
+        await tags_service.add_case_tag(case_with_first_tag.id, str(tag_one.id))
+        await tags_service.add_case_tag(case_with_second_tag.id, str(tag_two.id))
 
         params = CursorPaginationParams(limit=20, cursor=None, reverse=False)
         response = await cases_service.search_cases(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -276,12 +276,11 @@ class CasesService(BaseWorkspaceService):
             filters.append(assignee_clause)
 
         if tag_ids:
-            for tag_id in tag_ids:
-                filters.append(
-                    Case.id.in_(
-                        select(CaseTagLink.case_id).where(CaseTagLink.tag_id == tag_id)
-                    )
+            filters.append(
+                Case.id.in_(
+                    select(CaseTagLink.case_id).where(CaseTagLink.tag_id.in_(tag_ids))
                 )
+            )
 
         if dropdown_filters:
             for def_ref, option_refs in dropdown_filters.items():


### PR DESCRIPTION
### Motivation
- Filtering cases by multiple tags previously added one filter per tag which produced an implicit AND (requiring a case to have all selected tags) instead of returning cases that match any of the selected tags.

### Description
- Change `CasesService._build_search_filters` to use a single `IN` predicate: `CaseTagLink.tag_id.in_(tag_ids)` so multiple tag IDs are matched with OR semantics.
- Add a regression unit test `test_search_cases_tag_filter_uses_or_logic` in `tests/unit/test_cases_service.py` that creates two tags, attaches them to separate cases, and verifies `search_cases(tag_ids=[...])` returns cases that have either tag and excludes unrelated cases.
- Update test imports to include `TagCreate` and `CaseTagsService` used by the new test and run formatting/linting (`ruff`) on the modified files.

### Testing
- Ran linter/formatter checks with `uv run ruff check tracecat/cases/service.py tests/unit/test_cases_service.py` which passed.
- Attempted to run the new unit test with `uv run pytest tests/unit/test_cases_service.py -k tag_filter_uses_or_logic -q`, but the test run failed in this environment due to a missing local PostgreSQL instance (connection refused to `localhost:5432`), not due to application logic; the test should pass when run in CI or a local environment with the test DB available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74bec3d688320b74d1ffb9e71c3df)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix case search with multiple tag filters to return cases that match any selected tag. Replaces per-tag AND filters with a single IN predicate and adds a regression test.

- **Bug Fixes**
  - Build one filter with Case.id.in_(select where CaseTagLink.tag_id.in_(tag_ids)) to apply OR logic.
  - Add regression test using CaseTagsService to create/link tags and verify cases with either tag are returned while unrelated cases are excluded.

<sup>Written for commit 1b6ea9370e09758f20ce359af4bbb7d29cf45872. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

