### PR TITLE
feat(mcp): queue local stdio artifact execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,23 @@ RUN git clone https://github.com/google/nsjail.git /tmp/nsjail && \
     rm -rf /tmp/nsjail
 
 # ====================
+# Stage 1b: Build MCP egress guard
+# ====================
+FROM debian:bookworm-slim AS mcp-egress-guard-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c /tmp/tracecat_mcp_egress_guard.c
+
+RUN gcc -shared -fPIC -O2 -Wall -Wextra \
+    -o /usr/local/lib/libtracecat_mcp_egress_guard.so \
+    /tmp/tracecat_mcp_egress_guard.c -ldl -pthread
+
+# ====================
 # Stage 2: Create minimal sandbox rootfs
 # ====================
 FROM node:22.13.1-slim AS node-bin
@@ -50,6 +67,7 @@ ENV HOST=0.0.0.0 PORT=8000
 
 # Copy nsjail binary
 COPY --from=nsjail-builder /usr/local/bin/nsjail /usr/local/bin/nsjail
+COPY --from=mcp-egress-guard-builder /usr/local/lib/libtracecat_mcp_egress_guard.so /usr/local/lib/libtracecat_mcp_egress_guard.so
 
 # Copy Node.js + npx for in-process MCP command servers (stdio)
 COPY --from=node-bin /usr/local/bin/node /usr/local/bin/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uv /usr/local/bin/uv
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uvx /usr/local/bin/uvx
+COPY --from=mcp-egress-guard-builder /usr/local/lib/libtracecat_mcp_egress_guard.so /usr/local/lib/libtracecat_mcp_egress_guard.so
 COPY --from=node-bin /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-bin /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \

--- a/tests/unit/test_local_mcp_sandbox_workflow.py
+++ b/tests/unit/test_local_mcp_sandbox_workflow.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import pytest
 
+from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.mcp.sandbox import workflow as workflow_module
 
 
@@ -107,3 +108,26 @@ def test_build_stdio_client_config_wraps_with_nsjail(
     )
     assert temp_dir is not None
     assert (temp_dir / "nsjail.cfg").exists()
+
+
+def test_build_stdio_nsjail_config_rejects_unsafe_stdio_args(
+    tmp_path: Path,
+) -> None:
+    command_path = tmp_path / "server"
+    command_path.write_text("")
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    rootfs_path = tmp_path / "rootfs"
+    for subdir in ("usr", "lib", "bin", "etc"):
+        (rootfs_path / subdir).mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(
+        AgentSandboxValidationError, match="Invalid stdio arg at index 1"
+    ):
+        workflow_module._build_stdio_nsjail_config(
+            command_path=str(command_path),
+            command_args=["safe", 'unsafe" arg'],
+            cache_root=cache_root,
+            rootfs=rootfs_path,
+            allow_network=False,
+        )

