### PR TITLE
feat(ui): expose MCP discovery state in integrations

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
@@ -1,11 +1,14 @@
 "use client"
 
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { formatDistanceToNow } from "date-fns"
 import { ChevronRight, Loader2, RotateCcw, SquareAsterisk } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type {
   IntegrationStatus,
+  MCPDiscoveryStatus,
+  MCPIntegrationRead,
   OAuthGrantType,
   SecretDefinition,
 } from "@/client"
@@ -71,6 +74,7 @@ import {
   useDeleteMcpIntegration,
   useIntegrations,
   useListMcpIntegrations,
+  useRefreshMcpIntegration,
   useSecretDefinitions,
   useWorkspaceSecrets,
 } from "@/lib/hooks"
@@ -94,9 +98,7 @@ type IntegrationItem =
       name: string
       description: string | null
       slug: string
-      server_uri: string | null
-      auth_type: string
-      oauth_integration_id?: string | null
+      integration: MCPIntegrationRead
     }
   | {
       type: "credential"
@@ -194,6 +196,11 @@ export default function IntegrationsPage() {
     useWorkspaceSecrets(workspaceId)
   const { deleteMcpIntegration, deleteMcpIntegrationIsPending } =
     useDeleteMcpIntegration(workspaceId)
+  const {
+    refreshMcpIntegration,
+    refreshMcpIntegrationIsPending,
+    refreshMcpIntegrationVariables,
+  } = useRefreshMcpIntegration(workspaceId)
 
   const queryClient = useQueryClient()
   const handleTypeFilterToggle = useCallback(
@@ -339,13 +346,15 @@ export default function IntegrationsPage() {
 
   const isCustomMcpIntegration = useCallback(
     (item: Extract<IntegrationItem, { type: "mcp" }>) => {
-      if (item.auth_type !== "OAUTH2") {
+      if (item.integration.auth_type !== "OAUTH2") {
         return true
       }
-      if (!item.oauth_integration_id) {
+      if (!item.integration.oauth_integration_id) {
         return true
       }
-      const integration = integrationById.get(item.oauth_integration_id)
+      const integration = integrationById.get(
+        item.integration.oauth_integration_id
+      )
       return !integration?.provider_id.endsWith("_mcp")
     },
     [integrationById]
@@ -406,9 +415,7 @@ export default function IntegrationsPage() {
         name: mcp.name,
         description: mcp.description,
         slug: mcp.slug,
-        server_uri: mcp.server_uri,
-        auth_type: mcp.auth_type,
-        oauth_integration_id: mcp.oauth_integration_id,
+        integration: mcp,
       })) ?? []
 
     const credentialItems: IntegrationItem[] =
@@ -796,6 +803,10 @@ export default function IntegrationsPage() {
                           item.type === "mcp" &&
                           pendingMcpDeleteId === item.id &&
                           deleteMcpIntegrationIsPending
+                        const isRefreshingMcp =
+                          item.type === "mcp" &&
+                          refreshMcpIntegrationIsPending &&
+                          refreshMcpIntegrationVariables === item.id
                         const disconnectKey = getDisconnectKey(item)
                         const disconnectConfirmText =
                           disconnectConfirmTextByKey[disconnectKey] ?? ""
@@ -896,6 +907,65 @@ export default function IntegrationsPage() {
                                   {typeLabel}
                                 </span>
                               </ItemTitle>
+                              {isMcp ? (
+                                <div className="mt-1 space-y-1">
+                                  <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+                                    <Badge
+                                      variant="outline"
+                                      className={cn(
+                                        "rounded-sm px-1.5 py-0 text-[10px] font-medium capitalize",
+                                        getMcpDiscoveryBadgeClassName(
+                                          item.integration.discovery_status
+                                        )
+                                      )}
+                                    >
+                                      {item.integration.discovery_status}
+                                    </Badge>
+                                    <span>
+                                      {formatMcpCatalogCounts(
+                                        item.integration.catalog_counts,
+                                        item.integration.has_catalog ?? false
+                                      )}
+                                    </span>
+                                    {item.integration.last_discovered_at ? (
+                                      <TooltipProvider>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <span>
+                                              {formatRelativeTimestamp(
+                                                item.integration
+                                                  .last_discovered_at
+                                              )}
+                                            </span>
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            <p>
+                                              {new Date(
+                                                item.integration
+                                                  .last_discovered_at
+                                              ).toLocaleString()}
+                                            </p>
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                    ) : null}
+                                  </div>
+                                  {item.integration
+                                    .last_discovery_error_summary ? (
+                                    <p className="truncate text-[11px] text-muted-foreground">
+                                      Error:{" "}
+                                      {
+                                        item.integration
+                                          .last_discovery_error_summary
+                                      }
+                                    </p>
+                                  ) : item.description ? (
+                                    <p className="truncate text-[11px] text-muted-foreground">
+                                      {item.description}
+                                    </p>
+                                  ) : null}
+                                </div>
+                              ) : null}
                             </ItemContent>
                             <ItemActions className="ml-auto flex shrink-0 items-center gap-1.5 pl-3">
                               {isConfigured &&
@@ -957,6 +1027,36 @@ export default function IntegrationsPage() {
                                     </Tooltip>
                                   </TooltipProvider>
                                 ))}
+                              {isMcp && canMutateIntegrations && (
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-6 w-6"
+                                        aria-label={`Refresh ${item.name}`}
+                                        onClick={async (event) => {
+                                          event.stopPropagation()
+                                          await refreshMcpIntegration(item.id)
+                                        }}
+                                        disabled={
+                                          !isConnected || isRefreshingMcp
+                                        }
+                                      >
+                                        {isRefreshingMcp ? (
+                                          <Loader2 className="size-3.5 animate-spin" />
+                                        ) : (
+                                          <RotateCcw className="size-3.5" />
+                                        )}
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>Refresh catalog</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              )}
                               {isOAuth &&
                                 isConnected &&
                                 canMutateIntegrations && (
@@ -1198,12 +1298,60 @@ function getMcpDisplayStatus(
   item: Extract<IntegrationItem, { type: "mcp" }>,
   integrationById: Map<string, { status: IntegrationStatus }>
 ): IntegrationStatus {
-  if (item.auth_type === "OAUTH2") {
-    if (!item.oauth_integration_id) {
+  if (item.integration.auth_type === "OAUTH2") {
+    if (!item.integration.oauth_integration_id) {
       return "not_configured"
     }
-    const integration = integrationById.get(item.oauth_integration_id)
+    const integration = integrationById.get(
+      item.integration.oauth_integration_id
+    )
     return integration?.status === "connected" ? "connected" : "not_configured"
   }
   return "connected"
+}
+
+function formatMcpCatalogCounts(
+  counts: MCPIntegrationRead["catalog_counts"] | undefined,
+  hasCatalog: boolean
+): string {
+  if (!hasCatalog) {
+    return "No catalog yet"
+  }
+
+  if (!counts) {
+    return "Catalog available"
+  }
+
+  const toolCount = counts.tools ?? 0
+  const resourceCount = counts.resources ?? 0
+  const promptCount = counts.prompts ?? 0
+
+  const parts = [
+    toolCount > 0 ? `${toolCount} tool${toolCount === 1 ? "" : "s"}` : null,
+    resourceCount > 0
+      ? `${resourceCount} resource${resourceCount === 1 ? "" : "s"}`
+      : null,
+    promptCount > 0
+      ? `${promptCount} prompt${promptCount === 1 ? "" : "s"}`
+      : null,
+  ].filter((value): value is string => value !== null)
+
+  return parts.length > 0 ? parts.join(" · ") : "Catalog available"
+}
+
+function formatRelativeTimestamp(value: string): string {
+  return `Last success ${formatDistanceToNow(new Date(value), { addSuffix: true })}`
+}
+
+function getMcpDiscoveryBadgeClassName(status: MCPDiscoveryStatus): string {
+  switch (status) {
+    case "succeeded":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+    case "failed":
+      return "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300"
+    case "stale":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+    case "pending":
+      return "border-border bg-muted text-foreground"
+  }
 }

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -330,6 +330,8 @@ import type {
   McpIntegrationsGetMcpIntegrationResponse,
   McpIntegrationsListMcpIntegrationsData,
   McpIntegrationsListMcpIntegrationsResponse,
+  McpIntegrationsRefreshMcpIntegrationData,
+  McpIntegrationsRefreshMcpIntegrationResponse,
   McpIntegrationsUpdateMcpIntegrationData,
   McpIntegrationsUpdateMcpIntegrationResponse,
   OrganizationAcceptInvitationData,
@@ -9288,6 +9290,33 @@ export const mcpIntegrationsDeleteMcpIntegration = (
   return __request(OpenAPI, {
     method: "DELETE",
     url: "/mcp-integrations/{mcp_integration_id}",
+    path: {
+      mcp_integration_id: data.mcpIntegrationId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Refresh Mcp Integration
+ * Queue an MCP integration discovery refresh.
+ * @param data The data for the request.
+ * @param data.mcpIntegrationId
+ * @param data.workspaceId
+ * @returns MCPIntegrationRead Successful Response
+ * @throws ApiError
+ */
+export const mcpIntegrationsRefreshMcpIntegration = (
+  data: McpIntegrationsRefreshMcpIntegrationData
+): CancelablePromise<McpIntegrationsRefreshMcpIntegrationResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/mcp-integrations/{mcp_integration_id}/refresh",
     path: {
       mcp_integration_id: data.mcpIntegrationId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -10338,6 +10338,13 @@ export type McpIntegrationsDeleteMcpIntegrationData = {
 
 export type McpIntegrationsDeleteMcpIntegrationResponse = void
 
+export type McpIntegrationsRefreshMcpIntegrationData = {
+  mcpIntegrationId: string
+  workspaceId: string
+}
+
+export type McpIntegrationsRefreshMcpIntegrationResponse = MCPIntegrationRead
+
 export type FeatureFlagsGetFeatureFlagsResponse = FeatureFlagsRead
 
 export type VcsGetGithubAppManifestResponse = GitHubAppManifestResponse
@@ -15153,6 +15160,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/mcp-integrations/{mcp_integration_id}/refresh": {
+    post: {
+      req: McpIntegrationsRefreshMcpIntegrationData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: MCPIntegrationRead
         /**
          * Validation Error
          */

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -141,6 +141,7 @@ import {
   mcpIntegrationsDeleteMcpIntegration,
   mcpIntegrationsGetMcpIntegration,
   mcpIntegrationsListMcpIntegrations,
+  mcpIntegrationsRefreshMcpIntegration,
   mcpIntegrationsUpdateMcpIntegration,
   type OAuthGrantType,
   type OrganizationDeleteOrgMemberData,
@@ -4599,7 +4600,13 @@ export function useListMcpIntegrations(workspaceId: string) {
     queryFn: async () =>
       await mcpIntegrationsListMcpIntegrations({ workspaceId }),
     enabled: Boolean(workspaceId),
-    staleTime: 5 * 60 * 1000,
+    staleTime: 30 * 1000,
+    refetchInterval: ({ state }) =>
+      state.data?.some(
+        (integration) => integration.discovery_status === "pending"
+      )
+        ? 5000
+        : false,
     refetchOnWindowFocus: false,
   })
 
@@ -4626,7 +4633,9 @@ export function useGetMcpIntegration(
         mcpIntegrationId: mcpIntegrationId!,
       }),
     enabled: Boolean(workspaceId && mcpIntegrationId),
-    staleTime: 5 * 60 * 1000,
+    staleTime: 30 * 1000,
+    refetchInterval: ({ state }) =>
+      state.data?.discovery_status === "pending" ? 5000 : false,
     refetchOnWindowFocus: false,
   })
 
@@ -4634,6 +4643,51 @@ export function useGetMcpIntegration(
     mcpIntegration,
     mcpIntegrationIsLoading,
     mcpIntegrationError,
+  }
+}
+
+export function useRefreshMcpIntegration(workspaceId: string) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: refreshMcpIntegration,
+    isPending: refreshMcpIntegrationIsPending,
+    error: refreshMcpIntegrationError,
+    variables: refreshMcpIntegrationVariables,
+  } = useMutation({
+    mutationFn: async (mcpIntegrationId: string) => {
+      return await mcpIntegrationsRefreshMcpIntegration({
+        workspaceId,
+        mcpIntegrationId,
+      })
+    },
+    onSuccess: (integration) => {
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integrations", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integration", workspaceId, integration.id],
+      })
+      toast({
+        title: "MCP refresh queued",
+        description: `Refreshing ${integration.name}`,
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to refresh MCP integration:", error)
+      toast({
+        title: "Failed to refresh MCP integration",
+        description: `${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    refreshMcpIntegration,
+    refreshMcpIntegrationIsPending,
+    refreshMcpIntegrationError,
+    refreshMcpIntegrationVariables,
   }
 }
 

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -359,7 +359,13 @@ class TestMCPIntegrationCRUD:
         update_params = MCPIntegrationUpdate(
             name="Updated MCP",
             description="Updated description",
+            server_uri="https://api-2.example.com/mcp",
         )
+        created.discovery_status = MCPDiscoveryStatus.FAILED.value
+        created.last_discovery_error_code = "connect_error"
+        created.last_discovery_error_summary = "Timed out talking to MCP server."
+        integration_service.session.add(created)
+        await integration_service.session.commit()
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
@@ -369,7 +375,39 @@ class TestMCPIntegrationCRUD:
         assert updated.description == "Updated description"
         assert updated.slug == "updated-mcp"  # Slug regenerated when name changes
         assert updated.scope_namespace == original_scope_namespace
-        assert updated.server_uri == created.server_uri  # Unchanged
+        assert updated.server_uri == "https://api-2.example.com/mcp"
+        assert updated.discovery_status == MCPDiscoveryStatus.PENDING.value
+        assert updated.last_discovery_error_code is None
+        assert updated.last_discovery_error_summary is None
+
+    async def test_refresh_mcp_integration_marks_status_pending(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """Test refresh resets discovery status back to pending."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Refresh MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+        created.discovery_status = MCPDiscoveryStatus.FAILED.value
+        created.last_discovery_error_code = "connect_error"
+        created.last_discovery_error_summary = "Timed out talking to MCP server."
+        integration_service.session.add(created)
+        await integration_service.session.commit()
+
+        refreshed = await integration_service.refresh_mcp_integration(
+            mcp_integration_id=created.id
+        )
+
+        assert refreshed is not None
+        assert refreshed.discovery_status == MCPDiscoveryStatus.PENDING.value
+        assert refreshed.last_discovery_error_code is None
+        assert refreshed.last_discovery_error_summary is None
 
     async def test_get_mcp_catalog_counts(
         self,

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -986,6 +986,39 @@ async def update_mcp_integration(
     )
 
 
+@mcp_router.post("/{mcp_integration_id}/refresh")
+@require_scope("integration:update")
+async def refresh_mcp_integration(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    mcp_integration_id: uuid.UUID,
+) -> MCPIntegrationRead:
+    """Queue an MCP integration discovery refresh."""
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+
+    svc = IntegrationService(session, role=role)
+    integration = await svc.refresh_mcp_integration(
+        mcp_integration_id=mcp_integration_id
+    )
+    if integration is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="MCP integration not found",
+        )
+
+    catalog_counts = await svc.get_mcp_catalog_counts(
+        mcp_integration_ids=[integration.id]
+    )
+    return _serialize_mcp_integration(
+        integration,
+        counts_by_type=catalog_counts.get(integration.id),
+    )
+
+
 @mcp_router.delete("/{mcp_integration_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("integration:delete")
 async def delete_mcp_integration(

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1369,6 +1369,33 @@ class IntegrationService(BaseWorkspaceService):
         return counts_by_integration
 
     @require_scope("integration:update")
+    async def refresh_mcp_integration(
+        self, *, mcp_integration_id: uuid.UUID
+    ) -> MCPIntegration | None:
+        """Mark an MCP integration for discovery refresh."""
+        mcp_integration = await self.get_mcp_integration(
+            mcp_integration_id=mcp_integration_id
+        )
+        if not mcp_integration:
+            return None
+
+        mcp_integration.discovery_status = MCPDiscoveryStatus.PENDING.value
+        mcp_integration.last_discovery_error_code = None
+        mcp_integration.last_discovery_error_summary = None
+
+        self.session.add(mcp_integration)
+        await self.session.commit()
+        await self.session.refresh(mcp_integration)
+
+        self.logger.info(
+            "Queued MCP integration refresh",
+            mcp_integration_id=mcp_integration.id,
+            workspace_id=self.workspace_id,
+        )
+
+        return mcp_integration
+
+    @require_scope("integration:update")
     async def update_mcp_integration(
         self, *, mcp_integration_id: uuid.UUID, params: MCPIntegrationUpdate
     ) -> MCPIntegration | None:
@@ -1379,6 +1406,7 @@ class IntegrationService(BaseWorkspaceService):
         if not mcp_integration:
             return None
         previous_auth_type = mcp_integration.auth_type
+        should_refresh_discovery = False
 
         # Validate OAuth integration if auth_type is being changed to oauth2
         if params.auth_type == MCPAuthType.OAUTH2:
@@ -1411,10 +1439,13 @@ class IntegrationService(BaseWorkspaceService):
             )
         if params.server_uri is not None:
             mcp_integration.server_uri = params.server_uri.strip()
+            should_refresh_discovery = True
         if params.auth_type is not None:
             mcp_integration.auth_type = params.auth_type
+            should_refresh_discovery = True
         if params.oauth_integration_id is not None:
             mcp_integration.oauth_integration_id = params.oauth_integration_id
+            should_refresh_discovery = True
 
         if mcp_integration.server_type == "stdio" and (
             params.stdio_command is not None
@@ -1436,8 +1467,10 @@ class IntegrationService(BaseWorkspaceService):
             mcp_integration.stdio_command = (
                 params.stdio_command.strip() if params.stdio_command else None
             )
+            should_refresh_discovery = True
         if params.stdio_args is not None:
             mcp_integration.stdio_args = params.stdio_args
+            should_refresh_discovery = True
         if params.stdio_env is not None:
             if params.stdio_env:
                 mcp_integration.encrypted_stdio_env = self._encrypt_token(
@@ -1446,8 +1479,10 @@ class IntegrationService(BaseWorkspaceService):
             else:
                 # Empty dict means clear the env vars
                 mcp_integration.encrypted_stdio_env = None
+            should_refresh_discovery = True
         if params.timeout is not None:
             mcp_integration.timeout = params.timeout
+            should_refresh_discovery = True
 
         # Handle encrypted header credentials for CUSTOM/OAUTH2 auth types.
         if params.custom_credentials is not None:
@@ -1469,6 +1504,13 @@ class IntegrationService(BaseWorkspaceService):
             ):
                 # Avoid carrying CUSTOM credentials into OAuth unless explicitly set.
                 mcp_integration.encrypted_headers = None
+        if params.custom_credentials is not None:
+            should_refresh_discovery = True
+
+        if should_refresh_discovery:
+            mcp_integration.discovery_status = MCPDiscoveryStatus.PENDING.value
+            mcp_integration.last_discovery_error_code = None
+            mcp_integration.last_discovery_error_summary = None
 
         self.session.add(mcp_integration)
         await self.session.commit()


### PR DESCRIPTION
## Summary

- expose MCP discovery state, catalog counts, last successful discovery time, and redacted error summaries in the integrations UI
- add an explicit MCP integration refresh API and frontend mutation hook
- reset MCP discovery state back to `pending` when refresh is requested or discovery-affecting integration config changes

## Related Issues

- ENG-1323

## Steps to QA

1. Run `TRACECAT__SERVICE_KEY=test-service-key TRACECAT__DB_ENCRYPTION_KEY='Su3XazJf5Q9PexP8MaqkOawxaggUY8ailqXFz3vGN9w=' uv run pytest tests/unit/test_mcp_integrations.py -q`
2. Run `uv run ruff check tracecat/integrations/service.py tracecat/integrations/router.py tests/unit/test_mcp_integrations.py`
3. Run `uv run basedpyright tracecat/integrations/service.py tracecat/integrations/router.py tests/unit/test_mcp_integrations.py`
4. Run `pnpm -C frontend check`
5. Run `pnpm -C frontend run typecheck`
