### PR TITLE
chore(agents): increase default agent sandbox timeout to 30 minutes

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -41,6 +41,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.agent.types import AgentConfig
     from tracecat.auth.types import Role
+    from tracecat.config import TRACECAT__AGENT_SANDBOX_TIMEOUT
     from tracecat.contexts import ctx_role
     from tracecat.dsl.common import RETRY_POLICIES
     from tracecat.logger import logger
@@ -339,7 +340,9 @@ class DurableAgentWorkflow:
             result = await workflow.execute_activity(
                 run_agent_activity,
                 executor_input,
-                start_to_close_timeout=timedelta(seconds=600),
+                start_to_close_timeout=timedelta(
+                    seconds=TRACECAT__AGENT_SANDBOX_TIMEOUT
+                ),
                 heartbeat_timeout=timedelta(seconds=60),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )

--- a/tracecat/agent/common/config.py
+++ b/tracecat/agent/common/config.py
@@ -13,12 +13,12 @@ from pathlib import Path
 # === Agent Sandbox Config (read directly from env) === #
 
 TRACECAT__AGENT_SANDBOX_TIMEOUT = int(
-    os.environ.get("TRACECAT__AGENT_SANDBOX_TIMEOUT", "600")
+    os.environ.get("TRACECAT__AGENT_SANDBOX_TIMEOUT") or 1800
 )
-"""Default timeout for agent sandbox execution in seconds (10 minutes)."""
+"""Default timeout for agent sandbox execution in seconds (30 minutes)."""
 
 TRACECAT__AGENT_SANDBOX_MEMORY_MB = int(
-    os.environ.get("TRACECAT__AGENT_SANDBOX_MEMORY_MB", "4096")
+    os.environ.get("TRACECAT__AGENT_SANDBOX_MEMORY_MB") or 4096
 )
 """Default memory limit for agent sandbox execution in megabytes (4 GiB)."""
 

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -87,7 +87,7 @@ class AgentResourceLimits:
 
     Defaults are read from environment variables:
     - TRACECAT__AGENT_SANDBOX_MEMORY_MB: memory_mb (default 4096 = 4 GiB)
-    - TRACECAT__AGENT_SANDBOX_TIMEOUT: timeout_seconds and cpu_seconds (default 600s)
+    - TRACECAT__AGENT_SANDBOX_TIMEOUT: timeout_seconds and cpu_seconds (default 1800s)
 
     Attributes:
         memory_mb: Maximum memory in megabytes.

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -571,9 +571,9 @@ When False (default), metrics are not emitted to reduce log noise.
 
 # === Agent Sandbox (NSJail for ClaudeAgentRuntime) === #
 TRACECAT__AGENT_SANDBOX_TIMEOUT = int(
-    os.environ.get("TRACECAT__AGENT_SANDBOX_TIMEOUT") or 600
+    os.environ.get("TRACECAT__AGENT_SANDBOX_TIMEOUT") or 1800
 )
-"""Default timeout for agent sandbox execution in seconds (10 minutes)."""
+"""Default timeout for agent sandbox execution in seconds (30 minutes)."""
 
 TRACECAT__AGENT_SANDBOX_MEMORY_MB = int(
     os.environ.get("TRACECAT__AGENT_SANDBOX_MEMORY_MB") or 4096


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raised the default agent sandbox timeout from 10 minutes (600s) to 30 minutes (1800s) to prevent premature termination of longer-running agent tasks. The durable workflow now uses TRACECAT__AGENT_SANDBOX_TIMEOUT for activity timeouts, which remains configurable via env.

<sup>Written for commit c531454e4f03e380654cff4e07ed1e6b1eb23512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

