### PR TITLE
fix: sanitize Temporal payload conversion errors

### DIFF
--- a/tests/unit/test_dsl_converter.py
+++ b/tests/unit/test_dsl_converter.py
@@ -1,0 +1,94 @@
+"""Tests for tracecat.dsl._converter payload sanitization."""
+
+from __future__ import annotations
+
+import temporalio.api.common.v1
+from temporalio.api.common.v1 import Payload
+
+from tracecat.dsl._converter import PydanticORJSONPayloadConverter
+from tracecat.dsl.common import AgentActionMemo
+
+
+class _LeakyValue:
+    def __repr__(self) -> str:
+        return "Bearer secret-token"
+
+    def __str__(self) -> str:
+        return "Bearer secret-token"
+
+
+def test_to_payload_sanitizes_serializer_failures(monkeypatch) -> None:
+    """Encoding failures should not expose the serialized value."""
+
+    def fail_serializer(_obj: object) -> object:
+        raise ValueError("Bearer secret-token")
+
+    monkeypatch.setattr("tracecat.dsl._converter._serializer", fail_serializer)
+
+    converter = PydanticORJSONPayloadConverter()
+
+    try:
+        converter.to_payload(_LeakyValue())
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected to_payload to raise RuntimeError")
+
+    assert message == "Failed to encode payload value of type _LeakyValue"
+    assert "secret-token" not in message
+
+
+def test_from_payload_sanitizes_type_conversion_failures() -> None:
+    """Decode/type conversion failures should not expose payload data."""
+    converter = PydanticORJSONPayloadConverter()
+    payload = Payload(
+        metadata={"encoding": b"json/plain"},
+        data=b'{"token":"Bearer secret-token"}',
+    )
+
+    try:
+        converter.from_payload(payload, int)
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected from_payload to raise RuntimeError")
+
+    assert message == "Failed to decode payload for type int"
+    assert "secret-token" not in message
+
+
+def test_agent_action_memo_logging_omits_raw_payload(
+    monkeypatch,
+) -> None:
+    """Memo parse warnings should not log the full protobuf payload."""
+    warnings: list[dict[str, object]] = []
+
+    def capture_warning(message: str, **kwargs: object) -> None:
+        warnings.append({"message": message, **kwargs})
+
+    def fail_from_payload(_payload: Payload) -> object:
+        raise RuntimeError("decode failure")
+
+    monkeypatch.setattr("tracecat.dsl.common.logger.warning", capture_warning)
+    monkeypatch.setattr(
+        "tracecat.dsl.common._memo_payload_converter.from_payload", fail_from_payload
+    )
+
+    memo = temporalio.api.common.v1.Memo(
+        fields={
+            "action_ref": Payload(
+                metadata={"encoding": b"json/plain"},
+                data=b'{"token":"Bearer secret-token"}',
+            )
+        }
+    )
+
+    AgentActionMemo.from_temporal(memo)
+
+    assert len(warnings) == 1
+    warning = warnings[0]
+    assert warning["message"] == "Error parsing agent action memo field"
+    assert warning["key"] == "action_ref"
+    assert warning["encoding"] == "json/plain"
+    assert warning["payload_size_bytes"] == len(b'{"token":"Bearer secret-token"}')
+    assert "value" not in warning

--- a/tracecat/dsl/_converter.py
+++ b/tracecat/dsl/_converter.py
@@ -9,7 +9,6 @@ from temporalio.converter import (
     DataConverter,
     DefaultPayloadConverter,
     JSONPlainPayloadConverter,
-    value_to_type,
 )
 
 from tracecat.dsl.compression import get_compression_payload_codec
@@ -72,10 +71,7 @@ class PydanticORJSONPayloadConverter(JSONPlainPayloadConverter):
     ) -> Any:
         """Decode payloads without surfacing raw payload data in errors."""
         try:
