### PR TITLE
fix(temporal): pydantic decode errors

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -41,6 +41,7 @@ with workflow.unsafe.imports_passed_through():
         mint_mcp_token,
     )
     from tracecat.agent.types import AgentConfig
+    from tracecat.agent.workflow_config import agent_config_from_payload
     from tracecat.auth.types import Role
     from tracecat.config import TRACECAT__AGENT_SANDBOX_TIMEOUT
     from tracecat.contexts import ctx_role
@@ -180,7 +181,7 @@ class DurableAgentWorkflow:
 
     async def _build_config(self, args: AgentWorkflowArgs) -> AgentConfig:
         if args.agent_args.preset_slug:
-            preset_config = await workflow.execute_activity(
+            preset_config_payload = await workflow.execute_activity(
                 resolve_agent_preset_config_activity,
                 ResolveAgentPresetConfigActivityInput(
                     role=self.role, preset_slug=args.agent_args.preset_slug
@@ -188,6 +189,7 @@ class DurableAgentWorkflow:
                 start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
+            preset_config = agent_config_from_payload(preset_config_payload)
             # Apply overrides from the provided config (if any)
             # When using a preset, the 'config' in args acts as an override layer
             if override_cfg := args.agent_args.config:

--- a/tests/temporal/test_agent_config_decode.py
+++ b/tests/temporal/test_agent_config_decode.py
@@ -1,0 +1,176 @@
+"""Temporal regression tests for AgentConfig workflow-boundary decoding.
+
+These tests pin both sides of the behavior:
+- returning AgentConfig directly across the activity boundary reproduces the old
+  decode failure
+- returning AgentConfigPayload and rehydrating inside the workflow succeeds
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+
+import pytest
+from temporalio import activity, workflow
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import TimeoutError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from tracecat.agent.workflow_config import (
+    agent_config_from_payload,
+    agent_config_to_payload,
+)
+from tracecat.agent.workflow_schemas import AgentConfigPayload
+from tracecat.dsl._converter import get_data_converter
+from tracecat.dsl.worker import new_sandbox_runner
+
+with workflow.unsafe.imports_passed_through():
+    from tracecat_registry.sdk.agents import AgentConfig as RegistryAgentConfig
+
+    from tracecat.agent.types import AgentConfig as TracecatAgentConfig
+
+pytestmark = [pytest.mark.temporal]
+
+
+@pytest.fixture
+async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=get_data_converter(),
+    ) as workflow_env:
+        yield workflow_env
+
+
+def _build_agent_config() -> TracecatAgentConfig:
+    return TracecatAgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        instructions="You are a security analyst.",
+        actions=["tools.datadog.change_signal_state"],
+        namespaces=["tools.datadog"],
+        tool_approvals={"tools.datadog.change_signal_state": True},
+        mcp_servers=[
+            {
+                "name": "internal-tools",
+                "url": "http://host.docker.internal:8080",
+                "transport": "http",
+                "headers": {"Authorization": "Bearer secret123"},
+            }
+        ],
+        model_settings={"parallel_tool_calls": False},
+        retries=3,
+        enable_internet_access=True,
+    )
+
+
+@activity.defn(name="return_tracecat_agent_config")
+async def return_tracecat_agent_config() -> TracecatAgentConfig:
+    """Mock activity that returns the full runtime AgentConfig."""
+    return _build_agent_config()
+
+
+@activity.defn(name="return_agent_config_payload")
+async def return_agent_config_payload() -> AgentConfigPayload:
+    """Mock activity that returns the workflow-safe payload."""
+    return agent_config_to_payload(_build_agent_config())
+
+
+@workflow.defn
+class DirectAgentConfigDecodeWorkflow:
+    @workflow.run
+    async def run(self, _: str) -> str:
+        # Use the activity name string so Temporal respects result_type instead
+        # of replacing it with the callable's annotated return type.
+        config = await workflow.execute_activity(
+            "return_tracecat_agent_config",
+            start_to_close_timeout=timedelta(seconds=10),
+            result_type=RegistryAgentConfig,
+        )
+        return config.model_name
+
+
+@workflow.defn
+class AgentConfigDecodeWorkflow:
+    @workflow.run
+    async def run(self, _: str) -> str:
+        payload = await workflow.execute_activity(
+            return_agent_config_payload,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+        config = agent_config_from_payload(payload)
+        assert config.model_name == "gpt-5.2"
+        assert config.model_provider == "openai"
+        assert config.instructions == "You are a security analyst."
+        assert config.actions == ["tools.datadog.change_signal_state"]
+        assert config.namespaces == ["tools.datadog"]
+        assert config.tool_approvals == {"tools.datadog.change_signal_state": True}
+        assert config.mcp_servers == [
+            {
+                "type": "http",
+                "name": "internal-tools",
+                "url": "http://host.docker.internal:8080",
+                "transport": "http",
+                "headers": {"Authorization": "Bearer secret123"},
+            }
+        ]
+        assert config.model_settings == {"parallel_tool_calls": False}
+        assert config.retries == 3
+        return config.model_name
+
+
+@pytest.mark.anyio
+async def test_agent_config_direct_boundary_reproduces_decode_failure(
+    env: WorkflowEnvironment,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Direct AgentConfig workflow boundary should reproduce the old failure."""
+    task_queue = "test-agent-config-direct-decode"
+    caplog.set_level(logging.WARNING, logger="temporalio.worker._workflow_instance")
+
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        activities=[return_tracecat_agent_config],
+        workflows=[DirectAgentConfigDecodeWorkflow],
+        workflow_runner=new_sandbox_runner(),
+    ):
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await env.client.execute_workflow(
+                DirectAgentConfigDecodeWorkflow.run,
+                "x",
+                id="test-agent-config-direct-decode-1",
+                task_queue=task_queue,
+                execution_timeout=timedelta(seconds=3),
+            )
+
+    assert isinstance(exc_info.value.cause, TimeoutError)
+    assert "Failed to decode payload for type AgentConfig" in caplog.text
+    assert "Payload at index 0 with encoding json/plain could not be converted" in (
+        caplog.text
+    )
+    assert "Failed decoding arguments" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_agent_config_payload_survives_temporal_activity_boundary(
+    env: WorkflowEnvironment,
+) -> None:
+    """Workflow-safe payload must round-trip through the Temporal boundary."""
+    task_queue = "test-agent-config-decode"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        activities=[return_agent_config_payload],
+        workflows=[AgentConfigDecodeWorkflow],
+        workflow_runner=new_sandbox_runner(),
+    ):
+        result = await env.client.execute_workflow(
+            AgentConfigDecodeWorkflow.run,
+            "x",
+            id="test-agent-config-decode-1",
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=15),
+        )
+        assert result == "gpt-5.2"

