### PR TITLE
refactor: don't log agent args

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -160,14 +160,14 @@ class DurableAgentWorkflow:
     @workflow.run
     async def run(self, args: AgentWorkflowArgs) -> AgentOutput:
         """Run the agent until completion. The agent will call tools until it needs human approval."""
-        logger.info(
+        logger.debug(
             "DurableAgentWorkflow run", args=args, harness_type=self.harness_type
         )
         logger.debug("AGENT CONTEXT", agent_context=AgentContext.get())
         if workflow.unsafe.is_replaying():
-            logger.info("Workflow is replaying")
+            logger.debug("Workflow is replaying")
         else:
-            logger.info("Starting agent", prompt=args.agent_args.user_prompt)
+            logger.debug("Starting agent", prompt=args.agent_args.user_prompt)
 
         cfg = await self._build_config(args)
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered DurableAgentWorkflow logs from info to debug to prevent agent args and user prompts from appearing in production logs. This reduces sensitive data exposure and log noise.

<sup>Written for commit 77d89c7754f9bfbed593388fe30562783cdc751a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

