### PR TITLE
fix(workflow): invalidate directory-items query on tag add/remove success

### DIFF
--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -803,6 +803,7 @@ export function useWorkflowManager(
       await workflowsAddTag(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["directory-items"] })
     },
     onError: (error: TracecatApiError) => {
       console.error("Failed to add tag to workflow:", error)
@@ -818,6 +819,7 @@ export function useWorkflowManager(
       await workflowsRemoveTag(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["directory-items"] })
     },
     onError: (error: TracecatApiError) => {
       console.error("Failed to remove tag from workflow:", error)

--- a/tests/unit/test_tags_service.py
+++ b/tests/unit/test_tags_service.py
@@ -267,6 +267,26 @@ class TestWorkflowTagsService:
         assert retrieved_wf_tag.workflow_id == workflow_id
         assert retrieved_wf_tag.tag_id == tag.id
 
+    async def test_add_workflow_tag_is_idempotent(
+        self,
+        workflow_tags_service: WorkflowTagsService,
+        tags_service: TagsService,
+        tag_create_params: TagCreate,
+        workflow_id: WorkflowID,
+    ) -> None:
+        """Test adding the same workflow tag twice is a no-op."""
+        tag = await tags_service.create_tag(tag_create_params)
+
+        first_link = await workflow_tags_service.add_workflow_tag(workflow_id, tag.id)
+        second_link = await workflow_tags_service.add_workflow_tag(workflow_id, tag.id)
+
+        assert first_link.workflow_id == second_link.workflow_id
+        assert first_link.tag_id == second_link.tag_id
+
+        workflow_tags = await workflow_tags_service.list_tags_for_workflow(workflow_id)
+        assert len(workflow_tags) == 1
+        assert workflow_tags[0].id == tag.id
+
     async def test_list_tags_for_workflow(
         self,
         workflow_tags_service: WorkflowTagsService,

--- a/tracecat/workflow/tags/service.py
+++ b/tracecat/workflow/tags/service.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import WorkflowTag, WorkflowTagLink
@@ -36,9 +37,23 @@ class WorkflowTagsService(BaseWorkspaceService):
         self, wf_id: WorkflowID, tag_id: TagID
     ) -> WorkflowTagLink:
         """Add a tag association to a workflow."""
+        stmt = select(WorkflowTagLink).where(
+            WorkflowTagLink.workflow_id == wf_id,
+            WorkflowTagLink.tag_id == tag_id,
+        )
+        result = await self.session.execute(stmt)
+        existing = result.scalar_one_or_none()
+        if existing is not None:
+            return existing
+
         wf_tag = WorkflowTagLink(workflow_id=wf_id, tag_id=tag_id)
-        self.session.add(wf_tag)
-        await self.session.commit()
+        try:
+            self.session.add(wf_tag)
+            await self.session.commit()
+        except IntegrityError:
+            # Handle concurrent inserts for the same workflow/tag pair.
+            await self.session.rollback()
+            return await self.get_workflow_tag(wf_id, tag_id)
         return wf_tag
 
     @require_scope("workflow:update")

--- a/tracecat/workflow/tags/service.py
+++ b/tracecat/workflow/tags/service.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import WorkflowTag, WorkflowTagLink
@@ -37,23 +37,18 @@ class WorkflowTagsService(BaseWorkspaceService):
         self, wf_id: WorkflowID, tag_id: TagID
     ) -> WorkflowTagLink:
         """Add a tag association to a workflow."""
-        stmt = select(WorkflowTagLink).where(
-            WorkflowTagLink.workflow_id == wf_id,
-            WorkflowTagLink.tag_id == tag_id,
+        stmt = (
+            pg_insert(WorkflowTagLink)
+            .values(workflow_id=wf_id, tag_id=tag_id)
+            .on_conflict_do_nothing(index_elements=["tag_id", "workflow_id"])
+            .returning(WorkflowTagLink)
         )
         result = await self.session.execute(stmt)
-        existing = result.scalar_one_or_none()
-        if existing is not None:
-            return existing
-
-        wf_tag = WorkflowTagLink(workflow_id=wf_id, tag_id=tag_id)
-        try:
-            self.session.add(wf_tag)
-            await self.session.commit()
-        except IntegrityError:
-            # Handle concurrent inserts for the same workflow/tag pair.
-            await self.session.rollback()
-            return await self.get_workflow_tag(wf_id, tag_id)
+        wf_tag = result.scalar_one_or_none()
+        if wf_tag is None:
+            # Existing row was matched by ON CONFLICT; fetch and return it.
+            wf_tag = await self.get_workflow_tag(wf_id, tag_id)
+        await self.session.commit()
         return wf_tag
 
     @require_scope("workflow:update")


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR makes workflow tag add/remove updates reflect immediately in the directory view and simplifies workflow-tag link writes under concurrency.

- Frontend: invalidate `directory-items` and `workflows` queries after successful workflow tag add/remove mutations.
- Backend: replace pre-check + `IntegrityError` conflict handling in `add_workflow_tag` with PostgreSQL upsert (`ON CONFLICT DO NOTHING`) plus fallback fetch.
- Behavior: `add_workflow_tag` remains idempotent and race-safe, without exception-driven flow for normal duplicate inserts.

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

1. Run lint/type checks:
   - `uv run ruff check tracecat/workflow/tags/service.py`
   - `uv run basedpyright tracecat/workflow/tags/service.py`
2. Run workflow-tag unit tests:
   - `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_tags_service.py -k "TestWorkflowTagsService" -q`
3. In UI, add/remove a workflow tag and confirm directory items refresh without manual reload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate the directory-items query on tag add/remove so the directory view updates immediately. Switch workflow tag linking to a Postgres upsert for idempotent, race-safe inserts.

- **Bug Fixes**
  - Frontend: invalidate ["directory-items"] and ["workflows"] after successful tag add/remove.

- **Refactors**
  - Backend: add_workflow_tag uses ON CONFLICT DO NOTHING upsert and falls back to fetch the existing link; added an idempotency unit test.

<sup>Written for commit 5af6831ed1e50bb759fea1a529e2ccbaf6612e24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

