### PR TITLE
feat(mcp): add refresh-scope retry and 1h token fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,10 @@ OIDC_SCOPES="openid profile email"
 
 # MCP server (external IDE integrations)
 TRACECAT_MCP__BASE_URL=http://localhost:8099
+# MCP OAuth behavior:
+# - Requests `offline_access` by default to obtain refresh tokens when supported.
+# - If upstream rejects that scope (invalid_scope), retries once without it.
+# - If upstream omits `expires_in`, access token fallback TTL is 3600s (1 hour).
 TRACECAT_MCP__STARTUP_MAX_ATTEMPTS=3
 TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS=2
 

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -8,6 +8,18 @@ import pytest
 from tracecat.mcp import auth as mcp_auth
 
 
+def _mock_oidc_discovery_config(
+    *, scopes_supported: list[str] | None = None
+) -> MagicMock:
+    config = MagicMock()
+    config.issuer = "https://issuer.example.com"
+    config.authorization_endpoint = "https://issuer.example.com/oauth2/authorize"
+    config.token_endpoint = "https://issuer.example.com/oauth2/token"
+    config.jwks_uri = "https://issuer.example.com/.well-known/jwks.json"
+    config.scopes_supported = scopes_supported
+    return config
+
+
 def test_oidc_consent_html_escapes_values() -> None:
     page = mcp_auth._build_oidc_consent_html(
         client_id='client-"one"',
@@ -46,12 +58,13 @@ def test_create_mcp_auth_uses_oidc_mode(
         patch.object(
             mcp_auth.OIDCProxy,
             "get_oidc_configuration",
-            return_value=MagicMock(),
+            return_value=_mock_oidc_discovery_config(),
         ),
     ):
         auth = mcp_auth.create_mcp_auth()
 
     assert isinstance(auth, mcp_auth.OIDCProxy)
+    assert getattr(auth, "_fallback_access_token_expiry_seconds", None) == 3600
 
 
 def test_create_mcp_auth_raises_when_base_url_missing(
@@ -86,6 +99,37 @@ def test_create_mcp_auth_raises_when_oidc_issuer_missing(
             match="OIDC_ISSUER must be configured for the MCP server",
         ):
             mcp_auth.create_mcp_auth()
+
+
+def test_append_scope_if_missing_adds_unique_scope() -> None:
+    scopes = ["openid", "profile"]
+    assert mcp_auth.append_scope_if_missing(scopes, "offline_access") == [
+        "openid",
+        "profile",
+        "offline_access",
+    ]
+
+
+def test_append_scope_if_missing_does_not_duplicate_scope() -> None:
+    scopes = ["openid", "offline_access"]
+    assert mcp_auth.append_scope_if_missing(scopes, "offline_access") == scopes
+
+
+def test_remove_scope_removes_only_target_scope() -> None:
+    scopes = ["openid", "offline_access", "email"]
+    assert mcp_auth.remove_scope(scopes, "offline_access") == ["openid", "email"]
+
+
+def test_supports_refresh_scope_when_provider_metadata_missing() -> None:
+    assert mcp_auth.supports_refresh_scope(None) is True
+
+
+def test_supports_refresh_scope_when_scope_supported() -> None:
+    assert mcp_auth.supports_refresh_scope(["openid", "offline_access"]) is True
+
+
+def test_supports_refresh_scope_when_scope_not_supported() -> None:
+    assert mcp_auth.supports_refresh_scope(["openid", "profile", "email"]) is False
 
 
 def test_get_token_identity_extracts_ids_from_claims_and_scopes(

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -124,6 +124,10 @@ def test_supports_refresh_scope_when_provider_metadata_missing() -> None:
     assert mcp_auth.supports_refresh_scope(None) is True
 
 
+def test_supports_refresh_scope_when_provider_advertises_no_scopes() -> None:
+    assert mcp_auth.supports_refresh_scope([]) is False
+
+
 def test_supports_refresh_scope_when_scope_supported() -> None:
     assert mcp_auth.supports_refresh_scope(["openid", "offline_access"]) is True
 

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import html
 import json
 import re
+import time
 import uuid
 from base64 import urlsafe_b64decode
+from collections.abc import Sequence
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -17,7 +19,11 @@ from fastmcp.server.dependencies import get_access_token
 from key_value.aio.stores.redis import RedisStore
 from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 from key_value.aio.wrappers.prefix_collections import PrefixCollectionsWrapper
-from mcp.server.auth.provider import TokenError
+from mcp.server.auth.provider import (
+    AuthorizationParams,
+    TokenError,
+)
+from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import BaseModel, Field
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy import select
@@ -61,6 +67,30 @@ _UUID_SCOPE_PATTERNS: dict[str, re.Pattern[str]] = {
     ),
     "workspace": re.compile(r"^(?:workspace|workspace_id):(?P<uuid>[0-9a-fA-F-]{36})$"),
 }
+
+_MCP_REFRESH_SCOPE = "offline_access"
+_MCP_ACCESS_TOKEN_FALLBACK_EXPIRY_SECONDS = 60 * 60
+_MCP_OAUTH_TRANSACTION_TTL_SECONDS = 15 * 60
+
+
+def append_scope_if_missing(scopes: list[str], scope: str) -> list[str]:
+    """Append a scope only if it is not already present."""
+    if scope in scopes:
+        return scopes
+    return [*scopes, scope]
+
+
+def remove_scope(scopes: list[str], scope: str) -> list[str]:
+    """Return a scope list with the target scope removed."""
+    return [value for value in scopes if value != scope]
+
+
+def supports_refresh_scope(scopes_supported: Sequence[str] | None) -> bool:
+    """Return whether provider metadata supports MCP refresh scope requests."""
+    if not scopes_supported:
+        # If provider metadata omits scopes_supported, optimistically request.
+        return True
+    return _MCP_REFRESH_SCOPE in scopes_supported
 
 
 def _coerce_uuid(value: object) -> uuid.UUID | None:
@@ -422,6 +452,76 @@ def create_mcp_auth() -> AuthProvider:
     class TracecatOIDCProxy(OIDCProxy):
         """OIDC proxy with user-existence validation and a custom consent page."""
 
+        def _should_request_refresh_scope(self) -> bool:
+            """Return whether the upstream IdP appears to support offline refresh scopes."""
+            return supports_refresh_scope(self.oidc_config.scopes_supported)
+
+        async def authorize(
+            self,
+            client: OAuthClientInformationFull,
+            params: AuthorizationParams,
+        ) -> str:
+            """Inject refresh scope by default for MCP clients."""
+            scopes = list(params.scopes or [])
+            if self._should_request_refresh_scope():
+                scopes = append_scope_if_missing(scopes, _MCP_REFRESH_SCOPE)
+            else:
+                logger.info(
+                    "Skipping refresh scope request: upstream metadata does not advertise scope",
+                    scope=_MCP_REFRESH_SCOPE,
+                    issuer=self.oidc_config.issuer,
+                )
+
+            params_with_refresh = params.model_copy(update={"scopes": scopes})
+            return await super().authorize(client, params_with_refresh)
+
+        async def _retry_without_refresh_scope(
+            self,
+            *,
+            request: Request,
+        ) -> RedirectResponse | None:
+            """Retry OAuth authorization once without refresh scope on invalid_scope."""
+            if request.query_params.get("error") != "invalid_scope":
+                return None
+
+            txn_id = request.query_params.get("state")
+            if not txn_id:
+                return None
+
+            txn_model = await self._transaction_store.get(key=txn_id)
+            if txn_model is None:
+                return None
+
+            scopes = list(txn_model.scopes or [])
+            if _MCP_REFRESH_SCOPE not in scopes:
+                # We already retried (or refresh scope was never requested).
+                return None
+
+            updated_scopes = remove_scope(scopes, _MCP_REFRESH_SCOPE)
+            updated_txn = txn_model.model_copy(update={"scopes": updated_scopes})
+
+            age_seconds = max(0.0, time.time() - float(txn_model.created_at))
+            remaining_ttl = max(
+                1, int(_MCP_OAUTH_TRANSACTION_TTL_SECONDS - age_seconds)
+            )
+            await self._transaction_store.put(
+                key=txn_id,
+                value=updated_txn,
+                ttl=remaining_ttl,
+            )
+
+            logger.warning(
+                "OIDC provider rejected refresh scope; retrying authorization without refresh scope",
+                scope=_MCP_REFRESH_SCOPE,
+                transaction_id=txn_id,
+            )
+
+            retry_url = self._build_upstream_authorize_url(
+                txn_id,
+                updated_txn.model_dump(),
+            )
+            return RedirectResponse(url=retry_url)
+
         async def _extract_upstream_claims(
             self, idp_tokens: dict[str, Any]
         ) -> dict[str, Any] | None:
@@ -475,6 +575,11 @@ def create_mcp_auth() -> AuthProvider:
         async def _handle_idp_callback(
             self, request: Request
         ) -> HTMLResponse | RedirectResponse:
+            if fallback_response := await self._retry_without_refresh_scope(
+                request=request
+            ):
+                return fallback_response
+
             response = await super()._handle_idp_callback(request)
             if not isinstance(response, RedirectResponse):
                 return response
@@ -608,6 +713,7 @@ def create_mcp_auth() -> AuthProvider:
         client_secret=oidc_config.client_secret,
         base_url=base_url,
         client_storage=client_storage,
+        fallback_access_token_expiry_seconds=_MCP_ACCESS_TOKEN_FALLBACK_EXPIRY_SECONDS,
     )
 
 

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -87,7 +87,7 @@ def remove_scope(scopes: list[str], scope: str) -> list[str]:
 
 def supports_refresh_scope(scopes_supported: Sequence[str] | None) -> bool:
     """Return whether provider metadata supports MCP refresh scope requests."""
-    if not scopes_supported:
+    if scopes_supported is None:
         # If provider metadata omits scopes_supported, optimistically request.
         return True
     return _MCP_REFRESH_SCOPE in scopes_supported


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds refresh-token-oriented MCP OAuth behavior with a safe fallback strategy:

- Requests `offline_access` by default for MCP authorization when the upstream provider supports it (or does not advertise scopes).
- If the provider returns `invalid_scope`, retries once without `offline_access` to preserve compatibility with providers that reject refresh scopes.
- Sets a safe default fallback access-token expiry of 3600 seconds (1 hour) when upstream token responses omit `expires_in`.
- Adds unit coverage for scope helper behavior and fallback expiry wiring.
- Documents the MCP OAuth behavior in `.env.example`.

## Related Issues

N/A

## Screenshots / Recordings

N/A (backend-only auth behavior)

## Steps to QA

1. Run lint/type checks:
   - `uv run ruff check tracecat/mcp/auth.py tests/unit/test_mcp_auth.py`
   - `uv run basedpyright tracecat/mcp/auth.py tests/unit/test_mcp_auth.py`
2. Run focused unit tests:
   - `TRACECAT__SERVICE_KEY=test uv run pytest tests/unit/test_mcp_auth.py`
3. Validate behavior manually against an OIDC provider:
   - Confirm normal authorize flow includes `offline_access` when supported.
   - Confirm `invalid_scope` callback triggers a single retry without `offline_access`.
   - Confirm access token fallback expiry is 3600s when `expires_in` is omitted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds refresh-scope handling for MCP OAuth to request refresh tokens when possible and stay compatible with IdPs that reject offline_access. Sets a 1h fallback for access-token expiry when expires_in is missing.

- **New Features**
  - Request offline_access by default when provider metadata supports it (request if scopes_supported is missing; skip if it’s an empty list).
  - On invalid_scope during callback, retry once without offline_access.
  - Default access-token TTL to 3600s if expires_in is omitted.
  - Add unit tests for scope helpers and fallback expiry.
  - Document behavior in .env.example.

<sup>Written for commit c96221c8b712178b29f625018b3ef0a68d520e0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

