### PR TITLE
fix(agents): guard registry MCP server alias mismatch on resumed sess…

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -6,6 +6,7 @@ Tests the runtime execution with mocked Claude SDK.
 from __future__ import annotations
 
 import uuid
+from dataclasses import replace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -258,6 +259,45 @@ class TestClaudeAgentRuntimeRun:
 
         mock_socket_writer.send_error.assert_awaited_once()
         mock_socket_writer.send_done.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_adds_registry_mcp_alias_on_resume(
+        self,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+    ) -> None:
+        """Test that resumed sessions include the registry MCP alias."""
+        captured_options: list[Any] = []
+
+        def _mock_client_ctor(*_args: Any, **kwargs: Any) -> MagicMock:
+            captured_options.append(kwargs["options"])
+            return mock_claude_sdk_client
+
+        resumed_payload = replace(
+            sample_init_payload,
+            sdk_session_id="eed8297f-26fb-4e00-905f-a10f0cf20704",
+            sdk_session_data='{"type":"user","message":{"content":"test"}}\n',
+        )
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                side_effect=_mock_client_ctor,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+        ):
+            runtime = ClaudeAgentRuntime(mock_socket_writer)
+            await runtime.run(resumed_payload)
+
+        assert captured_options
+        mcp_servers = captured_options[0].mcp_servers
+        assert isinstance(mcp_servers, dict)
+        assert "tracecat-registry" in mcp_servers
+        assert "tracecat_registry" in mcp_servers
 
 
 class TestClaudeAgentRuntimePreToolUseHook:

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -1590,10 +1590,10 @@ def convert_chat_messages_to_ui(
                     # Extract underlying tool name for execute_tool wrapper
                     tool_name = part.name
                     tool_input = part.input or {}
-                    if (
-                        part.name == "mcp__tracecat-registry__execute_tool"
-                        and isinstance(tool_input, dict)
-                    ):
+                    if part.name in {
+                        "mcp__tracecat-registry__execute_tool",
+                        "mcp__tracecat_registry__execute_tool",
+                    } and isinstance(tool_input, dict):
                         tool_name = tool_input.get("tool_name", part.name)
                         tool_input = tool_input.get("args", tool_input)
                     # Normalize MCP registry prefix

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -191,8 +191,11 @@ class UserMCPClient:
             Tuple of (server_name, original_tool_name), or None if not a user MCP tool.
 
         """
-        # Skip tracecat-registry tools (handled separately)
-        if tool_name.startswith("mcp__tracecat-registry__"):
+        # Skip tracecat registry-reserved prefixes (handled separately).
+        # Support both alias forms.
+        if tool_name.startswith("mcp__tracecat-registry__") or tool_name.startswith(
+            "mcp__tracecat_registry__"
+        ):
             return None
 
         # Check for user MCP pattern

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -102,6 +102,12 @@ INTERNET_TOOLS = [
     "WebFetch",
 ]
 
+# Registry MCP server name aliases for backward compatibility.
+# Different execution/resume paths may reference either hyphen or underscore
+# forms, so we keep both aliases valid.
+REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
+REGISTRY_MCP_SERVER_NAME_ALIAS = "tracecat_registry"
+
 
 class ClaudeAgentRuntime:
     """Stateless, sandboxed Claude SDK runtime.
@@ -467,7 +473,10 @@ class ClaudeAgentRuntime:
                     allowed_actions=self.registry_tools,
                     auth_token=payload.mcp_auth_token,
                 )
-                mcp_servers["tracecat-registry"] = proxy_config
+                mcp_servers[REGISTRY_MCP_SERVER_NAME] = proxy_config
+                # Guard against alias drift in resumed session history/tool calls.
+                if payload.sdk_session_id:
+                    mcp_servers[REGISTRY_MCP_SERVER_NAME_ALIAS] = proxy_config
 
             stderr_queue: asyncio.Queue[str] = asyncio.Queue()
             if payload.config.mcp_servers:


### PR DESCRIPTION
### Problem
  In resumed agent sessions, tool-call names are generated from contextual history and can use an alternate MCP server alias (`tracecat_registry`) instead of the canonical runtime alias
  (`tracecat-registry`), causing otherwise valid registry actions (for example `core.cases.get_case`) to fail with `No such tool available`.

### Solution
Added alias guarding so both registry server-name forms resolve to the same proxy tool set, and updated tool parsing/UI wrapper handling to recognize both variants, eliminating alias-
induced lookup failures during resumed runs.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents MCP registry alias mismatches on resumed sessions by supporting both “tracecat-registry” and “tracecat_registry”. Ensures tool calls and UI parsing work even if session history uses a different alias.

- **Bug Fixes**
  - Runtime: adds the registry MCP alias on resume; both names are registered in mcp_servers. Includes a unit test to verify both aliases are present.
  - UI adapter: normalizes execute_tool wrappers for both alias forms and correctly extracts tool_name and args.
  - User client: skips both registry prefixes when parsing user MCP tool names to avoid misclassification.

<sup>Written for commit 4d2da7edcfebac4b54cb1901d1080de590562082. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

