### PR TITLE
feat(mcp): persist integration discovery catalog state

### DIFF
--- a/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
+++ b/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
@@ -121,50 +121,6 @@ def upgrade() -> None:
         "USING gin (lower(artifact_ref) gin_trgm_ops)"
     )
 
-    op.create_table(
-        "mcp_integration_discovery_attempt",
-        sa.Column("id", sa.UUID(), nullable=False),
-        sa.Column("mcp_integration_id", sa.UUID(), nullable=False),
-        sa.Column("workspace_id", sa.UUID(), nullable=False),
-        sa.Column("trigger", sa.String(length=32), nullable=False),
-        sa.Column("status", sa.String(length=16), nullable=False),
-        sa.Column("catalog_version", sa.Integer(), nullable=True),
-        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=False),
-        sa.Column("finished_at", sa.TIMESTAMP(timezone=True), nullable=True),
-        sa.Column("duration_ms", sa.Integer(), nullable=True),
-        sa.Column(
-            "artifact_counts", postgresql.JSONB(astext_type=sa.Text()), nullable=True
-        ),
-        sa.Column("error_code", sa.String(length=64), nullable=True),
-        sa.Column("error_summary", sa.String(length=1024), nullable=True),
-        sa.Column(
-            "error_details", postgresql.JSONB(astext_type=sa.Text()), nullable=True
-        ),
-        sa.ForeignKeyConstraint(
-            ["mcp_integration_id"],
-            ["mcp_integration.id"],
-            name=op.f(
-                "fk_mcp_integration_discovery_attempt_mcp_integration_id_mcp_integration"
-            ),
-            ondelete="CASCADE",
-        ),
-        sa.ForeignKeyConstraint(
-            ["workspace_id"],
-            ["workspace.id"],
-            name=op.f("fk_mcp_integration_discovery_attempt_workspace_id_workspace"),
-            ondelete="CASCADE",
-        ),
-        sa.PrimaryKeyConstraint(
-            "id", name=op.f("pk_mcp_integration_discovery_attempt")
-        ),
-    )
-    op.create_index(
-        op.f("ix_mcp_integration_discovery_attempt_id"),
-        "mcp_integration_discovery_attempt",
-        ["id"],
-        unique=True,
-    )
-
     op.add_column(
         "mcp_integration",
         sa.Column("scope_namespace", sa.String(length=16), nullable=True),
@@ -207,32 +163,6 @@ def upgrade() -> None:
             "last_discovery_error_summary", sa.String(length=1024), nullable=True
         ),
     )
-    op.add_column(
-        "mcp_integration",
-        sa.Column(
-            "sandbox_allow_network",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.text("false"),
-        ),
-    )
-    op.add_column(
-        "mcp_integration",
-        sa.Column(
-            "sandbox_egress_allowlist",
-            postgresql.JSONB(astext_type=sa.Text()),
-            nullable=True,
-        ),
-    )
-    op.add_column(
-        "mcp_integration",
-        sa.Column(
-            "sandbox_egress_denylist",
-            postgresql.JSONB(astext_type=sa.Text()),
-            nullable=True,
-        ),
-    )
-
     connection = op.get_bind()
     existing_namespaces = {
         namespace
@@ -274,9 +204,6 @@ def downgrade() -> None:
         "mcp_integration",
         type_="unique",
     )
-    op.drop_column("mcp_integration", "sandbox_egress_denylist")
-    op.drop_column("mcp_integration", "sandbox_egress_allowlist")
-    op.drop_column("mcp_integration", "sandbox_allow_network")
     op.drop_column("mcp_integration", "last_discovery_error_summary")
     op.drop_column("mcp_integration", "last_discovery_error_code")
     op.drop_column("mcp_integration", "last_discovered_at")
@@ -284,12 +211,6 @@ def downgrade() -> None:
     op.drop_column("mcp_integration", "catalog_version")
     op.drop_column("mcp_integration", "discovery_status")
     op.drop_column("mcp_integration", "scope_namespace")
-
-    op.drop_index(
-        op.f("ix_mcp_integration_discovery_attempt_id"),
-        table_name="mcp_integration_discovery_attempt",
-    )
-    op.drop_table("mcp_integration_discovery_attempt")
 
     op.execute(
         "DROP INDEX IF EXISTS ix_mcp_integration_catalog_entry_artifact_ref_trgm"

--- a/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
+++ b/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
@@ -261,12 +261,6 @@ def upgrade() -> None:
             },
         )
 
-    op.alter_column(
-        "mcp_integration",
-        "scope_namespace",
-        existing_type=sa.String(length=16),
-        nullable=False,
-    )
     op.create_unique_constraint(
         "uq_mcp_integration_scope_namespace",
         "mcp_integration",

--- a/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
+++ b/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
@@ -191,6 +191,12 @@ def upgrade() -> None:
             },
         )
 
