### PR TITLE
fix(agents): sanitize mcp and slack tool error handling

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -11203,17 +11203,6 @@ export const $MCPIntegrationUpdate = {
   description: "Request model for updating an MCP integration.",
 } as const
 
-export const $MCPServerConfig = {
-  anyOf: [
-    {
-      $ref: "#/components/schemas/MCPHttpServerConfig",
-    },
-    {
-      $ref: "#/components/schemas/MCPStdioServerConfig",
-    },
-  ],
-} as const
-
 export const $MCPServerType = {
   type: "string",
   enum: ["http", "stdio"],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3599,8 +3599,6 @@ export type MCPIntegrationUpdate = {
   timeout?: number | null
 }
 
-export type MCPServerConfig = MCPHttpServerConfig | MCPStdioServerConfig
-
 export type MCPServerType = "http" | "stdio"
 
 /**

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -4,7 +4,10 @@ import uuid
 from collections.abc import Callable
 from typing import Any, TypeGuard
 
-from pydantic import UUID4, BaseModel
+from pydantic import (
+    UUID4,
+    BaseModel,
+)
 from temporalio import activity
 
 from tracecat.agent.common.types import (
@@ -187,7 +190,8 @@ class AgentActivities:
             except Exception as e:
                 logger.error(
                     "Failed to discover user MCP tools",
-                    error=str(e),
+                    error_type=type(e).__name__,
+                    server_count=len(http_servers),
                 )
                 # Continue without user MCP tools - don't fail the whole operation
 

--- a/tests/unit/test_agent_channel_sinks.py
+++ b/tests/unit/test_agent_channel_sinks.py
@@ -207,6 +207,7 @@ async def test_slack_stream_sink_emits_task_updates_for_tool_events(
     statuses = [chunk["status"] for chunk in task_chunks]
     assert "complete" in statuses
     assert "in_progress" not in statuses
+    assert all("output" not in chunk for chunk in task_chunks)
     assert not markdown_chunks
 
 
@@ -250,7 +251,7 @@ async def test_slack_stream_sink_does_not_close_on_text_stop(
 
 
 @pytest.mark.anyio
-async def test_slack_stream_sink_formats_tool_output(
+async def test_slack_stream_sink_formats_failure_for_any_tool(
     patched_slack_client: _FakeSlackClient,
 ):
     fake_client = patched_slack_client
@@ -268,16 +269,8 @@ async def test_slack_stream_sink_formats_tool_output(
             type=StreamEventType.TOOL_RESULT,
             tool_call_id="tool-call-3",
             tool_name="core.cases.create_case",
-            tool_output=[
-                {
-                    "type": "text",
-                    "text": (
-                        '{"id":"7124a7bc-4ac0-4f0b-9fc4-e6a173f922dc",'
-                        '"case_number":11,"summary":"The Tokyo Tower Time Trouble"}'
-                    ),
-                }
-            ],
-            is_error=False,
+            tool_output={"message": "case creation failed"},
+            is_error=True,
         )
     )
     await sink.done()
@@ -287,19 +280,17 @@ async def test_slack_stream_sink_formats_tool_output(
         for method, payload in fake_client.calls
         if method == "chat.appendStream"
     ]
-    complete_chunks = [
+    error_chunks = [
         payload["chunks"][0]
         for payload in append_payloads
         if payload.get("chunks")
         and payload["chunks"][0].get("type") == "task_update"
-        and payload["chunks"][0].get("status") == "complete"
+        and payload["chunks"][0].get("status") == "error"
     ]
-    assert complete_chunks
-    formatted_output = complete_chunks[0].get("output")
-    assert isinstance(formatted_output, str)
-    assert formatted_output.startswith("```json\n")
-    assert '"case_number": 11' in formatted_output
-    assert '"id": "7124a7bc-4ac0-4f0b-9fc4-e6a173f922dc"' in formatted_output
+    assert error_chunks
+    error_chunk = error_chunks[0]
+    assert error_chunk["details"] == "case creation failed"
+    assert "output" not in error_chunk
 
 
 @pytest.mark.anyio
@@ -668,3 +659,93 @@ async def test_slack_stream_sink_skips_synthetic_approval_interrupt_error(
         if payload.get("chunks") and payload["chunks"][0].get("type") == "task_update"
     ]
     assert not task_updates
+
+
+@pytest.mark.anyio
+async def test_slack_stream_sink_suppresses_output_for_all_tool_success(
+    patched_slack_client: _FakeSlackClient,
+):
+    fake_client = patched_slack_client
+
+    sink = SlackStreamSink(
+        slack_bot_token="xoxb-test",
+        channel_id="C123",
+        thread_ts="1700000000.000001",
+        session_id="session-tool-success",
+        workspace_id="workspace-tool-success",
+    )
+
+    await sink.append(
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_CALL_STOP,
+            tool_call_id="tool-call-success",
+            tool_name="core.cases.create_case",
+            tool_input={"summary": "hello"},
+        )
+    )
+    await sink.append(
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_RESULT,
+            tool_call_id="tool-call-success",
+            tool_name="core.cases.create_case",
+            tool_output={"id": "case-123"},
+            is_error=False,
+        )
+    )
+    await sink.done()
+
+    append_payloads = [
+        payload
+        for method, payload in fake_client.calls
+        if method == "chat.appendStream"
+    ]
+    task_chunks = [
+        payload["chunks"][0]
+        for payload in append_payloads
+        if payload.get("chunks") and payload["chunks"][0].get("type") == "task_update"
+    ]
+    assert len(task_chunks) == 1
+    assert task_chunks[0]["status"] == "complete"
+    assert "output" not in task_chunks[0]
+
+
+@pytest.mark.anyio
+async def test_slack_stream_sink_formats_failure_for_slack_tool(
+    patched_slack_client: _FakeSlackClient,
+):
+    fake_client = patched_slack_client
+
+    sink = SlackStreamSink(
+        slack_bot_token="xoxb-test",
+        channel_id="C123",
+        thread_ts="1700000000.000001",
+        session_id="session-slack-tool-failure",
+        workspace_id="workspace-slack-tool-failure",
+    )
+
+    await sink.append(
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_RESULT,
+            tool_call_id="tool-call-slack-failure",
+            tool_name="tools.slack.post_message",
+            tool_output={"error": "channel_not_found"},
+            is_error=True,
+        )
+    )
+    await sink.done()
+
+    append_payloads = [
+        payload
+        for method, payload in fake_client.calls
+        if method == "chat.appendStream"
+    ]
+    task_chunks = [
+        payload["chunks"][0]
+        for payload in append_payloads
+        if payload.get("chunks") and payload["chunks"][0].get("type") == "task_update"
+    ]
+    assert len(task_chunks) == 1
+    task_chunk = task_chunks[0]
+    assert task_chunk["status"] == "error"
+    assert task_chunk["details"] == "channel_not_found"
+    assert "output" not in task_chunk

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -1,0 +1,78 @@
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from tracecat.agent.mcp import trusted_server
+from tracecat.agent.tokens import MCPTokenClaims, UserMCPServerClaim
+
+type ExecuteUserMCPTool = Callable[[str, str, dict[str, object], str], Awaitable[str]]
+
+
+def _build_claims(*, user_mcp_servers: list[UserMCPServerClaim]) -> MCPTokenClaims:
+    return MCPTokenClaims(
+        workspace_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        organization_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        session_id=uuid.UUID("00000000-0000-0000-0000-000000000003"),
+        allowed_actions=["core.http_request"],
+        user_mcp_servers=user_mcp_servers,
+    )
+
+
+@pytest.mark.anyio
+async def test_execute_user_mcp_tool_returns_server_name_when_not_authorized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        trusted_server,
+        "verify_mcp_token",
+        lambda _: _build_claims(user_mcp_servers=[]),
+    )
+    execute_user_mcp_tool = cast(
+        ExecuteUserMCPTool, trusted_server.execute_user_mcp_tool
+    )
+
+    with pytest.raises(ToolError, match="^Jira$"):
+        await execute_user_mcp_tool(
+            "Jira",
+            "getIssue",
+            {},
+            "token",
+        )
+
+
+@pytest.mark.anyio
+async def test_execute_user_mcp_tool_returns_server_name_on_execution_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        trusted_server,
+        "verify_mcp_token",
+        lambda _: _build_claims(
+            user_mcp_servers=[
+                UserMCPServerClaim(
+                    name="Jira",
+                    url="https://mcp.atlassian.com/v1/mcp",
+                )
+            ]
+        ),
+    )
+    mock_client = AsyncMock()
+    mock_client.call_tool.side_effect = RuntimeError(
+        "failed converting from {'Authorization': 'Bearer secret'}"
+    )
+    monkeypatch.setattr(trusted_server, "UserMCPClient", lambda _: mock_client)
+    execute_user_mcp_tool = cast(
+        ExecuteUserMCPTool, trusted_server.execute_user_mcp_tool
+    )
+
+    with pytest.raises(ToolError, match="^Jira$"):
+        await execute_user_mcp_tool(
+            "Jira",
+            "getIssue",
+            {},
+            "token",
+        )

--- a/tests/unit/test_agent_types.py
+++ b/tests/unit/test_agent_types.py
@@ -1,0 +1,30 @@
+from temporalio.converter import value_to_type
+
+from tracecat.agent.types import AgentConfig
+
+
+def test_temporal_converter_decodes_agent_config_with_mcp_servers() -> None:
+    config = value_to_type(
+        AgentConfig,
+        {
+            "model_name": "claude-3-5-sonnet-20241022",
+            "model_provider": "anthropic",
+            "mcp_servers": [
+                {
+                    "name": "Jira",
+                    "type": "http",
+                    "url": "https://mcp.atlassian.com/v1/mcp",
+                    "headers": {"Authorization": "Bearer test-token"},
+                }
+            ],
+        },
+    )
+
+    assert config.mcp_servers == [
+        {
+            "name": "Jira",
+            "type": "http",
+            "url": "https://mcp.atlassian.com/v1/mcp",
+            "headers": {"Authorization": "Bearer test-token"},
+        }
+    ]

--- a/tracecat/agent/channels/sinks/slack.py
+++ b/tracecat/agent/channels/sinks/slack.py
@@ -249,22 +249,16 @@ class SlackStreamSink:
         return value
 
     @classmethod
-    def _format_tool_output(
-        cls, value: Any, *, is_error: bool, max_len: int = 3000
-    ) -> str | None:
-        normalized = cls._normalize_tool_output(value)
-
-        if normalized is None:
-            return None
-
-        if isinstance(normalized, (dict, list)):
-            formatted = json.dumps(normalized, indent=2, sort_keys=True, default=str)
-            formatted = cls._coerce_output_text(formatted, max_len=max_len)
-            return f"```json\n{formatted}\n```"
-
-        # Keep scalar outputs as-is (including errors), just cap extreme length.
-        formatted = cls._coerce_output_text(normalized, max_len=max_len)
-        return f"```\n{formatted}\n```"
+    def _format_tool_error_output(cls, value: Any) -> str:
+        match cls._normalize_tool_output(value):
+            case str() as text if message := text.strip():
+                return message
+            case {"message": str(message)} if message := message.strip():
+                return message
+            case {"error": str(message)} if message := message.strip():
+                return message
+            case _:
+                return "Tool execution failed"
 
     def _resolve_task(
         self,
@@ -288,7 +282,6 @@ class SlackStreamSink:
         tool_name: str | None,
         status: str,
         details: str | None = None,
-        output: Any | None = None,
     ) -> None:
         task_id, title = self._resolve_task(
             tool_call_id=tool_call_id,
@@ -303,12 +296,6 @@ class SlackStreamSink:
         }
         if details:
             chunk["details"] = details
-        if output is not None:
-            formatted_output = self._format_tool_output(
-                output, is_error=(status == "error")
-            )
-            if formatted_output:
-                chunk["output"] = formatted_output
         logger.info(
             "Sending Slack task_update chunk",
             session_id=self._session_id,
@@ -553,12 +540,18 @@ class SlackStreamSink:
                 )
                 return
             self._pending_approval_tool_ids.discard(event.tool_call_id)
+
+            status = "error" if event.is_error else "complete"
+            details: str | None = None
+            if event.is_error:
+                details = self._format_tool_error_output(event.tool_output)
+
             await self._flush_delta_buffer(force=True)
             await self._emit_task_update(
                 tool_call_id=event.tool_call_id,
                 tool_name=event.tool_name,
-                status="error" if event.is_error else "complete",
-                output=event.tool_output,
+                status=status,
+                details=details,
             )
             return
 

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -55,7 +55,7 @@ class MCPStdioServerConfig(TypedDict):
     timeout: NotRequired[int]
 
 
-type MCPServerConfig = MCPHttpServerConfig | MCPStdioServerConfig
+MCPServerConfig = MCPHttpServerConfig | MCPStdioServerConfig
 
 
 @dataclass(kw_only=True, slots=True)

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -58,6 +58,11 @@ def _set_role_context(claims: MCPTokenClaims) -> Role:
     return role
 
 
+def _safe_error_type(exc: Exception) -> str:
+    """Return only the exception class name for log-safe reporting."""
+    return type(exc).__name__
+
+
 @mcp.tool
 async def execute_action_tool(
     action_name: str,
@@ -77,7 +82,7 @@ async def execute_action_tool(
     try:
         claims = verify_mcp_token(auth_token)
     except ValueError as e:
-        logger.warning("MCP token verification failed", error=str(e))
+        logger.warning("MCP token verification failed", error_type=_safe_error_type(e))
         raise ToolError("Authentication failed") from None
 
     normalized_action_name = normalize_mcp_tool_name(action_name)
@@ -121,8 +126,7 @@ async def execute_action_tool(
             "Action execution failed",
             action_name=normalized_action_name,
             workspace_id=str(claims.workspace_id),
-            error=str(e),
-            error_type=type(e).__name__,
+            error_type=_safe_error_type(e),
         )
         raise ToolError("Action execution failed") from None
 
@@ -152,7 +156,7 @@ async def execute_user_mcp_tool(
     try:
         claims = verify_mcp_token(auth_token)
     except ValueError as e:
-        logger.warning("MCP token verification failed", error=str(e))
+        logger.warning("MCP token verification failed", error_type=_safe_error_type(e))
         raise ToolError("Authentication failed") from None
 
     _set_role_context(claims)
@@ -167,9 +171,9 @@ async def execute_user_mcp_tool(
         logger.warning(
             "User MCP server not found in claims",
             server_name=server_name,
-            available_servers=[s.name for s in claims.user_mcp_servers],
+            workspace_id=str(claims.workspace_id),
         )
-        raise ToolError(f"User MCP server '{server_name}' not authorized")
+        raise ToolError(server_name) from None
 
     try:
         config_dict: MCPHttpServerConfig = {
@@ -201,9 +205,9 @@ async def execute_user_mcp_tool(
             server_name=server_name,
             tool_name=tool_name,
             workspace_id=str(claims.workspace_id),
-            error=str(e),
+            error_type=_safe_error_type(e),
         )
-        raise ToolError("Tool execution failed") from None
+        raise ToolError(server_name) from None
 
 
 @mcp.tool
@@ -229,7 +233,7 @@ async def execute_internal_tool(
     try:
         claims = verify_mcp_token(auth_token)
     except ValueError as e:
-        logger.warning("MCP token verification failed", error=str(e))
+        logger.warning("MCP token verification failed", error_type=_safe_error_type(e))
         raise ToolError("Authentication failed") from None
 
     _set_role_context(claims)
@@ -257,7 +261,7 @@ async def execute_internal_tool(
             "Internal tool execution error",
             tool_name=tool_name,
             workspace_id=str(claims.workspace_id),
-            error=str(e),
+            error_type=_safe_error_type(e),
         )
         raise ToolError(str(e)) from e
 
@@ -266,7 +270,7 @@ async def execute_internal_tool(
             "Internal tool execution failed",
             tool_name=tool_name,
             workspace_id=str(claims.workspace_id),
-            error=str(e),
+            error_type=_safe_error_type(e),
         )
         raise ToolError("Internal tool execution failed") from None
 

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -68,8 +68,7 @@ class UserMCPClient:
                 logger.error(
                     "Failed to discover tools from user MCP server",
                     server_name=server_name,
-                    url=config.get("url"),
-                    error=str(e),
+                    error_type=type(e).__name__,
                 )
                 # Continue with other servers - don't fail completely
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sanitized MCP and Slack tool error handling to prevent sensitive data leaks and make Slack task updates concise. Errors now show minimal details; successful tool runs no longer include output in Slack.

- **Bug Fixes**
  - Slack: emit error updates with a small details string; no output field for tool results; statuses are only complete or error.
  - MCP trusted server: log only exception types; return ToolError with the server name for unauthorized access or execution failures to avoid exposing request details.
  - Agent activities and user MCP client: sanitized logs (error_type, server_count) and removed sensitive fields.
  - Tests: updated coverage for Slack sink error formatting and success suppression, MCP token/server authorization, and Temporal decoding of MCP server configs.

<sup>Written for commit 723524ce347f7ceb1a0ae3be5859359c39d1f10d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

