### PR TITLE
feat(mcp): add persisted artifact wrapper operations

### DIFF
--- a/tests/unit/test_mcp_artifact_service.py
+++ b/tests/unit/test_mcp_artifact_service.py
@@ -16,7 +16,7 @@ from mcp.types import (
     TextContent,
     TextResourceContents,
 )
-from pydantic import AnyUrl
+from pydantic import AnyUrl, SecretStr
 from sqlalchemy import func, insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -61,8 +61,6 @@ class _FakeIntegrationService:
         token = self._decrypt_token(integration.encrypted_access_token)
         if token is None:
             return None
-        from pydantic import SecretStr
-
         return SecretStr(token)
 
 
@@ -146,6 +144,7 @@ async def _create_oauth_integration(
     workspace: Workspace,
     user: User,
     access_token: str = "oauth-token",
+    token_type: str = "Bearer",
 ) -> OAuthIntegration:
     integration = OAuthIntegration(
         id=uuid.uuid4(),
@@ -161,7 +160,7 @@ async def _create_oauth_integration(
             b"client-secret", key=TEST_ENCRYPTION_KEY
         ),
         use_workspace_credentials=False,
-        token_type="Bearer",
+        token_type=token_type,
         expires_at=datetime.now(UTC) + timedelta(hours=1),
         scope=None,
         requested_scopes=None,
@@ -259,6 +258,7 @@ class _FakeClient:
         self.call_tool_result = call_tool_result
         self.read_resource_result = read_resource_result or []
         self.get_prompt_result = get_prompt_result
+        self.last_prompt_arguments: dict[str, Any] | None = None
 
     async def __aenter__(self) -> _FakeClient:
         return self
@@ -277,6 +277,7 @@ class _FakeClient:
         self, name: str, arguments: dict[str, Any] | None
     ) -> GetPromptResult:
         assert self.get_prompt_result is not None
+        self.last_prompt_arguments = arguments
         return self.get_prompt_result
 
 
@@ -320,6 +321,51 @@ class TestMCPCatalogArtifactService:
 
         assert headers["X-Tracecat"] == "1"
         assert headers["Authorization"] == "Bearer secret-token"