--- a/tests/unit/test_local_mcp_sandbox_workflow.py
+++ b/tests/unit/test_local_mcp_sandbox_workflow.py
@@ -1,0 +1,86 @@
+"""Unit tests for local MCP stdio sandbox transport config."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from tracecat.agent.mcp.sandbox import workflow as workflow_module
+
+
+def _build_target(**overrides: object) -> SimpleNamespace:
+    base = {
+        "mcp_integration_id": uuid4(),
+        "stdio_command": "npx",
+        "stdio_args": ["@modelcontextprotocol/server-github"],
+        "timeout": 30,
+        "sandbox_allow_network": False,
+        "sandbox_egress_allowlist": None,
+        "sandbox_egress_denylist": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_build_stdio_client_config_warns_on_direct_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(workflow_module.config, "TRACECAT__DISABLE_NSJAIL", True)
+    monkeypatch.setattr(workflow_module, "_DIRECT_SANDBOX_WARNING_EMITTED", False)
+    caplog.set_level(logging.WARNING)
+
+    server_config, temp_dir = workflow_module._build_stdio_client_config(
+        target=_build_target(),
+        stdio_env={"PATH": "/usr/local/bin:/usr/bin:/bin"},
+    )
+
+    assert server_config["command"] == "npx"
+    assert temp_dir is None
+    assert workflow_module._DIRECT_SANDBOX_WARNING_EMITTED is True
+
+
+def test_build_stdio_client_config_wraps_with_nsjail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    nsjail_path = tmp_path / "nsjail"
+    nsjail_path.write_text("")
+    rootfs_path = tmp_path / "rootfs"
+    for subdir in ("usr", "lib", "bin", "etc"):
+        (rootfs_path / subdir).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(workflow_module.config, "TRACECAT__DISABLE_NSJAIL", False)
+    monkeypatch.setattr(
+        workflow_module.config, "TRACECAT__SANDBOX_NSJAIL_PATH", str(nsjail_path)
+    )
+    monkeypatch.setattr(
+        workflow_module.config, "TRACECAT__SANDBOX_ROOTFS_PATH", str(rootfs_path)
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "_resolve_stdio_command_path",
+        lambda command, env: "/usr/local/bin/npx",
+    )
+
+    stdio_env = {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "HOME": str(tmp_path / "cache" / "home"),
+    }
+    server_config, temp_dir = workflow_module._build_stdio_client_config(
+        target=_build_target(
+            sandbox_allow_network=True,
+            sandbox_egress_allowlist=["api.github.com:443"],
+        ),
+        stdio_env=stdio_env,
+    )
+
+    assert server_config["command"] == str(nsjail_path)
+    assert "--config" in server_config["args"]
+    assert "TRACECAT__MCP_SANDBOX_EGRESS_ALLOWLIST" in server_config["env"]
+    assert temp_dir is not None
+    assert (temp_dir / "nsjail.cfg").exists()

--- a/tests/unit/test_local_mcp_sandbox_workflow.py
+++ b/tests/unit/test_local_mcp_sandbox_workflow.py
@@ -32,6 +32,7 @@ def test_build_stdio_client_config_warns_on_direct_fallback(
 ) -> None:
     monkeypatch.setattr(workflow_module.config, "TRACECAT__DISABLE_NSJAIL", True)
     monkeypatch.setattr(workflow_module, "_DIRECT_SANDBOX_WARNING_EMITTED", False)
+    monkeypatch.setattr(workflow_module, "_EGRESS_POLICY_DIRECT_WARNING_EMITTED", False)
     caplog.set_level(logging.WARNING)
 
     server_config, temp_dir = workflow_module._build_stdio_client_config(
@@ -42,6 +43,24 @@ def test_build_stdio_client_config_warns_on_direct_fallback(
     assert server_config["command"] == "npx"
     assert temp_dir is None
     assert workflow_module._DIRECT_SANDBOX_WARNING_EMITTED is True
+    assert workflow_module._EGRESS_POLICY_DIRECT_WARNING_EMITTED is False
+
+
+def test_build_stdio_client_config_warns_when_egress_policy_degrades_in_direct_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(workflow_module.config, "TRACECAT__DISABLE_NSJAIL", True)
+    monkeypatch.setattr(workflow_module, "_DIRECT_SANDBOX_WARNING_EMITTED", False)
+    monkeypatch.setattr(workflow_module, "_EGRESS_POLICY_DIRECT_WARNING_EMITTED", False)
+
+    server_config, temp_dir = workflow_module._build_stdio_client_config(
+        target=_build_target(sandbox_egress_allowlist=["api.github.com:443"]),
+        stdio_env={"PATH": "/usr/local/bin:/usr/bin:/bin"},
+    )
+
+    assert server_config["command"] == "npx"
+    assert temp_dir is None
+    assert workflow_module._EGRESS_POLICY_DIRECT_WARNING_EMITTED is True
 
 
 def test_build_stdio_client_config_wraps_with_nsjail(
@@ -82,5 +101,9 @@ def test_build_stdio_client_config_wraps_with_nsjail(
     assert server_config["command"] == str(nsjail_path)
     assert "--config" in server_config["args"]
     assert "TRACECAT__MCP_SANDBOX_EGRESS_ALLOWLIST" in server_config["env"]
+    assert (
+        server_config["env"]["LD_PRELOAD"]
+        == "/usr/local/lib/libtracecat_mcp_egress_guard.so"
+    )
     assert temp_dir is not None
     assert (temp_dir / "nsjail.cfg").exists()

--- a/tests/unit/test_mcp_artifact_service.py
+++ b/tests/unit/test_mcp_artifact_service.py
@@ -707,4 +707,7 @@ class TestMCPCatalogArtifactService:
         assert result.result["structuredContent"] == {"status": "queued"}
         assert recorded["input"].artifact_ref_or_id == str(entry_id)
         assert recorded["input"].workspace_id == workspace.id
-        assert recorded["kwargs"]["task_queue"]
+        assert (
+            recorded["kwargs"]["task_queue"]
+            == artifact_service_module.config.TRACECAT__MCP_QUEUE
+        )

--- a/tests/unit/test_mcp_artifact_service.py
+++ b/tests/unit/test_mcp_artifact_service.py
@@ -20,6 +20,7 @@ from pydantic import AnyUrl, SecretStr
 from sqlalchemy import func, insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.agent.mcp.sandbox.types import RunLocalMCPArtifactWorkflowResult
 from tracecat.auth.types import Role
 from tracecat.db.models import (
     MCPIntegration,
@@ -31,7 +32,6 @@ from tracecat.db.models import (
     User,
     Workspace,
 )
-from tracecat.exceptions import TracecatValidationError
 from tracecat.integrations.enums import (
     MCPAuthType,
     MCPCatalogArtifactType,
@@ -656,11 +656,12 @@ class TestMCPCatalogArtifactService:
 
         assert fake_client.last_prompt_arguments == {}
 
-    async def test_stdio_artifacts_are_rejected_for_now(
+    async def test_stdio_artifacts_dispatch_through_mcp_queue(
         self,
         session: AsyncSession,
         org_admin_role: Role,
         workspace: Workspace,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         integration = await _create_mcp_integration(
             session=session,
@@ -675,10 +676,35 @@ class TestMCPCatalogArtifactService:
             artifact_ref="list_repos",
         )
         service = MCPCatalogArtifactService(session=session, role=org_admin_role)
+        recorded: dict[str, Any] = {}
 
-        with pytest.raises(TracecatValidationError):
-            await service.execute_tool(
-                workspace_id=workspace.id,
-                artifact_ref_or_id=str(entry_id),
-                arguments={"owner": "tracecat"},
-            )
+        class _FakeTemporalClient:
+            async def execute_workflow(
+                self, workflow: Any, input: Any, **kwargs: Any
+            ) -> Any:
+                recorded["workflow"] = workflow
+                recorded["input"] = input
+                recorded["kwargs"] = kwargs
+                return RunLocalMCPArtifactWorkflowResult(
+                    result={"structuredContent": {"status": "queued"}}
+                )
+
+        async def fake_get_temporal_client() -> _FakeTemporalClient:
+            return _FakeTemporalClient()
+
+        monkeypatch.setattr(
+            artifact_service_module,
+            "get_temporal_client",
+            fake_get_temporal_client,
+        )
+
+        result = await service.execute_tool(
+            workspace_id=workspace.id,
+            artifact_ref_or_id=str(entry_id),
+            arguments={"owner": "tracecat"},
+        )
+
+        assert result.result["structuredContent"] == {"status": "queued"}
+        assert recorded["input"].artifact_ref_or_id == str(entry_id)
+        assert recorded["input"].workspace_id == workspace.id
+        assert recorded["kwargs"]["task_queue"]

--- a/tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c
+++ b/tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c
@@ -14,6 +14,7 @@
 
 #define MAX_RULES 128
 #define MAX_ENTRY_LEN 256
+#define MAX_RESOLVED_ENDPOINTS 1024
 
 typedef struct {
   char host[MAX_ENTRY_LEN];
@@ -26,14 +27,25 @@ typedef struct {
   size_t count;
 } egress_rule_list_t;
 
+typedef struct {
+  char host[INET6_ADDRSTRLEN];
+  char port[16];
+} resolved_endpoint_t;
+
 static pthread_once_t guard_init_once = PTHREAD_ONCE_INIT;
+static pthread_mutex_t resolved_allow_mutex = PTHREAD_MUTEX_INITIALIZER;
 static egress_rule_list_t allow_rules = {0};
 static egress_rule_list_t deny_rules = {0};
+static resolved_endpoint_t resolved_allow_endpoints[MAX_RESOLVED_ENDPOINTS] = {0};
+static size_t resolved_allow_count = 0;
 static bool has_allow_rules = false;
 
 static int (*real_connect)(int, const struct sockaddr *, socklen_t) = NULL;
 static int (*real_getaddrinfo)(const char *, const char *, const struct addrinfo *,
                                struct addrinfo **) = NULL;
+
+static void sockaddr_to_host_port(
+    const struct sockaddr *addr, char *host, size_t host_len, char *port, size_t port_len);
 
 static void trim_copy(char *dst, size_t dst_size, const char *src, size_t src_len) {
   while (src_len > 0 && (*src == ' ' || *src == '"' || *src == '\'')) {
@@ -124,8 +136,7 @@ static bool port_matches(const egress_rule_t *rule, const char *port) {
   return port != NULL && strcmp(rule->port, port) == 0;
 }
 
-static bool list_matches(
-    const egress_rule_list_t *rules, const char *host, const char *port) {
+static bool list_matches(const egress_rule_list_t *rules, const char *host, const char *port) {
   for (size_t i = 0; i < rules->count; ++i) {
     if (host_matches(rules->rules[i].host, host) && port_matches(&rules->rules[i], port)) {
       return true;
@@ -134,14 +145,83 @@ static bool list_matches(
   return false;
 }
 
-static bool is_blocked_request(const char *host, const char *port) {
-  if (list_matches(&deny_rules, host, port)) {
+static bool resolution_matches(
+    const egress_rule_list_t *rules, const char *node, const char *service,
+    const struct addrinfo *res) {
+  if (list_matches(rules, node, service)) {
     return true;
   }
-  if (has_allow_rules && !list_matches(&allow_rules, host, port)) {
+
+  for (const struct addrinfo *entry = res; entry != NULL; entry = entry->ai_next) {
+    char host[INET6_ADDRSTRLEN] = {0};
+    char port[16] = {0};
+    sockaddr_to_host_port(entry->ai_addr, host, sizeof(host), port, sizeof(port));
+    if (host[0] == '\0') {
+      continue;
+    }
+    if (list_matches(rules, host, port) || list_matches(rules, node, port)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool is_blocked_resolution(
+    const char *node, const char *service, const struct addrinfo *res) {
+  if (resolution_matches(&deny_rules, node, service, res)) {
+    return true;
+  }
+  if (has_allow_rules && !resolution_matches(&allow_rules, node, service, res)) {
     return true;
   }
   return false;
+}
+
+static bool resolved_allow_matches(const char *host, const char *port) {
+  bool matched = false;
+  pthread_mutex_lock(&resolved_allow_mutex);
+  for (size_t i = 0; i < resolved_allow_count; ++i) {
+    if (strcmp(resolved_allow_endpoints[i].host, host) == 0 &&
+        strcmp(resolved_allow_endpoints[i].port, port) == 0) {
+      matched = true;
+      break;
+    }
+  }
+  pthread_mutex_unlock(&resolved_allow_mutex);
+  return matched;
+}
+
+static void cache_allowed_resolution(const struct addrinfo *res) {
+  pthread_mutex_lock(&resolved_allow_mutex);
+  for (const struct addrinfo *entry = res; entry != NULL; entry = entry->ai_next) {
+    char host[INET6_ADDRSTRLEN] = {0};
+    char port[16] = {0};
+    bool exists = false;
+    sockaddr_to_host_port(entry->ai_addr, host, sizeof(host), port, sizeof(port));
+    if (host[0] == '\0' || port[0] == '\0') {
+      continue;
+    }
+
+    for (size_t i = 0; i < resolved_allow_count; ++i) {
+      if (strcmp(resolved_allow_endpoints[i].host, host) == 0 &&
+          strcmp(resolved_allow_endpoints[i].port, port) == 0) {
+        exists = true;
+        break;
+      }
+    }
+    if (exists || resolved_allow_count >= MAX_RESOLVED_ENDPOINTS) {
+      continue;
+    }
+
+    snprintf(
+        resolved_allow_endpoints[resolved_allow_count].host,
+        sizeof(resolved_allow_endpoints[resolved_allow_count].host), "%s", host);
+    snprintf(
+        resolved_allow_endpoints[resolved_allow_count].port,
+        sizeof(resolved_allow_endpoints[resolved_allow_count].port), "%s", port);
+    resolved_allow_count++;
+  }
+  pthread_mutex_unlock(&resolved_allow_mutex);
 }
 
 static void sockaddr_to_host_port(
@@ -172,19 +252,50 @@ static void sockaddr_to_host_port(
 int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints,
                 struct addrinfo **res) {
   pthread_once(&guard_init_once, init_guard);
-  if (is_blocked_request(node, service)) {
+  if (real_getaddrinfo == NULL) {
+    errno = ENOSYS;
+    return EAI_SYSTEM;
+  }
+  if (node == NULL) {
+    return real_getaddrinfo(node, service, hints, res);
+  }
+  if (list_matches(&deny_rules, node, service)) {
     return EAI_FAIL;
   }
-  return real_getaddrinfo(node, service, hints, res);
+  int rc = real_getaddrinfo(node, service, hints, res);
+  if (rc != 0 || res == NULL || *res == NULL) {
+    return rc;
+  }
+  if (is_blocked_resolution(node, service, *res)) {
+    freeaddrinfo(*res);
+    *res = NULL;
+    return EAI_FAIL;
+  }
+  if (has_allow_rules) {
+    cache_allowed_resolution(*res);
+  }
+  return rc;
 }
 
 int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
-  (void)addrlen;
   pthread_once(&guard_init_once, init_guard);
+  if (real_connect == NULL) {
+    errno = ENOSYS;
+    return -1;
+  }
   char host[INET6_ADDRSTRLEN] = {0};
   char port[16] = {0};
   sockaddr_to_host_port(addr, host, sizeof(host), port, sizeof(port));
-  if (is_blocked_request(host, port)) {
+  if (host[0] == '\0') {
+    return real_connect(sockfd, addr, addrlen);
+  }
+  if (list_matches(&deny_rules, host, port)) {
+    errno = EACCES;
+    return -1;
+  }
+  if (has_allow_rules &&
+      !list_matches(&allow_rules, host, port) &&
+      !resolved_allow_matches(host, port)) {
     errno = EACCES;
     return -1;
   }

--- a/tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c
+++ b/tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c
@@ -191,8 +191,10 @@ static bool resolved_allow_matches(const char *host, const char *port) {
   return matched;
 }
 
-static void cache_allowed_resolution(const struct addrinfo *res) {
+static bool cache_allowed_resolution(const struct addrinfo *res) {
+  bool overflowed = false;
   pthread_mutex_lock(&resolved_allow_mutex);
+  size_t original_count = resolved_allow_count;
   for (const struct addrinfo *entry = res; entry != NULL; entry = entry->ai_next) {
     char host[INET6_ADDRSTRLEN] = {0};
     char port[16] = {0};
@@ -209,8 +211,12 @@ static void cache_allowed_resolution(const struct addrinfo *res) {
         break;
       }
     }
-    if (exists || resolved_allow_count >= MAX_RESOLVED_ENDPOINTS) {
+    if (exists) {
       continue;
+    }
+    if (resolved_allow_count >= MAX_RESOLVED_ENDPOINTS) {
+      overflowed = true;
+      break;
     }
 
     snprintf(
@@ -221,7 +227,11 @@ static void cache_allowed_resolution(const struct addrinfo *res) {
         sizeof(resolved_allow_endpoints[resolved_allow_count].port), "%s", port);
     resolved_allow_count++;
   }
+  if (overflowed) {
+    resolved_allow_count = original_count;
+  }
   pthread_mutex_unlock(&resolved_allow_mutex);
+  return !overflowed;
 }
 
 static void sockaddr_to_host_port(
@@ -271,8 +281,11 @@ int getaddrinfo(const char *node, const char *service, const struct addrinfo *hi
     *res = NULL;
     return EAI_FAIL;
   }
-  if (has_allow_rules) {
-    cache_allowed_resolution(*res);
+  if (has_allow_rules && !cache_allowed_resolution(*res)) {
+    freeaddrinfo(*res);
+    *res = NULL;
+    errno = ENOSPC;
+    return EAI_SYSTEM;
   }
   return rc;
 }

--- a/tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c
+++ b/tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c
@@ -1,0 +1,192 @@
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <netdb.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#define MAX_RULES 128
+#define MAX_ENTRY_LEN 256
+
+typedef struct {
+  char host[MAX_ENTRY_LEN];
+  char port[MAX_ENTRY_LEN];
+  bool has_port;
+} egress_rule_t;
+
+typedef struct {
+  egress_rule_t rules[MAX_RULES];
+  size_t count;
+} egress_rule_list_t;
+
+static pthread_once_t guard_init_once = PTHREAD_ONCE_INIT;
+static egress_rule_list_t allow_rules = {0};
+static egress_rule_list_t deny_rules = {0};
+static bool has_allow_rules = false;
+
+static int (*real_connect)(int, const struct sockaddr *, socklen_t) = NULL;
+static int (*real_getaddrinfo)(const char *, const char *, const struct addrinfo *,
+                               struct addrinfo **) = NULL;
+
+static void trim_copy(char *dst, size_t dst_size, const char *src, size_t src_len) {
+  while (src_len > 0 && (*src == ' ' || *src == '"' || *src == '\'')) {
+    src++;
+    src_len--;
+  }
+  while (src_len > 0 &&
+         (src[src_len - 1] == ' ' || src[src_len - 1] == '"' || src[src_len - 1] == '\'')) {
+    src_len--;
+  }
+  if (src_len >= dst_size) {
+    src_len = dst_size - 1;
+  }
+  memcpy(dst, src, src_len);
+  dst[src_len] = '\0';
+}
+
+static const char *find_last_colon(const char *token, size_t token_len) {
+  for (size_t i = token_len; i > 0; --i) {
+    if (token[i - 1] == ':') {
+      return token + (i - 1);
+    }
+  }
+  return NULL;
+}
+
+static void parse_rule_token(const char *token, size_t token_len, egress_rule_t *rule) {
+  memset(rule, 0, sizeof(*rule));
+  const char *colon = find_last_colon(token, token_len);
+  if (colon != NULL && memchr(token, ']', token_len) == NULL && memchr(token, ':', token_len) == colon) {
+    trim_copy(rule->host, sizeof(rule->host), token, (size_t)(colon - token));
+    trim_copy(rule->port, sizeof(rule->port), colon + 1, token_len - (size_t)(colon - token) - 1);
+    rule->has_port = rule->port[0] != '\0';
+    return;
+  }
+  trim_copy(rule->host, sizeof(rule->host), token, token_len);
+}
+
+static void parse_rule_env(const char *raw, egress_rule_list_t *out) {
+  if (raw == NULL) {
+    return;
+  }
+  const char *cursor = raw;
+  while (*cursor != '\0' && out->count < MAX_RULES) {
+    while (*cursor != '\0' && *cursor != '"') {
+      cursor++;
+    }
+    if (*cursor == '\0') {
+      break;
+    }
+    cursor++;
+    const char *start = cursor;
+    while (*cursor != '\0' && *cursor != '"') {
+      cursor++;
+    }
+    if (*cursor == '"') {
+      parse_rule_token(start, (size_t)(cursor - start), &out->rules[out->count]);
+      if (out->rules[out->count].host[0] != '\0') {
+        out->count++;
+      }
+      cursor++;
+    }
+  }
+}
+
+static void init_guard(void) {
+  real_connect = dlsym(RTLD_NEXT, "connect");
+  real_getaddrinfo = dlsym(RTLD_NEXT, "getaddrinfo");
+  parse_rule_env(getenv("TRACECAT__MCP_SANDBOX_EGRESS_ALLOWLIST"), &allow_rules);
+  parse_rule_env(getenv("TRACECAT__MCP_SANDBOX_EGRESS_DENYLIST"), &deny_rules);
+  has_allow_rules = allow_rules.count > 0;
+}
+
+static bool host_matches(const char *rule_host, const char *host) {
+  if (rule_host[0] == '\0' || host == NULL || host[0] == '\0') {
+    return false;
+  }
+  if (strcmp(rule_host, "*") == 0) {
+    return true;
+  }
+  return strcasecmp(rule_host, host) == 0;
+}
+
+static bool port_matches(const egress_rule_t *rule, const char *port) {
+  if (!rule->has_port) {
+    return true;
+  }
+  return port != NULL && strcmp(rule->port, port) == 0;
+}
+
+static bool list_matches(
+    const egress_rule_list_t *rules, const char *host, const char *port) {
+  for (size_t i = 0; i < rules->count; ++i) {
+    if (host_matches(rules->rules[i].host, host) && port_matches(&rules->rules[i], port)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool is_blocked_request(const char *host, const char *port) {
+  if (list_matches(&deny_rules, host, port)) {
+    return true;
+  }
+  if (has_allow_rules && !list_matches(&allow_rules, host, port)) {
+    return true;
+  }
+  return false;
+}
+
+static void sockaddr_to_host_port(
+    const struct sockaddr *addr, char *host, size_t host_len, char *port, size_t port_len) {
+  host[0] = '\0';
+  port[0] = '\0';
+  if (addr == NULL) {
+    return;
+  }
+  switch (addr->sa_family) {
+    case AF_INET: {
+      const struct sockaddr_in *addr4 = (const struct sockaddr_in *)addr;
+      inet_ntop(AF_INET, &addr4->sin_addr, host, (socklen_t)host_len);
+      snprintf(port, port_len, "%u", ntohs(addr4->sin_port));
+      return;
+    }
+    case AF_INET6: {
+      const struct sockaddr_in6 *addr6 = (const struct sockaddr_in6 *)addr;
+      inet_ntop(AF_INET6, &addr6->sin6_addr, host, (socklen_t)host_len);
+      snprintf(port, port_len, "%u", ntohs(addr6->sin6_port));
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints,
+                struct addrinfo **res) {
+  pthread_once(&guard_init_once, init_guard);
+  if (is_blocked_request(node, service)) {
+    return EAI_FAIL;
+  }
+  return real_getaddrinfo(node, service, hints, res);
+}
+
+int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
+  (void)addrlen;
+  pthread_once(&guard_init_once, init_guard);
+  char host[INET6_ADDRSTRLEN] = {0};
+  char port[16] = {0};
+  sockaddr_to_host_port(addr, host, sizeof(host), port, sizeof(port));
+  if (is_blocked_request(host, port)) {
+    errno = EACCES;
+    return -1;
+  }
+  return real_connect(sockfd, addr, addrlen);
+}

--- a/tracecat/agent/mcp/sandbox/types.py
+++ b/tracecat/agent/mcp/sandbox/types.py
@@ -1,0 +1,50 @@
+"""Types for local stdio MCP artifact execution."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from tracecat.auth.types import Role
+from tracecat.identifiers import WorkspaceID
+from tracecat.integrations.enums import MCPCatalogArtifactType
+
+
+class LocalMCPArtifactOperation(StrEnum):
+    """Operation executed against a local stdio MCP server."""
+
+    TOOL = "tool"
+    RESOURCE = "resource"
+    PROMPT = "prompt"
+
+
+class RunLocalMCPArtifactWorkflowInput(BaseModel):
+    """Input for local stdio MCP artifact workflow execution."""
+
+    role: Role
+    workspace_id: WorkspaceID
+    artifact_ref_or_id: str
+    operation: LocalMCPArtifactOperation
+    arguments: dict[str, Any] | None = Field(default=None)
+
+    @property
+    def artifact_type(self) -> MCPCatalogArtifactType:
+        match self.operation:
+            case LocalMCPArtifactOperation.TOOL:
+                return MCPCatalogArtifactType.TOOL
+            case LocalMCPArtifactOperation.RESOURCE:
+                return MCPCatalogArtifactType.RESOURCE
+            case LocalMCPArtifactOperation.PROMPT:
+                return MCPCatalogArtifactType.PROMPT
+
+
+class RunLocalMCPArtifactWorkflowResult(BaseModel):
+    """Result for one local stdio MCP artifact operation."""
+
+    result: dict[str, Any] | None = Field(default=None)
+    contents: tuple[dict[str, Any], ...] = Field(default=())
+    truncated: bool = False
+    max_content_chars: int | None = Field(default=None)
+    total_content_chars: int | None = Field(default=None)

