### PR TITLE
feat(enterprise+ui): add a Gemini agent type and dedicated icons

### DIFF
--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6494,6 +6494,7 @@ export type WatchtowerAgentToolCallRead = {
 export type WatchtowerAgentType =
   | "claude_code"
   | "codex"
+  | "gemini"
   | "cursor"
   | "windsurf"
   | "opencode"

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -745,6 +745,106 @@ export function ClaudeIcon({ className, ...rest }: IconProps) {
   )
 }
 
+export function GeminiIcon({ className, ...rest }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      {...rest}
+    >
+      <path
+        d="M12 2.5 14.75 9.25 21.5 12l-6.75 2.75L12 21.5l-2.75-6.75L2.5 12l6.75-2.75L12 2.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+export function CursorIcon({ className, ...rest }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      {...rest}
+    >
+      <path d="M4 3.5 20 12 4 20.5V3.5Z" fill="currentColor" />
+      <path d="m10.5 10.25 5.25 8.25" stroke="#fff" strokeWidth="1.75" />
+    </svg>
+  )
+}
+
+export function WindsurfIcon({ className, ...rest }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      {...rest}
+    >
+      <path
+        d="M3 15.5c2.4 0 2.4-2 4.8-2s2.4 2 4.8 2 2.4-2 4.8-2 2.4 2 3.6 2"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M3 10.5c2.4 0 2.4-2 4.8-2s2.4 2 4.8 2 2.4-2 4.8-2 2.4 2 3.6 2"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+export function OpenCodeIcon({ className, ...rest }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      {...rest}
+    >
+      <path
+        d="m8 7-4 5 4 5M16 7l4 5-4 5M13 5l-2 14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export function OpenClawIcon({ className, ...rest }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      {...rest}
+    >
+      <path
+        d="M7 5v5M12 4v6M17 5v5M6.5 12.5c1.2 2.8 3 4.5 5.5 5.5 2.5-1 4.3-2.7 5.5-5.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
 export function OpenAIIcon({ className, ...rest }: IconProps) {
   return (
     <svg

--- a/frontend/src/components/watchtower/watchtower-monitor.tsx
+++ b/frontend/src/components/watchtower/watchtower-monitor.tsx
@@ -22,7 +22,16 @@ import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import type { WatchtowerAgentRead, WatchtowerAgentToolCallRead } from "@/client"
 import { Tool, ToolContent, ToolHeader } from "@/components/ai-elements/tool"
 import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
-import { ClaudeIcon, getIcon, OpenAIIcon } from "@/components/icons"
+import {
+  ClaudeIcon,
+  CursorIcon,
+  GeminiIcon,
+  getIcon,
+  OpenAIIcon,
+  OpenClawIcon,
+  OpenCodeIcon,
+  WindsurfIcon,
+} from "@/components/icons"
 import { JsonViewWithControls } from "@/components/json-viewer"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import {
@@ -72,6 +81,7 @@ import { cn } from "@/lib/utils"
 const AGENT_TYPE_ORDER = [
   "claude_code",
   "codex",
+  "gemini",
   "cursor",
   "windsurf",
   "opencode",
@@ -97,6 +107,12 @@ const AGENT_TYPE_GROUPS: Record<string, AgentTypeGroupConfig> = {
     iconColor: "text-green-600",
     triggerClassName:
       "data-[state=open]:border-l-green-600 data-[state=open]:bg-green-600/[0.03] dark:data-[state=open]:bg-green-600/[0.08]",
+  },
+  gemini: {
+    label: "Gemini",
+    iconColor: "text-indigo-600",
+    triggerClassName:
+      "data-[state=open]:border-l-indigo-600 data-[state=open]:bg-indigo-600/[0.03] dark:data-[state=open]:bg-indigo-600/[0.08]",
   },
   cursor: {
     label: "Cursor",
@@ -1229,38 +1245,22 @@ function AgentTypeIcon({
   if (agentType === "codex") {
     return <OpenAIIcon className={className} />
   }
+  if (agentType === "gemini") {
+    return <GeminiIcon className={className} />
+  }
   if (agentType === "cursor") {
-    return <MonogramIcon label="C" size={size} />
+    return <CursorIcon className={className} />
   }
   if (agentType === "windsurf") {
-    return <MonogramIcon label="W" size={size} />
+    return <WindsurfIcon className={className} />
   }
   if (agentType === "opencode") {
-    return <MonogramIcon label="O" size={size} />
+    return <OpenCodeIcon className={className} />
   }
   if (agentType === "openclaw") {
-    return <MonogramIcon label="OC" size={size} />
+    return <OpenClawIcon className={className} />
   }
   return <BotIcon className={className} />
-}
-
-function MonogramIcon({
-  label,
-  size,
-}: {
-  label: string
-  size: "default" | "lg"
-}) {
-  return (
-    <span
-      className={cn(
-        "flex items-center justify-center border text-[10px] font-semibold",
-        size === "lg" ? "size-6" : "size-4"
-      )}
-    >
-      {label}
-    </span>
-  )
 }
 
 function shortId(value: string) {

--- a/packages/tracecat-ee/tracecat_ee/watchtower/service.py
+++ b/packages/tracecat-ee/tracecat_ee/watchtower/service.py
@@ -518,6 +518,8 @@ def _classify_agent_text(value: str) -> WatchtowerAgentType:
         return WatchtowerAgentType.CLAUDE_CODE
     if "codex" in text or "openai" in text:
         return WatchtowerAgentType.CODEX
+    if "gemini" in text:
+        return WatchtowerAgentType.GEMINI
     if "cursor" in text:
         return WatchtowerAgentType.CURSOR
     if "windsurf" in text:

--- a/packages/tracecat-ee/tracecat_ee/watchtower/types.py
+++ b/packages/tracecat-ee/tracecat_ee/watchtower/types.py
@@ -10,6 +10,7 @@ class WatchtowerAgentType(StrEnum):
 
     CLAUDE_CODE = "claude_code"
     CODEX = "codex"
+    GEMINI = "gemini"
     CURSOR = "cursor"
     WINDSURF = "windsurf"
     OPENCODE = "opencode"

--- a/tests/unit/test_watchtower_service.py
+++ b/tests/unit/test_watchtower_service.py
@@ -93,6 +93,16 @@ def test_normalize_agent_identity_prefers_client_info() -> None:
     assert icon == "claude_code"
 
 
+def test_normalize_agent_identity_recognizes_gemini() -> None:
+    agent_type, source, icon = normalize_agent_identity(
+        user_agent="gemini-cli/0.1.0",
+        client_info={"name": "Gemini", "version": "0.1.0"},
+    )
+    assert agent_type == WatchtowerAgentType.GEMINI
+    assert source == "client_info"
+    assert icon == WatchtowerAgentType.GEMINI
+
+
 def test_redact_tool_call_args_does_not_store_raw_strings() -> None:
     result = redact_tool_call_args(
         {


### PR DESCRIPTION
### Motivation

- Introduce explicit support for a new `gemini` agent classification across backend and frontend so Watchtower can recognize and display Gemini clients. 
- Replace monogram placeholders with dedicated SVG icons for several agent types to provide clearer, consistent UI representation.

### Description

- Added `GEMINI` to `WatchtowerAgentType` in `packages/tracecat-ee/tracecat_ee/watchtower/types.py` and included `gemini` in the generated frontend type `frontend/src/client/types.gen.ts`.
- Updated agent classification in `packages/tracecat-ee/tracecat_ee/watchtower/service.py` by recognizing the string `"gemini"` in `_classify_agent_text` and keeping `normalize_agent_identity` behavior consistent.
- Added new SVG icon components `GeminiIcon`, `CursorIcon`, `WindsurfIcon`, `OpenCodeIcon`, and `OpenClawIcon` in `frontend/src/components/icons.tsx` and wired them into the monitor UI by importing them and updating `AgentTypeIcon` in `frontend/src/components/watchtower/watchtower-monitor.tsx`.
- Added `gemini` to `AGENT_TYPE_ORDER` and `AGENT_TYPE_GROUPS` in the watchtower monitor so Gemini appears in the correct ordering and with UI styling.
- Replaced the previous `MonogramIcon` usage with the new dedicated icons for `cursor`, `windsurf`, `opencode`, and `openclaw`.

### Testing

- Added unit test `test_normalize_agent_identity_recognizes_gemini` in `tests/unit/test_watchtower_service.py` and ran it with `pytest`, which passed.
- Ran the unit test suite (`pytest tests/unit`) to validate the Watchtower changes and the relevant tests passed.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c19776a48320a4f3b65a877f197d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Gemini agent type and replaces monogram placeholders with dedicated SVG icons in the monitor. Watchtower now classifies Gemini clients and shows clearer, consistent icons.

- **New Features**
  - Backend: added GEMINI to WatchtowerAgentType and classify "gemini" in _classify_agent_text.
  - Frontend: added "gemini" to generated types; added Gemini, Cursor, Windsurf, OpenCode, and OpenClaw icons; updated AgentTypeIcon and AGENT_TYPE_ORDER/AGENT_TYPE_GROUPS (indigo styling for Gemini); replaced MonogramIcon usage.
  - Tests: added unit test to confirm Gemini is recognized from client info and user agent.

<sup>Written for commit c24c0d526828b9d8b27bd2b763485a52f536f2b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

