### PR TITLE
feat(rbac): sync mcp catalog scopes

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
@@ -17,6 +18,8 @@ from tracecat.db.models import (
     Group,
     GroupMember,
     GroupRoleAssignment,
+    MCPIntegration,
+    MCPIntegrationCatalogEntry,
     OrganizationMembership,
     RoleScope,
     Scope,
@@ -33,6 +36,7 @@ from tracecat.exceptions import (
     TracecatValidationError,
 )
 from tracecat.identifiers import WorkspaceID
+from tracecat.integrations.enums import MCPCatalogArtifactType
 from tracecat.service import BaseOrgService
 
 
@@ -153,6 +157,157 @@ class RBACService(BaseOrgService):
 
         await self.session.delete(scope)
         await self.session.commit()
+
+    def _build_mcp_scope_name(
+        self,
+        *,
+        scope_namespace: str,
+        artifact_type: MCPCatalogArtifactType,
+        artifact_key: str,
+    ) -> tuple[str, str, str]:
+        """Build the scope name plus resource/action columns for an MCP artifact."""
+        match artifact_type:
+            case MCPCatalogArtifactType.TOOL:
+                resource = "mcp-tool"
+                action = "execute"
+            case MCPCatalogArtifactType.RESOURCE:
+                resource = "mcp-resource"
+                action = "read"
+            case MCPCatalogArtifactType.PROMPT:
+                resource = "mcp-prompt"
+                action = "use"
+        return (
+            f"{resource}:{scope_namespace}.{artifact_key}:{action}",
+            resource,
+            action,
+        )
+
+    def _build_mcp_scope_description(
+        self,
+        *,
+        integration_name: str,
+        artifact_type: MCPCatalogArtifactType,
+        display_name: str | None,
+        artifact_ref: str,
+        description: str | None,
+    ) -> str:
+        """Build a stable user-facing description for an MCP-derived scope."""
+        artifact_label = display_name or artifact_ref
+        summary = (
+            description.strip()
+            if isinstance(description, str) and (description := description.strip())
+            else None
+        )
+        noun = artifact_type.value
+        if summary is not None:
+            return f"{integration_name} {noun} {artifact_label}: {summary}"[:512]
+        return f"Access {integration_name} {noun} {artifact_label}"[:512]
+
+    async def sync_mcp_integration_scopes(
+        self,
+        *,
+        mcp_integration_id: UUID,
+    ) -> Sequence[Scope]:
+        """Synchronize active MCP catalog entries into org-scoped custom scopes."""
+        integration_stmt = (
+            select(MCPIntegration)
+            .join(Workspace, Workspace.id == MCPIntegration.workspace_id)
+            .where(
+                MCPIntegration.id == mcp_integration_id,
+                Workspace.organization_id == self.organization_id,
+            )
+        )
+        integration_result = await self.session.execute(integration_stmt)
+        mcp_integration = integration_result.scalar_one_or_none()
+        if mcp_integration is None:
+            raise TracecatNotFoundError("MCP integration not found")
+
+        entries_stmt = (
+            select(MCPIntegrationCatalogEntry)
+            .where(
+                MCPIntegrationCatalogEntry.mcp_integration_id == mcp_integration_id,
+                MCPIntegrationCatalogEntry.workspace_id == mcp_integration.workspace_id,
+                MCPIntegrationCatalogEntry.is_active.is_(True),
+            )
+            .order_by(
+                MCPIntegrationCatalogEntry.artifact_type,
+                MCPIntegrationCatalogEntry.artifact_key,
+            )
+        )
+        entries_result = await self.session.execute(entries_stmt)
+        active_entries = entries_result.scalars().all()
+
+        scope_rows: list[dict[str, str | UUID]] = []
+        desired_source_refs: list[str] = []
+        for entry in active_entries:
+            artifact_type = MCPCatalogArtifactType(entry.artifact_type)
+            name, resource, action = self._build_mcp_scope_name(
+                scope_namespace=mcp_integration.scope_namespace,
+                artifact_type=artifact_type,
+                artifact_key=entry.artifact_key,
+            )
+            source_ref = (
+                f"mcp:{mcp_integration.id}:{artifact_type.value}:{entry.artifact_key}"
+            )
+            desired_source_refs.append(source_ref)
+            scope_rows.append(
+                {
+                    "name": name,
+                    "resource": resource,
+                    "action": action,
+                    "description": self._build_mcp_scope_description(
+                        integration_name=mcp_integration.name,
+                        artifact_type=artifact_type,
+                        display_name=entry.display_name,
+                        artifact_ref=entry.artifact_ref,
+                        description=entry.description,
+                    ),
+                    "source": ScopeSource.CUSTOM,
+                    "source_ref": source_ref,
+                    "organization_id": self.organization_id,
+                }
+            )
+
+        if scope_rows:
+            stmt = pg_insert(Scope).values(scope_rows)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["organization_id", "name"],
+                set_={
+                    "resource": stmt.excluded.resource,
+                    "action": stmt.excluded.action,
+                    "description": stmt.excluded.description,
+                    "source": stmt.excluded.source,
+                    "source_ref": stmt.excluded.source_ref,
+                },
+            )
+            await self.session.execute(stmt)
+
+        delete_stmt = delete(Scope).where(
+            Scope.organization_id == self.organization_id,
+            Scope.source == ScopeSource.CUSTOM,
+            Scope.source_ref.like(f"mcp:{mcp_integration.id}:%"),
+        )
+        if desired_source_refs:
+            delete_stmt = delete_stmt.where(
+                Scope.source_ref.not_in(desired_source_refs)
+            )
+        await self.session.execute(delete_stmt)
+        await self.session.commit()
+
+        if not desired_source_refs:
+            return []
+
+        scopes_stmt = (
+            select(Scope)
+            .where(
+                Scope.organization_id == self.organization_id,
+                Scope.source_ref.in_(desired_source_refs),
+            )
+            .execution_options(populate_existing=True)
+            .order_by(Scope.name)
+        )
+        scopes_result = await self.session.execute(scopes_stmt)
+        return scopes_result.scalars().all()
 
     # =========================================================================
     # Role Management

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_ee.rbac.service import RBACService
 
