### PR TITLE
feat(mcp): add remote discovery refresh workflow

### DIFF
--- a/alembic/versions/5cb936f82dd6_add_mcp_transport.py
+++ b/alembic/versions/5cb936f82dd6_add_mcp_transport.py
@@ -1,0 +1,35 @@
+"""add mcp transport
+
+Revision ID: 5cb936f82dd6
+Revises: 3758bd2248e6
+Create Date: 2026-03-05 18:15:49.872417
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5cb936f82dd6"
+down_revision: str | None = "3758bd2248e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_integration",
+        sa.Column(
+            "transport",
+            sa.String(length=16),
+            server_default="http",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_integration", "transport")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10859,6 +10859,11 @@ export const $MCPHttpIntegrationCreate = {
       title: "Server Type",
       default: "http",
     },
+    transport: {
+      $ref: "#/components/schemas/MCPTransport",
+      description: "Transport used to connect to the remote MCP server",
+      default: "http",
+    },
     server_uri: {
       type: "string",
       title: "Server Uri",
@@ -11002,6 +11007,16 @@ export const $MCPIntegrationRead = {
     },
     server_type: {
       $ref: "#/components/schemas/MCPServerType",
+    },
+    transport: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/MCPTransport",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     server_uri: {
       anyOf: [
@@ -11151,6 +11166,7 @@ export const $MCPIntegrationRead = {
     "slug",
     "scope_namespace",
     "server_type",
+    "transport",
     "server_uri",
     "auth_type",
     "oauth_integration_id",
@@ -11196,6 +11212,16 @@ export const $MCPIntegrationUpdate = {
         },
       ],
       title: "Description",
+    },
+    transport: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/MCPTransport",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     server_uri: {
       anyOf: [
@@ -11439,6 +11465,13 @@ export const $MCPStdioServerConfig = {
   required: ["type", "name", "command"],
   title: "MCPStdioServerConfig",
   description: "Configuration for a stdio MCP server.",
+} as const
+
+export const $MCPTransport = {
+  type: "string",
+  enum: ["http", "sse"],
+  title: "MCPTransport",
+  description: "Transport used to connect to a remote MCP server.",
 } as const
 
 export const $MessageKind = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -330,6 +330,8 @@ import type {
   McpIntegrationsGetMcpIntegrationResponse,
   McpIntegrationsListMcpIntegrationsData,
   McpIntegrationsListMcpIntegrationsResponse,
+  McpIntegrationsRefreshMcpIntegrationData,
+  McpIntegrationsRefreshMcpIntegrationResponse,
   McpIntegrationsUpdateMcpIntegrationData,
   McpIntegrationsUpdateMcpIntegrationResponse,
   OrganizationAcceptInvitationData,
@@ -9288,6 +9290,33 @@ export const mcpIntegrationsDeleteMcpIntegration = (
   return __request(OpenAPI, {
     method: "DELETE",
     url: "/mcp-integrations/{mcp_integration_id}",
+    path: {
+      mcp_integration_id: data.mcpIntegrationId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Refresh Mcp Integration
+ * Enqueue remote discovery refresh for an HTTP/SSE MCP integration.
+ * @param data The data for the request.
+ * @param data.mcpIntegrationId
+ * @param data.workspaceId
+ * @returns MCPIntegrationRead Successful Response
+ * @throws ApiError
+ */
+export const mcpIntegrationsRefreshMcpIntegration = (
+  data: McpIntegrationsRefreshMcpIntegrationData
+): CancelablePromise<McpIntegrationsRefreshMcpIntegrationResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/mcp-integrations/{mcp_integration_id}/refresh",
     path: {
       mcp_integration_id: data.mcpIntegrationId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3510,6 +3510,10 @@ export type MCPHttpIntegrationCreate = {
   timeout?: number | null
   server_type?: "http"
   /**
+   * Transport used to connect to the remote MCP server
+   */
+  transport?: MCPTransport
+  /**
    * MCP server endpoint URL (required for http type)
    */
   server_uri: string
@@ -3570,6 +3574,7 @@ export type MCPIntegrationRead = {
   slug: string
   scope_namespace: string
   server_type: MCPServerType
+  transport: MCPTransport | null
   server_uri: string | null
   auth_type: MCPAuthType
   oauth_integration_id: string | null
@@ -3595,6 +3600,7 @@ export type MCPIntegrationRead = {
 export type MCPIntegrationUpdate = {
   name?: string | null
   description?: string | null
+  transport?: MCPTransport | null
   server_uri?: string | null
   auth_type?: MCPAuthType | null
   oauth_integration_id?: string | null
@@ -3670,6 +3676,11 @@ export type MCPStdioServerConfig = {
   }
   timeout?: number
 }
+
+/**
+ * Transport used to connect to a remote MCP server.
+ */
+export type MCPTransport = "http" | "sse"
 
 /**
  * The type/kind of message stored in the chat.
@@ -10338,6 +10349,13 @@ export type McpIntegrationsDeleteMcpIntegrationData = {
 
 export type McpIntegrationsDeleteMcpIntegrationResponse = void
 
+export type McpIntegrationsRefreshMcpIntegrationData = {
+  mcpIntegrationId: string
+  workspaceId: string
+}
+
+export type McpIntegrationsRefreshMcpIntegrationResponse = MCPIntegrationRead
+
 export type FeatureFlagsGetFeatureFlagsResponse = FeatureFlagsRead
 
 export type VcsGetGithubAppManifestResponse = GitHubAppManifestResponse
@@ -15153,6 +15171,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/mcp-integrations/{mcp_integration_id}/refresh": {
+    post: {
+      req: McpIntegrationsRefreshMcpIntegrationData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: MCPIntegrationRead
         /**
          * Validation Error
          */

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -9,14 +9,18 @@ This test suite covers MCP integration functionality including:
 """
 
 import uuid
+from datetime import UTC, datetime, timedelta
+from typing import cast
 from urllib.parse import parse_qs, urlparse
 
+import httpx
 import pytest
 from pydantic import SecretStr, TypeAdapter
 from sqlalchemy import func, insert, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.agent.mcp import user_client as mcp_user_client
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
@@ -24,14 +28,19 @@ from tracecat.db.models import (
     AgentPreset,
     MCPIntegration,
     MCPIntegrationCatalogEntry,
+    MCPIntegrationDiscoveryAttempt,
     OAuthIntegration,
 )
 from tracecat.integrations.enums import (
     MCPAuthType,
     MCPCatalogArtifactType,
+    MCPDiscoveryAttemptStatus,
     MCPDiscoveryStatus,
+    MCPDiscoveryTrigger,
+    MCPTransport,
     OAuthGrantType,
 )
