### PR TITLE
fix(cases): scope case numbers to workspace

### DIFF
--- a/alembic/versions/13cfd6e83e36_scope_case_numbers_to_workspace.py
+++ b/alembic/versions/13cfd6e83e36_scope_case_numbers_to_workspace.py
@@ -30,7 +30,7 @@ def upgrade() -> None:
         ),
     )
     # `case_number` used to be a global identity column. Drop the identity first so
-    # future inserts must use workspace-scoped allocation in application code.
+    # future inserts can be allocated by the workspace-scoped trigger below.
     op.execute('ALTER TABLE "case" ALTER COLUMN case_number DROP IDENTITY IF EXISTS')
     op.drop_index("ix_case_case_number", table_name="case")
     op.execute(
@@ -66,6 +66,43 @@ def upgrade() -> None:
         "uq_case_workspace_case_number",
         "case",
         ["workspace_id", "case_number"],
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION assign_workspace_case_number()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF NEW.case_number IS NULL THEN
+                UPDATE workspace
+                SET last_case_number = last_case_number + 1
+                WHERE id = NEW.workspace_id
+                RETURNING last_case_number INTO NEW.case_number;
+            ELSE
+                UPDATE workspace
+                SET last_case_number = GREATEST(last_case_number, NEW.case_number)
+                WHERE id = NEW.workspace_id;
+            END IF;
+
+            IF NOT FOUND THEN
+                RAISE EXCEPTION
+                    'Workspace % not found while allocating case number',
+                    NEW.workspace_id;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_case_assign_workspace_case_number
+        BEFORE INSERT ON "case"
+        FOR EACH ROW
+        EXECUTE FUNCTION assign_workspace_case_number()
+        """
     )
 
 

--- a/alembic/versions/13cfd6e83e36_scope_case_numbers_to_workspace.py
+++ b/alembic/versions/13cfd6e83e36_scope_case_numbers_to_workspace.py
@@ -1,0 +1,75 @@
+"""scope case numbers to workspace
+
+Revision ID: 13cfd6e83e36
+Revises: 8e2a638ae873
+Create Date: 2026-03-06 13:47:47.535750
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "13cfd6e83e36"
+down_revision: str | None = "8e2a638ae873"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace",
+        sa.Column(
+            "last_case_number",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    # `case_number` used to be a global identity column. Drop the identity first so
+    # future inserts must use workspace-scoped allocation in application code.
+    op.execute('ALTER TABLE "case" ALTER COLUMN case_number DROP IDENTITY IF EXISTS')
+    op.drop_index("ix_case_case_number", table_name="case")
+    op.execute(
+        """
+        WITH renumbered AS (
+            SELECT
+                id,
+                row_number() OVER (
+                    PARTITION BY workspace_id
+                    ORDER BY case_number
+                ) AS next_case_number
+            FROM "case"
+        )
+        UPDATE "case" AS c
+        SET case_number = renumbered.next_case_number
+        FROM renumbered
+        WHERE c.id = renumbered.id
+        """
+    )
+    op.execute(
+        """
+        UPDATE workspace AS w
+        SET last_case_number = counters.max_case_number
+        FROM (
+            SELECT workspace_id, max(case_number) AS max_case_number
+            FROM "case"
+            GROUP BY workspace_id
+        ) AS counters
+        WHERE w.id = counters.workspace_id
+        """
+    )
+    op.create_unique_constraint(
+        "uq_case_workspace_case_number",
+        "case",
+        ["workspace_id", "case_number"],
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Downgrade is not supported because historical case numbers are renumbered."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,56 @@ else:
 
 # Port configuration - reads from environment for worktree cluster support
 # Default ports are for cluster 1, override with PG_PORT, TEMPORAL_PORT, MINIO_PORT, REDIS_PORT
+
+
+def _install_case_number_allocator(conn: Any) -> None:
+    """Mirror the production trigger used to allocate workspace-local case numbers."""
+    conn.execute(
+        text(
+            """
+            CREATE OR REPLACE FUNCTION assign_workspace_case_number()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF NEW.case_number IS NULL THEN
+                    UPDATE workspace
+                    SET last_case_number = last_case_number + 1
+                    WHERE id = NEW.workspace_id
+                    RETURNING last_case_number INTO NEW.case_number;
+                ELSE
+                    UPDATE workspace
+                    SET last_case_number = GREATEST(last_case_number, NEW.case_number)
+                    WHERE id = NEW.workspace_id;
+                END IF;
+
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION
+                        'Workspace % not found while allocating case number',
+                        NEW.workspace_id;
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$;
+            """
+        )
+    )
+    conn.execute(
+        text('DROP TRIGGER IF EXISTS trg_case_assign_workspace_case_number ON "case"')
+    )
+    conn.execute(
+        text(
+            """
+            CREATE TRIGGER trg_case_assign_workspace_case_number
+            BEFORE INSERT ON "case"
+            FOR EACH ROW
+            EXECUTE FUNCTION assign_workspace_case_number()
+            """
+        )
+    )
+
+
 PG_PORT = int(os.environ.get("PG_PORT", "5432"))
 TEMPORAL_PORT = int(os.environ.get("TEMPORAL_PORT", "7233"))
 MINIO_PORT = int(os.environ.get("MINIO_PORT", "9000"))
@@ -248,6 +298,7 @@ def db() -> Iterator[None]:
         with test_engine.begin() as conn:
             logger.info("Creating all tables")
             Base.metadata.create_all(conn)
+            _install_case_number_allocator(conn)
         yield
     finally:
         if test_engine is not None:
@@ -279,7 +330,9 @@ def default_org(db: None, env_sandbox: None) -> Iterator[None]:
         sync_engine = create_engine(sync_db_uri)
 
         # Ensure schema exists for service sessions that target the default DB.
-        Base.metadata.create_all(sync_engine)
+        with sync_engine.begin() as conn:
+            Base.metadata.create_all(conn)
+            _install_case_number_allocator(conn)
 
         with Session(sync_engine) as session:
             base_org_slug = f"test-org-{TEST_ORG_ID.hex[:8]}"

--- a/tests/migration/test_case_numbers_workspace_migration.py
+++ b/tests/migration/test_case_numbers_workspace_migration.py
@@ -1,0 +1,271 @@
+"""Tests for workspace-scoped case number migration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.pool import NullPool
+
+from tests.database import TEST_DB_CONFIG
+
+MIGRATION_REVISION = "13cfd6e83e36"
+PREVIOUS_REVISION = "8e2a638ae873"
+
+
+def _run_alembic(db_url: str, *args: str) -> None:
+    env = os.environ.copy()
+    env["TRACECAT__DB_URI"] = db_url
+    result = subprocess.run(
+        ["uv", "run", "alembic", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Alembic command failed:\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+
+@pytest.fixture(scope="function")
+def migration_db_url() -> Iterator[str]:
+    default_engine = create_engine(
+        TEST_DB_CONFIG.sys_url_sync,
+        isolation_level="AUTOCOMMIT",
+        poolclass=NullPool,
+    )
+    db_name = f"test_case_numbers_{uuid.uuid4().hex[:8]}"
+    termination_query = text(
+        f"""
+        SELECT pg_terminate_backend(pg_stat_activity.pid)
+        FROM pg_stat_activity
+        WHERE pg_stat_activity.datname = '{db_name}'
+          AND pid <> pg_backend_pid();
+        """
+    )
+
+    try:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+        db_url = TEST_DB_CONFIG.test_url_sync.replace(
+            TEST_DB_CONFIG.test_db_name, db_name
+        )
+        _run_alembic(db_url, "upgrade", PREVIOUS_REVISION)
+        yield db_url
+    finally:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        default_engine.dispose()
+
+
+def _seed_pre_migration_cases(db_url: str) -> tuple[uuid.UUID, uuid.UUID]:
+    engine = create_engine(db_url, poolclass=NullPool)
+    organization_id = uuid.uuid4()
+    workspace_a_id = uuid.uuid4()
+    workspace_b_id = uuid.uuid4()
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, slug, is_active)
+                    VALUES (:id, :name, :slug, true)
+                    """
+                ),
+                {
+                    "id": organization_id,
+                    "name": "Test organization",
+                    "slug": f"test-org-{organization_id.hex[:8]}",
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO workspace (id, organization_id, name)
+                    VALUES
+                        (:workspace_a_id, :organization_id, 'Workspace A'),
+                        (:workspace_b_id, :organization_id, 'Workspace B')
+                    """
+                ),
+                {
+                    "workspace_a_id": workspace_a_id,
+                    "workspace_b_id": workspace_b_id,
+                    "organization_id": organization_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO "case" (
+                        id,
+                        workspace_id,
+                        case_number,
+                        summary,
+                        description,
+                        priority,
+                        severity,
+                        status
+                    )
+                    VALUES
+                        (:case_a1_id, :workspace_a_id, 1, 'A-1', 'A-1', 'MEDIUM', 'LOW', 'NEW'),
+                        (:case_b1_id, :workspace_b_id, 2, 'B-2', 'B-2', 'MEDIUM', 'LOW', 'NEW'),
+                        (:case_a2_id, :workspace_a_id, 3, 'A-3', 'A-3', 'MEDIUM', 'LOW', 'NEW'),
+                        (:case_b2_id, :workspace_b_id, 4, 'B-4', 'B-4', 'MEDIUM', 'LOW', 'NEW')
+                    """
+                ),
+                {
+                    "case_a1_id": uuid.uuid4(),
+                    "case_b1_id": uuid.uuid4(),
+                    "case_a2_id": uuid.uuid4(),
+                    "case_b2_id": uuid.uuid4(),
+                    "workspace_a_id": workspace_a_id,
+                    "workspace_b_id": workspace_b_id,
+                },
+            )
+    finally:
+        engine.dispose()
+
+    return workspace_a_id, workspace_b_id
+
+
+def test_case_numbers_are_scoped_to_workspace(migration_db_url: str) -> None:
+    workspace_a_id, workspace_b_id = _seed_pre_migration_cases(migration_db_url)
+    _run_alembic(migration_db_url, "upgrade", MIGRATION_REVISION)
+
+    engine = create_engine(migration_db_url, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            workspace_a_cases = conn.execute(
+                text(
+                    """
+                    SELECT summary, case_number
+                    FROM "case"
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY case_number
+                    """
+                ),
+                {"workspace_id": workspace_a_id},
+            ).all()
+            workspace_b_cases = conn.execute(
+                text(
+                    """
+                    SELECT summary, case_number
+                    FROM "case"
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY case_number
+                    """
+                ),
+                {"workspace_id": workspace_b_id},
+            ).all()
+
+            assert workspace_a_cases == [("A-1", 1), ("A-3", 2)]
+            assert workspace_b_cases == [("B-2", 1), ("B-4", 2)]
+
+            workspace_counters = (
+                conn.execute(
+                    text(
+                        """
+                    SELECT id, last_case_number
+                    FROM workspace
+                    WHERE id = :workspace_a_id
+                       OR id = :workspace_b_id
+                    """
+                    ),
+                    {
+                        "workspace_a_id": workspace_a_id,
+                        "workspace_b_id": workspace_b_id,
+                    },
+                )
+                .tuples()
+                .all()
+            )
+            assert dict(workspace_counters) == {
+                workspace_a_id: 2,
+                workspace_b_id: 2,
+            }
+
+            duplicate_case_numbers = conn.execute(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM "case"
+                    WHERE case_number = 1
+                    """
+                )
+            ).scalar_one()
+            assert duplicate_case_numbers == 2
+
+            identity_generation = conn.execute(
+                text(
+                    """
+                    SELECT identity_generation
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'case'
+                      AND column_name = 'case_number'
+                    """
+                )
+            ).scalar_one()
+            assert identity_generation is None
+
+            unique_constraint_count = conn.execute(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM information_schema.table_constraints
+                    WHERE table_schema = 'public'
+                      AND table_name = 'case'
+                      AND constraint_name = 'uq_case_workspace_case_number'
+                      AND constraint_type = 'UNIQUE'
+                    """
+                )
+            ).scalar_one()
+            assert unique_constraint_count == 1
+
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO "case" (
+                            id,
+                            workspace_id,
+                            case_number,
+                            summary,
+                            description,
+                            priority,
+                            severity,
+                            status
+                        )
+                        VALUES (
+                            :id,
+                            :workspace_id,
+                            1,
+                            'duplicate',
+                            'duplicate',
+                            'MEDIUM',
+                            'LOW',
+                            'NEW'
+                        )
+                        """
+                    ),
+                    {
+                        "id": uuid.uuid4(),
+                        "workspace_id": workspace_a_id,
+                    },
+                )
+    finally:
+        engine.dispose()

--- a/tests/migration/test_case_numbers_workspace_migration.py
+++ b/tests/migration/test_case_numbers_workspace_migration.py
@@ -8,8 +8,9 @@ migration and verifies:
 2. workspace.last_case_number is backfilled to the max per workspace
 3. Cross-workspace duplicate case numbers are allowed
 4. The identity property is dropped from case_number
-5. The uq_case_workspace_case_number unique constraint exists
-6. The unique constraint is enforced (duplicate within a workspace raises IntegrityError)
+5. Post-migration inserts without case_number still work via a DB trigger
+6. The uq_case_workspace_case_number unique constraint exists
+7. The unique constraint is enforced (duplicate within a workspace raises IntegrityError)
 """
 
 from __future__ import annotations
@@ -159,7 +160,7 @@ def test_case_numbers_are_scoped_to_workspace(migration_db_url: str) -> None:
 
     engine = create_engine(migration_db_url, poolclass=NullPool)
     try:
-        with engine.connect() as conn:
+        with engine.begin() as conn:
             workspace_a_cases = (
                 conn.execute(
                     text(
@@ -254,6 +255,49 @@ def test_case_numbers_are_scoped_to_workspace(migration_db_url: str) -> None:
                 )
             ).scalar_one()
             assert unique_constraint_count == 1
+
+            generated_case_number = conn.execute(
+                text(
+                    """
+                    INSERT INTO "case" (
+                        id,
+                        workspace_id,
+                        summary,
+                        description,
+                        priority,
+                        severity,
+                        status
+                    )
+                    VALUES (
+                        :id,
+                        :workspace_id,
+                        'A-4',
+                        'A-4',
+                        'MEDIUM',
+                        'LOW',
+                        'NEW'
+                    )
+                    RETURNING case_number
+                    """
+                ),
+                {
+                    "id": uuid.uuid4(),
+                    "workspace_id": workspace_a_id,
+                },
+            ).scalar_one()
+            assert generated_case_number == 3
+
+            next_workspace_counter = conn.execute(
+                text(
+                    """
+                    SELECT last_case_number
+                    FROM workspace
+                    WHERE id = :workspace_id
+                    """
+                ),
+                {"workspace_id": workspace_a_id},
+            ).scalar_one()
+            assert next_workspace_counter == 3
 
         with pytest.raises(IntegrityError):
             with engine.begin() as conn:

--- a/tests/migration/test_case_numbers_workspace_migration.py
+++ b/tests/migration/test_case_numbers_workspace_migration.py
@@ -148,28 +148,36 @@ def test_case_numbers_are_scoped_to_workspace(migration_db_url: str) -> None:
     engine = create_engine(migration_db_url, poolclass=NullPool)
     try:
         with engine.connect() as conn:
-            workspace_a_cases = conn.execute(
-                text(
-                    """
+            workspace_a_cases = (
+                conn.execute(
+                    text(
+                        """
                     SELECT summary, case_number
                     FROM "case"
                     WHERE workspace_id = :workspace_id
                     ORDER BY case_number
                     """
-                ),
-                {"workspace_id": workspace_a_id},
-            ).all()
-            workspace_b_cases = conn.execute(
-                text(
-                    """
+                    ),
+                    {"workspace_id": workspace_a_id},
+                )
+                .tuples()
+                .all()
+            )
+            workspace_b_cases = (
+                conn.execute(
+                    text(
+                        """
                     SELECT summary, case_number
                     FROM "case"
                     WHERE workspace_id = :workspace_id
                     ORDER BY case_number
                     """
-                ),
-                {"workspace_id": workspace_b_id},
-            ).all()
+                    ),
+                    {"workspace_id": workspace_b_id},
+                )
+                .tuples()
+                .all()
+            )
 
             assert workspace_a_cases == [("A-1", 1), ("A-3", 2)]
             assert workspace_b_cases == [("B-2", 1), ("B-4", 2)]

