### PR TITLE
fix: Centralize assignee filter parsing and accept frontend unassigned sentinel

### DIFF
--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -654,6 +654,74 @@ async def test_search_cases_success(
 
 
 @pytest.mark.anyio
+async def test_search_cases_accepts_frontend_unassigned_sentinel(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /cases/search accepts frontend unassigned filter sentinel."""
+    with (
+        patch.object(cases_router, "CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.search_cases.return_value = CursorPaginatedResponse[CaseReadMinimal](
+            items=[],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        MockService.return_value = mock_svc
+
+        response = client.get(
+            "/cases/search",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "assignee_id": "__UNASSIGNED__",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_svc.search_cases.assert_called_once()
+        assert mock_svc.search_cases.call_args.kwargs["assignee_ids"] is None
+        assert mock_svc.search_cases.call_args.kwargs["include_unassigned"] is True
+
+
+@pytest.mark.anyio
+async def test_search_case_aggregates_accepts_frontend_unassigned_sentinel(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /cases/search/aggregate accepts frontend unassigned sentinel."""
+    with (
+        patch.object(cases_router, "CasesService") as MockService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_search_case_aggregates.return_value = CaseSearchAggregateRead(
+            total=0,
+            status_groups=CaseStatusGroupCounts(),
+        )
+        MockService.return_value = mock_svc
+
+        response = client.get(
+            "/cases/search/aggregate",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "assignee_id": "__UNASSIGNED__",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_svc.get_search_case_aggregates.assert_called_once()
+        assert (
+            mock_svc.get_search_case_aggregates.call_args.kwargs["assignee_ids"] is None
+        )
+        assert (
+            mock_svc.get_search_case_aggregates.call_args.kwargs["include_unassigned"]
+            is True
+        )
+
+
+@pytest.mark.anyio
 async def test_search_cases_forwards_date_filters(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/test_case_filters.py
+++ b/tests/unit/test_case_filters.py
@@ -1,0 +1,34 @@
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from tracecat.cases.filters import parse_assignee_filter
+
+
+def test_parse_assignee_filter_accepts_legacy_unassigned() -> None:
+    result = parse_assignee_filter(["unassigned"])
+
+    assert result["assignee_ids"] is None
+    assert result["include_unassigned"] is True
+
+
+def test_parse_assignee_filter_accepts_frontend_unassigned_sentinel() -> None:
+    result = parse_assignee_filter(["__UNASSIGNED__"])
+
+    assert result["assignee_ids"] is None
+    assert result["include_unassigned"] is True
+
+
+def test_parse_assignee_filter_accepts_uuid_and_unassigned() -> None:
+    assignee_id = uuid.uuid4()
+
+    result = parse_assignee_filter([str(assignee_id), "__UNASSIGNED__"])
+
+    assert result["assignee_ids"] == [assignee_id]
+    assert result["include_unassigned"] is True
+
+
+def test_parse_assignee_filter_rejects_invalid_identifier() -> None:
+    with pytest.raises(HTTPException, match="Invalid assignee_id"):
+        parse_assignee_filter(["not-a-uuid"])

--- a/tracecat/cases/filters.py
+++ b/tracecat/cases/filters.py
@@ -1,0 +1,34 @@
+import uuid
+from typing import TypedDict
+
+from fastapi import HTTPException
+from starlette.status import HTTP_400_BAD_REQUEST
+
+UNASSIGNED_ASSIGNEE_IDENTIFIERS = frozenset({"unassigned", "__UNASSIGNED__"})
+
+
+class ParsedAssigneeFilter(TypedDict):
+    assignee_ids: list[uuid.UUID] | None
+    include_unassigned: bool
+
+
+def parse_assignee_filter(assignee_id: list[str] | None) -> ParsedAssigneeFilter:
+    parsed_assignee_ids: list[uuid.UUID] = []
+    include_unassigned = False
+    if assignee_id:
+        for identifier in assignee_id:
+            if identifier in UNASSIGNED_ASSIGNEE_IDENTIFIERS:
+                include_unassigned = True
+                continue
+            try:
+                parsed_assignee_ids.append(uuid.UUID(identifier))
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid assignee_id: {identifier}",
+                ) from e
+
+    return {
+        "assignee_ids": parsed_assignee_ids or None,
+        "include_unassigned": include_unassigned,
+    }

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -25,6 +25,7 @@ from tracecat.cases.dropdowns.service import CaseDropdownValuesService
 from tracecat.cases.durations.schemas import CaseDurationMetric
 from tracecat.cases.durations.service import CaseDurationService
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.filters import parse_assignee_filter
 from tracecat.cases.rows.schemas import CaseTableRowRead
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
@@ -239,20 +240,7 @@ async def search_cases(
         reverse=reverse,
     )
 
-    parsed_assignee_ids: list[uuid.UUID] = []
-    include_unassigned = False
-    if assignee_id:
-        for identifier in assignee_id:
-            if identifier == "unassigned":
-                include_unassigned = True
-                continue
-            try:
-                parsed_assignee_ids.append(uuid.UUID(identifier))
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=HTTP_400_BAD_REQUEST,
-                    detail=f"Invalid assignee_id: {identifier}",
-                ) from e
+    parsed_assignee_filters = parse_assignee_filter(assignee_id)
 
     parsed_dropdown_filters: dict[str, list[str]] | None = None
     if dropdown:
@@ -273,8 +261,8 @@ async def search_cases(
             status=status,
             priority=priority,
             severity=severity,
-            assignee_ids=parsed_assignee_ids or None,
-            include_unassigned=include_unassigned,
+            assignee_ids=parsed_assignee_filters["assignee_ids"],
+            include_unassigned=parsed_assignee_filters["include_unassigned"],
             tag_ids=tag_ids if tag_ids else None,
             dropdown_filters=parsed_dropdown_filters,
             start_time=start_time,

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -23,6 +23,7 @@ from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.filters import parse_assignee_filter
 from tracecat.cases.rows.service import CaseTableRowsService
 from tracecat.cases.schemas import (
     AssigneeChangedEventRead,
@@ -77,38 +78,11 @@ WorkspaceUser = Annotated[
 ]
 
 
-class ParsedAssigneeFilter(TypedDict):
-    assignee_ids: list[uuid.UUID] | None
-    include_unassigned: bool
-
-
 class ParsedCaseSearchFilters(TypedDict):
     assignee_ids: list[uuid.UUID] | None
     include_unassigned: bool
     tag_ids: list[uuid.UUID] | None
     dropdown_filters: dict[str, list[str]] | None
-
-
-def _parse_assignee_filter(assignee_id: list[str] | None) -> ParsedAssigneeFilter:
-    parsed_assignee_ids: list[uuid.UUID] = []
-    include_unassigned = False
-    if assignee_id:
-        for identifier in assignee_id:
-            if identifier == "unassigned":
-                include_unassigned = True
-                continue
-            try:
-                parsed_assignee_ids.append(uuid.UUID(identifier))
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=HTTP_400_BAD_REQUEST,
-                    detail=f"Invalid assignee_id: {identifier}",
-                ) from e
-
-    return {
-        "assignee_ids": parsed_assignee_ids or None,
-        "include_unassigned": include_unassigned,
-    }
 
 
 def _parse_dropdown_filter(
@@ -156,7 +130,7 @@ async def _parse_case_search_filters(
     tags: list[str] | None,
     dropdown: list[str] | None,
 ) -> ParsedCaseSearchFilters:
-    include_assignees = _parse_assignee_filter(assignee_id)
+    include_assignees = parse_assignee_filter(assignee_id)
 
     return {
         "assignee_ids": include_assignees["assignee_ids"],


### PR DESCRIPTION
### Motivation
- Accept the frontend sentinel `__UNASSIGNED__` (in addition to legacy `unassigned`) for assignee filters and propagate that intent to service calls.
- Remove duplicated parsing logic from routers and centralize validation and parsing in a single helper to reduce code duplication and ensure consistent behavior.

### Description
- Add `tracecat/cases/filters.py` which implements `parse_assignee_filter` and the `UNASSIGNED_ASSIGNEE_IDENTIFIERS` set and returns a `ParsedAssigneeFilter` dict with `assignee_ids` and `include_unassigned`.
- Replace inline assignee parsing in `tracecat/cases/router.py` and `tracecat/cases/internal_router.py` with calls to `parse_assignee_filter` and wire the returned `assignee_ids` and `include_unassigned` into service calls.
- Remove the prior local `_parse_assignee_filter` implementation and related duplication from `router.py`.
- Add unit tests: new `tests/unit/test_case_filters.py` to validate parsing behavior (legacy and frontend sentinels, mixed UUID + sentinel, and invalid identifier), and extend `tests/unit/api/test_api_cases.py` with two tests to ensure the API accepts the frontend sentinel and forwards it into service method calls.

### Testing
- Ran `pytest tests/unit/test_case_filters.py` and the new tests passed.
- Ran the updated API unit tests `pytest tests/unit/api/test_api_cases.py::test_search_cases_accepts_frontend_unassigned_sentinel` and `pytest tests/unit/api/test_api_cases.py::test_search_case_aggregates_accepts_frontend_unassigned_sentinel`, and both passed.
- Ran `pytest tests/unit -q` to validate the unit test suite for the changed modules and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84d3172388320a5617296af4e18b9)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized assignee filter parsing and added support for the frontend "__UNASSIGNED__" sentinel so searches include unassigned cases correctly. This removes duplicated parsing in routers and ensures consistent service call parameters.

- **New Features**
  - Accept "__UNASSIGNED__" (and legacy "unassigned") in assignee filters; include_unassigned is set correctly.
  - When the sentinel is used, API forwards assignee_ids=None and include_unassigned=True to services.

- **Refactors**
  - Added parse_assignee_filter in tracecat/cases/filters.py and removed inline parsing from cases/router.py and cases/internal_router.py.
  - Added unit tests for parser behavior and API endpoints.

<sup>Written for commit 5aafecd795ff81b4868a3c4cb7859bd92e9bbf54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