+from tracecat.integrations.mcp_discovery_types import MCPDiscoveryWorkflowArgs
 from tracecat.integrations.providers.base import (
     MCPAuthProvider,
     OAuthDiscoveryResult,
@@ -51,6 +60,39 @@ from tracecat.integrations.schemas import (
 from tracecat.integrations.service import IntegrationService
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+class FakeTemporalClient:
+    """Minimal Temporal client stub for MCP discovery enqueue tests."""
+
+    def __init__(self) -> None:
+        self.started_workflows: list[dict[str, object]] = []
+
+    async def start_workflow(
+        self, workflow: object, args: object, **kwargs: object
+    ) -> None:
+        self.started_workflows.append(
+            {
+                "workflow": workflow,
+                "args": args,
+                "kwargs": kwargs,
+            }
+        )
+
+
+@pytest.fixture(autouse=True)
+def temporal_client_stub(monkeypatch: pytest.MonkeyPatch) -> FakeTemporalClient:
+    """Stub Temporal workflow starts for MCP discovery enqueue paths."""
+    client = FakeTemporalClient()
+
+    async def _get_temporal_client() -> FakeTemporalClient:
+        return client
+
+    monkeypatch.setattr(
+        "tracecat.integrations.service.get_temporal_client",
+        _get_temporal_client,
+    )
+    return client
 
 
 @pytest.fixture
@@ -83,10 +125,42 @@ async def oauth_integration(
 class TestMCPIntegrationCRUD:
     """Test basic CRUD operations for MCP integrations."""
 
+    async def _insert_catalog_entry(
+        self,
+        *,
+        integration_service: IntegrationService,
+        mcp_integration_id: uuid.UUID,
+        integration_name: str,
+        artifact_type: MCPCatalogArtifactType,
+        artifact_key: str,
+        artifact_ref: str,
+        is_active: bool = True,
+    ) -> None:
+        await integration_service.session.execute(
+            insert(MCPIntegrationCatalogEntry).values(
+                id=uuid.uuid4(),
+                mcp_integration_id=mcp_integration_id,
+                workspace_id=integration_service.workspace_id,
+                integration_name=integration_name,
+                artifact_type=artifact_type.value,
+                artifact_key=artifact_key,
+                artifact_ref=artifact_ref,
+                display_name=artifact_ref,
+                description=None,
+                input_schema={"type": "object"},
+                artifact_metadata=None,
+                raw_payload={"name": artifact_ref},
+                content_hash=artifact_key.ljust(64, "0"),
+                is_active=is_active,
+                search_vector=func.to_tsvector("simple", artifact_ref),
+            )
+        )
+
     async def test_create_mcp_integration_with_oauth2(
         self,
         integration_service: IntegrationService,
         oauth_integration: OAuthIntegration,
+        temporal_client_stub: FakeTemporalClient,
     ) -> None:
         """Test creating an MCP integration with OAuth2 authentication."""
         params = MCPHttpIntegrationCreate(
@@ -105,6 +179,7 @@ class TestMCPIntegrationCRUD:
         assert mcp_integration.name == "Test OAuth MCP"
         assert mcp_integration.slug == "test-oauth-mcp"
         assert mcp_integration.description == "Test description"
+        assert mcp_integration.transport == MCPTransport.HTTP.value
         assert mcp_integration.server_uri == "https://api.example.com/mcp"
         assert mcp_integration.auth_type == MCPAuthType.OAUTH2
         assert mcp_integration.oauth_integration_id == oauth_integration.id
@@ -112,7 +187,7 @@ class TestMCPIntegrationCRUD:
         assert len(mcp_integration.scope_namespace) == 16
         assert mcp_integration.discovery_status == MCPDiscoveryStatus.PENDING.value
         assert mcp_integration.catalog_version == 0
-        assert mcp_integration.last_discovery_attempt_at is None
+        assert mcp_integration.last_discovery_attempt_at is not None
         assert mcp_integration.last_discovered_at is None
         assert mcp_integration.last_discovery_error_code is None
         assert mcp_integration.last_discovery_error_summary is None
@@ -121,6 +196,7 @@ class TestMCPIntegrationCRUD:
         assert mcp_integration.sandbox_egress_denylist is None
         assert mcp_integration.created_at is not None
         assert mcp_integration.updated_at is not None
+        assert len(temporal_client_stub.started_workflows) == 1
 
     async def test_create_mcp_integration_with_oauth2_additional_headers(
         self,
@@ -371,6 +447,87 @@ class TestMCPIntegrationCRUD:
         assert updated.scope_namespace == original_scope_namespace
         assert updated.server_uri == created.server_uri  # Unchanged
 
+    async def test_create_mcp_integration_with_sse_transport(
+        self,
+        integration_service: IntegrationService,
+        temporal_client_stub: FakeTemporalClient,
+    ) -> None:
+        """Test remote MCP integrations persist the requested transport."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="SSE MCP",
+                server_uri="https://api.example.com/sse",
+                transport=MCPTransport.SSE,
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+
+        assert created.transport == MCPTransport.SSE.value
+        assert len(temporal_client_stub.started_workflows) == 1
+
+    async def test_update_mcp_integration_enqueues_remote_discovery(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+        temporal_client_stub: FakeTemporalClient,
+    ) -> None:
+        """Test updating an HTTP MCP integration re-enqueues discovery."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Refreshable MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        temporal_client_stub.started_workflows.clear()
+
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(transport=MCPTransport.SSE),
+        )
+
+        assert updated is not None
+        assert updated.transport == MCPTransport.SSE.value
+        assert updated.last_discovery_attempt_at is not None
+        assert len(temporal_client_stub.started_workflows) == 1
+        args = cast(
+            MCPDiscoveryWorkflowArgs,
+            temporal_client_stub.started_workflows[0]["args"],
+        )
+        assert args.trigger == MCPDiscoveryTrigger.UPDATE
+
+    async def test_refresh_mcp_integration_discovery_enqueues_remote_discovery(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+        temporal_client_stub: FakeTemporalClient,
+    ) -> None:
+        """Test explicit refresh re-enqueues discovery for HTTP MCP integrations."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Manual refresh MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        temporal_client_stub.started_workflows.clear()
+
+        refreshed = await integration_service.refresh_mcp_integration_discovery(
+            mcp_integration_id=created.id
+        )
+
+        assert refreshed is not None
+        assert refreshed.discovery_status == MCPDiscoveryStatus.PENDING.value
+        assert refreshed.last_discovery_attempt_at is not None
+        assert len(temporal_client_stub.started_workflows) == 1
+        args = cast(
+            MCPDiscoveryWorkflowArgs,
+            temporal_client_stub.started_workflows[0]["args"],
+        )
+        assert args.trigger == MCPDiscoveryTrigger.REFRESH
+
     async def test_get_mcp_catalog_counts(
         self,
         integration_service: IntegrationService,
@@ -394,59 +551,34 @@ class TestMCPIntegrationCRUD:
             )
         )
 
-        async def insert_catalog_entry(
-            *,
-            mcp_integration_id: uuid.UUID,
-            integration_name: str,
-            artifact_type: MCPCatalogArtifactType,
-            artifact_key: str,
-            artifact_ref: str,
-            is_active: bool = True,
-        ) -> None:
-            await integration_service.session.execute(
-                insert(MCPIntegrationCatalogEntry).values(
-                    id=uuid.uuid4(),
-                    mcp_integration_id=mcp_integration_id,
-                    workspace_id=integration_service.workspace_id,
-                    integration_name=integration_name,
-                    artifact_type=artifact_type.value,
-                    artifact_key=artifact_key,
-                    artifact_ref=artifact_ref,
-                    display_name=artifact_ref,
-                    description=None,
-                    input_schema={"type": "object"},
-                    artifact_metadata=None,
-                    raw_payload={"name": artifact_ref},
-                    content_hash=artifact_key.ljust(64, "0"),
-                    is_active=is_active,
-                    search_vector=func.to_tsvector("simple", artifact_ref),
-                )
-            )
-
-        await insert_catalog_entry(
+        await self._insert_catalog_entry(
             mcp_integration_id=created.id,
+            integration_service=integration_service,
             integration_name=created.name,
             artifact_type=MCPCatalogArtifactType.TOOL,
             artifact_key="tool-alpha-1234567890",
             artifact_ref="tool.alpha",
         )
-        await insert_catalog_entry(
+        await self._insert_catalog_entry(
             mcp_integration_id=created.id,
+            integration_service=integration_service,
             integration_name=created.name,
             artifact_type=MCPCatalogArtifactType.RESOURCE,
             artifact_key="resource-alpha-1234567890",
             artifact_ref="resource://alpha",
         )
-        await insert_catalog_entry(
+        await self._insert_catalog_entry(
             mcp_integration_id=created.id,
+            integration_service=integration_service,
             integration_name=created.name,
             artifact_type=MCPCatalogArtifactType.PROMPT,
             artifact_key="prompt-inactive-1234567890",
             artifact_ref="prompt.inactive",
             is_active=False,
         )
-        await insert_catalog_entry(
+        await self._insert_catalog_entry(
             mcp_integration_id=other.id,
+            integration_service=integration_service,
             integration_name=other.name,
             artifact_type=MCPCatalogArtifactType.PROMPT,
             artifact_key="prompt-beta-1234567890",
@@ -463,6 +595,234 @@ class TestMCPIntegrationCRUD:
             MCPCatalogArtifactType.RESOURCE: 1,
         }
         assert counts[other.id] == {MCPCatalogArtifactType.PROMPT: 1}
+
+    async def test_run_remote_mcp_discovery_persists_catalog_and_deactivates_removed(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test remote discovery upserts catalog rows and deactivates removed ones."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Catalog refresh MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        assert created.last_discovery_attempt_at is not None
+
+        async def _discover_first(_: object) -> dict[str, object]:
+            return {
+                "artifacts": [
+                    {
+                        "artifact_type": MCPCatalogArtifactType.TOOL.value,
+                        "artifact_ref": "search",
+                        "display_name": "Search",
+                        "description": "Search everything",
+                        "input_schema": {"type": "object"},
+                        "metadata": {"source": "tool"},
+                        "raw_payload": {"name": "search"},
+                        "content_hash": "a" * 64,
+                    },
+                    {
+                        "artifact_type": MCPCatalogArtifactType.PROMPT.value,
+                        "artifact_ref": "triage",
+                        "display_name": "Triage",
+                        "description": "Triage incidents",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"ticket": {"type": "string"}},
+                        },
+                        "metadata": {"source": "prompt"},
+                        "raw_payload": {"name": "triage"},
+                        "content_hash": "b" * 64,
+                    },
+                ]
+            }
+
+        monkeypatch.setattr(
+            mcp_user_client,
+            "discover_mcp_server_catalog",
+            _discover_first,
+        )
+        first_started_at = created.last_discovery_attempt_at + timedelta(seconds=1)
+        first_result = await integration_service.run_remote_mcp_discovery(
+            mcp_integration_id=created.id,
+            trigger=MCPDiscoveryTrigger.CREATE,
+            started_at=first_started_at,
+        )
+        first_attempt_result = await integration_service.session.execute(
+            select(MCPIntegrationDiscoveryAttempt).where(
+                MCPIntegrationDiscoveryAttempt.mcp_integration_id == created.id
+            )
+        )
+        first_attempt = first_attempt_result.scalars().one()
+
+        assert first_result.status == MCPDiscoveryStatus.SUCCEEDED.value, (
+            first_result.model_dump(),
+            first_attempt.error_details,
+        )
+        assert first_result.catalog_version == 1
+
+        async def _discover_second(_: object) -> dict[str, object]:
+            return {
+                "artifacts": [
+                    {
+                        "artifact_type": MCPCatalogArtifactType.TOOL.value,
+                        "artifact_ref": "search",
+                        "display_name": "Search",
+                        "description": "Search everything",
+                        "input_schema": {"type": "object"},
+                        "metadata": {"source": "tool"},
+                        "raw_payload": {"name": "search"},
+                        "content_hash": "c" * 64,
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(
+            mcp_user_client,
+            "discover_mcp_server_catalog",
+            _discover_second,
+        )
+        second_started_at = first_started_at + timedelta(seconds=1)
+        second_result = await integration_service.run_remote_mcp_discovery(
+            mcp_integration_id=created.id,
+            trigger=MCPDiscoveryTrigger.REFRESH,
+            started_at=second_started_at,
+        )
+
+        assert second_result.status == MCPDiscoveryStatus.SUCCEEDED.value
+        assert second_result.catalog_version == 2
+
+        refreshed = await integration_service.get_mcp_integration(
+            mcp_integration_id=created.id
+        )
+        assert refreshed is not None
+        assert refreshed.discovery_status == MCPDiscoveryStatus.SUCCEEDED.value
+        assert refreshed.catalog_version == 2
+        assert refreshed.last_discovered_at is not None
+        assert refreshed.last_discovery_error_code is None
+        assert refreshed.last_discovery_error_summary is None
+
+        catalog_result = await integration_service.session.execute(
+            select(MCPIntegrationCatalogEntry).where(
+                MCPIntegrationCatalogEntry.mcp_integration_id == created.id
+            )
+        )
+        catalog_entries = catalog_result.scalars().all()
+        assert len(catalog_entries) == 2
+        active_entries = [entry for entry in catalog_entries if entry.is_active]
+        inactive_entries = [entry for entry in catalog_entries if not entry.is_active]
+        assert len(active_entries) == 1
+        assert active_entries[0].artifact_type == MCPCatalogArtifactType.TOOL.value
+        assert active_entries[0].content_hash == "c" * 64
+        assert len(inactive_entries) == 1
+        assert inactive_entries[0].artifact_type == MCPCatalogArtifactType.PROMPT.value
+
+        attempts_result = await integration_service.session.execute(
+            select(MCPIntegrationDiscoveryAttempt)
+            .where(MCPIntegrationDiscoveryAttempt.mcp_integration_id == created.id)
+            .order_by(MCPIntegrationDiscoveryAttempt.started_at)
+        )
+        attempts = attempts_result.scalars().all()
+        assert [attempt.status for attempt in attempts] == [
+            MCPDiscoveryAttemptStatus.SUCCEEDED.value,
+            MCPDiscoveryAttemptStatus.SUCCEEDED.value,
+        ]
+        assert attempts[0].catalog_version == 1
+        assert attempts[0].artifact_counts == {
+            MCPCatalogArtifactType.TOOL.value: 1,
+            MCPCatalogArtifactType.RESOURCE.value: 0,
+            MCPCatalogArtifactType.PROMPT.value: 1,
+        }
+        assert attempts[1].catalog_version == 2
+        assert attempts[1].artifact_counts == {
+            MCPCatalogArtifactType.TOOL.value: 1,
+            MCPCatalogArtifactType.RESOURCE.value: 0,
+            MCPCatalogArtifactType.PROMPT.value: 0,
+        }
+
+    async def test_run_remote_mcp_discovery_failure_marks_stale_and_keeps_catalog(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test failed discovery preserves active catalog and marks integration stale."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Stale MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        assert created.last_discovery_attempt_at is not None
+
+        await self._insert_catalog_entry(
+            integration_service=integration_service,
+            mcp_integration_id=created.id,
+            integration_name=created.name,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="existing-tool-1234567890",
+            artifact_ref="existing.tool",
+        )
+        created.catalog_version = 1
+        created.discovery_status = MCPDiscoveryStatus.SUCCEEDED.value
+        created.last_discovered_at = datetime.now(UTC)
+        integration_service.session.add(created)
+        await integration_service.session.commit()
+
+        request = httpx.Request("GET", "https://api.example.com/mcp")
+
+        async def _fail_discovery(_: object) -> dict[str, object]:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        monkeypatch.setattr(
+            mcp_user_client,
+            "discover_mcp_server_catalog",
+            _fail_discovery,
+        )
+        started_at = created.last_discovery_attempt_at + timedelta(seconds=1)
+        result = await integration_service.run_remote_mcp_discovery(
+            mcp_integration_id=created.id,
+            trigger=MCPDiscoveryTrigger.REFRESH,
+            started_at=started_at,
+        )
+
+        assert result.status == MCPDiscoveryStatus.STALE.value
+        assert result.catalog_version == 1
+        assert result.error_code == "connection_error"
+
+        refreshed = await integration_service.get_mcp_integration(
+            mcp_integration_id=created.id
+        )
+        assert refreshed is not None
+        assert refreshed.discovery_status == MCPDiscoveryStatus.STALE.value
+        assert refreshed.catalog_version == 1
+        assert refreshed.last_discovery_error_code == "connection_error"
+        assert (
+            refreshed.last_discovery_error_summary
+            == "Could not connect to the MCP server."
+        )
+
+        catalog_result = await integration_service.session.execute(
+            select(MCPIntegrationCatalogEntry).where(
+                MCPIntegrationCatalogEntry.mcp_integration_id == created.id
+            )
+        )
+        catalog_entries = catalog_result.scalars().all()
+        assert len(catalog_entries) == 1
+        assert catalog_entries[0].is_active is True
+
+        attempt_result = await integration_service.session.execute(
+            select(MCPIntegrationDiscoveryAttempt).where(
+                MCPIntegrationDiscoveryAttempt.mcp_integration_id == created.id
+            )
+        )
+        attempt = attempt_result.scalars().one()
+        assert attempt.status == MCPDiscoveryAttemptStatus.FAILED.value
+        assert attempt.trigger == MCPDiscoveryTrigger.REFRESH.value
+        assert attempt.error_code == "connection_error"
 
     async def test_update_mcp_integration_partial(
         self,
@@ -606,6 +966,7 @@ class TestMCPIntegrationCRUD:
         assert mcp_integration.slug == "github_mcp"
         assert len(mcp_integration.scope_namespace) == 16
         assert mcp_integration.discovery_status == MCPDiscoveryStatus.PENDING.value
+        assert mcp_integration.last_discovery_attempt_at is not None
         assert mcp_integration.catalog_version == 0
 
         await integration_service.delete_mcp_integration(

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -824,6 +824,155 @@ class TestMCPIntegrationCRUD:
         assert attempt.trigger == MCPDiscoveryTrigger.REFRESH.value
         assert attempt.error_code == "connection_error"
 
+    async def test_run_remote_mcp_discovery_failure_persists_when_config_resolution_raises(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test config resolution exceptions are persisted as discovery failures."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Broken config MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        assert created.last_discovery_attempt_at is not None
+
+        async def _raise_config_error(**_: object) -> None:
+            raise ValueError("missing server configuration")
+
+        monkeypatch.setattr(
+            integration_service,
+            "resolve_mcp_http_server_config",
+            _raise_config_error,
+        )
+        started_at = created.last_discovery_attempt_at + timedelta(seconds=1)
+        result = await integration_service.run_remote_mcp_discovery(
+            mcp_integration_id=created.id,
+            trigger=MCPDiscoveryTrigger.REFRESH,
+            started_at=started_at,
+        )
+
+        assert result.status == MCPDiscoveryStatus.FAILED.value
+        assert result.catalog_version == 0
+        assert result.error_code == "invalid_config"
+
+        refreshed = await integration_service.get_mcp_integration(
+            mcp_integration_id=created.id
+        )
+        assert refreshed is not None
+        assert refreshed.discovery_status == MCPDiscoveryStatus.FAILED.value
+        assert refreshed.last_discovery_error_code == "invalid_config"
+        assert (
+            refreshed.last_discovery_error_summary
+            == "The MCP integration configuration is incomplete."
+        )
+
+        attempt_result = await integration_service.session.execute(
+            select(MCPIntegrationDiscoveryAttempt).where(
+                MCPIntegrationDiscoveryAttempt.mcp_integration_id == created.id
+            )
+        )
+        attempt = attempt_result.scalars().one()
+        assert attempt.status == MCPDiscoveryAttemptStatus.FAILED.value
+        assert attempt.trigger == MCPDiscoveryTrigger.REFRESH.value
+        assert attempt.error_code == "invalid_config"
+
+    async def test_run_remote_mcp_discovery_keeps_artifact_keys_stable_when_display_name_changes(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test display-name changes reuse the same catalog row."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Stable key MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        assert created.last_discovery_attempt_at is not None
+
+        async def _discover_first(_: object) -> dict[str, object]:
+            return {
+                "artifacts": [
+                    {
+                        "artifact_type": MCPCatalogArtifactType.TOOL.value,
+                        "artifact_ref": "search",
+                        "display_name": "Search",
+                        "description": "Search everything",
+                        "input_schema": {"type": "object"},
+                        "metadata": {"source": "tool"},
+                        "raw_payload": {"name": "search"},
+                        "content_hash": "d" * 64,
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(
+            mcp_user_client,
+            "discover_mcp_server_catalog",
+            _discover_first,
+        )
+        first_started_at = created.last_discovery_attempt_at + timedelta(seconds=1)
+        first_result = await integration_service.run_remote_mcp_discovery(
+            mcp_integration_id=created.id,
+            trigger=MCPDiscoveryTrigger.CREATE,
+            started_at=first_started_at,
+        )
+        assert first_result.status == MCPDiscoveryStatus.SUCCEEDED.value
+
+        first_catalog_result = await integration_service.session.execute(
+            select(MCPIntegrationCatalogEntry).where(
+                MCPIntegrationCatalogEntry.mcp_integration_id == created.id
+            )
+        )
+        first_catalog_entries = first_catalog_result.scalars().all()
+        assert len(first_catalog_entries) == 1
+        original_artifact_key = first_catalog_entries[0].artifact_key
+
+        async def _discover_second(_: object) -> dict[str, object]:
+            return {
+                "artifacts": [
+                    {
+                        "artifact_type": MCPCatalogArtifactType.TOOL.value,
+                        "artifact_ref": "search",
+                        "display_name": "Search docs",
+                        "description": "Search everything",
+                        "input_schema": {"type": "object"},
+                        "metadata": {"source": "tool"},
+                        "raw_payload": {"name": "search"},
+                        "content_hash": "e" * 64,
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(
+            mcp_user_client,
+            "discover_mcp_server_catalog",
+            _discover_second,
+        )
+        second_started_at = first_started_at + timedelta(seconds=1)
+        second_result = await integration_service.run_remote_mcp_discovery(
+            mcp_integration_id=created.id,
+            trigger=MCPDiscoveryTrigger.REFRESH,
+            started_at=second_started_at,
+        )
+        assert second_result.status == MCPDiscoveryStatus.SUCCEEDED.value
+        assert second_result.catalog_version == 2
+
+        second_catalog_result = await integration_service.session.execute(
+            select(MCPIntegrationCatalogEntry)
+            .where(MCPIntegrationCatalogEntry.mcp_integration_id == created.id)
+            .execution_options(populate_existing=True)
+        )
+        second_catalog_entries = second_catalog_result.scalars().all()
+        assert len(second_catalog_entries) == 1
+        assert second_catalog_entries[0].artifact_key == original_artifact_key
+        assert second_catalog_entries[0].display_name == "Search docs"
+        assert second_catalog_entries[0].is_active is True
+
     async def test_update_mcp_integration_partial(
         self,
         integration_service: IntegrationService,

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -166,6 +166,7 @@ async def test_workflow_execution_stop_scope_guards(
         (integrations_router.list_mcp_integrations, "integration:read"),
         (integrations_router.get_mcp_integration, "integration:read"),
         (integrations_router.update_mcp_integration, "integration:update"),
+        (integrations_router.refresh_mcp_integration, "integration:update"),
         (integrations_router.delete_mcp_integration, "integration:delete"),
     ],
 )

--- a/tests/unit/test_user_mcp_client.py
+++ b/tests/unit/test_user_mcp_client.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from typing import Any
+
+import mcp.types as mcp_types
+import pytest
+from mcp import McpError
+from pydantic import AnyUrl
+
+from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.mcp import user_client
+
+
+def _server_config() -> MCPHttpServerConfig:
+    return {
+        "name": "remote-catalog",
+        "url": "https://example.test/mcp",
+        "transport": "http",
+        "headers": {"Authorization": "Bearer token"},
+        "timeout": 30,
+    }
+
+
+def _fake_client_factory(
+    *,
+    tools: list[mcp_types.Tool] | Exception,
+    resources: list[mcp_types.Resource] | Exception,
+    prompts: list[mcp_types.Prompt] | Exception,
+):
+    class FakeClient:
+        def __init__(self, transport: Any) -> None:
+            self.transport = transport
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: Any,
+        ) -> bool:
+            return False
+
+        async def list_tools(self) -> list[mcp_types.Tool]:
+            if isinstance(tools, Exception):
+                raise tools
+            return tools
+
+        async def list_resources(self) -> list[mcp_types.Resource]:
+            if isinstance(resources, Exception):
+                raise resources
+            return resources
+
+        async def list_prompts(self) -> list[mcp_types.Prompt]:
+            if isinstance(prompts, Exception):
+                raise prompts
+            return prompts
+
+    return FakeClient
+
+
+@pytest.mark.anyio
+async def test_discover_mcp_server_catalog_normalizes_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = mcp_types.Tool(
+        name="search",
+        title="Search docs",
+        description="Search remote docs",
+        inputSchema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        outputSchema={"type": "object"},
+        _meta={"origin": "tool-meta"},
+    )
+    resource = mcp_types.Resource(
+        name="Playbook",
+        title="Playbook resource",
+        uri=AnyUrl("resource://playbooks/1"),
+        description="Incident playbook",
+        mimeType="text/markdown",
+        size=42,
+        _meta={"origin": "resource-meta"},
+    )
+    prompt = mcp_types.Prompt(
+        name="draft_report",
+        title="Draft report",
+        description="Create a report draft",
+        arguments=[
+            mcp_types.PromptArgument(
+                name="incident_id",
+                description="Incident identifier",
+                required=True,
+            )
+        ],
+        _meta={"origin": "prompt-meta"},
+    )
+
+    monkeypatch.setattr(
+        user_client,
+        "Client",
+        _fake_client_factory(tools=[tool], resources=[resource], prompts=[prompt]),
+    )
+
+    catalog = await user_client.discover_mcp_server_catalog(_server_config())
+
+    assert catalog.server_name == "remote-catalog"
+    assert len(catalog.tools) == 1
+    assert len(catalog.resources) == 1
+    assert len(catalog.prompts) == 1
+    assert [artifact["artifact_type"] for artifact in catalog.artifacts] == [
+        "tool",
+        "resource",
+        "prompt",
+    ]
+
+    tool_artifact = catalog.tools[0]
+    assert tool_artifact["artifact_ref"] == "search"
+    assert tool_artifact["display_name"] == "Search docs"
+    assert tool_artifact["input_schema"] == tool.inputSchema
+    assert tool_artifact["metadata"] == {
+        "meta": {"origin": "tool-meta"},
+        "output_schema": {"type": "object"},
+    }
+    assert tool_artifact["raw_payload"]["name"] == "search"
+    assert tool_artifact["raw_payload"]["title"] == "Search docs"
+    assert tool_artifact["content_hash"]
+
+    resource_artifact = catalog.resources[0]
+    assert resource_artifact["artifact_ref"] == "resource://playbooks/1"
+    assert resource_artifact["display_name"] == "Playbook resource"
+    assert resource_artifact["input_schema"] is None
+    assert resource_artifact["metadata"] == {
+        "name": "Playbook",
+        "mime_type": "text/markdown",
+        "size": 42,
+        "meta": {"origin": "resource-meta"},
+    }
+    assert resource_artifact["raw_payload"]["mimeType"] == "text/markdown"
+
+    prompt_artifact = catalog.prompts[0]
+    assert prompt_artifact["artifact_ref"] == "draft_report"
+    assert prompt_artifact["display_name"] == "Draft report"
+    assert prompt_artifact["input_schema"] == {
+        "type": "object",
+        "properties": {
+            "incident_id": {
+                "type": "string",
+                "description": "Incident identifier",
+            }
+        },
+        "required": ["incident_id"],
+        "additionalProperties": False,
+    }
+    assert prompt_artifact["metadata"] == {
+        "arguments": [
+            {
+                "name": "incident_id",
+                "description": "Incident identifier",
+                "required": True,
+            }
+        ],
+        "meta": {"origin": "prompt-meta"},
+    }
+
+    tool_definitions = catalog.to_tool_definitions()
+    assert tool_definitions == {
+        "mcp__remote-catalog__search": user_client.MCPToolDefinition(
+            name="mcp__remote-catalog__search",
+            description="Search remote docs",
+            parameters_json_schema=tool.inputSchema,
+        )
+    }
+
+
+@pytest.mark.anyio
+async def test_discover_mcp_server_catalog_treats_unsupported_optional_capabilities_as_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = mcp_types.Tool(
+        name="lookup",
+        description="Lookup a record",
+        inputSchema={"type": "object"},
+    )
+    unsupported_error = McpError(
+        mcp_types.ErrorData(
+            code=mcp_types.METHOD_NOT_FOUND,
+            message="Method not found",
+        )
+    )
+
+    monkeypatch.setattr(
+        user_client,
+        "Client",
+        _fake_client_factory(
+            tools=[tool],
+            resources=unsupported_error,
+            prompts=unsupported_error,
+        ),
+    )
+
+    catalog = await user_client.discover_mcp_server_catalog(_server_config())
+
+    assert len(catalog.tools) == 1
+    assert catalog.resources == ()
+    assert catalog.prompts == ()
+
+
+@pytest.mark.anyio
+async def test_discover_user_mcp_tools_preserves_existing_bootstrap_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = mcp_types.Tool(
+        name="lookup",
+        description="Lookup a record",
+        inputSchema={"type": "object", "properties": {"id": {"type": "string"}}},
+    )
+
+    monkeypatch.setattr(
+        user_client,
+        "Client",
+        _fake_client_factory(tools=[tool], resources=[], prompts=[]),
+    )
+
+    discovered = await user_client.discover_user_mcp_tools([_server_config()])
+
+    assert discovered == {
+        "mcp__remote-catalog__lookup": user_client.MCPToolDefinition(
+            name="mcp__remote-catalog__lookup",
+            description="Lookup a record",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {"id": {"type": "string"}},
+            },
+        )
+    }
+
+
+@pytest.mark.anyio
+async def test_discover_mcp_server_catalog_still_raises_tool_discovery_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_error = McpError(
+        mcp_types.ErrorData(
+            code=mcp_types.METHOD_NOT_FOUND,
+            message="Method not found",
+        )
+    )
+
+    monkeypatch.setattr(
+        user_client,
+        "Client",
+        _fake_client_factory(tools=tool_error, resources=[], prompts=[]),
+    )
+
+    with pytest.raises(McpError):
+        await user_client.discover_mcp_server_catalog(_server_config())

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -9,13 +9,60 @@ allowing the sandboxed runtime to access user tools via the Unix socket proxy.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+import hashlib
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict
 
+import mcp.types as mcp_types
+import orjson
 from fastmcp import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+from mcp import McpError
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.logger import logger
+
+
+class MCPServerCatalogArtifact(TypedDict):
+    """Normalized MCP artifact payload for persisted discovery."""
+
+    artifact_type: Literal["tool", "resource", "prompt"]
+    artifact_ref: str
+    display_name: str | None
+    description: str | None
+    input_schema: dict[str, Any] | None
+    metadata: dict[str, Any] | None
+    raw_payload: dict[str, Any]
+    content_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class MCPServerCatalog:
+    """Normalized catalog for a single remote MCP server."""
+
+    server_name: str
+    tools: tuple[MCPServerCatalogArtifact, ...]
+    resources: tuple[MCPServerCatalogArtifact, ...]
+    prompts: tuple[MCPServerCatalogArtifact, ...]
+
+    @property
+    def artifacts(self) -> tuple[MCPServerCatalogArtifact, ...]:
+        """Return a flattened view across all MCP artifact types."""
+        return self.tools + self.resources + self.prompts
+
+    def to_tool_definitions(self) -> dict[str, MCPToolDefinition]:
+        """Convert catalog tools into the existing bootstrap tool definition map."""
+        tools: dict[str, MCPToolDefinition] = {}
+        for tool in self.tools:
+            tool_name = tool["artifact_ref"]
+            prefixed_name = f"mcp__{self.server_name}__{tool_name}"
+            tools[prefixed_name] = MCPToolDefinition(
+                name=prefixed_name,
+                description=tool["description"] or f"Tool from {self.server_name}",
+                parameters_json_schema=tool["input_schema"] or {},
+            )
+        return tools
 
 
 def _create_transport(
@@ -29,6 +76,227 @@ def _create_transport(
         return SSETransport(url=url, headers=headers, sse_read_timeout=timeout)
     # Default to HTTP (Streamable HTTP transport)
     return StreamableHttpTransport(url=url, headers=headers, sse_read_timeout=timeout)
+
+
+def _model_to_payload(model: Any) -> dict[str, Any]:
+    """Convert an MCP model into a stable JSON payload."""
+    if not hasattr(model, "model_dump"):
+        raise TypeError(f"Unsupported MCP artifact type: {type(model).__name__}")
+    payload = model.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if not isinstance(payload, dict):
+        raise TypeError(f"Unexpected MCP artifact payload: {type(payload).__name__}")
+    return payload
+
+
+def _content_hash(payload: dict[str, Any]) -> str:
+    """Compute a stable content hash for a normalized MCP artifact."""
+    canonical = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _compact_metadata(metadata: dict[str, Any]) -> dict[str, Any] | None:
+    """Drop empty metadata fields to keep persisted payloads compact."""
+    compact = {key: value for key, value in metadata.items() if value is not None}
+    return compact or None
+
+
+def _prompt_input_schema(
+    arguments: list[mcp_types.PromptArgument] | None,
+) -> dict[str, Any]:
+    """Build a simple JSON schema for prompt arguments."""
+    properties: dict[str, dict[str, Any]] = {}
+    required: list[str] = []
+    for argument in arguments or []:
+        property_schema: dict[str, Any] = {"type": "string"}
+        if argument.description is not None:
+            property_schema["description"] = argument.description
+        properties[argument.name] = property_schema
+        if argument.required:
+            required.append(argument.name)
+
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        input_schema["required"] = required
+    return input_schema
+
+
+def _normalize_tool(tool: mcp_types.Tool) -> MCPServerCatalogArtifact:
+    """Normalize a remote MCP tool into the persisted discovery shape."""
+    raw_payload = _model_to_payload(tool)
+    display_name = tool.title or (tool.annotations.title if tool.annotations else None)
+    metadata = _compact_metadata(
+        {
+            "icons": [
+                icon.model_dump(mode="json", exclude_none=True) for icon in tool.icons
+            ]
+            if tool.icons
+            else None,
+            "annotations": tool.annotations.model_dump(mode="json", exclude_none=True)
+            if tool.annotations
+            else None,
+            "meta": tool.meta,
+            "output_schema": tool.outputSchema,
+            "execution": tool.execution.model_dump(mode="json", exclude_none=True)
+            if tool.execution
+            else None,
+        }
+    )
+    return {
+        "artifact_type": "tool",
+        "artifact_ref": tool.name,
+        "display_name": display_name or tool.name,
+        "description": tool.description,
+        "input_schema": tool.inputSchema,
+        "metadata": metadata,
+        "raw_payload": raw_payload,
+        "content_hash": _content_hash(raw_payload),
+    }
+
+
+def _normalize_resource(resource: mcp_types.Resource) -> MCPServerCatalogArtifact:
+    """Normalize a remote MCP resource into the persisted discovery shape."""
+    raw_payload = _model_to_payload(resource)
+    metadata = _compact_metadata(
+        {
+            "name": resource.name,
+            "mime_type": resource.mimeType,
+            "size": resource.size,
+            "icons": [
+                icon.model_dump(mode="json", exclude_none=True)
+                for icon in resource.icons
+            ]
+            if resource.icons
+            else None,
+            "annotations": resource.annotations.model_dump(
+                mode="json", exclude_none=True
+            )
+            if resource.annotations
+            else None,
+            "meta": resource.meta,
+        }
+    )
+    display_name = resource.title or resource.name or str(resource.uri)
+    return {
+        "artifact_type": "resource",
+        "artifact_ref": str(resource.uri),
+        "display_name": display_name,
+        "description": resource.description,
+        "input_schema": None,
+        "metadata": metadata,
+        "raw_payload": raw_payload,
+        "content_hash": _content_hash(raw_payload),
+    }
+
+
+def _normalize_prompt(prompt: mcp_types.Prompt) -> MCPServerCatalogArtifact:
+    """Normalize a remote MCP prompt into the persisted discovery shape."""
+    raw_payload = _model_to_payload(prompt)
+    input_schema = _prompt_input_schema(prompt.arguments)
+    metadata = _compact_metadata(
+        {
+            "arguments": [
+                argument.model_dump(mode="json", exclude_none=True)
+                for argument in prompt.arguments or []
+            ],
+            "icons": [
+                icon.model_dump(mode="json", exclude_none=True) for icon in prompt.icons
+            ]
+            if prompt.icons
+            else None,
+            "meta": prompt.meta,
+        }
+    )
+    return {
+        "artifact_type": "prompt",
+        "artifact_ref": prompt.name,
+        "display_name": prompt.title or prompt.name,
+        "description": prompt.description,
+        "input_schema": input_schema,
+        "metadata": metadata,
+        "raw_payload": raw_payload,
+        "content_hash": _content_hash(raw_payload),
+    }
+
+
+def _is_unsupported_optional_capability(exc: McpError) -> bool:
+    """Return whether a list_resources/list_prompts error means unsupported."""
+    message = exc.error.message.lower()
+    return exc.error.code == mcp_types.METHOD_NOT_FOUND or (
+        "method not found" in message or "not supported" in message
+    )
+
+
+async def _list_optional_capability[T](
+    *,
+    server_name: str,
+    capability_name: str,
+    list_fn: Callable[[], Awaitable[list[T]]],
+) -> list[T]:
+    """List an optional MCP capability, downgrading unsupported methods to empty."""
+    try:
+        return await list_fn()
+    except McpError as exc:
+        if not _is_unsupported_optional_capability(exc):
+            raise
+        logger.info(
+            "Remote MCP capability not supported",
+            server_name=server_name,
+            capability=capability_name,
+            error_code=exc.error.code,
+            error_message=exc.error.message,
+        )
+        return []
+
+
+async def discover_mcp_server_catalog(
+    config: MCPHttpServerConfig,
+) -> MCPServerCatalog:
+    """Discover normalized tools/resources/prompts for a single MCP server."""
+    server_name = config["name"]
+    url = config["url"]
+    transport_type: Literal["http", "sse"] = config.get("transport", "http")
+    headers = config.get("headers")
+    timeout = config.get("timeout")
+
+    transport = _create_transport(url, transport_type, headers, timeout)
+
+    async with Client(transport) as client:
+        tools = tuple(_normalize_tool(tool) for tool in await client.list_tools())
+        resources = tuple(
+            _normalize_resource(resource)
+            for resource in await _list_optional_capability(
+                server_name=server_name,
+                capability_name="resources",
+                list_fn=client.list_resources,
+            )
+        )
+        prompts = tuple(
+            _normalize_prompt(prompt)
+            for prompt in await _list_optional_capability(
+                server_name=server_name,
+                capability_name="prompts",
+                list_fn=client.list_prompts,
+            )
+        )
+
+    logger.debug(
+        "Discovered remote MCP server catalog",
+        server_name=server_name,
+        tool_count=len(tools),
+        resource_count=len(resources),
+        prompt_count=len(prompts),
+    )
+
+    return MCPServerCatalog(
+        server_name=server_name,
+        tools=tools,
+        resources=resources,
+        prompts=prompts,
+    )
 
 
 class UserMCPClient:
@@ -96,36 +364,15 @@ class UserMCPClient:
             Dict mapping prefixed tool names to definitions.
 
         """
-        url = config["url"]
-        transport_type: Literal["http", "sse"] = config.get("transport", "http")
-        headers = config.get("headers")
-        timeout = config.get("timeout")
-
-        transport = _create_transport(url, transport_type, headers, timeout)
-        tools: dict[str, MCPToolDefinition] = {}
-
-        async with Client(transport) as client:
-            # List tools from the server
-            server_tools = await client.list_tools()
-
-            for tool in server_tools:
-                # Create prefixed tool name: mcp__{server_name}__{tool_name}
-                prefixed_name = f"mcp__{server_name}__{tool.name}"
-
-                # Convert MCP tool schema to our format
-                tools[prefixed_name] = MCPToolDefinition(
-                    name=prefixed_name,
-                    description=tool.description or f"Tool from {server_name}",
-                    parameters_json_schema=tool.inputSchema or {},
-                )
-
-                logger.debug(
-                    "Discovered user MCP tool",
-                    server_name=server_name,
-                    tool_name=tool.name,
-                    prefixed_name=prefixed_name,
-                )
-
+        catalog = await discover_mcp_server_catalog(config)
+        tools = catalog.to_tool_definitions()
+        for tool_name in tools:
+            logger.debug(
+                "Discovered user MCP tool",
+                server_name=server_name,
+                tool_name=tool_name.removeprefix(f"mcp__{server_name}__"),
+                prefixed_name=tool_name,
+            )
         return tools
 
     async def call_tool(

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import uuid
 from collections.abc import Sequence
 from typing import cast
@@ -10,8 +9,6 @@ from typing import cast
 from slugify import slugify
 from sqlalchemy import select
 
-from tracecat import config
-from tracecat.agent.common.types import MCPHttpServerConfig
 from tracecat.agent.preset.schemas import AgentPresetCreate, AgentPresetUpdate
 from tracecat.agent.types import (
     AgentConfig,
@@ -22,13 +19,11 @@ from tracecat.audit.logger import audit_log
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentPreset,
-    OAuthIntegration,
 )
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
 from tracecat.expressions.eval import collect_expressions, eval_templated_object
-from tracecat.integrations.enums import MCPAuthType
 from tracecat.integrations.mcp_validation import (
     MCPValidationError,
     validate_mcp_command_config,
@@ -37,7 +32,6 @@ from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets import secrets_manager
-from tracecat.secrets.encryption import decrypt_value
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
 
@@ -218,58 +212,6 @@ class AgentPresetService(BaseWorkspaceService):
                 f"{len(missing_ids)} MCP integrations were not found in this workspace: {missing_str}"
             )
 
-    def _decrypt_mcp_headers(
-        self,
-        *,
-        encrypted_headers: bytes,
-        encryption_key: str,
-        mcp_integration_id: uuid.UUID,
-        mcp_integration_name: str,
-    ) -> dict[str, str] | None:
-        """Decrypt and validate MCP custom headers from encrypted storage."""
-        try:
-            decrypted_bytes = decrypt_value(encrypted_headers, key=encryption_key)
-            custom_credentials_str = decrypted_bytes.decode("utf-8")
-            parsed_headers = json.loads(custom_credentials_str)
-        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as err:
-            logger.warning(
-                "Failed to parse custom credentials for MCP integration %r: %s",
-                mcp_integration_name,
-                str(err),
-                extra={
-                    "workspace_id": str(self.workspace_id),
-                    "mcp_integration_id": str(mcp_integration_id),
-                },
-            )
-            return None
-
-        if not isinstance(parsed_headers, dict):
-            logger.warning(
-                "Custom credentials for MCP integration %r must be a JSON object",
-                mcp_integration_name,
-                extra={
-                    "workspace_id": str(self.workspace_id),
-                    "mcp_integration_id": str(mcp_integration_id),
-                },
-            )
-            return None
-
-        custom_headers: dict[str, str] = {}
-        for key, value in parsed_headers.items():
-            if not isinstance(key, str) or not isinstance(value, str):
-                logger.warning(
-                    "Custom credentials for MCP integration %r must contain string header values",
-                    mcp_integration_name,
-                    extra={
-                        "workspace_id": str(self.workspace_id),
-                        "mcp_integration_id": str(mcp_integration_id),
-                    },
-                )
-                return None
-            custom_headers[key] = value
-
-        return custom_headers
-
     async def _resolve_mcp_integrations(
         self, mcp_integrations: list[str] | None
     ) -> list[MCPServerConfig] | None:
@@ -283,13 +225,6 @@ class AgentPresetService(BaseWorkspaceService):
             mcp_integration.id: mcp_integration
             for mcp_integration in available_mcp_integrations
         }
-
-        # Get encryption key for decrypting custom credentials
-        encryption_key = config.TRACECAT__DB_ENCRYPTION_KEY
-        if not encryption_key:
-            raise TracecatValidationError(
-                "TRACECAT__DB_ENCRYPTION_KEY is not set, cannot resolve MCP integrations"
-            )
 
         mcp_servers: list[MCPServerConfig] = []
 
@@ -391,157 +326,11 @@ class AgentPresetService(BaseWorkspaceService):
                 mcp_servers.append(command_config)
                 continue
 
-            # Handle HTTP-type servers (default)
-            if not mcp_integration.server_uri:
-                logger.warning(
-                    "HTTP-type MCP integration %r has no server_uri specified",
-                    mcp_integration.name,
-                    extra={
-                        "workspace_id": str(self.workspace_id),
-                        "mcp_integration_id": str(mcp_integration.id),
-                    },
-                )
-                continue
-
-            headers: dict[str, str] = {}
-
-            # Resolve headers based on auth type
-            if mcp_integration.auth_type == MCPAuthType.OAUTH2:
-                # OAuth2: Get access token from linked OAuth integration
-                if not mcp_integration.oauth_integration_id:
-                    logger.warning(
-                        "MCP integration %r has OAUTH2 auth type but no oauth_integration_id",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                        },
-                    )
-                    continue
-
-                # Get OAuth integration by ID
-                stmt = select(OAuthIntegration).where(
-                    OAuthIntegration.id == mcp_integration.oauth_integration_id,
-                    OAuthIntegration.workspace_id == self.workspace_id,
-                )
-                result = await self.session.execute(stmt)
-                oauth_integration = result.scalars().first()
-                if not oauth_integration:
-                    logger.warning(
-                        "OAuth integration not found for MCP integration %r",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                            "oauth_integration_id": str(
-                                mcp_integration.oauth_integration_id
-                            ),
-                        },
-                    )
-                    continue
-
-                await integrations_service.refresh_token_if_needed(oauth_integration)
-                access_token = await integrations_service.get_access_token(
-                    oauth_integration
-                )
-                if not access_token:
-                    logger.warning(
-                        "No access token for MCP integration %r (likely disconnected)",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                            "integration_status": oauth_integration.status,
-                        },
-                    )
-                    continue
-
-                token_type = oauth_integration.token_type or "Bearer"
-                headers["Authorization"] = (
-                    f"{token_type} {access_token.get_secret_value()}"
-                )
-
-                if mcp_integration.encrypted_headers:
-                    custom_headers = self._decrypt_mcp_headers(
-                        encrypted_headers=mcp_integration.encrypted_headers,
-                        encryption_key=encryption_key,
-                        mcp_integration_id=mcp_integration.id,
-                        mcp_integration_name=mcp_integration.name,
-                    )
-                    if custom_headers is None:
-                        # OAuth2 additional headers are optional; malformed values should
-                        # not disable the integration when an access token is available.
-                        custom_headers = {}
-
-                    auth_header_keys = [
-                        key
-                        for key in custom_headers
-                        if key.strip().casefold() == "authorization"
-                    ]
-                    if auth_header_keys:
-                        logger.warning(
-                            "Ignoring custom Authorization header variants for OAUTH2 MCP integration %r",
-                            mcp_integration.name,
-                            extra={
-                                "workspace_id": str(self.workspace_id),
-                                "mcp_integration_id": str(mcp_integration.id),
-                                "dropped_header_keys": auth_header_keys,
-                            },
-                        )
-                        for auth_header_key in auth_header_keys:
-                            custom_headers.pop(auth_header_key, None)
-                    headers.update(custom_headers)
-
-            elif mcp_integration.auth_type == MCPAuthType.CUSTOM:
-                # CUSTOM: Decrypt and parse custom credentials (JSON string with headers)
-                if not mcp_integration.encrypted_headers:
-                    logger.warning(
-                        "MCP integration %r has CUSTOM auth type but no encrypted_headers",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                        },
-                    )
-                    continue
-
-                custom_headers = self._decrypt_mcp_headers(
-                    encrypted_headers=mcp_integration.encrypted_headers,
-                    encryption_key=encryption_key,
-                    mcp_integration_id=mcp_integration.id,
-                    mcp_integration_name=mcp_integration.name,
-                )
-                if custom_headers is None:
-                    continue
-                # Merge custom headers (e.g., {"Authorization": "Bearer ...", "X-API-Key": "..."})
-                headers.update(custom_headers)
-
-            elif mcp_integration.auth_type == MCPAuthType.NONE:
-                pass
-
-            else:
-                logger.warning(
-                    "Unknown auth type for MCP integration %r: %s",
-                    mcp_integration.name,
-                    mcp_integration.auth_type,
-                    extra={
-                        "workspace_id": str(self.workspace_id),
-                        "mcp_integration_id": str(mcp_integration.id),
-                        "auth_type": str(mcp_integration.auth_type),
-                    },
-                )
-                continue
-
-            # Build MCP server config
-            http_config: MCPHttpServerConfig = {
-                "type": "http",
-                "name": mcp_integration.name,
-                "url": mcp_integration.server_uri,
-                "headers": headers,
-            }
-            if mcp_integration.timeout is not None:
-                http_config["timeout"] = mcp_integration.timeout
-            mcp_servers.append(http_config)
+            if http_config := await integrations_service.resolve_mcp_http_server_config(
+                mcp_integration=mcp_integration,
+                server_name=mcp_integration.name,
+            ):
+                mcp_servers.append(http_config)
 
         if not mcp_servers:
             raise TracecatValidationError(

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -63,6 +63,10 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.interceptor import SentryInterceptor
     from tracecat.dsl.plugins import TracecatPydanticAIPlugin
+    from tracecat.integrations.mcp_discovery_workflow import (
+        MCPRemoteDiscoveryWorkflow,
+        get_mcp_discovery_activities,
+    )
     from tracecat.logger import logger
 
 
@@ -267,6 +271,9 @@ def get_activities() -> list[Callable[..., object]]:
     # Session management activities
     activities.extend(get_session_activities())
 
+    # Persisted MCP discovery activities
+    activities.extend(get_mcp_discovery_activities())
+
     # Agent executor activity
     activities.append(run_agent_activity)
     activities.append(execute_approved_tools_activity)
@@ -323,7 +330,10 @@ async def main() -> None:
         )
 
         with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