@@ -14,8 +14,11 @@ from tracecat.authz.enums import ScopeSource
 from tracecat.authz.scopes import ORG_ADMIN_SCOPES
 from tracecat.authz.seeding import seed_system_scopes
 from tracecat.db.models import (
+    MCPIntegration,
+    MCPIntegrationCatalogEntry,
     Organization,
     OrganizationMembership,
+    RoleScope,
     Scope,
     User,
     Workspace,
@@ -25,6 +28,7 @@ from tracecat.exceptions import (
     TracecatNotFoundError,
     TracecatValidationError,
 )
+from tracecat.integrations.enums import MCPAuthType, MCPCatalogArtifactType
 
 
 @pytest.fixture
@@ -94,6 +98,67 @@ def role(org: Organization, user: User) -> Role:
         service_id="tracecat-api",
         scopes=ORG_ADMIN_SCOPES,
     )
+
+
+async def _create_mcp_integration(
+    *,
+    session: AsyncSession,
+    workspace: Workspace,
+    name: str = "GitHub MCP",
+    scope_namespace: str = "mcpnamespace0001",
+) -> MCPIntegration:
+    """Insert a test MCP integration for RBAC sync coverage."""
+    integration = MCPIntegration(
+        id=uuid.uuid4(),
+        workspace_id=workspace.id,
+        name=name,
+        description="Test MCP integration",
+        slug=f"{name.lower().replace(' ', '-')}-{uuid.uuid4().hex[:6]}",
+        scope_namespace=scope_namespace,
+        server_type="http",
+        server_uri="https://api.example.com/mcp",
+        auth_type=MCPAuthType.NONE,
+        discovery_status="succeeded",
+        catalog_version=1,
+    )
+    session.add(integration)
+    await session.commit()
+    await session.refresh(integration)
+    return integration
+
+
+async def _insert_catalog_entry(
+    *,
+    session: AsyncSession,
+    integration: MCPIntegration,
+    artifact_type: MCPCatalogArtifactType,
+    artifact_key: str,
+    artifact_ref: str,
+    display_name: str,
+    description: str | None,
+    is_active: bool = True,
+) -> None:
+    """Insert a persisted MCP catalog entry for RBAC sync coverage."""
+    await session.execute(
+        insert(MCPIntegrationCatalogEntry).values(
+            id=uuid.uuid4(),
+            mcp_integration_id=integration.id,
+            workspace_id=integration.workspace_id,
+            integration_name=integration.name,
+            artifact_type=artifact_type.value,
+            artifact_key=artifact_key,
+            artifact_ref=artifact_ref,
+            display_name=display_name,
+            description=description,
+            input_schema={"type": "object"},
+            artifact_metadata={"origin": "test"},
+            raw_payload={"name": artifact_ref},
+            content_hash=artifact_key.ljust(64, "0"),
+            is_active=is_active,
+            search_vector=func.to_tsvector("simple", artifact_ref),
+        )
+    )
+    await session.commit()
 
 
 @pytest.mark.anyio
@@ -181,6 +246,152 @@ class TestRBACServiceScopes:
 
         with pytest.raises(TracecatAuthorizationError):
             await service.delete_scope(system_scope.id)