+
+    async def test_build_headers_oauth_overrides_custom_authorization_variants(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+        user: User,
+    ) -> None:
+        oauth_integration = await _create_oauth_integration(
+            session=session,
+            workspace=workspace,
+            user=user,
+            access_token="secret-token",
+            token_type="Token",
+        )
+        integration = await _create_mcp_integration(
+            session=session,
+            workspace=workspace,
+            oauth_integration=oauth_integration,
+            auth_type=MCPAuthType.OAUTH2,
+            custom_headers={
+                "Authorization": "Bearer stale-token",
+                "authorization": "Bearer stale-lower",
+                "X-Tracecat": "1",
+            },
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="tool-a2",
+            artifact_ref="describe_repo",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        target = await service.resolve_artifact(
+            workspace_id=workspace.id,
+            artifact_ref_or_id=str(entry_id),
+            artifact_type=MCPCatalogArtifactType.TOOL,
+        )
+
+        headers = await service._build_headers(target)
+
+        assert headers["Authorization"] == "Token secret-token"
+        assert headers["X-Tracecat"] == "1"
+        assert "authorization" not in headers
 
     async def test_execute_tool_returns_remote_call_result(
         self,
@@ -457,6 +503,53 @@ class TestMCPCatalogArtifactService:
 
         assert result.result["messages"][0]["role"] == "user"
         assert result.result["messages"][0]["content"]["text"] == "Investigate this"
+
+    async def test_get_prompt_preserves_explicit_empty_dict_arguments(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="prompt-a2",
+            artifact_ref="triage_incident",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        fake_client = _FakeClient(
+            get_prompt_result=GetPromptResult(
+                description="Prompt description",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(type="text", text="Investigate this"),
+                    )
+                ],
+            )
+        )
+
+        async def fake_create_remote_client(target: Any) -> _FakeClient:
+            return fake_client
+
+        monkeypatch.setattr(
+            service,
+            "_create_remote_client",
+            fake_create_remote_client,
+        )
+
+        await service.get_prompt(
+            workspace_id=workspace.id,
+            artifact_ref_or_id=str(entry_id),
+            arguments={},
+        )
+
+        assert fake_client.last_prompt_arguments == {}
 
     async def test_stdio_artifacts_are_rejected_for_now(
         self,

--- a/tests/unit/test_mcp_artifact_service.py
+++ b/tests/unit/test_mcp_artifact_service.py
@@ -1,0 +1,486 @@
+"""Unit tests for persisted MCP catalog artifact execution service."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import orjson
+import pytest
+from cryptography.fernet import Fernet
+from mcp.types import (
+    CallToolResult,
+    GetPromptResult,
+    PromptMessage,
+    TextContent,
+    TextResourceContents,
+)
+from pydantic import AnyUrl
+from sqlalchemy import func, insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import (
+    MCPIntegration,
+    MCPIntegrationCatalogEntry,
+    Membership,
+    OAuthIntegration,
+    Organization,
+    OrganizationMembership,
+    User,
+    Workspace,
+)
+from tracecat.exceptions import TracecatValidationError
+from tracecat.integrations.enums import (
+    MCPAuthType,
+    MCPCatalogArtifactType,
+    OAuthGrantType,
+)
+from tracecat.mcp.catalog import artifact_service as artifact_service_module
+from tracecat.mcp.catalog.artifact_service import MCPCatalogArtifactService
+from tracecat.secrets.encryption import decrypt_value, encrypt_value
+
+TEST_ENCRYPTION_KEY = Fernet.generate_key().decode()
+
+
+class _FakeIntegrationService:
+    def __init__(self, *, session: AsyncSession, role: Role) -> None:
+        self.session = session
+        self.role = role
+
+    def _decrypt_token(self, encrypted_token: bytes) -> str | None:
+        return decrypt_value(encrypted_token, key=TEST_ENCRYPTION_KEY).decode("utf-8")
+
+    async def refresh_token_if_needed(
+        self, integration: OAuthIntegration
+    ) -> OAuthIntegration:
+        return integration
+
+    async def get_access_token(self, integration: OAuthIntegration) -> Any:
+        token = self._decrypt_token(integration.encrypted_access_token)
+        if token is None:
+            return None
+        from pydantic import SecretStr
+
+        return SecretStr(token)
+
+
+@pytest.fixture(autouse=True)
+def patch_integration_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        artifact_service_module,
+        "IntegrationService",
+        _FakeIntegrationService,
+    )
+
+
+@pytest.fixture
+async def org(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Artifact Org",
+        slug=f"artifact-org-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(org)
+    await session.commit()
+    await session.refresh(org)
+    return org
+
+
+@pytest.fixture
+async def user(session: AsyncSession, org: Organization) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email="artifact@example.com",
+        hashed_password="test",
+    )
+    session.add(user)
+    await session.flush()
+    session.add(
+        OrganizationMembership(
+            user_id=user.id,
+            organization_id=org.id,
+        )
+    )
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def workspace(session: AsyncSession, org: Organization, user: User) -> Workspace:
+    workspace = Workspace(
+        id=uuid.uuid4(),
+        name="Artifact Workspace",
+        organization_id=org.id,
+    )
+    session.add(workspace)
+    await session.flush()
+    session.add(
+        Membership(
+            user_id=user.id,
+            workspace_id=workspace.id,
+        )
+    )
+    await session.commit()
+    await session.refresh(workspace)
+    return workspace
+
+
+@pytest.fixture
+def org_admin_role(org: Organization, user: User, workspace: Workspace) -> Role:
+    return Role(
+        type="user",
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+        service_id="tracecat-mcp",
+        scopes=frozenset({"org:workspace:read", "integration:read"}),
+    )
+
+
+async def _create_oauth_integration(
+    *,
+    session: AsyncSession,
+    workspace: Workspace,
+    user: User,
+    access_token: str = "oauth-token",
+) -> OAuthIntegration:
+    integration = OAuthIntegration(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        workspace_id=workspace.id,
+        provider_id="github",
+        encrypted_access_token=encrypt_value(
+            access_token.encode("utf-8"), key=TEST_ENCRYPTION_KEY
+        ),
+        encrypted_refresh_token=None,
+        encrypted_client_id=encrypt_value(b"client-id", key=TEST_ENCRYPTION_KEY),
+        encrypted_client_secret=encrypt_value(
+            b"client-secret", key=TEST_ENCRYPTION_KEY
+        ),
+        use_workspace_credentials=False,
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scope=None,
+        requested_scopes=None,
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        authorization_endpoint="https://github.com/login/oauth/authorize",
+        token_endpoint="https://github.com/login/oauth/access_token",
+    )
+    session.add(integration)
+    await session.commit()
+    await session.refresh(integration)
+    return integration
+
+
+async def _create_mcp_integration(
+    *,
+    session: AsyncSession,
+    workspace: Workspace,
+    oauth_integration: OAuthIntegration | None = None,
+    auth_type: MCPAuthType = MCPAuthType.NONE,
+    server_type: str = "http",
+    custom_headers: dict[str, str] | None = None,
+) -> MCPIntegration:
+    encrypted_headers = None
+    if custom_headers is not None:
+        encrypted_headers = encrypt_value(
+            orjson.dumps(custom_headers),
+            key=TEST_ENCRYPTION_KEY,
+        )
+    integration = MCPIntegration(
+        id=uuid.uuid4(),
+        workspace_id=workspace.id,
+        name="Artifact MCP",
+        description="Artifact MCP",
+        slug=f"artifact-mcp-{uuid.uuid4().hex[:6]}",
+        scope_namespace="mcpartifact00001",
+        server_type=server_type,
+        server_uri="https://api.example.com/mcp" if server_type == "http" else None,
+        auth_type=auth_type,
+        oauth_integration_id=oauth_integration.id if oauth_integration else None,
+        encrypted_headers=encrypted_headers,
+        stdio_command=None if server_type == "http" else "npx",
+        stdio_args=None,
+        encrypted_stdio_env=None,
+        timeout=30,
+        discovery_status="succeeded",
+        catalog_version=1,
+        sandbox_allow_network=False,
+    )
+    session.add(integration)
+    await session.commit()
+    await session.refresh(integration)
+    return integration
+
+
+async def _insert_catalog_entry(
+    *,
+    session: AsyncSession,
+    integration: MCPIntegration,
+    artifact_type: MCPCatalogArtifactType,
+    artifact_key: str,
+    artifact_ref: str,
+) -> uuid.UUID:
+    entry_id = uuid.uuid4()
+    await session.execute(
+        insert(MCPIntegrationCatalogEntry).values(
+            id=entry_id,
+            mcp_integration_id=integration.id,
+            workspace_id=integration.workspace_id,
+            integration_name=integration.name,
+            artifact_type=artifact_type.value,
+            artifact_key=artifact_key,
+            artifact_ref=artifact_ref,
+            display_name=artifact_ref,
+            description=f"{artifact_type.value} {artifact_ref}",
+            input_schema={"type": "object"},
+            artifact_metadata={"origin": "test"},
+            raw_payload={"name": artifact_ref},
+            content_hash=artifact_key.ljust(64, "0"),
+            is_active=True,
+            search_vector=func.to_tsvector("simple", artifact_ref),
+        )
+    )
+    await session.commit()
+    return entry_id
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        *,
+        call_tool_result: CallToolResult | None = None,
+        read_resource_result: list[TextResourceContents] | None = None,
+        get_prompt_result: GetPromptResult | None = None,
+    ) -> None:
+        self.call_tool_result = call_tool_result
+        self.read_resource_result = read_resource_result or []
+        self.get_prompt_result = get_prompt_result
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        assert self.call_tool_result is not None
+        return self.call_tool_result
+
+    async def read_resource(self, uri: str) -> list[TextResourceContents]:
+        return self.read_resource_result
+
+    async def get_prompt(
+        self, name: str, arguments: dict[str, Any] | None
+    ) -> GetPromptResult:
+        assert self.get_prompt_result is not None
+        return self.get_prompt_result
+
+
+@pytest.mark.anyio
+class TestMCPCatalogArtifactService:
+    async def test_build_headers_combines_custom_headers_and_oauth_token(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+        user: User,
+    ) -> None:
+        oauth_integration = await _create_oauth_integration(
+            session=session,
+            workspace=workspace,
+            user=user,
+            access_token="secret-token",
+        )
+        integration = await _create_mcp_integration(
+            session=session,
+            workspace=workspace,
+            oauth_integration=oauth_integration,
+            auth_type=MCPAuthType.OAUTH2,
+            custom_headers={"X-Tracecat": "1"},
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="tool-a1",
+            artifact_ref="list_repos",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        target = await service.resolve_artifact(
+            workspace_id=workspace.id,
+            artifact_ref_or_id=str(entry_id),
+            artifact_type=MCPCatalogArtifactType.TOOL,
+        )
+
+        headers = await service._build_headers(target)
+
+        assert headers["X-Tracecat"] == "1"
+        assert headers["Authorization"] == "Bearer secret-token"
+
+    async def test_execute_tool_returns_remote_call_result(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="tool-a1",
+            artifact_ref="list_repos",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        fake_client = _FakeClient(
+            call_tool_result=CallToolResult(
+                content=[TextContent(type="text", text="ok")],
+                structuredContent={"status": "ok"},
+                isError=False,
+            )
+        )
+
+        async def fake_create_remote_client(target: Any) -> _FakeClient:
+            return fake_client
+
+        monkeypatch.setattr(
+            service,
+            "_create_remote_client",
+            fake_create_remote_client,
+        )
+
+        result = await service.execute_tool(
+            workspace_id=workspace.id,
+            artifact_ref_or_id=str(entry_id),
+            arguments={"owner": "tracecat"},
+        )
+
+        assert result.result["structuredContent"] == {"status": "ok"}
+        assert result.artifact.artifact_ref == "list_repos"
+
+    async def test_read_resource_truncates_large_content(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+            artifact_key="resource-a1",
+            artifact_ref="docs://readme",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        fake_client = _FakeClient(
+            read_resource_result=[
+                TextResourceContents(
+                    uri=AnyUrl("https://example.com/readme"),
+                    text="a" * 40000,
+                )
+            ]
+        )
+
+        async def fake_create_remote_client(target: Any) -> _FakeClient:
+            return fake_client
+
+        monkeypatch.setattr(
+            service,
+            "_create_remote_client",
+            fake_create_remote_client,
+        )
+
+        result = await service.read_resource(
+            workspace_id=workspace.id,
+            artifact_ref_or_id=str(entry_id),
+        )
+
+        assert result.truncated is True
+        assert result.contents[0]["truncated"] is True
+        assert len(result.contents[0]["text"]) == result.max_content_chars
+
+    async def test_get_prompt_preserves_structured_messages(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+            artifact_key="prompt-a1",
+            artifact_ref="triage_incident",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        fake_client = _FakeClient(
+            get_prompt_result=GetPromptResult(
+                description="Prompt description",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(type="text", text="Investigate this"),
+                    )
+                ],
+            )
+        )
+
+        async def fake_create_remote_client(target: Any) -> _FakeClient:
+            return fake_client
+
+        monkeypatch.setattr(
+            service,
+            "_create_remote_client",
+            fake_create_remote_client,
+        )
+
+        result = await service.get_prompt(
+            workspace_id=workspace.id,
+            artifact_ref_or_id=str(entry_id),
+            arguments={"severity": "high"},
+        )
+
+        assert result.result["messages"][0]["role"] == "user"
+        assert result.result["messages"][0]["content"]["text"] == "Investigate this"
+
+    async def test_stdio_artifacts_are_rejected_for_now(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session,
+            workspace=workspace,
+            server_type="stdio",
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="tool-a1",
+            artifact_ref="list_repos",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+
+        with pytest.raises(TracecatValidationError):
+            await service.execute_tool(
+                workspace_id=workspace.id,
+                artifact_ref_or_id=str(entry_id),
+                arguments={"owner": "tracecat"},
+            )

--- a/tests/unit/test_mcp_catalog_service.py
+++ b/tests/unit/test_mcp_catalog_service.py
@@ -20,7 +20,7 @@ from tracecat.db.models import (
 )
 from tracecat.integrations.enums import MCPAuthType, MCPCatalogArtifactType
 from tracecat.integrations.mcp_scopes import build_mcp_scope_name
-from tracecat.mcp.catalog.service import MCPCatalogSearchService
+from tracecat.mcp.catalog.service import MCPCatalogSearchService, _escape_like_pattern
 
 
 @pytest.fixture
@@ -110,7 +110,7 @@ async def _create_mcp_integration(
     *,
     session: AsyncSession,
     workspace: Workspace,
-    scope_namespace: str = "mcpcatalog000001",
+    scope_namespace: str | None = None,
 ) -> MCPIntegration:
     integration = MCPIntegration(
         id=uuid.uuid4(),
@@ -118,7 +118,7 @@ async def _create_mcp_integration(
         name="Catalog MCP",
         description="Catalog MCP",
         slug=f"catalog-mcp-{uuid.uuid4().hex[:6]}",
-        scope_namespace=scope_namespace,
+        scope_namespace=scope_namespace or uuid.uuid4().hex[:16],
         server_type="http",
         server_uri="https://api.example.com/mcp",
         auth_type=MCPAuthType.NONE,
@@ -169,6 +169,11 @@ async def _insert_catalog_entry(
 
 @pytest.mark.anyio
 class TestMCPCatalogSearchService:
+    async def test_escape_like_pattern_treats_wildcards_literally(self) -> None:
+        assert _escape_like_pattern(r"tools.%_catalog\name") == (
+            r"tools.\%\_catalog\\name"
+        )
+
     async def test_search_catalog_ranks_exact_matches_first(
         self,
         session: AsyncSession,

--- a/tests/unit/test_mcp_catalog_service.py
+++ b/tests/unit/test_mcp_catalog_service.py
@@ -1,0 +1,257 @@
+"""Unit tests for persisted MCP catalog search service."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import func, insert, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import (
+    MCPIntegration,
+    MCPIntegrationCatalogEntry,
+    Membership,
+    Organization,
+    OrganizationMembership,
+    User,
+    Workspace,
+)
+from tracecat.integrations.enums import MCPAuthType, MCPCatalogArtifactType
+from tracecat.integrations.mcp_scopes import build_mcp_scope_name
+from tracecat.mcp.catalog.service import MCPCatalogSearchService
+
+
+@pytest.fixture
+async def org(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Catalog Org",
+        slug=f"catalog-org-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(org)
+    await session.commit()
+    await session.refresh(org)
+    return org
+
+
+@pytest.fixture(autouse=True)
+async def enable_pg_trgm(session: AsyncSession) -> None:
+    await session.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+    await session.commit()
+
+
+@pytest.fixture
+async def user(session: AsyncSession, org: Organization) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email="catalog@example.com",
+        hashed_password="test",
+    )
+    session.add(user)
+    await session.flush()
+    session.add(
+        OrganizationMembership(
+            user_id=user.id,
+            organization_id=org.id,
+        )
+    )
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def workspace(session: AsyncSession, org: Organization, user: User) -> Workspace:
+    workspace = Workspace(
+        id=uuid.uuid4(),
+        name="Catalog Workspace",
+        organization_id=org.id,
+    )
+    session.add(workspace)
+    await session.flush()
+    session.add(
+        Membership(
+            user_id=user.id,
+            workspace_id=workspace.id,
+        )
+    )
+    await session.commit()
+    await session.refresh(workspace)
+    return workspace
+
+
+@pytest.fixture
+def org_admin_role(org: Organization, user: User, workspace: Workspace) -> Role:
+    return Role(
+        type="user",
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+        service_id="tracecat-mcp",
+        scopes=frozenset({"org:workspace:read"}),
+    )
+
+
+@pytest.fixture
+def member_role(org: Organization, user: User, workspace: Workspace) -> Role:
+    return Role(
+        type="user",
+        user_id=user.id,
+        organization_id=org.id,
+        workspace_id=workspace.id,
+        service_id="tracecat-mcp",
+        scopes=frozenset(),
+    )
+
+
+async def _create_mcp_integration(
+    *,
+    session: AsyncSession,
+    workspace: Workspace,
+    scope_namespace: str = "mcpcatalog000001",
+) -> MCPIntegration:
+    integration = MCPIntegration(
+        id=uuid.uuid4(),
+        workspace_id=workspace.id,
+        name="Catalog MCP",
+        description="Catalog MCP",
+        slug=f"catalog-mcp-{uuid.uuid4().hex[:6]}",
+        scope_namespace=scope_namespace,
+        server_type="http",
+        server_uri="https://api.example.com/mcp",
+        auth_type=MCPAuthType.NONE,
+        discovery_status="succeeded",
+        catalog_version=1,
+    )
+    session.add(integration)
+    await session.commit()
+    await session.refresh(integration)
+    return integration
+
+
+async def _insert_catalog_entry(
+    *,
+    session: AsyncSession,
+    integration: MCPIntegration,
+    artifact_type: MCPCatalogArtifactType,
+    artifact_key: str,
+    artifact_ref: str,
+    display_name: str | None = None,
+    is_active: bool = True,
+) -> uuid.UUID:
+    entry_id = uuid.uuid4()
+    await session.execute(
+        insert(MCPIntegrationCatalogEntry).values(
+            id=entry_id,
+            mcp_integration_id=integration.id,
+            workspace_id=integration.workspace_id,
+            integration_name=integration.name,
+            artifact_type=artifact_type.value,
+            artifact_key=artifact_key,
+            artifact_ref=artifact_ref,
+            display_name=display_name,
+            description=f"{artifact_type.value} {artifact_ref}",
+            input_schema={"type": "object"},
+            artifact_metadata={"origin": "test"},
+            raw_payload={"name": artifact_ref},
+            content_hash=artifact_key.ljust(64, "0"),
+            is_active=is_active,
+            search_vector=func.to_tsvector(
+                "simple", f"{display_name or ''} {artifact_ref}".strip()
+            ),
+        )
+    )
+    await session.commit()
+    return entry_id
+
+
+@pytest.mark.anyio
+class TestMCPCatalogSearchService:
+    async def test_search_catalog_ranks_exact_matches_first(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        exact_entry = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="list_repos",
+            display_name="List repos",
+        )
+        fuzzy_entry = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-org-repos-a1b2c3d4e6",
+            artifact_ref="list_org_repos",
+            display_name="List organization repos",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+            artifact_key="docs-readme-a1b2c3d4e7",
+            artifact_ref="docs://readme",
+            display_name="Readme",
+        )
+
+        service = MCPCatalogSearchService(session=session, role=org_admin_role)
+        results = await service.search_catalog(
+            workspace_id=workspace.id,
+            query="list repos",
+            limit=10,
+        )
+
+        assert [item.id for item in results.results[:2]] == [exact_entry, fuzzy_entry]
+        assert results.results[0].rank >= results.results[1].rank
+
+    async def test_search_catalog_filters_by_authorized_scopes_and_artifact_type(
+        self,
+        session: AsyncSession,
+        member_role: Role,
+        workspace: Workspace,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session, workspace=workspace
+        )
+        allowed_entry = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+            artifact_ref="list_repos",
+            display_name="List repos",
+        )
+        await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+            artifact_key="docs-readme-a1b2c3d4e7",
+            artifact_ref="docs://readme",
+            display_name="Readme",
+        )
+        allowed_scope, _resource, _action = build_mcp_scope_name(
+            scope_namespace=integration.scope_namespace,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="github-list-repos-a1b2c3d4e5",
+        )
+        role = member_role.model_copy(update={"scopes": frozenset({allowed_scope})})
+
+        service = MCPCatalogSearchService(session=session, role=role)
+        results = await service.search_catalog(
+            workspace_id=workspace.id,
+            query="repos",
+            artifact_types=[MCPCatalogArtifactType.TOOL],
+            limit=10,
+        )
+
+        assert [item.id for item in results.results] == [allowed_entry]
+        assert results.results[0].scope_name == allowed_scope

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -18,6 +18,21 @@ def test_mcp_startup_retry_settings_parse_from_env(
     assert reloaded.TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS == 1.25
 
 
+def test_numeric_mcp_settings_fall_back_when_env_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRACECAT_MCP__PORT", "")
+    monkeypatch.setenv("TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS", "")
+    monkeypatch.setenv("TRACECAT_MCP__STARTUP_MAX_ATTEMPTS", "")
+    monkeypatch.setenv("TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS", "")
+    reloaded = importlib.reload(mcp_config)
+
+    assert reloaded.TRACECAT_MCP__PORT == 8099
+    assert reloaded.TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS == 32768
+    assert reloaded.TRACECAT_MCP__STARTUP_MAX_ATTEMPTS == 3
+    assert reloaded.TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS == 2.0
+
+
 def test_removed_auth_mode_env_has_no_effect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tracecat/mcp/catalog/__init__.py
+++ b/tracecat/mcp/catalog/__init__.py
@@ -1,0 +1,1 @@
+"""Persisted MCP catalog query services."""

--- a/tracecat/mcp/catalog/artifact_service.py
+++ b/tracecat/mcp/catalog/artifact_service.py
@@ -127,9 +127,7 @@ class MCPCatalogArtifactService(BaseOrgService):
         )
         client = await self._create_remote_client(target)
         async with client as remote_client:
-            result = await remote_client.get_prompt(
-                target.artifact_ref, arguments or None
-            )
+            result = await remote_client.get_prompt(target.artifact_ref, arguments)
         return MCPCatalogPromptResult(
             workspace_id=workspace_id,
             artifact=target,
@@ -307,10 +305,13 @@ class MCPCatalogArtifactService(BaseOrgService):
                 raise TracecatValidationError(
                     "OAuth access token is not available for MCP integration"
                 )
-            headers.setdefault(
-                "Authorization",
-                f"Bearer {access_token.get_secret_value()}",
-            )
+            if auth_header_keys := [
+                key for key in headers if key.strip().casefold() == "authorization"
+            ]:
+                for auth_header_key in auth_header_keys:
+                    headers.pop(auth_header_key, None)
+            token_type = oauth_integration.token_type or "Bearer"
+            headers["Authorization"] = f"{token_type} {access_token.get_secret_value()}"
         return headers
 
     @staticmethod

--- a/tracecat/mcp/catalog/artifact_service.py
+++ b/tracecat/mcp/catalog/artifact_service.py
@@ -1,0 +1,321 @@
+"""Persisted MCP catalog artifact resolution and remote execution."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+from uuid import UUID
+
+import orjson
+from fastmcp import Client
+from sqlalchemy import select
+
+from tracecat.agent.mcp.user_client import _create_transport
+from tracecat.db.models import (
+    MCPIntegration,
+    MCPIntegrationCatalogEntry,
+    OAuthIntegration,
+)
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.identifiers import WorkspaceID
+from tracecat.integrations.enums import MCPAuthType, MCPCatalogArtifactType
+from tracecat.integrations.mcp_scopes import build_mcp_scope_name
+from tracecat.integrations.service import IntegrationService
+from tracecat.mcp.catalog.types import (
+    MCPCatalogPromptResult,
+    MCPCatalogResolvedArtifact,
+    MCPCatalogResourceResult,
+    MCPCatalogToolResult,
+)
+from tracecat.mcp.config import TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS
+from tracecat.mcp.policy.service import MCPCatalogPolicyService
+from tracecat.service import BaseOrgService
+
+
+class MCPCatalogArtifactService(BaseOrgService):
+    """Resolve and execute persisted MCP catalog artifacts for wrapper operations."""
+
+    service_name = "mcp_catalog_artifact"
+
+    async def execute_tool(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        artifact_ref_or_id: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> MCPCatalogToolResult:
+        """Execute a persisted MCP tool artifact."""
+        target = await self.resolve_artifact(
+            workspace_id=workspace_id,
+            artifact_ref_or_id=artifact_ref_or_id,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+        )
+        client = await self._create_remote_client(target)
+        async with client as remote_client:
+            result = await remote_client.call_tool(target.artifact_ref, arguments or {})
+        return MCPCatalogToolResult(
+            workspace_id=workspace_id,
+            artifact=target,
+            result=cast(Any, result).model_dump(mode="json"),
+        )
+
+    async def read_resource(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        artifact_ref_or_id: str,
+    ) -> MCPCatalogResourceResult:
+        """Read a persisted MCP resource artifact with wrapper-side truncation."""
+        target = await self.resolve_artifact(
+            workspace_id=workspace_id,
+            artifact_ref_or_id=artifact_ref_or_id,
+            artifact_type=MCPCatalogArtifactType.RESOURCE,
+        )
+        client = await self._create_remote_client(target)
+        async with client as remote_client:
+            contents = await remote_client.read_resource(target.artifact_ref)
+
+        total_chars = 0
+        truncated = False
+        serialized_contents: list[dict[str, Any]] = []
+        for content in contents:
+            payload = content.model_dump(mode="json")
+            match payload:
+                case {"text": str(text)}:
+                    original_length = len(text)
+                    total_chars += original_length
+                    if original_length > TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS:
+                        payload["text"] = text[
+                            :TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS
+                        ]
+                        payload["truncated"] = True
+                        payload["original_length"] = original_length
+                        truncated = True
+                case {"blob": str(blob)}:
+                    original_length = len(blob)
+                    total_chars += original_length
+                    if original_length > TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS:
+                        payload["blob"] = blob[
+                            :TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS
+                        ]
+                        payload["truncated"] = True
+                        payload["original_length"] = original_length
+                        truncated = True
+            serialized_contents.append(payload)
+
+        return MCPCatalogResourceResult(
+            workspace_id=workspace_id,
+            artifact=target,
+            contents=tuple(serialized_contents),
+            truncated=truncated,
+            max_content_chars=TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS,
+            total_content_chars=total_chars,
+        )
+
+    async def get_prompt(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        artifact_ref_or_id: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> MCPCatalogPromptResult:
+        """Read a persisted MCP prompt artifact."""
+        target = await self.resolve_artifact(
+            workspace_id=workspace_id,
+            artifact_ref_or_id=artifact_ref_or_id,
+            artifact_type=MCPCatalogArtifactType.PROMPT,
+        )
+        client = await self._create_remote_client(target)
+        async with client as remote_client:
+            result = await remote_client.get_prompt(
+                target.artifact_ref, arguments or None
+            )
+        return MCPCatalogPromptResult(
+            workspace_id=workspace_id,
+            artifact=target,
+            result=cast(Any, result).model_dump(mode="json"),
+        )
+
+    async def resolve_artifact(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        artifact_ref_or_id: str,
+        artifact_type: MCPCatalogArtifactType,
+    ) -> MCPCatalogResolvedArtifact:
+        """Resolve a single authorized persisted artifact by UUID or exact ref."""
+        policy_service = MCPCatalogPolicyService(session=self.session, role=self.role)
+        if maybe_uuid := self._parse_uuid(artifact_ref_or_id):
+            authorized_entry = await policy_service.authorize_catalog_entry(
+                workspace_id=workspace_id,
+                entry_id=maybe_uuid,
+            )
+            if authorized_entry.artifact_type != artifact_type:
+                raise TracecatNotFoundError("MCP catalog entry not found")
+            stmt = self._base_artifact_stmt().where(
+                MCPIntegrationCatalogEntry.id == authorized_entry.id,
+                MCPIntegrationCatalogEntry.workspace_id == workspace_id,
+            )
+            result = await self.session.execute(stmt)
+            row = result.tuples().first()
+            if row is None:
+                raise TracecatNotFoundError("MCP catalog entry not found")
+            return self._row_to_target(row)
+
+        authorization = await policy_service.authorize_catalog_search(
+            workspace_id=workspace_id
+        )
+        if not authorization.allowed_entry_ids:
+            raise TracecatNotFoundError("MCP catalog entry not found")
+
+        stmt = (
+            self._base_artifact_stmt()
+            .where(
+                MCPIntegrationCatalogEntry.workspace_id == workspace_id,
+                MCPIntegrationCatalogEntry.is_active.is_(True),
+                MCPIntegrationCatalogEntry.id.in_(authorization.allowed_entry_ids),
+                MCPIntegrationCatalogEntry.artifact_type == artifact_type.value,
+                MCPIntegrationCatalogEntry.artifact_ref == artifact_ref_or_id,
+            )
+            .order_by(MCPIntegrationCatalogEntry.id)
+        )
+        result = await self.session.execute(stmt)
+        rows = result.tuples().all()
+        if not rows:
+            raise TracecatNotFoundError("MCP catalog entry not found")
+        if len(rows) > 1:
+            raise TracecatValidationError(
+                "Artifact reference is ambiguous; use the MCP catalog entry ID instead"
+            )
+        return self._row_to_target(rows[0])
+
+    def _base_artifact_stmt(self) -> Any:
+        return select(
+            MCPIntegrationCatalogEntry.id,
+            MCPIntegrationCatalogEntry.mcp_integration_id,
+            MCPIntegrationCatalogEntry.workspace_id,
+            MCPIntegrationCatalogEntry.artifact_type,
+            MCPIntegrationCatalogEntry.artifact_key,
+            MCPIntegrationCatalogEntry.artifact_ref,
+            MCPIntegrationCatalogEntry.display_name,
+            MCPIntegrationCatalogEntry.description,
+            MCPIntegration.scope_namespace,
+            MCPIntegration.server_type,
+            MCPIntegration.server_uri,
+            MCPIntegration.auth_type,
+            MCPIntegration.oauth_integration_id,
+            MCPIntegration.encrypted_headers,
+            MCPIntegration.timeout,
+        ).join(
+            MCPIntegration,
+            MCPIntegration.id == MCPIntegrationCatalogEntry.mcp_integration_id,
+        )
+
+    def _row_to_target(self, row: Sequence[Any]) -> MCPCatalogResolvedArtifact:
+        (
+            entry_id,
+            mcp_integration_id,
+            workspace_id,
+            artifact_type_value,
+            artifact_key,
+            artifact_ref,
+            display_name,
+            description,
+            scope_namespace,
+            server_type,
+            server_uri,
+            auth_type,
+            oauth_integration_id,
+            encrypted_headers,
+            timeout,
+        ) = row
+        artifact_type = MCPCatalogArtifactType(artifact_type_value)
+        scope_name, _resource, _action = build_mcp_scope_name(
+            scope_namespace=scope_namespace,
+            artifact_type=artifact_type,
+            artifact_key=artifact_key,
+        )
+        return MCPCatalogResolvedArtifact(
+            id=entry_id,
+            mcp_integration_id=mcp_integration_id,
+            workspace_id=workspace_id,
+            artifact_type=artifact_type,
+            artifact_key=artifact_key,
+            artifact_ref=artifact_ref,
+            display_name=display_name,
+            description=description,
+            scope_name=scope_name,
+            server_type=server_type,
+            server_uri=server_uri,
+            auth_type=auth_type,
+            oauth_integration_id=oauth_integration_id,
+            encrypted_headers=encrypted_headers,
+            timeout=timeout,
+        )
+
+    async def _create_remote_client(self, target: MCPCatalogResolvedArtifact) -> Client:
+        if target.server_type != "http":
+            raise TracecatValidationError(
+                "Local stdio MCP artifacts are not available through this wrapper yet"
+            )
+        if not target.server_uri:
+            raise TracecatValidationError("MCP integration server URI is missing")
+        headers = await self._build_headers(target)
+        transport = _create_transport(
+            target.server_uri,
+            "http",
+            headers or None,
+            target.timeout,
+        )
+        return Client(transport)
+
+    async def _build_headers(
+        self, target: MCPCatalogResolvedArtifact
+    ) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        integration_service = IntegrationService(session=self.session, role=self.role)
+        if target.encrypted_headers:
+            if decrypted := integration_service._decrypt_token(
+                target.encrypted_headers
+            ):
+                loaded = orjson.loads(decrypted)
+                if not isinstance(loaded, dict):
+                    raise TracecatValidationError(
+                        "Stored MCP integration headers must decode to an object"
+                    )
+                for key, value in loaded.items():
+                    if not isinstance(key, str) or not isinstance(value, str):
+                        raise TracecatValidationError(
+                            "Stored MCP integration headers must be string pairs"
+                        )
+                    headers[key] = value
+
+        if (
+            target.auth_type == MCPAuthType.OAUTH2
+            and target.oauth_integration_id is not None
+        ):
+            oauth_integration = await self.session.get(
+                OAuthIntegration, target.oauth_integration_id
+            )
+            if oauth_integration is None:
+                raise TracecatNotFoundError("OAuth integration not found")
+            oauth_integration = await integration_service.refresh_token_if_needed(
+                oauth_integration
+            )
+            access_token = await integration_service.get_access_token(oauth_integration)
+            if access_token is None:
+                raise TracecatValidationError(
+                    "OAuth access token is not available for MCP integration"
+                )
+            headers.setdefault(
+                "Authorization",
+                f"Bearer {access_token.get_secret_value()}",
+            )
+        return headers
+
+    @staticmethod
+    def _parse_uuid(value: str) -> UUID | None:
+        try:
+            return UUID(value)
+        except ValueError:
+            return None

--- a/tracecat/mcp/catalog/service.py
+++ b/tracecat/mcp/catalog/service.py
@@ -1,0 +1,183 @@
+"""Persisted MCP catalog search service for external wrapper operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import Float, Text, case, cast, func, literal, or_, select
+
+from tracecat.db.models import MCPIntegration, MCPIntegrationCatalogEntry
+from tracecat.identifiers import WorkspaceID
+from tracecat.integrations.enums import MCPCatalogArtifactType
+from tracecat.integrations.mcp_scopes import build_mcp_scope_name
+from tracecat.mcp.catalog.types import MCPCatalogSearchResult, MCPCatalogSearchResults
+from tracecat.mcp.policy.service import MCPCatalogPolicyService
+from tracecat.service import BaseOrgService
+
+
+class MCPCatalogSearchService(BaseOrgService):
+    """Search active persisted catalog entries visible to the current caller."""
+
+    service_name = "mcp_catalog_search"
+
+    async def search_catalog(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        query: str,
+        artifact_types: Sequence[MCPCatalogArtifactType] | None = None,
+        integration_ids: Sequence[UUID] | None = None,
+        limit: int = 20,
+    ) -> MCPCatalogSearchResults:
+        """Search policy-authorized persisted catalog entries for a workspace."""
+        policy_service = MCPCatalogPolicyService(session=self.session, role=self.role)
+        authorization = await policy_service.authorize_catalog_search(
+            workspace_id=workspace_id
+        )
+        if not authorization.allowed_entry_ids:
+            return MCPCatalogSearchResults(
+                workspace_id=workspace_id,
+                query=query,
+                results=(),
+            )
+
+        normalized_query = query.strip().lower()
+        normalized_query_text = cast(literal(normalized_query), Text)
+        display_name = func.lower(
+            func.coalesce(MCPIntegrationCatalogEntry.display_name, "")
+        )
+        artifact_ref = func.lower(MCPIntegrationCatalogEntry.artifact_ref)
+        base_stmt = (
+            select(
+                MCPIntegrationCatalogEntry.id,
+                MCPIntegrationCatalogEntry.mcp_integration_id,
+                MCPIntegrationCatalogEntry.workspace_id,
+                MCPIntegrationCatalogEntry.artifact_type,
+                MCPIntegrationCatalogEntry.artifact_key,
+                MCPIntegrationCatalogEntry.artifact_ref,
+                MCPIntegrationCatalogEntry.display_name,
+                MCPIntegrationCatalogEntry.description,
+                MCPIntegrationCatalogEntry.input_schema,
+                MCPIntegration.scope_namespace,
+            )
+            .join(
+                MCPIntegration,
+                MCPIntegration.id == MCPIntegrationCatalogEntry.mcp_integration_id,
+            )
+            .where(
+                MCPIntegrationCatalogEntry.workspace_id == workspace_id,
+                MCPIntegrationCatalogEntry.is_active.is_(True),
+                MCPIntegrationCatalogEntry.id.in_(authorization.allowed_entry_ids),
+            )
+        )
+        if artifact_types:
+            base_stmt = base_stmt.where(
+                MCPIntegrationCatalogEntry.artifact_type.in_(
+                    [artifact_type.value for artifact_type in artifact_types]
+                )
+            )
+        if integration_ids:
+            base_stmt = base_stmt.where(
+                MCPIntegrationCatalogEntry.mcp_integration_id.in_(integration_ids)
+            )
+
+        if normalized_query:
+            tsquery = func.websearch_to_tsquery("simple", query)
+            similarity_score = func.greatest(
+                func.similarity(display_name, normalized_query_text),
+                func.similarity(artifact_ref, normalized_query_text),
+            )
+            rank = (
+                cast(
+                    func.ts_rank_cd(
+                        MCPIntegrationCatalogEntry.search_vector, tsquery, 32
+                    ),
+                    Float,
+                )
+                + cast(
+                    case((display_name == normalized_query, 1.25), else_=0.0),
+                    Float,
+                )
+                + cast(
+                    case((artifact_ref == normalized_query, 1.0), else_=0.0),
+                    Float,
+                )
+                + cast(
+                    case((display_name.like(f"{normalized_query}%"), 0.35), else_=0.0),
+                    Float,
+                )
+                + cast(similarity_score * 0.20, Float)
+            ).label("rank")
+            stmt = (
+                base_stmt.add_columns(rank)
+                .where(
+                    or_(
+                        MCPIntegrationCatalogEntry.search_vector.op("@@")(tsquery),
+                        display_name == normalized_query,
+                        artifact_ref == normalized_query,
+                        display_name.like(f"{normalized_query}%"),
+                        func.similarity(display_name, normalized_query_text) >= 0.1,
+                        func.similarity(artifact_ref, normalized_query_text) >= 0.1,
+                    )
+                )
+                .order_by(
+                    rank.desc(),
+                    MCPIntegrationCatalogEntry.artifact_type,
+                    display_name,
+                    MCPIntegrationCatalogEntry.artifact_ref,
+                    MCPIntegrationCatalogEntry.id,
+                )
+            )
+        else:
+            rank = literal(0.0, type_=Float).label("rank")
+            stmt = base_stmt.add_columns(rank).order_by(
+                MCPIntegrationCatalogEntry.artifact_type,
+                display_name,
+                MCPIntegrationCatalogEntry.artifact_ref,
+                MCPIntegrationCatalogEntry.id,
+            )
+
+        result = await self.session.execute(stmt.limit(limit))
+        rows = result.tuples().all()
+        items: list[MCPCatalogSearchResult] = []
+        for (
+            entry_id,
+            mcp_integration_id,
+            entry_workspace_id,
+            artifact_type_value,
+            artifact_key,
+            artifact_ref_value,
+            display_name_value,
+            description,
+            input_schema,
+            scope_namespace,
+            rank_value,
+        ) in rows:
+            artifact_type = MCPCatalogArtifactType(artifact_type_value)
+            scope_name, _resource, _action = build_mcp_scope_name(
+                scope_namespace=scope_namespace,
+                artifact_type=artifact_type,
+                artifact_key=artifact_key,
+            )
+            items.append(
+                MCPCatalogSearchResult(
+                    id=entry_id,
+                    mcp_integration_id=mcp_integration_id,
+                    workspace_id=entry_workspace_id,
+                    artifact_type=artifact_type,
+                    artifact_key=artifact_key,
+                    artifact_ref=artifact_ref_value,
+                    display_name=display_name_value,
+                    description=description,
+                    input_schema=input_schema,
+                    scope_name=scope_name,
+                    rank=float(rank_value),
+                )
+            )
+
+        return MCPCatalogSearchResults(
+            workspace_id=workspace_id,
+            query=query,
+            results=tuple(items),
+        )

--- a/tracecat/mcp/catalog/service.py
+++ b/tracecat/mcp/catalog/service.py
@@ -15,6 +15,16 @@ from tracecat.mcp.catalog.types import MCPCatalogSearchResult, MCPCatalogSearchR
 from tracecat.mcp.policy.service import MCPCatalogPolicyService
 from tracecat.service import BaseOrgService
 
+_LIKE_ESCAPE_CHAR = "\\"
+
+
+def _escape_like_pattern(value: str) -> str:
+    return (
+        value.replace(_LIKE_ESCAPE_CHAR, _LIKE_ESCAPE_CHAR * 2)
+        .replace("%", f"{_LIKE_ESCAPE_CHAR}%")
+        .replace("_", f"{_LIKE_ESCAPE_CHAR}_")
+    )
+
 
 class MCPCatalogSearchService(BaseOrgService):
     """Search active persisted catalog entries visible to the current caller."""
@@ -84,6 +94,8 @@ class MCPCatalogSearchService(BaseOrgService):
 
         if normalized_query:
             tsquery = func.websearch_to_tsquery("simple", query)
+            prefix_pattern = f"{_escape_like_pattern(normalized_query)}%"
+            prefix_match = display_name.like(prefix_pattern, escape=_LIKE_ESCAPE_CHAR)
             similarity_score = func.greatest(
                 func.similarity(display_name, normalized_query_text),
                 func.similarity(artifact_ref, normalized_query_text),
@@ -104,7 +116,7 @@ class MCPCatalogSearchService(BaseOrgService):
                     Float,
                 )
                 + cast(
-                    case((display_name.like(f"{normalized_query}%"), 0.35), else_=0.0),
+                    case((prefix_match, 0.35), else_=0.0),
                     Float,
                 )
                 + cast(similarity_score * 0.20, Float)
@@ -116,7 +128,7 @@ class MCPCatalogSearchService(BaseOrgService):
                         MCPIntegrationCatalogEntry.search_vector.op("@@")(tsquery),
                         display_name == normalized_query,
                         artifact_ref == normalized_query,
-                        display_name.like(f"{normalized_query}%"),
+                        prefix_match,
                         func.similarity(display_name, normalized_query_text) >= 0.1,
                         func.similarity(artifact_ref, normalized_query_text) >= 0.1,
                     )