-            obj = orjson.loads(payload.data)
-            if type_hint is not None:
-                obj = value_to_type(type_hint, obj, self._custom_type_converters)
-            return obj
+            return super().from_payload(payload, type_hint)
         except Exception:
             raise RuntimeError(
                 f"Failed to decode payload for {_format_type_hint(type_hint)}"

--- a/tracecat/dsl/_converter.py
+++ b/tracecat/dsl/_converter.py
@@ -9,6 +9,7 @@ from temporalio.converter import (
     DataConverter,
     DefaultPayloadConverter,
     JSONPlainPayloadConverter,
+    value_to_type,
 )
 
 from tracecat.dsl.compression import get_compression_payload_codec
@@ -26,6 +27,15 @@ def _serializer(obj: Any) -> Any:
     return to_jsonable_python(obj, fallback=str)
 
 
+def _format_type_hint(type_hint: type[Any] | None) -> str:
+    """Return a stable, non-data-bearing label for a payload type hint."""
+    if type_hint is None:
+        return "untyped payload"
+    if name := getattr(type_hint, "__name__", None):
+        return f"type {name}"
+    return f"type {type_hint}"
+
+
 class PydanticORJSONPayloadConverter(JSONPlainPayloadConverter):
     """Pydantic ORJSON payload converter.
 
@@ -40,15 +50,36 @@ class PydanticORJSONPayloadConverter(JSONPlainPayloadConverter):
         converter is expected to be the last in the chain, so it can fail if
         unable to convert.
         """
-        # We let JSON conversion errors be thrown to caller
-        return Payload(
-            metadata={"encoding": self.encoding.encode()},
-            data=orjson.dumps(
+        try:
+            data = orjson.dumps(
                 value,
                 default=_serializer,
                 option=orjson.OPT_SORT_KEYS | orjson.OPT_NON_STR_KEYS,
-            ),
+            )
+        except Exception:
+            raise RuntimeError(
+                f"Failed to encode payload value of type {type(value).__name__}"
+            ) from None
+        return Payload(
+            metadata={"encoding": self.encoding.encode()},
+            data=data,
         )
+
+    def from_payload(
+        self,
+        payload: Payload,
+        type_hint: type[Any] | None = None,
+    ) -> Any:
+        """Decode payloads without surfacing raw payload data in errors."""
+        try:
+            obj = orjson.loads(payload.data)
+            if type_hint is not None:
+                obj = value_to_type(type_hint, obj, self._custom_type_converters)
+            return obj
+        except Exception:
+            raise RuntimeError(
+                f"Failed to decode payload for {_format_type_hint(type_hint)}"
+            ) from None
 
 
 class PydanticPayloadConverter(CompositePayloadConverter):

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -1087,7 +1087,10 @@ class AgentActionMemo(BaseModel):
                     "Error parsing agent action memo field",
                     error=e,
                     key=key,
-                    value=value,
+                    encoding=value.metadata.get("encoding", b"").decode(
+                        "utf-8", errors="replace"
+                    ),
+                    payload_size_bytes=len(value.data),
                 )
         if not data.get("action_ref"):
             data["action_ref"] = "unknown_agent_action"


### PR DESCRIPTION
## Summary
- sanitize Temporal payload encode/decode failures so error messages do not include raw payload data
- scrub raw memo payloads from `AgentActionMemo.from_temporal()` warning logs while preserving encoding and payload size for debugging
- add unit tests covering sanitized encode errors, decode/type-conversion errors, and memo log behavior

## Testing
- `uv run pytest tests/unit/test_dsl_converter.py`
- `uv run ruff check tracecat/dsl/_converter.py tracecat/dsl/common.py tests/unit/test_dsl_converter.py`
- `uv run basedpyright tracecat/dsl/_converter.py tracecat/dsl/common.py tests/unit/test_dsl_converter.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes Temporal payload encode/decode errors to avoid leaking raw data in exceptions and logs, while preserving Temporal’s default decode behavior. Also scrubs AgentActionMemo memo warnings while keeping helpful metadata for debugging.

- **Bug Fixes**
  - Wrap payload encode failures and raise a sanitized RuntimeError using the value’s type only.
  - Preserve Temporal JSON decode behavior; only sanitize from_payload errors with messages that reference the type hint, never raw payload data.
  - Memo parsing warnings no longer include raw Payload; they log encoding and payload_size_bytes instead.
  - Added unit tests for encode errors, decode/type conversion errors, and memo logging behavior.

<sup>Written for commit 94643ad9bb9fc2056afb2d04c30b1fc4d33ac855. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

