### PR TITLE
feat(mcp): route remote artifact calls through user client

### DIFF
--- a/tests/unit/test_mcp_artifact_service.py
+++ b/tests/unit/test_mcp_artifact_service.py
@@ -38,7 +38,10 @@ from tracecat.integrations.enums import (
     OAuthGrantType,
 )
 from tracecat.mcp.catalog import artifact_service as artifact_service_module
-from tracecat.mcp.catalog.artifact_service import MCPCatalogArtifactService
+from tracecat.mcp.catalog.artifact_service import (
+    MCPCatalogArtifactService,
+    _sanitize_remote_endpoint_for_log,
+)
 from tracecat.secrets.encryption import decrypt_value, encrypt_value
 
 TEST_ENCRYPTION_KEY = Fernet.generate_key().decode()
@@ -181,6 +184,7 @@ async def _create_mcp_integration(
     oauth_integration: OAuthIntegration | None = None,
     auth_type: MCPAuthType = MCPAuthType.NONE,
     server_type: str = "http",
+    server_uri: str | None = None,
     custom_headers: dict[str, str] | None = None,
 ) -> MCPIntegration:
     encrypted_headers = None
@@ -197,7 +201,13 @@ async def _create_mcp_integration(
         slug=f"artifact-mcp-{uuid.uuid4().hex[:6]}",
         scope_namespace="mcpartifact00001",
         server_type=server_type,
-        server_uri="https://api.example.com/mcp" if server_type == "http" else None,
+        server_uri=(
+            server_uri
+            if server_uri is not None
+            else "https://api.example.com/mcp"
+            if server_type == "http"
+            else None
+        ),
         auth_type=auth_type,
         oauth_integration_id=oauth_integration.id if oauth_integration else None,
         encrypted_headers=encrypted_headers,
@@ -295,6 +305,23 @@ class _FakeClient:
         self.last_prompt_arguments = arguments
         assert self._get_prompt_result is not None
         return self._get_prompt_result
+
+
+class _LoggerCapture:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def error(self, event: str, **kwargs: Any) -> None:
+        self.calls.append((event, kwargs))
+
+
+def test_sanitize_remote_endpoint_for_log_strips_credentials_and_query() -> None:
+    assert (
+        _sanitize_remote_endpoint_for_log(
+            "https://user:secret@example.com:8443/mcp?access_token=abc#frag"
+        )
+        == "https://example.com:8443/mcp"
+    )
 
 
 @pytest.mark.anyio
@@ -426,6 +453,59 @@ class TestMCPCatalogArtifactService:
 
         assert result.result["structuredContent"] == {"status": "ok"}
         assert result.artifact.artifact_ref == "list_repos"
+
+    async def test_execute_tool_logs_sanitized_remote_endpoint_on_failure(
+        self,
+        session: AsyncSession,
+        org_admin_role: Role,
+        workspace: Workspace,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        integration = await _create_mcp_integration(
+            session=session,
+            workspace=workspace,
+            server_uri="https://user:secret@example.com:8443/mcp?token=abc",
+        )
+        entry_id = await _insert_catalog_entry(
+            session=session,
+            integration=integration,
+            artifact_type=MCPCatalogArtifactType.TOOL,
+            artifact_key="tool-a2",
+            artifact_ref="list_repos",
+        )
+        service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        logger_capture = _LoggerCapture()
+        monkeypatch.setattr(service, "logger", logger_capture)
+
+        class _FailingClient(_FakeClient):
+            async def call_tool_result(
+                self,
+                server_name: str,
+                tool_name: str,
+                arguments: dict[str, Any],
+            ) -> CallToolResult:
+                raise RuntimeError("boom")
+
+        async def fake_create_remote_client(target: Any) -> _FailingClient:
+            return _FailingClient()
+
+        monkeypatch.setattr(
+            service,
+            "_create_remote_client",
+            fake_create_remote_client,
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.execute_tool(
+                workspace_id=workspace.id,
+                artifact_ref_or_id=str(entry_id),
+                arguments={"owner": "tracecat"},
+            )
+
+        assert logger_capture.calls
+        event, kwargs = logger_capture.calls[0]
+        assert event == "Remote MCP tool execution failed"
+        assert kwargs["remote_endpoint"] == "https://example.com:8443/mcp"
 
     async def test_read_resource_truncates_large_content(
         self,

--- a/tests/unit/test_mcp_artifact_service.py
+++ b/tests/unit/test_mcp_artifact_service.py
@@ -324,6 +324,15 @@ def test_sanitize_remote_endpoint_for_log_strips_credentials_and_query() -> None
     )
 
 
+def test_sanitize_remote_endpoint_for_log_tolerates_malformed_port() -> None:
+    assert (
+        _sanitize_remote_endpoint_for_log(
+            "https://user:secret@example.com:badport/mcp?access_token=abc"
+        )
+        == "example.com:badport/mcp"
+    )
+
+
 @pytest.mark.anyio
 class TestMCPCatalogArtifactService:
     async def test_build_headers_combines_custom_headers_and_oauth_token(

--- a/tests/unit/test_mcp_artifact_service.py
+++ b/tests/unit/test_mcp_artifact_service.py
@@ -255,9 +255,9 @@ class _FakeClient:
         read_resource_result: list[TextResourceContents] | None = None,
         get_prompt_result: GetPromptResult | None = None,
     ) -> None:
-        self.call_tool_result = call_tool_result
-        self.read_resource_result = read_resource_result or []
-        self.get_prompt_result = get_prompt_result
+        self._call_tool_result = call_tool_result
+        self._read_resource_result = read_resource_result or []
+        self._get_prompt_result = get_prompt_result
         self.last_prompt_arguments: dict[str, Any] | None = None
 
     async def __aenter__(self) -> _FakeClient:
@@ -266,19 +266,35 @@ class _FakeClient:
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         return None
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
-        assert self.call_tool_result is not None
-        return self.call_tool_result
+    async def call_tool_result(
+        self,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        assert server_name
+        assert tool_name
+        assert self._call_tool_result is not None
+        return self._call_tool_result
 
-    async def read_resource(self, uri: str) -> list[TextResourceContents]:
-        return self.read_resource_result
+    async def read_resource(
+        self, server_name: str, resource_uri: str
+    ) -> list[TextResourceContents]:
+        assert server_name
+        assert resource_uri
+        return self._read_resource_result
 
     async def get_prompt(
-        self, name: str, arguments: dict[str, Any] | None
+        self,
+        server_name: str,
+        prompt_name: str,
+        arguments: dict[str, Any] | None,
     ) -> GetPromptResult:
-        assert self.get_prompt_result is not None
+        assert server_name
+        assert prompt_name
         self.last_prompt_arguments = arguments
-        return self.get_prompt_result
+        assert self._get_prompt_result is not None
+        return self._get_prompt_result
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_user_mcp_client.py
+++ b/tests/unit/test_user_mcp_client.py
@@ -1,0 +1,89 @@
+"""Unit tests for user MCP client helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mcp.types import (
+    CallToolResult,
+    GetPromptResult,
+    PromptMessage,
+    TextContent,
+    TextResourceContents,
+)
+from pydantic import AnyUrl
+
+from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.mcp import user_client as user_client_module
+from tracecat.agent.mcp.user_client import UserMCPClient, infer_transport_type
+
+
+class _FakeClient:
+    def __init__(self, transport: Any) -> None:
+        self.transport = transport
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        return CallToolResult(
+            content=[TextContent(type="text", text=f"{name}:{arguments['value']}")],
+            structuredContent={"ok": True},
+            isError=False,
+        )
+
+    async def read_resource(self, uri: str) -> list[TextResourceContents]:
+        return [
+            TextResourceContents(uri=AnyUrl("https://example.com/readme"), text=uri)
+        ]
+
+    async def get_prompt(
+        self, name: str, arguments: dict[str, Any] | None
+    ) -> GetPromptResult:
+        return GetPromptResult(
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(
+                        type="text",
+                        text=f"{name}:{(arguments or {}).get('severity', 'none')}",
+                    ),
+                )
+            ]
+        )
+
+
+def test_infer_transport_type_uses_sse_suffix() -> None:
+    assert infer_transport_type("https://example.com/mcp/sse") == "sse"
+    assert infer_transport_type("https://example.com/mcp") == "http"
+
+
+@pytest.mark.anyio
+async def test_user_mcp_client_supports_full_result_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config: MCPHttpServerConfig = {
+        "type": "http",
+        "name": "server",
+        "url": "https://example.com/mcp",
+        "transport": "http",
+    }
+    monkeypatch.setattr(user_client_module, "Client", _FakeClient)
+    client = UserMCPClient([config])
+
+    tool_result = await client.call_tool_result("server", "list_repos", {"value": "x"})
+    resource_result = await client.read_resource("server", "docs://readme")
+    prompt_result = await client.get_prompt(
+        "server", "triage_incident", {"severity": "high"}
+    )
+
+    assert tool_result.structuredContent == {"ok": True}
+    assert resource_result[0].model_dump(mode="json")["text"] == "docs://readme"
+    assert (
+        prompt_result.messages[0].content.model_dump(mode="json")["text"]
+        == "triage_incident:high"
+    )

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -9,10 +9,16 @@ allowing the sandboxed runtime to access user tools via the Unix socket proxy.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from fastmcp import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+from mcp.types import (
+    BlobResourceContents,
+    GetPromptResult,
+    TextResourceContents,
+)
+from yarl import URL
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.logger import logger
@@ -29,6 +35,14 @@ def _create_transport(
         return SSETransport(url=url, headers=headers, sse_read_timeout=timeout)
     # Default to HTTP (Streamable HTTP transport)
     return StreamableHttpTransport(url=url, headers=headers, sse_read_timeout=timeout)
+
+
+def infer_transport_type(url: str) -> Literal["http", "sse"]:
+    """Infer transport type from a persisted MCP server URL."""
+    path = URL(url).path.lower()
+    if path.endswith("/sse") or "/sse/" in path:
+        return "sse"
+    return "http"
 
 
 class UserMCPClient:
@@ -50,6 +64,21 @@ class UserMCPClient:
 
         """
         self._configs = {cfg["name"]: cfg for cfg in configs}
+
+    def _get_config(self, server_name: str) -> MCPHttpServerConfig:
+        if server_name not in self._configs:
+            raise ValueError(f"Unknown user MCP server: {server_name}")
+        return self._configs[server_name]
+
+    def _get_transport(
+        self, server_name: str
+    ) -> StreamableHttpTransport | SSETransport:
+        config = self._get_config(server_name)
+        url = config["url"]
+        transport_type: Literal["http", "sse"] = config.get("transport", "http")
+        headers = config.get("headers")
+        timeout = config.get("timeout")
+        return _create_transport(url, transport_type, headers, timeout)
 
     async def discover_tools(self) -> dict[str, MCPToolDefinition]:
         """Connect to all configured servers and discover their tools.
@@ -149,16 +178,7 @@ class UserMCPClient:
             Exception: If tool call fails.
 
         """
-        if server_name not in self._configs:
-            raise ValueError(f"Unknown user MCP server: {server_name}")
-
-        config = self._configs[server_name]
-        url = config["url"]
-        transport_type: Literal["http", "sse"] = config.get("transport", "http")
-        headers = config.get("headers")
-        timeout = config.get("timeout")
-
-        transport = _create_transport(url, transport_type, headers, timeout)
+        transport = self._get_transport(server_name)
 
         logger.info(
             "Calling user MCP tool",
@@ -176,6 +196,56 @@ class UserMCPClient:
                 return getattr(first_block, "text", str(first_block))
 
             return ""
+
+    async def call_tool_result(
+        self,
+        server_name: str,
+        tool_name: str,
+        args: dict[str, Any],
+    ) -> Any:
+        """Execute a tool and return the full MCP result payload."""
+        transport = self._get_transport(server_name)
+        logger.info(
+            "Calling user MCP tool with full result",
+            server_name=server_name,
+            tool_name=tool_name,
+        )
+        async with Client(transport) as client:
+            return cast(Any, await client.call_tool(tool_name, args))
+
+    async def read_resource(
+        self,
+        server_name: str,
+        resource_uri: str,
+    ) -> list[TextResourceContents | BlobResourceContents]:
+        """Read a resource from a user MCP server."""
+        transport = self._get_transport(server_name)
+        logger.info(
+            "Reading user MCP resource",
+            server_name=server_name,
+            resource_uri=resource_uri,
+        )
+        async with Client(transport) as client:
+            return cast(
+                list[TextResourceContents | BlobResourceContents],
+                await client.read_resource(resource_uri),
+            )
+
+    async def get_prompt(
+        self,
+        server_name: str,
+        prompt_name: str,
+        args: dict[str, Any] | None = None,
+    ) -> GetPromptResult:
+        """Fetch a prompt from a user MCP server."""
+        transport = self._get_transport(server_name)
+        logger.info(
+            "Fetching user MCP prompt",
+            server_name=server_name,
+            prompt_name=prompt_name,
+        )
+        async with Client(transport) as client:
+            return cast(GetPromptResult, await client.get_prompt(prompt_name, args))
 
     @staticmethod
     def parse_user_mcp_tool_name(tool_name: str) -> tuple[str, str] | None:

--- a/tracecat/mcp/catalog/artifact_service.py
+++ b/tracecat/mcp/catalog/artifact_service.py
@@ -7,10 +7,10 @@ from typing import Any, cast
 from uuid import UUID
 
 import orjson
-from fastmcp import Client
 from sqlalchemy import select
 
-from tracecat.agent.mcp.user_client import _create_transport
+from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.mcp.user_client import UserMCPClient, infer_transport_type
 from tracecat.db.models import (
     MCPIntegration,
     MCPIntegrationCatalogEntry,
@@ -51,8 +51,22 @@ class MCPCatalogArtifactService(BaseOrgService):
             artifact_type=MCPCatalogArtifactType.TOOL,
         )
         client = await self._create_remote_client(target)
-        async with client as remote_client:
-            result = await remote_client.call_tool(target.artifact_ref, arguments or {})
+        try:
+            result = await client.call_tool_result(
+                str(target.mcp_integration_id),
+                target.artifact_ref,
+                arguments or {},
+            )
+        except Exception as exc:
+            self.logger.error(
+                "Remote MCP tool execution failed",
+                mcp_integration_id=target.mcp_integration_id,
+                catalog_entry_id=target.id,
+                artifact_type=target.artifact_type.value,
+                remote_endpoint=target.server_uri,
+                error_type=type(exc).__name__,
+            )
+            raise
         return MCPCatalogToolResult(
             workspace_id=workspace_id,
             artifact=target,
@@ -72,8 +86,21 @@ class MCPCatalogArtifactService(BaseOrgService):
             artifact_type=MCPCatalogArtifactType.RESOURCE,
         )
         client = await self._create_remote_client(target)
-        async with client as remote_client:
-            contents = await remote_client.read_resource(target.artifact_ref)
+        try:
+            contents = await client.read_resource(
+                str(target.mcp_integration_id),
+                target.artifact_ref,
+            )
+        except Exception as exc:
+            self.logger.error(
+                "Remote MCP resource read failed",
+                mcp_integration_id=target.mcp_integration_id,
+                catalog_entry_id=target.id,
+                artifact_type=target.artifact_type.value,
+                remote_endpoint=target.server_uri,
+                error_type=type(exc).__name__,
+            )
+            raise
 
         total_chars = 0
         truncated = False
@@ -126,8 +153,22 @@ class MCPCatalogArtifactService(BaseOrgService):
             artifact_type=MCPCatalogArtifactType.PROMPT,
         )
         client = await self._create_remote_client(target)
-        async with client as remote_client:
-            result = await remote_client.get_prompt(target.artifact_ref, arguments)
+        try:
+            result = await client.get_prompt(
+                str(target.mcp_integration_id),
+                target.artifact_ref,
+                arguments,
+            )
+        except Exception as exc:
+            self.logger.error(
+                "Remote MCP prompt fetch failed",
+                mcp_integration_id=target.mcp_integration_id,
+                catalog_entry_id=target.id,
+                artifact_type=target.artifact_type.value,
+                remote_endpoint=target.server_uri,
+                error_type=type(exc).__name__,
+            )
+            raise
         return MCPCatalogPromptResult(
             workspace_id=workspace_id,
             artifact=target,
@@ -251,7 +292,9 @@ class MCPCatalogArtifactService(BaseOrgService):
             timeout=timeout,
         )
 
-    async def _create_remote_client(self, target: MCPCatalogResolvedArtifact) -> Client:
+    async def _create_remote_client(
+        self, target: MCPCatalogResolvedArtifact
+    ) -> UserMCPClient:
         if target.server_type != "http":
             raise TracecatValidationError(
                 "Local stdio MCP artifacts are not available through this wrapper yet"
@@ -259,13 +302,17 @@ class MCPCatalogArtifactService(BaseOrgService):
         if not target.server_uri:
             raise TracecatValidationError("MCP integration server URI is missing")
         headers = await self._build_headers(target)
-        transport = _create_transport(
-            target.server_uri,
-            "http",
-            headers or None,
-            target.timeout,
-        )
-        return Client(transport)
+        config: MCPHttpServerConfig = {
+            "type": "http",
+            "name": str(target.mcp_integration_id),
+            "url": target.server_uri,
+            "transport": infer_transport_type(target.server_uri),
+        }
+        if headers:
+            config["headers"] = headers
+        if target.timeout is not None:
+            config["timeout"] = target.timeout
+        return UserMCPClient([config])
 
     async def _build_headers(
         self, target: MCPCatalogResolvedArtifact

--- a/tracecat/mcp/catalog/artifact_service.py
+++ b/tracecat/mcp/catalog/artifact_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any, cast
+from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
 
 import orjson
@@ -30,6 +31,22 @@ from tracecat.mcp.catalog.types import (
 from tracecat.mcp.config import TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS
 from tracecat.mcp.policy.service import MCPCatalogPolicyService
 from tracecat.service import BaseOrgService
+
+
+def _sanitize_remote_endpoint_for_log(server_uri: str | None) -> str | None:
+    if not server_uri:
+        return server_uri
+    parsed = urlsplit(server_uri)
+    if parsed.hostname is None:
+        return server_uri.split("?", 1)[0].rsplit("@", 1)[-1]
+
+    hostname = parsed.hostname
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    netloc = hostname
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
 
 
 class MCPCatalogArtifactService(BaseOrgService):
@@ -63,7 +80,7 @@ class MCPCatalogArtifactService(BaseOrgService):
                 mcp_integration_id=target.mcp_integration_id,
                 catalog_entry_id=target.id,
                 artifact_type=target.artifact_type.value,
-                remote_endpoint=target.server_uri,
+                remote_endpoint=_sanitize_remote_endpoint_for_log(target.server_uri),
                 error_type=type(exc).__name__,
             )
             raise
@@ -97,7 +114,7 @@ class MCPCatalogArtifactService(BaseOrgService):
                 mcp_integration_id=target.mcp_integration_id,
                 catalog_entry_id=target.id,
                 artifact_type=target.artifact_type.value,
-                remote_endpoint=target.server_uri,
+                remote_endpoint=_sanitize_remote_endpoint_for_log(target.server_uri),
                 error_type=type(exc).__name__,
             )
             raise
@@ -165,7 +182,7 @@ class MCPCatalogArtifactService(BaseOrgService):
                 mcp_integration_id=target.mcp_integration_id,
                 catalog_entry_id=target.id,
                 artifact_type=target.artifact_type.value,
-                remote_endpoint=target.server_uri,
+                remote_endpoint=_sanitize_remote_endpoint_for_log(target.server_uri),
                 error_type=type(exc).__name__,
             )
             raise

--- a/tracecat/mcp/catalog/artifact_service.py
+++ b/tracecat/mcp/catalog/artifact_service.py
@@ -39,13 +39,17 @@ def _sanitize_remote_endpoint_for_log(server_uri: str | None) -> str | None:
     parsed = urlsplit(server_uri)
     if parsed.hostname is None:
         return server_uri.split("?", 1)[0].rsplit("@", 1)[-1]
+    try:
+        port = parsed.port
+    except ValueError:
+        return server_uri.split("?", 1)[0].rsplit("@", 1)[-1]
 
     hostname = parsed.hostname
     if ":" in hostname and not hostname.startswith("["):
         hostname = f"[{hostname}]"
     netloc = hostname
-    if parsed.port is not None:
-        netloc = f"{netloc}:{parsed.port}"
+    if port is not None:
+        netloc = f"{netloc}:{port}"
     return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
 
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes remote MCP artifact operations (tool, resource, prompt) through UserMCPClient, returning full MCP results and standardizing transport, headers, and timeouts. Adds SSE endpoint inference and robust, sanitized error logging. Addresses Linear ENG-1321 by executing and reading remote MCP artifacts via Tracecat MCP.

- **New Features**
  - UserMCPClient supports call_tool_result, read_resource (text/blob), and get_prompt to return full MCP payloads.
  - Added infer_transport_type to auto-detect SSE endpoints from URL path.

- **Bug Fixes**
  - Sanitized remote endpoint in error logs for tool/resource/prompt failures (strips credentials, query, fragment; normalizes host/port; tolerates malformed ports).

<sup>Written for commit e92149b88e85674701caa3bc87ce32e732a78b2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