--- a/tests/migration/test_case_numbers_workspace_migration.py
+++ b/tests/migration/test_case_numbers_workspace_migration.py
@@ -1,4 +1,16 @@
-"""Tests for workspace-scoped case number migration."""
+"""Tests for workspace-scoped case number migration.
+
+Seeds 4 cases across 2 workspaces with globally sequential case numbers
+(workspace A gets cases 1, 3; workspace B gets cases 2, 4), then runs the
+migration and verifies:
+
+1. Case numbers are compacted per workspace (A: 1,3 → 1,2; B: 2,4 → 1,2)
+2. workspace.last_case_number is backfilled to the max per workspace
+3. Cross-workspace duplicate case numbers are allowed
+4. The identity property is dropped from case_number
+5. The uq_case_workspace_case_number unique constraint exists
+6. The unique constraint is enforced (duplicate within a workspace raises IntegrityError)
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -36,6 +36,7 @@ async def test_case(session: AsyncSession, svc_role: Role) -> Case:
     # Create a case directly using SQLAlchemy
     case = Case(
         workspace_id=svc_role.workspace_id if svc_role.workspace_id else uuid.uuid4(),
+        case_number=1,
         summary="Test Case for Fields",
         description="This is a test case for testing fields",
         status=CaseStatus.NEW,

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -2,10 +2,11 @@ import uuid  # noqa: I001
 import asyncio
 from datetime import UTC, datetime
 from typing import Literal
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
@@ -28,7 +29,7 @@ from tracecat.cases.schemas import (
 from tracecat.tags.schemas import TagCreate
 from tracecat.cases.service import CaseFieldsService, CasesService
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.db.models import Case
+from tracecat.db.models import Case, Workspace
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.pagination import CursorPaginationParams
 from tracecat.tables.enums import SqlType
@@ -216,6 +217,187 @@ class TestCasesService:
         case_ids = {case.id for case in cases}
         assert case1.id in case_ids
         assert case2.id in case_ids
+
+    async def test_create_case_allocates_consecutive_workspace_case_numbers(
+        self, cases_service: CasesService
+    ) -> None:
+        """Case numbers should advance monotonically within one workspace."""
+        first_case = await cases_service.create_case(
+            CaseCreate(
+                summary="First numbered case",
+                description="First numbered case",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+        second_case = await cases_service.create_case(
+            CaseCreate(
+                summary="Second numbered case",
+                description="Second numbered case",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+
+        assert first_case.case_number == 1
+        assert first_case.short_id == "CASE-0001"
+        assert second_case.case_number == 2
+        assert second_case.short_id == "CASE-0002"
+
+    async def test_create_case_allows_duplicate_short_ids_across_workspaces(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+        svc_organization,
+    ) -> None:
+        """Different workspaces should each be able to allocate CASE-0001."""
+        first_case = await cases_service.create_case(
+            CaseCreate(
+                summary="Workspace one",
+                description="Workspace one",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+        second_workspace = Workspace(
+            name="second-workspace",
+            organization_id=svc_organization.id,
+        )
+        session.add(second_workspace)
+        await session.commit()
+
+        second_role = cases_service.role.model_copy(
+            update={
+                "workspace_id": second_workspace.id,
+                "organization_id": second_workspace.organization_id,
+            }
+        )
+        second_service = CasesService(session=session, role=second_role)
+        second_case = await second_service.create_case(
+            CaseCreate(
+                summary="Workspace two",
+                description="Workspace two",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+
+        assert first_case.case_number == 1
+        assert second_case.case_number == 1
+        assert first_case.short_id == second_case.short_id == "CASE-0001"
+
+    async def test_search_cases_short_id_is_workspace_scoped(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+        svc_organization,
+    ) -> None:
+        """Exact short ID search should not cross workspace boundaries."""
+        target_case = await cases_service.create_case(
+            CaseCreate(
+                summary="Workspace one target",
+                description="Workspace one target",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+        second_workspace = Workspace(
+            name="search-scope-workspace",
+            organization_id=svc_organization.id,
+        )
+        session.add(second_workspace)
+        await session.commit()
+
+        second_role = cases_service.role.model_copy(
+            update={
+                "workspace_id": second_workspace.id,
+                "organization_id": second_workspace.organization_id,
+            }
+        )
+        second_service = CasesService(session=session, role=second_role)
+        second_case = await second_service.create_case(
+            CaseCreate(
+                summary="Workspace two target",
+                description="Workspace two target",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+            )
+        )
+
+        assert target_case.short_id == second_case.short_id == "CASE-0001"
+
+        params = CursorPaginationParams(limit=20, cursor=None, reverse=False)
+        response = await cases_service.search_cases(
+            params=params,
+            short_id="CASE-0001",
+            order_by="created_at",
+            sort="asc",
+        )
+
+        result_ids = {item.id for item in response.items}
+        assert target_case.id in result_ids
+        assert second_case.id not in result_ids
+
+    async def test_create_case_concurrently_allocates_unique_workspace_numbers(
+        self,
+        cases_service: CasesService,
+        session: AsyncSession,
+        svc_role: Role,
+        svc_workspace: Workspace,
+    ) -> None:
+        """Concurrent creates should serialize on the workspace counter row."""
+        await cases_service.fields._ensure_schema_ready()
+        await cases_service.session.commit()
+        assert session.bind is not None
+        session_factory = async_sessionmaker(bind=session.bind, expire_on_commit=False)
+
+        async def create_case(index: int) -> int:
+            async with session_factory() as concurrent_session:
+                service = CasesService(
+                    session=concurrent_session,
+                    role=svc_role.model_copy(deep=True),
+                )
+                case = await service.create_case(
+                    CaseCreate(
+                        summary=f"Concurrent case {index}",
+                        description=f"Concurrent case {index}",
+                        status=CaseStatus.NEW,
+                        priority=CasePriority.MEDIUM,
+                        severity=CaseSeverity.LOW,
+                    )
+                )
+                return case.case_number
+
+        with patch.object(
+            CaseFieldsService,
+            "_ensure_schema_ready",
+            new=AsyncMock(return_value=None),
+        ):
+            case_numbers = await asyncio.gather(*(create_case(i) for i in range(5)))
+
+        assert sorted(case_numbers) == [1, 2, 3, 4, 5]
+
+        async with session_factory() as verification_session:
+            workspace = await verification_session.scalar(
+                select(Workspace).where(Workspace.id == svc_workspace.id)
+            )
+            assert workspace is not None
+            assert workspace.last_case_number == 5
+
+            stored_case_numbers = (
+                await verification_session.execute(
+                    select(Case.case_number).where(
+                        Case.workspace_id == svc_workspace.id
+                    )
+                )
+            ).scalars()
+            assert sorted(stored_case_numbers.all()) == [1, 2, 3, 4, 5]
 
     async def test_list_cases_with_limit(
         self, cases_service: CasesService, case_create_params: CaseCreate
@@ -944,6 +1126,7 @@ class TestCasesService:
             [
                 Case(
                     workspace_id=cases_service.workspace_id,
+                    case_number=1,
                     summary="Case A",
                     description="A",
                     status=CaseStatus.NEW,
@@ -954,6 +1137,7 @@ class TestCasesService:
                 ),
                 Case(
                     workspace_id=cases_service.workspace_id,
+                    case_number=2,
                     summary="Case B",
                     description="B",
                     status=CaseStatus.IN_PROGRESS,
@@ -964,6 +1148,7 @@ class TestCasesService:
                 ),
                 Case(
                     workspace_id=cases_service.workspace_id,
+                    case_number=3,
                     summary="Case C",
                     description="C",
                     status=CaseStatus.ON_HOLD,
@@ -974,6 +1159,7 @@ class TestCasesService:
                 ),
                 Case(
                     workspace_id=cases_service.workspace_id,
+                    case_number=4,
                     summary="Case D",
                     description="D",
                     status=CaseStatus.RESOLVED,
@@ -984,6 +1170,7 @@ class TestCasesService:
                 ),
                 Case(
                     workspace_id=cases_service.workspace_id,
+                    case_number=5,
                     summary="Case E",
                     description="E",
                     status=CaseStatus.CLOSED,

--- a/tests/unit/test_db_model.py
+++ b/tests/unit/test_db_model.py
@@ -157,6 +157,7 @@ class TestToDict:
         # Create a case with enum fields
         case = Case(
             workspace_id=svc_workspace.id,
+            case_number=1,
             summary="Test Case",
             description="Test description",
             priority=CasePriority.HIGH,

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -81,6 +81,7 @@ from tracecat.db.models import (
     CaseTask,
     User,
     Workflow,
+    Workspace,
 )
 from tracecat.db.session_events import add_after_commit_callback
 from tracecat.exceptions import (
@@ -762,6 +763,20 @@ class CasesService(BaseWorkspaceService):
 
         return case
 
+    async def _allocate_next_case_number(self) -> int:
+        stmt = (
+            sa.update(Workspace)
+            .where(Workspace.id == self.workspace_id)
+            .values(last_case_number=Workspace.last_case_number + 1)
+            .returning(Workspace.last_case_number)
+        )
+        next_case_number = await self.session.scalar(stmt)
+        if next_case_number is None:
+            raise TracecatNotFoundError(
+                f"Workspace {self.workspace_id} not found while allocating case number"
+            )
+        return next_case_number
+
     @require_scope("case:create")
     @audit_log(resource_type="case", action="create")
     async def create_case(self, params: CaseCreate) -> Case:
@@ -773,9 +788,10 @@ class CasesService(BaseWorkspaceService):
             await self.fields._ensure_schema_ready()
 
             now = datetime.now(UTC)
-            # Create the base case first
+            next_case_number = await self._allocate_next_case_number()
             case = Case(
                 workspace_id=self.workspace_id,
+                case_number=next_case_number,
                 summary=params.summary,
                 description=params.description,
                 priority=params.priority,

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -81,7 +81,6 @@ from tracecat.db.models import (
     CaseTask,
     User,
     Workflow,
-    Workspace,
 )
 from tracecat.db.session_events import add_after_commit_callback
 from tracecat.exceptions import (
@@ -763,20 +762,6 @@ class CasesService(BaseWorkspaceService):
 
         return case
 
-    async def _allocate_next_case_number(self) -> int:
-        stmt = (
-            sa.update(Workspace)
-            .where(Workspace.id == self.workspace_id)
-            .values(last_case_number=Workspace.last_case_number + 1)
-            .returning(Workspace.last_case_number)
-        )
-        next_case_number = await self.session.scalar(stmt)
-        if next_case_number is None:
-            raise TracecatNotFoundError(
-                f"Workspace {self.workspace_id} not found while allocating case number"
-            )
-        return next_case_number
-
     @require_scope("case:create")
     @audit_log(resource_type="case", action="create")
     async def create_case(self, params: CaseCreate) -> Case:
@@ -788,10 +773,8 @@ class CasesService(BaseWorkspaceService):
             await self.fields._ensure_schema_ready()
 
             now = datetime.now(UTC)
-            next_case_number = await self._allocate_next_case_number()
             case = Case(
                 workspace_id=self.workspace_id,
-                case_number=next_case_number,
                 summary=params.summary,
                 description=params.description,
                 priority=params.priority,

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     TIMESTAMP,
     Boolean,
     Enum,
+    FetchedValue,
     Float,
     ForeignKey,
     Identity,
@@ -2026,8 +2027,9 @@ class Case(WorkspaceModel):
     )
     case_number: Mapped[int] = mapped_column(
         Integer,
+        server_default=FetchedValue(),
         nullable=False,
-        doc="Workspace-scoped case number for human readable IDs like CASE-1234",
+        doc="Server-generated workspace-scoped case number for human readable IDs like CASE-1234",
     )
     summary: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(String(5000), nullable=False)

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -410,6 +410,13 @@ class Workspace(OrganizationModel):
         unique=True,
     )
     name: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    last_case_number: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        server_default=text("0"),
+        nullable=False,
+        doc="Last allocated workspace-scoped case number.",
+    )
     settings: Mapped[WorkspaceSettings] = mapped_column(
         JSONB,
         default=WorkspaceSettings(workflow_unlimited_timeout_enabled=True),
@@ -2002,6 +2009,11 @@ class Case(WorkspaceModel):
 
     __tablename__ = "case"
     __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "case_number",
+            name="uq_case_workspace_case_number",
+        ),
         Index("ix_case_cursor_pagination", "workspace_id", "created_at", "id"),
     )
 
@@ -2014,11 +2026,8 @@ class Case(WorkspaceModel):
     )
     case_number: Mapped[int] = mapped_column(
         Integer,
-        Identity(start=1, increment=1),
-        unique=True,
         nullable=False,
-        index=True,
-        doc="Auto-incrementing case number for human readable IDs like CASE-1234",
+        doc="Workspace-scoped case number for human readable IDs like CASE-1234",
     )
     summary: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(String(5000), nullable=False)


### PR DESCRIPTION
## Summary
- scope `case.case_number` to each workspace instead of using a global identity sequence
- allocate new case numbers from `workspace.last_case_number` inside the case creation transaction
- backfill existing cases to monotonic per-workspace numbering and add migration/service coverage for duplicate short IDs across workspaces
- make the migration intentionally non-reversible because historical case numbers are renumbered in place

## Testing
- `env TRACECAT__SERVICE_KEY=test-service-key PG_PORT=5532 REDIS_PORT=6479 TEMPORAL_PORT=7333 MINIO_PORT=9100 uv run pytest tests/unit/test_cases_service.py tests/unit/test_case_fields_service.py tests/unit/test_db_model.py tests/migration/test_case_numbers_workspace_migration.py`
- `uv run ruff check tracecat/db/models.py tracecat/cases/service.py tests/unit/test_cases_service.py tests/unit/test_case_fields_service.py tests/unit/test_db_model.py tests/migration/test_case_numbers_workspace_migration.py alembic/versions/13cfd6e83e36_scope_case_numbers_to_workspace.py`
- `uv run basedpyright tracecat/db/models.py tracecat/cases/service.py tests/unit/test_cases_service.py tests/unit/test_case_fields_service.py tests/unit/test_db_model.py tests/migration/test_case_numbers_workspace_migration.py alembic/versions/13cfd6e83e36_scope_case_numbers_to_workspace.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes case numbers to each workspace and moves allocation to Postgres for safe, atomic numbering. Existing cases are renumbered per workspace so short IDs like CASE-0001 can exist in different workspaces.

- **Bug Fixes**
  - Allocate case numbers in Postgres via a BEFORE INSERT trigger that increments workspace.last_case_number; explicit case_number updates the counter to the max.
  - Enforce uniqueness per workspace; short IDs can repeat across workspaces, and short ID search is workspace-scoped.
  - Concurrent creates in one workspace yield unique, consecutive numbers and advance workspace.last_case_number.

- **Migration**
  - Add workspace.last_case_number (default 0) and backfill it to the per-workspace max.
  - Drop identity from case.case_number and the global index; renumber cases per workspace and add UNIQUE(workspace_id, case_number).
  - Create assign_workspace_case_number() + trigger; non-reversible due to in-place renumbering.

<sup>Written for commit f162dd92381a30c8bfa6969dfd74154606231c78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

