### PR TITLE
feat(mcp): add catalog authorization policy service

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -37,6 +37,7 @@ from tracecat.exceptions import (
 )
 from tracecat.identifiers import WorkspaceID
 from tracecat.integrations.enums import MCPCatalogArtifactType
+from tracecat.integrations.mcp_scopes import build_mcp_scope_name
 from tracecat.service import BaseOrgService
 
 
@@ -166,20 +167,10 @@ class RBACService(BaseOrgService):
         artifact_key: str,
     ) -> tuple[str, str, str]:
         """Build the scope name plus resource/action columns for an MCP artifact."""
-        match artifact_type:
-            case MCPCatalogArtifactType.TOOL:
-                resource = "mcp-tool"
-                action = "execute"
-            case MCPCatalogArtifactType.RESOURCE:
-                resource = "mcp-resource"
-                action = "read"
-            case MCPCatalogArtifactType.PROMPT:
-                resource = "mcp-prompt"
-                action = "use"
-        return (
-            f"{resource}:{scope_namespace}.{artifact_key}:{action}",
-            resource,
-            action,
+        return build_mcp_scope_name(
+            scope_namespace=scope_namespace,
+            artifact_type=artifact_type,
+            artifact_key=artifact_key,
         )
 
     def _build_mcp_scope_description(

--- a/tests/unit/test_mcp_policy_service.py
+++ b/tests/unit/test_mcp_policy_service.py
@@ -1,0 +1,336 @@
+"""Unit tests for MCP catalog policy service."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import func, insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import (
+    MCPIntegration,
+    MCPIntegrationCatalogEntry,
+    Membership,
+    Organization,
+    OrganizationMembership,
+    User,
+    Workspace,
+)
+from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
+from tracecat.identifiers import WorkspaceID
+from tracecat.integrations.enums import MCPAuthType, MCPCatalogArtifactType
+from tracecat.integrations.mcp_scopes import build_mcp_scope_name
+from tracecat.mcp.policy.service import MCPCatalogPolicyService
+
+
+@pytest.fixture
+async def org(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Policy Org",
+        slug=f"policy-org-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(org)
+    await session.commit()
+    await session.refresh(org)
+    return org
+
+
+@pytest.fixture
+async def user(session: AsyncSession, org: Organization) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email="policy@example.com",
+        hashed_password="test",
+    )
+    session.add(user)
+    await session.flush()
+    session.add(
+        OrganizationMembership(
+            user_id=user.id,
+            organization_id=org.id,
+        )
+    )
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def workspace(session: AsyncSession, org: Organization, user: User) -> Workspace:
+    workspace = Workspace(
+        id=uuid.uuid4(),
+        name="Policy Workspace",
+        organization_id=org.id,
+    )
+    session.add(workspace)
+    await session.flush()
+    session.add(
+        Membership(
+            user_id=user.id,
+            workspace_id=workspace.id,
+        )
+    )
+    await session.commit()
+    await session.refresh(workspace)
+    return workspace
+
+
+@pytest.fixture
+async def other_org_workspace(session: AsyncSession) -> Workspace:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Other Org",
+        slug=f"other-org-{uuid.uuid4().hex[:8]}",
+    )
+    workspace = Workspace(
+        id=uuid.uuid4(),
+        name="Other Workspace",
+        organization_id=org.id,
+    )
+    session.add_all([org, workspace])
+    await session.commit()
+    await session.refresh(workspace)
+    return workspace
+
+
+@pytest.fixture
+def org_admin_role(org: Organization, user: User, workspace: Workspace) -> Role:
+    return Role(
+        type="user",
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+        service_id="tracecat-mcp",
+        scopes=frozenset({"org:workspace:read"}),
+    )
+
+
+@pytest.fixture
+def member_role(org: Organization, user: User, workspace: Workspace) -> Role:
+    return Role(
+        type="user",
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+        service_id="tracecat-mcp",
+        scopes=frozenset(),
+    )
+
+
+async def _create_mcp_integration(
+    *,
+    session: AsyncSession,
+    workspace: Workspace,
+    scope_namespace: str = "mcppolicy0000001",
+) -> MCPIntegration:
+    integration = MCPIntegration(
+        id=uuid.uuid4(),
+        workspace_id=workspace.id,
+        name="Policy MCP",
+        description="Policy MCP",
+        slug=f"policy-mcp-{uuid.uuid4().hex[:6]}",
+        scope_namespace=scope_namespace,
+        server_type="http",
+        server_uri="https://api.example.com/mcp",
+        auth_type=MCPAuthType.NONE,
+        discovery_status="succeeded",
+        catalog_version=1,
+    )
+    session.add(integration)
+    await session.commit()
+    await session.refresh(integration)
+    return integration
+
+
+async def _insert_catalog_entry(
+    *,
+    session: AsyncSession,
+    integration: MCPIntegration,
+    artifact_type: MCPCatalogArtifactType,
+    artifact_key: str,
+    artifact_ref: str,
+    is_active: bool = True,
+) -> uuid.UUID:
+    entry_id = uuid.uuid4()
+    await session.execute(
+        insert(MCPIntegrationCatalogEntry).values(
+            id=entry_id,
+            mcp_integration_id=integration.id,
+            workspace_id=integration.workspace_id,
+            integration_name=integration.name,
+            artifact_type=artifact_type.value,
+            artifact_key=artifact_key,
+            artifact_ref=artifact_ref,
+            display_name=artifact_ref,
+            description=f"{artifact_type.value} {artifact_ref}",
+            input_schema={"type": "object"},
+            artifact_metadata={"origin": "test"},
+            raw_payload={"name": artifact_ref},
+            content_hash=artifact_key.ljust(64, "0"),
+            is_active=is_active,
+            search_vector=func.to_tsvector("simple", artifact_ref),
+        )
+    )
+    await session.commit()
+    return entry_id
+
+
+@pytest.mark.anyio
+class TestMCPCatalogPolicyService:
+    async def test_authorize_catalog_search_allows_org_admin_all_active_entries(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        tool_entry = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="list_repos",
+        )
+        resource_entry = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+            artifact_key="docs-readme-7f8e9d0c1b",
+            artifact_ref="docs://readme",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="inactive-prompt-6a5b4c3d2e",
+            artifact_ref="triage_incident",
+            is_active=False,
+        )
+
+        service = MCPCatalogPolicyService(session=session, role=org_admin_role)
+        result = await service.authorize_catalog_search(workspace_id=workspace.id)
+
+        assert result.is_org_admin is True
+        assert result.allowed_entry_ids == frozenset({tool_entry, resource_entry})
+        assert len(result.entries) == 2
+
+    async def test_authorize_catalog_search_filters_non_admin_scopes(
+        self,
+        session: AsyncSession,
+        member_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        allowed_entry = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="list_repos",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+            artifact_key="docs-readme-7f8e9d0c1b",
+            artifact_ref="docs://readme",
+        )
+        allowed_scope, _resource, _action = build_mcp_scope_name(
+            scope_namespace=integration.scope_namespace,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+        )
+        role = member_role.model_copy(update={"scopes": frozenset({allowed_scope})})
+
+        service = MCPCatalogPolicyService(session=session, role=role)
+        result = await service.authorize_catalog_search(workspace_id=workspace.id)
+
+        assert result.is_org_admin is False
+        assert result.allowed_scope_names == frozenset({allowed_scope})
+        assert result.allowed_entry_ids == frozenset({allowed_entry})
+        assert len(result.entries) == 1
+
+    async def test_authorize_catalog_entry_rejects_unauthorized_entry(
+        self,
+        session: AsyncSession,
+        member_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="triage-incident-6a5b4c3d2e",
+            artifact_ref="triage_incident",
+        )
+        service = MCPCatalogPolicyService(session=session, role=member_role)
+
+        with pytest.raises(TracecatAuthorizationError):
+            await service.authorize_catalog_entry(
+                workspace_id=workspace.id,
+                entry_id=entry_id,
+            )
+
+    async def test_authorize_catalog_entries_empty_filter_returns_no_entries(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="list_repos",
+        )
+
+        service = MCPCatalogPolicyService(session=session, role=org_admin_role)
+        result = await service.authorize_catalog_entries(
+            workspace_id=workspace.id,
+            entry_ids=[],
+        )
+
+        assert result.entries == ()
+        assert result.allowed_entry_ids == frozenset()
+        assert result.allowed_scope_names == frozenset()
+
+    async def test_authorize_catalog_entry_raises_not_found_for_missing_entry(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        service = MCPCatalogPolicyService(session=session, role=org_admin_role)
+
+        with pytest.raises(TracecatNotFoundError):
+            await service.authorize_catalog_entry(
+                workspace_id=workspace.id,
+                entry_id=uuid.uuid4(),
+            )
+
+    async def test_authorize_catalog_search_rejects_workspace_outside_org(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        other_org_workspace: Workspace,
+    ) -> None:
+        service = MCPCatalogPolicyService(session=session, role=org_admin_role)
+
+        with pytest.raises(TracecatAuthorizationError):
+            await service.authorize_catalog_search(
+                workspace_id=WorkspaceID(str(other_org_workspace.id)),
+            )

--- a/tests/unit/test_mcp_policy_service.py
+++ b/tests/unit/test_mcp_policy_service.py
@@ -257,6 +257,75 @@ class TestMCPCatalogPolicyService:
         assert result.allowed_entry_ids == frozenset({allowed_entry})
         assert len(result.entries) == 1
 
+    async def test_authorize_catalog_search_accepts_wildcard_scope_grants(
+        self,
+        session: AsyncSession,
+        member_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        allowed_entry = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="list_repos",
+        )
+        wildcard_scope = f"mcp-tool:{integration.scope_namespace}.*:execute"
+        role = member_role.model_copy(update={"scopes": frozenset({wildcard_scope})})
+
+        service = MCPCatalogPolicyService(session=session, role=role)
+        result = await service.authorize_catalog_search(workspace_id=workspace.id)
+
+        assert result.is_org_admin is False
+        assert result.allowed_entry_ids == frozenset({allowed_entry})
+        assert len(result.entries) == 1
+        assert result.entries[0].scope_name == (
+            f"mcp-tool:{integration.scope_namespace}.github-list-repos-a1b2c3d4e5:execute"
+        )
+
+    async def test_get_effective_scopes_uses_rbac_fallback_when_scopes_unset(
+        self,
+        session: AsyncSession,
+        member_role: Role,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        expected_scopes = frozenset({"mcp-tool:mcppolicy0000001.*:execute"})
+
+        async def _compute_effective_scopes(_: Role) -> frozenset[str]:
+            return expected_scopes
+
+        monkeypatch.setattr(
+            "tracecat.mcp.policy.service.compute_effective_scopes",
+            _compute_effective_scopes,
+        )
+        role = member_role.model_copy(update={"scopes": None})
+
+        service = MCPCatalogPolicyService(session=session, role=role)
+
+        assert await service._get_effective_scopes() == expected_scopes
+
+    async def test_get_effective_scopes_does_not_fallback_for_explicit_empty_scopes(
+        self,
+        session: AsyncSession,
+        member_role: Role,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _compute_effective_scopes(_: Role) -> frozenset[str]:
+            return frozenset({"mcp-tool:mcppolicy0000001.*:execute"})
+
+        monkeypatch.setattr(
+            "tracecat.mcp.policy.service.compute_effective_scopes",
+            _compute_effective_scopes,
+        )
+        role = member_role.model_copy(update={"scopes": frozenset()})
+
+        service = MCPCatalogPolicyService(session=session, role=role)
+
+        assert await service._get_effective_scopes() == frozenset()
+
     async def test_authorize_catalog_entry_rejects_unauthorized_entry(
         self,
         session: AsyncSession,

--- a/tracecat/integrations/mcp_scopes.py
+++ b/tracecat/integrations/mcp_scopes.py
@@ -1,0 +1,29 @@
+"""Shared MCP scope derivation helpers."""
+
+from __future__ import annotations
+
+from tracecat.integrations.enums import MCPCatalogArtifactType
+
+
+def build_mcp_scope_name(
+    *,
+    scope_namespace: str,
+    artifact_type: MCPCatalogArtifactType,
+    artifact_key: str,
+) -> tuple[str, str, str]:
+    """Build the scope name plus resource/action columns for an MCP artifact."""
+    match artifact_type:
+        case MCPCatalogArtifactType.TOOL:
+            resource = "mcp-tool"
+            action = "execute"
+        case MCPCatalogArtifactType.RESOURCE:
+            resource = "mcp-resource"
+            action = "read"
+        case MCPCatalogArtifactType.PROMPT:
+            resource = "mcp-prompt"
+            action = "use"
+    return (
+        f"{resource}:{scope_namespace}.{artifact_key}:{action}",
+        resource,
+        action,
+    )

--- a/tracecat/mcp/policy/__init__.py
+++ b/tracecat/mcp/policy/__init__.py
@@ -1,0 +1,1 @@
+"""MCP catalog policy service package."""

--- a/tracecat/mcp/policy/service.py
+++ b/tracecat/mcp/policy/service.py
@@ -145,7 +145,7 @@ class MCPCatalogPolicyService(BaseOrgService):
                 artifact_type=artifact_type,
                 artifact_key=artifact_key,
             )
-            if not is_org_admin and scope_name not in effective_scopes:
+            if not is_org_admin and not has_scope(effective_scopes, scope_name):
                 continue
             allowed_scope_names.add(scope_name)
             entries.append(
@@ -184,6 +184,6 @@ class MCPCatalogPolicyService(BaseOrgService):
         return organization_id
 
     async def _get_effective_scopes(self) -> frozenset[str]:
-        if self.role.scopes:
+        if self.role.scopes is not None:
             return frozenset(self.role.scopes)
         return frozenset(await compute_effective_scopes(self.role))

--- a/tracecat/mcp/policy/service.py
+++ b/tracecat/mcp/policy/service.py
@@ -1,0 +1,189 @@
+"""Authorization service for persisted MCP catalog entries."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+
+from tracecat.auth.credentials import compute_effective_scopes
+from tracecat.authz.controls import has_scope
+from tracecat.db.models import MCPIntegration, MCPIntegrationCatalogEntry, Workspace
+from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
+from tracecat.identifiers import OrganizationID, WorkspaceID
+from tracecat.integrations.enums import MCPCatalogArtifactType
+from tracecat.integrations.mcp_scopes import build_mcp_scope_name
+from tracecat.mcp.policy.types import (
+    AuthorizedMCPCatalogEntry,
+    MCPCatalogAuthorizationResult,
+)
+from tracecat.service import BaseOrgService
+
+
+class MCPCatalogPolicyService(BaseOrgService):
+    """Resolve caller-specific authorization over persisted MCP catalog entries."""
+
+    service_name = "mcp_catalog_policy"
+
+    async def authorize_catalog_search(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+    ) -> MCPCatalogAuthorizationResult:
+        """Authorize catalog search/list operations for a workspace."""
+        return await self._authorize_entries(workspace_id=workspace_id)
+
+    async def authorize_catalog_entries(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        entry_ids: Sequence[UUID],
+    ) -> MCPCatalogAuthorizationResult:
+        """Authorize a batch of catalog entries for the current caller."""
+        return await self._authorize_entries(
+            workspace_id=workspace_id,
+            entry_ids=frozenset(entry_ids),
+        )
+
+    async def authorize_catalog_entry(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        entry_id: UUID,
+    ) -> AuthorizedMCPCatalogEntry:
+        """Authorize a single catalog entry for the current caller."""
+        result = await self._authorize_entries(
+            workspace_id=workspace_id,
+            entry_ids=frozenset({entry_id}),
+        )
+        if result.entries:
+            return result.entries[0]
+
+        exists_stmt = (
+            select(MCPIntegrationCatalogEntry.id)
+            .join(
+                MCPIntegration,
+                MCPIntegration.id == MCPIntegrationCatalogEntry.mcp_integration_id,
+            )
+            .join(Workspace, Workspace.id == MCPIntegrationCatalogEntry.workspace_id)
+            .where(
+                MCPIntegrationCatalogEntry.id == entry_id,
+                MCPIntegrationCatalogEntry.workspace_id == workspace_id,
+                MCPIntegrationCatalogEntry.is_active.is_(True),
+                Workspace.organization_id == self.organization_id,
+            )
+        )
+        exists_result = await self.session.execute(exists_stmt)
+        if exists_result.scalar_one_or_none() is None:
+            raise TracecatNotFoundError("MCP catalog entry not found")
+        raise TracecatAuthorizationError("Not authorized to access MCP catalog entry")
+
+    async def _authorize_entries(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        entry_ids: frozenset[UUID] | None = None,
+    ) -> MCPCatalogAuthorizationResult:
+        organization_id = await self._validate_workspace(workspace_id)
+        effective_scopes = await self._get_effective_scopes()
+        is_org_admin = has_scope(effective_scopes, "org:workspace:read")
+        if entry_ids is not None and not entry_ids:
+            return MCPCatalogAuthorizationResult(
+                workspace_id=workspace_id,
+                organization_id=organization_id,
+                is_org_admin=is_org_admin,
+                allowed_scope_names=frozenset(),
+                entries=(),
+            )
+
+        stmt = (
+            select(
+                MCPIntegrationCatalogEntry.id,
+                MCPIntegrationCatalogEntry.mcp_integration_id,
+                MCPIntegrationCatalogEntry.workspace_id,
+                MCPIntegrationCatalogEntry.artifact_type,
+                MCPIntegrationCatalogEntry.artifact_key,
+                MCPIntegrationCatalogEntry.artifact_ref,
+                MCPIntegrationCatalogEntry.display_name,
+                MCPIntegrationCatalogEntry.description,
+                MCPIntegration.scope_namespace,
+            )
+            .join(
+                MCPIntegration,
+                MCPIntegration.id == MCPIntegrationCatalogEntry.mcp_integration_id,
+            )
+            .where(
+                MCPIntegrationCatalogEntry.workspace_id == workspace_id,
+                MCPIntegrationCatalogEntry.is_active.is_(True),
+            )
+            .order_by(
+                MCPIntegrationCatalogEntry.artifact_type,
+                MCPIntegrationCatalogEntry.artifact_key,
+            )
+        )
+        if entry_ids is not None:
+            stmt = stmt.where(MCPIntegrationCatalogEntry.id.in_(entry_ids))
+
+        result = await self.session.execute(stmt)
+        entries: list[AuthorizedMCPCatalogEntry] = []
+        allowed_scope_names: set[str] = set()
+        for (
+            entry_id,
+            mcp_integration_id,
+            entry_workspace_id,
+            artifact_type_value,
+            artifact_key,
+            artifact_ref,
+            display_name,
+            description,
+            scope_namespace,
+        ) in result.tuples().all():
+            artifact_type = MCPCatalogArtifactType(artifact_type_value)
+            scope_name, _resource, _action = build_mcp_scope_name(
+                scope_namespace=scope_namespace,
+                artifact_type=artifact_type,
+                artifact_key=artifact_key,
+            )
+            if not is_org_admin and scope_name not in effective_scopes:
+                continue
+            allowed_scope_names.add(scope_name)
+            entries.append(
+                AuthorizedMCPCatalogEntry(
+                    id=entry_id,
+                    mcp_integration_id=mcp_integration_id,
+                    workspace_id=entry_workspace_id,
+                    organization_id=organization_id,
+                    scope_name=scope_name,
+                    artifact_type=artifact_type,
+                    artifact_key=artifact_key,
+                    artifact_ref=artifact_ref,
+                    display_name=display_name,
+                    description=description,
+                )
+            )
+
+        return MCPCatalogAuthorizationResult(
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+            is_org_admin=is_org_admin,
+            allowed_scope_names=frozenset(allowed_scope_names),
+            entries=tuple(entries),
+        )
+
+    async def _validate_workspace(self, workspace_id: WorkspaceID) -> OrganizationID:
+        stmt = select(Workspace.organization_id).where(Workspace.id == workspace_id)
+        result = await self.session.execute(stmt)
+        organization_id = result.scalar_one_or_none()
+        if organization_id is None:
+            raise TracecatNotFoundError("Workspace not found")
+        if organization_id != self.organization_id:
+            raise TracecatAuthorizationError(
+                "Workspace is outside the caller organization"
+            )
+        return organization_id
+
+    async def _get_effective_scopes(self) -> frozenset[str]:
+        if self.role.scopes:
+            return frozenset(self.role.scopes)
+        return frozenset(await compute_effective_scopes(self.role))

--- a/tracecat/mcp/policy/types.py
+++ b/tracecat/mcp/policy/types.py
@@ -1,0 +1,41 @@
+"""Types for MCP catalog authorization decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from tracecat.identifiers import OrganizationID, WorkspaceID
+from tracecat.integrations.enums import MCPCatalogArtifactType
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizedMCPCatalogEntry:
+    """Caller-authorized MCP catalog entry metadata."""
+
+    id: UUID
+    mcp_integration_id: UUID
+    workspace_id: WorkspaceID
+    organization_id: OrganizationID
+    scope_name: str
+    artifact_type: MCPCatalogArtifactType
+    artifact_key: str
+    artifact_ref: str
+    display_name: str | None
+    description: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MCPCatalogAuthorizationResult:
+    """Authorization result for MCP catalog search or batch access."""
+
+    workspace_id: WorkspaceID
+    organization_id: OrganizationID
+    is_org_admin: bool
+    allowed_scope_names: frozenset[str]
+    entries: tuple[AuthorizedMCPCatalogEntry, ...]
+    agent_metadata: dict[str, str] | None = None
+
+    @property
+    def allowed_entry_ids(self) -> frozenset[UUID]:
+        return frozenset(entry.id for entry in self.entries)


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MCP catalog authorization service that filters visible catalog entries by workspace org and user scopes, centralizes MCP scope naming, and honors wildcard scope grants. Implements ENG-1319 and aligns with ENG-1318 scope naming.

- **New Features**
  - Introduces MCPCatalogPolicyService for search, batch, and single-entry authorization.
  - Enforces org boundary checks and scope-based access; admins with org:workspace:read see all active entries, others need explicit entry scopes.
  - Adds unit tests for admin vs member access, wildcard grants, empty filters, not-found vs unauthorized single-entry, and cross-org rejection.

- **Bug Fixes**
  - Honors wildcard catalog scopes (e.g., mcp-tool:namespace.*:execute) and only falls back to RBAC scope computation when role.scopes is None.

<sup>Written for commit 87cae0694a17967f8ebedffc0a27ee6f769e1920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