--- a/tracecat/agent/mcp/sandbox/workflow.py
+++ b/tracecat/agent/mcp/sandbox/workflow.py
@@ -1,0 +1,198 @@
+"""Temporal workflow and activity for local stdio MCP artifact execution."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, cast
+
+from fastmcp import Client
+from mcp.types import BlobResourceContents, GetPromptResult, TextResourceContents
+from temporalio import activity, workflow
+
+from tracecat import config
+from tracecat.agent.mcp.sandbox.types import (
+    LocalMCPArtifactOperation,
+    RunLocalMCPArtifactWorkflowInput,
+    RunLocalMCPArtifactWorkflowResult,
+)
+from tracecat.integrations.service import IntegrationService
+from tracecat.logger import logger
+from tracecat.mcp.catalog.artifact_service import MCPCatalogArtifactService
+from tracecat.mcp.config import TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS
+
+_LOCAL_MCP_SANDBOX_SEMAPHORE = asyncio.Semaphore(
+    config.TRACECAT__MCP_MAX_CONCURRENT_LOCAL_SANDBOXES
+)
+
+
+def _cache_env(
+    *,
+    organization_id: Any,
+    base_env: dict[str, str] | None,
+) -> dict[str, str]:
+    """Inject shared per-org cache paths for package managers."""
+    cache_root = Path(config.TRACECAT__MCP_SANDBOX_CACHE_DIR) / str(organization_id)
+    xdg_cache = cache_root / "xdg"
+    npm_cache = cache_root / "npm"
+    pip_cache = cache_root / "pip"
+    uv_cache = cache_root / "uv"
+    home_dir = cache_root / "home"
+    for path in (cache_root, xdg_cache, npm_cache, pip_cache, uv_cache, home_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = dict(base_env or {})
+    env.setdefault("HOME", str(home_dir))
+    env["XDG_CACHE_HOME"] = str(xdg_cache)
+    env["npm_config_cache"] = str(npm_cache)
+    env["PIP_CACHE_DIR"] = str(pip_cache)
+    env["UV_CACHE_DIR"] = str(uv_cache)
+    return env
+
+
+def _truncate_resource_contents(
+    contents: list[TextResourceContents | BlobResourceContents],
+) -> tuple[tuple[dict[str, Any], ...], bool, int]:
+    total_chars = 0
+    truncated = False
+    serialized_contents: list[dict[str, Any]] = []
+    for content in contents:
+        payload = content.model_dump(mode="json")
+        match payload:
+            case {"text": str(text)}:
+                original_length = len(text)
+                total_chars += original_length
+                if original_length > TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS:
+                    payload["text"] = text[:TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS]
+                    payload["truncated"] = True
+                    payload["original_length"] = original_length
+                    truncated = True
+            case {"blob": str(blob)}:
+                original_length = len(blob)
+                total_chars += original_length
+                if original_length > TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS:
+                    payload["blob"] = blob[:TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS]
+                    payload["truncated"] = True
+                    payload["original_length"] = original_length
+                    truncated = True
+        serialized_contents.append(payload)
+    return tuple(serialized_contents), truncated, total_chars
+
+
+@workflow.defn
+class RunLocalMCPArtifactWorkflow:
+    """Execute one local stdio MCP artifact operation on the MCP queue."""
+
+    @workflow.run
+    async def run(
+        self, request: RunLocalMCPArtifactWorkflowInput
+    ) -> RunLocalMCPArtifactWorkflowResult:
+        return await workflow.execute_activity(
+            run_local_mcp_artifact_activity,
+            request,
+            start_to_close_timeout=timedelta(minutes=5),
+        )
+
+
+@activity.defn
+async def run_local_mcp_artifact_activity(
+    request: RunLocalMCPArtifactWorkflowInput,
+) -> RunLocalMCPArtifactWorkflowResult:
+    """Execute one local stdio MCP artifact call in an ephemeral subprocess."""
+    async with _LOCAL_MCP_SANDBOX_SEMAPHORE:
+        async with MCPCatalogArtifactService.with_session(role=request.role) as service:
+            target = await service.resolve_artifact(
+                workspace_id=request.workspace_id,
+                artifact_ref_or_id=request.artifact_ref_or_id,
+                artifact_type=request.artifact_type,
+            )
+            if target.server_type != "stdio":
+                raise ValueError("Local MCP sandbox workflow requires a stdio artifact")
+            if not target.stdio_command:
+                raise ValueError("Local MCP integration is missing stdio_command")
+
+            integration_service = IntegrationService(service.session, role=request.role)
+            sandbox_phase = "resolve_env"
+            stdio_env = integration_service.decrypt_marshaled_stdio_env(
+                target.encrypted_stdio_env
+            )
+            if stdio_env:
+                stdio_env = await integration_service.resolve_stdio_env(
+                    stdio_env=stdio_env,
+                    mcp_integration_id=target.mcp_integration_id,
+                    mcp_integration_slug=target.integration_slug,
+                )
+            stdio_env = _cache_env(
+                organization_id=request.role.organization_id,
+                base_env=stdio_env,
+            )
+
+            client_config = {
+                "mcpServers": {
+                    str(target.mcp_integration_id): {
+                        "transport": "stdio",
+                        "command": target.stdio_command,
+                        "args": target.stdio_args or [],
+                        "env": stdio_env,
+                    }
+                }
+            }
+
+            try:
+                sandbox_phase = "launch"
+                async with Client(client_config, timeout=target.timeout) as client:
+                    sandbox_phase = "execute"
+                    match request.operation:
+                        case LocalMCPArtifactOperation.TOOL:
+                            result = await client.call_tool(
+                                target.artifact_ref, request.arguments or {}
+                            )
+                            return RunLocalMCPArtifactWorkflowResult(
+                                result=cast(Any, result).model_dump(mode="json")
+                            )
+                        case LocalMCPArtifactOperation.RESOURCE:
+                            contents = await client.read_resource(target.artifact_ref)
+                            payload, truncated, total_chars = (
+                                _truncate_resource_contents(
+                                    cast(
+                                        list[
+                                            TextResourceContents | BlobResourceContents
+                                        ],
+                                        contents,
+                                    )
+                                )
+                            )
+                            return RunLocalMCPArtifactWorkflowResult(
+                                contents=payload,
+                                truncated=truncated,
+                                max_content_chars=TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS,
+                                total_content_chars=total_chars,
+                            )
+                        case LocalMCPArtifactOperation.PROMPT:
+                            result = await client.get_prompt(
+                                target.artifact_ref, request.arguments or None
+                            )
+                            return RunLocalMCPArtifactWorkflowResult(
+                                result=cast(GetPromptResult, result).model_dump(
+                                    mode="json"
+                                )
+                            )
+            except Exception as exc:
+                logger.error(
+                    "Local MCP artifact execution failed",
+                    mcp_integration_id=target.mcp_integration_id,
+                    catalog_entry_id=target.id,
+                    artifact_type=target.artifact_type.value,
+                    sandbox_phase=sandbox_phase,
+                    error_type=type(exc).__name__,
+                )
+                raise
+
+
+class LocalMCPArtifactActivities:
+    """Worker registration container for local MCP artifact activities."""
+
+    @classmethod
+    def get_activities(cls) -> list:
+        return [run_local_mcp_artifact_activity]

--- a/tracecat/agent/mcp/sandbox/workflow.py
+++ b/tracecat/agent/mcp/sandbox/workflow.py
@@ -31,6 +31,7 @@ _LOCAL_MCP_SANDBOX_SEMAPHORE = asyncio.Semaphore(
     config.TRACECAT__MCP_MAX_CONCURRENT_LOCAL_SANDBOXES
 )
 _DIRECT_SANDBOX_WARNING_EMITTED = False
+_EGRESS_POLICY_DIRECT_WARNING_EMITTED = False
 
 
 def _cache_env(
@@ -192,7 +193,7 @@ def _build_stdio_client_config(
     stdio_env: dict[str, str],
 ) -> tuple[dict[str, Any], Path | None]:
     """Build a FastMCP stdio client config, using nsjail when available."""
-    global _DIRECT_SANDBOX_WARNING_EMITTED
+    global _DIRECT_SANDBOX_WARNING_EMITTED, _EGRESS_POLICY_DIRECT_WARNING_EMITTED
 
     direct_config = {
         "transport": "stdio",
@@ -220,6 +221,14 @@ def _build_stdio_client_config(
                 mcp_integration_id=target.mcp_integration_id,
             )
             _DIRECT_SANDBOX_WARNING_EMITTED = True
+        if not _EGRESS_POLICY_DIRECT_WARNING_EMITTED and (
+            target.sandbox_egress_allowlist or target.sandbox_egress_denylist
+        ):
+            logger.warning(
+                "Egress allowlist/denylist is not enforced without nsjail; local MCP process will use degraded policy mode",
+                mcp_integration_id=target.mcp_integration_id,
+            )
+            _EGRESS_POLICY_DIRECT_WARNING_EMITTED = True
         return direct_config, None
 
     command_path = _resolve_stdio_command_path(target.stdio_command, stdio_env)
@@ -264,6 +273,8 @@ def _build_stdio_client_config(
         nsjail_env["TRACECAT__MCP_SANDBOX_EGRESS_DENYLIST"] = orjson.dumps(
             target.sandbox_egress_denylist
         ).decode()
+    if target.sandbox_egress_allowlist or target.sandbox_egress_denylist:
+        nsjail_env["LD_PRELOAD"] = "/usr/local/lib/libtracecat_mcp_egress_guard.so"
 
     nsjail_args = ["--config", str(config_path)]
     for key in sorted(nsjail_env):

--- a/tracecat/agent/mcp/sandbox/workflow.py
+++ b/tracecat/agent/mcp/sandbox/workflow.py
@@ -16,12 +16,13 @@ from mcp.types import BlobResourceContents, GetPromptResult, TextResourceContent
 from temporalio import activity, workflow
 
 from tracecat import config
+from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.mcp.sandbox.types import (
     LocalMCPArtifactOperation,
     RunLocalMCPArtifactWorkflowInput,
     RunLocalMCPArtifactWorkflowResult,
 )
-from tracecat.agent.sandbox.config import _validate_path
+from tracecat.agent.sandbox.config import _contains_dangerous_chars, _validate_path
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.mcp.catalog.artifact_service import MCPCatalogArtifactService
@@ -100,6 +101,32 @@ def _is_supported_nsjail_command_path(command_path: str) -> bool:
     return command_path.startswith(supported_prefixes)
 
 
+def _validate_stdio_nsjail_arg(arg: str, index: int) -> None:
+    """Reject stdio args that could break protobuf text-format parsing."""
+    is_dangerous, reason = _contains_dangerous_chars(arg)
+    if is_dangerous:
+        raise AgentSandboxValidationError(
+            f"Invalid stdio arg at index {index}: {reason}"
+        )
+
+    dangerous_chars = ('"', "'", "\\", "{", "}", "\n", "\r", "\t")
+    if found_chars := [char for char in dangerous_chars if char in arg]:
+        raise AgentSandboxValidationError(
+            f"Invalid stdio arg at index {index}: contains dangerous characters {found_chars!r}"
+        )
+
+
+def _validate_stdio_nsjail_args(command_args: list[str]) -> tuple[str, ...]:
+    """Validate stdio args before interpolating them into nsjail config."""
+    for index, arg in enumerate(command_args):
+        if not isinstance(arg, str):
+            raise AgentSandboxValidationError(
+                f"Invalid stdio arg at index {index}: expected str, got {type(arg).__name__}"
+            )
+        _validate_stdio_nsjail_arg(arg, index)
+    return tuple(command_args)
+
+
 def _build_stdio_nsjail_config(
     *,
     command_path: str,
@@ -112,6 +139,7 @@ def _build_stdio_nsjail_config(
     _validate_path(rootfs, "rootfs")
     _validate_path(cache_root, "cache_root")
     _validate_path(Path(command_path), "command_path")
+    validated_command_args = _validate_stdio_nsjail_args(command_args)
 
     clone_newnet = not allow_network
     lines = [
@@ -180,7 +208,7 @@ def _build_stdio_nsjail_config(
     )
 
     exec_parts = [f'exec_bin {{ path: "{command_path}"']
-    for arg in command_args:
+    for arg in validated_command_args:
         exec_parts.append(f' arg: "{arg}"')
     exec_parts.append(" }")
     lines.append("".join(exec_parts))

--- a/tracecat/agent/mcp/sandbox/workflow.py
+++ b/tracecat/agent/mcp/sandbox/workflow.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import shutil
+import tempfile
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, cast
 
+import orjson
 from fastmcp import Client
 from mcp.types import BlobResourceContents, GetPromptResult, TextResourceContents
 from temporalio import activity, workflow
@@ -17,6 +21,7 @@ from tracecat.agent.mcp.sandbox.types import (
     RunLocalMCPArtifactWorkflowInput,
     RunLocalMCPArtifactWorkflowResult,
 )
+from tracecat.agent.sandbox.config import _validate_path
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.mcp.catalog.artifact_service import MCPCatalogArtifactService
@@ -25,6 +30,7 @@ from tracecat.mcp.config import TRACECAT_MCP__MAX_RESOURCE_CONTENT_CHARS
 _LOCAL_MCP_SANDBOX_SEMAPHORE = asyncio.Semaphore(
     config.TRACECAT__MCP_MAX_CONCURRENT_LOCAL_SANDBOXES
 )
+_DIRECT_SANDBOX_WARNING_EMITTED = False
 
 
 def _cache_env(
@@ -80,6 +86,198 @@ def _truncate_resource_contents(
     return tuple(serialized_contents), truncated, total_chars
 
 
+def _resolve_stdio_command_path(command: str, env: dict[str, str]) -> str | None:
+    """Resolve a stdio command to an absolute executable path."""
+    if os.path.isabs(command):
+        return command if Path(command).exists() else None
+    return shutil.which(command, path=env.get("PATH"))
+
+
+def _is_supported_nsjail_command_path(command_path: str) -> bool:
+    """Only use nsjail when the executable path is covered by mounted rootfs paths."""
+    supported_prefixes = ("/usr/", "/bin/", "/sbin/", "/lib/", "/lib64/")
+    return command_path.startswith(supported_prefixes)
+
+
+def _build_stdio_nsjail_config(
+    *,
+    command_path: str,
+    command_args: list[str],
+    cache_root: Path,
+    rootfs: Path,
+    allow_network: bool,
+) -> str:
+    """Build a minimal nsjail config for one stdio MCP process."""
+    _validate_path(rootfs, "rootfs")
+    _validate_path(cache_root, "cache_root")
+    _validate_path(Path(command_path), "command_path")
+
+    clone_newnet = not allow_network
+    lines = [
+        'name: "local_mcp_stdio"',
+        "mode: ONCE",
+        'hostname: "mcp"',
+        "keep_env: false",
+        "",
+        "# Namespace isolation",
+        f"clone_newnet: {'true' if clone_newnet else 'false'}",
+        "clone_newuser: true",
+        "clone_newns: true",
+        "clone_newpid: true",
+        "clone_newipc: true",
+        "clone_newuts: true",
+        "",
+        "# UID/GID mapping",
+        f'uidmap {{ inside_id: "1000" outside_id: "{os.getuid()}" count: 1 }}',
+        f'gidmap {{ inside_id: "1000" outside_id: "{os.getgid()}" count: 1 }}',
+        "",
+        "# Rootfs mounts",
+        f'mount {{ src: "{rootfs}/usr" dst: "/usr" is_bind: true rw: false }}',
+        f'mount {{ src: "{rootfs}/lib" dst: "/lib" is_bind: true rw: false }}',
+        f'mount {{ src: "{rootfs}/bin" dst: "/bin" is_bind: true rw: false }}',
+        f'mount {{ src: "{rootfs}/etc" dst: "/etc" is_bind: true rw: false }}',
+    ]
+
+    for optional_dir in ("lib64", "sbin"):
+        optional_path = rootfs / optional_dir
+        if optional_path.exists():
+            lines.append(
+                f'mount {{ src: "{optional_path}" dst: "/{optional_dir}" is_bind: true rw: false }}'
+            )
+
+    if allow_network:
+        lines.extend(
+            [
+                "",
+                "# DNS config",
+                'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
+                'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
+                'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "# Runtime mounts",
+            'mount { src: "/proc" dst: "/proc" is_bind: true rw: false }',
+            'mount { src: "/dev/null" dst: "/dev/null" is_bind: true rw: true }',
+            'mount { src: "/dev/urandom" dst: "/dev/urandom" is_bind: true rw: false }',
+            'mount { src: "/dev/random" dst: "/dev/random" is_bind: true rw: false }',
+            'mount { src: "/dev/zero" dst: "/dev/zero" is_bind: true rw: false }',
+            'mount { dst: "/tmp" fstype: "tmpfs" rw: true options: "size=256M" }',
+            f'mount {{ src: "{cache_root}" dst: "/cache" is_bind: true rw: true }}',
+            "",
+            "# Resource limits",
+            f"rlimit_as: {2048 * 1024 * 1024}",
+            "rlimit_cpu: 300",
+            f"time_limit: {300}",
+            "",
+            "# Execution",
+            'cwd: "/cache/home"',
+        ]
+    )
+
+    exec_parts = [f'exec_bin {{ path: "{command_path}"']
+    for arg in command_args:
+        exec_parts.append(f' arg: "{arg}"')
+    exec_parts.append(" }")
+    lines.append("".join(exec_parts))
+    return "\n".join(lines)
+
+
+def _build_stdio_client_config(
+    *,
+    target: Any,
+    stdio_env: dict[str, str],
+) -> tuple[dict[str, Any], Path | None]:
+    """Build a FastMCP stdio client config, using nsjail when available."""
+    global _DIRECT_SANDBOX_WARNING_EMITTED
+
+    direct_config = {
+        "transport": "stdio",
+        "command": target.stdio_command,
+        "args": target.stdio_args or [],
+        "env": stdio_env,
+    }
+    if target.timeout is not None:
+        direct_config["timeout"] = target.timeout
+
+    nsjail_path = Path(config.TRACECAT__SANDBOX_NSJAIL_PATH)
+    rootfs_path = Path(config.TRACECAT__SANDBOX_ROOTFS_PATH)
+    if (
+        config.TRACECAT__DISABLE_NSJAIL
+        or not nsjail_path.exists()
+        or not rootfs_path.exists()
+    ):
+        if not _DIRECT_SANDBOX_WARNING_EMITTED and (
+            not target.sandbox_allow_network
+            or target.sandbox_egress_allowlist
+            or target.sandbox_egress_denylist
+        ):
+            logger.warning(
+                "Network isolation is not enforced without nsjail; local MCP process will run unsandboxed",
+                mcp_integration_id=target.mcp_integration_id,
+            )
+            _DIRECT_SANDBOX_WARNING_EMITTED = True
+        return direct_config, None
+
+    command_path = _resolve_stdio_command_path(target.stdio_command, stdio_env)
+    if command_path is None or not _is_supported_nsjail_command_path(command_path):
+        logger.warning(
+            "Falling back to direct local MCP execution because stdio command path cannot be jailed",
+            mcp_integration_id=target.mcp_integration_id,
+            command=target.stdio_command,
+            resolved_command=command_path,
+        )
+        return direct_config, None
+
+    cache_root = Path(stdio_env["HOME"]).parent
+    nsjail_job_dir = Path(tempfile.mkdtemp(prefix="local-mcp-nsjail-"))
+    nsjail_cfg = _build_stdio_nsjail_config(
+        command_path=command_path,
+        command_args=target.stdio_args or [],
+        cache_root=cache_root,
+        rootfs=rootfs_path,
+        allow_network=target.sandbox_allow_network,
+    )
+    config_path = nsjail_job_dir / "nsjail.cfg"
+    config_path.write_text(nsjail_cfg)
+    config_path.chmod(0o600)
+
+    nsjail_env = {
+        "PATH": stdio_env.get(
+            "PATH", os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")
+        ),
+        "HOME": "/cache/home",
+        "USER": "agent",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        **stdio_env,
+    }
+    nsjail_env["HOME"] = "/cache/home"
+    if target.sandbox_egress_allowlist:
+        nsjail_env["TRACECAT__MCP_SANDBOX_EGRESS_ALLOWLIST"] = orjson.dumps(
+            target.sandbox_egress_allowlist
+        ).decode()
+    if target.sandbox_egress_denylist:
+        nsjail_env["TRACECAT__MCP_SANDBOX_EGRESS_DENYLIST"] = orjson.dumps(
+            target.sandbox_egress_denylist
+        ).decode()
+
+    nsjail_args = ["--config", str(config_path)]
+    for key in sorted(nsjail_env):
+        nsjail_args.extend(["--env", key])
+
+    return {
+        "transport": "stdio",
+        "command": str(nsjail_path),
+        "args": nsjail_args,
+        "env": nsjail_env,
+        "timeout": target.timeout,
+    }, nsjail_job_dir
+
+
 @workflow.defn
 class RunLocalMCPArtifactWorkflow:
     """Execute one local stdio MCP artifact operation on the MCP queue."""
@@ -128,20 +326,16 @@ async def run_local_mcp_artifact_activity(
                 base_env=stdio_env,
             )
 
-            client_config = {
-                "mcpServers": {
-                    str(target.mcp_integration_id): {
-                        "transport": "stdio",
-                        "command": target.stdio_command,
-                        "args": target.stdio_args or [],
-                        "env": stdio_env,
-                    }
-                }
-            }
-
+            server_config, temp_dir = _build_stdio_client_config(
+                target=target,
+                stdio_env=stdio_env,
+            )
             try:
                 sandbox_phase = "launch"
-                async with Client(client_config, timeout=target.timeout) as client:
+                async with Client(
+                    {"mcpServers": {str(target.mcp_integration_id): server_config}},
+                    timeout=target.timeout,
+                ) as client:
                     sandbox_phase = "execute"
                     match request.operation:
                         case LocalMCPArtifactOperation.TOOL:
@@ -188,6 +382,9 @@ async def run_local_mcp_artifact_activity(
                     error_type=type(exc).__name__,
                 )
                 raise
+            finally:
+                if temp_dir is not None:
+                    shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 class LocalMCPArtifactActivities:

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -24,10 +24,7 @@ from tracecat.db.models import (
     AgentPreset,
     OAuthIntegration,
 )
-from tracecat.dsl.common import create_default_execution_context
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
-from tracecat.executor.service import get_workspace_variables
-from tracecat.expressions.eval import collect_expressions, eval_templated_object
 from tracecat.integrations.enums import MCPAuthType
 from tracecat.integrations.mcp_validation import (
     MCPValidationError,
@@ -36,7 +33,6 @@ from tracecat.integrations.mcp_validation import (
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
-from tracecat.secrets import secrets_manager
 from tracecat.secrets.encryption import decrypt_value
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
@@ -337,7 +333,7 @@ class AgentPresetService(BaseWorkspaceService):
                 stdio_env = integrations_service.decrypt_stdio_env(mcp_integration)
                 if stdio_env:
                     try:
-                        stdio_env = await self._resolve_stdio_env(
+                        stdio_env = await integrations_service.resolve_stdio_env(
                             stdio_env=stdio_env,
                             mcp_integration_id=mcp_integration.id,
                             mcp_integration_slug=mcp_integration.slug,
@@ -549,58 +545,6 @@ class AgentPresetService(BaseWorkspaceService):
             )
 
         return mcp_servers
-
-    async def _resolve_stdio_env(
-        self,
-        *,
-        stdio_env: dict[str, str],
-        mcp_integration_id: uuid.UUID,
-        mcp_integration_slug: str,
-    ) -> dict[str, str]:
-        """Resolve template expressions in stdio_env using workspace secrets/vars."""
-        collected = collect_expressions(stdio_env)
-        if not collected.secrets and not collected.variables:
-            return stdio_env
-
-        secrets = await secrets_manager.get_action_secrets(
-            secret_exprs=collected.secrets,
-            action_secrets=set(),
-        )
-        vars_map = await get_workspace_variables(
-            variable_exprs=collected.variables,
-            role=self.role,
-        )
-
-        context = create_default_execution_context()
-        context["SECRETS"] = secrets
-        context["VARS"] = vars_map
-
-        resolved = eval_templated_object(stdio_env, operand=context)
-        if not isinstance(resolved, dict):
-            raise TracecatValidationError(
-                "Resolved stdio_env must be a JSON object with string values"
-            )
-
-        non_string_keys = [
-            key for key, value in resolved.items() if not isinstance(value, str)
-        ]
-        if non_string_keys:
-            raise TracecatValidationError(
-                "Resolved stdio_env values must be strings "
-                f"(invalid keys: {sorted(non_string_keys)})"
-            )
-
-        logger.info(
-            "Resolved stdio_env template expressions",
-            workspace_id=str(self.workspace_id),
-            mcp_integration_id=str(mcp_integration_id),
-            mcp_integration_slug=mcp_integration_slug,
-            env_key_count=len(resolved),
-            secret_ref_count=len(collected.secrets),
-            var_ref_count=len(collected.variables),
-        )
-
-        return cast(dict[str, str], resolved)
 
     async def _normalize_and_validate_slug(
         self,

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -55,6 +55,10 @@ with workflow.unsafe.imports_passed_through():
         execute_approved_tools_activity,
         run_agent_activity,
     )
+    from tracecat.agent.mcp.sandbox.workflow import (
+        LocalMCPArtifactActivities,
+        RunLocalMCPArtifactWorkflow,
+    )
     from tracecat.agent.mcp.trusted_server import app
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_config_activity,
@@ -322,23 +326,38 @@ async def main() -> None:
             ],
         )
 
-        with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
-            workflows: list[type] = [DurableAgentWorkflow]
+        mcp_max_concurrent = config.TRACECAT__MCP_MAX_CONCURRENT_ACTIVITIES
+        mcp_threadpool_max_workers = config.TRACECAT__MCP_THREADPOOL_MAX_WORKERS
 
-            async with Worker(
-                client,
-                task_queue=config.TRACECAT__AGENT_QUEUE,
-                activities=activities,
-                workflows=workflows,
-                workflow_runner=new_sandbox_runner(),
-                interceptors=interceptors,
-                max_concurrent_activities=max_concurrent,
-                disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-                activity_executor=executor,
+        with (
+            ThreadPoolExecutor(max_workers=threadpool_max_workers) as agent_executor,
+            ThreadPoolExecutor(max_workers=mcp_threadpool_max_workers) as mcp_executor,
+        ):
+            async with (
+                Worker(
+                    client,
+                    task_queue=config.TRACECAT__AGENT_QUEUE,
+                    activities=activities,
+                    workflows=[DurableAgentWorkflow],
+                    workflow_runner=new_sandbox_runner(),
+                    interceptors=interceptors,
+                    max_concurrent_activities=max_concurrent,
+                    disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
+                    activity_executor=agent_executor,
+                ),
+                Worker(
+                    client,
+                    task_queue=config.TRACECAT__MCP_QUEUE,
+                    activities=LocalMCPArtifactActivities.get_activities(),
+                    workflows=[RunLocalMCPArtifactWorkflow],
+                    workflow_runner=new_sandbox_runner(),
+                    interceptors=interceptors,
+                    max_concurrent_activities=mcp_max_concurrent,
+                    disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
+                    activity_executor=mcp_executor,
+                ),
             ):
-                logger.info(
-                    "AgentWorker started, ctrl+c to exit",
-                )
+                logger.info("AgentWorker started, ctrl+c to exit")
                 await interrupt_event.wait()
                 logger.info("Shutting down AgentWorker")
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -125,6 +125,29 @@ TRACECAT__EXECUTOR_REGISTRY_CACHE_DIR = os.environ.get(
 )
 """Directory for caching extracted registry tarballs in subprocess mode. Uses /tmp for ephemeral storage."""
 
+TRACECAT__MCP_QUEUE = os.environ.get("TRACECAT__MCP_QUEUE", "tracecat-mcp-queue")
+"""Task queue for MCP discovery and local stdio artifact execution."""
+
+TRACECAT__MCP_MAX_CONCURRENT_ACTIVITIES = int(
+    os.environ.get("TRACECAT__MCP_MAX_CONCURRENT_ACTIVITIES") or 32
+)
+"""Maximum concurrent activities for the MCP Temporal worker queue."""
+
+TRACECAT__MCP_THREADPOOL_MAX_WORKERS = int(
+    os.environ.get("TRACECAT__MCP_THREADPOOL_MAX_WORKERS") or 32
+)
+"""Thread pool worker count for the MCP Temporal worker queue."""
+
+TRACECAT__MCP_MAX_CONCURRENT_LOCAL_SANDBOXES = int(
+    os.environ.get("TRACECAT__MCP_MAX_CONCURRENT_LOCAL_SANDBOXES") or 8
+)
+"""Maximum concurrent local stdio MCP subprocesses per agent worker process."""
+
+TRACECAT__MCP_SANDBOX_CACHE_DIR = os.environ.get(
+    "TRACECAT__MCP_SANDBOX_CACHE_DIR", "/tmp/tracecat/mcp-cache"
+)
+"""Base directory for per-organization local MCP package-manager caches."""
+
 # TODO: Set this as an environment variable
 TRACECAT__SERVICE_ROLES_WHITELIST = [
     "tracecat-api",

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -792,11 +792,18 @@ class IntegrationService(BaseWorkspaceService):
         self, mcp_integration: MCPIntegration
     ) -> dict[str, str] | None:
         """Decrypt and return stdio_env for an MCP integration."""
-        if not mcp_integration.encrypted_stdio_env:
+        return self.decrypt_marshaled_stdio_env(mcp_integration.encrypted_stdio_env)
+
+    @require_scope("integration:read")
+    def decrypt_marshaled_stdio_env(
+        self, encrypted_stdio_env: bytes | None
+    ) -> dict[str, str] | None:
+        """Decrypt and return serialized stdio_env bytes."""
+        if not encrypted_stdio_env:
             return None
-        if not is_set(mcp_integration.encrypted_stdio_env):
+        if not is_set(encrypted_stdio_env):
             return None
-        decrypted = self._decrypt_token(mcp_integration.encrypted_stdio_env)
+        decrypted = self._decrypt_token(encrypted_stdio_env)
         if not decrypted:
             return None
         loaded = orjson.loads(decrypted)
@@ -809,6 +816,63 @@ class IntegrationService(BaseWorkspaceService):
                 return None
             env[key] = value
         return env
+
+    @require_scope("integration:read")
+    async def resolve_stdio_env(
+        self,
+        *,
+        stdio_env: dict[str, str],
+        mcp_integration_id: uuid.UUID,
+        mcp_integration_slug: str,
+    ) -> dict[str, str]:
+        """Resolve template expressions in stdio_env using workspace secrets/vars."""
+        from tracecat.dsl.common import create_default_execution_context
+        from tracecat.executor.service import get_workspace_variables
+        from tracecat.expressions.eval import collect_expressions, eval_templated_object
+        from tracecat.secrets import secrets_manager
+
+        collected = collect_expressions(stdio_env)
+        if not collected.secrets and not collected.variables:
+            return stdio_env
+
+        secrets = await secrets_manager.get_action_secrets(
+            secret_exprs=collected.secrets,
+            action_secrets=set(),
+        )
+        vars_map = await get_workspace_variables(
+            variable_exprs=collected.variables,
+            role=self.role,
+        )
+
+        context = create_default_execution_context()
+        context["SECRETS"] = secrets
+        context["VARS"] = vars_map
+
+        resolved = eval_templated_object(stdio_env, operand=context)
+        if not isinstance(resolved, dict):
+            raise ValueError(
+                "Resolved stdio_env must be a JSON object with string values"
+            )
+
+        invalid_keys = [
+            key for key, value in resolved.items() if not isinstance(value, str)
+        ]
+        if invalid_keys:
+            raise ValueError(
+                "Resolved stdio_env values must be strings "
+                f"(invalid keys: {sorted(invalid_keys)})"
+            )
+
+        self.logger.info(
+            "Resolved stdio_env template expressions",
+            workspace_id=str(self.workspace_id),
+            mcp_integration_id=str(mcp_integration_id),
+            mcp_integration_slug=mcp_integration_slug,
+            env_key_count=len(resolved),
+            secret_ref_count=len(collected.secrets),
+            var_ref_count=len(collected.variables),
+        )
+        return cast(dict[str, str], resolved)
 
     @require_scope("integration:create", "integration:update", require_all=False)
     async def store_provider_config(

--- a/tracecat/mcp/catalog/artifact_service.py
+++ b/tracecat/mcp/catalog/artifact_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
@@ -10,6 +11,7 @@ from uuid import UUID
 import orjson
 from sqlalchemy import select
 
+from tracecat import config
 from tracecat.agent.common.types import MCPHttpServerConfig
 from tracecat.agent.mcp.user_client import UserMCPClient, infer_transport_type
 from tracecat.db.models import (
@@ -17,6 +19,7 @@ from tracecat.db.models import (
     MCPIntegrationCatalogEntry,
     OAuthIntegration,
 )
+from tracecat.dsl.client import get_temporal_client
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.identifiers import WorkspaceID
 from tracecat.integrations.enums import MCPAuthType, MCPCatalogArtifactType
@@ -71,6 +74,18 @@ class MCPCatalogArtifactService(BaseOrgService):
             artifact_ref_or_id=artifact_ref_or_id,
             artifact_type=MCPCatalogArtifactType.TOOL,
         )
+        if target.server_type == "stdio":
+            workflow_result = await self._execute_local_workflow(
+                workspace_id=workspace_id,
+                artifact_ref_or_id=str(target.id),
+                operation="tool",
+                arguments=arguments,
+            )
+            return MCPCatalogToolResult(
+                workspace_id=workspace_id,
+                artifact=target,
+                result=cast(dict[str, Any], workflow_result.result),
+            )
         client = await self._create_remote_client(target)
         try:
             result = await client.call_tool_result(
@@ -106,6 +121,20 @@ class MCPCatalogArtifactService(BaseOrgService):
             artifact_ref_or_id=artifact_ref_or_id,
             artifact_type=MCPCatalogArtifactType.RESOURCE,
         )
+        if target.server_type == "stdio":
+            workflow_result = await self._execute_local_workflow(
+                workspace_id=workspace_id,
+                artifact_ref_or_id=str(target.id),
+                operation="resource",
+            )
+            return MCPCatalogResourceResult(
+                workspace_id=workspace_id,
+                artifact=target,
+                contents=workflow_result.contents,
+                truncated=workflow_result.truncated,
+                max_content_chars=cast(int, workflow_result.max_content_chars),
+                total_content_chars=cast(int, workflow_result.total_content_chars),
+            )
         client = await self._create_remote_client(target)
         try:
             contents = await client.read_resource(
@@ -173,6 +202,18 @@ class MCPCatalogArtifactService(BaseOrgService):
             artifact_ref_or_id=artifact_ref_or_id,
             artifact_type=MCPCatalogArtifactType.PROMPT,
         )
+        if target.server_type == "stdio":
+            workflow_result = await self._execute_local_workflow(
+                workspace_id=workspace_id,
+                artifact_ref_or_id=str(target.id),
+                operation="prompt",
+                arguments=arguments,
+            )
+            return MCPCatalogPromptResult(
+                workspace_id=workspace_id,
+                artifact=target,
+                result=cast(dict[str, Any], workflow_result.result),
+            )
         client = await self._create_remote_client(target)
         try:
             result = await client.get_prompt(
@@ -259,12 +300,19 @@ class MCPCatalogArtifactService(BaseOrgService):
             MCPIntegrationCatalogEntry.artifact_ref,
             MCPIntegrationCatalogEntry.display_name,
             MCPIntegrationCatalogEntry.description,
+            MCPIntegration.slug,
             MCPIntegration.scope_namespace,
             MCPIntegration.server_type,
             MCPIntegration.server_uri,
             MCPIntegration.auth_type,
             MCPIntegration.oauth_integration_id,
             MCPIntegration.encrypted_headers,
+            MCPIntegration.stdio_command,
+            MCPIntegration.stdio_args,
+            MCPIntegration.encrypted_stdio_env,
+            MCPIntegration.sandbox_allow_network,
+            MCPIntegration.sandbox_egress_allowlist,
+            MCPIntegration.sandbox_egress_denylist,
             MCPIntegration.timeout,
         ).join(
             MCPIntegration,
@@ -281,12 +329,19 @@ class MCPCatalogArtifactService(BaseOrgService):
             artifact_ref,
             display_name,
             description,
+            integration_slug,
             scope_namespace,
             server_type,
             server_uri,
             auth_type,
             oauth_integration_id,
             encrypted_headers,
+            stdio_command,
+            stdio_args,
+            encrypted_stdio_env,
+            sandbox_allow_network,
+            sandbox_egress_allowlist,
+            sandbox_egress_denylist,
             timeout,
         ) = row
         artifact_type = MCPCatalogArtifactType(artifact_type_value)
@@ -305,11 +360,18 @@ class MCPCatalogArtifactService(BaseOrgService):
             display_name=display_name,
             description=description,
             scope_name=scope_name,
+            integration_slug=integration_slug,
             server_type=server_type,
             server_uri=server_uri,
             auth_type=auth_type,
             oauth_integration_id=oauth_integration_id,
             encrypted_headers=encrypted_headers,
+            stdio_command=stdio_command,
+            stdio_args=cast(list[str] | None, stdio_args),
+            encrypted_stdio_env=encrypted_stdio_env,
+            sandbox_allow_network=sandbox_allow_network,
+            sandbox_egress_allowlist=cast(list[str] | None, sandbox_egress_allowlist),
+            sandbox_egress_denylist=cast(list[str] | None, sandbox_egress_denylist),
             timeout=timeout,
         )
 
@@ -317,9 +379,7 @@ class MCPCatalogArtifactService(BaseOrgService):
         self, target: MCPCatalogResolvedArtifact
     ) -> UserMCPClient:
         if target.server_type != "http":
-            raise TracecatValidationError(
-                "Local stdio MCP artifacts are not available through this wrapper yet"
-            )
+            raise TracecatValidationError("MCP integration server type must be HTTP")
         if not target.server_uri:
             raise TracecatValidationError("MCP integration server URI is missing")
         headers = await self._build_headers(target)
@@ -334,6 +394,39 @@ class MCPCatalogArtifactService(BaseOrgService):
         if target.timeout is not None:
             config["timeout"] = target.timeout
         return UserMCPClient([config])
+
+    async def _execute_local_workflow(
+        self,
+        *,
+        workspace_id: WorkspaceID,
+        artifact_ref_or_id: str,
+        operation: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> Any:
+        from tracecat.agent.mcp.sandbox.types import (
+            LocalMCPArtifactOperation,
+            RunLocalMCPArtifactWorkflowInput,
+        )
+        from tracecat.agent.mcp.sandbox.workflow import RunLocalMCPArtifactWorkflow
+
+        client = await get_temporal_client()
+        workflow_id = (
+            f"local-mcp-{operation}-{artifact_ref_or_id}-"
+            f"{datetime.now(UTC).strftime('%Y%m%d%H%M%S%f')}"
+        )
+        return await client.execute_workflow(
+            RunLocalMCPArtifactWorkflow.run,
+            RunLocalMCPArtifactWorkflowInput(
+                role=self.role,
+                workspace_id=workspace_id,
+                artifact_ref_or_id=artifact_ref_or_id,
+                operation=LocalMCPArtifactOperation(operation),
+                arguments=arguments,
+            ),
+            id=workflow_id,
+            task_queue=config.TRACECAT__MCP_QUEUE,
+            execution_timeout=timedelta(minutes=6),
+        )
 
     async def _build_headers(
         self, target: MCPCatalogResolvedArtifact

--- a/tracecat/mcp/catalog/types.py
+++ b/tracecat/mcp/catalog/types.py
@@ -49,11 +49,18 @@ class MCPCatalogResolvedArtifact:
     display_name: str | None
     description: str | None
     scope_name: str
+    integration_slug: str
     server_type: str
     server_uri: str | None
     auth_type: MCPAuthType
     oauth_integration_id: UUID | None
     encrypted_headers: bytes | None
+    stdio_command: str | None
+    stdio_args: list[str] | None
+    encrypted_stdio_env: bytes | None
+    sandbox_allow_network: bool
+    sandbox_egress_allowlist: list[str] | None
+    sandbox_egress_denylist: list[str] | None
     timeout: int | None
 
 


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Executes persisted local `stdio` MCP artifacts through the dedicated MCP Temporal queue and worker path instead of rejecting them at the wrapper layer.

This PR adds three pieces:
- queue-backed local MCP artifact workflows and dual-queue agent worker registration
- ephemeral stdio execution with shared per-org cache mounts and nsjail wrapping when available
- per-integration outbound policy wiring for local stdio MCPs via an egress guard preload, with explicit degraded-mode warnings when nsjail is unavailable

Wrapper behavior now covers local tool execution, resource reads with truncation metadata, and prompt retrieval while preserving the persisted catalog + MCP policy authorization path.

## Related Issues

- ENG-1322

## Screenshots / Recordings

- None

## Steps to QA

1. Run `uv run ruff check tracecat/config.py tracecat/integrations/service.py tracecat/agent/preset/service.py tracecat/agent/mcp/sandbox/workflow.py tracecat/agent/mcp/sandbox/types.py tracecat/mcp/catalog/types.py tracecat/mcp/catalog/artifact_service.py tracecat/agent/worker.py tests/unit/test_local_mcp_sandbox_workflow.py tests/unit/test_mcp_artifact_service.py`
2. Run `uv run basedpyright tracecat/config.py tracecat/integrations/service.py tracecat/agent/preset/service.py tracecat/agent/mcp/sandbox/workflow.py tracecat/agent/mcp/sandbox/types.py tracecat/mcp/catalog/types.py tracecat/mcp/catalog/artifact_service.py tracecat/agent/worker.py tests/unit/test_local_mcp_sandbox_workflow.py tests/unit/test_mcp_artifact_service.py`
3. Run `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_local_mcp_sandbox_workflow.py tests/unit/test_mcp_artifact_service.py tests/unit/test_user_mcp_client.py tests/unit/test_mcp_catalog_service.py tests/unit/test_mcp_policy_service.py`
4. Optionally compile the egress guard locally with `cc -shared -fPIC -O2 -Wall -Wextra -o /tmp/libtracecat_mcp_egress_guard.so tracecat/agent/mcp/sandbox/tracecat_mcp_egress_guard.c -ldl -pthread`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queues local stdio MCP artifact execution on a dedicated Temporal MCP queue and wraps processes with optional nsjail plus enforced egress policy. Implements ENG-1322 by routing stdio tool/resource/prompt calls through a sandboxed workflow; HTTP artifacts remain unchanged.

- **New Features**
  - Added RunLocalMCPArtifactWorkflow and a separate MCP worker queue (TRACECAT__MCP_QUEUE); HTTP artifacts still execute directly.
  - Optional nsjail sandbox with per‑org caches (npm/pip/uv/XDG via TRACECAT__MCP_SANDBOX_CACHE_DIR); enforces egress allow/deny via an LD_PRELOAD guard library built and shipped in the Docker image.
  - Worker runs a second MCP queue with separate limits; new config: TRACECAT__MCP_MAX_CONCURRENT_ACTIVITIES, TRACECAT__MCP_THREADPOOL_MAX_WORKERS, TRACECAT__MCP_MAX_CONCURRENT_LOCAL_SANDBOXES, TRACECAT__MCP_SANDBOX_CACHE_DIR.
  - Centralized stdio_env decryption and template resolution in IntegrationService; artifact service dispatches stdio tools/resources/prompts via the workflow and returns truncation metadata (truncated, max_content_chars, total_content_chars).
  - Added tests for sandbox config, egress policy, and artifact dispatch.

- **Bug Fixes**
  - Hardened nsjail config: validate paths and reject unsafe stdio args to prevent injection; only jail commands within supported rootfs paths, otherwise fall back to direct mode with warnings (including egress policy degradation).
  - Strengthened egress guard: stricter host:port parsing, DNS resolution checks (IPv4/IPv6), allowlist caching, and fail‑closed behavior on allowlist cache overflow.

<sup>Written for commit d680094f3225a82fd9cf7fb2394aa0e7285a6044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