--- a/tests/temporal/test_agent_config_sandbox_parity.py
+++ b/tests/temporal/test_agent_config_sandbox_parity.py
@@ -1,0 +1,152 @@
+"""Temporal regression tests for AgentConfig sandbox decode parity."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+
+import pytest
+from pydantic import BaseModel
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from tracecat.agent.worker import new_sandbox_runner as new_agent_sandbox_runner
+from tracecat.dsl._converter import get_data_converter
+from tracecat.dsl.worker import new_sandbox_runner as new_dsl_sandbox_runner
+
+with workflow.unsafe.imports_passed_through():
+    from tracecat.agent.common.types import (
+        MCPHttpServerConfig,
+        MCPServerConfig,
+        MCPStdioServerConfig,
+    )
+    from tracecat.agent.types import AgentConfig
+
+pytestmark = [pytest.mark.temporal]
+
+
+class AgentConfigRoundTripResult(BaseModel):
+    model_name: str
+    enable_internet_access: bool
+    server_count: int
+    server_names: list[str]
+    server_types: list[str]
+
+
+@pytest.fixture
+async def env() -> AsyncGenerator[WorkflowEnvironment, None]:
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=get_data_converter(),
+    ) as workflow_env:
+        yield workflow_env
+
+
+def _build_mcp_servers(variant: str) -> list[MCPServerConfig] | None:
+    http_server: MCPHttpServerConfig = {
+        "name": "internal-tools",
+        "url": "http://host.docker.internal:8080",
+        "transport": "http",
+        "headers": {"Authorization": "Bearer secret123"},
+    }
+    stdio_server: MCPStdioServerConfig = {
+        "type": "stdio",
+        "name": "local-tools",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        "env": {"HOME": "/tmp"},
+    }
+    servers: list[MCPServerConfig]
+    match variant:
+        case "none":
+            return None
+        case "http":
+            servers = [http_server]
+        case "stdio":
+            servers = [stdio_server]
+        case "both":
+            servers = [http_server, stdio_server]
+        case _:
+            raise AssertionError(f"Unexpected MCP variant: {variant}")
+    return servers
+
+
+def _build_agent_config(variant: str) -> AgentConfig:
+    return AgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        instructions="You are a security analyst.",
+        actions=["tools.datadog.change_signal_state"],
+        namespaces=["tools.datadog"],
+        tool_approvals={"tools.datadog.change_signal_state": True},
+        mcp_servers=_build_mcp_servers(variant),
+        model_settings={"parallel_tool_calls": False},
+        retries=3,
+        enable_internet_access=True,
+    )
+
+
+@activity.defn(name="return_agent_config_round_trip")
+async def return_agent_config_round_trip(variant: str) -> AgentConfig:
+    return _build_agent_config(variant)
+
+
+@workflow.defn
+class AgentConfigRoundTripWorkflow:
+    @workflow.run
+    async def run(self, variant: str) -> AgentConfigRoundTripResult:
+        config = await workflow.execute_activity(
+            return_agent_config_round_trip,
+            variant,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+        servers = config.mcp_servers or []
+        return AgentConfigRoundTripResult(
+            model_name=config.model_name,
+            enable_internet_access=config.enable_internet_access,
+            server_count=len(servers),
+            server_names=[server["name"] for server in servers],
+            server_types=[server.get("type", "http") for server in servers],
+        )
+
+
+def _runner(kind: str):
+    return new_agent_sandbox_runner() if kind == "agent" else new_dsl_sandbox_runner()
+
+
+def _expected_round_trip(variant: str) -> AgentConfigRoundTripResult:
+    servers = _build_mcp_servers(variant) or []
+    return AgentConfigRoundTripResult(
+        model_name="gpt-5.2",
+        enable_internet_access=True,
+        server_count=len(servers),
+        server_names=[server["name"] for server in servers],
+        server_types=[server.get("type", "http") for server in servers],
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("runner_kind", ["agent", "dsl"])
+@pytest.mark.parametrize("variant", ["none", "http", "stdio", "both"])
+async def test_agent_config_round_trips_in_both_workflow_sandboxes(
+    env: WorkflowEnvironment,
+    runner_kind: str,
+    variant: str,
+) -> None:
+    task_queue = f"agent-config-round-trip-{runner_kind}-{variant}"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        activities=[return_agent_config_round_trip],
+        workflows=[AgentConfigRoundTripWorkflow],
+        workflow_runner=_runner(runner_kind),
+    ):
+        result = await env.client.execute_workflow(
+            AgentConfigRoundTripWorkflow.run,
+            variant,
+            id=f"agent-config-round-trip-{runner_kind}-{variant}",
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=15),
+        )
+
+    assert result == _expected_round_trip(variant)

--- a/tests/temporal/test_agent_config_workflow_boundary.py
+++ b/tests/temporal/test_agent_config_workflow_boundary.py
@@ -19,13 +19,13 @@ from temporalio.exceptions import TimeoutError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
+from tracecat.agent.worker import new_sandbox_runner
 from tracecat.agent.workflow_config import (
     agent_config_from_payload,
     agent_config_to_payload,
 )
 from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.dsl._converter import get_data_converter
-from tracecat.dsl.worker import new_sandbox_runner
 
 with workflow.unsafe.imports_passed_through():
     from tracecat_registry.sdk.agents import AgentConfig as RegistryAgentConfig

--- a/tests/temporal/test_agent_config_workflow_boundary.py
+++ b/tests/temporal/test_agent_config_workflow_boundary.py
@@ -120,6 +120,21 @@ class AgentConfigDecodeWorkflow:
         return config.model_name
 
 
+@workflow.defn
+class LegacyAgentConfigPayloadDecodeWorkflow:
+    @workflow.run
+    async def run(self, _: str) -> str:
+        # This simulates replaying an activity result recorded before
+        # resolve_agent_preset_config_activity switched to AgentConfigPayload.
+        payload = await workflow.execute_activity(
+            "return_tracecat_agent_config",
+            start_to_close_timeout=timedelta(seconds=10),
+            result_type=AgentConfigPayload,
+        )
+        config = agent_config_from_payload(payload)
+        return config.model_name
+
+
 @pytest.mark.anyio
 async def test_agent_config_direct_boundary_reproduces_decode_failure(
     env: WorkflowEnvironment,
@@ -170,6 +185,29 @@ async def test_agent_config_payload_survives_temporal_activity_boundary(
             AgentConfigDecodeWorkflow.run,
             "x",
             id="test-agent-config-decode-1",
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=15),
+        )
+        assert result == "gpt-5.2"
+
+
+@pytest.mark.anyio
+async def test_legacy_agent_config_payload_replays_as_agent_config_payload(
+    env: WorkflowEnvironment,
+) -> None:
+    """Legacy AgentConfig activity results should decode into AgentConfigPayload."""
+    task_queue = "test-legacy-agent-config-payload-decode"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        activities=[return_tracecat_agent_config],
+        workflows=[LegacyAgentConfigPayloadDecodeWorkflow],
+        workflow_runner=new_sandbox_runner(),
+    ):
+        result = await env.client.execute_workflow(
+            LegacyAgentConfigPayloadDecodeWorkflow.run,
+            "x",
+            id="test-legacy-agent-config-payload-decode-1",
             task_queue=task_queue,
             execution_timeout=timedelta(seconds=15),
         )

--- a/tests/unit/test_dsl_converter.py
+++ b/tests/unit/test_dsl_converter.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
 import temporalio.api.common.v1
 from temporalio.api.common.v1 import Payload
+from tracecat_registry.sdk.agents import AgentConfig as RegistryAgentConfig
 
+from tracecat.agent.types import AgentConfig as TracecatAgentConfig
 from tracecat.dsl._converter import PydanticORJSONPayloadConverter
 from tracecat.dsl.common import AgentActionMemo
 
@@ -92,3 +95,49 @@ def test_agent_action_memo_logging_omits_raw_payload(
     assert warning["encoding"] == "json/plain"
     assert warning["payload_size_bytes"] == len(b'{"token":"Bearer secret-token"}')
     assert "value" not in warning
+
+
+def _build_tracecat_agent_config_payload() -> Payload:
+    converter = PydanticORJSONPayloadConverter()
+    payload = converter.to_payload(
+        TracecatAgentConfig(
+            model_name="gpt-5.2",
+            model_provider="openai",
+            instructions="You are a security analyst.",
+            actions=["tools.datadog.change_signal_state"],
+            namespaces=["tools.datadog"],
+            tool_approvals={"tools.datadog.change_signal_state": True},
+            mcp_servers=[
+                {
+                    "name": "internal-tools",
+                    "url": "http://host.docker.internal:8080",
+                    "transport": "http",
+                    "headers": {"Authorization": "Bearer secret123"},
+                }
+            ],
+            model_settings={"parallel_tool_calls": False},
+            retries=3,
+            enable_internet_access=True,
+        )
+    )
+    if payload is None:
+        raise AssertionError("Expected JSON payload for AgentConfig")
+    return payload
+
+
+def test_converter_rejects_registry_agent_config_from_tracecat_agent_config_payload() -> (
+    None
+):
+    """Current converter still fails on mixed AgentConfig types.
+
+    The durable workflow fix avoids this by returning a workflow-safe payload
+    across the activity boundary instead of AgentConfig directly.
+    """
+    converter = PydanticORJSONPayloadConverter()
+    payload = _build_tracecat_agent_config_payload()
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to decode payload for type AgentConfig",
+    ):
+        converter.from_payload(payload, RegistryAgentConfig)

--- a/tests/unit/test_dsl_converter.py
+++ b/tests/unit/test_dsl_converter.py
@@ -8,6 +8,7 @@ from temporalio.api.common.v1 import Payload
 from tracecat_registry.sdk.agents import AgentConfig as RegistryAgentConfig
 
 from tracecat.agent.types import AgentConfig as TracecatAgentConfig
+from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.dsl._converter import PydanticORJSONPayloadConverter
 from tracecat.dsl.common import AgentActionMemo
 
@@ -141,3 +142,31 @@ def test_converter_rejects_registry_agent_config_from_tracecat_agent_config_payl
         match="Failed to decode payload for type AgentConfig",
     ):
         converter.from_payload(payload, RegistryAgentConfig)
+
+
+def test_converter_decodes_legacy_tracecat_agent_config_as_agent_config_payload() -> (
+    None
+):
+    """Legacy AgentConfig payloads should decode for workflow replay compatibility."""
+    converter = PydanticORJSONPayloadConverter()
+    payload = _build_tracecat_agent_config_payload()
+
+    decoded = converter.from_payload(payload, AgentConfigPayload)
+
+    assert decoded.model_name == "gpt-5.2"
+    assert decoded.model_provider == "openai"
+    assert decoded.instructions == "You are a security analyst."
+    assert decoded.actions == ["tools.datadog.change_signal_state"]
+    assert decoded.namespaces == ["tools.datadog"]
+    assert decoded.tool_approvals == {"tools.datadog.change_signal_state": True}
+    assert decoded.model_settings == {"parallel_tool_calls": False}
+    assert decoded.retries == 3
+    assert decoded.enable_internet_access is True
+    assert decoded.mcp_servers is not None
+    assert len(decoded.mcp_servers) == 1
+    server = decoded.mcp_servers[0]
+    assert server.type == "http"
+    assert server.name == "internal-tools"
+    assert server.url == "http://host.docker.internal:8080"
+    assert server.transport == "http"
+    assert server.headers == {"Authorization": "Bearer secret123"}

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -6,7 +6,8 @@ from pydantic import BaseModel, model_validator
 from temporalio import activity
 
 from tracecat.agent.preset.service import AgentPresetService
-from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_config import agent_config_to_payload
+from tracecat.agent.workflow_schemas import AgentConfigPayload
 from tracecat.auth.types import Role
 
 
@@ -25,9 +26,10 @@ class ResolveAgentPresetConfigActivityInput(BaseModel):
 @activity.defn
 async def resolve_agent_preset_config_activity(
     args: ResolveAgentPresetConfigActivityInput,
-) -> AgentConfig:
+) -> AgentConfigPayload:
     async with AgentPresetService.with_session(role=args.role) as service:
-        return await service.resolve_agent_preset_config(
+        config = await service.resolve_agent_preset_config(
             preset_id=args.preset_id,
             slug=args.preset_slug,
         )
+        return agent_config_to_payload(config)

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -73,10 +73,16 @@ def new_sandbox_runner() -> SandboxedWorkflowRunner:
     )
     del invalid_module_member_children["datetime"]
 
-    # Add beartype to passthrough modules to avoid circular import issues
-    # with its custom import hooks conflicting with Temporal's sandbox
-    passthrough_modules = set(SandboxRestrictions.passthrough_modules_default)
-    passthrough_modules.add("beartype")
+    # Match the DSL worker passthrough set so both workflow sandboxes resolve
+    # Tracecat/runtime annotations consistently.
+    passthrough_modules = SandboxRestrictions.passthrough_modules_default | {
+        "tracecat",
+        "tracecat_ee",
+        "tracecat_registry",
+        "jsonpath_ng",
+        "dateparser",
+        "beartype",
+    }
 
     return SandboxedWorkflowRunner(
         restrictions=dataclasses.replace(

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -1,0 +1,123 @@
+"""Conversions between workflow-safe agent config payloads and runtime config."""
+
+from __future__ import annotations
+
+from tracecat.agent.common.types import (
+    MCPHttpServerConfig,
+    MCPServerConfig,
+    MCPStdioServerConfig,
+)
+from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_schemas import (
+    AgentConfigPayload,
+    MCPHttpServerConfigPayload,
+    MCPServerConfigPayload,
+    MCPStdioServerConfigPayload,
+)
+
+
+def _mcp_server_to_payload(
+    server: MCPServerConfig,
+) -> MCPHttpServerConfigPayload | MCPStdioServerConfigPayload:
+    match server:
+        case {
+            "type": "stdio",
+            "name": str(name),
+            "command": str(command),
+        }:
+            return MCPStdioServerConfigPayload(
+                type="stdio",
+                name=name,
+                command=command,
+                args=server.get("args"),
+                env=server.get("env"),
+                timeout=server.get("timeout"),
+            )
+        case {
+            "name": str(name),
+            "url": str(url),
+        }:
+            return MCPHttpServerConfigPayload(
+                type="http",
+                name=name,
+                url=url,
+                headers=server.get("headers"),
+                transport=server.get("transport"),
+                timeout=server.get("timeout"),
+            )
+        case _:
+            raise ValueError(f"Unsupported MCP server config: {server!r}")
+
+
+def _mcp_server_from_payload(server: MCPServerConfigPayload) -> MCPServerConfig:
+    match server:
+        case MCPStdioServerConfigPayload():
+            stdio_server: MCPStdioServerConfig = {
+                "type": "stdio",
+                "name": server.name,
+                "command": server.command,
+            }
+            if server.args is not None:
+                stdio_server["args"] = server.args
+            if server.env is not None:
+                stdio_server["env"] = server.env
+            if server.timeout is not None:
+                stdio_server["timeout"] = server.timeout
+            return stdio_server
+        case MCPHttpServerConfigPayload():
+            http_server: MCPHttpServerConfig = {
+                "type": "http",
+                "name": server.name,
+                "url": server.url,
+            }
+            if server.headers is not None:
+                http_server["headers"] = server.headers
+            if server.transport is not None:
+                http_server["transport"] = server.transport
+            if server.timeout is not None:
+                http_server["timeout"] = server.timeout
+            return http_server
+
+
+def agent_config_to_payload(config: AgentConfig) -> AgentConfigPayload:
+    """Convert runtime AgentConfig to workflow-safe payload."""
+    return AgentConfigPayload(
+        model_name=config.model_name,
+        model_provider=config.model_provider,
+        base_url=config.base_url,
+        instructions=config.instructions,
+        output_type=config.output_type,
+        actions=config.actions,
+        namespaces=config.namespaces,
+        tool_approvals=config.tool_approvals,
+        model_settings=config.model_settings,
+        mcp_servers=(
+            [_mcp_server_to_payload(server) for server in config.mcp_servers]
+            if config.mcp_servers
+            else None
+        ),
+        retries=config.retries,
+        enable_internet_access=config.enable_internet_access,
+    )
+
+
+def agent_config_from_payload(payload: AgentConfigPayload) -> AgentConfig:
+    """Convert workflow-safe payload back to runtime AgentConfig."""
+    return AgentConfig(
+        model_name=payload.model_name,
+        model_provider=payload.model_provider,
+        base_url=payload.base_url,
+        instructions=payload.instructions,
+        output_type=payload.output_type,
+        actions=payload.actions,
+        namespaces=payload.namespaces,
+        tool_approvals=payload.tool_approvals,
+        model_settings=payload.model_settings,
+        mcp_servers=(
+            [_mcp_server_from_payload(server) for server in payload.mcp_servers]
+            if payload.mcp_servers
+            else None
+        ),
+        retries=payload.retries,
+        enable_internet_access=payload.enable_internet_access,
+    )

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -1,0 +1,66 @@
+"""Workflow-safe schemas for agent configuration.
+
+These models avoid importing agent runtime dependencies so they can be used
+across Temporal workflow/activity boundaries predictably.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Discriminator, Field
+
+
+class MCPHttpServerConfigPayload(BaseModel):
+    """Workflow-safe HTTP/SSE MCP server config."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["http"] = Field(default="http")
+    name: str
+    url: str
+    headers: dict[str, str] | None = Field(default=None)
+    transport: Literal["http", "sse"] | None = Field(default=None)
+    timeout: int | None = Field(default=None)
+
+
+class MCPStdioServerConfigPayload(BaseModel):
+    """Workflow-safe stdio MCP server config."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["stdio"] = Field(default="stdio")
+    name: str
+    command: str
+    args: list[str] | None = Field(default=None)
+    env: dict[str, str] | None = Field(default=None)
+    timeout: int | None = Field(default=None)
+
+
+type MCPServerConfigPayload = Annotated[
+    MCPHttpServerConfigPayload | MCPStdioServerConfigPayload,
+    Discriminator("type"),
+]
+
+
+class AgentConfigPayload(BaseModel):
+    """Workflow-safe agent config payload.
+
+    This intentionally contains only JSON-safe fields needed across Temporal
+    boundaries. Runtime-only fields like deps_type and custom_tools are omitted.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_name: str
+    model_provider: str
+    base_url: str | None = Field(default=None)
+    instructions: str | None = Field(default=None)
+    output_type: str | dict[str, Any] | None = Field(default=None)
+    actions: list[str] | None = Field(default=None)
+    namespaces: list[str] | None = Field(default=None)
+    tool_approvals: dict[str, bool] | None = Field(default=None)
+    model_settings: dict[str, Any] | None = Field(default=None)
+    mcp_servers: list[MCPServerConfigPayload] | None = Field(default=None)
+    retries: int
+    enable_internet_access: bool = Field(default=False)

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -8,7 +8,23 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, model_validator
+
+_LEGACY_AGENT_CONFIG_KEYS = frozenset({"deps_type", "custom_tools"})
+
+
+def _normalize_legacy_mcp_server_payload(value: Any) -> Any:
+    """Backfill the HTTP discriminator for MCP configs recorded before payload split."""
+    if not isinstance(value, dict):
+        return value
+
+    match value:
+        case {"type": str()}:
+            return value
+        case {"url": str()}:
+            return {"type": "http", **value}
+        case _:
+            return value
 
 
 class MCPHttpServerConfigPayload(BaseModel):
@@ -51,6 +67,24 @@ class AgentConfigPayload(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_legacy_workflow_history(cls, value: Any) -> Any:
+        """Accept the pre-payload AgentConfig shape stored in workflow history."""
+        if not isinstance(value, dict):
+            return value
+
+        normalized = {
+            key: item
+            for key, item in value.items()
+            if key not in _LEGACY_AGENT_CONFIG_KEYS
+        }
+        if isinstance(mcp_servers := normalized.get("mcp_servers"), list):
+            normalized["mcp_servers"] = [
+                _normalize_legacy_mcp_server_payload(server) for server in mcp_servers
+            ]
+        return normalized
 
     model_name: str
     model_provider: str


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Temporal Pydantic decode errors when AgentConfig crosses activity/workflow boundaries. We now send a workflow-safe AgentConfigPayload, rebuild AgentConfig in the workflow, and keep legacy workflow history compatible.

- **Bug Fixes**
  - resolve_agent_preset_config_activity returns AgentConfigPayload; durable workflow rehydrates with agent_config_from_payload before applying overrides.
  - Added workflow_schemas.py and workflow_config.py with AgentConfigPayload and MCP http/stdio models; legacy replay drops deprecated fields and backfills missing MCP type="http".
  - Aligned agent workflow sandbox passthrough modules with the DSL worker for consistent annotation resolution.
  - Added regression tests for direct boundary failure vs payload success, legacy replay as AgentConfigPayload, DSL/agent sandbox parity; converter tests cover mixed AgentConfig types and legacy decode.

<sup>Written for commit f6ed7fb8cf0f17797d0e5a7d844eaef88eeeeeaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

