### PR TITLE
refactor(action-panel): normalize expression handling in action form schema

### DIFF
--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -120,6 +120,18 @@ import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
+const EMPTY_TEMPLATE_EXPRESSION_RE = /^\$\{\{\s*\}\}$/
+
+function normalizeOptionalExpression(
+  value: string | null | undefined
+): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed || EMPTY_TEMPLATE_EXPRESSION_RE.test(trimmed)) {
+    return undefined
+  }
+  return trimmed
+}
+
 // These are YAML strings
 const actionFormSchema = z.object({
   title: z
@@ -142,10 +154,11 @@ const actionFormSchema = z.object({
     .transform((val) => {
       if (Array.isArray(val)) {
         // Trim each expression and drop any that are empty after trimming.
-        return val.map((item) => item.trim()).filter((item) => item !== "")
+        return val
+          .map((item) => normalizeOptionalExpression(item))
+          .filter((item): item is string => item !== undefined)
       } else if (typeof val === "string") {
-        const trimmed = val.trim()
-        return trimmed !== "" ? trimmed : undefined
+        return normalizeOptionalExpression(val)
       }
       return val
     })
@@ -153,7 +166,7 @@ const actionFormSchema = z.object({
   run_if: z
     .string()
     .max(1000, "Run if must be less than 1000 characters")
-    .transform((val) => (val?.trim() ? val.trim() : undefined))
+    .transform((val) => normalizeOptionalExpression(val))
     .optional(),
   // Retry policy fields
   max_attempts: z.number().int().min(0).optional(),
@@ -161,7 +174,7 @@ const actionFormSchema = z.object({
   retry_until: z
     .string()
     .max(1000, "Retry until must be less than 1000 characters")
-    .transform((val) => (val?.trim() ? val.trim() : undefined))
+    .transform((val) => normalizeOptionalExpression(val))
     .optional(),
   // Control flow options fields
   start_delay: z.number().min(0).optional(),
@@ -169,12 +182,12 @@ const actionFormSchema = z.object({
   wait_until: z
     .string()
     .max(1000, "Wait until must be less than 1000 characters")
-    .transform((val) => (val?.trim() ? val.trim() : undefined))
+    .transform((val) => normalizeOptionalExpression(val))
     .optional(),
   environment: z
     .string()
     .max(1000, "Environment must be less than 1000 characters")
-    .transform((val) => (val?.trim() ? val.trim() : undefined))
+    .transform((val) => normalizeOptionalExpression(val))
     .optional(),
   is_interactive: z.boolean().default(false),
   interaction: z
@@ -566,7 +579,7 @@ function ActionPanelContent({
           inputs: inputsYaml, // Use preserved/raw YAML
           control_flow: {
             for_each: values.for_each,
-            run_if: values.run_if,
+            run_if: values.run_if ?? null,
             retry_policy: {
               max_attempts: values.max_attempts,
               timeout: values.timeout,


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized expression handling in the Action Panel form to trim values, treat whitespace-only and `${{ }}` as empty, and persist run_if as null when unset. Prevents saving invalid control-flow fields and keeps payloads consistent.

- **Refactors**
  - Added EMPTY_TEMPLATE_EXPRESSION_RE and normalizeOptionalExpression to return undefined for empty or `${{ }}` expressions.
  - Applied normalization to for_each (arrays/strings), run_if, retry_until, wait_until, and environment; for arrays, map and drop undefined items.

<sup>Written for commit a0b98439e2b787463b920aaf6c8e6d4983522680. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

