### PR TITLE
Fix case trigger workflow listing

### DIFF
--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { ToolUIPart } from "ai"
+import type { DynamicToolUIPart, ToolUIPart } from "ai"
 import {
   ChevronDownIcon,
   CircleCheckIcon,
@@ -36,26 +36,35 @@ export const Tool = ({ className, ...props }: ToolProps) => (
 
 export type ToolHeaderProps = {
   title?: string
-  type: ToolUIPart["type"]
+  type: ToolUIPart["type"] | DynamicToolUIPart["type"]
   state: ToolUIPart["state"]
   className?: string
   icon?: ReactNode
 }
 
 const getStatusBadge = (status: ToolUIPart["state"]) => {
-  const labels = {
+  const labels: Record<ToolUIPart["state"], string> = {
     "input-streaming": "Pending",
     "input-available": "Running",
+    "approval-requested": "Needs approval",
+    "approval-responded": "Approval received",
     "output-available": "Completed",
     "output-error": "Error",
-  } as const
+    "output-denied": "Denied",
+  }
 
-  const icons = {
+  const icons: Record<ToolUIPart["state"], ReactNode> = {
     "input-streaming": (
       <CircleIcon className="size-3.5 text-muted-foreground animate-pulse" />
     ),
     "input-available": (
       <ClockIcon className="size-3.5 text-amber-500 animate-pulse" />
+    ),
+    "approval-requested": (
+      <ClockIcon className="size-3.5 text-amber-500 animate-pulse" />
+    ),
+    "approval-responded": (
+      <CircleCheckIcon className="size-4 fill-amber-500 stroke-white" />
     ),
     "output-available": (
       <CircleCheckIcon className="size-4 fill-emerald-500 stroke-white" />
@@ -63,7 +72,10 @@ const getStatusBadge = (status: ToolUIPart["state"]) => {
     "output-error": (
       <XCircleIcon className="size-4 fill-rose-500 stroke-white" />
     ),
-  } as const
+    "output-denied": (
+      <XCircleIcon className="size-4 fill-amber-500 stroke-white" />
+    ),
+  }
 
   return (
     <TooltipProvider>

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -5,7 +5,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query"
-import { DefaultChatTransport, type UIMessage } from "ai"
+import { type UIMessage as AiUIMessage, DefaultChatTransport } from "ai"
 import { useMemo, useState } from "react"
 import {
   type AgentSessionCreate,
@@ -16,6 +16,7 @@ import {
   type AgentSessionsListSessionsResponse,
   type AgentSessionUpdate,
   type ApiError,
+  type UIMessage as ApiUIMessage,
   agentSessionsCreateSession,
   agentSessionsDeleteSession,
   agentSessionsGetSession,
@@ -270,7 +271,7 @@ export function useVercelChat({
 }: {
   chatId?: string
   workspaceId: string
-  messages: UIMessage[]
+  messages: AiUIMessage[]
   modelInfo: ModelInfo
 }) {
   const queryClient = useQueryClient()
@@ -312,7 +313,7 @@ export function useVercelChat({
           kind: "vercel",
           model: modelInfo?.name,
           model_provider: modelInfo?.provider,
-          message: last,
+          message: last as ApiUIMessage,
         }
         const baseUrl = (modelInfo as { baseUrl?: string | null })?.baseUrl
         if (baseUrl != null) body.base_url = baseUrl
@@ -359,7 +360,7 @@ export type ApprovalCard = {
 export function makeContinueMessage(
   decisions: ContinueRunRequest["decisions"],
   source: ContinueRunRequest["source"] = "inbox"
-): UIMessage {
+): AiUIMessage {
   return {
     id: `continue-${Date.now()}`,
     role: "user",
@@ -367,7 +368,7 @@ export function makeContinueMessage(
       {
         type: "data-continue",
         data: { kind: "continue", source, decisions },
-      } as UIMessage["parts"][number],
+      } as AiUIMessage["parts"][number],
     ],
   }
 }

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -37,8 +37,11 @@ function isToolPart(
     typeof (part as { state?: string }).state === "string" &&
     ((part as { state: string }).state === "input-streaming" ||
       (part as { state: string }).state === "input-available" ||
+      (part as { state: string }).state === "approval-requested" ||
+      (part as { state: string }).state === "approval-responded" ||
       (part as { state: string }).state === "output-available" ||
-      (part as { state: string }).state === "output-error")
+      (part as { state: string }).state === "output-error" ||
+      (part as { state: string }).state === "output-denied")
   )
 }
 
@@ -303,7 +306,7 @@ export function transformMessages(messages: ai.UIMessage[]): ai.UIMessage[] {
         // Handle output parts
         const { toolCallId } = part
         const currState = states.get(toolCallId)
-        const newPart: ai.ToolUIPart = {
+        const newPart = {
           ...part,
         }
         if (currState?.open) {

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -1219,7 +1219,6 @@ export function useLastExecution({
         workspaceId,
         workflowId,
         limit: 1,
-        userId: "current",
         trigger: triggerTypes,
       })
 


### PR DESCRIPTION
Summary:
- remove the hard-coded `userId` filter from the `useLastExecution` hook so case-triggered workflows show up again in the workflow builder left panel

Testing:
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores case-triggered workflows in the Workflow Builder left panel by removing a hard-coded userId filter. Also adds approval/denied tool states and aligns chat types to avoid mismatches.

- **Bug Fixes**
  - Removed userId="current" from useLastExecution, so case-triggered workflows list correctly.
  - Tool UI now supports approval-requested, approval-responded, and output-denied states with proper badges/icons; parser recognizes these states.

- **Refactors**
  - Aligned message types between the AI SDK and API (AiUIMessage vs ApiUIMessage) to prevent send/continue type issues.
  - Minor typing cleanup in transformMessages for tool parts.

<sup>Written for commit 3e9db60e1f006f93a632df534ab4aa607b2cb8af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

