### PR TITLE
fix(mcp): pass async redis client to OAuth state store

### DIFF
--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -18,6 +18,7 @@ from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 from key_value.aio.wrappers.prefix_collections import PrefixCollectionsWrapper
 from mcp.server.auth.provider import TokenError
 from pydantic import BaseModel, Field
+from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy import select
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
@@ -493,7 +494,8 @@ def create_mcp_auth() -> AuthProvider:
     # Build Redis-backed storage for OAuth state (client registrations,
     # auth codes, tokens, transactions) so state survives restarts and
     # is shared across MCP replicas.
-    redis_store = RedisStore(url=REDIS_URL)
+    redis_client = AsyncRedis.from_url(REDIS_URL, decode_responses=True)
+    redis_store = RedisStore(client=redis_client)
     prefixed_store = PrefixCollectionsWrapper(redis_store, prefix="mcp")
     if TRACECAT__DB_ENCRYPTION_KEY:
         client_storage = FernetEncryptionWrapper(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the OAuth state store to use the async Redis client (redis.asyncio.Redis) instead of a URL string. This fixes MCP authorization by making Redis calls non-blocking and compatible with our async flow.

<sup>Written for commit 7781341d6e0bb54bf75ee8dba79ecc8ef64055ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