-            workflows: list[type] = [DurableAgentWorkflow]
+            workflows: list[type] = [
+                DurableAgentWorkflow,
+                MCPRemoteDiscoveryWorkflow,
+            ]
 
             async with Worker(
                 client,

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3349,6 +3349,13 @@ class MCPIntegration(TimestampMixin, Base):
         nullable=False,
         doc="Server type: 'http' (HTTP/SSE) or 'stdio' (stdio)",
     )
+    transport: Mapped[str] = mapped_column(
+        String(16),
+        default="http",
+        server_default="http",
+        nullable=False,
+        doc="Transport for remote HTTP MCP servers: 'http' or 'sse'",
+    )
     # HTTP-type server fields
     server_uri: Mapped[str | None] = mapped_column(
         String,

--- a/tracecat/integrations/enums.py
+++ b/tracecat/integrations/enums.py
@@ -38,6 +38,28 @@ class MCPDiscoveryStatus(StrEnum):
     STALE = "stale"
 
 
+class MCPDiscoveryAttemptStatus(StrEnum):
+    """Status of an individual MCP discovery attempt."""
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class MCPDiscoveryTrigger(StrEnum):
+    """Source that initiated an MCP discovery run."""
+
+    CREATE = "create"
+    UPDATE = "update"
+    REFRESH = "refresh"
+
+
+class MCPTransport(StrEnum):
+    """Transport used to connect to a remote MCP server."""
+
+    HTTP = "http"
+    SSE = "sse"
+
+
 class MCPCatalogArtifactType(StrEnum):
     """Supported MCP catalog artifact types."""
 

--- a/tracecat/integrations/mcp_discovery_types.py
+++ b/tracecat/integrations/mcp_discovery_types.py
@@ -1,0 +1,44 @@
+"""Shared types for persisted remote MCP discovery."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+from tracecat.auth.types import Role
+from tracecat.integrations.enums import MCPCatalogArtifactType, MCPDiscoveryTrigger
+
+
+class NormalizedMCPArtifact(BaseModel):
+    """Normalized MCP artifact persisted into the discovery catalog."""
+
+    artifact_type: MCPCatalogArtifactType
+    artifact_ref: str
+    display_name: str | None = None
+    description: str | None = None
+    input_schema: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+    raw_payload: dict[str, Any]
+    content_hash: str
+
+
+class MCPDiscoveryWorkflowArgs(BaseModel):
+    """Arguments for the remote MCP discovery workflow."""
+
+    role: Role
+    mcp_integration_id: uuid.UUID
+    trigger: MCPDiscoveryTrigger
+    started_at: datetime
+
+
+class MCPDiscoveryWorkflowResult(BaseModel):
+    """Result for a remote MCP discovery workflow run."""
+
+    mcp_integration_id: uuid.UUID
+    status: str
+    catalog_version: int | None = None
+    error_code: str | None = None
+    error_summary: str | None = None

--- a/tracecat/integrations/mcp_discovery_workflow.py
+++ b/tracecat/integrations/mcp_discovery_workflow.py
@@ -1,0 +1,55 @@
+"""Temporal workflow for persisted remote MCP discovery."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from temporalio import activity, workflow
+
+from tracecat.contexts import ctx_role
+from tracecat.integrations.mcp_discovery_types import (
+    MCPDiscoveryWorkflowArgs,
+    MCPDiscoveryWorkflowResult,
+)
+
+with workflow.unsafe.imports_passed_through():
+    from tracecat.dsl.common import RETRY_POLICIES
+    from tracecat.integrations.service import IntegrationService
+
+
+@workflow.defn(name="mcp_remote_discovery")
+class MCPRemoteDiscoveryWorkflow:
+    """Workflow wrapper for persisted remote HTTP/SSE MCP discovery."""
+
+    @workflow.run
+    async def run(self, args: MCPDiscoveryWorkflowArgs) -> MCPDiscoveryWorkflowResult:
+        return await workflow.execute_activity(
+            run_remote_mcp_discovery_activity,
+            args,
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        )
+
+
+@activity.defn
+async def run_remote_mcp_discovery_activity(
+    args: MCPDiscoveryWorkflowArgs,
+) -> MCPDiscoveryWorkflowResult:
+    """Run persisted remote MCP discovery and catalog persistence."""
+    ctx_role.set(args.role)
+    async with IntegrationService.with_session(role=args.role) as service:
+        return await service.run_remote_mcp_discovery(
+            mcp_integration_id=args.mcp_integration_id,
+            trigger=args.trigger,
+            started_at=args.started_at,
+        )
+
+
+def get_mcp_discovery_activities() -> list:
+    """Return activities required for remote MCP discovery."""
+    return [run_remote_mcp_discovery_activity]
+
+
+def get_mcp_discovery_workflows() -> list[type]:
+    """Return workflows required for remote MCP discovery."""
+    return [MCPRemoteDiscoveryWorkflow]

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -26,6 +26,7 @@ from tracecat.integrations.enums import (
     IntegrationStatus,
     MCPCatalogArtifactType,
     MCPDiscoveryStatus,
+    MCPTransport,
     OAuthGrantType,
 )
 from tracecat.integrations.providers import all_providers
@@ -92,6 +93,11 @@ def _serialize_mcp_integration(
         description=integration.description,
         slug=integration.slug,
         scope_namespace=integration.scope_namespace,
+        transport=(
+            MCPTransport(integration.transport)
+            if integration.server_type == "http"
+            else None
+        ),
         server_uri=integration.server_uri,
         auth_type=integration.auth_type,
         oauth_integration_id=integration.oauth_integration_id,
@@ -976,6 +982,40 @@ async def update_mcp_integration(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         ) from exc
+
+    catalog_counts = await svc.get_mcp_catalog_counts(
+        mcp_integration_ids=[integration.id]
+    )
+    return _serialize_mcp_integration(
+        integration,
+        counts_by_type=catalog_counts.get(integration.id),
+    )
+
+
+@mcp_router.post("/{mcp_integration_id}/refresh")
+@require_scope("integration:update")
+async def refresh_mcp_integration(
+    *,
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    mcp_integration_id: uuid.UUID,
+) -> MCPIntegrationRead:
+    """Enqueue remote discovery refresh for an HTTP/SSE MCP integration."""
+    svc = IntegrationService(session, role=role)
+    try:
+        integration = await svc.refresh_mcp_integration_discovery(
+            mcp_integration_id=mcp_integration_id
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    if integration is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="MCP integration not found",
+        )
 
     catalog_counts = await svc.get_mcp_catalog_counts(
         mcp_integration_ids=[integration.id]

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -26,6 +26,7 @@ from tracecat.integrations.enums import (
     MCPAuthType,
     MCPCatalogArtifactType,
     MCPDiscoveryStatus,
+    MCPTransport,
     OAuthGrantType,
 )
 from tracecat.integrations.types import MCPServerType
@@ -379,6 +380,10 @@ class MCPHttpIntegrationCreate(_MCPIntegrationCreateBase):
     """Request model for creating an HTTP MCP integration."""
 
     server_type: Literal["http"] = Field(default="http")
+    transport: MCPTransport = Field(
+        default=MCPTransport.HTTP,
+        description="Transport used to connect to the remote MCP server",
+    )
     server_uri: str = Field(
         ..., description="MCP server endpoint URL (required for http type)"
     )
@@ -477,6 +482,7 @@ class MCPIntegrationUpdate(BaseModel):
     description: str | None = Field(default=None, max_length=512)
     # Server type cannot be changed after creation (would require migrating fields)
     # HTTP-type server fields
+    transport: MCPTransport | None = None
     server_uri: str | None = None
     auth_type: MCPAuthType | None = None
     oauth_integration_id: uuid.UUID | None = None
@@ -569,6 +575,7 @@ class MCPIntegrationRead(BaseModel):
     # Server type
     server_type: MCPServerType
     # HTTP-type server fields
+    transport: MCPTransport | None
     server_uri: str | None
     auth_type: MCPAuthType
     oauth_integration_id: UUID4 | None

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1,34 +1,48 @@
 """Service for managing user integrations with external services."""
 
+import hashlib
 import os
 import secrets
 import uuid
 from collections.abc import Sequence
-from datetime import datetime, timedelta
-from typing import cast
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
+import httpx
 import orjson
 from pydantic import SecretStr
 from slugify import slugify
-from sqlalchemy import and_, func, or_, select, update
+from sqlalchemy import and_, func, or_, select, tuple_, update
+from sqlalchemy.dialects.postgresql import insert
 
 from tracecat import config
+from tracecat.agent.common.types import MCPHttpServerConfig
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentPreset,
     MCPIntegration,
     MCPIntegrationCatalogEntry,
+    MCPIntegrationDiscoveryAttempt,
     OAuthIntegration,
     WorkspaceOAuthProvider,
 )
+from tracecat.dsl.client import get_temporal_client
 from tracecat.identifiers import UserID
 from tracecat.integrations.enums import (
     MCPAuthType,
     MCPCatalogArtifactType,
+    MCPDiscoveryAttemptStatus,
     MCPDiscoveryStatus,
+    MCPDiscoveryTrigger,
+    MCPTransport,
     OAuthGrantType,
+)
+from tracecat.integrations.mcp_discovery_types import (
+    MCPDiscoveryWorkflowArgs,
+    MCPDiscoveryWorkflowResult,
+    NormalizedMCPArtifact,
 )
 from tracecat.integrations.mcp_validation import (
     MAX_SERVER_NAME_LENGTH,
@@ -1075,6 +1089,7 @@ class IntegrationService(BaseWorkspaceService):
                 server_uri=provider_impl.mcp_server_uri,
                 auth_type=MCPAuthType.OAUTH2,
                 oauth_integration_id=integration.id,
+                transport=MCPTransport.HTTP.value,
                 discovery_status=MCPDiscoveryStatus.PENDING.value,
                 catalog_version=0,
                 sandbox_allow_network=False,
@@ -1089,6 +1104,10 @@ class IntegrationService(BaseWorkspaceService):
                 provider=provider_key.id,
                 oauth_integration_id=integration.id,
             )
+            await self.enqueue_mcp_http_discovery(
+                mcp_integration_id=mcp_integration.id,
+                trigger=MCPDiscoveryTrigger.CREATE,
+            )
         else:
             # Update existing MCP integration to ensure it references the OAuth integration
             if mcp_integration.oauth_integration_id != integration.id:
@@ -1100,6 +1119,12 @@ class IntegrationService(BaseWorkspaceService):
                     "Updated MCP integration OAuth reference",
                     mcp_integration_id=mcp_integration.id,
                     oauth_integration_id=integration.id,
+                )
+
+            if mcp_integration.server_type == "http":
+                await self.enqueue_mcp_http_discovery(
+                    mcp_integration_id=mcp_integration.id,
+                    trigger=MCPDiscoveryTrigger.UPDATE,
                 )
 
     async def _generate_mcp_integration_slug(
@@ -1160,6 +1185,626 @@ class IntegrationService(BaseWorkspaceService):
             if not await self._mcp_scope_namespace_taken(candidate):
                 return candidate
 
+    async def _get_mcp_integration_for_update(
+        self, *, mcp_integration_id: uuid.UUID
+    ) -> MCPIntegration | None:
+        """Lock and return an MCP integration for serialized discovery writes."""
+        statement = (
+            select(MCPIntegration)
+            .where(
+                MCPIntegration.id == mcp_integration_id,
+                MCPIntegration.workspace_id == self.workspace_id,
+            )
+            .with_for_update()
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().first()
+
+    @staticmethod
+    def _build_mcp_artifact_key(
+        *,
+        artifact_type: MCPCatalogArtifactType,
+        artifact_ref: str,
+        display_name: str | None,
+    ) -> str:
+        """Build the stable per-integration artifact key."""
+        slug_source = display_name or artifact_ref
+        prefix = slugify(slug_source, separator="-")[:48].rstrip("-")
+        if not prefix:
+            prefix = artifact_type.value
+        digest = hashlib.sha256(
+            f"{artifact_type.value}\n{artifact_ref}".encode()
+        ).hexdigest()[:10]
+        return f"{prefix}-{digest}"
+
+    @staticmethod
+    def _build_mcp_artifact_search_text(
+        *,
+        artifact_ref: str,
+        display_name: str | None,
+        description: str | None,
+    ) -> str:
+        return "\n".join(
+            part for part in (display_name, artifact_ref, description) if part
+        )
+
+    @staticmethod
+    def _build_mcp_artifact_counts(
+        artifacts: Sequence[NormalizedMCPArtifact],
+    ) -> dict[str, int]:
+        counts = {artifact_type.value: 0 for artifact_type in MCPCatalogArtifactType}
+        for artifact in artifacts:
+            counts[artifact.artifact_type.value] += 1
+        return counts
+
+    def _decrypt_mcp_headers(
+        self, *, mcp_integration: MCPIntegration
+    ) -> dict[str, str] | None:
+        """Decrypt and validate stored MCP custom headers."""
+        if not mcp_integration.encrypted_headers:
+            return None
+        if not is_set(mcp_integration.encrypted_headers):
+            return None
+        if not (decrypted := self._decrypt_token(mcp_integration.encrypted_headers)):
+            return None
+
+        try:
+            parsed_headers = orjson.loads(decrypted)
+        except orjson.JSONDecodeError as err:
+            self.logger.warning(
+                "Failed to parse custom credentials for MCP integration",
+                mcp_integration_id=mcp_integration.id,
+                error=str(err),
+            )
+            return None
+
+        if not isinstance(parsed_headers, dict):
+            self.logger.warning(
+                "Custom credentials for MCP integration must be a JSON object",
+                mcp_integration_id=mcp_integration.id,
+            )
+            return None
+
+        custom_headers: dict[str, str] = {}
+        for key, value in parsed_headers.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                self.logger.warning(
+                    "Custom credentials for MCP integration must contain string header values",
+                    mcp_integration_id=mcp_integration.id,
+                )
+                return None
+            custom_headers[key] = value
+        return custom_headers
+
+    @require_scope("integration:read")
+    async def resolve_mcp_http_server_config(
+        self,
+        *,
+        mcp_integration: MCPIntegration,
+        server_name: str | None = None,
+    ) -> MCPHttpServerConfig | None:
+        """Resolve a stored HTTP/SSE MCP integration into a live client config."""
+        if mcp_integration.server_type != "http":
+            return None
+        if not mcp_integration.server_uri:
+            self.logger.warning(
+                "HTTP-type MCP integration has no server URI",
+                mcp_integration_id=mcp_integration.id,
+            )
+            return None
+
+        headers: dict[str, str] = {}
+
+        match mcp_integration.auth_type:
+            case MCPAuthType.OAUTH2:
+                oauth_integration_id = mcp_integration.oauth_integration_id
+                if oauth_integration_id is None:
+                    self.logger.warning(
+                        "OAUTH2 MCP integration has no linked OAuth integration",
+                        mcp_integration_id=mcp_integration.id,
+                    )
+                    return None
+
+                stmt = select(OAuthIntegration).where(
+                    OAuthIntegration.id == oauth_integration_id,
+                    OAuthIntegration.workspace_id == self.workspace_id,
+                )
+                result = await self.session.execute(stmt)
+                oauth_integration = result.scalars().first()
+                if oauth_integration is None:
+                    self.logger.warning(
+                        "OAuth integration not found for MCP integration",
+                        mcp_integration_id=mcp_integration.id,
+                        oauth_integration_id=oauth_integration_id,
+                    )
+                    return None
+
+                await self.refresh_token_if_needed(oauth_integration)
+                access_token = await self.get_access_token(oauth_integration)
+                if access_token is None:
+                    self.logger.warning(
+                        "No access token available for MCP integration",
+                        mcp_integration_id=mcp_integration.id,
+                        oauth_integration_id=oauth_integration_id,
+                    )
+                    return None
+
+                token_type = oauth_integration.token_type or "Bearer"
+                headers["Authorization"] = (
+                    f"{token_type} {access_token.get_secret_value()}"
+                )
+
+                custom_headers = self._decrypt_mcp_headers(
+                    mcp_integration=mcp_integration
+                )
+                if custom_headers is None:
+                    custom_headers = {}
+
+                auth_header_keys = [
+                    key
+                    for key in custom_headers
+                    if key.strip().casefold() == "authorization"
+                ]
+                for auth_header_key in auth_header_keys:
+                    custom_headers.pop(auth_header_key, None)
+                headers.update(custom_headers)
+
+            case MCPAuthType.CUSTOM:
+                custom_headers = self._decrypt_mcp_headers(
+                    mcp_integration=mcp_integration
+                )
+                if custom_headers is None:
+                    self.logger.warning(
+                        "CUSTOM MCP integration has invalid stored credentials",
+                        mcp_integration_id=mcp_integration.id,
+                    )
+                    return None
+                headers.update(custom_headers)
+
+            case MCPAuthType.NONE:
+                pass
+
+            case _:
+                self.logger.warning(
+                    "Unknown auth type for MCP integration",
+                    mcp_integration_id=mcp_integration.id,
+                    auth_type=str(mcp_integration.auth_type),
+                )
+                return None
+
+        http_config: MCPHttpServerConfig = {
+            "type": "http",
+            "name": server_name or mcp_integration.name,
+            "url": mcp_integration.server_uri,
+            "transport": MCPTransport(mcp_integration.transport).value,
+            "headers": headers,
+        }
+        if mcp_integration.timeout is not None:
+            http_config["timeout"] = mcp_integration.timeout
+        return http_config
+
+    async def _integration_has_active_catalog(
+        self, *, mcp_integration_id: uuid.UUID
+    ) -> bool:
+        statement = select(MCPIntegrationCatalogEntry.id).where(
+            MCPIntegrationCatalogEntry.workspace_id == self.workspace_id,
+            MCPIntegrationCatalogEntry.mcp_integration_id == mcp_integration_id,
+            MCPIntegrationCatalogEntry.is_active.is_(True),
+        )
+        result = await self.session.execute(statement.limit(1))
+        return result.scalar_one_or_none() is not None
+
+    async def _insert_mcp_discovery_attempt(
+        self,
+        *,
+        mcp_integration_id: uuid.UUID,
+        trigger: MCPDiscoveryTrigger,
+        status: MCPDiscoveryAttemptStatus,
+        started_at: datetime,
+        finished_at: datetime,
+        catalog_version: int | None = None,
+        artifact_counts: dict[str, int] | None = None,
+        error_code: str | None = None,
+        error_summary: str | None = None,
+        error_details: dict[str, Any] | None = None,
+    ) -> None:
+        duration_ms = int((finished_at - started_at).total_seconds() * 1000)
+        self.session.add(
+            MCPIntegrationDiscoveryAttempt(
+                mcp_integration_id=mcp_integration_id,
+                workspace_id=self.workspace_id,
+                trigger=trigger.value,
+                status=status.value,
+                catalog_version=catalog_version,
+                started_at=started_at,
+                finished_at=finished_at,
+                duration_ms=duration_ms,
+                artifact_counts=artifact_counts,
+                error_code=error_code,
+                error_summary=error_summary,
+                error_details=error_details,
+            )
+        )
+
+    async def persist_mcp_remote_discovery_success(
+        self,
+        *,
+        mcp_integration_id: uuid.UUID,
+        trigger: MCPDiscoveryTrigger,
+        started_at: datetime,
+        finished_at: datetime,
+        artifacts: Sequence[NormalizedMCPArtifact],
+    ) -> MCPIntegration:
+        """Persist a successful remote MCP discovery run."""
+        mcp_integration = await self._get_mcp_integration_for_update(
+            mcp_integration_id=mcp_integration_id
+        )
+        if mcp_integration is None:
+            raise ValueError("MCP integration not found")
+
+        artifact_counts = self._build_mcp_artifact_counts(artifacts)
+        if (
+            mcp_integration.last_discovery_attempt_at is not None
+            and mcp_integration.last_discovery_attempt_at > started_at
+        ):
+            await self._insert_mcp_discovery_attempt(
+                mcp_integration_id=mcp_integration_id,
+                trigger=trigger,
+                status=MCPDiscoveryAttemptStatus.SUCCEEDED,
+                started_at=started_at,
+                finished_at=finished_at,
+                catalog_version=None,
+                artifact_counts=artifact_counts,
+            )
+            await self.session.commit()
+            await self.session.refresh(mcp_integration)
+            return mcp_integration
+
+        catalog_version = mcp_integration.catalog_version + 1
+        upsert_rows: list[dict[str, Any]] = []
+        active_pairs: list[tuple[str, str]] = []
+        for artifact in artifacts:
+            artifact_key = self._build_mcp_artifact_key(
+                artifact_type=artifact.artifact_type,
+                artifact_ref=artifact.artifact_ref,
+                display_name=artifact.display_name,
+            )
+            active_pairs.append((artifact.artifact_type.value, artifact_key))
+            upsert_rows.append(
+                {
+                    "mcp_integration_id": mcp_integration_id,
+                    "workspace_id": self.workspace_id,
+                    "integration_name": mcp_integration.name,
+                    "artifact_type": artifact.artifact_type.value,
+                    "artifact_key": artifact_key,
+                    "artifact_ref": artifact.artifact_ref,
+                    "display_name": artifact.display_name,
+                    "description": artifact.description,
+                    "input_schema": artifact.input_schema,
+                    "metadata": artifact.metadata,
+                    "raw_payload": artifact.raw_payload,
+                    "content_hash": artifact.content_hash,
+                    "is_active": True,
+                    "search_vector": func.to_tsvector(
+                        "simple",
+                        self._build_mcp_artifact_search_text(
+                            artifact_ref=artifact.artifact_ref,
+                            display_name=artifact.display_name,
+                            description=artifact.description,
+                        ),
+                    ),
+                }
+            )
+
+        if upsert_rows:
+            catalog_table = cast(Any, MCPIntegrationCatalogEntry.__table__)
+            upsert_stmt = insert(catalog_table).values(upsert_rows)
+            metadata_column = catalog_table.c["metadata"]
+            await self.session.execute(
+                upsert_stmt.on_conflict_do_update(
+                    index_elements=[
+                        catalog_table.c.mcp_integration_id,
+                        catalog_table.c.artifact_type,
+                        catalog_table.c.artifact_key,
+                    ],
+                    set_={
+                        "workspace_id": upsert_stmt.excluded.workspace_id,
+                        "integration_name": upsert_stmt.excluded.integration_name,
+                        "artifact_ref": upsert_stmt.excluded.artifact_ref,
+                        "display_name": upsert_stmt.excluded.display_name,
+                        "description": upsert_stmt.excluded.description,
+                        "input_schema": upsert_stmt.excluded.input_schema,
+                        metadata_column: upsert_stmt.excluded["metadata"],
+                        "raw_payload": upsert_stmt.excluded.raw_payload,
+                        "content_hash": upsert_stmt.excluded.content_hash,
+                        "is_active": True,
+                        "search_vector": upsert_stmt.excluded.search_vector,
+                        "updated_at": func.now(),
+                    },
+                )
+            )
+
+        deactivate_stmt = (
+            update(MCPIntegrationCatalogEntry)
+            .where(
+                MCPIntegrationCatalogEntry.workspace_id == self.workspace_id,
+                MCPIntegrationCatalogEntry.mcp_integration_id == mcp_integration_id,
+                MCPIntegrationCatalogEntry.is_active.is_(True),
+            )
+            .values(is_active=False, updated_at=func.now())
+        )
+        if active_pairs:
+            deactivate_stmt = deactivate_stmt.where(
+                tuple_(
+                    MCPIntegrationCatalogEntry.artifact_type,
+                    MCPIntegrationCatalogEntry.artifact_key,
+                ).not_in(active_pairs)
+            )
+        await self.session.execute(deactivate_stmt)
+
+        mcp_integration.catalog_version = catalog_version
+        mcp_integration.discovery_status = MCPDiscoveryStatus.SUCCEEDED.value
+        mcp_integration.last_discovered_at = finished_at
+        mcp_integration.last_discovery_error_code = None
+        mcp_integration.last_discovery_error_summary = None
+        self.session.add(mcp_integration)
+        await self._insert_mcp_discovery_attempt(
+            mcp_integration_id=mcp_integration_id,
+            trigger=trigger,
+            status=MCPDiscoveryAttemptStatus.SUCCEEDED,
+            started_at=started_at,
+            finished_at=finished_at,
+            catalog_version=catalog_version,
+            artifact_counts=artifact_counts,
+        )
+        await self.session.commit()
+        await self.session.refresh(mcp_integration)
+        return mcp_integration
+
+    def _redact_mcp_discovery_error(
+        self,
+        *,
+        exc: Exception,
+        has_active_catalog: bool,
+    ) -> tuple[str, str, MCPDiscoveryStatus, dict[str, Any]]:
+        """Map internal discovery failures to user-safe persisted state."""
+        discovery_status = (
+            MCPDiscoveryStatus.STALE
+            if has_active_catalog
+            else MCPDiscoveryStatus.FAILED
+        )
+        details: dict[str, Any] = {
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+
+        if isinstance(exc, httpx.TimeoutException):
+            return (
+                "timeout",
+                "Timed out while discovering MCP artifacts.",
+                discovery_status,
+                details,
+            )
+        if isinstance(exc, httpx.HTTPError):
+            return (
+                "connection_error",
+                "Could not connect to the MCP server.",
+                discovery_status,
+                details,
+            )
+        if isinstance(exc, ValueError):
+            return (
+                "invalid_config",
+                "The MCP integration configuration is incomplete.",
+                discovery_status,
+                details,
+            )
+        return (
+            "unexpected_error",
+            "Unexpected error during MCP discovery.",
+            discovery_status,
+            details,
+        )
+
+    async def persist_mcp_remote_discovery_failure(
+        self,
+        *,
+        mcp_integration_id: uuid.UUID,
+        trigger: MCPDiscoveryTrigger,
+        started_at: datetime,
+        finished_at: datetime,
+        exc: Exception,
+    ) -> MCPIntegration:
+        """Persist a failed remote MCP discovery run without touching active rows."""
+        mcp_integration = await self._get_mcp_integration_for_update(
+            mcp_integration_id=mcp_integration_id
+        )
+        if mcp_integration is None:
+            raise ValueError("MCP integration not found")
+
+        has_active_catalog = await self._integration_has_active_catalog(
+            mcp_integration_id=mcp_integration_id
+        )
+        error_code, error_summary, discovery_status, error_details = (
+            self._redact_mcp_discovery_error(
+                exc=exc, has_active_catalog=has_active_catalog
+            )
+        )
+
+        if (
+            mcp_integration.last_discovery_attempt_at is None
+            or mcp_integration.last_discovery_attempt_at <= started_at
+        ):
+            mcp_integration.discovery_status = discovery_status.value
+            mcp_integration.last_discovery_error_code = error_code
+            mcp_integration.last_discovery_error_summary = error_summary
+            self.session.add(mcp_integration)
+
+        await self._insert_mcp_discovery_attempt(
+            mcp_integration_id=mcp_integration_id,
+            trigger=trigger,
+            status=MCPDiscoveryAttemptStatus.FAILED,
+            started_at=started_at,
+            finished_at=finished_at,
+            catalog_version=None,
+            error_code=error_code,
+            error_summary=error_summary,
+            error_details=error_details,
+        )
+        await self.session.commit()
+        await self.session.refresh(mcp_integration)
+        return mcp_integration
+
+    async def enqueue_mcp_http_discovery(
+        self,
+        *,
+        mcp_integration_id: uuid.UUID,
+        trigger: MCPDiscoveryTrigger,
+    ) -> MCPIntegration:
+        """Schedule persisted discovery for a remote HTTP/SSE MCP integration."""
+        mcp_integration = await self.get_mcp_integration(
+            mcp_integration_id=mcp_integration_id
+        )
+        if mcp_integration is None:
+            raise ValueError("MCP integration not found")
+        if mcp_integration.server_type != "http":
+            raise ValueError("Only HTTP/SSE MCP integrations support remote discovery")
+
+        started_at = datetime.now(UTC)
+        mcp_integration.discovery_status = MCPDiscoveryStatus.PENDING.value
+        mcp_integration.last_discovery_attempt_at = started_at
+        self.session.add(mcp_integration)
+        await self.session.commit()
+        await self.session.refresh(mcp_integration)
+
+        workflow_args = MCPDiscoveryWorkflowArgs(
+            role=self.role,
+            mcp_integration_id=mcp_integration_id,
+            trigger=trigger,
+            started_at=started_at,
+        )
+        workflow_id = f"mcp-remote-discovery-{mcp_integration_id}-{started_at.strftime('%Y%m%d%H%M%S%f')}"
+
+        try:
+            client = await get_temporal_client()
+            await client.start_workflow(
+                "mcp_remote_discovery",
+                workflow_args,
+                id=workflow_id,
+                task_queue=config.TRACECAT__AGENT_QUEUE,
+                execution_timeout=timedelta(minutes=10),
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to enqueue remote MCP discovery",
+                mcp_integration_id=mcp_integration_id,
+                trigger=trigger.value,
+                error=str(exc),
+            )
+            return await self.persist_mcp_remote_discovery_failure(
+                mcp_integration_id=mcp_integration_id,
+                trigger=trigger,
+                started_at=started_at,
+                finished_at=datetime.now(UTC),
+                exc=exc,
+            )
+
+        return mcp_integration
+
+    @require_scope("integration:update")
+    async def refresh_mcp_integration_discovery(
+        self, *, mcp_integration_id: uuid.UUID
+    ) -> MCPIntegration | None:
+        """Enqueue a remote discovery refresh for an HTTP/SSE MCP integration."""
+        mcp_integration = await self.get_mcp_integration(
+            mcp_integration_id=mcp_integration_id
+        )
+        if mcp_integration is None:
+            return None
+        return await self.enqueue_mcp_http_discovery(
+            mcp_integration_id=mcp_integration_id,
+            trigger=MCPDiscoveryTrigger.REFRESH,
+        )
+
+    async def run_remote_mcp_discovery(
+        self,
+        *,
+        mcp_integration_id: uuid.UUID,
+        trigger: MCPDiscoveryTrigger,
+        started_at: datetime,
+    ) -> MCPDiscoveryWorkflowResult:
+        """Discover and persist the catalog for a remote HTTP/SSE MCP integration."""
+        from tracecat.agent.mcp import user_client
+
+        mcp_integration = await self.get_mcp_integration(
+            mcp_integration_id=mcp_integration_id
+        )
+        if mcp_integration is None:
+            raise ValueError("MCP integration not found")
+
+        http_config = await self.resolve_mcp_http_server_config(
+            mcp_integration=mcp_integration,
+            server_name=mcp_integration.scope_namespace,
+        )
+        if http_config is None:
+            updated = await self.persist_mcp_remote_discovery_failure(
+                mcp_integration_id=mcp_integration_id,
+                trigger=trigger,
+                started_at=started_at,
+                finished_at=datetime.now(UTC),
+                exc=ValueError("MCP integration could not be resolved for discovery"),
+            )
+            return MCPDiscoveryWorkflowResult(
+                mcp_integration_id=mcp_integration_id,
+                status=updated.discovery_status,
+                catalog_version=updated.catalog_version,
+                error_code=updated.last_discovery_error_code,
+                error_summary=updated.last_discovery_error_summary,
+            )
+
+        try:
+            raw_catalog: object = await user_client.discover_mcp_server_catalog(
+                http_config
+            )
+            if isinstance(raw_catalog, dict):
+                raw_artifacts = raw_catalog.get("artifacts", [])
+            else:
+                raw_artifacts = cast("Sequence[object]", raw_catalog.artifacts)
+
+            artifacts = [
+                artifact
+                if isinstance(artifact, NormalizedMCPArtifact)
+                else NormalizedMCPArtifact.model_validate(artifact)
+                for artifact in raw_artifacts
+            ]
+            updated = await self.persist_mcp_remote_discovery_success(
+                mcp_integration_id=mcp_integration_id,
+                trigger=trigger,
+                started_at=started_at,
+                finished_at=datetime.now(UTC),
+                artifacts=artifacts,
+            )
+            return MCPDiscoveryWorkflowResult(
+                mcp_integration_id=mcp_integration_id,
+                status=updated.discovery_status,
+                catalog_version=updated.catalog_version,
+            )
+        except Exception as exc:
+            updated = await self.persist_mcp_remote_discovery_failure(
+                mcp_integration_id=mcp_integration_id,
+                trigger=trigger,
+                started_at=started_at,
+                finished_at=datetime.now(UTC),
+                exc=exc,
+            )
+            return MCPDiscoveryWorkflowResult(
+                mcp_integration_id=mcp_integration_id,
+                status=updated.discovery_status,
+                catalog_version=updated.catalog_version,
+                error_code=updated.last_discovery_error_code,
+                error_summary=updated.last_discovery_error_summary,
+            )
+
     @require_scope("integration:create")
     async def create_mcp_integration(
         self, *, params: MCPIntegrationCreate
@@ -1175,6 +1820,7 @@ class IntegrationService(BaseWorkspaceService):
         stdio_command: str | None = None
         stdio_args: list[str] | None = None
         encrypted_stdio_env: bytes | None = None
+        transport = MCPTransport.HTTP
 
         if params.server_type == "http":
             # Validate OAuth integration if auth_type is oauth2
@@ -1195,6 +1841,7 @@ class IntegrationService(BaseWorkspaceService):
                     )
 
             server_uri = params.server_uri.strip()
+            transport = params.transport
             auth_type = params.auth_type
             oauth_integration_id = params.oauth_integration_id
             if (
@@ -1230,6 +1877,7 @@ class IntegrationService(BaseWorkspaceService):
             oauth_integration_id=oauth_integration_id,
             encrypted_headers=encrypted_custom_credentials,  # Reuse field for custom credentials
             server_type=params.server_type,
+            transport=transport.value,
             stdio_command=stdio_command,
             stdio_args=stdio_args,
             encrypted_stdio_env=encrypted_stdio_env,
@@ -1251,6 +1899,11 @@ class IntegrationService(BaseWorkspaceService):
             server_type=params.server_type,
         )
 
+        if params.server_type == "http":
+            return await self.enqueue_mcp_http_discovery(
+                mcp_integration_id=mcp_integration.id,
+                trigger=MCPDiscoveryTrigger.CREATE,
+            )
         return mcp_integration
 
     async def list_mcp_integrations(self) -> Sequence[MCPIntegration]:
@@ -1347,6 +2000,8 @@ class IntegrationService(BaseWorkspaceService):
             )
         if params.server_uri is not None:
             mcp_integration.server_uri = params.server_uri.strip()
+        if params.transport is not None and mcp_integration.server_type == "http":
+            mcp_integration.transport = params.transport.value
         if params.auth_type is not None:
             mcp_integration.auth_type = params.auth_type
         if params.oauth_integration_id is not None:
@@ -1415,6 +2070,11 @@ class IntegrationService(BaseWorkspaceService):
             mcp_integration_id=mcp_integration.id,
         )
 
+        if mcp_integration.server_type == "http":
+            return await self.enqueue_mcp_http_discovery(
+                mcp_integration_id=mcp_integration.id,
+                trigger=MCPDiscoveryTrigger.UPDATE,
+            )
         return mcp_integration
 
     @require_scope("integration:delete")

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1205,11 +1205,9 @@ class IntegrationService(BaseWorkspaceService):
         *,
         artifact_type: MCPCatalogArtifactType,
         artifact_ref: str,
-        display_name: str | None,
     ) -> str:
         """Build the stable per-integration artifact key."""
-        slug_source = display_name or artifact_ref
-        prefix = slugify(slug_source, separator="-")[:48].rstrip("-")
+        prefix = slugify(artifact_ref, separator="-")[:48].rstrip("-")
         if not prefix:
             prefix = artifact_type.value
         digest = hashlib.sha256(
@@ -1467,7 +1465,6 @@ class IntegrationService(BaseWorkspaceService):
             artifact_key = self._build_mcp_artifact_key(
                 artifact_type=artifact.artifact_type,
                 artifact_ref=artifact.artifact_ref,
-                display_name=artifact.display_name,
             )
             active_pairs.append((artifact.artifact_type.value, artifact_key))
             upsert_rows.append(
@@ -1742,27 +1739,13 @@ class IntegrationService(BaseWorkspaceService):
         if mcp_integration is None:
             raise ValueError("MCP integration not found")
 
-        http_config = await self.resolve_mcp_http_server_config(
-            mcp_integration=mcp_integration,
-            server_name=mcp_integration.scope_namespace,
-        )
-        if http_config is None:
-            updated = await self.persist_mcp_remote_discovery_failure(
-                mcp_integration_id=mcp_integration_id,
-                trigger=trigger,
-                started_at=started_at,
-                finished_at=datetime.now(UTC),
-                exc=ValueError("MCP integration could not be resolved for discovery"),
-            )
-            return MCPDiscoveryWorkflowResult(
-                mcp_integration_id=mcp_integration_id,
-                status=updated.discovery_status,
-                catalog_version=updated.catalog_version,
-                error_code=updated.last_discovery_error_code,
-                error_summary=updated.last_discovery_error_summary,
-            )
-
         try:
+            http_config = await self.resolve_mcp_http_server_config(
+                mcp_integration=mcp_integration,
+                server_name=mcp_integration.scope_namespace,
+            )
+            if http_config is None:
+                raise ValueError("MCP integration could not be resolved for discovery")
             raw_catalog: object = await user_client.discover_mcp_server_catalog(
                 http_config
             )


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds remote MCP discovery refresh with a Temporal workflow and a POST refresh endpoint for HTTP/SSE integrations. Persists a normalized catalog with content hashes, tracks discovery attempts and triggers, and stabilizes status updates (READY on no change, STALE on failures).

- **New Features**
  - Temporal workflow mcp_remote_discovery with activities registered in the worker.
  - POST /mcp_integrations/{id}/refresh (requires integration:update) to enqueue remote discovery for HTTP/SSE integrations.
  - Normalizes tools/resources/prompts with content hashes; upserts catalog; logs attempts with status and trigger (create/update/refresh); handles HTTP errors; consistent discovery status updates.
  - Transport field for HTTP integrations (http or sse). Enums, API schemas, router, and frontend client updated.
  - Unit tests for the user MCP client, integrations service discovery, and route scope guards.

- **Migration**
  - Adds transport column to mcp_integration with default "http". Run the Alembic migration.
  - No manual steps unless switching existing integrations to SSE.

<sup>Written for commit f123ed2d260dc11daae063f60a63b1c904882c84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