--- a/tracecat/mcp/catalog/types.py
+++ b/tracecat/mcp/catalog/types.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 from uuid import UUID
 
 from tracecat.identifiers import WorkspaceID
-from tracecat.integrations.enums import MCPCatalogArtifactType
+from tracecat.integrations.enums import MCPAuthType, MCPCatalogArtifactType
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,3 +34,54 @@ class MCPCatalogSearchResults:
     workspace_id: WorkspaceID
     query: str
     results: tuple[MCPCatalogSearchResult, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MCPCatalogResolvedArtifact:
+    """Authorized persisted artifact plus integration execution metadata."""
+
+    id: UUID
+    mcp_integration_id: UUID
+    workspace_id: WorkspaceID
+    artifact_type: MCPCatalogArtifactType
+    artifact_key: str
+    artifact_ref: str
+    display_name: str | None
+    description: str | None
+    scope_name: str
+    server_type: str
+    server_uri: str | None
+    auth_type: MCPAuthType
+    oauth_integration_id: UUID | None
+    encrypted_headers: bytes | None
+    timeout: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class MCPCatalogToolResult:
+    """Wrapper result for an MCP tool call."""
+
+    workspace_id: WorkspaceID
+    artifact: MCPCatalogResolvedArtifact
+    result: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class MCPCatalogResourceResult:
+    """Wrapper result for an MCP resource read."""
+
+    workspace_id: WorkspaceID
+    artifact: MCPCatalogResolvedArtifact
+    contents: tuple[dict[str, Any], ...]
+    truncated: bool
+    max_content_chars: int
+    total_content_chars: int
+
+
+@dataclass(frozen=True, slots=True)
+class MCPCatalogPromptResult:
+    """Wrapper result for an MCP prompt fetch."""
+
+    workspace_id: WorkspaceID
+    artifact: MCPCatalogResolvedArtifact
+    result: dict[str, Any]

--- a/tracecat/mcp/catalog/types.py
+++ b/tracecat/mcp/catalog/types.py
@@ -1,0 +1,35 @@
+"""Domain types for persisted MCP catalog queries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from tracecat.identifiers import WorkspaceID
+from tracecat.integrations.enums import MCPCatalogArtifactType
+
+
+@dataclass(frozen=True, slots=True)
+class MCPCatalogSearchResult:
+    """Persisted catalog artifact returned from a wrapper search."""
+
+    id: UUID
+    mcp_integration_id: UUID
+    workspace_id: WorkspaceID
+    artifact_type: MCPCatalogArtifactType
+    artifact_key: str
+    artifact_ref: str
+    display_name: str | None
+    description: str | None
+    input_schema: dict[str, object] | None
+    scope_name: str
+    rank: float
+
+
+@dataclass(frozen=True, slots=True)
+class MCPCatalogSearchResults:
+    """Search response for persisted wrapper-visible catalog artifacts."""
+
+    workspace_id: WorkspaceID
+    query: str
+    results: tuple[MCPCatalogSearchResult, ...]

--- a/tracecat/mcp/config.py
+++ b/tracecat/mcp/config.py
@@ -39,6 +39,11 @@ TRACECAT_MCP__MAX_INPUT_SIZE_BYTES: int = int(
 )
 """Maximum size in bytes for any single string argument to a tool call (default 512KB)."""
 
+TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS: int = int(
+    os.environ.get("TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS", "32768")
+)
+"""Maximum characters returned for any single MCP resource content payload."""
+
 TRACECAT_MCP__STARTUP_MAX_ATTEMPTS: int = int(
     os.environ.get("TRACECAT_MCP__STARTUP_MAX_ATTEMPTS", "3")
 )

--- a/tracecat/mcp/config.py
+++ b/tracecat/mcp/config.py
@@ -7,7 +7,7 @@ import os
 TRACECAT_MCP__HOST: str = os.environ.get("TRACECAT_MCP__HOST", "127.0.0.1")
 """Host to bind the MCP HTTP server to."""
 
-TRACECAT_MCP__PORT: int = int(os.environ.get("TRACECAT_MCP__PORT", "8099"))
+TRACECAT_MCP__PORT: int = int(os.environ.get("TRACECAT_MCP__PORT") or "8099")
 """Port for the MCP HTTP server."""
 
 TRACECAT_MCP__BASE_URL: str = (
@@ -20,36 +20,36 @@ Defaults to http://localhost:<TRACECAT_MCP__PORT> for local development.
 """
 
 TRACECAT_MCP__RATE_LIMIT_RPS: float = float(
-    os.environ.get("TRACECAT_MCP__RATE_LIMIT_RPS", "2.0")
+    os.environ.get("TRACECAT_MCP__RATE_LIMIT_RPS") or "2.0"
 )
 """Sustained requests per second per user (token bucket refill rate)."""
 
 TRACECAT_MCP__RATE_LIMIT_BURST: int = int(
-    os.environ.get("TRACECAT_MCP__RATE_LIMIT_BURST", "10")
+    os.environ.get("TRACECAT_MCP__RATE_LIMIT_BURST") or "10"
 )
 """Burst capacity for per-user rate limiting."""
 
 TRACECAT_MCP__TOOL_TIMEOUT_SECONDS: int = int(
-    os.environ.get("TRACECAT_MCP__TOOL_TIMEOUT_SECONDS", "120")
+    os.environ.get("TRACECAT_MCP__TOOL_TIMEOUT_SECONDS") or "120"
 )
 """Maximum execution time in seconds for a single tool call."""
 
 TRACECAT_MCP__MAX_INPUT_SIZE_BYTES: int = int(
-    os.environ.get("TRACECAT_MCP__MAX_INPUT_SIZE_BYTES", "524288")
+    os.environ.get("TRACECAT_MCP__MAX_INPUT_SIZE_BYTES") or "524288"
 )
 """Maximum size in bytes for any single string argument to a tool call (default 512KB)."""
 
 TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS: int = int(
-    os.environ.get("TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS", "32768")
+    os.environ.get("TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS") or "32768"
 )
 """Maximum characters returned for any single MCP resource content payload."""
 
 TRACECAT_MCP__STARTUP_MAX_ATTEMPTS: int = int(
-    os.environ.get("TRACECAT_MCP__STARTUP_MAX_ATTEMPTS", "3")
+    os.environ.get("TRACECAT_MCP__STARTUP_MAX_ATTEMPTS") or "3"
 )
 """Maximum MCP server startup attempts before failing hard."""
 
 TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS: float = float(
-    os.environ.get("TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS", "2")
+    os.environ.get("TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS") or "2"
 )
 """Seconds to wait between MCP startup retries."""

--- a/tracecat/mcp/schemas.py
+++ b/tracecat/mcp/schemas.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from tracecat.dsl.common import DSLInput
+from tracecat.integrations.enums import MCPCatalogArtifactType
 
 
 class LayoutPosition(BaseModel):
@@ -154,3 +155,27 @@ class WorkflowRunResponse(BaseModel):
     workflow_id: str
     execution_id: str
     message: str
+
+
+class MCPCatalogSearchItem(BaseModel):
+    """Wrapper-visible persisted MCP catalog artifact."""
+
+    id: str
+    mcp_integration_id: str
+    workspace_id: str
+    artifact_type: MCPCatalogArtifactType
+    artifact_key: str
+    artifact_ref: str
+    display_name: str | None
+    description: str | None
+    input_schema: dict[str, Any] | None = None
+    scope_name: str
+    rank: float
+
+
+class MCPCatalogSearchResponse(BaseModel):
+    """Response schema for `search_mcp_catalog`."""
+
+    workspace_id: str
+    query: str
+    results: list[MCPCatalogSearchItem] = Field(default_factory=list)

--- a/tracecat/mcp/schemas.py
+++ b/tracecat/mcp/schemas.py
@@ -179,3 +179,44 @@ class MCPCatalogSearchResponse(BaseModel):
     workspace_id: str
     query: str
     results: list[MCPCatalogSearchItem] = Field(default_factory=list)
+
+
+class MCPCatalogArtifactSummary(BaseModel):
+    """Artifact identity metadata returned by wrapper execution operations."""
+
+    id: str
+    mcp_integration_id: str
+    workspace_id: str
+    artifact_type: MCPCatalogArtifactType
+    artifact_key: str
+    artifact_ref: str
+    display_name: str | None
+    description: str | None
+    scope_name: str
+
+
+class MCPCatalogToolExecutionResponse(BaseModel):
+    """Response schema for `execute_mcp_tool`."""
+
+    workspace_id: str
+    artifact: MCPCatalogArtifactSummary
+    result: dict[str, Any]
+
+
+class MCPCatalogResourceReadResponse(BaseModel):
+    """Response schema for `read_mcp_resource`."""
+
+    workspace_id: str
+    artifact: MCPCatalogArtifactSummary
+    contents: list[dict[str, Any]] = Field(default_factory=list)
+    truncated: bool
+    max_content_chars: int
+    total_content_chars: int
+
+
+class MCPCatalogPromptResponse(BaseModel):
+    """Response schema for `get_mcp_prompt`."""
+
+    workspace_id: str
+    artifact: MCPCatalogArtifactSummary
+    result: dict[str, Any]

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -62,12 +62,14 @@ from tracecat.identifiers.workflow import (
     WorkflowUUID,
     exec_id_to_parts,
 )
+from tracecat.integrations.enums import MCPCatalogArtifactType
 from tracecat.logger import logger
 from tracecat.mcp.auth import (
     create_mcp_auth,
     list_workspaces_for_request,
     resolve_role_for_request,
 )
+from tracecat.mcp.catalog.service import MCPCatalogSearchService
 from tracecat.mcp.config import (
     TRACECAT_MCP__RATE_LIMIT_BURST,
     TRACECAT_MCP__RATE_LIMIT_RPS,
@@ -78,6 +80,7 @@ from tracecat.mcp.middleware import (
     WatchtowerMonitorMiddleware,
     get_mcp_client_id,
 )
+from tracecat.mcp.schemas import MCPCatalogSearchItem, MCPCatalogSearchResponse
 from tracecat.pagination import CursorPaginationParams
 from tracecat.registry.actions.schemas import TemplateAction
 from tracecat.registry.actions.service import (
@@ -1354,6 +1357,99 @@ async def list_workspaces() -> str:
     except Exception as e:
         logger.error("Failed to list workspaces", error=str(e))
         raise ToolError(f"Failed to list workspaces: {e}") from None
+
+
+@mcp.tool()
+async def search_mcp_catalog(
+    workspace_id: str,
+    query: str = "",
+    artifact_types_json: str | None = None,
+    integration_ids_json: str | None = None,
+    limit: int = 20,
+) -> str:
+    """Search persisted MCP catalog artifacts visible to the caller.
+
+    Args:
+        workspace_id: The workspace ID (from list_workspaces).
+        query: Search query text. Empty queries list authorized artifacts.
+        artifact_types_json: Optional JSON array of artifact types (`tool`,
+            `resource`, `prompt`).
+        integration_ids_json: Optional JSON array of MCP integration UUIDs.
+        limit: Max results to return. Must be between 1 and 50.
+
+    Returns:
+        JSON payload containing the filtered persisted catalog results.
+    """
+    if limit < 1 or limit > 50:
+        raise ToolError("limit must be between 1 and 50")
+
+    raw_artifact_types = _parse_json_arg(artifact_types_json, "artifact_types_json")
+    raw_integration_ids = _parse_json_arg(integration_ids_json, "integration_ids_json")
+    if raw_artifact_types is not None and not isinstance(raw_artifact_types, list):
+        raise ToolError("artifact_types_json must be a JSON array of strings")
+    if raw_integration_ids is not None and not isinstance(raw_integration_ids, list):
+        raise ToolError("integration_ids_json must be a JSON array of UUIDs")
+
+    artifact_types: list[MCPCatalogArtifactType] | None = None
+    if raw_artifact_types is not None:
+        artifact_types = []
+        for raw_artifact_type in raw_artifact_types:
+            if not isinstance(raw_artifact_type, str):
+                raise ToolError("artifact_types_json must be a JSON array of strings")
+            try:
+                artifact_types.append(MCPCatalogArtifactType(raw_artifact_type))
+            except ValueError as exc:
+                raise ToolError(f"Invalid artifact type: {raw_artifact_type}") from exc
+
+    integration_ids: list[uuid.UUID] | None = None
+    if raw_integration_ids is not None:
+        integration_ids = []
+        for raw_integration_id in raw_integration_ids:
+            if not isinstance(raw_integration_id, str):
+                raise ToolError("integration_ids_json must be a JSON array of UUIDs")
+            try:
+                integration_ids.append(uuid.UUID(raw_integration_id))
+            except ValueError as exc:
+                raise ToolError(
+                    f"Invalid integration ID: {raw_integration_id}"
+                ) from exc
+
+    try:
+        ws_id, role = await _resolve_workspace_role(workspace_id)
+        async with MCPCatalogSearchService.with_session(role=role) as svc:
+            results = await svc.search_catalog(
+                workspace_id=ws_id,
+                query=query,
+                artifact_types=artifact_types,
+                integration_ids=integration_ids,
+                limit=limit,
+            )
+        payload = MCPCatalogSearchResponse(
+            workspace_id=str(results.workspace_id),
+            query=results.query,
+            results=[
+                MCPCatalogSearchItem(
+                    id=str(item.id),
+                    mcp_integration_id=str(item.mcp_integration_id),
+                    workspace_id=str(item.workspace_id),
+                    artifact_type=item.artifact_type,
+                    artifact_key=item.artifact_key,
+                    artifact_ref=item.artifact_ref,
+                    display_name=item.display_name,
+                    description=item.description,
+                    input_schema=item.input_schema,
+                    scope_name=item.scope_name,
+                    rank=item.rank,
+                )
+                for item in results.results
+            ],
+        )
+        return payload.model_dump_json()
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    except Exception as exc:
+        logger.error("Failed to search MCP catalog", error=str(exc))
+        raise ToolError(f"Failed to search MCP catalog: {exc}") from None
 
 
 # ---------------------------------------------------------------------------

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -69,6 +69,7 @@ from tracecat.mcp.auth import (
     list_workspaces_for_request,
     resolve_role_for_request,
 )
+from tracecat.mcp.catalog.artifact_service import MCPCatalogArtifactService
 from tracecat.mcp.catalog.service import MCPCatalogSearchService
 from tracecat.mcp.config import (
     TRACECAT_MCP__RATE_LIMIT_BURST,
@@ -80,7 +81,14 @@ from tracecat.mcp.middleware import (
     WatchtowerMonitorMiddleware,
     get_mcp_client_id,
 )
-from tracecat.mcp.schemas import MCPCatalogSearchItem, MCPCatalogSearchResponse
+from tracecat.mcp.schemas import (
+    MCPCatalogArtifactSummary,
+    MCPCatalogPromptResponse,
+    MCPCatalogResourceReadResponse,
+    MCPCatalogSearchItem,
+    MCPCatalogSearchResponse,
+    MCPCatalogToolExecutionResponse,
+)
 from tracecat.pagination import CursorPaginationParams
 from tracecat.registry.actions.schemas import TemplateAction
 from tracecat.registry.actions.service import (
@@ -1450,6 +1458,152 @@ async def search_mcp_catalog(
     except Exception as exc:
         logger.error("Failed to search MCP catalog", error=str(exc))
         raise ToolError(f"Failed to search MCP catalog: {exc}") from None
+
+
+def _catalog_artifact_summary_payload(
+    *,
+    id: str,
+    mcp_integration_id: str,
+    workspace_id: str,
+    artifact_type: MCPCatalogArtifactType,
+    artifact_key: str,
+    artifact_ref: str,
+    display_name: str | None,
+    description: str | None,
+    scope_name: str,
+) -> MCPCatalogArtifactSummary:
+    return MCPCatalogArtifactSummary(
+        id=id,
+        mcp_integration_id=mcp_integration_id,
+        workspace_id=workspace_id,
+        artifact_type=artifact_type,
+        artifact_key=artifact_key,
+        artifact_ref=artifact_ref,
+        display_name=display_name,
+        description=description,
+        scope_name=scope_name,
+    )
+
+
+@mcp.tool()
+async def execute_mcp_tool(
+    workspace_id: str,
+    artifact_ref_or_id: str,
+    arguments_json: str | None = None,
+) -> str:
+    """Execute a persisted MCP tool artifact through the wrapper surface."""
+    raw_arguments = _parse_json_arg(arguments_json, "arguments_json")
+    if raw_arguments is not None and not isinstance(raw_arguments, dict):
+        raise ToolError("arguments_json must decode to a JSON object")
+    try:
+        ws_id, role = await _resolve_workspace_role(workspace_id)
+        async with MCPCatalogArtifactService.with_session(role=role) as svc:
+            result = await svc.execute_tool(
+                workspace_id=ws_id,
+                artifact_ref_or_id=artifact_ref_or_id,
+                arguments=raw_arguments,
+            )
+        payload = MCPCatalogToolExecutionResponse(
+            workspace_id=str(result.workspace_id),
+            artifact=_catalog_artifact_summary_payload(
+                id=str(result.artifact.id),
+                mcp_integration_id=str(result.artifact.mcp_integration_id),
+                workspace_id=str(result.artifact.workspace_id),
+                artifact_type=result.artifact.artifact_type,
+                artifact_key=result.artifact.artifact_key,
+                artifact_ref=result.artifact.artifact_ref,
+                display_name=result.artifact.display_name,
+                description=result.artifact.description,
+                scope_name=result.artifact.scope_name,
+            ),
+            result=result.result,
+        )
+        return payload.model_dump_json()
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    except Exception as exc:
+        logger.error("Failed to execute MCP tool", error=str(exc))
+        raise ToolError(f"Failed to execute MCP tool: {exc}") from None
+
+
+@mcp.tool()
+async def read_mcp_resource(
+    workspace_id: str,
+    artifact_ref_or_id: str,
+) -> str:
+    """Read a persisted MCP resource artifact through the wrapper surface."""
+    try:
+        ws_id, role = await _resolve_workspace_role(workspace_id)
+        async with MCPCatalogArtifactService.with_session(role=role) as svc:
+            result = await svc.read_resource(
+                workspace_id=ws_id,
+                artifact_ref_or_id=artifact_ref_or_id,
+            )
+        payload = MCPCatalogResourceReadResponse(
+            workspace_id=str(result.workspace_id),
+            artifact=_catalog_artifact_summary_payload(
+                id=str(result.artifact.id),
+                mcp_integration_id=str(result.artifact.mcp_integration_id),
+                workspace_id=str(result.artifact.workspace_id),
+                artifact_type=result.artifact.artifact_type,
+                artifact_key=result.artifact.artifact_key,
+                artifact_ref=result.artifact.artifact_ref,
+                display_name=result.artifact.display_name,
+                description=result.artifact.description,
+                scope_name=result.artifact.scope_name,
+            ),
+            contents=list(result.contents),
+            truncated=result.truncated,
+            max_content_chars=result.max_content_chars,
+            total_content_chars=result.total_content_chars,
+        )
+        return payload.model_dump_json()
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    except Exception as exc:
+        logger.error("Failed to read MCP resource", error=str(exc))
+        raise ToolError(f"Failed to read MCP resource: {exc}") from None
+
+
+@mcp.tool()
+async def get_mcp_prompt(
+    workspace_id: str,
+    artifact_ref_or_id: str,
+    arguments_json: str | None = None,
+) -> str:
+    """Get a persisted MCP prompt artifact through the wrapper surface."""
+    raw_arguments = _parse_json_arg(arguments_json, "arguments_json")
+    if raw_arguments is not None and not isinstance(raw_arguments, dict):
+        raise ToolError("arguments_json must decode to a JSON object")
+    try:
+        ws_id, role = await _resolve_workspace_role(workspace_id)
+        async with MCPCatalogArtifactService.with_session(role=role) as svc:
+            result = await svc.get_prompt(
+                workspace_id=ws_id,
+                artifact_ref_or_id=artifact_ref_or_id,
+                arguments=raw_arguments,
+            )
+        payload = MCPCatalogPromptResponse(
+            workspace_id=str(result.workspace_id),
+            artifact=_catalog_artifact_summary_payload(
+                id=str(result.artifact.id),
+                mcp_integration_id=str(result.artifact.mcp_integration_id),
+                workspace_id=str(result.artifact.workspace_id),
+                artifact_type=result.artifact.artifact_type,
+                artifact_key=result.artifact.artifact_key,
+                artifact_ref=result.artifact.artifact_ref,
+                display_name=result.artifact.display_name,
+                description=result.artifact.description,
+                scope_name=result.artifact.scope_name,
+            ),
+            result=result.result,
+        )
+        return payload.model_dump_json()
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    except Exception as exc:
+        logger.error("Failed to get MCP prompt", error=str(exc))
+        raise ToolError(f"Failed to get MCP prompt: {exc}") from None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persisted MCP catalog search and artifact wrapper operations (tool, resource, prompt) with policy enforcement, ranking, and safe content limits. Implements ENG-1320 by exposing filtered, authorized catalog operations with strict request validation.

- **New Features**
  - New MCP tools: search_mcp_catalog, execute_mcp_tool, read_mcp_resource, get_mcp_prompt.
  - Catalog search: policy-filtered; optional artifact_types/integration_ids (JSON arrays); ranked via full‑text + trigram with exact/prefix boosts; returns scope_name and input_schema.
  - Artifact execution: resolve by ID or exact ref with type checks; HTTP-only (stdio rejected); OAuth token (respects token_type) overrides any custom Authorization header (case‑insensitive); stored custom headers must be string pairs; resource reads truncated to TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS.
  - Config: new TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS (default 32768); numeric MCP env vars fall back to defaults when set empty.

- **Migration**
  - Ensure the Postgres pg_trgm extension is enabled for similarity ranking.
  - Optionally set TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS to adjust resource truncation.

<sup>Written for commit b99c1deab8a7ea47804f523c8a0b6fc6b496dc09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