+    op.alter_column(
+        "mcp_integration",
+        "scope_namespace",
+        existing_type=sa.String(length=16),
+        nullable=False,
+    )
     op.create_unique_constraint(
         "uq_mcp_integration_scope_namespace",
         "mcp_integration",

--- a/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
+++ b/alembic/versions/3758bd2248e6_persist_mcp_discovery_catalog_state.py
@@ -1,0 +1,319 @@
+"""persist mcp discovery catalog state
+
+Revision ID: 3758bd2248e6
+Revises: 8e2a638ae873
+Create Date: 2026-03-05 17:26:55.837099
+
+"""
+
+import secrets
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3758bd2248e6"
+down_revision: str | None = "8e2a638ae873"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _generate_scope_namespace(existing_namespaces: set[str]) -> str:
+    while True:
+        if (candidate := secrets.token_hex(8)) not in existing_namespaces:
+            existing_namespaces.add(candidate)
+            return candidate
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    op.create_table(
+        "mcp_integration_catalog_entry",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("mcp_integration_id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("integration_name", sa.String(), nullable=False),
+        sa.Column("artifact_type", sa.String(length=16), nullable=False),
+        sa.Column("artifact_key", sa.String(length=96), nullable=False),
+        sa.Column("artifact_ref", sa.String(length=512), nullable=False),
+        sa.Column("display_name", sa.String(length=512), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "input_schema", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "raw_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("search_vector", postgresql.TSVECTOR(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["mcp_integration_id"],
+            ["mcp_integration.id"],
+            name=op.f(
+                "fk_mcp_integration_catalog_entry_mcp_integration_id_mcp_integration"
+            ),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_mcp_integration_catalog_entry_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_mcp_integration_catalog_entry")),
+        sa.UniqueConstraint(
+            "mcp_integration_id",
+            "artifact_type",
+            "artifact_key",
+            name="uq_mcp_integration_catalog_entry_integration_artifact",
+        ),
+    )
+    op.create_index(
+        op.f("ix_mcp_integration_catalog_entry_id"),
+        "mcp_integration_catalog_entry",
+        ["id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_mcp_integration_catalog_entry_search_vector",
+        "mcp_integration_catalog_entry",
+        ["search_vector"],
+        unique=False,
+        postgresql_using="gin",
+    )
+    op.create_index(
+        "ix_mcp_integration_catalog_entry_workspace_active_type",
+        "mcp_integration_catalog_entry",
+        ["workspace_id", "is_active", "artifact_type"],
+        unique=False,
+    )
+    op.execute(
+        "CREATE INDEX ix_mcp_integration_catalog_entry_display_name_trgm "
+        "ON mcp_integration_catalog_entry "
+        "USING gin (lower(display_name) gin_trgm_ops)"
+    )
+    op.execute(
+        "CREATE INDEX ix_mcp_integration_catalog_entry_artifact_ref_trgm "
+        "ON mcp_integration_catalog_entry "
+        "USING gin (lower(artifact_ref) gin_trgm_ops)"
+    )
+
+    op.create_table(
+        "mcp_integration_discovery_attempt",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("mcp_integration_id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("trigger", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("catalog_version", sa.Integer(), nullable=True),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column(
+            "artifact_counts", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column("error_code", sa.String(length=64), nullable=True),
+        sa.Column("error_summary", sa.String(length=1024), nullable=True),
+        sa.Column(
+            "error_details", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.ForeignKeyConstraint(
+            ["mcp_integration_id"],
+            ["mcp_integration.id"],
+            name=op.f(
+                "fk_mcp_integration_discovery_attempt_mcp_integration_id_mcp_integration"
+            ),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_mcp_integration_discovery_attempt_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "id", name=op.f("pk_mcp_integration_discovery_attempt")
+        ),
+    )
+    op.create_index(
+        op.f("ix_mcp_integration_discovery_attempt_id"),
+        "mcp_integration_discovery_attempt",
+        ["id"],
+        unique=True,
+    )
+
+    op.add_column(
+        "mcp_integration",
+        sa.Column("scope_namespace", sa.String(length=16), nullable=True),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "discovery_status",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "catalog_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "last_discovery_attempt_at", sa.TIMESTAMP(timezone=True), nullable=True
+        ),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column("last_discovered_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column("last_discovery_error_code", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "last_discovery_error_summary", sa.String(length=1024), nullable=True
+        ),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "sandbox_allow_network",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "sandbox_egress_allowlist",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "sandbox_egress_denylist",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+    connection = op.get_bind()
+    existing_namespaces = {
+        namespace
+        for namespace in connection.execute(
+            sa.text(
+                "SELECT scope_namespace "
+                "FROM mcp_integration "
+                "WHERE scope_namespace IS NOT NULL"
+            )
+        ).scalars()
+        if namespace is not None
+    }
+    integration_ids = connection.execute(
+        sa.text("SELECT id FROM mcp_integration WHERE scope_namespace IS NULL")
+    ).scalars()
+    for integration_id in integration_ids:
+        connection.execute(
+            sa.text(
+                "UPDATE mcp_integration "
+                "SET scope_namespace = :scope_namespace "
+                "WHERE id = :integration_id"
+            ),
+            {
+                "scope_namespace": _generate_scope_namespace(existing_namespaces),
+                "integration_id": integration_id,
+            },
+        )
+
+    op.alter_column(
+        "mcp_integration",
+        "scope_namespace",
+        existing_type=sa.String(length=16),
+        nullable=False,
+    )
+    op.create_unique_constraint(
+        "uq_mcp_integration_scope_namespace",
+        "mcp_integration",
+        ["scope_namespace"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_mcp_integration_scope_namespace",
+        "mcp_integration",
+        type_="unique",
+    )
+    op.drop_column("mcp_integration", "sandbox_egress_denylist")
+    op.drop_column("mcp_integration", "sandbox_egress_allowlist")
+    op.drop_column("mcp_integration", "sandbox_allow_network")
+    op.drop_column("mcp_integration", "last_discovery_error_summary")
+    op.drop_column("mcp_integration", "last_discovery_error_code")
+    op.drop_column("mcp_integration", "last_discovered_at")
+    op.drop_column("mcp_integration", "last_discovery_attempt_at")
+    op.drop_column("mcp_integration", "catalog_version")
+    op.drop_column("mcp_integration", "discovery_status")
+    op.drop_column("mcp_integration", "scope_namespace")
+
+    op.drop_index(
+        op.f("ix_mcp_integration_discovery_attempt_id"),
+        table_name="mcp_integration_discovery_attempt",
+    )
+    op.drop_table("mcp_integration_discovery_attempt")
+
+    op.execute(
+        "DROP INDEX IF EXISTS ix_mcp_integration_catalog_entry_artifact_ref_trgm"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS ix_mcp_integration_catalog_entry_display_name_trgm"
+    )
+    op.drop_index(
+        "ix_mcp_integration_catalog_entry_workspace_active_type",
+        table_name="mcp_integration_catalog_entry",
+    )
+    op.drop_index(
+        "ix_mcp_integration_catalog_entry_search_vector",
+        table_name="mcp_integration_catalog_entry",
+        postgresql_using="gin",
+    )
+    op.drop_index(
+        op.f("ix_mcp_integration_catalog_entry_id"),
+        table_name="mcp_integration_catalog_entry",
+    )
+    op.drop_table("mcp_integration_catalog_entry")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10926,11 +10926,6 @@ export const $MCPHttpServerConfig = {
       type: "object",
       title: "Headers",
     },
-    transport: {
-      type: "string",
-      enum: ["http", "sse"],
-      title: "Transport",
-    },
     timeout: {
       type: "integer",
       title: "Timeout",
@@ -10939,17 +10934,17 @@ export const $MCPHttpServerConfig = {
   type: "object",
   required: ["name", "url"],
   title: "MCPHttpServerConfig",
-  description: `Configuration for a user-defined MCP server over HTTP/SSE.
+  description: `Configuration for a user-defined MCP server over HTTP.
 
 Users can connect custom MCP servers to their agents - whether running as
-Docker containers, local processes, or remote services. The server must
-expose an HTTP or SSE endpoint.
+Docker containers, local processes, or remote services. Streamable HTTP is
+the canonical transport; the trusted client may fall back to SSE internally
+for compatibility with older servers.
 
 Example:
     {
         "name": "internal-tools",
         "url": "http://host.docker.internal:8080",
-        "transport": "http",
         "headers": {"Authorization": "Bearer \${{ SECRETS.internal.API_KEY }}"}
     }`,
 } as const

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10783,6 +10783,39 @@ export const $MCPAuthType = {
   description: "Authentication type for MCP integrations.",
 } as const
 
+export const $MCPCatalogCounts = {
+  properties: {
+    tools: {
+      type: "integer",
+      minimum: 0,
+      title: "Tools",
+      default: 0,
+    },
+    resources: {
+      type: "integer",
+      minimum: 0,
+      title: "Resources",
+      default: 0,
+    },
+    prompts: {
+      type: "integer",
+      minimum: 0,
+      title: "Prompts",
+      default: 0,
+    },
+  },
+  type: "object",
+  title: "MCPCatalogCounts",
+  description: "Active catalog counts grouped by artifact type.",
+} as const
+
+export const $MCPDiscoveryStatus = {
+  type: "string",
+  enum: ["pending", "succeeded", "failed", "stale"],
+  title: "MCPDiscoveryStatus",
+  description: "Discovery status for a persisted MCP integration catalog.",
+} as const
+
 export const $MCPHttpIntegrationCreate = {
   properties: {
     name: {
@@ -10963,6 +10996,10 @@ export const $MCPIntegrationRead = {
       type: "string",
       title: "Slug",
     },
+    scope_namespace: {
+      type: "string",
+      title: "Scope Namespace",
+    },
     server_type: {
       $ref: "#/components/schemas/MCPServerType",
     },
@@ -11033,6 +11070,67 @@ export const $MCPIntegrationRead = {
       ],
       title: "Timeout",
     },
+    discovery_status: {
+      $ref: "#/components/schemas/MCPDiscoveryStatus",
+    },
+    catalog_version: {
+      type: "integer",
+      title: "Catalog Version",
+    },
+    last_discovery_attempt_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Discovery Attempt At",
+    },
+    last_discovered_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Discovered At",
+    },
+    last_discovery_error_code: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Discovery Error Code",
+    },
+    last_discovery_error_summary: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Discovery Error Summary",
+    },
+    catalog_counts: {
+      $ref: "#/components/schemas/MCPCatalogCounts",
+    },
+    has_catalog: {
+      type: "boolean",
+      title: "Has Catalog",
+      default: false,
+    },
     created_at: {
       type: "string",
       format: "date-time",
@@ -11051,6 +11149,7 @@ export const $MCPIntegrationRead = {
     "name",
     "description",
     "slug",
+    "scope_namespace",
     "server_type",
     "server_uri",
     "auth_type",
@@ -11058,6 +11157,12 @@ export const $MCPIntegrationRead = {
     "stdio_command",
     "stdio_args",
     "timeout",
+    "discovery_status",
+    "catalog_version",
+    "last_discovery_attempt_at",
+    "last_discovered_at",
+    "last_discovery_error_code",
+    "last_discovery_error_summary",
     "created_at",
     "updated_at",
   ],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3479,6 +3479,20 @@ export type JoinStrategy = "any" | "all"
 export type MCPAuthType = "OAUTH2" | "CUSTOM" | "NONE"
 
 /**
+ * Active catalog counts grouped by artifact type.
+ */
+export type MCPCatalogCounts = {
+  tools?: number
+  resources?: number
+  prompts?: number
+}
+
+/**
+ * Discovery status for a persisted MCP integration catalog.
+ */
+export type MCPDiscoveryStatus = "pending" | "succeeded" | "failed" | "stale"
+
+/**
  * Request model for creating an HTTP MCP integration.
  */
 export type MCPHttpIntegrationCreate = {
@@ -3554,6 +3568,7 @@ export type MCPIntegrationRead = {
   name: string
   description: string | null
   slug: string
+  scope_namespace: string
   server_type: MCPServerType
   server_uri: string | null
   auth_type: MCPAuthType
@@ -3562,6 +3577,14 @@ export type MCPIntegrationRead = {
   stdio_args: Array<string> | null
   has_stdio_env?: boolean
   timeout: number | null
+  discovery_status: MCPDiscoveryStatus
+  catalog_version: number
+  last_discovery_attempt_at: string | null
+  last_discovered_at: string | null
+  last_discovery_error_code: string | null
+  last_discovery_error_summary: string | null
+  catalog_counts?: MCPCatalogCounts
+  has_catalog?: boolean
   created_at: string
   updated_at: string
 }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3528,17 +3528,17 @@ export type MCPHttpIntegrationCreate = {
 }
 
 /**
- * Configuration for a user-defined MCP server over HTTP/SSE.
+ * Configuration for a user-defined MCP server over HTTP.
  *
  * Users can connect custom MCP servers to their agents - whether running as
- * Docker containers, local processes, or remote services. The server must
- * expose an HTTP or SSE endpoint.
+ * Docker containers, local processes, or remote services. Streamable HTTP is
+ * the canonical transport; the trusted client may fall back to SSE internally
+ * for compatibility with older servers.
  *
  * Example:
  * {
  * "name": "internal-tools",
  * "url": "http://host.docker.internal:8080",
- * "transport": "http",
  * "headers": {"Authorization": "Bearer ${{ SECRETS.internal.API_KEY }}"}
  * }
  */
@@ -3549,11 +3549,8 @@ export type MCPHttpServerConfig = {
   headers?: {
     [key: string]: string
   }
-  transport?: "http" | "sse"
   timeout?: number
 }
-
-export type transport = "http" | "sse"
 
 export type MCPIntegrationCreate =
   | MCPHttpIntegrationCreate

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -20,6 +20,7 @@ from tracecat.agent.mcp.internal_tools import (
     BUILDER_INTERNAL_TOOL_NAMES,
     get_builder_internal_tool_definitions,
 )
+from tracecat.agent.mcp.utils import parse_canonical_user_mcp_tool_name
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.tokens import InternalToolContext, UserMCPServerClaim
 from tracecat.agent.tools import build_agent_tools
@@ -200,7 +201,8 @@ class AgentActivities:
         registry_action_names = {
             name
             for name in defs.keys()
-            if not name.startswith("mcp__") and not name.startswith("internal.")
+            if parse_canonical_user_mcp_tool_name(name) is None
+            and not name.startswith("internal.")
         }
         async with RegistryLockService.with_session() as lock_service:
             registry_lock = await lock_service.resolve_lock_with_bindings(

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -175,7 +175,6 @@ class AgentActivities:
                     UserMCPServerClaim(
                         name=cfg["name"],
                         url=cfg["url"],
-                        transport=cfg.get("transport", "http"),
                         headers=cfg.get("headers", {}),
                         timeout=cfg.get("timeout"),
                     )

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -38,13 +38,10 @@ class MCPServerConfig(TypedDict):
     """Required: Unique identifier for the server."""
 
     url: str
-    """Required: HTTP/SSE endpoint URL for the MCP server."""
+    """Required: HTTP endpoint URL for the MCP server."""
 
     headers: NotRequired[dict[str, str]]
     """Optional: Auth headers."""
-
-    transport: NotRequired[Literal["http", "sse"]]
-    """Optional: Transport type. Defaults to 'http'."""
 
 
 class RankableItem(TypedDict):

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -275,11 +275,12 @@ build_env() {
     export MINIO_CONSOLE_PORT
     export MCP_PORT
 
-    # URL variables that reference the public port (allow explicit env overrides, e.g. ngrok)
-    export TRACECAT__PUBLIC_APP_URL="${TRACECAT__PUBLIC_APP_URL:-${PUBLIC_APP_URL}}"
-    export TRACECAT__PUBLIC_API_URL="${TRACECAT__PUBLIC_API_URL:-${PUBLIC_API_URL}}"
-    export NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL:-${PUBLIC_APP_URL}}"
-    export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-${PUBLIC_API_URL}}"
+    # URL variables that reference the public port
+    # Always use cluster-computed values — .env defaults use port 80 which is wrong for cluster 2+
+    export TRACECAT__PUBLIC_APP_URL="${PUBLIC_APP_URL}"
+    export TRACECAT__PUBLIC_API_URL="${PUBLIC_API_URL}"
+    export NEXT_PUBLIC_APP_URL="${PUBLIC_APP_URL}"
+    export NEXT_PUBLIC_API_URL="${PUBLIC_API_URL}"
 
     # Caddy configuration
     export BASE_DOMAIN=":${PUBLIC_APP_PORT}"

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -8,6 +8,7 @@ These tests cover:
 from __future__ import annotations
 
 import uuid
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +17,9 @@ from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
+    ApprovedToolCall,
+    ExecuteApprovedToolsInput,
+    execute_approved_tools_activity,
     run_agent_activity,
 )
 from tracecat.agent.session.activities import (
@@ -31,6 +35,7 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.registry.lock.types import RegistryLock
 
 
 @pytest.fixture
@@ -439,3 +444,90 @@ class TestRunAgentActivity:
 
             # Should send heartbeat at start and end
             assert mock_activity.heartbeat.call_count >= 2
+
+
+class TestExecuteApprovedToolsActivity:
+    """Tests for execute_approved_tools_activity."""
+
+    @pytest.fixture
+    def mock_registry_lock(self) -> RegistryLock:
+        """Create a mock registry lock for testing."""
+        return RegistryLock(
+            origins={"tracecat_registry": "test-version"},
+            actions={"core.http_request": "tracecat_registry"},
+        )
+
+    @pytest.fixture
+    def mock_execute_approved_input(
+        self,
+        mock_role: Role,
+        mock_session_id: uuid.UUID,
+        mock_registry_lock: RegistryLock,
+    ) -> ExecuteApprovedToolsInput:
+        """Create input with a pydantic-ai encoded tool name."""
+        return ExecuteApprovedToolsInput(
+            session_id=mock_session_id,
+            workspace_id=mock_role.workspace_id or uuid.uuid4(),
+            role=mock_role,
+            approved_tools=[
+                ApprovedToolCall(
+                    tool_call_id="call_123",
+                    tool_name="core__http_request",
+                    args={"url": "https://example.com"},
+                )
+            ],
+            denied_tools=[],
+            allowed_actions=["core.http_request"],
+            registry_lock=mock_registry_lock,
+        )
+
+    @pytest.mark.anyio
+    async def test_decodes_approved_tool_name_before_execution(
+        self,
+        mock_execute_approved_input: ExecuteApprovedToolsInput,
+    ) -> None:
+        """Test approval execution canonicalizes encoded tool names."""
+        mock_stream = MagicMock()
+        mock_stream.append = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_session(*args, **kwargs):
+            service = AsyncMock()
+            yield service
+
+        with (
+            patch("tracecat.agent.executor.activity.activity") as mock_activity,
+            patch(
+                "tracecat.agent.executor.activity.registry_resolver.prefetch_lock",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "tracecat.agent.executor.activity.AgentStream.new",
+                new_callable=AsyncMock,
+                return_value=mock_stream,
+            ),
+            patch(
+                "tracecat.agent.executor.activity._execute_action_with_heartbeat",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_execute_action,
+            patch(
+                "tracecat.agent.executor.activity.AgentSessionService.with_session",
+                mock_session,
+            ),
+        ):
+            mock_activity.heartbeat = MagicMock()
+
+            result = await execute_approved_tools_activity(mock_execute_approved_input)
+
+        assert result.success is True
+        assert len(result.results) == 1
+        assert result.results[0].is_error is False
+        mock_execute_action.assert_awaited_once()
+        assert mock_execute_action.await_args is not None
+        assert (
+            mock_execute_action.await_args.kwargs["action_name"] == "core.http_request"
+        )
+        assert (
+            mock_execute_action.await_args.kwargs["tool_name"] == "core__http_request"
+        )

--- a/tests/unit/test_agent_ee_activities.py
+++ b/tests/unit/test_agent_ee_activities.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from tracecat_ee.agent.activities import AgentActivities, BuildToolDefsArgs
+
+from tracecat.agent.common.types import MCPToolDefinition
+from tracecat.agent.schemas import ToolFilters
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.registry.lock.types import RegistryLock
+
+
+@pytest.fixture
+def mock_role() -> Role:
+    """Create a mock role for testing."""
+    return Role(
+        type="service",
+        service_id="tracecat-agent-executor",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-agent-executor"],
+    )
+
+
+@pytest.mark.anyio
+async def test_build_tool_definitions_excludes_canonical_user_mcp_tools_from_lock_resolution(
+    mock_role: Role,
+) -> None:
+    """Test canonical user MCP tools are not sent to registry lock resolution."""
+    agent_activities = AgentActivities()
+    registry_tool = MCPToolDefinition(
+        name="core.http_request",
+        description="Make HTTP requests",
+        parameters_json_schema={},
+    )
+    user_mcp_tool = MCPToolDefinition(
+        name="mcp.jira.lookup",
+        description="Look up Jira issues",
+        parameters_json_schema={},
+    )
+    registry_lock = RegistryLock(
+        origins={"tracecat_registry": "test-version"},
+        actions={"core.http_request": "tracecat_registry"},
+    )
+    mock_lock_service = AsyncMock()
+    mock_lock_service.resolve_lock_with_bindings.return_value = registry_lock
+
+    @asynccontextmanager
+    async def mock_lock_session(*args, **kwargs):
+        yield mock_lock_service
+
+    with (
+        patch(
+            "tracecat_ee.agent.activities.build_agent_tools",
+            new_callable=AsyncMock,
+            return_value=MagicMock(tools=[registry_tool]),
+        ),
+        patch(
+            "tracecat.agent.mcp.user_client.discover_user_mcp_tools",
+            new_callable=AsyncMock,
+            return_value={user_mcp_tool.name: user_mcp_tool},
+        ),
+        patch(
+            "tracecat_ee.agent.activities.RegistryLockService.with_session",
+            mock_lock_session,
+        ),
+    ):
+        result = await agent_activities.build_tool_definitions(
+            BuildToolDefsArgs(
+                role=mock_role,
+                tool_filters=ToolFilters(actions=["core.http_request"]),
+                mcp_servers=[
+                    {
+                        "type": "http",
+                        "name": "jira",
+                        "url": "https://jira.example.com/mcp",
+                    }
+                ],
+            )
+        )
+
+    assert "core.http_request" in result.tool_definitions
+    assert "mcp.jira.lookup" in result.tool_definitions
+    mock_lock_service.resolve_lock_with_bindings.assert_awaited_once_with(
+        {"core.http_request"}
+    )

--- a/tests/unit/test_agent_mcp_user_client.py
+++ b/tests/unit/test_agent_mcp_user_client.py
@@ -59,7 +59,7 @@ async def test_discover_user_mcp_tools_falls_back_to_sse(
         ("list_tools", "streamable-http"),
         ("list_tools", "sse"),
     ]
-    assert "mcp__jira__lookup" in tools
+    assert "mcp.jira.lookup" in tools
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_mcp_user_client.py
+++ b/tests/unit/test_agent_mcp_user_client.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tracecat.agent.mcp import user_client
+
+
+def _set_transport_factories(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        user_client,
+        "_create_streamable_http_transport",
+        lambda url, headers=None, timeout=None: "streamable-http",
+    )
+    monkeypatch.setattr(
+        user_client,
+        "_create_sse_transport",
+        lambda url, headers=None, timeout=None: "sse",
+    )
+
+
+@pytest.mark.anyio
+async def test_discover_user_mcp_tools_falls_back_to_sse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_transport_factories(monkeypatch)
+    attempts: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, transport: str) -> None:
+            self.transport = transport
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def list_tools(self) -> list[SimpleNamespace]:
+            attempts.append(("list_tools", self.transport))
+            if self.transport == "streamable-http":
+                raise RuntimeError("streamable-http unsupported")
+            return [
+                SimpleNamespace(
+                    name="lookup",
+                    description="Lookup",
+                    inputSchema={"type": "object"},
+                )
+            ]
+
+    monkeypatch.setattr(user_client, "Client", FakeClient)
+
+    tools = await user_client.discover_user_mcp_tools(
+        [{"name": "jira", "url": "https://example.com/mcp"}]
+    )
+
+    assert attempts == [
+        ("list_tools", "streamable-http"),
+        ("list_tools", "sse"),
+    ]
+    assert "mcp__jira__lookup" in tools
+
+
+@pytest.mark.anyio
+async def test_call_user_mcp_tool_prefers_streamable_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_transport_factories(monkeypatch)
+    attempts: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, transport: str) -> None:
+            self.transport = transport
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def list_tools(self) -> list[SimpleNamespace]:
+            attempts.append(("list_tools", self.transport))
+            return []
+
+        async def call_tool(
+            self, tool_name: str, args: dict[str, object]
+        ) -> SimpleNamespace:
+            attempts.append(("call_tool", self.transport))
+            assert tool_name == "getIssue"
+            assert args == {"id": 1}
+            return SimpleNamespace(content=[SimpleNamespace(text="ok")])
+
+    monkeypatch.setattr(user_client, "Client", FakeClient)
+
+    result = await user_client.call_user_mcp_tool(
+        [{"name": "jira", "url": "https://example.com/mcp"}],
+        "jira",
+        "getIssue",
+        {"id": 1},
+    )
+
+    assert result == "ok"
+    assert attempts == [
+        ("list_tools", "streamable-http"),
+        ("call_tool", "streamable-http"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_call_user_mcp_tool_falls_back_to_sse_when_probe_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_transport_factories(monkeypatch)
+    attempts: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, transport: str) -> None:
+            self.transport = transport
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def list_tools(self) -> list[SimpleNamespace]:
+            attempts.append(("list_tools", self.transport))
+            if self.transport == "streamable-http":
+                raise RuntimeError("streamable-http unsupported")
+            return []
+
+        async def call_tool(
+            self, tool_name: str, args: dict[str, object]
+        ) -> SimpleNamespace:
+            attempts.append(("call_tool", self.transport))
+            assert tool_name == "getIssue"
+            assert args == {"id": 1}
+            return SimpleNamespace(content=[SimpleNamespace(text="fallback-ok")])
+
+    monkeypatch.setattr(user_client, "Client", FakeClient)
+
+    result = await user_client.call_user_mcp_tool(
+        [{"name": "jira", "url": "https://example.com/mcp"}],
+        "jira",
+        "getIssue",
+        {"id": 1},
+    )
+
+    assert result == "fallback-ok"
+    assert attempts == [
+        ("list_tools", "streamable-http"),
+        ("list_tools", "sse"),
+        ("call_tool", "sse"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_call_user_mcp_tool_falls_back_to_sse_when_connect_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_transport_factories(monkeypatch)
+    attempts: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, transport: str) -> None:
+            self.transport = transport
+
+        async def __aenter__(self) -> FakeClient:
+            attempts.append(("enter", self.transport))
+            if self.transport == "streamable-http":
+                raise RuntimeError("streamable-http connect failed")
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def list_tools(self) -> list[SimpleNamespace]:
+            attempts.append(("list_tools", self.transport))
+            return []
+
+        async def call_tool(
+            self, tool_name: str, args: dict[str, object]
+        ) -> SimpleNamespace:
+            attempts.append(("call_tool", self.transport))
+            assert tool_name == "getIssue"
+            assert args == {"id": 1}
+            return SimpleNamespace(content=[SimpleNamespace(text="fallback-ok")])
+
+    monkeypatch.setattr(user_client, "Client", FakeClient)
+
+    result = await user_client.call_user_mcp_tool(
+        [{"name": "jira", "url": "https://example.com/mcp"}],
+        "jira",
+        "getIssue",
+        {"id": 1},
+    )
+
+    assert result == "fallback-ok"
+    assert attempts == [
+        ("enter", "streamable-http"),
+        ("enter", "sse"),
+        ("list_tools", "sse"),
+        ("call_tool", "sse"),
+    ]
+
+
+@pytest.mark.anyio
+async def test_call_user_mcp_tool_does_not_retry_after_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_transport_factories(monkeypatch)
+    attempts: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, transport: str) -> None:
+            self.transport = transport
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def list_tools(self) -> list[SimpleNamespace]:
+            attempts.append(("list_tools", self.transport))
+            return []
+
+        async def call_tool(
+            self, tool_name: str, args: dict[str, object]
+        ) -> SimpleNamespace:
+            attempts.append(("call_tool", self.transport))
+            raise RuntimeError("tool failed")
+
+    monkeypatch.setattr(user_client, "Client", FakeClient)
+
+    with pytest.raises(RuntimeError, match="tool failed"):
+        await user_client.call_user_mcp_tool(
+            [{"name": "jira", "url": "https://example.com/mcp"}],
+            "jira",
+            "getIssue",
+            {"id": 1},
+        )
+
+    assert attempts == [
+        ("list_tools", "streamable-http"),
+        ("call_tool", "streamable-http"),
+    ]

--- a/tests/unit/test_agent_mcp_utils.py
+++ b/tests/unit/test_agent_mcp_utils.py
@@ -4,6 +4,8 @@ from tracecat.agent.mcp.utils import (
     decode_legacy_tool_name_to_canonical,
     decode_sdk_tool_name_to_canonical,
     encode_canonical_tool_name_to_sdk,
+    is_reserved_mcp_server_name,
+    is_tracecat_sdk_tool_name,
     parse_canonical_user_mcp_tool_name,
 )
 
@@ -20,6 +22,17 @@ def test_decode_sdk_tool_name_to_canonical_for_user_mcp_tool() -> None:
         decode_sdk_tool_name_to_canonical("mcp__tracecat-registry__mcp__jira__getIssue")
         == "mcp.jira.getIssue"
     )
+
+
+def test_decode_sdk_tool_name_to_canonical_for_tracecat_registry_wire_name() -> None:
+    assert (
+        decode_sdk_tool_name_to_canonical("tools__slack__post_message")
+        == "tools.slack.post_message"
+    )
+
+
+def test_decode_sdk_tool_name_to_canonical_preserves_raw_stdio_tool_name() -> None:
+    assert decode_sdk_tool_name_to_canonical("foo__bar") == "foo__bar"
 
 
 def test_decode_legacy_tool_name_to_canonical_supports_registry_alias() -> None:
@@ -46,3 +59,15 @@ def test_parse_canonical_user_mcp_tool_name() -> None:
         "jira",
         "getIssue",
     )
+
+
+def test_is_reserved_mcp_server_name() -> None:
+    assert is_reserved_mcp_server_name("tracecat-registry") is True
+    assert is_reserved_mcp_server_name("tracecat_registry") is True
+    assert is_reserved_mcp_server_name("jira") is False
+
+
+def test_is_tracecat_sdk_tool_name() -> None:
+    assert is_tracecat_sdk_tool_name("core__http_request") is True
+    assert is_tracecat_sdk_tool_name("tools__slack__post_message") is True
+    assert is_tracecat_sdk_tool_name("foo__bar") is False

--- a/tests/unit/test_agent_mcp_utils.py
+++ b/tests/unit/test_agent_mcp_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from tracecat.agent.mcp.utils import (
+    decode_legacy_tool_name_to_canonical,
+    decode_sdk_tool_name_to_canonical,
+    encode_canonical_tool_name_to_sdk,
+    parse_canonical_user_mcp_tool_name,
+)
+
+
+def test_decode_sdk_tool_name_to_canonical_for_registry_tool() -> None:
+    assert (
+        decode_sdk_tool_name_to_canonical("mcp__tracecat-registry__core__http_request")
+        == "core.http_request"
+    )
+
+
+def test_decode_sdk_tool_name_to_canonical_for_user_mcp_tool() -> None:
+    assert (
+        decode_sdk_tool_name_to_canonical("mcp__tracecat-registry__mcp__jira__getIssue")
+        == "mcp.jira.getIssue"
+    )
+
+
+def test_decode_legacy_tool_name_to_canonical_supports_registry_alias() -> None:
+    assert (
+        decode_legacy_tool_name_to_canonical("mcp.tracecat_registry.core.http_request")
+        == "core.http_request"
+    )
+
+
+def test_encode_canonical_tool_name_to_sdk_for_registry_tool() -> None:
+    assert (
+        encode_canonical_tool_name_to_sdk("core.http_request") == "core__http_request"
+    )
+
+
+def test_encode_canonical_tool_name_to_sdk_for_user_mcp_tool() -> None:
+    assert (
+        encode_canonical_tool_name_to_sdk("mcp.jira.getIssue") == "mcp__jira__getIssue"
+    )
+
+
+def test_parse_canonical_user_mcp_tool_name() -> None:
+    assert parse_canonical_user_mcp_tool_name("mcp.jira.getIssue") == (
+        "jira",
+        "getIssue",
+    )

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -304,7 +304,7 @@ class TestClaudeAgentRuntimePreToolUseHook:
     """Tests for ClaudeAgentRuntime._pre_tool_use_hook().
 
     The hook uses these rules:
-    1. Auto-approve if it's a user MCP tool (starts with mcp__ but not mcp__tracecat-registry__)
+    1. Auto-approve if it's a user MCP tool
     2. Auto-approve if action is in registry_tools AND doesn't require approval
     3. Deny with reason if requires_approval is True
     4. Deny without reason otherwise (tool not allowed)
@@ -321,10 +321,10 @@ class TestClaudeAgentRuntimePreToolUseHook:
         runtime.registry_tools = sample_init_payload.allowed_actions
         runtime.tool_approvals = sample_init_payload.config.tool_approvals
 
-        # User MCP tool format: mcp__{server_name}__{tool_name}
+        # Claude SDK tool name routed through the registry MCP proxy.
         result = await runtime._pre_tool_use_hook(
             input_data=make_hook_input(
-                tool_name="mcp__tracecat-registry__mcp__some_tool",
+                tool_name="mcp__tracecat-registry__mcp__jira__getIssue",
                 tool_input={"arg": "value"},
             ),
             tool_use_id="call-1",

--- a/tests/unit/test_agent_types.py
+++ b/tests/unit/test_agent_types.py
@@ -1,5 +1,8 @@
+import pytest
+from pydantic import ValidationError
 from temporalio.converter import value_to_type
 
+from tracecat.agent.schemas import AgentConfigSchema
 from tracecat.agent.types import AgentConfig
 
 
@@ -28,3 +31,18 @@ def test_temporal_converter_decodes_agent_config_with_mcp_servers() -> None:
             "headers": {"Authorization": "Bearer test-token"},
         }
     ]
+
+
+def test_agent_config_schema_rejects_reserved_mcp_server_name() -> None:
+    with pytest.raises(ValidationError, match="reserved for Tracecat"):
+        AgentConfigSchema(
+            model_name="claude-3-5-sonnet-20241022",
+            model_provider="anthropic",
+            mcp_servers=[
+                {
+                    "name": "tracecat-registry",
+                    "type": "http",
+                    "url": "https://example.com/mcp",
+                }
+            ],
+        )

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -13,21 +13,31 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from pydantic import SecretStr, TypeAdapter
-from sqlalchemy import select
+from sqlalchemy import func, insert, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
-from tracecat.db.models import AgentPreset, MCPIntegration, OAuthIntegration
-from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
+from tracecat.db.models import (
+    AgentPreset,
+    MCPIntegration,
+    MCPIntegrationCatalogEntry,
+    OAuthIntegration,
+)
+from tracecat.integrations.enums import (
+    MCPAuthType,
+    MCPCatalogArtifactType,
+    MCPDiscoveryStatus,
+    OAuthGrantType,
+)
 from tracecat.integrations.providers.base import (
     MCPAuthProvider,
     OAuthDiscoveryResult,
 )
-from tracecat.integrations.providers.wiz.mcp import WizMCPProvider
 from tracecat.integrations.providers.sentry.mcp import SentryMCPProvider
+from tracecat.integrations.providers.wiz.mcp import WizMCPProvider
 from tracecat.integrations.schemas import (
     MCPHttpIntegrationCreate,
     MCPIntegrationCreate,
@@ -99,6 +109,16 @@ class TestMCPIntegrationCRUD:
         assert mcp_integration.auth_type == MCPAuthType.OAUTH2
         assert mcp_integration.oauth_integration_id == oauth_integration.id
         assert mcp_integration.encrypted_headers is None
+        assert len(mcp_integration.scope_namespace) == 16
+        assert mcp_integration.discovery_status == MCPDiscoveryStatus.PENDING.value
+        assert mcp_integration.catalog_version == 0
+        assert mcp_integration.last_discovery_attempt_at is None
+        assert mcp_integration.last_discovered_at is None
+        assert mcp_integration.last_discovery_error_code is None
+        assert mcp_integration.last_discovery_error_summary is None
+        assert mcp_integration.sandbox_allow_network is False
+        assert mcp_integration.sandbox_egress_allowlist is None
+        assert mcp_integration.sandbox_egress_denylist is None
         assert mcp_integration.created_at is not None
         assert mcp_integration.updated_at is not None
 
@@ -334,6 +354,7 @@ class TestMCPIntegrationCRUD:
             oauth_integration_id=oauth_integration.id,
         )
         created = await integration_service.create_mcp_integration(params=params)
+        original_scope_namespace = created.scope_namespace
 
         update_params = MCPIntegrationUpdate(
             name="Updated MCP",
@@ -347,7 +368,101 @@ class TestMCPIntegrationCRUD:
         assert updated.name == "Updated MCP"
         assert updated.description == "Updated description"
         assert updated.slug == "updated-mcp"  # Slug regenerated when name changes
+        assert updated.scope_namespace == original_scope_namespace
         assert updated.server_uri == created.server_uri  # Unchanged
+
+    async def test_get_mcp_catalog_counts(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """Test active catalog counts are grouped by integration and artifact type."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Catalog MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        other = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Other Catalog MCP",
+                server_uri="https://api2.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+
+        async def insert_catalog_entry(
+            *,
+            mcp_integration_id: uuid.UUID,
+            integration_name: str,
+            artifact_type: MCPCatalogArtifactType,
+            artifact_key: str,
+            artifact_ref: str,
+            is_active: bool = True,
+        ) -> None:
+            await integration_service.session.execute(
+                insert(MCPIntegrationCatalogEntry).values(
+                    id=uuid.uuid4(),
+                    mcp_integration_id=mcp_integration_id,
+                    workspace_id=integration_service.workspace_id,
+                    integration_name=integration_name,
+                    artifact_type=artifact_type.value,
+                    artifact_key=artifact_key,
+                    artifact_ref=artifact_ref,
+                    display_name=artifact_ref,
+                    description=None,
+                    input_schema={"type": "object"},
+                    artifact_metadata=None,
+                    raw_payload={"name": artifact_ref},
+                    content_hash=artifact_key.ljust(64, "0"),
+                    is_active=is_active,
+                    search_vector=func.to_tsvector("simple", artifact_ref),
+                )
+            )
+
+        await insert_catalog_entry(
+            mcp_integration_id=created.id,
+            integration_name=created.name,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="tool-alpha-1234567890",
+            artifact_ref="tool.alpha",
+        )
+        await insert_catalog_entry(
+            mcp_integration_id=created.id,
+            integration_name=created.name,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+            artifact_key="resource-alpha-1234567890",
+            artifact_ref="resource://alpha",
+        )
+        await insert_catalog_entry(
+            mcp_integration_id=created.id,
+            integration_name=created.name,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="prompt-inactive-1234567890",
+            artifact_ref="prompt.inactive",
+            is_active=False,
+        )
+        await insert_catalog_entry(
+            mcp_integration_id=other.id,
+            integration_name=other.name,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="prompt-beta-1234567890",
+            artifact_ref="prompt.beta",
+        )
+        await integration_service.session.commit()
+
+        counts = await integration_service.get_mcp_catalog_counts(
+            mcp_integration_ids=[created.id, other.id]
+        )
+
+        assert counts[created.id] == {
+            MCPCatalogArtifactType.TOOL: 1,
+            MCPCatalogArtifactType.RESOURCE: 1,
+        }
+        assert counts[other.id] == {MCPCatalogArtifactType.PROMPT: 1}
 
     async def test_update_mcp_integration_partial(
         self,
@@ -489,6 +604,9 @@ class TestMCPIntegrationCRUD:
         mcp_integration = auto_created.scalars().first()
         assert mcp_integration is not None
         assert mcp_integration.slug == "github_mcp"
+        assert len(mcp_integration.scope_namespace) == 16
+        assert mcp_integration.discovery_status == MCPDiscoveryStatus.PENDING.value
+        assert mcp_integration.catalog_version == 0
 
         await integration_service.delete_mcp_integration(
             mcp_integration_id=mcp_integration.id
@@ -1003,6 +1121,7 @@ class TestMCPIntegrationValidation:
             name="Existing MCP",
             description=None,
             slug="github_mcp",
+            scope_namespace="0" * 16,
             server_uri="https://api.example.com/mcp",
             auth_type=MCPAuthType.NONE,
             oauth_integration_id=None,

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -116,9 +116,6 @@ class TestMCPIntegrationCRUD:
         assert mcp_integration.last_discovered_at is None
         assert mcp_integration.last_discovery_error_code is None
         assert mcp_integration.last_discovery_error_summary is None
-        assert mcp_integration.sandbox_allow_network is False
-        assert mcp_integration.sandbox_egress_allowlist is None
-        assert mcp_integration.sandbox_egress_denylist is None
         assert mcp_integration.created_at is not None
         assert mcp_integration.updated_at is not None
 

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -12,7 +12,7 @@ import uuid
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from pydantic import SecretStr, TypeAdapter
+from pydantic import SecretStr, TypeAdapter, ValidationError
 from sqlalchemy import func, insert, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -917,6 +917,65 @@ class TestMCPIntegrationValidation:
 
         with pytest.raises(ValueError, match="is not allowed"):
             await integration_service.create_mcp_integration(params=params)
+
+    async def test_create_rejects_reserved_mcp_server_name(self) -> None:
+        """Test reserved MCP server aliases cannot be used as integration names."""
+        with pytest.raises(ValidationError, match="reserved for Tracecat"):
+            MCPHttpIntegrationCreate(
+                name="tracecat-registry",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+
+    async def test_create_strips_name_before_validation(self) -> None:
+        """Test MCP create normalizes the integration name before validation."""
+        params = MCPHttpIntegrationCreate(
+            name="  Test MCP  ",
+            server_uri="https://api.example.com/mcp",
+            auth_type=MCPAuthType.NONE,
+        )
+
+        assert params.name == "Test MCP"
+
+    async def test_create_rejects_whitespace_only_name(self) -> None:
+        """Test MCP create rejects names that are blank after trimming."""
+        with pytest.raises(ValidationError, match="at least 3 characters"):
+            MCPHttpIntegrationCreate(
+                name="   ",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+
+    async def test_update_rejects_reserved_mcp_server_name(self) -> None:
+        """Test reserved MCP server aliases cannot be used during updates."""
+        with pytest.raises(ValidationError, match="reserved for Tracecat"):
+            MCPIntegrationUpdate(name="tracecat_registry")
+
+    async def test_update_strips_name_before_validation(self) -> None:
+        """Test MCP update normalizes the integration name before validation."""
+        params = MCPIntegrationUpdate(name="  Updated MCP  ")
+
+        assert params.name == "Updated MCP"
+
+    async def test_update_rejects_whitespace_only_name(self) -> None:
+        """Test MCP update rejects names that are blank after trimming."""
+        with pytest.raises(ValidationError, match="at least 3 characters"):
+            MCPIntegrationUpdate(name="   ")
+
+    async def test_generated_slug_avoids_reserved_mcp_server_name(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Test slug generation skips reserved MCP server aliases."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="tracecat registry",
+                stdio_command="npx",
+                stdio_args=["@modelcontextprotocol/server-github"],
+            )
+        )
+
+        assert created.slug == "tracecat-registry-1"
 
     async def test_update_stdio_rejects_unsafe_args(
         self,

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -60,7 +60,7 @@ from pydantic_ai.messages import (
 from pydantic_core import to_json
 
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
-from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.mcp.utils import decode_legacy_tool_name_to_canonical
 from tracecat.agent.stream.events import (
     StreamDelta,
     StreamEnd,
@@ -1491,7 +1491,7 @@ def convert_chat_messages_to_ui(
             approval = chat_message.approval
             # Create an assistant message with the approval data part
             # Normalize tool name for display
-            tool_name = normalize_mcp_tool_name(approval.tool_name)
+            tool_name = decode_legacy_tool_name_to_canonical(approval.tool_name)
             approval_data = {
                 "tool_call_id": approval.tool_call_id,
                 "tool_name": tool_name,
@@ -1573,7 +1573,7 @@ def convert_chat_messages_to_ui(
                 case "ToolCallPart" | "BuiltinToolCallPart":
                     if approval_payload:
                         continue
-                    tool_name = normalize_mcp_tool_name(part.tool_name)
+                    tool_name = part.tool_name
                     tool_part = MutableToolPart(
                         type=f"tool-{tool_name}",
                         tool_call_id=part.tool_call_id,
@@ -1597,7 +1597,7 @@ def convert_chat_messages_to_ui(
                         tool_name = tool_input.get("tool_name", part.name)
                         tool_input = tool_input.get("args", tool_input)
                     # Normalize MCP registry prefix
-                    tool_name = normalize_mcp_tool_name(tool_name)
+                    tool_name = decode_legacy_tool_name_to_canonical(tool_name)
                     tool_part = MutableToolPart(
                         type=f"tool-{tool_name}",
                         tool_call_id=part.id,
@@ -1616,7 +1616,7 @@ def convert_chat_messages_to_ui(
                     if existing is not None:
                         existing.set_result(part.content, structured_error)
                     else:
-                        tool_name = normalize_mcp_tool_name(part.tool_name)
+                        tool_name = part.tool_name
                         tool_part = MutableToolPart.with_result(
                             type=f"tool-{tool_name}",
                             tool_call_id=part.tool_call_id,
@@ -1658,9 +1658,7 @@ def convert_chat_messages_to_ui(
                         if existing is not None:
                             existing.set_result(part.content, is_error=True)
                         else:
-                            tool_name = normalize_mcp_tool_name(
-                                getattr(part, "tool_name", "unknown")
-                            )
+                            tool_name = getattr(part, "tool_name", "unknown")
                             tool_part = MutableToolPart.with_result(
                                 type=f"tool-{tool_name}",
                                 tool_call_id=tool_call_id,

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -10,17 +10,17 @@ from typing import Any, Literal, NotRequired, TypedDict
 
 
 class MCPHttpServerConfig(TypedDict):
-    """Configuration for a user-defined MCP server over HTTP/SSE.
+    """Configuration for a user-defined MCP server over HTTP.
 
     Users can connect custom MCP servers to their agents - whether running as
-    Docker containers, local processes, or remote services. The server must
-    expose an HTTP or SSE endpoint.
+    Docker containers, local processes, or remote services. Streamable HTTP is
+    the canonical transport; the trusted client may fall back to SSE internally
+    for compatibility with older servers.
 
     Example:
         {
             "name": "internal-tools",
             "url": "http://host.docker.internal:8080",
-            "transport": "http",
             "headers": {"Authorization": "Bearer ${{ SECRETS.internal.API_KEY }}"}
         }
     """
@@ -32,13 +32,10 @@ class MCPHttpServerConfig(TypedDict):
     """Required: Unique identifier for the server. Tools will be prefixed with mcp__{name}__."""
 
     url: str
-    """Required: HTTP/SSE endpoint URL for the MCP server."""
+    """Required: HTTP endpoint URL for the MCP server."""
 
     headers: NotRequired[dict[str, str]]
     """Optional: Auth headers (can reference Tracecat secrets)."""
-
-    transport: NotRequired[Literal["http", "sse"]]
-    """Optional: Transport type. Defaults to 'http'."""
 
     timeout: NotRequired[int]
     """Optional: Request timeout in seconds."""

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -46,7 +46,6 @@ from tracecat.agent.executor.loopback import (
     LoopbackResult,
 )
 from tracecat.agent.mcp.executor import ActionExecutionError, execute_action
-from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 from tracecat.agent.sandbox.llm_proxy import LLM_SOCKET_NAME, LLMSocketProxy
 from tracecat.agent.sandbox.nsjail import spawn_jailed_runtime
 from tracecat.agent.session.service import AgentSessionService
@@ -752,8 +751,7 @@ async def execute_approved_tools_activity(
         activity.heartbeat(f"Executing tool: {tool_call.tool_name}")
 
         try:
-            # Normalize tool name (MCP format -> action name)
-            action_name = normalize_mcp_tool_name(tool_call.tool_name)
+            action_name = tool_call.tool_name
 
             logger.info(
                 "Executing approved tool",

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -46,6 +46,7 @@ from tracecat.agent.executor.loopback import (
     LoopbackResult,
 )
 from tracecat.agent.mcp.executor import ActionExecutionError, execute_action
+from tracecat.agent.mcp.utils import decode_legacy_tool_name_to_canonical
 from tracecat.agent.sandbox.llm_proxy import LLM_SOCKET_NAME, LLMSocketProxy
 from tracecat.agent.sandbox.nsjail import spawn_jailed_runtime
 from tracecat.agent.session.service import AgentSessionService
@@ -751,7 +752,7 @@ async def execute_approved_tools_activity(
         activity.heartbeat(f"Executing tool: {tool_call.tool_name}")
 
         try:
-            action_name = tool_call.tool_name
+            action_name = decode_legacy_tool_name_to_canonical(tool_call.tool_name)
 
             logger.info(
                 "Executing approved tool",

--- a/tracecat/agent/mcp/proxy_server.py
+++ b/tracecat/agent/mcp/proxy_server.py
@@ -5,7 +5,7 @@ forwards execution requests to the trusted MCP server via Unix socket.
 
 Handles two types of tools:
 1. Registry actions (e.g., core.cases.list_cases) -> execute_action_tool
-2. User MCP tools (e.g., mcp__my-server__my_tool) -> execute_user_mcp_tool
+2. User MCP tools (e.g., mcp.jira.getIssue) -> execute_user_mcp_tool
 """
 
 from __future__ import annotations
@@ -20,8 +20,10 @@ from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 
 from tracecat.agent.common.types import MCPToolDefinition
-from tracecat.agent.mcp.user_client import UserMCPClient
-from tracecat.agent.mcp.utils import action_name_to_mcp_tool_name
+from tracecat.agent.mcp.utils import (
+    encode_canonical_tool_name_to_sdk,
+    parse_canonical_user_mcp_tool_name,
+)
 from tracecat.agent.sandbox.config import TRUSTED_MCP_SOCKET_PATH
 from tracecat.logger import logger
 
@@ -137,12 +139,12 @@ async def create_proxy_mcp_server(
 
     Handles three types of tools:
     - Registry actions (e.g., core.cases.list_cases) -> execute_action_tool
-    - User MCP tools (e.g., mcp__my-server__my_tool) -> execute_user_mcp_tool
+    - User MCP tools (e.g., mcp.Linear.list_issues) -> execute_user_mcp_tool
     - Internal tools (e.g., internal.builder.get_preset_summary) -> execute_internal_tool
 
     Args:
         allowed_actions: Dict mapping action names to their definitions.
-            User MCP tools use the format mcp__{server_name}__{tool_name}.
+            User MCP tools use the canonical format mcp.{server_name}.{tool_name}.
             Internal tools use the format internal.{category}.{tool_name}.
         auth_token: JWT token for authenticating with trusted server.
 
@@ -153,10 +155,10 @@ async def create_proxy_mcp_server(
 
     for action_name, defn in allowed_actions.items():
         # Check if this is a user MCP tool
-        parsed = UserMCPClient.parse_user_mcp_tool_name(action_name)
+        parsed = parse_canonical_user_mcp_tool_name(action_name)
 
         if parsed:
-            # User MCP tool: mcp__{server_name}__{tool_name}
+            # User MCP tool: mcp.{server_name}.{tool_name}
             server_name, original_tool_name = parsed
             handler = _make_tool_handler(
                 "execute_user_mcp_tool",
@@ -168,8 +170,7 @@ async def create_proxy_mcp_server(
                     "tool_name": original_tool_name,
                 },
             )
-            # Use the full prefixed name as MCP tool name (already in correct format)
-            mcp_tool_name = action_name
+            mcp_tool_name = encode_canonical_tool_name_to_sdk(action_name)
             tool_type = "user_mcp"
         elif action_name.startswith("internal."):
             # Internal tool: internal.{category}.{tool_name}
@@ -179,8 +180,7 @@ async def create_proxy_mcp_server(
                 auth_token,
                 {"tool_type": "internal", "tool_name": action_name},
             )
-            # Convert dots to underscores for MCP compatibility
-            mcp_tool_name = action_name_to_mcp_tool_name(action_name)
+            mcp_tool_name = encode_canonical_tool_name_to_sdk(action_name)
             tool_type = "internal"
         else:
             # Registry action tool
@@ -190,8 +190,7 @@ async def create_proxy_mcp_server(
                 auth_token,
                 {"tool_type": "registry", "action_name": action_name},
             )
-            # Convert dots to underscores for MCP compatibility
-            mcp_tool_name = action_name_to_mcp_tool_name(action_name)
+            mcp_tool_name = encode_canonical_tool_name_to_sdk(action_name)
             tool_type = "registry"
 
         decorated = tool(mcp_tool_name, defn.description, defn.parameters_json_schema)(

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -29,7 +29,7 @@ from tracecat.agent.mcp.internal_tools import (
     InternalToolError,
 )
 from tracecat.agent.mcp.user_client import UserMCPClient
-from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.mcp.utils import decode_legacy_tool_name_to_canonical
 from tracecat.agent.tokens import MCPTokenClaims, verify_mcp_token
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
@@ -85,7 +85,7 @@ async def execute_action_tool(
         logger.warning("MCP token verification failed", error_type=_safe_error_type(e))
         raise ToolError("Authentication failed") from None
 
-    normalized_action_name = normalize_mcp_tool_name(action_name)
+    normalized_action_name = decode_legacy_tool_name_to_canonical(action_name)
 
     # Set role context before any service calls that require organization context
     _set_role_context(claims)

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -180,7 +180,6 @@ async def execute_user_mcp_tool(
             "type": "http",
             "name": server_config.name,
             "url": server_config.url,
-            "transport": server_config.transport,
             "headers": server_config.headers,
         }
         if server_config.timeout is not None:

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -15,6 +15,12 @@ from fastmcp import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
+from tracecat.agent.mcp.utils import (
+    REGISTRY_MCP_SERVER_NAMES,
+    canonical_user_mcp_tool_name,
+    decode_legacy_tool_name_to_canonical,
+    parse_canonical_user_mcp_tool_name,
+)
 from tracecat.logger import logger
 
 
@@ -64,7 +70,7 @@ class UserMCPClient:
         """Connect to all configured servers and discover their tools.
 
         Returns:
-            Dict mapping tool names (mcp__{server_name}__{tool_name}) to definitions.
+            Dict mapping canonical tool names to definitions.
 
         """
         tools: dict[str, MCPToolDefinition] = {}
@@ -102,19 +108,18 @@ class UserMCPClient:
             config: Server configuration.
 
         Returns:
-            Dict mapping prefixed tool names to definitions.
+            Dict mapping canonical tool names to definitions.
 
         """
         server_tools = await self._list_server_tools(server_name, config)
         tools: dict[str, MCPToolDefinition] = {}
 
         for tool in server_tools:
-            # Create prefixed tool name: mcp__{server_name}__{tool_name}
-            prefixed_name = f"mcp__{server_name}__{tool.name}"
+            canonical_name = canonical_user_mcp_tool_name(server_name, tool.name)
 
             # Convert MCP tool schema to our format
-            tools[prefixed_name] = MCPToolDefinition(
-                name=prefixed_name,
+            tools[canonical_name] = MCPToolDefinition(
+                name=canonical_name,
                 description=tool.description or f"Tool from {server_name}",
                 parameters_json_schema=tool.inputSchema or {},
             )
@@ -123,7 +128,7 @@ class UserMCPClient:
                 "Discovered user MCP tool",
                 server_name=server_name,
                 tool_name=tool.name,
-                prefixed_name=prefixed_name,
+                canonical_name=canonical_name,
             )
 
         return tools
@@ -271,7 +276,7 @@ class UserMCPClient:
     def parse_user_mcp_tool_name(tool_name: str) -> tuple[str, str] | None:
         """Parse a user MCP tool name into (server_name, tool_name).
 
-        User MCP tools follow the pattern: mcp__{server_name}__{tool_name}
+        Canonical user MCP tools follow the pattern: mcp.{server_name}.{tool_name}
 
         Args:
             tool_name: Full tool name to parse.
@@ -280,23 +285,17 @@ class UserMCPClient:
             Tuple of (server_name, original_tool_name), or None if not a user MCP tool.
 
         """
-        # Skip tracecat registry-reserved prefixes (handled separately).
-        # Support both alias forms.
-        if tool_name.startswith("mcp__tracecat-registry__") or tool_name.startswith(
-            "mcp__tracecat_registry__"
+        canonical_name = decode_legacy_tool_name_to_canonical(tool_name)
+        if parsed := parse_canonical_user_mcp_tool_name(canonical_name):
+            return parsed
+
+        if any(
+            canonical_name.startswith(f"mcp.{alias}.")
+            for alias in REGISTRY_MCP_SERVER_NAMES
         ):
             return None
 
-        # Check for user MCP pattern
-        if not tool_name.startswith("mcp__"):
-            return None
-
-        parts = tool_name.split("__", 2)
-        if len(parts) < 3:
-            return None
-
-        # parts[0] = "mcp", parts[1] = server_name, parts[2] = tool_name
-        return (parts[1], parts[2])
+        return None
 
 
 async def discover_user_mcp_tools(

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -1,7 +1,7 @@
 """User MCP client for connecting to user-defined MCP servers.
 
-This client handles HTTP/SSE connections to user-provided MCP servers
-and proxies tool calls through the trusted server.
+This client prefers streamable HTTP for user-provided MCP servers and falls
+back to SSE internally for compatibility with older servers.
 
 The client connects to external MCP servers from outside the sandbox,
 allowing the sandboxed runtime to access user tools via the Unix socket proxy.
@@ -9,7 +9,7 @@ allowing the sandboxed runtime to access user tools via the Unix socket proxy.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 from fastmcp import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
@@ -18,17 +18,26 @@ from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.logger import logger
 
 
-def _create_transport(
+class _TransportProbeError(Exception):
+    """Raised when the preferred MCP transport probe fails."""
+
+
+def _create_streamable_http_transport(
     url: str,
-    transport_type: Literal["http", "sse"],
     headers: dict[str, str] | None = None,
     timeout: int | None = None,
-) -> StreamableHttpTransport | SSETransport:
-    """Create the appropriate transport for the MCP server."""
-    if transport_type == "sse":
-        return SSETransport(url=url, headers=headers, sse_read_timeout=timeout)
-    # Default to HTTP (Streamable HTTP transport)
+) -> StreamableHttpTransport:
+    """Create a streamable HTTP transport."""
     return StreamableHttpTransport(url=url, headers=headers, sse_read_timeout=timeout)
+
+
+def _create_sse_transport(
+    url: str,
+    headers: dict[str, str] | None = None,
+    timeout: int | None = None,
+) -> SSETransport:
+    """Create an SSE transport for compatibility fallback."""
+    return SSETransport(url=url, headers=headers, sse_read_timeout=timeout)
 
 
 class UserMCPClient:
@@ -96,37 +105,57 @@ class UserMCPClient:
             Dict mapping prefixed tool names to definitions.
 
         """
+        server_tools = await self._list_server_tools(server_name, config)
+        tools: dict[str, MCPToolDefinition] = {}
+
+        for tool in server_tools:
+            # Create prefixed tool name: mcp__{server_name}__{tool_name}
+            prefixed_name = f"mcp__{server_name}__{tool.name}"
+
+            # Convert MCP tool schema to our format
+            tools[prefixed_name] = MCPToolDefinition(
+                name=prefixed_name,
+                description=tool.description or f"Tool from {server_name}",
+                parameters_json_schema=tool.inputSchema or {},
+            )
+
+            logger.debug(
+                "Discovered user MCP tool",
+                server_name=server_name,
+                tool_name=tool.name,
+                prefixed_name=prefixed_name,
+            )
+
+        return tools
+
+    async def _list_server_tools(
+        self,
+        server_name: str,
+        config: MCPHttpServerConfig,
+    ) -> list[Any]:
+        """List tools, preferring streamable HTTP and falling back to SSE."""
         url = config["url"]
-        transport_type: Literal["http", "sse"] = config.get("transport", "http")
         headers = config.get("headers")
         timeout = config.get("timeout")
 
-        transport = _create_transport(url, transport_type, headers, timeout)
-        tools: dict[str, MCPToolDefinition] = {}
+        try:
+            async with Client(
+                _create_streamable_http_transport(url, headers, timeout)
+            ) as client:
+                return await client.list_tools()
+        except Exception as exc:
+            logger.info(
+                "Streamable HTTP MCP discovery failed; trying SSE fallback",
+                server_name=server_name,
+                error_type=type(exc).__name__,
+            )
 
-        async with Client(transport) as client:
-            # List tools from the server
-            server_tools = await client.list_tools()
-
-            for tool in server_tools:
-                # Create prefixed tool name: mcp__{server_name}__{tool_name}
-                prefixed_name = f"mcp__{server_name}__{tool.name}"
-
-                # Convert MCP tool schema to our format
-                tools[prefixed_name] = MCPToolDefinition(
-                    name=prefixed_name,
-                    description=tool.description or f"Tool from {server_name}",
-                    parameters_json_schema=tool.inputSchema or {},
-                )
-
-                logger.debug(
-                    "Discovered user MCP tool",
-                    server_name=server_name,
-                    tool_name=tool.name,
-                    prefixed_name=prefixed_name,
-                )
-
-        return tools
+        async with Client(_create_sse_transport(url, headers, timeout)) as client:
+            logger.info(
+                "Using SSE fallback for user MCP discovery",
+                server_name=server_name,
+            )
+            return await client.list_tools()
 
     async def call_tool(
         self,
@@ -152,30 +181,91 @@ class UserMCPClient:
         if server_name not in self._configs:
             raise ValueError(f"Unknown user MCP server: {server_name}")
 
-        config = self._configs[server_name]
-        url = config["url"]
-        transport_type: Literal["http", "sse"] = config.get("transport", "http")
-        headers = config.get("headers")
-        timeout = config.get("timeout")
-
-        transport = _create_transport(url, transport_type, headers, timeout)
-
         logger.info(
             "Calling user MCP tool",
             server_name=server_name,
             tool_name=tool_name,
         )
 
-        async with Client(transport) as client:
-            result = await client.call_tool(tool_name, args)
+        config = self._configs[server_name]
+        result = await self._call_tool_with_fallback(
+            server_name=server_name,
+            config=config,
+            tool_name=tool_name,
+            args=args,
+        )
+        return self._extract_tool_result(result)
 
-            # Extract result from CallToolResult
-            if result.content and len(result.content) > 0:
-                first_block = result.content[0]
-                # TextContent has a .text attribute
-                return getattr(first_block, "text", str(first_block))
+    async def _call_tool_with_fallback(
+        self,
+        *,
+        server_name: str,
+        config: MCPHttpServerConfig,
+        tool_name: str,
+        args: dict[str, Any],
+    ) -> Any:
+        """Call a tool, probing streamable HTTP first and falling back to SSE."""
+        url = config["url"]
+        headers = config.get("headers")
+        timeout = config.get("timeout")
 
-            return ""
+        try:
+            client_cm, client = await self._open_and_probe_client(
+                _create_streamable_http_transport(url, headers, timeout)
+            )
+        except _TransportProbeError as exc:
+            logger.info(
+                "Streamable HTTP MCP call failed during compatibility probe; trying SSE fallback",
+                server_name=server_name,
+                tool_name=tool_name,
+                error_type=type(exc.__cause__).__name__ if exc.__cause__ else None,
+            )
+        else:
+            try:
+                return await client.call_tool(tool_name, args)
+            finally:
+                await client_cm.__aexit__(None, None, None)
+
+        client_cm, client = await self._open_and_probe_client(
+            _create_sse_transport(url, headers, timeout)
+        )
+        try:
+            logger.info(
+                "Using SSE fallback for user MCP tool call",
+                server_name=server_name,
+                tool_name=tool_name,
+            )
+            return await client.call_tool(tool_name, args)
+        finally:
+            await client_cm.__aexit__(None, None, None)
+
+    async def _open_and_probe_client(self, transport: Any) -> tuple[Any, Any]:
+        """Open an MCP client and probe compatibility with list_tools."""
+        client_cm = Client(transport)
+        try:
+            client = await client_cm.__aenter__()
+        except Exception as exc:
+            raise _TransportProbeError from exc
+
+        try:
+            # Probe compatibility before invoking a potentially side-effecting
+            # tool call.
+            await client.list_tools()
+        except Exception as exc:
+            await client_cm.__aexit__(type(exc), exc, exc.__traceback__)
+            raise _TransportProbeError from exc
+
+        return client_cm, client
+
+    @staticmethod
+    def _extract_tool_result(result: Any) -> Any:
+        """Extract a user-facing payload from a CallToolResult."""
+        if result.content and len(result.content) > 0:
+            first_block = result.content[0]
+            # TextContent has a .text attribute
+            return getattr(first_block, "text", str(first_block))
+
+        return ""
 
     @staticmethod
     def parse_user_mcp_tool_name(tool_name: str) -> tuple[str, str] | None:

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -1,7 +1,15 @@
-"""MCP utility functions for tool name normalization and definition fetching.
+"""MCP utility functions for canonical tool naming and definition fetching.
 
-This module provides pure utility functions for MCP tool name conversion
-that can be imported without pulling in heavy dependencies (DB, logging).
+This module owns the conversion between Tracecat's canonical internal tool names
+and the wire names used by Claude/MCP.
+
+Canonical internal names:
+- Registry tools: ``core.http_request``
+- Internal tools: ``internal.builder.get_preset_summary``
+- User MCP tools: ``mcp.Linear.list_issues``
+
+Wire/legacy names are decoded at the edges and should not leak deeper into
+Tracecat-owned state.
 
 The fetch_tool_definitions() function requires DB access and uses lazy imports.
 """
@@ -9,6 +17,8 @@ The fetch_tool_definitions() function requires DB access and uses lazy imports.
 from __future__ import annotations
 
 from tracecat.agent.common.types import MCPToolDefinition
+
+REGISTRY_MCP_SERVER_NAMES = frozenset({"tracecat-registry", "tracecat_registry"})
 
 
 def action_name_to_mcp_tool_name(action_name: str) -> str:
@@ -27,66 +37,69 @@ def mcp_tool_name_to_action_name(tool_name: str) -> str:
     return tool_name.replace("__", ".")
 
 
+def canonical_user_mcp_tool_name(server_name: str, tool_name: str) -> str:
+    """Build the canonical internal name for a user MCP tool."""
+    return f"mcp.{server_name}.{tool_name}"
+
+
+def parse_canonical_user_mcp_tool_name(
+    tool_name: str,
+) -> tuple[str, str] | None:
+    """Parse a canonical user MCP tool name into ``(server_name, tool_name)``."""
+    if not tool_name.startswith("mcp."):
+        return None
+
+    parts = tool_name.split(".", 2)
+    if len(parts) < 3 or parts[1] in REGISTRY_MCP_SERVER_NAMES:
+        return None
+    return (parts[1], parts[2])
+
+
+def encode_canonical_tool_name_to_sdk(tool_name: str) -> str:
+    """Encode a canonical tool name into the MCP tool name exposed to Claude."""
+    if parsed := parse_canonical_user_mcp_tool_name(tool_name):
+        server_name, original_tool_name = parsed
+        return f"mcp__{server_name}__{original_tool_name}"
+    return action_name_to_mcp_tool_name(tool_name)
+
+
+def decode_sdk_tool_name_to_canonical(raw_tool_name: str) -> str:
+    """Decode a raw SDK/MCP tool name into Tracecat's canonical form."""
+    if parsed := parse_canonical_user_mcp_tool_name(raw_tool_name):
+        return canonical_user_mcp_tool_name(*parsed)
+
+    if raw_tool_name.startswith("mcp__"):
+        parts = raw_tool_name.split("__", 2)
+        if len(parts) >= 3:
+            server_name, server_tool_name = parts[1], parts[2]
+            if server_name in REGISTRY_MCP_SERVER_NAMES:
+                return decode_sdk_tool_name_to_canonical(server_tool_name)
+            return canonical_user_mcp_tool_name(server_name, server_tool_name)
+
+    if "__" in raw_tool_name:
+        return mcp_tool_name_to_action_name(raw_tool_name)
+
+    return raw_tool_name
+
+
+def decode_legacy_tool_name_to_canonical(tool_name: str) -> str:
+    """Decode legacy persisted/wire tool names into Tracecat's canonical form."""
+    if any(
+        tool_name.startswith(f"mcp.{alias}.") for alias in REGISTRY_MCP_SERVER_NAMES
+    ):
+        _, _, remainder = tool_name.split(".", 2)
+        return decode_sdk_tool_name_to_canonical(remainder)
+
+    return decode_sdk_tool_name_to_canonical(tool_name)
+
+
 def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
-    """Convert MCP tool name to readable action name for display.
+    """Backward-compatible wrapper for legacy call sites.
 
-    MCP tool naming convention: mcp__{server_name}__{tool_name}
-
-    Handles Tracecat registry tools:
-    - mcp__tracecat-registry__tools__slack__post_message -> tools.slack.post_message
-    - mcp.tracecat-registry.core.cases.create_case -> core.cases.create_case
-
-    Handles user MCP servers routed through the proxy:
-    - mcp__tracecat-registry__mcp__Linear__list_issues -> mcp.Linear.list_issues
-    - mcp.tracecat-registry.mcp.Linear.list_issues -> mcp.Linear.list_issues
-
-    Other MCP tool names are returned as-is.
-
-    Args:
-        mcp_tool_name: The MCP tool name to normalize
-
-    Returns:
-        Human-readable action/tool name
+    Prefer ``decode_sdk_tool_name_to_canonical()`` or
+    ``decode_legacy_tool_name_to_canonical()`` at new call sites.
     """
-    # Handle user MCP tools routed through proxy (dot-separated, persisted)
-    # Pattern: mcp.tracecat-registry.mcp.{server}.{tool}
-    if mcp_tool_name.startswith("mcp.tracecat-registry.mcp."):
-        # Extract mcp.{server}.{tool} part
-        return mcp_tool_name.replace("mcp.tracecat-registry.", "", 1)
-
-    # Handle user MCP tools routed through proxy (underscore-separated, runtime)
-    # Pattern: mcp__tracecat-registry__mcp__{server}__{tool}
-    if mcp_tool_name.startswith("mcp__tracecat-registry__mcp__"):
-        # Extract mcp__{server}__{tool} part and convert to mcp.{server}.{tool}
-        tool_part = mcp_tool_name.replace("mcp__tracecat-registry__", "")
-        return mcp_tool_name_to_action_name(tool_part)
-
-    # Handle dot-separated format (persisted messages) for registry tools
-    if mcp_tool_name.startswith("mcp.tracecat-registry."):
-        return mcp_tool_name.replace("mcp.tracecat-registry.", "", 1)
-
-    # Handle underscore-separated format (runtime MCP tool names) for registry tools
-    if mcp_tool_name.startswith("mcp__tracecat-registry__"):
-        tool_part = mcp_tool_name.replace("mcp__tracecat-registry__", "")
-        return mcp_tool_name_to_action_name(tool_part)
-
-    # Generic MCP prefix stripping for any other servers
-    # Handle pattern: mcp.{server-name}.{tool_name}
-    if mcp_tool_name.startswith("mcp."):
-        parts = mcp_tool_name.split(".", 2)
-        if len(parts) >= 3:
-            # Return everything after mcp.{server-name}.
-            return parts[2]
-
-    # Handle pattern: mcp__{server-name}__{tool_name}
-    if mcp_tool_name.startswith("mcp__"):
-        parts = mcp_tool_name.split("__", 2)
-        if len(parts) >= 3:
-            # Return everything after mcp__{server-name}__ with underscores -> dots
-            return mcp_tool_name_to_action_name(parts[2])
-
-    # Other tool names returned as-is
-    return mcp_tool_name
+    return decode_legacy_tool_name_to_canonical(mcp_tool_name)
 
 
 async def fetch_tool_definitions(

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -19,6 +19,12 @@ from __future__ import annotations
 from tracecat.agent.common.types import MCPToolDefinition
 
 REGISTRY_MCP_SERVER_NAMES = frozenset({"tracecat-registry", "tracecat_registry"})
+TRACECAT_ACTION_NAMESPACE_PREFIXES = frozenset({"core", "internal", "tools"})
+
+
+def is_reserved_mcp_server_name(server_name: str) -> bool:
+    """Return whether a server name is reserved for Tracecat's registry proxy."""
+    return server_name in REGISTRY_MCP_SERVER_NAMES
 
 
 def action_name_to_mcp_tool_name(action_name: str) -> str:
@@ -50,7 +56,7 @@ def parse_canonical_user_mcp_tool_name(
         return None
 
     parts = tool_name.split(".", 2)
-    if len(parts) < 3 or parts[1] in REGISTRY_MCP_SERVER_NAMES:
+    if len(parts) < 3 or is_reserved_mcp_server_name(parts[1]):
         return None
     return (parts[1], parts[2])
 
@@ -63,6 +69,12 @@ def encode_canonical_tool_name_to_sdk(tool_name: str) -> str:
     return action_name_to_mcp_tool_name(tool_name)
 
 
+def is_tracecat_sdk_tool_name(raw_tool_name: str) -> bool:
+    """Return whether a raw SDK tool name uses Tracecat's action encoding."""
+    prefix, _, _ = raw_tool_name.partition("__")
+    return prefix in TRACECAT_ACTION_NAMESPACE_PREFIXES
+
+
 def decode_sdk_tool_name_to_canonical(raw_tool_name: str) -> str:
     """Decode a raw SDK/MCP tool name into Tracecat's canonical form."""
     if parsed := parse_canonical_user_mcp_tool_name(raw_tool_name):
@@ -72,11 +84,11 @@ def decode_sdk_tool_name_to_canonical(raw_tool_name: str) -> str:
         parts = raw_tool_name.split("__", 2)
         if len(parts) >= 3:
             server_name, server_tool_name = parts[1], parts[2]
-            if server_name in REGISTRY_MCP_SERVER_NAMES:
+            if is_reserved_mcp_server_name(server_name):
                 return decode_sdk_tool_name_to_canonical(server_tool_name)
             return canonical_user_mcp_tool_name(server_name, server_tool_name)
 
-    if "__" in raw_tool_name:
+    if "__" in raw_tool_name and is_tracecat_sdk_tool_name(raw_tool_name):
         return mcp_tool_name_to_action_name(raw_tool_name)
 
     return raw_tool_name

--- a/tracecat/agent/runtime/claude_code/adapter.py
+++ b/tracecat/agent/runtime/claude_code/adapter.py
@@ -20,7 +20,7 @@ from tracecat.agent.common.stream_types import (
     StreamEventType,
     UnifiedStreamEvent,
 )
-from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.mcp.utils import decode_sdk_tool_name_to_canonical
 
 
 @dataclass(slots=True, kw_only=True)
@@ -175,12 +175,12 @@ class ClaudeSDKAdapter(BaseHarnessAdapter):
             if tool_call_id is None:
                 raise ValueError("Claude tool_use block missing required 'id' field")
             raw_tool_name = content_block.get("name", "unknown")
-            normalized_tool_name = normalize_mcp_tool_name(raw_tool_name)
+            canonical_tool_name = decode_sdk_tool_name_to_canonical(raw_tool_name)
             return UnifiedStreamEvent(
                 type=StreamEventType.TOOL_CALL_START,
                 part_id=index,
                 tool_call_id=tool_call_id,
-                tool_name=normalized_tool_name,
+                tool_name=canonical_tool_name,
                 tool_input={},
             )
         else:
@@ -256,12 +256,12 @@ class ClaudeSDKAdapter(BaseHarnessAdapter):
                 )
             # Normalize tool name for display
             raw_tool_name = (state.tool_name if state else None) or "unknown"
-            normalized_tool_name = normalize_mcp_tool_name(raw_tool_name)
+            canonical_tool_name = decode_sdk_tool_name_to_canonical(raw_tool_name)
             return UnifiedStreamEvent(
                 type=StreamEventType.TOOL_CALL_STOP,
                 part_id=index,
                 tool_call_id=tool_call_id,
-                tool_name=normalized_tool_name,
+                tool_name=canonical_tool_name,
                 tool_input=args,
             )
         else:

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -52,7 +52,7 @@ from tracecat.agent.common.types import (
     MCPToolDefinition,
 )
 from tracecat.agent.mcp.proxy_server import create_proxy_mcp_server
-from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.mcp.utils import decode_sdk_tool_name_to_canonical
 from tracecat.agent.runtime.claude_code.adapter import ClaudeSDKAdapter
 from tracecat.logger import logger
 
@@ -379,7 +379,7 @@ class ClaudeAgentRuntime:
         tool_name: str = input_data.get("tool_name", "")
         tool_input: dict[str, Any] = input_data.get("tool_input", {})
 
-        action_name = normalize_mcp_tool_name(tool_name)
+        action_name = decode_sdk_tool_name_to_canonical(tool_name)
         requires_approval = (
             self.tool_approvals is not None
             and self.tool_approvals.get(action_name) is True

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -16,6 +16,7 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import DeferredToolResults
 
+from tracecat.agent.mcp.utils import is_reserved_mcp_server_name
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
@@ -252,6 +253,18 @@ class AgentConfigSchema(BaseModel):
     model_settings: dict[str, Any] | None = None
     mcp_servers: list[MCPServerConfigSchema] | None = None
     retries: int = Field(default=20)
+
+    @model_validator(mode="after")
+    def validate_mcp_server_names(self) -> AgentConfigSchema:
+        """Reject MCP server names reserved for Tracecat's registry proxy."""
+        if self.mcp_servers is None:
+            return self
+        for server in self.mcp_servers:
+            if is_reserved_mcp_server_name(server["name"].strip()):
+                raise ValueError(
+                    f"MCP server name '{server['name']}' is reserved for Tracecat"
+                )
+        return self
 
 
 class RankableItemSchema(TypedDict):

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -215,13 +215,12 @@ class ToolFilters(BaseModel):
 
 
 class MCPHttpServerConfigSchema(TypedDict):
-    """HTTP/SSE MCP server configuration for request validation."""
+    """HTTP MCP server configuration for request validation."""
 
     type: NotRequired[Literal["http"]]
     name: str
     url: str
     headers: NotRequired[dict[str, str]]
-    transport: NotRequired[Literal["http", "sse"]]
     timeout: NotRequired[int]
 
 

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Any
 
 import jwt
 from jwt import PyJWTError
@@ -51,9 +51,7 @@ class UserMCPServerClaim(BaseModel):
     name: str
     """Unique identifier for the server."""
     url: str
-    """HTTP/SSE endpoint URL."""
-    transport: Literal["http", "sse"] = "http"
-    """Transport type: 'http' or 'sse'."""
+    """HTTP endpoint URL."""
     headers: dict[str, str] = Field(default_factory=dict)
     """Auth headers."""
     timeout: int | None = None

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -34,7 +34,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -3303,6 +3303,7 @@ class MCPIntegration(TimestampMixin, Base):
         UniqueConstraint(
             "workspace_id", "slug", name="uq_mcp_integration_workspace_slug"
         ),
+        UniqueConstraint("scope_namespace", name="uq_mcp_integration_scope_namespace"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -3334,6 +3335,11 @@ class MCPIntegration(TimestampMixin, Base):
         String,
         nullable=False,
         doc="Slug of the MCP integration",
+    )
+    scope_namespace: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        doc="Immutable RBAC namespace for this MCP integration",
     )
     # Server type: 'http' (HTTP/SSE) or 'stdio' (stdio)
     server_type: Mapped[str] = mapped_column(
@@ -3387,12 +3393,273 @@ class MCPIntegration(TimestampMixin, Base):
         nullable=True,
         doc="Timeout in seconds (HTTP timeout for http type, process timeout for stdio type)",
     )
+    discovery_status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default="pending",
+        server_default="pending",
+        doc="Current catalog discovery status",
+    )
+    catalog_version: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default=text("0"),
+        doc="Monotonic version of the persisted MCP catalog",
+    )
+    last_discovery_attempt_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        doc="When the most recent discovery attempt started",
+    )
+    last_discovered_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        doc="When the catalog was most recently refreshed successfully",
+    )
+    last_discovery_error_code: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        doc="Last user-safe discovery error code",
+    )
+    last_discovery_error_summary: Mapped[str | None] = mapped_column(
+        String(1024),
+        nullable=True,
+        doc="Last user-safe discovery error summary",
+    )
+    sandbox_allow_network: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
+        doc="Whether sandboxed stdio discovery/execution may access the network",
+    )
+    sandbox_egress_allowlist: Mapped[list[str] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        doc="Optional sandbox egress allowlist",
+    )
+    sandbox_egress_denylist: Mapped[list[str] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        doc="Optional sandbox egress denylist",
+    )
 
     oauth_integration: Mapped[OAuthIntegration | None] = relationship(
         "OAuthIntegration",
         uselist=False,
         lazy="selectin",
     )
+    catalog_entries: Mapped[list[MCPIntegrationCatalogEntry]] = relationship(
+        "MCPIntegrationCatalogEntry",
+        back_populates="mcp_integration",
+        passive_deletes=True,
+    )
+    discovery_attempts: Mapped[list[MCPIntegrationDiscoveryAttempt]] = relationship(
+        "MCPIntegrationDiscoveryAttempt",
+        back_populates="mcp_integration",
+        passive_deletes=True,
+    )
+
+
+class MCPIntegrationCatalogEntry(TimestampMixin, Base):
+    """Persisted MCP catalog entry for a discovered integration artifact."""
+
+    __tablename__ = "mcp_integration_catalog_entry"
+    __table_args__ = (
+        UniqueConstraint(
+            "mcp_integration_id",
+            "artifact_type",
+            "artifact_key",
+            name="uq_mcp_integration_catalog_entry_integration_artifact",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        primary_key=True,
+        nullable=False,
+        unique=True,
+        index=True,
+        doc="Unique MCP catalog entry identifier",
+    )
+    mcp_integration_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("mcp_integration.id", ondelete="CASCADE"),
+        nullable=False,
+        doc="Owning MCP integration",
+    )
+    workspace_id: Mapped[WorkspaceID] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=False,
+        doc="Workspace ID associated with this catalog entry",
+    )
+    integration_name: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        doc="Cached integration display name at discovery time",
+    )
+    artifact_type: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        doc="Catalog artifact type",
+    )
+    artifact_key: Mapped[str] = mapped_column(
+        String(96),
+        nullable=False,
+        doc="Stable per-integration artifact key used for RBAC scopes",
+    )
+    artifact_ref: Mapped[str] = mapped_column(
+        String(512),
+        nullable=False,
+        doc="Canonical original MCP identifier",
+    )
+    display_name: Mapped[str | None] = mapped_column(
+        String(512),
+        nullable=True,
+        doc="Optional display name for the MCP artifact",
+    )
+    description: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        doc="Optional artifact description",
+    )
+    input_schema: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        doc="Artifact input schema payload",
+    )
+    artifact_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=True,
+        doc="Artifact metadata payload",
+    )
+    raw_payload: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        doc="Raw discovered MCP payload",
+    )
+    content_hash: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        doc="Hash of the normalized discovered artifact payload",
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=text("true"),
+        doc="Whether the artifact is part of the active catalog",
+    )
+    search_vector: Mapped[str] = mapped_column(
+        TSVECTOR,
+        nullable=False,
+        doc="Lexical search vector for the catalog entry",
+    )
+
+    mcp_integration: Mapped[MCPIntegration] = relationship(
+        "MCPIntegration",
+        back_populates="catalog_entries",
+    )
+
+
+class MCPIntegrationDiscoveryAttempt(Base):
+    """History of MCP catalog discovery attempts for an integration."""
+
+    __tablename__ = "mcp_integration_discovery_attempt"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        primary_key=True,
+        nullable=False,
+        unique=True,
+        index=True,
+        doc="Unique MCP discovery attempt identifier",
+    )
+    mcp_integration_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("mcp_integration.id", ondelete="CASCADE"),
+        nullable=False,
+        doc="Owning MCP integration",
+    )
+    workspace_id: Mapped[WorkspaceID] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=False,
+        doc="Workspace ID associated with this discovery attempt",
+    )
+    trigger: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        doc="Discovery trigger source",
+    )
+    status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        doc="Discovery attempt status",
+    )
+    catalog_version: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        doc="Catalog version produced by this attempt",
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        doc="When discovery started",
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+        doc="When discovery finished",
+    )
+    duration_ms: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        doc="Discovery duration in milliseconds",
+    )
+    artifact_counts: Mapped[dict[str, int] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        doc="Artifact counts recorded for this attempt",
+    )
+    error_code: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        doc="Optional machine-readable error code",
+    )
+    error_summary: Mapped[str | None] = mapped_column(
+        String(1024),
+        nullable=True,
+        doc="User-safe error summary",
+    )
+    error_details: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        doc="Structured internal error details",
+    )
+
+    mcp_integration: Mapped[MCPIntegration] = relationship(
+        "MCPIntegration",
+        back_populates="discovery_attempts",
+    )
+
+
+Index(
+    "ix_mcp_integration_catalog_entry_workspace_active_type",
+    MCPIntegrationCatalogEntry.workspace_id,
+    MCPIntegrationCatalogEntry.is_active,
+    MCPIntegrationCatalogEntry.artifact_type,
+)
+Index(
+    "ix_mcp_integration_catalog_entry_search_vector",
+    MCPIntegrationCatalogEntry.search_vector,
+    postgresql_using="gin",
+)
 
 
 class OAuthStateDB(TimestampMixin, Base):

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3427,24 +3427,6 @@ class MCPIntegration(TimestampMixin, Base):
         nullable=True,
         doc="Last user-safe discovery error summary",
     )
-    sandbox_allow_network: Mapped[bool] = mapped_column(
-        Boolean,
-        nullable=False,
-        default=False,
-        server_default=text("false"),
-        doc="Whether sandboxed stdio discovery/execution may access the network",
-    )
-    sandbox_egress_allowlist: Mapped[list[str] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Optional sandbox egress allowlist",
-    )
-    sandbox_egress_denylist: Mapped[list[str] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Optional sandbox egress denylist",
-    )
-
     oauth_integration: Mapped[OAuthIntegration | None] = relationship(
         "OAuthIntegration",
         uselist=False,
@@ -3452,11 +3434,6 @@ class MCPIntegration(TimestampMixin, Base):
     )
     catalog_entries: Mapped[list[MCPIntegrationCatalogEntry]] = relationship(
         "MCPIntegrationCatalogEntry",
-        back_populates="mcp_integration",
-        passive_deletes=True,
-    )
-    discovery_attempts: Mapped[list[MCPIntegrationDiscoveryAttempt]] = relationship(
-        "MCPIntegrationDiscoveryAttempt",
         back_populates="mcp_integration",
         passive_deletes=True,
     )
@@ -3563,89 +3540,6 @@ class MCPIntegrationCatalogEntry(TimestampMixin, Base):
     mcp_integration: Mapped[MCPIntegration] = relationship(
         "MCPIntegration",
         back_populates="catalog_entries",
-    )
-
-
-class MCPIntegrationDiscoveryAttempt(Base):
-    """History of MCP catalog discovery attempts for an integration."""
-
-    __tablename__ = "mcp_integration_discovery_attempt"
-
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        default=uuid.uuid4,
-        primary_key=True,
-        nullable=False,
-        unique=True,
-        index=True,
-        doc="Unique MCP discovery attempt identifier",
-    )
-    mcp_integration_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("mcp_integration.id", ondelete="CASCADE"),
-        nullable=False,
-        doc="Owning MCP integration",
-    )
-    workspace_id: Mapped[WorkspaceID] = mapped_column(
-        UUID,
-        ForeignKey("workspace.id", ondelete="CASCADE"),
-        nullable=False,
-        doc="Workspace ID associated with this discovery attempt",
-    )
-    trigger: Mapped[str] = mapped_column(
-        String(32),
-        nullable=False,
-        doc="Discovery trigger source",
-    )
-    status: Mapped[str] = mapped_column(
-        String(16),
-        nullable=False,
-        doc="Discovery attempt status",
-    )
-    catalog_version: Mapped[int | None] = mapped_column(
-        Integer,
-        nullable=True,
-        doc="Catalog version produced by this attempt",
-    )
-    started_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True),
-        nullable=False,
-        doc="When discovery started",
-    )
-    finished_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True),
-        nullable=True,
-        doc="When discovery finished",
-    )
-    duration_ms: Mapped[int | None] = mapped_column(
-        Integer,
-        nullable=True,
-        doc="Discovery duration in milliseconds",
-    )
-    artifact_counts: Mapped[dict[str, int] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Artifact counts recorded for this attempt",
-    )
-    error_code: Mapped[str | None] = mapped_column(
-        String(64),
-        nullable=True,
-        doc="Optional machine-readable error code",
-    )
-    error_summary: Mapped[str | None] = mapped_column(
-        String(1024),
-        nullable=True,
-        doc="User-safe error summary",
-    )
-    error_details: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB,
-        nullable=True,
-        doc="Structured internal error details",
-    )
-
-    mcp_integration: Mapped[MCPIntegration] = relationship(
-        "MCPIntegration",
-        back_populates="discovery_attempts",
     )
 
 

--- a/tracecat/integrations/enums.py
+++ b/tracecat/integrations/enums.py
@@ -27,3 +27,20 @@ class MCPAuthType(StrEnum):
     OAUTH2 = "OAUTH2"
     CUSTOM = "CUSTOM"
     NONE = "NONE"
+
+
+class MCPDiscoveryStatus(StrEnum):
+    """Discovery status for a persisted MCP integration catalog."""
+
+    PENDING = "pending"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    STALE = "stale"
+
+
+class MCPCatalogArtifactType(StrEnum):
+    """Supported MCP catalog artifact types."""
+
+    TOOL = "tool"
+    RESOURCE = "resource"
+    PROMPT = "prompt"

--- a/tracecat/integrations/mcp_validation.py
+++ b/tracecat/integrations/mcp_validation.py
@@ -6,6 +6,8 @@ command injection and other security vulnerabilities.
 
 import re
 
+from tracecat.agent.mcp.utils import REGISTRY_MCP_SERVER_NAMES
+
 # Allowlist of commands that can be used for MCP servers
 ALLOWED_MCP_COMMANDS = frozenset({"npx", "uvx", "python", "python3", "node"})
 
@@ -224,6 +226,12 @@ def validate_mcp_server_name(name: str) -> None:
 
     if not name:
         raise MCPValidationError("Server name cannot be empty")
+
+    if name in REGISTRY_MCP_SERVER_NAMES:
+        aliases = ", ".join(sorted(REGISTRY_MCP_SERVER_NAMES))
+        raise MCPValidationError(
+            f"Server name '{name}' is reserved. Reserved names: {aliases}"
+        )
 
     if len(name) > MAX_SERVER_NAME_LENGTH:
         raise MCPValidationError(

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -15,13 +15,19 @@ from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.db.models import MCPIntegration as MCPIntegrationModel
 from tracecat.db.models import OAuthStateDB
 from tracecat.integrations.dependencies import (
     ACProviderInfoDep,
     CCProviderInfoDep,
     ProviderInfoDep,
 )
-from tracecat.integrations.enums import IntegrationStatus, OAuthGrantType
+from tracecat.integrations.enums import (
+    IntegrationStatus,
+    MCPCatalogArtifactType,
+    MCPDiscoveryStatus,
+    OAuthGrantType,
+)
 from tracecat.integrations.providers import all_providers
 from tracecat.integrations.providers.base import (
     AuthorizationCodeOAuthProvider,
@@ -35,6 +41,7 @@ from tracecat.integrations.schemas import (
     IntegrationReadMinimal,
     IntegrationTestConnectionResponse,
     IntegrationUpdate,
+    MCPCatalogCounts,
     MCPIntegrationCreate,
     MCPIntegrationRead,
     MCPIntegrationUpdate,
@@ -58,6 +65,58 @@ providers_router = APIRouter(prefix="/providers", tags=["providers"])
 
 mcp_router = APIRouter(prefix="/mcp-integrations", tags=["mcp-integrations"])
 """Routes for managing MCP integrations."""
+
+
+def _build_mcp_catalog_counts(
+    counts_by_type: dict[MCPCatalogArtifactType, int] | None,
+) -> MCPCatalogCounts:
+    if counts_by_type is None:
+        return MCPCatalogCounts()
+    return MCPCatalogCounts(
+        tools=counts_by_type.get(MCPCatalogArtifactType.TOOL, 0),
+        resources=counts_by_type.get(MCPCatalogArtifactType.RESOURCE, 0),
+        prompts=counts_by_type.get(MCPCatalogArtifactType.PROMPT, 0),
+    )
+
+
+def _serialize_mcp_integration(
+    integration: MCPIntegrationModel,
+    *,
+    counts_by_type: dict[MCPCatalogArtifactType, int] | None = None,
+) -> MCPIntegrationRead:
+    catalog_counts = _build_mcp_catalog_counts(counts_by_type)
+    return MCPIntegrationRead(
+        id=integration.id,
+        workspace_id=integration.workspace_id,
+        name=integration.name,
+        description=integration.description,
+        slug=integration.slug,
+        scope_namespace=integration.scope_namespace,
+        server_uri=integration.server_uri,
+        auth_type=integration.auth_type,
+        oauth_integration_id=integration.oauth_integration_id,
+        created_at=integration.created_at,
+        updated_at=integration.updated_at,
+        server_type=cast(MCPServerType, integration.server_type),
+        stdio_command=integration.stdio_command,
+        stdio_args=integration.stdio_args,
+        has_stdio_env=bool(integration.encrypted_stdio_env),
+        timeout=integration.timeout,
+        discovery_status=MCPDiscoveryStatus(integration.discovery_status),
+        catalog_version=integration.catalog_version,
+        last_discovery_attempt_at=integration.last_discovery_attempt_at,
+        last_discovered_at=integration.last_discovered_at,
+        last_discovery_error_code=integration.last_discovery_error_code,
+        last_discovery_error_summary=integration.last_discovery_error_summary,
+        catalog_counts=catalog_counts,
+        has_catalog=any(
+            (
+                catalog_counts.tools,
+                catalog_counts.resources,
+                catalog_counts.prompts,
+            )
+        ),
+    )
 
 
 @integrations_router.get("/callback")
@@ -825,23 +884,7 @@ async def create_mcp_integration(
             detail=str(exc),
         ) from exc
 
-    return MCPIntegrationRead(
-        id=mcp_integration.id,
-        workspace_id=mcp_integration.workspace_id,
-        name=mcp_integration.name,
-        description=mcp_integration.description,
-        slug=mcp_integration.slug,
-        server_uri=mcp_integration.server_uri,
-        auth_type=mcp_integration.auth_type,
-        oauth_integration_id=mcp_integration.oauth_integration_id,
-        created_at=mcp_integration.created_at,
-        updated_at=mcp_integration.updated_at,
-        server_type=cast(MCPServerType, mcp_integration.server_type),
-        stdio_command=mcp_integration.stdio_command,
-        stdio_args=mcp_integration.stdio_args,
-        has_stdio_env=bool(mcp_integration.encrypted_stdio_env),
-        timeout=mcp_integration.timeout,
-    )
+    return _serialize_mcp_integration(mcp_integration)
 
 
 @mcp_router.get("")
@@ -859,24 +902,14 @@ async def list_mcp_integrations(
 
     svc = IntegrationService(session, role=role)
     integrations = await svc.list_mcp_integrations()
+    catalog_counts = await svc.get_mcp_catalog_counts(
+        mcp_integration_ids=[integration.id for integration in integrations]
+    )
 
     return [
-        MCPIntegrationRead(
-            id=integration.id,
-            workspace_id=integration.workspace_id,
-            name=integration.name,
-            description=integration.description,
-            slug=integration.slug,
-            server_uri=integration.server_uri,
-            auth_type=integration.auth_type,
-            oauth_integration_id=integration.oauth_integration_id,
-            created_at=integration.created_at,
-            updated_at=integration.updated_at,
-            server_type=cast(MCPServerType, integration.server_type),
-            stdio_command=integration.stdio_command,
-            stdio_args=integration.stdio_args,
-            has_stdio_env=bool(integration.encrypted_stdio_env),
-            timeout=integration.timeout,
+        _serialize_mcp_integration(
+            integration,
+            counts_by_type=catalog_counts.get(integration.id),
         )
         for integration in integrations
     ]
@@ -904,22 +937,12 @@ async def get_mcp_integration(
             detail="MCP integration not found",
         )
 
-    return MCPIntegrationRead(
-        id=integration.id,
-        workspace_id=integration.workspace_id,
-        name=integration.name,
-        description=integration.description,
-        slug=integration.slug,
-        server_uri=integration.server_uri,
-        auth_type=integration.auth_type,
-        oauth_integration_id=integration.oauth_integration_id,
-        created_at=integration.created_at,
-        updated_at=integration.updated_at,
-        server_type=cast(MCPServerType, integration.server_type),
-        stdio_command=integration.stdio_command,
-        stdio_args=integration.stdio_args,
-        has_stdio_env=bool(integration.encrypted_stdio_env),
-        timeout=integration.timeout,
+    catalog_counts = await svc.get_mcp_catalog_counts(
+        mcp_integration_ids=[integration.id]
+    )
+    return _serialize_mcp_integration(
+        integration,
+        counts_by_type=catalog_counts.get(integration.id),
     )
 
 
@@ -954,22 +977,12 @@ async def update_mcp_integration(
             detail=str(exc),
         ) from exc
 
-    return MCPIntegrationRead(
-        id=integration.id,
-        workspace_id=integration.workspace_id,
-        name=integration.name,
-        description=integration.description,
-        slug=integration.slug,
-        server_uri=integration.server_uri,
-        auth_type=integration.auth_type,
-        oauth_integration_id=integration.oauth_integration_id,
-        created_at=integration.created_at,
-        updated_at=integration.updated_at,
-        server_type=cast(MCPServerType, integration.server_type),
-        stdio_command=integration.stdio_command,
-        stdio_args=integration.stdio_args,
-        has_stdio_env=bool(integration.encrypted_stdio_env),
-        timeout=integration.timeout,
+    catalog_counts = await svc.get_mcp_catalog_counts(
+        mcp_integration_ids=[integration.id]
+    )
+    return _serialize_mcp_integration(
+        integration,
+        counts_by_type=catalog_counts.get(integration.id),
     )
 
 

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -21,7 +21,13 @@ from pydantic import (
 )
 
 from tracecat.identifiers import UserID, WorkspaceID
-from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
+from tracecat.integrations.enums import (
+    IntegrationStatus,
+    MCPAuthType,
+    MCPCatalogArtifactType,
+    MCPDiscoveryStatus,
+    OAuthGrantType,
+)
 from tracecat.integrations.types import MCPServerType
 
 
@@ -524,6 +530,33 @@ class MCPIntegrationUpdate(BaseModel):
         return value
 
 
+class MCPCatalogCounts(BaseModel):
+    """Active catalog counts grouped by artifact type."""
+
+    tools: int = Field(default=0, ge=0)
+    resources: int = Field(default=0, ge=0)
+    prompts: int = Field(default=0, ge=0)
+
+
+class MCPIntegrationCatalogEntryRead(BaseModel):
+    """Response model for a persisted MCP catalog entry."""
+
+    id: UUID4
+    mcp_integration_id: UUID4
+    workspace_id: WorkspaceID
+    integration_name: str
+    artifact_type: MCPCatalogArtifactType
+    artifact_key: str
+    artifact_ref: str
+    display_name: str | None
+    description: str | None
+    input_schema: dict[str, Any] | None
+    metadata: dict[str, Any] | None = None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
 class MCPIntegrationRead(BaseModel):
     """Response model for MCP integration."""
 
@@ -532,6 +565,7 @@ class MCPIntegrationRead(BaseModel):
     name: str
     description: str | None
     slug: str
+    scope_namespace: str
     # Server type
     server_type: MCPServerType
     # HTTP-type server fields
@@ -546,5 +580,13 @@ class MCPIntegrationRead(BaseModel):
     """Whether stdio_env is configured (actual values are not exposed)."""
     # General fields
     timeout: int | None
+    discovery_status: MCPDiscoveryStatus
+    catalog_version: int
+    last_discovery_attempt_at: datetime | None
+    last_discovered_at: datetime | None
+    last_discovery_error_code: str | None
+    last_discovery_error_summary: str | None
+    catalog_counts: MCPCatalogCounts = Field(default_factory=MCPCatalogCounts)
+    has_catalog: bool = False
     created_at: datetime
     updated_at: datetime

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -20,6 +20,7 @@ from pydantic import (
     field_validator,
 )
 
+from tracecat.agent.mcp.utils import is_reserved_mcp_server_name
 from tracecat.identifiers import UserID, WorkspaceID
 from tracecat.integrations.enums import (
     IntegrationStatus,
@@ -374,6 +375,19 @@ class _MCPIntegrationCreateBase(BaseModel):
         description="Timeout in seconds",
     )
 
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_name_not_reserved(cls, value: Any) -> Any:
+        """Reject integration names that collide with reserved MCP server aliases."""
+        if not isinstance(value, str):
+            return value
+        normalized = value.strip()
+        if is_reserved_mcp_server_name(normalized):
+            raise ValueError(
+                f"MCP integration name '{normalized}' is reserved for Tracecat"
+            )
+        return normalized
+
 
 class MCPHttpIntegrationCreate(_MCPIntegrationCreateBase):
     """Request model for creating an HTTP MCP integration."""
@@ -508,6 +522,21 @@ class MCPIntegrationUpdate(BaseModel):
         le=300,
         description="Timeout in seconds",
     )
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _validate_name_not_reserved(cls, value: Any) -> Any:
+        """Reject integration names that collide with reserved MCP server aliases."""
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return value
+        normalized = value.strip()
+        if is_reserved_mcp_server_name(normalized):
+            raise ValueError(
+                f"MCP integration name '{normalized}' is reserved for Tracecat"
+            )
+        return normalized
 
     @field_validator("server_uri", mode="before")
     @classmethod

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1,6 +1,7 @@
 """Service for managing user integrations with external services."""
 
 import os
+import secrets
 import uuid
 from collections.abc import Sequence
 from datetime import datetime, timedelta
@@ -11,18 +12,24 @@ from uuid import uuid4
 import orjson
 from pydantic import SecretStr
 from slugify import slugify
-from sqlalchemy import and_, or_, select, update
+from sqlalchemy import and_, func, or_, select, update
 
 from tracecat import config
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentPreset,
     MCPIntegration,
+    MCPIntegrationCatalogEntry,
     OAuthIntegration,
     WorkspaceOAuthProvider,
 )
 from tracecat.identifiers import UserID
-from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
+from tracecat.integrations.enums import (
+    MCPAuthType,
+    MCPCatalogArtifactType,
+    MCPDiscoveryStatus,
+    OAuthGrantType,
+)
 from tracecat.integrations.mcp_validation import (
     MAX_SERVER_NAME_LENGTH,
     MCPValidationError,
@@ -1064,9 +1071,13 @@ class IntegrationService(BaseWorkspaceService):
                 name=metadata.name,
                 description=metadata.description,
                 slug=slug,
+                scope_namespace=await self._generate_mcp_scope_namespace(),
                 server_uri=provider_impl.mcp_server_uri,
                 auth_type=MCPAuthType.OAUTH2,
                 oauth_integration_id=integration.id,
+                discovery_status=MCPDiscoveryStatus.PENDING.value,
+                catalog_version=0,
+                sandbox_allow_network=False,
             )
             self.session.add(mcp_integration)
             await self.session.commit()
@@ -1134,6 +1145,21 @@ class IntegrationService(BaseWorkspaceService):
         result = await self.session.execute(statement)
         return result.scalars().first() is not None
 
+    async def _mcp_scope_namespace_taken(self, scope_namespace: str) -> bool:
+        """Check if an MCP scope namespace is already taken."""
+        statement = select(MCPIntegration).where(
+            MCPIntegration.scope_namespace == scope_namespace
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().first() is not None
+
+    async def _generate_mcp_scope_namespace(self) -> str:
+        """Generate an immutable scope namespace for a new MCP integration."""
+        while True:
+            candidate = secrets.token_hex(8)
+            if not await self._mcp_scope_namespace_taken(candidate):
+                return candidate
+
     @require_scope("integration:create")
     async def create_mcp_integration(
         self, *, params: MCPIntegrationCreate
@@ -1198,6 +1224,7 @@ class IntegrationService(BaseWorkspaceService):
             name=params.name.strip(),
             description=params.description.strip() if params.description else None,
             slug=slug,
+            scope_namespace=await self._generate_mcp_scope_namespace(),
             server_uri=server_uri,
             auth_type=auth_type,
             oauth_integration_id=oauth_integration_id,
@@ -1207,6 +1234,9 @@ class IntegrationService(BaseWorkspaceService):
             stdio_args=stdio_args,
             encrypted_stdio_env=encrypted_stdio_env,
             timeout=params.timeout,
+            discovery_status=MCPDiscoveryStatus.PENDING.value,
+            catalog_version=0,
+            sandbox_allow_network=False,
         )
 
         self.session.add(mcp_integration)
@@ -1241,6 +1271,38 @@ class IntegrationService(BaseWorkspaceService):
         )
         result = await self.session.execute(statement)
         return result.scalars().first()
+
+    async def get_mcp_catalog_counts(
+        self, *, mcp_integration_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, dict[MCPCatalogArtifactType, int]]:
+        """Return active catalog counts grouped by integration and artifact type."""
+        if not mcp_integration_ids:
+            return {}
+
+        statement = (
+            select(
+                MCPIntegrationCatalogEntry.mcp_integration_id,
+                MCPIntegrationCatalogEntry.artifact_type,
+                func.count(MCPIntegrationCatalogEntry.id),
+            )
+            .where(
+                MCPIntegrationCatalogEntry.workspace_id == self.workspace_id,
+                MCPIntegrationCatalogEntry.is_active.is_(True),
+                MCPIntegrationCatalogEntry.mcp_integration_id.in_(
+                    list(mcp_integration_ids)
+                ),
+            )
+            .group_by(
+                MCPIntegrationCatalogEntry.mcp_integration_id,
+                MCPIntegrationCatalogEntry.artifact_type,
+            )
+        )
+        result = await self.session.execute(statement)
+        counts_by_integration: dict[uuid.UUID, dict[MCPCatalogArtifactType, int]] = {}
+        for integration_id, artifact_type, count in result.all():
+            by_type = counts_by_integration.setdefault(integration_id, {})
+            by_type[MCPCatalogArtifactType(artifact_type)] = count
+        return counts_by_integration
 
     @require_scope("integration:update")
     async def update_mcp_integration(

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1077,7 +1077,6 @@ class IntegrationService(BaseWorkspaceService):
                 oauth_integration_id=integration.id,
                 discovery_status=MCPDiscoveryStatus.PENDING.value,
                 catalog_version=0,
-                sandbox_allow_network=False,
             )
             self.session.add(mcp_integration)
             await self.session.commit()
@@ -1236,7 +1235,6 @@ class IntegrationService(BaseWorkspaceService):
             timeout=params.timeout,
             discovery_status=MCPDiscoveryStatus.PENDING.value,
             catalog_version=0,
-            sandbox_allow_network=False,
         )
 
         self.session.add(mcp_integration)

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -15,6 +15,7 @@ from slugify import slugify
 from sqlalchemy import and_, func, or_, select, update
 
 from tracecat import config
+from tracecat.agent.mcp.utils import is_reserved_mcp_server_name
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentPreset,
@@ -1118,7 +1119,9 @@ class IntegrationService(BaseWorkspaceService):
 
         candidate = slug
         suffix = 1
-        while await self._mcp_integration_slug_taken(candidate):
+        while is_reserved_mcp_server_name(
+            candidate
+        ) or await self._mcp_integration_slug_taken(candidate):
             candidate = f"{slug}-{suffix}"
             suffix += 1
         return candidate

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1299,7 +1299,7 @@ class IntegrationService(BaseWorkspaceService):
         )
         result = await self.session.execute(statement)
         counts_by_integration: dict[uuid.UUID, dict[MCPCatalogArtifactType, int]] = {}
-        for integration_id, artifact_type, count in result.all():
+        for integration_id, artifact_type, count in result.tuples().all():
             by_type = counts_by_integration.setdefault(integration_id, {})
             by_type[MCPCatalogArtifactType(artifact_type)] = count
         return counts_by_integration


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists MCP integration discovery catalog/state, exposes active catalog counts in API/UI, and standardizes canonical MCP tool naming across the agent/proxy/runtime. Drops the `transport` option in favor of Streamable HTTP with SSE fallback and reserves Tracecat MCP namespaces to avoid collisions (ENG-1315).

- **New Features**
  - Persisted catalog: new `mcp_integration_catalog_entry` and `mcp_integration_discovery_attempt` tables with `tsvector` + `pg_trgm` indexes.
  - Integration state: `MCPIntegration` adds immutable `scope_namespace` (unique), `discovery_status`, `catalog_version`, last attempt/success timestamps, and error code/summary.
  - API/UI: list/get include `scope_namespace`, discovery fields, `catalog_counts` (`tools`/`resources`/`prompts`), and `has_catalog`.
  - Tool names: canonical encode/decode across agent, proxy, and runtime (`mcp.{server}.{tool}` for user MCP; dotted names for registry/internal). Legacy names still work; tool approvals and registry lock resolution updated. Removed redundant MCP internet policy flags.
  - Transport: user MCP client prefers Streamable HTTP with automatic SSE fallback; no retries on tool errors; tests cover discovery and fallback behavior.
  - Validation: reject reserved MCP server/integration names used by Tracecat (e.g., `tracecat-registry`, `tracecat_registry`) in agent configs and integration create APIs.

- **Migration**
  - Run Alembic upgrade to create new tables/columns and ensure `pg_trgm` is installed.
  - `scope_namespace` is added as nullable, backfilled, then made unique to maintain compatibility.
  - Remove `transport` from MCP HTTP server configs and tokens; Streamable HTTP is default with automatic SSE fallback.

<sup>Written for commit 367d765632fcc3835868480ae4c16f8a54da9ff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

