### PR TITLE
feat(agent): improve local MCP runtime failure logs

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -477,6 +477,7 @@ class TestLocalMCPFailureClassification:
                 )
             },
             stderr_tail=(
+                "github-local initialize timed out after 15s",
                 "Authorization: Bearer secret-token",
                 "GITHUB_TOKEN=super-secret-value",
             ),
@@ -488,3 +489,20 @@ class TestLocalMCPFailureClassification:
         assert details.timeout == 15
         assert all("secret-token" not in line for line in details.stderr_tail)
         assert all("super-secret-value" not in line for line in details.stderr_tail)
+
+    def test_ignores_generic_timeout_without_matching_server(self) -> None:
+        """Generic runtime failures should not blame an unrelated local MCP server."""
+        details = _classify_local_mcp_failure(
+            error=RuntimeError("Tool server timeout while calling upstream API"),
+            servers={
+                "github-local": LocalMCPServerContext(
+                    server_name="github-local",
+                    command="github-mcp",
+                    timeout=15,
+                    env_keys=("GITHUB_TOKEN",),
+                )
+            },
+            stderr_tail=(),
+        )
+
+        assert details is None

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -27,7 +27,11 @@ from tracecat.agent.common.types import (
 from tracecat.agent.common.types import (
     MCPToolDefinition as SharedMCPToolDefinition,
 )
-from tracecat.agent.runtime.claude_code.runtime import ClaudeAgentRuntime
+from tracecat.agent.runtime.claude_code.runtime import (
+    ClaudeAgentRuntime,
+    LocalMCPServerContext,
+    _classify_local_mcp_failure,
+)
 from tracecat.agent.types import AgentConfig
 
 
@@ -103,6 +107,7 @@ def sample_init_payload(
 def mock_socket_writer() -> MagicMock:
     """Create a mock SocketStreamWriter."""
     writer = MagicMock(spec=SocketStreamWriter)
+    writer.send_log = AsyncMock()
     writer.send_stream_event = AsyncMock()
     writer.send_message = AsyncMock()
     writer.send_session_line = AsyncMock()
@@ -261,6 +266,66 @@ class TestClaudeAgentRuntimeRun:
         mock_socket_writer.send_done.assert_awaited_once()
 
     @pytest.mark.anyio
+    async def test_surfaces_local_mcp_spawn_failures_with_context(
+        self,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+    ) -> None:
+        """Test that local stdio MCP spawn failures become actionable runtime errors."""
+        mock_claude_sdk_client.query = AsyncMock(
+            side_effect=FileNotFoundError(
+                "MCP server github-local failed to spawn: npx not found"
+            )
+        )
+        payload = replace(
+            sample_init_payload,
+            config=replace(
+                sample_init_payload.config,
+                mcp_servers=[
+                    {
+                        "type": "stdio",
+                        "name": "github-local",
+                        "command": "npx",
+                        "args": ["@modelcontextprotocol/server-github"],
+                        "env": {"GITHUB_TOKEN": "super-secret-token"},
+                        "timeout": 20,
+                    }
+                ],
+            ),
+        )
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                return_value=mock_claude_sdk_client,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+            pytest.raises(FileNotFoundError, match="github-local"),
+        ):
+            runtime = ClaudeAgentRuntime(mock_socket_writer)
+            await runtime.run(payload)
+
+        assert mock_socket_writer.send_log.await_count >= 1
+        error_logs = [
+            call
+            for call in mock_socket_writer.send_log.await_args_list
+            if call.args[:2] == ("error", "Local MCP server failure")
+        ]
+        assert error_logs
+        assert error_logs[0].kwargs["server_name"] == "github-local"
+        assert error_logs[0].kwargs["phase"] == "spawn"
+        assert error_logs[0].kwargs["stderr_tail"] is None
+        mock_socket_writer.send_error.assert_awaited_once()
+        assert (
+            "Local MCP server 'github-local' failed during spawn"
+            in (mock_socket_writer.send_error.await_args.args[0])
+        )
+
+    @pytest.mark.anyio
     async def test_adds_registry_mcp_alias_on_resume(
         self,
         mock_socket_writer: MagicMock,
@@ -394,3 +459,32 @@ class TestClaudeAgentRuntimePreToolUseHook:
         # Should have sent approval request and interrupted
         mock_socket_writer.send_stream_event.assert_awaited()
         runtime.client.interrupt.assert_awaited()
+
+
+class TestLocalMCPFailureClassification:
+    """Tests for local MCP runtime failure attribution helpers."""
+
+    def test_classifies_local_mcp_initialize_timeout_and_redacts_stderr(self) -> None:
+        """Timeout failures should identify the server and redact sensitive stderr."""
+        details = _classify_local_mcp_failure(
+            error=RuntimeError("MCP initialize timed out after 15s"),
+            servers={
+                "github-local": LocalMCPServerContext(
+                    server_name="github-local",
+                    command="npx",
+                    timeout=15,
+                    env_keys=("GITHUB_TOKEN", "DEBUG"),
+                )
+            },
+            stderr_tail=(
+                "Authorization: Bearer secret-token",
+                "GITHUB_TOKEN=super-secret-value",
+            ),
+        )
+
+        assert details is not None
+        assert details.server_name == "github-local"
+        assert details.phase == "initialize"
+        assert details.timeout == 15
+        assert all("secret-token" not in line for line in details.stderr_tail)
+        assert all("super-secret-value" not in line for line in details.stderr_tail)

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import tempfile
 import uuid
+from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -107,6 +110,163 @@ INTERNET_TOOLS = [
 # forms, so we keep both aliases valid.
 REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
 REGISTRY_MCP_SERVER_NAME_ALIAS = "tracecat_registry"
+MAX_LOCAL_MCP_STDERR_TAIL_LINES = 8
+MAX_LOCAL_MCP_STDERR_LINE_CHARS = 300
+
+
+@dataclass(frozen=True, slots=True)
+class LocalMCPServerContext:
+    """Log-safe metadata for a configured local stdio MCP server."""
+
+    server_name: str
+    command: str
+    timeout: int | None
+    env_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalMCPFailureDetails:
+    """Derived MCP failure details for logging and user-facing errors."""
+
+    server_name: str
+    phase: str
+    message: str
+    timeout: int | None = None
+    exit_code: int | None = None
+    stderr_tail: tuple[str, ...] = ()
+
+
+def _truncate_stderr_line(line: str) -> str:
+    """Bound stderr lines before storing or logging them."""
+    normalized = " ".join(line.strip().split())
+    if len(normalized) <= MAX_LOCAL_MCP_STDERR_LINE_CHARS:
+        return normalized
+    return f"{normalized[: MAX_LOCAL_MCP_STDERR_LINE_CHARS - 3]}..."
+
+
+def _redact_sensitive_text(value: str) -> str:
+    """Redact common secret-bearing fragments from error and stderr text."""
+    redacted = re.sub(
+        r"(?i)(authorization\s*:\s*)(.+)",
+        r"\1<redacted>",
+        value,
+    )
+    redacted = re.sub(
+        r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+",
+        r"\1<redacted>",
+        redacted,
+    )
+    redacted = re.sub(
+        r"(?i)\b([A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|KEY))=(\S+)",
+        r"\1=<redacted>",
+        redacted,
+    )
+    return redacted
+
+
+def _extract_exit_code(message: str) -> int | None:
+    """Extract a process exit code from an error message when present."""
+    if match := re.search(r"(?i)\bexit(?:ed)?(?:\s+with)?\s+code\s+(-?\d+)\b", message):
+        return int(match.group(1))
+    return None
+
+
+def _infer_mcp_phase(message: str) -> str:
+    """Infer the most likely MCP lifecycle phase from an error message."""
+    phase_patterns: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("config_validate", ("invalid mcp", "validation", "config", "malformed")),
+        ("spawn", ("spawn", "enoent", "no such file or directory", "not found")),
+        ("initialize", ("initialize", "initialization", "handshake")),
+        ("list_tools", ("list_tools", "tools/list", "list tools")),
+        ("list_resources", ("list_resources", "resources/list", "list resources")),
+        ("list_prompts", ("list_prompts", "prompts/list", "list prompts")),
+        ("call_tool", ("call_tool", "tools/call", "tool call", "call tool")),
+        (
+            "read_resource",
+            ("read_resource", "resources/read", "read resource"),
+        ),
+        ("get_prompt", ("get_prompt", "prompts/get", "get prompt")),
+        ("shutdown", ("shutdown", "close", "terminate")),
+    )
+    for phase, patterns in phase_patterns:
+        if any(pattern in message for pattern in patterns):
+            return phase
+    if "timed out" in message or "timeout" in message:
+        return "initialize"
+    return "initialize"
+
+
+def _format_local_mcp_error(details: LocalMCPFailureDetails) -> str:
+    """Format a bounded user-facing error for local MCP failures."""
+    prefix = f"Local MCP server '{details.server_name}' failed during {details.phase}"
+    if details.phase == "spawn" and "not found" in details.message.lower():
+        return f"{prefix}: command not found."
+    if details.phase == "spawn" and "npm err" in details.message.lower():
+        return f"{prefix}: package install or startup failed."
+    if details.phase == "initialize" and (
+        "timed out" in details.message.lower() or "timeout" in details.message.lower()
+    ):
+        return f"{prefix}: handshake timed out."
+    return f"{prefix}: {details.message}"
+
+
+def _classify_local_mcp_failure(
+    *,
+    error: Exception,
+    servers: dict[str, LocalMCPServerContext],
+    stderr_tail: tuple[str, ...],
+) -> LocalMCPFailureDetails | None:
+    """Best-effort attribution of a runtime failure to a local stdio MCP server."""
+    if not servers:
+        return None
+
+    combined = _redact_sensitive_text(
+        " ".join([str(error), *stderr_tail]).strip()
+    ).lower()
+    if not combined:
+        return None
+
+    if not any(
+        signal in combined
+        for signal in (
+            "mcp",
+            "stdio",
+            "server",
+            "spawn",
+            "initialize",
+            "tool",
+            "resource",
+            "prompt",
+            "timed out",
+            "timeout",
+            "enoent",
+            "not found",
+        )
+    ):
+        return None
+
+    server = next(
+        (
+            context
+            for context in servers.values()
+            if context.server_name.lower() in combined
+            or context.command.lower() in combined
+        ),
+        next(iter(servers.values())),
+    )
+    phase = _infer_mcp_phase(combined)
+    message = _redact_sensitive_text(str(error)) or "Unknown MCP runtime failure"
+    redacted_stderr_tail = tuple(_redact_sensitive_text(line) for line in stderr_tail)
+    return LocalMCPFailureDetails(
+        server_name=server.server_name,
+        phase=phase,
+        message=message,
+        timeout=server.timeout
+        if "timeout" in combined or "timed out" in combined
+        else None,
+        exit_code=_extract_exit_code(combined),
+        stderr_tail=redacted_stderr_tail,
+    )
 
 
 class ClaudeAgentRuntime:
@@ -465,6 +625,8 @@ class ClaudeAgentRuntime:
                 # Count lines from the session data we just wrote to disk (avoid I/O).
                 self._last_seen_line_index = len(payload.sdk_session_data.splitlines())
 
+        local_mcp_servers: dict[str, LocalMCPServerContext] = {}
+        stderr_tail: deque[str] = deque(maxlen=MAX_LOCAL_MCP_STDERR_TAIL_LINES)
         try:
             # Build MCP servers config for registry actions and stdio servers
             mcp_servers: dict[str, Any] = {}
@@ -503,10 +665,27 @@ class ClaudeAgentRuntime:
                         server_config["timeout"] = timeout
 
                     mcp_servers[server_name] = server_config
+                    local_mcp_servers[server_name] = LocalMCPServerContext(
+                        server_name=server_name,
+                        command=stdio_config["command"],
+                        timeout=stdio_config.get("timeout"),
+                        env_keys=tuple(sorted((stdio_config.get("env") or {}).keys())),
+                    )
+                    await self._socket_writer.send_log(
+                        "debug",
+                        "Configured local MCP stdio server",
+                        server_name=server_name,
+                        phase="config_validate",
+                        command=stdio_config["command"],
+                        timeout=stdio_config.get("timeout"),
+                        env_keys=sorted((stdio_config.get("env") or {}).keys()),
+                    )
 
             def handle_claude_stderr(line: str) -> None:
                 """Forward Claude CLI stderr to loopback via queue."""
-                stderr_queue.put_nowait(line)
+                redacted_line = _truncate_stderr_line(_redact_sensitive_text(line))
+                stderr_tail.append(redacted_line)
+                stderr_queue.put_nowait(redacted_line)
 
             await self._socket_writer.send_log(
                 "debug",
@@ -561,7 +740,11 @@ class ClaudeAgentRuntime:
                 """Background task to drain stderr queue to loopback."""
                 while True:
                     line = await stderr_queue.get()
-                    await self._socket_writer.send_log("warning", f"[stderr] {line}")
+                    await self._socket_writer.send_log(
+                        "warning",
+                        "Claude runtime stderr",
+                        stderr_line=line,
+                    )
 
             logger.debug(
                 "Creating ClaudeSDKClient",
@@ -705,13 +888,31 @@ class ClaudeAgentRuntime:
                         pass
 
         except Exception as e:
-            await self._socket_writer.send_log(
-                "error",
-                "Runtime error",
-                error_type=type(e).__name__,
-                error_message=str(e),
-            )
-            await self._socket_writer.send_error(str(e))
+            if details := _classify_local_mcp_failure(
+                error=e,
+                servers=local_mcp_servers,
+                stderr_tail=tuple(stderr_tail),
+            ):
+                await self._socket_writer.send_log(
+                    "error",
+                    "Local MCP server failure",
+                    server_name=details.server_name,
+                    phase=details.phase,
+                    timeout=details.timeout,
+                    exit_code=details.exit_code,
+                    stderr_tail=list(details.stderr_tail) or None,
+                    error_type=type(e).__name__,
+                    error_message=details.message,
+                )
+                await self._socket_writer.send_error(_format_local_mcp_error(details))
+            else:
+                await self._socket_writer.send_log(
+                    "error",
+                    "Runtime error",
+                    error_type=type(e).__name__,
+                    error_message=_redact_sensitive_text(str(e)),
+                )
+                await self._socket_writer.send_error(_redact_sensitive_text(str(e)))
             raise
         finally:
             self.client = None

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -252,8 +252,10 @@ def _classify_local_mcp_failure(
             if context.server_name.lower() in combined
             or context.command.lower() in combined
         ),
-        next(iter(servers.values())),
+        None,
     )
+    if server is None:
+        return None
     phase = _infer_mcp_phase(combined)
     message = _redact_sensitive_text(str(error)) or "Unknown MCP runtime failure"
     redacted_stderr_tail = tuple(_redact_sensitive_text(line) for line in stderr_tail)


### PR DESCRIPTION
## Summary

- add local stdio MCP runtime classification helpers so Claude runtime failures are attributed to a server and lifecycle phase instead of collapsing into a generic runtime error
- redact and bound stderr tails before forwarding them into runtime logs
- surface more actionable user-facing errors for spawn and initialize failures in the local MCP path

## Related Issues

- ENG-1314

## Steps to QA

1. Run `uv run ruff check tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py`
2. Run `uv run basedpyright tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py`
3. Run `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_agent_runtime.py tests/unit/test_agent_socket_io.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves error reporting for local stdio MCP servers in ClaudeAgentRuntime and prevents blaming unrelated servers. Adds structured, redacted logs and clearer user errors to meet ENG-1314.

- **New Features**
  - Classifies local MCP failures by server and phase (spawn, initialize, tool/resource/prompt) with timeout/exit code when available; only attributes when the server name or command appears in error/stderr.
  - Streams redacted, truncated stderr lines as structured "Claude runtime stderr" logs and keeps a small tail; logs safe server config (command, timeout, env keys) at debug.
  - Emits structured "Local MCP server failure" logs and formats user-facing errors for common cases (command not found, npm install/startup issues, handshake timeouts); redacts secrets in all error messages, including non-MCP runtime errors.

<sup>Written for commit f10685aa2a7d6460e0e91ac2e4a60f77ae7927fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