+
+    async def test_sync_mcp_integration_scopes_creates_custom_scopes(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ) -> None:
+        """Active MCP catalog entries should map to org-scoped custom scopes."""
+        integration = await _create_mcp_integration(
+            session=session,
+            workspace=workspace,
+            scope_namespace="syncscope0000001",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="github.list_repos",
+            display_name="List repos",
+            description="List GitHub repositories",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+            artifact_key="docs-readme-7f8e9d0c1b",
+            artifact_ref="docs://README",
+            display_name="README",
+            description="Read the repository README",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="triage-incident-6a5b4c3d2e",
+            artifact_ref="triage_incident",
+            display_name="Triage incident",
+            description="Guide incident triage",
+        )
+
+        service = RBACService(session, role=role)
+        scopes = await service.sync_mcp_integration_scopes(
+            mcp_integration_id=integration.id
+        )
+
+        assert [scope.name for scope in scopes] == [
+            "mcp-prompt:syncscope0000001.triage-incident-6a5b4c3d2e:use",
+            "mcp-resource:syncscope0000001.docs-readme-7f8e9d0c1b:read",
+            "mcp-tool:syncscope0000001.github-list-repos-a1b2c3d4e5:execute",
+        ]
+        assert {scope.resource for scope in scopes} == {
+            "mcp-tool",
+            "mcp-resource",
+            "mcp-prompt",
+        }
+        assert {scope.action for scope in scopes} == {"execute", "read", "use"}
+        assert all(scope.source == ScopeSource.CUSTOM for scope in scopes)
+        assert all(scope.organization_id == org.id for scope in scopes)
+        assert {scope.source_ref for scope in scopes} == {
+            f"mcp:{integration.id}:tool:github-list-repos-a1b2c3d4e5",
+            f"mcp:{integration.id}:resource:docs-readme-7f8e9d0c1b",
+            f"mcp:{integration.id}:prompt:triage-incident-6a5b4c3d2e",
+        }
+
+    async def test_sync_mcp_integration_scopes_updates_and_deletes_removed_entries(
+        self,
+        session: AsyncSession,
+        role: Role,
+        workspace: Workspace,
+    ) -> None:
+        """Resync should update descriptions and delete removed MCP scopes."""
+        integration = await _create_mcp_integration(
+            session=session,
+            workspace=workspace,
+            scope_namespace="syncscope0000002",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="github.list_repos",
+            display_name="List repos",
+            description="Initial tool description",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="triage-incident-6a5b4c3d2e",
+            artifact_ref="triage_incident",
+            display_name="Triage incident",
+            description="Initial prompt description",
+        )
+
+        service = RBACService(session, role=role)
+        scopes = await service.sync_mcp_integration_scopes(
+            mcp_integration_id=integration.id
+        )
+        tool_scope = next(scope for scope in scopes if scope.resource == "mcp-tool")
+        role_with_scope = await service.create_role(
+            name="MCP Operator",
+            scope_ids=[tool_scope.id],
+        )
+
+        tool_entry_stmt = select(MCPIntegrationCatalogEntry).where(
+            MCPIntegrationCatalogEntry.mcp_integration_id == integration.id,
+            MCPIntegrationCatalogEntry.artifact_type
+            == MCPCatalogArtifactType.TOOL.value,
+        )
+        tool_entry = (await session.execute(tool_entry_stmt)).scalar_one()
+        tool_entry.is_active = False
+
+        prompt_entry_stmt = select(MCPIntegrationCatalogEntry).where(
+            MCPIntegrationCatalogEntry.mcp_integration_id == integration.id,
+            MCPIntegrationCatalogEntry.artifact_type
+            == MCPCatalogArtifactType.PROMPT.value,
+        )
+        prompt_entry = (await session.execute(prompt_entry_stmt)).scalar_one()
+        prompt_entry.description = "Updated prompt description"
+        session.add_all([tool_entry, prompt_entry])
+        await session.commit()
+
+        updated_scopes = await service.sync_mcp_integration_scopes(
+            mcp_integration_id=integration.id
+        )
+
+        assert [scope.name for scope in updated_scopes] == [
+            "mcp-prompt:syncscope0000002.triage-incident-6a5b4c3d2e:use"
+        ]
+        assert updated_scopes[0].description is not None
+        assert "Updated prompt description" in updated_scopes[0].description
+
+        removed_scope = await session.execute(
+            select(Scope).where(Scope.id == tool_scope.id)
+        )
+        assert removed_scope.scalar_one_or_none() is None
+
+        role_scope_count = await session.execute(
+            select(func.count())
+            .select_from(RoleScope)
+            .where(RoleScope.role_id == role_with_scope.id)
+        )
+        assert role_scope_count.scalar_one() == 0
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes MCP catalog entries into org-scoped custom RBAC scopes so permissions track the latest catalog. Upserts scopes for active entries and removes scopes that are no longer active. Implements ENG-1318.

- **New Features**
  - Added RBACService.sync_mcp_integration_scopes(mcp_integration_id) to upsert active MCP-derived scopes and delete obsolete ones, validating the integration belongs to the org.
  - Standardized naming/actions: mcp-tool execute, mcp-resource read, mcp-prompt use; name format: resource:namespace.artifact_key:action; source_ref: mcp:{integration_id}:{type}:{artifact_key}.
  - Auto-generated descriptions from integration and artifact metadata; Postgres upsert on (organization_id, name); stale scopes for the integration are removed by source_ref and RoleScope links are cleared via cascade.

<sup>Written for commit 6ff89a387ff0d7aa6e1d87bed0d21783ff49c54f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

