### PR TITLE
feat: Add bulk GitHub push for workflows

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -21679,7 +21679,7 @@ export const $WorkflowBulkPushExcludedWorkflow = {
 
 export const $WorkflowBulkPushExclusionReason = {
   type: "string",
-  enum: ["not_found", "not_published"],
+  enum: ["not_found", "not_published", "invalid_configuration"],
   title: "WorkflowBulkPushExclusionReason",
 } as const
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -21639,6 +21639,347 @@ export const $WorkflowAlias = {
   title: "WorkflowAlias",
 } as const
 
+export const $WorkflowBulkPushExcludedWorkflow = {
+  properties: {
+    workflow_id: {
+      anyOf: [
+        {
+          type: "string",
+          pattern: "wf_[0-9a-zA-Z]+",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Workflow Id",
+    },
+    title: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Title",
+    },
+    reason: {
+      $ref: "#/components/schemas/WorkflowBulkPushExclusionReason",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+  },
+  type: "object",
+  required: ["reason", "message"],
+  title: "WorkflowBulkPushExcludedWorkflow",
+} as const
+
+export const $WorkflowBulkPushExclusionReason = {
+  type: "string",
+  enum: ["not_found", "not_published"],
+  title: "WorkflowBulkPushExclusionReason",
+} as const
+
+export const $WorkflowBulkPushPreviewRequest = {
+  properties: {
+    workflow_ids: {
+      items: {
+        type: "string",
+        pattern: "wf_[0-9a-zA-Z]+",
+      },
+      type: "array",
+      maxItems: 500,
+      title: "Workflow Ids",
+    },
+    folder_paths: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      maxItems: 100,
+      title: "Folder Paths",
+    },
+  },
+  type: "object",
+  title: "WorkflowBulkPushPreviewRequest",
+} as const
+
+export const $WorkflowBulkPushPreviewResponse = {
+  properties: {
+    eligible_workflows: {
+      items: {
+        $ref: "#/components/schemas/WorkflowBulkPushWorkflowSummary",
+      },
+      type: "array",
+      title: "Eligible Workflows",
+    },
+    excluded_workflows: {
+      items: {
+        $ref: "#/components/schemas/WorkflowBulkPushExcludedWorkflow",
+      },
+      type: "array",
+      title: "Excluded Workflows",
+    },
+    resolved_workflow_ids: {
+      items: {
+        type: "string",
+        pattern: "wf_[0-9a-zA-Z]+",
+      },
+      type: "array",
+      title: "Resolved Workflow Ids",
+    },
+    branch: {
+      type: "string",
+      title: "Branch",
+    },
+    commit_message: {
+      type: "string",
+      title: "Commit Message",
+    },
+    pr_title: {
+      type: "string",
+      title: "Pr Title",
+    },
+    pr_body: {
+      type: "string",
+      title: "Pr Body",
+    },
+    can_submit: {
+      type: "boolean",
+      title: "Can Submit",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["branch", "commit_message", "pr_title", "pr_body"],
+  title: "WorkflowBulkPushPreviewResponse",
+} as const
+
+export const $WorkflowBulkPushRequest = {
+  properties: {
+    workflow_ids: {
+      items: {
+        type: "string",
+        pattern: "wf_[0-9a-zA-Z]+",
+      },
+      type: "array",
+      minItems: 1,
+      title: "Workflow Ids",
+    },
+    branch: {
+      type: "string",
+      title: "Branch",
+    },
+    commit_message: {
+      type: "string",
+      maxLength: 512,
+      minLength: 1,
+      title: "Commit Message",
+    },
+    pr_title: {
+      type: "string",
+      maxLength: 256,
+      minLength: 1,
+      title: "Pr Title",
+    },
+    pr_body: {
+      type: "string",
+      title: "Pr Body",
+      default: "",
+    },
+  },
+  type: "object",
+  required: ["branch", "commit_message", "pr_title"],
+  title: "WorkflowBulkPushRequest",
+} as const
+
+export const $WorkflowBulkPushResult = {
+  properties: {
+    status: {
+      type: "string",
+      enum: ["committed", "no_op"],
+      title: "Status",
+    },
+    commit_sha: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Commit Sha",
+    },
+    branch: {
+      type: "string",
+      title: "Branch",
+    },
+    base_branch: {
+      type: "string",
+      title: "Base Branch",
+    },
+    pr_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Url",
+    },
+    pr_number: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Number",
+    },
+    pr_reused: {
+      type: "boolean",
+      title: "Pr Reused",
+      default: false,
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+    selected_count: {
+      type: "integer",
+      title: "Selected Count",
+    },
+    eligible_count: {
+      type: "integer",
+      title: "Eligible Count",
+    },
+    excluded_count: {
+      type: "integer",
+      title: "Excluded Count",
+    },
+    workflow_results: {
+      items: {
+        $ref: "#/components/schemas/WorkflowBulkPushWorkflowResult",
+      },
+      type: "array",
+      title: "Workflow Results",
+    },
+  },
+  type: "object",
+  required: [
+    "status",
+    "branch",
+    "base_branch",
+    "message",
+    "selected_count",
+    "eligible_count",
+    "excluded_count",
+  ],
+  title: "WorkflowBulkPushResult",
+} as const
+
+export const $WorkflowBulkPushWorkflowResult = {
+  properties: {
+    workflow_id: {
+      type: "string",
+      pattern: "wf_[0-9a-zA-Z]+",
+      title: "Workflow Id",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+    },
+    path: {
+      type: "string",
+      title: "Path",
+    },
+    status: {
+      $ref: "#/components/schemas/WorkflowBulkPushWorkflowStatus",
+    },
+    message: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Message",
+    },
+  },
+  type: "object",
+  required: ["workflow_id", "title", "path", "status"],
+  title: "WorkflowBulkPushWorkflowResult",
+} as const
+
+export const $WorkflowBulkPushWorkflowStatus = {
+  type: "string",
+  enum: ["committed", "no_op", "excluded"],
+  title: "WorkflowBulkPushWorkflowStatus",
+} as const
+
+export const $WorkflowBulkPushWorkflowSummary = {
+  properties: {
+    workflow_id: {
+      type: "string",
+      pattern: "wf_[0-9a-zA-Z]+",
+      title: "Workflow Id",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+    },
+    alias: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Alias",
+    },
+    folder_path: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Path",
+    },
+    latest_definition_version: {
+      type: "integer",
+      title: "Latest Definition Version",
+    },
+    latest_definition_created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Latest Definition Created At",
+    },
+  },
+  type: "object",
+  required: [
+    "workflow_id",
+    "title",
+    "latest_definition_version",
+    "latest_definition_created_at",
+  ],
+  title: "WorkflowBulkPushWorkflowSummary",
+} as const
+
 export const $WorkflowCommitResponse = {
   properties: {
     workflow_id: {
@@ -21880,6 +22221,17 @@ export const $WorkflowDirectoryItem = {
         },
       ],
       title: "Folder Id",
+    },
+    folder_path: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Path",
     },
     trigger_summary: {
       anyOf: [
@@ -23712,6 +24064,17 @@ export const $WorkflowReadMinimal = {
         },
       ],
       title: "Folder Id",
+    },
+    folder_path: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Path",
     },
     trigger_summary: {
       anyOf: [

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -654,6 +654,8 @@ import type {
   WorkflowExecutionsTerminateWorkflowExecutionResponse,
   WorkflowsAddTagData,
   WorkflowsAddTagResponse,
+  WorkflowsBulkPushWorkflowsData,
+  WorkflowsBulkPushWorkflowsResponse,
   WorkflowsCommitWorkflowData,
   WorkflowsCommitWorkflowResponse,
   WorkflowsCreateWorkflowData,
@@ -680,6 +682,8 @@ import type {
   WorkflowsListWorkflowsResponse,
   WorkflowsMoveWorkflowToFolderData,
   WorkflowsMoveWorkflowToFolderResponse,
+  WorkflowsPreviewBulkPushWorkflowsData,
+  WorkflowsPreviewBulkPushWorkflowsResponse,
   WorkflowsPublishWorkflowData,
   WorkflowsPublishWorkflowResponse,
   WorkflowsPullWorkflowsData,
@@ -2681,6 +2685,56 @@ export const workflowsPublishWorkflow = (
     path: {
       workflow_id: data.workflowId,
     },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Preview Bulk Push Workflows
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns WorkflowBulkPushPreviewResponse Successful Response
+ * @throws ApiError
+ */
+export const workflowsPreviewBulkPushWorkflows = (
+  data: WorkflowsPreviewBulkPushWorkflowsData
+): CancelablePromise<WorkflowsPreviewBulkPushWorkflowsResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workflows/push/preview",
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Bulk Push Workflows
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns WorkflowBulkPushResult Successful Response
+ * @throws ApiError
+ */
+export const workflowsBulkPushWorkflows = (
+  data: WorkflowsBulkPushWorkflowsData
+): CancelablePromise<WorkflowsBulkPushWorkflowsResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workflows/push",
     query: {
       workspace_id: data.workspaceId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6747,7 +6747,10 @@ export type WorkflowBulkPushExcludedWorkflow = {
   message: string
 }
 
-export type WorkflowBulkPushExclusionReason = "not_found" | "not_published"
+export type WorkflowBulkPushExclusionReason =
+  | "not_found"
+  | "not_published"
+  | "invalid_configuration"
 
 export type WorkflowBulkPushPreviewRequest = {
   workflow_ids?: Array<string>

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6740,6 +6740,75 @@ export type WorkflowAlias = {
   component_id?: "workflow-alias"
 }
 
+export type WorkflowBulkPushExcludedWorkflow = {
+  workflow_id?: string | null
+  title?: string | null
+  reason: WorkflowBulkPushExclusionReason
+  message: string
+}
+
+export type WorkflowBulkPushExclusionReason = "not_found" | "not_published"
+
+export type WorkflowBulkPushPreviewRequest = {
+  workflow_ids?: Array<string>
+  folder_paths?: Array<string>
+}
+
+export type WorkflowBulkPushPreviewResponse = {
+  eligible_workflows?: Array<WorkflowBulkPushWorkflowSummary>
+  excluded_workflows?: Array<WorkflowBulkPushExcludedWorkflow>
+  resolved_workflow_ids?: Array<string>
+  branch: string
+  commit_message: string
+  pr_title: string
+  pr_body: string
+  can_submit?: boolean
+}
+
+export type WorkflowBulkPushRequest = {
+  workflow_ids?: Array<string>
+  branch: string
+  commit_message: string
+  pr_title: string
+  pr_body?: string
+}
+
+export type WorkflowBulkPushResult = {
+  status: "committed" | "no_op"
+  commit_sha?: string | null
+  branch: string
+  base_branch: string
+  pr_url?: string | null
+  pr_number?: number | null
+  pr_reused?: boolean
+  message: string
+  selected_count: number
+  eligible_count: number
+  excluded_count: number
+  workflow_results?: Array<WorkflowBulkPushWorkflowResult>
+}
+
+export type status3 = "committed" | "no_op"
+
+export type WorkflowBulkPushWorkflowResult = {
+  workflow_id: string
+  title: string
+  path: string
+  status: WorkflowBulkPushWorkflowStatus
+  message?: string | null
+}
+
+export type WorkflowBulkPushWorkflowStatus = "committed" | "no_op" | "excluded"
+
+export type WorkflowBulkPushWorkflowSummary = {
+  workflow_id: string
+  title: string
+  alias?: string | null
+  folder_path?: string | null
+  latest_definition_version: number
+  latest_definition_created_at: string
+}
+
 export type WorkflowCommitResponse = {
   workflow_id: string
   status: "success" | "failure"
@@ -6750,7 +6819,7 @@ export type WorkflowCommitResponse = {
   } | null
 }
 
-export type status3 = "success" | "failure"
+export type status4 = "success" | "failure"
 
 /**
  * API response model for persisted workflow definitions.
@@ -6787,6 +6856,7 @@ export type WorkflowDirectoryItem = {
   error_handler?: string | null
   latest_definition?: WorkflowDefinitionReadMinimal | null
   folder_id?: string | null
+  folder_path?: string | null
   trigger_summary?: WorkflowTriggerSummary | null
   type: "workflow"
 }
@@ -6808,8 +6878,6 @@ export type WorkflowDslPublishResult = {
   pr_reused?: boolean
   message: string
 }
-
-export type status4 = "committed" | "no_op"
 
 export type WorkflowEntrypointValidationRequest = {
   expects?: {
@@ -7355,6 +7423,7 @@ export type WorkflowReadMinimal = {
   error_handler?: string | null
   latest_definition?: WorkflowDefinitionReadMinimal | null
   folder_id?: string | null
+  folder_path?: string | null
   trigger_summary?: WorkflowTriggerSummary | null
 }
 
@@ -8289,6 +8358,21 @@ export type WorkflowsPublishWorkflowData = {
 }
 
 export type WorkflowsPublishWorkflowResponse = WorkflowDslPublishResult
+
+export type WorkflowsPreviewBulkPushWorkflowsData = {
+  requestBody: WorkflowBulkPushPreviewRequest
+  workspaceId: string
+}
+
+export type WorkflowsPreviewBulkPushWorkflowsResponse =
+  WorkflowBulkPushPreviewResponse
+
+export type WorkflowsBulkPushWorkflowsData = {
+  requestBody: WorkflowBulkPushRequest
+  workspaceId: string
+}
+
+export type WorkflowsBulkPushWorkflowsResponse = WorkflowBulkPushResult
 
 export type WorkflowsListWorkflowCommitsData = {
   /**
@@ -11597,6 +11681,36 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: WorkflowDslPublishResult
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workflows/push/preview": {
+    post: {
+      req: WorkflowsPreviewBulkPushWorkflowsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowBulkPushPreviewResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workflows/push": {
+    post: {
+      req: WorkflowsBulkPushWorkflowsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowBulkPushResult
         /**
          * Validation Error
          */

--- a/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
@@ -2,7 +2,13 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { GitBranchIcon, GitPullRequestIcon } from "lucide-react"
+import {
+  FolderIcon,
+  GitBranchIcon,
+  GitPullRequestIcon,
+  WorkflowIcon,
+} from "lucide-react"
+import Link from "next/link"
 import { useEffect, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
@@ -98,55 +104,99 @@ function getPushToastTitle(result: {
   return "Workflows pushed"
 }
 
+function getDisplayFolderPath(folderPath?: string | null): string {
+  if (!folderPath || folderPath === "/") {
+    return "/"
+  }
+
+  return folderPath.endsWith("/") ? folderPath.slice(0, -1) : folderPath
+}
+
 function SelectedWorkflowList({
+  workspaceId,
   preview,
 }: {
+  workspaceId: string
   preview: WorkflowBulkPushPreviewResponse
 }) {
   const eligibleWorkflows = preview.eligible_workflows ?? []
   const excludedWorkflows = preview.excluded_workflows ?? []
+  const excludedWorkflowGroups = excludedWorkflows.reduce<
+    Array<{
+      message: string
+      workflows: WorkflowBulkPushExcludedWorkflow[]
+    }>
+  >((groups, workflow) => {
+    const message = workflow.message || "Unknown exclusion reason"
+    const existingGroup = groups.find((group) => group.message === message)
+
+    if (existingGroup) {
+      existingGroup.workflows.push(workflow)
+      return groups
+    }
+
+    groups.push({ message, workflows: [workflow] })
+    return groups
+  }, [])
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant="secondary" className="h-6 rounded-md px-2 text-xs">
-          {eligibleWorkflows.length} eligible
-        </Badge>
-        <Badge variant="secondary" className="h-6 rounded-md px-2 text-xs">
-          {excludedWorkflows.length} excluded
-        </Badge>
-        <Badge variant="secondary" className="h-6 rounded-md px-2 text-xs">
-          1 pull request
-        </Badge>
-      </div>
-
       <div className="space-y-2">
-        <div className="text-xs font-medium text-foreground">Included</div>
+        <div className="flex items-center gap-2">
+          <div className="text-xs font-medium text-foreground">Included</div>
+          <span className="text-xs text-muted-foreground">
+            {eligibleWorkflows.length}
+          </span>
+        </div>
         <div className="max-h-44 overflow-auto rounded-md border">
           {eligibleWorkflows.length > 0 ? (
             <div className="divide-y">
-              {eligibleWorkflows.map((workflow) => (
-                <div
-                  key={workflow.workflow_id}
-                  className="flex items-start justify-between gap-3 px-3 py-2"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium">
-                      {workflow.title}
-                    </p>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {workflow.workflow_id}
-                      {workflow.folder_path ? ` • ${workflow.folder_path}` : ""}
-                    </p>
+              {eligibleWorkflows.map((workflow) => {
+                const content = (
+                  <div className="flex items-center justify-between gap-3 px-3 py-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <WorkflowIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                        <p className="truncate text-sm font-medium">
+                          {workflow.title}
+                        </p>
+                      </div>
+                      <span className="inline-flex shrink-0 items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] text-foreground">
+                        <FolderIcon className="size-3 shrink-0 text-muted-foreground" />
+                        <span>
+                          {getDisplayFolderPath(workflow.folder_path)}
+                        </span>
+                      </span>
+                    </div>
+                    <Badge
+                      variant="secondary"
+                      className="h-5 shrink-0 rounded-sm px-2 text-[10px] font-normal"
+                    >
+                      v{workflow.latest_definition_version}
+                    </Badge>
                   </div>
-                  <Badge
-                    variant="secondary"
-                    className="h-5 shrink-0 rounded-sm px-2 text-[10px] font-normal"
+                )
+
+                return workflow.workflow_id ? (
+                  <Link
+                    key={workflow.workflow_id}
+                    href={`/workspaces/${workspaceId}/workflows/${workflow.workflow_id}`}
+                    title={workflow.workflow_id}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block transition-colors hover:bg-muted/40"
                   >
-                    v{workflow.latest_definition_version}
-                  </Badge>
-                </div>
-              ))}
+                    {content}
+                  </Link>
+                ) : (
+                  <div
+                    key={workflow.title}
+                    title={workflow.workflow_id ?? undefined}
+                  >
+                    {content}
+                  </div>
+                )
+              })}
             </div>
           ) : (
             <div className="px-3 py-4 text-sm text-muted-foreground">
@@ -157,14 +207,21 @@ function SelectedWorkflowList({
       </div>
 
       <div className="space-y-2">
-        <div className="text-xs font-medium text-foreground">Excluded</div>
+        <div className="flex items-center gap-2">
+          <div className="text-xs font-medium text-foreground">Excluded</div>
+          <span className="text-xs text-muted-foreground">
+            {excludedWorkflows.length}
+          </span>
+        </div>
         <div className="max-h-36 overflow-auto rounded-md border">
-          {excludedWorkflows.length > 0 ? (
+          {excludedWorkflowGroups.length > 0 ? (
             <div className="divide-y">
-              {excludedWorkflows.map((workflow, index) => (
-                <ExcludedWorkflowRow
-                  key={`${workflow.workflow_id ?? "excluded"}-${index}`}
-                  workflow={workflow}
+              {excludedWorkflowGroups.map((group) => (
+                <ExcludedWorkflowGroupRow
+                  key={group.message}
+                  message={group.message}
+                  workspaceId={workspaceId}
+                  workflows={group.workflows}
                 />
               ))}
             </div>
@@ -179,17 +236,59 @@ function SelectedWorkflowList({
   )
 }
 
-function ExcludedWorkflowRow({
-  workflow,
+function ExcludedWorkflowGroupRow({
+  message,
+  workspaceId,
+  workflows,
 }: {
-  workflow: WorkflowBulkPushExcludedWorkflow
+  message: string
+  workspaceId: string
+  workflows: WorkflowBulkPushExcludedWorkflow[]
 }) {
   return (
-    <div className="px-3 py-2">
-      <p className="truncate text-sm font-medium">
-        {workflow.title || workflow.workflow_id || "Unknown workflow"}
-      </p>
-      <p className="text-xs text-muted-foreground">{workflow.message}</p>
+    <div className="space-y-1 px-3 py-2">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-xs text-muted-foreground">{message}</p>
+        <Badge
+          variant="secondary"
+          className="h-5 shrink-0 rounded-sm px-2 text-[10px] font-normal"
+        >
+          {workflows.length}
+        </Badge>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {workflows.map((workflow) => {
+          const label =
+            workflow.title || workflow.workflow_id || "Unknown workflow"
+          const workflowId = workflow.workflow_id
+
+          if (workflowId) {
+            return (
+              <Link
+                key={workflowId}
+                href={`/workspaces/${workspaceId}/workflows/${workflowId}`}
+                title={workflowId}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] text-foreground transition-colors hover:bg-muted/80"
+              >
+                <WorkflowIcon className="size-3 text-muted-foreground" />
+                <span>{label}</span>
+              </Link>
+            )
+          }
+
+          return (
+            <span
+              key={label}
+              className="inline-flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] text-foreground"
+            >
+              <WorkflowIcon className="size-3 text-muted-foreground" />
+              <span>{label}</span>
+            </span>
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -367,7 +466,7 @@ export function WorkflowBulkPushDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-hidden sm:max-w-[760px]">
+      <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-[760px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <GitBranchIcon className="size-4" />
@@ -395,171 +494,176 @@ export function WorkflowBulkPushDialog({
             {previewErrorMessage}
           </div>
         ) : previewQuery.data ? (
-          <div className="min-h-0 overflow-auto pr-1">
+          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
             <Form {...form}>
               <form
                 onSubmit={form.handleSubmit((values) =>
                   pushMutation.mutateAsync(values)
                 )}
-                className="space-y-5"
+                className="flex min-h-0 flex-col"
               >
-                <SelectedWorkflowList preview={previewQuery.data} />
+                <div className="space-y-5">
+                  <SelectedWorkflowList
+                    workspaceId={workspaceId}
+                    preview={previewQuery.data}
+                  />
 
-                <div className="grid gap-4 md:grid-cols-2">
-                  <FormField
-                    control={form.control}
-                    name="branch"
-                    render={({ field }) => (
-                      <FormItem className="md:col-span-2">
-                        <FormLabel>Target branch</FormLabel>
-                        <Select
-                          value={
-                            isCreatingBranch ||
-                            !repoBranches?.some(
-                              (branch) => branch.name === field.value
-                            )
-                              ? CREATE_NEW_BRANCH_VALUE
-                              : field.value
-                          }
-                          onValueChange={(value) => {
-                            if (value === CREATE_NEW_BRANCH_VALUE) {
-                              setIsCreatingBranch(true)
-                              field.onChange("")
-                              return
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <FormField
+                      control={form.control}
+                      name="branch"
+                      render={({ field }) => (
+                        <FormItem className="md:col-span-2">
+                          <FormLabel>Target branch</FormLabel>
+                          <Select
+                            value={
+                              isCreatingBranch ||
+                              !repoBranches?.some(
+                                (branch) => branch.name === field.value
+                              )
+                                ? CREATE_NEW_BRANCH_VALUE
+                                : field.value
                             }
-                            setIsCreatingBranch(false)
-                            field.onChange(value)
-                          }}
-                          disabled={branchesLoading || !hasBranches}
-                        >
-                          <FormControl>
-                            <SelectTrigger className="h-9">
-                              <SelectValue placeholder="Select branch" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {hasBranches ? (
-                              <>
-                                <SelectItem value={CREATE_NEW_BRANCH_VALUE}>
-                                  Create new branch...
-                                </SelectItem>
-                                <SelectSeparator />
-                                {(repoBranches ?? []).map((branch) => (
-                                  <SelectItem
-                                    key={branch.name}
-                                    value={branch.name}
-                                  >
-                                    <div className="flex items-center gap-2">
-                                      <span>{branch.name}</span>
-                                      {branch.is_default && (
-                                        <Badge
-                                          variant="secondary"
-                                          className="h-4 rounded-sm px-1 text-[10px] font-normal"
-                                        >
-                                          default
-                                        </Badge>
-                                      )}
-                                    </div>
+                            onValueChange={(value) => {
+                              if (value === CREATE_NEW_BRANCH_VALUE) {
+                                setIsCreatingBranch(true)
+                                field.onChange("")
+                                return
+                              }
+                              setIsCreatingBranch(false)
+                              field.onChange(value)
+                            }}
+                            disabled={branchesLoading || !hasBranches}
+                          >
+                            <FormControl>
+                              <SelectTrigger className="h-9">
+                                <SelectValue placeholder="Select branch" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {hasBranches ? (
+                                <>
+                                  <SelectItem value={CREATE_NEW_BRANCH_VALUE}>
+                                    Create new branch...
                                   </SelectItem>
-                                ))}
-                              </>
-                            ) : (
-                              <SelectItem value="__no_branches" disabled>
-                                No branches found
-                              </SelectItem>
-                            )}
-                          </SelectContent>
-                        </Select>
-                        {isCreatingBranch ? (
-                          <div className="mt-2">
-                            <Input
-                              value={field.value}
-                              onChange={field.onChange}
-                              placeholder="tracecat/bulk-push"
-                            />
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              The branch will be created from the repository
-                              default branch if it does not exist.
+                                  <SelectSeparator />
+                                  {(repoBranches ?? []).map((branch) => (
+                                    <SelectItem
+                                      key={branch.name}
+                                      value={branch.name}
+                                    >
+                                      <div className="flex items-center gap-2">
+                                        <span>{branch.name}</span>
+                                        {branch.is_default && (
+                                          <Badge
+                                            variant="secondary"
+                                            className="h-4 rounded-sm px-1 text-[10px] font-normal"
+                                          >
+                                            default
+                                          </Badge>
+                                        )}
+                                      </div>
+                                    </SelectItem>
+                                  ))}
+                                </>
+                              ) : (
+                                <SelectItem value="__no_branches" disabled>
+                                  No branches found
+                                </SelectItem>
+                              )}
+                            </SelectContent>
+                          </Select>
+                          {isCreatingBranch ? (
+                            <div className="mt-2">
+                              <Input
+                                value={field.value}
+                                onChange={field.onChange}
+                                placeholder="tracecat/bulk-push"
+                              />
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                The branch will be created from the repository
+                                default branch if it does not exist.
+                              </p>
+                            </div>
+                          ) : null}
+                          {branchesErrorMessage ? (
+                            <p className="text-xs text-destructive">
+                              {branchesErrorMessage}
                             </p>
-                          </div>
-                        ) : null}
-                        {branchesErrorMessage ? (
-                          <p className="text-xs text-destructive">
-                            {branchesErrorMessage}
-                          </p>
-                        ) : null}
-                        {!branchesLoading && !hasBranches ? (
-                          <p className="text-xs text-muted-foreground">
-                            No branches are available from the configured
-                            repository.
-                          </p>
-                        ) : null}
-                        {selectedBranchInfo?.is_default ? (
-                          <p className="text-xs text-muted-foreground">
-                            A pull request will still be created for this bulk
-                            push.
-                          </p>
-                        ) : null}
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                          ) : null}
+                          {!branchesLoading && !hasBranches ? (
+                            <p className="text-xs text-muted-foreground">
+                              No branches are available from the configured
+                              repository.
+                            </p>
+                          ) : null}
+                          {selectedBranchInfo?.is_default ? (
+                            <p className="text-xs text-muted-foreground">
+                              A pull request will still be created for this bulk
+                              push.
+                            </p>
+                          ) : null}
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="commitMessage"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Commit message</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="prTitle"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Pull request title</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
 
                   <FormField
                     control={form.control}
-                    name="commitMessage"
+                    name="prBody"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Commit message</FormLabel>
+                        <FormLabel>Pull request description</FormLabel>
                         <FormControl>
-                          <Input {...field} />
+                          <Textarea
+                            {...field}
+                            className="min-h-32 resize-y"
+                            placeholder="Describe this workflow push"
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
 
-                  <FormField
-                    control={form.control}
-                    name="prTitle"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Pull request title</FormLabel>
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                  {!previewQuery.data.can_submit ? (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                      Nothing eligible to push. Only published workflows can be
+                      included in the pull request.
+                    </div>
+                  ) : null}
                 </div>
 
-                <FormField
-                  control={form.control}
-                  name="prBody"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Pull request description</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          {...field}
-                          className="min-h-32 resize-y"
-                          placeholder="Describe this workflow push"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {!previewQuery.data.can_submit ? (
-                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                    Nothing eligible to push. Only published workflows can be
-                    included in the pull request.
-                  </div>
-                ) : null}
-
-                <DialogFooter className="gap-2">
+                <DialogFooter className="mt-5 gap-2">
                   <Button
                     type="button"
                     variant="outline"

--- a/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
@@ -151,7 +151,7 @@ function SelectedWorkflowList({
         <div className="max-h-44 overflow-auto rounded-md border">
           {eligibleWorkflows.length > 0 ? (
             <div className="divide-y">
-              {eligibleWorkflows.map((workflow) => {
+              {eligibleWorkflows.map((workflow, index) => {
                 const content = (
                   <div className="flex items-center justify-between gap-3 px-3 py-2">
                     <div className="flex min-w-0 items-center gap-2">
@@ -190,7 +190,7 @@ function SelectedWorkflowList({
                   </Link>
                 ) : (
                   <div
-                    key={workflow.title}
+                    key={`included-${workflow.title ?? "workflow"}-${index}`}
                     title={workflow.workflow_id ?? undefined}
                   >
                     {content}
@@ -257,7 +257,7 @@ function ExcludedWorkflowGroupRow({
         </Badge>
       </div>
       <div className="flex flex-wrap gap-1">
-        {workflows.map((workflow) => {
+        {workflows.map((workflow, index) => {
           const label =
             workflow.title || workflow.workflow_id || "Unknown workflow"
           const workflowId = workflow.workflow_id
@@ -280,7 +280,7 @@ function ExcludedWorkflowGroupRow({
 
           return (
             <span
-              key={label}
+              key={`excluded-${label}-${index}`}
               className="inline-flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] text-foreground"
             >
               <WorkflowIcon className="size-3 text-muted-foreground" />

--- a/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
@@ -443,6 +443,7 @@ export function WorkflowBulkPushDialog({
   const selectedBranchInfo = repoBranches?.find(
     (branch) => branch.name === selectedBranch
   )
+  const isSelectedDefaultBranch = selectedBranchInfo?.is_default ?? false
   const previewErrorMessage = previewQuery.error
     ? getErrorMessage(
         previewQuery.error,
@@ -462,6 +463,7 @@ export function WorkflowBulkPushDialog({
     (previewQuery.data.can_submit ?? false) &&
     hasBranches &&
     !branchesLoading &&
+    !isSelectedDefaultBranch &&
     !pushMutation.isPending
 
   return (
@@ -551,6 +553,7 @@ export function WorkflowBulkPushDialog({
                                     <SelectItem
                                       key={branch.name}
                                       value={branch.name}
+                                      disabled={branch.is_default}
                                     >
                                       <div className="flex items-center gap-2">
                                         <span>{branch.name}</span>
@@ -597,10 +600,10 @@ export function WorkflowBulkPushDialog({
                               repository.
                             </p>
                           ) : null}
-                          {selectedBranchInfo?.is_default ? (
-                            <p className="text-xs text-muted-foreground">
-                              A pull request will still be created for this bulk
-                              push.
+                          {isSelectedDefaultBranch ? (
+                            <p className="text-xs text-destructive">
+                              Bulk pushes always open a pull request, so select
+                              or create a branch other than the default branch.
                             </p>
                           ) : null}
                           <FormMessage />

--- a/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
@@ -1,0 +1,596 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { GitBranchIcon, GitPullRequestIcon } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import {
+  type ApiError,
+  type GitBranchInfo,
+  type WorkflowBulkPushExcludedWorkflow,
+  type WorkflowBulkPushPreviewResponse,
+  workflowsBulkPushWorkflows,
+  workflowsListWorkflowBranches,
+  workflowsPreviewBulkPushWorkflows,
+} from "@/client"
+import { Spinner } from "@/components/loading/spinner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { ToastAction } from "@/components/ui/toast"
+import { toast } from "@/components/ui/use-toast"
+import type { TracecatApiError } from "@/lib/errors"
+
+const CREATE_NEW_BRANCH_VALUE = "__create_new_branch__"
+
+const bulkPushFormSchema = z.object({
+  branch: z.string().trim().min(1, "Target branch is required"),
+  commitMessage: z.string().trim().min(1, "Commit message is required"),
+  prTitle: z.string().trim().min(1, "Pull request title is required"),
+  prBody: z.string().trim(),
+})
+
+type BulkPushFormValues = z.infer<typeof bulkPushFormSchema>
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  const apiError = error as TracecatApiError<unknown>
+  const detail =
+    typeof apiError === "object" && apiError !== null
+      ? apiError.body?.detail
+      : undefined
+  if (typeof detail === "string" && detail.trim()) {
+    return detail
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message
+  }
+  return fallback
+}
+
+function getPushToastTitle(result: {
+  status: "committed" | "no_op"
+  pr_url?: string | null
+  pr_reused?: boolean
+}): string {
+  if (result.status === "no_op") {
+    if (result.pr_url && result.pr_reused) {
+      return "No changes (PR reused)"
+    }
+    if (result.pr_url) {
+      return "No changes (PR created)"
+    }
+    return "No changes to push"
+  }
+
+  if (result.pr_url && result.pr_reused) {
+    return "Workflows pushed (PR reused)"
+  }
+  if (result.pr_url) {
+    return "Workflows pushed (PR created)"
+  }
+  return "Workflows pushed"
+}
+
+function SelectedWorkflowList({
+  preview,
+}: {
+  preview: WorkflowBulkPushPreviewResponse
+}) {
+  const eligibleWorkflows = preview.eligible_workflows ?? []
+  const excludedWorkflows = preview.excluded_workflows ?? []
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="secondary" className="h-6 rounded-md px-2 text-xs">
+          {eligibleWorkflows.length} eligible
+        </Badge>
+        <Badge variant="secondary" className="h-6 rounded-md px-2 text-xs">
+          {excludedWorkflows.length} excluded
+        </Badge>
+        <Badge variant="secondary" className="h-6 rounded-md px-2 text-xs">
+          1 pull request
+        </Badge>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium text-foreground">Included</div>
+        <div className="max-h-44 overflow-auto rounded-md border">
+          {eligibleWorkflows.length > 0 ? (
+            <div className="divide-y">
+              {eligibleWorkflows.map((workflow) => (
+                <div
+                  key={workflow.workflow_id}
+                  className="flex items-start justify-between gap-3 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">
+                      {workflow.title}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {workflow.workflow_id}
+                      {workflow.folder_path ? ` • ${workflow.folder_path}` : ""}
+                    </p>
+                  </div>
+                  <Badge
+                    variant="secondary"
+                    className="h-5 shrink-0 rounded-sm px-2 text-[10px] font-normal"
+                  >
+                    v{workflow.latest_definition_version}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="px-3 py-4 text-sm text-muted-foreground">
+              No published workflows are eligible to push.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium text-foreground">Excluded</div>
+        <div className="max-h-36 overflow-auto rounded-md border">
+          {excludedWorkflows.length > 0 ? (
+            <div className="divide-y">
+              {excludedWorkflows.map((workflow, index) => (
+                <ExcludedWorkflowRow
+                  key={`${workflow.workflow_id ?? "excluded"}-${index}`}
+                  workflow={workflow}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="px-3 py-4 text-sm text-muted-foreground">
+              Nothing excluded from this push.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ExcludedWorkflowRow({
+  workflow,
+}: {
+  workflow: WorkflowBulkPushExcludedWorkflow
+}) {
+  return (
+    <div className="px-3 py-2">
+      <p className="truncate text-sm font-medium">
+        {workflow.title || workflow.workflow_id || "Unknown workflow"}
+      </p>
+      <p className="text-xs text-muted-foreground">{workflow.message}</p>
+    </div>
+  )
+}
+
+export function WorkflowBulkPushDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  selectedWorkflowIds,
+  selectedFolderPaths,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  selectedWorkflowIds: string[]
+  selectedFolderPaths: string[]
+  onSuccess?: () => void
+}) {
+  const queryClient = useQueryClient()
+  const [isCreatingBranch, setIsCreatingBranch] = useState(false)
+
+  const sortedWorkflowIds = useMemo(
+    () => [...selectedWorkflowIds].sort(),
+    [selectedWorkflowIds]
+  )
+  const sortedFolderPaths = useMemo(
+    () => [...selectedFolderPaths].sort(),
+    [selectedFolderPaths]
+  )
+  const hasSelection =
+    sortedWorkflowIds.length > 0 || sortedFolderPaths.length > 0
+
+  const form = useForm<BulkPushFormValues>({
+    resolver: zodResolver(bulkPushFormSchema),
+    defaultValues: {
+      branch: "",
+      commitMessage: "",
+      prTitle: "",
+      prBody: "",
+    },
+  })
+
+  const previewQuery = useQuery<WorkflowBulkPushPreviewResponse, ApiError>({
+    queryKey: [
+      "workflow-bulk-push-preview",
+      workspaceId,
+      sortedWorkflowIds,
+      sortedFolderPaths,
+    ],
+    queryFn: async () =>
+      await workflowsPreviewBulkPushWorkflows({
+        workspaceId,
+        requestBody: {
+          workflow_ids: sortedWorkflowIds,
+          folder_paths: sortedFolderPaths,
+        },
+      }),
+    enabled: open && hasSelection,
+    refetchOnWindowFocus: false,
+  })
+
+  const {
+    data: repoBranches,
+    isLoading: branchesLoading,
+    error: branchesError,
+  } = useQuery<Array<GitBranchInfo>, ApiError>({
+    queryKey: ["workflow-sync-branches", workspaceId],
+    queryFn: async () =>
+      await workflowsListWorkflowBranches({
+        workspaceId,
+        limit: 200,
+      }),
+    enabled: open,
+    refetchOnWindowFocus: false,
+  })
+
+  const hasBranches = (repoBranches?.length ?? 0) > 0
+
+  useEffect(() => {
+    if (!open || !previewQuery.data) {
+      return
+    }
+
+    form.reset({
+      branch: previewQuery.data.branch,
+      commitMessage: previewQuery.data.commit_message,
+      prTitle: previewQuery.data.pr_title,
+      prBody: previewQuery.data.pr_body,
+    })
+    setIsCreatingBranch(true)
+  }, [form, open, previewQuery.data])
+
+  useEffect(() => {
+    if (!open || !repoBranches || repoBranches.length === 0) {
+      return
+    }
+
+    const branchNames = new Set(repoBranches.map((branch) => branch.name))
+    const currentBranch = form.getValues("branch")
+    setIsCreatingBranch(!currentBranch || !branchNames.has(currentBranch))
+  }, [form, open, repoBranches])
+
+  const pushMutation = useMutation({
+    mutationFn: async (values: BulkPushFormValues) => {
+      if (!previewQuery.data) {
+        throw new Error("Bulk push preview has not loaded.")
+      }
+      return await workflowsBulkPushWorkflows({
+        workspaceId,
+        requestBody: {
+          workflow_ids: previewQuery.data.resolved_workflow_ids ?? [],
+          branch: values.branch,
+          commit_message: values.commitMessage,
+          pr_title: values.prTitle,
+          pr_body: values.prBody || undefined,
+        },
+      })
+    },
+    onSuccess: (result) => {
+      toast({
+        title: getPushToastTitle(result),
+        description: result.message,
+        action: result.pr_url ? (
+          <ToastAction
+            altText="Open pull request"
+            onClick={() =>
+              window.open(result.pr_url ?? "", "_blank", "noopener,noreferrer")
+            }
+          >
+            View PR
+          </ToastAction>
+        ) : undefined,
+      })
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["directory-items"] })
+      queryClient.invalidateQueries({ queryKey: ["workflow-sync-branches"] })
+      onSuccess?.()
+      onOpenChange(false)
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Failed to push workflows",
+        description: getErrorMessage(
+          error,
+          "The workflows could not be pushed to GitHub."
+        ),
+      })
+    },
+  })
+
+  const selectedBranch = form.watch("branch")
+  const selectedBranchInfo = repoBranches?.find(
+    (branch) => branch.name === selectedBranch
+  )
+  const previewErrorMessage = previewQuery.error
+    ? getErrorMessage(
+        previewQuery.error,
+        "The bulk push preview could not be loaded."
+      )
+    : null
+  const branchesErrorMessage = branchesError
+    ? getErrorMessage(
+        branchesError,
+        "The GitHub branches could not be loaded for this workspace."
+      )
+    : null
+
+  const canSubmit =
+    hasSelection &&
+    previewQuery.isSuccess &&
+    (previewQuery.data.can_submit ?? false) &&
+    hasBranches &&
+    !branchesLoading &&
+    !pushMutation.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-hidden sm:max-w-[760px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitBranchIcon className="size-4" />
+            Push to GitHub
+          </DialogTitle>
+          <DialogDescription>
+            Push the latest published definitions for the selected workflows to
+            one branch and one pull request.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!hasSelection ? (
+          <div className="rounded-md border px-3 py-4 text-sm text-muted-foreground">
+            Select at least one workflow or folder to continue.
+          </div>
+        ) : previewQuery.isLoading ? (
+          <div className="flex min-h-[280px] items-center justify-center">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner className="size-4" segmentColor="currentColor" />
+              Loading preview...
+            </div>
+          </div>
+        ) : previewErrorMessage ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-4 text-sm text-destructive">
+            {previewErrorMessage}
+          </div>
+        ) : previewQuery.data ? (
+          <div className="min-h-0 overflow-auto pr-1">
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit((values) =>
+                  pushMutation.mutateAsync(values)
+                )}
+                className="space-y-5"
+              >
+                <SelectedWorkflowList preview={previewQuery.data} />
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="branch"
+                    render={({ field }) => (
+                      <FormItem className="md:col-span-2">
+                        <FormLabel>Target branch</FormLabel>
+                        <Select
+                          value={
+                            isCreatingBranch ||
+                            !repoBranches?.some(
+                              (branch) => branch.name === field.value
+                            )
+                              ? CREATE_NEW_BRANCH_VALUE
+                              : field.value
+                          }
+                          onValueChange={(value) => {
+                            if (value === CREATE_NEW_BRANCH_VALUE) {
+                              setIsCreatingBranch(true)
+                              field.onChange("")
+                              return
+                            }
+                            setIsCreatingBranch(false)
+                            field.onChange(value)
+                          }}
+                          disabled={branchesLoading || !hasBranches}
+                        >
+                          <FormControl>
+                            <SelectTrigger className="h-9">
+                              <SelectValue placeholder="Select branch" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {hasBranches ? (
+                              <>
+                                <SelectItem value={CREATE_NEW_BRANCH_VALUE}>
+                                  Create new branch...
+                                </SelectItem>
+                                <SelectSeparator />
+                                {(repoBranches ?? []).map((branch) => (
+                                  <SelectItem
+                                    key={branch.name}
+                                    value={branch.name}
+                                  >
+                                    <div className="flex items-center gap-2">
+                                      <span>{branch.name}</span>
+                                      {branch.is_default && (
+                                        <Badge
+                                          variant="secondary"
+                                          className="h-4 rounded-sm px-1 text-[10px] font-normal"
+                                        >
+                                          default
+                                        </Badge>
+                                      )}
+                                    </div>
+                                  </SelectItem>
+                                ))}
+                              </>
+                            ) : (
+                              <SelectItem value="__no_branches" disabled>
+                                No branches found
+                              </SelectItem>
+                            )}
+                          </SelectContent>
+                        </Select>
+                        {isCreatingBranch ? (
+                          <div className="mt-2">
+                            <Input
+                              value={field.value}
+                              onChange={field.onChange}
+                              placeholder="tracecat/bulk-push"
+                            />
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              The branch will be created from the repository
+                              default branch if it does not exist.
+                            </p>
+                          </div>
+                        ) : null}
+                        {branchesErrorMessage ? (
+                          <p className="text-xs text-destructive">
+                            {branchesErrorMessage}
+                          </p>
+                        ) : null}
+                        {!branchesLoading && !hasBranches ? (
+                          <p className="text-xs text-muted-foreground">
+                            No branches are available from the configured
+                            repository.
+                          </p>
+                        ) : null}
+                        {selectedBranchInfo?.is_default ? (
+                          <p className="text-xs text-muted-foreground">
+                            A pull request will still be created for this bulk
+                            push.
+                          </p>
+                        ) : null}
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="commitMessage"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Commit message</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="prTitle"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Pull request title</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="prBody"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Pull request description</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          className="min-h-32 resize-y"
+                          placeholder="Describe this workflow push"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {!previewQuery.data.can_submit ? (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                    Nothing eligible to push. Only published workflows can be
+                    included in the pull request.
+                  </div>
+                ) : null}
+
+                <DialogFooter className="gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => onOpenChange(false)}
+                    disabled={pushMutation.isPending}
+                  >
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={!canSubmit}>
+                    {pushMutation.isPending ? (
+                      <>
+                        <Spinner
+                          className="mr-2 size-4"
+                          segmentColor="currentColor"
+                        />
+                        Pushing to GitHub...
+                      </>
+                    ) : (
+                      <>
+                        <GitPullRequestIcon className="mr-2 size-4" />
+                        Push to GitHub
+                      </>
+                    )}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
@@ -280,8 +280,9 @@ export function WorkflowBulkPushDialog({
       prTitle: previewQuery.data.pr_title,
       prBody: previewQuery.data.pr_body,
     })
-    setIsCreatingBranch(true)
   }, [form, open, previewQuery.data])
+
+  const selectedBranch = form.watch("branch")
 
   useEffect(() => {
     if (!open || !repoBranches || repoBranches.length === 0) {
@@ -289,9 +290,8 @@ export function WorkflowBulkPushDialog({
     }
 
     const branchNames = new Set(repoBranches.map((branch) => branch.name))
-    const currentBranch = form.getValues("branch")
-    setIsCreatingBranch(!currentBranch || !branchNames.has(currentBranch))
-  }, [form, open, repoBranches])
+    setIsCreatingBranch(!selectedBranch || !branchNames.has(selectedBranch))
+  }, [open, repoBranches, selectedBranch])
 
   const pushMutation = useMutation({
     mutationFn: async (values: BulkPushFormValues) => {
@@ -341,7 +341,6 @@ export function WorkflowBulkPushDialog({
     },
   })
 
-  const selectedBranch = form.watch("branch")
   const selectedBranchInfo = repoBranches?.find(
     (branch) => branch.name === selectedBranch
   )

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -4,6 +4,7 @@ import { format } from "date-fns"
 import {
   AtSignIcon,
   CalendarClockIcon,
+  Check,
   CircleCheck,
   CircleDot,
   Clock3,
@@ -16,6 +17,7 @@ import {
 } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
 import {
+  type MouseEvent,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -53,7 +55,6 @@ import {
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import {
   ContextMenu,
   ContextMenuContent,
@@ -840,6 +841,17 @@ function WorkflowsListRow({
   onToggleSelection?: (checked: boolean) => void
 }) {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
+  const showSelectedState = isSelected || isSelectionDisabled
+
+  function handleSelectionClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation()
+
+    if (isSelectionDisabled) {
+      return
+    }
+
+    onToggleSelection?.(!isSelected)
+  }
 
   if (item.type === "folder") {
     return (
@@ -853,14 +865,30 @@ function WorkflowsListRow({
           >
             {showSelectionControl ? (
               <div className="flex shrink-0 items-center">
-                <Checkbox
-                  checked={isSelected}
+                <button
+                  type="button"
+                  className="flex size-4 shrink-0 items-center justify-center disabled:cursor-not-allowed"
+                  onClick={handleSelectionClick}
                   disabled={isSelectionDisabled}
+                  role="checkbox"
+                  aria-checked={isSelected}
                   aria-label={`Select folder ${item.name}`}
-                  onCheckedChange={(checked) =>
-                    onToggleSelection?.(checked === true)
-                  }
-                />
+                >
+                  <span
+                    className={cn(
+                      "flex size-4 shrink-0 items-center justify-center rounded-sm border transition-all duration-150",
+                      !showSelectedState &&
+                        "opacity-0 group-hover/item:opacity-100",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-muted-foreground/40 bg-transparent"
+                    )}
+                  >
+                    {isSelected ? (
+                      <Check className="size-3" aria-hidden />
+                    ) : null}
+                  </span>
+                </button>
               </div>
             ) : null}
             <button
@@ -868,7 +896,7 @@ function WorkflowsListRow({
               onClick={() => onOpenFolder(item.path)}
               className="flex min-w-0 flex-1 items-center gap-3 bg-transparent p-0 text-left"
             >
-              <FolderIcon className="size-4 shrink-0 text-black" />
+              <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 <span className={ROW_NAME_COLUMN_CLASS}>{item.name}</span>
                 <FolderMetadataBadges item={item} />
@@ -898,14 +926,28 @@ function WorkflowsListRow({
         >
           {showSelectionControl ? (
             <div className="flex shrink-0 items-center">
-              <Checkbox
-                checked={isSelected}
+              <button
+                type="button"
+                className="flex size-4 shrink-0 items-center justify-center disabled:cursor-not-allowed"
+                onClick={handleSelectionClick}
                 disabled={isSelectionDisabled}
+                role="checkbox"
+                aria-checked={isSelected}
                 aria-label={`Select workflow ${item.title}`}
-                onCheckedChange={(checked) =>
-                  onToggleSelection?.(checked === true)
-                }
-              />
+              >
+                <span
+                  className={cn(
+                    "flex size-4 shrink-0 items-center justify-center rounded-sm border transition-all duration-150",
+                    !showSelectedState &&
+                      "opacity-0 group-hover/item:opacity-100",
+                    isSelected
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-muted-foreground/40 bg-transparent"
+                  )}
+                >
+                  {isSelected ? <Check className="size-3" aria-hidden /> : null}
+                </span>
+              </button>
             </div>
           ) : null}
           <button
@@ -1237,6 +1279,41 @@ export function WorkflowsDashboard() {
 
   const visibleItems =
     view === "folders" ? folderVisibleItems : listVisibleItems
+  const visibleSelectedCount = useMemo(
+    () =>
+      visibleItems.reduce((count, item) => {
+        if (item.type === "folder") {
+          const normalizedPath = normalizeFolderPath(item.path)
+          return (
+            count +
+            (selectedFolderPathSet.has(normalizedPath) ||
+            isFolderCoveredBySelection(
+              normalizedPath,
+              normalizedSelectedFolderPaths
+            )
+              ? 1
+              : 0)
+          )
+        }
+
+        return (
+          count +
+          (selectedWorkflowIdSet.has(item.id) ||
+          isWorkflowCoveredBySelection(
+            item.folder_path,
+            normalizedSelectedFolderPaths
+          )
+            ? 1
+            : 0)
+        )
+      }, 0),
+    [
+      normalizedSelectedFolderPaths,
+      selectedFolderPathSet,
+      selectedWorkflowIdSet,
+      visibleItems,
+    ]
+  )
   const isLoading =
     view === "folders" ? directoryItemsIsLoading : workflowPagination.isLoading
   const error =
@@ -1325,67 +1402,54 @@ export function WorkflowsDashboard() {
     setSelectedFolderPaths([])
   }, [])
 
-  const isCurrentFolderExplicitlySelected =
-    view === "folders" && selectedFolderPathSet.has(currentPath)
-  const isCurrentFolderCoveredBySelection =
-    view === "folders" &&
-    isFolderCoveredBySelection(currentPath, normalizedSelectedFolderPaths)
-  const showCurrentFolderSelectionAction = gitSyncEnabled && view === "folders"
-  const hasSelectionActions =
-    showCurrentFolderSelectionAction || selectedItemCount > 0
+  const handleSelectAllVisible = useCallback(() => {
+    const visibleFolderPaths = visibleItems
+      .filter((item): item is FolderDirectoryItem => item.type === "folder")
+      .map((item) => normalizeFolderPath(item.path))
+
+    const nextFolderPaths = new Set([
+      ...normalizedSelectedFolderPaths,
+      ...visibleFolderPaths,
+    ])
+
+    const visibleWorkflowIds = visibleItems
+      .filter((item): item is WorkflowDirectoryItem => item.type === "workflow")
+      .filter(
+        (item) =>
+          !isWorkflowCoveredBySelection(item.folder_path, [...nextFolderPaths])
+      )
+      .map((item) => item.id)
+
+    setSelectedFolderPaths([...nextFolderPaths])
+    setSelectedWorkflowIds((current) => [
+      ...new Set([...current, ...visibleWorkflowIds]),
+    ])
+  }, [normalizedSelectedFolderPaths, visibleItems])
+
+  const hasSelectionActions = selectedItemCount > 0
 
   const selectionActions = hasSelectionActions ? (
     <div className="flex items-center gap-2">
-      {showCurrentFolderSelectionAction ? (
-        <Button
-          type="button"
-          variant="outline"
-          className="h-6 gap-1.5 px-2 text-xs"
-          onClick={() => {
-            if (isCurrentFolderExplicitlySelected) {
-              handleToggleFolderSelection(currentPath, false)
-              return
-            }
-            handleToggleFolderSelection(currentPath, true)
-          }}
-          disabled={isCurrentFolderCoveredBySelection}
-        >
-          <FolderIcon className="size-3.5" />
-          {isCurrentFolderCoveredBySelection
-            ? "Folder selected"
-            : isCurrentFolderExplicitlySelected
-              ? currentPath === "/"
-                ? "Deselect all"
-                : "Deselect folder"
-              : currentPath === "/"
-                ? "Select all"
-                : "Select folder"}
-        </Button>
-      ) : null}
-      {selectedItemCount > 0 ? (
-        <>
-          <span className="text-xs text-muted-foreground">
-            {selectedItemCount} selected
-          </span>
-          <Button
-            type="button"
-            variant="outline"
-            className="h-6 gap-1.5 px-2 text-xs"
-            onClick={() => setBulkPushOpen(true)}
-          >
-            <GitBranchIcon className="size-3.5" />
-            Push to GitHub
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-6 px-2 text-xs text-muted-foreground"
-            onClick={clearBulkPushSelection}
-          >
-            Clear
-          </Button>
-        </>
-      ) : null}
+      <span className="text-xs text-muted-foreground">
+        {selectedItemCount} selected
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-6 gap-1.5 px-2 text-xs"
+        onClick={() => setBulkPushOpen(true)}
+      >
+        <GitBranchIcon className="size-3.5" />
+        Push to GitHub
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        className="h-6 px-2 text-xs text-muted-foreground"
+        onClick={clearBulkPushSelection}
+      >
+        Clear
+      </Button>
     </div>
   ) : undefined
 
@@ -1476,6 +1540,10 @@ export function WorkflowsDashboard() {
             onPreviousPage={handlePreviousPage}
             onNextPage={handleNextPage}
             isPaginationLoading={isLoading}
+            selectableItemCount={gitSyncEnabled ? visibleItems.length : 0}
+            selectedCount={gitSyncEnabled ? visibleSelectedCount : 0}
+            onSelectAll={handleSelectAllVisible}
+            onDeselectAll={clearBulkPushSelection}
             selectionActions={selectionActions}
           />
 

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -9,6 +9,7 @@ import {
   Clock3,
   FlagTriangleRight,
   FolderIcon,
+  GitBranchIcon,
   HistoryIcon,
   WebhookIcon,
   WorkflowIcon,
@@ -38,6 +39,7 @@ import {
   WorkflowActions,
 } from "@/components/dashboard/table-actions"
 import { ActiveDialog } from "@/components/dashboard/table-common"
+import { WorkflowBulkPushDialog } from "@/components/dashboard/workflow-bulk-push-dialog"
 import { WorkflowMoveDialog } from "@/components/dashboard/workflow-move-dialog"
 import {
   DEFAULT_WORKFLOW_SORT,
@@ -50,6 +52,8 @@ import {
 } from "@/components/dashboard/workflows-header"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   ContextMenu,
   ContextMenuContent,
@@ -93,6 +97,42 @@ function normalizeFolderPath(rawPath: string | null): string {
   return withLeadingSlash.endsWith("/") && withLeadingSlash !== "/"
     ? withLeadingSlash.slice(0, -1)
     : withLeadingSlash
+}
+
+function isPathWithinFolder(path: string, folderPath: string): boolean {
+  const normalizedPath = normalizeFolderPath(path)
+  const normalizedFolderPath = normalizeFolderPath(folderPath)
+
+  if (normalizedFolderPath === "/") {
+    return true
+  }
+
+  return (
+    normalizedPath === normalizedFolderPath ||
+    normalizedPath.startsWith(`${normalizedFolderPath}/`)
+  )
+}
+
+function isFolderCoveredBySelection(
+  folderPath: string,
+  selectedFolderPaths: string[]
+): boolean {
+  const normalizedFolderPath = normalizeFolderPath(folderPath)
+  return selectedFolderPaths.some(
+    (selectedPath) =>
+      selectedPath !== normalizedFolderPath &&
+      isPathWithinFolder(normalizedFolderPath, selectedPath)
+  )
+}
+
+function isWorkflowCoveredBySelection(
+  folderPath: string | null | undefined,
+  selectedFolderPaths: string[]
+): boolean {
+  const normalizedFolderPath = normalizeFolderPath(folderPath ?? "/")
+  return selectedFolderPaths.some((selectedPath) =>
+    isPathWithinFolder(normalizedFolderPath, selectedPath)
+  )
 }
 
 function getRelativeDateLabel(dateValue: string): string {
@@ -782,6 +822,10 @@ function WorkflowsListRow({
   setSelectedFolder,
   setActiveDialog,
   availableTags,
+  showSelectionControl,
+  isSelected,
+  isSelectionDisabled,
+  onToggleSelection,
 }: {
   item: DirectoryItem
   onOpenWorkflow: (workflowId: string) => void
@@ -790,6 +834,10 @@ function WorkflowsListRow({
   setSelectedFolder: (folder: FolderDirectoryItem | null) => void
   setActiveDialog: (activeDialog: ActiveDialog | null) => void
   availableTags?: TagRead[]
+  showSelectionControl?: boolean
+  isSelected?: boolean
+  isSelectionDisabled?: boolean
+  onToggleSelection?: (checked: boolean) => void
 }) {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
 
@@ -803,6 +851,18 @@ function WorkflowsListRow({
               isContextMenuOpen && "bg-muted/70"
             )}
           >
+            {showSelectionControl ? (
+              <div className="flex shrink-0 items-center">
+                <Checkbox
+                  checked={isSelected}
+                  disabled={isSelectionDisabled}
+                  aria-label={`Select folder ${item.name}`}
+                  onCheckedChange={(checked) =>
+                    onToggleSelection?.(checked === true)
+                  }
+                />
+              </div>
+            ) : null}
             <button
               type="button"
               onClick={() => onOpenFolder(item.path)}
@@ -836,6 +896,18 @@ function WorkflowsListRow({
             isContextMenuOpen && "bg-muted/70"
           )}
         >
+          {showSelectionControl ? (
+            <div className="flex shrink-0 items-center">
+              <Checkbox
+                checked={isSelected}
+                disabled={isSelectionDisabled}
+                aria-label={`Select workflow ${item.title}`}
+                onCheckedChange={(checked) =>
+                  onToggleSelection?.(checked === true)
+                }
+              />
+            </div>
+          ) : null}
           <button
             type="button"
             onClick={() => onOpenWorkflow(item.id)}
@@ -873,6 +945,7 @@ export function WorkflowsDashboard() {
   const searchParams = useSearchParams()
   const { hasEntitlement } = useEntitlements()
   const caseAddonsEnabled = hasEntitlement("case_addons")
+  const gitSyncEnabled = hasEntitlement("git_sync")
 
   const view = parseWorkflowsViewMode(searchParams?.get("view"))
   const currentPath = normalizeFolderPath(searchParams?.get("path"))
@@ -893,10 +966,13 @@ export function WorkflowsDashboard() {
   const [listPage, setListPage] = useState(0)
 
   const [activeDialog, setActiveDialog] = useState<ActiveDialog | null>(null)
+  const [bulkPushOpen, setBulkPushOpen] = useState(false)
   const [selectedWorkflow, setSelectedWorkflow] =
     useState<WorkflowReadMinimal | null>(null)
   const [selectedFolder, setSelectedFolder] =
     useState<FolderDirectoryItem | null>(null)
+  const [selectedWorkflowIds, setSelectedWorkflowIds] = useState<string[]>([])
+  const [selectedFolderPaths, setSelectedFolderPaths] = useState<string[]>([])
 
   const { tags } = useWorkflowTags(workspaceId)
 
@@ -921,6 +997,20 @@ export function WorkflowsDashboard() {
     () => new Set(caseTriggerFilter),
     [caseTriggerFilter]
   )
+  const normalizedSelectedFolderPaths = useMemo(
+    () => selectedFolderPaths.map((path) => normalizeFolderPath(path)),
+    [selectedFolderPaths]
+  )
+  const selectedFolderPathSet = useMemo(
+    () => new Set(normalizedSelectedFolderPaths),
+    [normalizedSelectedFolderPaths]
+  )
+  const selectedWorkflowIdSet = useMemo(
+    () => new Set(selectedWorkflowIds),
+    [selectedWorkflowIds]
+  )
+  const selectedItemCount =
+    selectedWorkflowIds.length + normalizedSelectedFolderPaths.length
   const hasTriggerFiltersActive =
     webhookFilter !== "all" ||
     scheduleFilter !== "all" ||
@@ -978,6 +1068,13 @@ export function WorkflowsDashboard() {
     nextParams.set("path", normalizeFolderPath(path))
     router.push(buildRoute(nextParams))
   }
+
+  const handleOpenWorkflow = useCallback(
+    (workflowId: string) => {
+      router.push(`/workspaces/${workspaceId}/workflows/${workflowId}`)
+    },
+    [router, workspaceId]
+  )
 
   const matchesFilters = useCallback(
     (item: DirectoryItem): boolean => {
@@ -1087,6 +1184,20 @@ export function WorkflowsDashboard() {
   }, [caseAddonsEnabled, caseTriggerFilter])
 
   useEffect(() => {
+    if (!gitSyncEnabled) {
+      setBulkPushOpen(false)
+      setSelectedWorkflowIds([])
+      setSelectedFolderPaths([])
+    }
+  }, [gitSyncEnabled])
+
+  useEffect(() => {
+    if (bulkPushOpen && selectedItemCount === 0) {
+      setBulkPushOpen(false)
+    }
+  }, [bulkPushOpen, selectedItemCount])
+
+  useEffect(() => {
     setFolderPage(0)
     setListPage(0)
   }, [
@@ -1178,6 +1289,160 @@ export function WorkflowsDashboard() {
     })
   }
 
+  const handleToggleWorkflowSelection = useCallback(
+    (workflowId: string, checked: boolean) => {
+      setSelectedWorkflowIds((current) => {
+        const next = new Set(current)
+        if (checked) {
+          next.add(workflowId)
+        } else {
+          next.delete(workflowId)
+        }
+        return [...next]
+      })
+    },
+    []
+  )
+
+  const handleToggleFolderSelection = useCallback(
+    (folderPath: string, checked: boolean) => {
+      const normalizedPath = normalizeFolderPath(folderPath)
+      setSelectedFolderPaths((current) => {
+        const next = new Set(current.map((path) => normalizeFolderPath(path)))
+        if (checked) {
+          next.add(normalizedPath)
+        } else {
+          next.delete(normalizedPath)
+        }
+        return [...next]
+      })
+    },
+    []
+  )
+
+  const clearBulkPushSelection = useCallback(() => {
+    setSelectedWorkflowIds([])
+    setSelectedFolderPaths([])
+  }, [])
+
+  const isCurrentFolderExplicitlySelected =
+    view === "folders" && selectedFolderPathSet.has(currentPath)
+  const isCurrentFolderCoveredBySelection =
+    view === "folders" &&
+    isFolderCoveredBySelection(currentPath, normalizedSelectedFolderPaths)
+  const showCurrentFolderSelectionAction = gitSyncEnabled && view === "folders"
+  const hasSelectionActions =
+    showCurrentFolderSelectionAction || selectedItemCount > 0
+
+  const selectionActions = hasSelectionActions ? (
+    <div className="flex items-center gap-2">
+      {showCurrentFolderSelectionAction ? (
+        <Button
+          type="button"
+          variant="outline"
+          className="h-6 gap-1.5 px-2 text-xs"
+          onClick={() => {
+            if (isCurrentFolderExplicitlySelected) {
+              handleToggleFolderSelection(currentPath, false)
+              return
+            }
+            handleToggleFolderSelection(currentPath, true)
+          }}
+          disabled={isCurrentFolderCoveredBySelection}
+        >
+          <FolderIcon className="size-3.5" />
+          {isCurrentFolderCoveredBySelection
+            ? "Folder selected"
+            : isCurrentFolderExplicitlySelected
+              ? currentPath === "/"
+                ? "Deselect all"
+                : "Deselect folder"
+              : currentPath === "/"
+                ? "Select all"
+                : "Select folder"}
+        </Button>
+      ) : null}
+      {selectedItemCount > 0 ? (
+        <>
+          <span className="text-xs text-muted-foreground">
+            {selectedItemCount} selected
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-6 gap-1.5 px-2 text-xs"
+            onClick={() => setBulkPushOpen(true)}
+          >
+            <GitBranchIcon className="size-3.5" />
+            Push to GitHub
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-6 px-2 text-xs text-muted-foreground"
+            onClick={clearBulkPushSelection}
+          >
+            Clear
+          </Button>
+        </>
+      ) : null}
+    </div>
+  ) : undefined
+
+  const renderWorkflowRow = (item: DirectoryItem) => {
+    if (item.type === "folder") {
+      const normalizedPath = normalizeFolderPath(item.path)
+      const isExplicitlySelected = selectedFolderPathSet.has(normalizedPath)
+      const isCoveredBySelection = isFolderCoveredBySelection(
+        normalizedPath,
+        normalizedSelectedFolderPaths
+      )
+
+      return (
+        <WorkflowsListRow
+          key={`${item.type}-${item.id}`}
+          item={item}
+          availableTags={tags}
+          showSelectionControl={gitSyncEnabled}
+          isSelected={isExplicitlySelected || isCoveredBySelection}
+          isSelectionDisabled={isCoveredBySelection && !isExplicitlySelected}
+          onToggleSelection={(checked) =>
+            handleToggleFolderSelection(item.path, checked)
+          }
+          onOpenWorkflow={handleOpenWorkflow}
+          onOpenFolder={handleOpenFolder}
+          setSelectedWorkflow={setSelectedWorkflow}
+          setSelectedFolder={setSelectedFolder}
+          setActiveDialog={setActiveDialog}
+        />
+      )
+    }
+
+    const isCoveredBySelection = isWorkflowCoveredBySelection(
+      item.folder_path,
+      normalizedSelectedFolderPaths
+    )
+
+    return (
+      <WorkflowsListRow
+        key={`${item.type}-${item.id}`}
+        item={item}
+        availableTags={tags}
+        showSelectionControl={gitSyncEnabled}
+        isSelected={selectedWorkflowIdSet.has(item.id) || isCoveredBySelection}
+        isSelectionDisabled={isCoveredBySelection}
+        onToggleSelection={(checked) =>
+          handleToggleWorkflowSelection(item.id, checked)
+        }
+        onOpenWorkflow={handleOpenWorkflow}
+        onOpenFolder={handleOpenFolder}
+        setSelectedWorkflow={setSelectedWorkflow}
+        setSelectedFolder={setSelectedFolder}
+        setActiveDialog={setActiveDialog}
+      />
+    )
+  }
+
   return (
     <DeleteWorkflowAlertDialog
       selectedWorkflow={selectedWorkflow}
@@ -1211,6 +1476,7 @@ export function WorkflowsDashboard() {
             onPreviousPage={handlePreviousPage}
             onNextPage={handleNextPage}
             isPaginationLoading={isLoading}
+            selectionActions={selectionActions}
           />
 
           <div className="min-h-0 flex-1 overflow-auto">
@@ -1237,22 +1503,7 @@ export function WorkflowsDashboard() {
               </div>
             ) : (
               <div className="divide-y">
-                {visibleItems.map((item) => (
-                  <WorkflowsListRow
-                    key={`${item.type}-${item.id}`}
-                    item={item}
-                    availableTags={tags}
-                    onOpenWorkflow={(workflowId) => {
-                      router.push(
-                        `/workspaces/${workspaceId}/workflows/${workflowId}`
-                      )
-                    }}
-                    onOpenFolder={handleOpenFolder}
-                    setSelectedWorkflow={setSelectedWorkflow}
-                    setSelectedFolder={setSelectedFolder}
-                    setActiveDialog={setActiveDialog}
-                  />
-                ))}
+                {visibleItems.map(renderWorkflowRow)}
               </div>
             )}
           </div>
@@ -1282,6 +1533,14 @@ export function WorkflowsDashboard() {
         onOpenChange={() => setActiveDialog(null)}
         selectedFolder={selectedFolder}
         setSelectedFolder={setSelectedFolder}
+      />
+      <WorkflowBulkPushDialog
+        open={bulkPushOpen}
+        onOpenChange={setBulkPushOpen}
+        workspaceId={workspaceId}
+        selectedWorkflowIds={selectedWorkflowIds}
+        selectedFolderPaths={selectedFolderPaths}
+        onSuccess={clearBulkPushSelection}
       />
     </DeleteWorkflowAlertDialog>
   )

--- a/frontend/src/components/dashboard/workflows-header.tsx
+++ b/frontend/src/components/dashboard/workflows-header.tsx
@@ -492,6 +492,7 @@ interface WorkflowsHeaderProps {
   onPreviousPage: () => void
   onNextPage: () => void
   isPaginationLoading?: boolean
+  selectionActions?: ReactNode
 }
 
 export function WorkflowsHeader({
@@ -520,6 +521,7 @@ export function WorkflowsHeader({
   onPreviousPage,
   onNextPage,
   isPaginationLoading = false,
+  selectionActions,
 }: WorkflowsHeaderProps) {
   const hasFilters =
     searchQuery.trim().length > 0 ||
@@ -671,7 +673,8 @@ export function WorkflowsHeader({
           </button>
         )}
 
-        <div className="ml-auto flex items-center">
+        <div className="ml-auto flex items-center gap-2">
+          {selectionActions}
           <Select
             value={`${limit}`}
             onValueChange={(value) => onLimitChange(Number(value))}

--- a/frontend/src/components/dashboard/workflows-header.tsx
+++ b/frontend/src/components/dashboard/workflows-header.tsx
@@ -492,6 +492,10 @@ interface WorkflowsHeaderProps {
   onPreviousPage: () => void
   onNextPage: () => void
   isPaginationLoading?: boolean
+  selectableItemCount?: number
+  selectedCount?: number
+  onSelectAll?: () => void
+  onDeselectAll?: () => void
   selectionActions?: ReactNode
 }
 
@@ -521,6 +525,10 @@ export function WorkflowsHeader({
   onPreviousPage,
   onNextPage,
   isPaginationLoading = false,
+  selectableItemCount = 0,
+  selectedCount = 0,
+  onSelectAll,
+  onDeselectAll,
   selectionActions,
 }: WorkflowsHeaderProps) {
   const hasFilters =
@@ -609,7 +617,42 @@ export function WorkflowsHeader({
         </div>
       </header>
 
-      <div className="flex flex-wrap items-center gap-2 px-4 py-2">
+      <div className="flex flex-wrap items-center gap-2 py-2 pl-3 pr-4">
+        {selectableItemCount > 0 && (
+          <button
+            type="button"
+            onClick={
+              selectedCount === selectableItemCount
+                ? onDeselectAll
+                : onSelectAll
+            }
+            className="flex h-7 w-7 shrink-0 items-center justify-center"
+            aria-label={
+              selectedCount === selectableItemCount
+                ? "Deselect all"
+                : "Select all"
+            }
+            title={
+              selectedCount === selectableItemCount
+                ? "Deselect all"
+                : "Select all"
+            }
+          >
+            <div
+              className={cn(
+                "flex size-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
+                selectedCount === selectableItemCount
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-muted-foreground/40 bg-transparent"
+              )}
+            >
+              {selectedCount === selectableItemCount && (
+                <Check className="size-3" aria-hidden />
+              )}
+            </div>
+          </button>
+        )}
+
         <Select
           value={view}
           onValueChange={(nextView) =>

--- a/frontend/src/providers/workflow.tsx
+++ b/frontend/src/providers/workflow.tsx
@@ -236,6 +236,8 @@ export function WorkflowProvider({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["directory-items"] })
     },
     onError: (error: TracecatApiError) => {
       console.error("Failed to update workflow:", error)

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -1,6 +1,7 @@
 """HTTP-level tests for workflow publish API endpoint."""
 
 import uuid
+from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -11,7 +12,16 @@ from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
 from tracecat.registry.repositories.schemas import GitBranchInfo
 from tracecat.vcs.github.app import GitHubAppError
-from tracecat.workflow.store.schemas import WorkflowDslPublishResult
+from tracecat.workflow.store.schemas import (
+    WorkflowBulkPushExcludedWorkflow,
+    WorkflowBulkPushExclusionReason,
+    WorkflowBulkPushPreviewResponse,
+    WorkflowBulkPushResult,
+    WorkflowBulkPushWorkflowResult,
+    WorkflowBulkPushWorkflowStatus,
+    WorkflowBulkPushWorkflowSummary,
+    WorkflowDslPublishResult,
+)
 
 
 def _sample_dsl_content() -> dict[str, object]:
@@ -176,6 +186,138 @@ async def test_publish_workflow_invalid_create_pr_type_returns_422(
     )
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+@pytest.mark.anyio
+async def test_preview_bulk_push_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push/preview returns preview data."""
+    with patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls:
+        mock_store_svc = AsyncMock()
+        mock_store_svc.preview_bulk_push.return_value = WorkflowBulkPushPreviewResponse(
+            eligible_workflows=[
+                WorkflowBulkPushWorkflowSummary(
+                    workflow_id="wf_123abc",
+                    title="Workflow 1",
+                    alias="workflow-1",
+                    folder_path="/security",
+                    latest_definition_version=3,
+                    latest_definition_created_at=datetime(2026, 3, 6, 12, 0, 0),
+                )
+            ],
+            excluded_workflows=[
+                WorkflowBulkPushExcludedWorkflow(
+                    workflow_id="wf_missing",
+                    title="Missing workflow",
+                    reason=WorkflowBulkPushExclusionReason.NOT_PUBLISHED,
+                    message="Workflow has not been published yet",
+                )
+            ],
+            resolved_workflow_ids=["wf_123abc"],
+            branch="tracecat/bulk-push-20260306-120000",
+            commit_message="Push workflows to GitHub",
+            pr_title="Push workflows to GitHub",
+            pr_body="Bulk push preview",
+            can_submit=True,
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            "/workflows/push/preview",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "workflow_ids": ["wf_123abc"],
+                "folder_paths": ["/security"],
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["branch"] == "tracecat/bulk-push-20260306-120000"
+    assert payload["commit_message"] == "Push workflows to GitHub"
+    assert payload["pr_title"] == "Push workflows to GitHub"
+    assert payload["can_submit"] is True
+    assert payload["resolved_workflow_ids"] == ["wf_123abc"]
+    assert payload["eligible_workflows"][0]["workflow_id"] == "wf_123abc"
+    assert payload["excluded_workflows"][0]["reason"] == "not_published"
+
+    called_params = mock_store_svc.preview_bulk_push.call_args.args[0]
+    assert called_params.workflow_ids == ["wf_123abc"]
+    assert called_params.folder_paths == ["/security"]
+
+
+@pytest.mark.anyio
+async def test_bulk_push_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push returns structured bulk push result."""
+    with patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls:
+        mock_store_svc = AsyncMock()
+        mock_store_svc.bulk_push.return_value = WorkflowBulkPushResult(
+            status="committed",
+            commit_sha="abc123",
+            branch="feature/bulk-push",
+            base_branch="main",
+            pr_url="https://github.com/test-org/test-repo/pull/456",
+            pr_number=456,
+            pr_reused=False,
+            message="Committed changes for 2 workflow file(s).",
+            selected_count=2,
+            eligible_count=2,
+            excluded_count=0,
+            workflow_results=[
+                WorkflowBulkPushWorkflowResult(
+                    workflow_id="wf_123abc",
+                    title="Workflow 1",
+                    path="workflows/wf_123abc/definition.yml",
+                    status=WorkflowBulkPushWorkflowStatus.COMMITTED,
+                    message="Committed",
+                ),
+                WorkflowBulkPushWorkflowResult(
+                    workflow_id="wf_456def",
+                    title="Workflow 2",
+                    path="workflows/wf_456def/definition.yml",
+                    status=WorkflowBulkPushWorkflowStatus.NO_OP,
+                    message="Already up to date",
+                ),
+            ],
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            "/workflows/push",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "workflow_ids": ["wf_123abc", "wf_456def"],
+                "branch": "feature/bulk-push",
+                "commit_message": "Push workflows to GitHub",
+                "pr_title": "Push workflows to GitHub",
+                "pr_body": "Bulk push body",
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["status"] == "committed"
+    assert payload["commit_sha"] == "abc123"
+    assert payload["branch"] == "feature/bulk-push"
+    assert payload["base_branch"] == "main"
+    assert payload["pr_number"] == 456
+    assert payload["selected_count"] == 2
+    assert payload["eligible_count"] == 2
+    assert payload["excluded_count"] == 0
+    assert payload["workflow_results"][0]["workflow_id"] == "wf_123abc"
+    assert payload["workflow_results"][1]["status"] == "no_op"
+
+    called_params = mock_store_svc.bulk_push.call_args.args[0]
+    assert called_params.workflow_ids == ["wf_123abc", "wf_456def"]
+    assert called_params.branch == "feature/bulk-push"
+    assert called_params.commit_message == "Push workflows to GitHub"
+    assert called_params.pr_title == "Push workflows to GitHub"
+    assert called_params.pr_body == "Bulk push body"
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -249,6 +249,24 @@ async def test_preview_bulk_push_success(
 
 
 @pytest.mark.anyio
+async def test_preview_bulk_push_invalid_folder_paths_type_returns_422(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push/preview rejects non-list folder_paths."""
+    response = client.post(
+        "/workflows/push/preview",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={
+            "workflow_ids": ["wf_123abc"],
+            "folder_paths": "/security",
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+@pytest.mark.anyio
 async def test_bulk_push_success(
     client: TestClient,
     test_admin_role: Role,
@@ -318,6 +336,27 @@ async def test_bulk_push_success(
     assert called_params.commit_message == "Push workflows to GitHub"
     assert called_params.pr_title == "Push workflows to GitHub"
     assert called_params.pr_body == "Bulk push body"
+
+
+@pytest.mark.anyio
+async def test_bulk_push_whitespace_required_fields_return_422(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push rejects whitespace-only required text fields."""
+    response = client.post(
+        "/workflows/push",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={
+            "workflow_ids": ["wf_123abc"],
+            "branch": "feature/bulk-push",
+            "commit_message": "   ",
+            "pr_title": "   ",
+            "pr_body": "body",
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_workflow_store_service.py
+++ b/tests/unit/test_workflow_store_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import datetime
 from types import SimpleNamespace
@@ -13,10 +14,12 @@ from sqlalchemy.dialects import postgresql
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.store.schemas import (
     WorkflowBulkPushExclusionReason,
     WorkflowBulkPushPreviewRequest,
+    WorkflowBulkPushWorkflowSummary,
 )
 from tracecat.workflow.store.service import WorkflowStoreService
 
@@ -136,3 +139,58 @@ def test_bulk_push_preview_request_rejects_non_list_folder_paths() -> None:
                 "folder_paths": "/security",
             }
         )
+
+
+def test_to_workflow_uuids_rejects_invalid_short_ids(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Malformed short IDs should be translated into a validation error."""
+    with patch(
+        "tracecat.workflow.store.service.WorkflowUUID.new",
+        side_effect=ValueError("bad workflow id"),
+    ):
+        with pytest.raises(
+            TracecatValidationError,
+            match="workflow_ids contains an invalid workflow ID",
+        ):
+            workflow_store_service._to_workflow_uuids(["wf_badbadbad"])
+
+
+def test_build_bulk_push_defaults_adds_entropy_to_branch_names(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Default bulk branch names should not collide within the same timestamp."""
+    eligible_workflows = [
+        WorkflowBulkPushWorkflowSummary(
+            workflow_id="wf_123abc",
+            title="Workflow 1",
+            alias="workflow-1",
+            folder_path="/security",
+            latest_definition_version=3,
+            latest_definition_created_at=datetime(2026, 3, 6, 12, 0, 0),
+        )
+    ]
+
+    with (
+        patch("tracecat.workflow.store.service.datetime") as mock_datetime,
+        patch("tracecat.workflow.store.service.uuid4") as mock_uuid4,
+    ):
+        mock_datetime.now.return_value.strftime.return_value = "20260306-120000-123456"
+        mock_uuid4.side_effect = [
+            SimpleNamespace(hex="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            SimpleNamespace(hex="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        ]
+
+        first_branch, *_ = workflow_store_service._build_bulk_push_defaults(
+            workspace_name="Test workspace",
+            eligible_workflows=eligible_workflows,
+        )
+        second_branch, *_ = workflow_store_service._build_bulk_push_defaults(
+            workspace_name="Test workspace",
+            eligible_workflows=eligible_workflows,
+        )
+
+    assert first_branch == "tracecat/bulk-push-20260306-120000-123456-aaaaaaaa"
+    assert second_branch == "tracecat/bulk-push-20260306-120000-123456-bbbbbbbb"
+    assert first_branch != second_branch
+    assert re.match(r"^tracecat/bulk-push-\d{8}-\d{6}-\d{6}-[0-9a-f]{8}$", first_branch)

--- a/tests/unit/test_workflow_store_service.py
+++ b/tests/unit/test_workflow_store_service.py
@@ -1,0 +1,138 @@
+"""Unit tests for WorkflowStoreService bulk push behavior."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
+
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.store.schemas import (
+    WorkflowBulkPushExclusionReason,
+    WorkflowBulkPushPreviewRequest,
+)
+from tracecat.workflow.store.service import WorkflowStoreService
+
+
+def _sample_dsl_content() -> dict[str, object]:
+    return {
+        "title": "Test workflow",
+        "description": "A test workflow",
+        "entrypoint": {"ref": "start", "expects": {}},
+        "actions": [
+            {
+                "ref": "start",
+                "action": "core.transform.passthrough",
+                "args": {"value": "test"},
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def workflow_store_service() -> WorkflowStoreService:
+    workspace_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+    organization_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440001")
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-api"],
+    )
+    return WorkflowStoreService(session=AsyncMock(), role=role)
+
+
+@pytest.mark.anyio
+async def test_resolve_bulk_push_selection_excludes_invalid_configuration(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Bulk preview should exclude workflows that fail remote export validation."""
+    workflow_id = WorkflowUUID.new(uuid.uuid4())
+    workflow = SimpleNamespace(
+        title="Broken workflow",
+        alias="broken-workflow",
+        webhook=None,
+        folder=None,
+        tags=[],
+        schedules=[],
+        case_trigger=None,
+    )
+    definition = SimpleNamespace(
+        content=_sample_dsl_content(),
+        version=3,
+        created_at=datetime(2026, 3, 6, 12, 0, 0),
+    )
+
+    with (
+        patch.object(
+            workflow_store_service,
+            "_get_workflows_by_short_id",
+            AsyncMock(return_value={workflow_id.short(): workflow}),
+        ),
+        patch.object(
+            workflow_store_service,
+            "_get_latest_definitions_by_short_id",
+            AsyncMock(return_value={workflow_id.short(): definition}),
+        ),
+    ):
+        resolution = await workflow_store_service._resolve_bulk_push_selection(
+            workflow_ids=[workflow_id],
+            folder_paths=[],
+        )
+
+    assert resolution.prepared_items == []
+    assert resolution.eligible_workflows == []
+    assert resolution.resolved_workflow_ids == [workflow_id.short()]
+    assert len(resolution.excluded_workflows) == 1
+    assert (
+        resolution.excluded_workflows[0].reason
+        == WorkflowBulkPushExclusionReason.INVALID_CONFIGURATION
+    )
+    assert workflow_id.short() in resolution.excluded_workflows[0].message
+
+
+@pytest.mark.anyio
+async def test_list_workflow_ids_in_selected_folders_autoescapes_like_wildcards(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Folder selection SQL should escape wildcard characters in user paths."""
+    result = Mock()
+    result.scalars.return_value.all.return_value = []
+    with patch.object(
+        workflow_store_service.session,
+        "execute",
+        AsyncMock(return_value=result),
+    ) as mock_execute:
+        await workflow_store_service._list_workflow_ids_in_selected_folders(
+            ["/sec_ur/%ops"]
+        )
+
+    statement = mock_execute.call_args.args[0]
+    compiled = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+    assert "ESCAPE '/'" in compiled
+    assert "LIKE" in compiled
+
+
+def test_bulk_push_preview_request_rejects_non_list_folder_paths() -> None:
+    """Schema should reject malformed folder_paths values before normalization."""
+    with pytest.raises(ValidationError, match="folder_paths must be a list of strings"):
+        WorkflowBulkPushPreviewRequest.model_validate(
+            {
+                "workflow_ids": ["wf_123abc"],
+                "folder_paths": "/security",
+            }
+        )

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -105,6 +105,88 @@ def workflow_import_service(workspace_id, organization_id):
     return WorkflowImportService(session=mock_session, role=role)
 
 
+async def _mock_to_thread(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def _tree_element_path(tree_element: object) -> str:
+    return vars(tree_element)["_InputGitTreeElement__path"]
+
+
+def _create_target_branch_repo(
+    *,
+    branch_name: str,
+    base_branch_name: str = "main",
+    default_branch: str = "main",
+    branch_exists: bool = True,
+    existing_file_contents: dict[str, str] | None = None,
+    base_commit_sha: str = "base123",
+    branch_head_sha: str = "branch-head123",
+    parent_commit_sha: str = "parent123",
+    new_commit_sha: str = "new-commit123",
+) -> tuple[Mock, Mock, Mock, Mock]:
+    mock_repo = Mock()
+    mock_repo.default_branch = default_branch
+
+    base_branch = Mock()
+    base_branch.commit.sha = base_commit_sha
+
+    target_branch = Mock()
+    target_branch.commit.sha = branch_head_sha
+
+    def get_branch(name: str):
+        if name == base_branch_name:
+            return base_branch
+        if name == branch_name:
+            if not branch_exists:
+                raise GithubException(404, {"message": "Not Found"}, {})
+            return target_branch
+        raise AssertionError(f"Unexpected branch lookup: {name}")
+
+    mock_repo.get_branch.side_effect = get_branch
+
+    encoded_contents = {
+        path: base64.b64encode(content.encode("utf-8")).decode("utf-8")
+        for path, content in (existing_file_contents or {}).items()
+    }
+
+    def get_contents(path: str, ref: str):
+        assert ref == branch_name
+        if path not in encoded_contents:
+            raise GithubException(404, {"message": "Not Found"}, {})
+        content_file = Mock()
+        content_file.path = path
+        content_file.sha = f"sha-{path}"
+        content_file.content = encoded_contents[path]
+        return content_file
+
+    mock_repo.get_contents.side_effect = get_contents
+
+    branch_ref = Mock()
+    branch_ref.object.sha = parent_commit_sha
+    branch_ref.edit = Mock()
+
+    parent_commit = Mock()
+    parent_commit.sha = parent_commit_sha
+    parent_commit.tree = Mock()
+
+    new_tree = Mock()
+    new_tree.sha = "tree123"
+
+    new_commit = Mock()
+    new_commit.sha = new_commit_sha
+
+    mock_repo.get_git_ref.return_value = branch_ref
+    mock_repo.get_git_commit.return_value = parent_commit
+    mock_repo.create_git_tree.return_value = new_tree
+    mock_repo.create_git_commit.return_value = new_commit
+    mock_repo.create_git_ref = Mock()
+    mock_repo.get_pulls.return_value = []
+    mock_repo.create_pull = Mock()
+
+    return mock_repo, branch_ref, parent_commit, new_commit
+
+
 class TestWorkflowSyncService:
     """Tests for WorkflowSyncService."""
 
@@ -318,7 +400,7 @@ class TestWorkflowSyncService:
         options = PushOptions(message="Update workflows", author=author)
 
         with pytest.raises(
-            ValueError, match="We only support pushing one workflow object at a time"
+            ValueError, match="At least one workflow object is required"
         ):
             await workflow_sync_service.push(objects=[], url=git_url, options=options)
 
@@ -329,7 +411,7 @@ class TestWorkflowSyncService:
         options = PushOptions(message="Update workflows", author=author)
 
         with pytest.raises(
-            ValueError, match="We only support pushing one workflow object at a time"
+            ValueError, match="At least one workflow object is required"
         ):
             await workflow_sync_service.push(objects=[], url=git_url, options=options)
 
@@ -449,20 +531,11 @@ class TestWorkflowSyncService:
             branch="feature/shared-workflow",
         )
 
-        mock_repo = Mock()
-        base_branch = Mock()
-        base_branch.commit.sha = "base123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-        mock_repo.get_branch.side_effect = lambda name: (
-            base_branch if name == "main" else target_branch
+        mock_repo, branch_ref, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
         )
-        mock_repo.get_contents.side_effect = GithubException(
-            404, {"message": "Not Found"}, {}
-        )
-        mock_repo.create_file = Mock()
-        mock_repo.create_git_ref = Mock()
 
         mock_github_client = Mock()
         mock_github_client.get_repo.return_value = mock_repo
@@ -480,24 +553,36 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
             )
 
             assert result.status == PushStatus.COMMITTED
-            assert result.sha == "target123"
+            assert result.sha == new_commit.sha
             assert result.ref == "feature/shared-workflow"
             assert result.base_ref == "main"
             assert result.pr_url is None
             assert result.pr_number is None
             assert result.pr_reused is False
+            assert result.object_results is not None
             mock_repo.create_git_ref.assert_not_called()
-            mock_repo.create_file.assert_called_once()
+            mock_repo.get_git_ref.assert_called_once_with(
+                "heads/feature/shared-workflow"
+            )
+            mock_repo.create_git_tree.assert_called_once()
+            mock_repo.create_git_commit.assert_called_once()
+            branch_ref.edit.assert_called_once_with(new_commit.sha)
+
+            object_results = result.object_results or []
+            assert len(object_results) == 1
+            assert object_results[0].path == "workflows/test-workflow.yml"
+            assert object_results[0].status == PushStatus.COMMITTED
+
+            tree_elements = mock_repo.create_git_tree.call_args.args[0]
+            assert len(tree_elements) == 1
+            assert _tree_element_path(tree_elements[0]) == "workflows/test-workflow.yml"
 
     @pytest.mark.anyio
     async def test_push_target_branch_creates_missing_branch_from_base(
@@ -515,32 +600,12 @@ class TestWorkflowSyncService:
             branch="feature/new-workflow",
         )
 
-        mock_repo = Mock()
-        base_branch = Mock()
-        base_branch.commit.sha = "base123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-
-        target_branch_lookup_count = 0
-
-        def get_branch(name: str):
-            nonlocal target_branch_lookup_count
-            if name == "main":
-                return base_branch
-            if name == "feature/new-workflow":
-                target_branch_lookup_count += 1
-                if target_branch_lookup_count == 1:
-                    raise GithubException(404, {"message": "Not Found"}, {})
-                return target_branch
-            raise AssertionError(f"Unexpected branch lookup: {name}")
-
-        mock_repo.get_branch.side_effect = get_branch
-        mock_repo.get_contents.side_effect = GithubException(
-            404, {"message": "Not Found"}, {}
+        mock_repo, branch_ref, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/new-workflow",
+            branch_exists=False,
+            existing_file_contents={},
+            new_commit_sha="target123",
         )
-        mock_repo.create_file = Mock()
-        mock_repo.create_git_ref = Mock()
 
         mock_github_client = Mock()
         mock_github_client.get_repo.return_value = mock_repo
@@ -558,22 +623,22 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
             )
 
             assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
             assert result.ref == "feature/new-workflow"
             assert result.base_ref == "main"
             mock_repo.create_git_ref.assert_called_once_with(
                 ref="refs/heads/feature/new-workflow",
                 sha="base123",
             )
+            mock_repo.create_git_tree.assert_called_once()
+            branch_ref.edit.assert_called_once_with(new_commit.sha)
 
     @pytest.mark.anyio
     async def test_push_target_branch_defaults_base_to_url_ref(
@@ -594,26 +659,13 @@ class TestWorkflowSyncService:
             host="github.com", org="test-org", repo="test-repo", ref="release"
         )
 
-        mock_repo = Mock()
-        release_branch = Mock()
-        release_branch.commit.sha = "release123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-
-        def get_branch(name: str):
-            if name == "release":
-                return release_branch
-            if name == "feature/new-workflow":
-                return target_branch
-            raise AssertionError(f"Unexpected branch lookup: {name}")
-
-        mock_repo.get_branch.side_effect = get_branch
-        mock_repo.get_contents.side_effect = GithubException(
-            404, {"message": "Not Found"}, {}
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/new-workflow",
+            base_branch_name="release",
+            existing_file_contents={},
+            base_commit_sha="release123",
+            new_commit_sha="target123",
         )
-        mock_repo.create_file = Mock()
-        mock_repo.create_git_ref = Mock()
 
         mock_github_client = Mock()
         mock_github_client.get_repo.return_value = mock_repo
@@ -631,16 +683,14 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
             )
 
             assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
             assert result.base_ref == "release"
             mock_repo.create_git_ref.assert_not_called()
 
@@ -667,25 +717,12 @@ class TestWorkflowSyncService:
             sort_keys=False,
         )
 
-        mock_repo = Mock()
-        base_branch = Mock()
-        base_branch.commit.sha = "base123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-        mock_repo.get_branch.side_effect = lambda name: (
-            base_branch if name == "main" else target_branch
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={
+                "workflows/test-workflow.yml": expected_yaml,
+            },
         )
-
-        mock_contents = Mock()
-        mock_contents.path = "workflows/test-workflow.yml"
-        mock_contents.sha = "file123"
-        mock_contents.content = base64.b64encode(expected_yaml.encode("utf-8")).decode(
-            "utf-8"
-        )
-        mock_repo.get_contents.return_value = mock_contents
-        mock_repo.update_file = Mock()
-        mock_repo.create_file = Mock()
 
         mock_github_client = Mock()
         mock_github_client.get_repo.return_value = mock_repo
@@ -703,10 +740,7 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
@@ -716,8 +750,13 @@ class TestWorkflowSyncService:
             assert result.sha is None
             assert result.ref == "feature/shared-workflow"
             assert result.base_ref == "main"
-            mock_repo.update_file.assert_not_called()
-            mock_repo.create_file.assert_not_called()
+            assert result.object_results is not None
+            assert len(result.object_results) == 1
+            assert result.object_results[0].status == PushStatus.NO_OP
+            mock_repo.get_git_ref.assert_not_called()
+            mock_repo.get_git_commit.assert_not_called()
+            mock_repo.create_git_tree.assert_not_called()
+            mock_repo.create_git_commit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_push_empty_branch_still_uses_target_branch_mode(
@@ -764,10 +803,7 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
@@ -793,19 +829,11 @@ class TestWorkflowSyncService:
             branch="feature/shared-workflow",
         )
 
-        mock_repo = Mock()
-        base_branch = Mock()
-        base_branch.commit.sha = "base123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-        mock_repo.get_branch.side_effect = lambda name: (
-            base_branch if name == "main" else target_branch
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
         )
-        mock_repo.get_contents.side_effect = GithubException(
-            404, {"message": "Not Found"}, {}
-        )
-        mock_repo.create_file = Mock()
 
         mock_github_client = Mock()
         mock_github_client.get_repo.return_value = mock_repo
@@ -832,22 +860,20 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
             )
 
             assert result.status == PushStatus.COMMITTED
-            assert result.sha == "target123"
+            assert result.sha == new_commit.sha
             assert result.pr_url is None
             assert result.pr_number is None
             assert result.pr_reused is False
             mock_upsert_pr.assert_awaited_once()
-            mock_repo.create_file.assert_called_once()
+            mock_repo.create_git_tree.assert_called_once()
+            mock_repo.create_git_commit.assert_called_once()
 
     @pytest.mark.anyio
     async def test_push_target_branch_noop_pr_failure_returns_no_op_result(
@@ -872,25 +898,12 @@ class TestWorkflowSyncService:
             sort_keys=False,
         )
 
-        mock_repo = Mock()
-        base_branch = Mock()
-        base_branch.commit.sha = "base123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-        mock_repo.get_branch.side_effect = lambda name: (
-            base_branch if name == "main" else target_branch
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={
+                "workflows/test-workflow.yml": expected_yaml,
+            },
         )
-
-        mock_contents = Mock()
-        mock_contents.path = "workflows/test-workflow.yml"
-        mock_contents.sha = "file123"
-        mock_contents.content = base64.b64encode(expected_yaml.encode("utf-8")).decode(
-            "utf-8"
-        )
-        mock_repo.get_contents.return_value = mock_contents
-        mock_repo.update_file = Mock()
-        mock_repo.create_file = Mock()
 
         mock_github_client = Mock()
         mock_github_client.get_repo.return_value = mock_repo
@@ -917,10 +930,7 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
@@ -932,8 +942,10 @@ class TestWorkflowSyncService:
             assert result.pr_number is None
             assert result.pr_reused is False
             mock_upsert_pr.assert_awaited_once()
-            mock_repo.update_file.assert_not_called()
-            mock_repo.create_file.assert_not_called()
+            mock_repo.get_git_ref.assert_not_called()
+            mock_repo.get_git_commit.assert_not_called()
+            mock_repo.create_git_tree.assert_not_called()
+            mock_repo.create_git_commit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_push_target_branch_create_pr_creates_new_pull_request(
@@ -951,20 +963,11 @@ class TestWorkflowSyncService:
             branch="feature/shared-workflow",
         )
 
-        mock_repo = Mock()
-        base_branch = Mock()
-        base_branch.commit.sha = "base123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-        mock_repo.get_branch.side_effect = lambda name: (
-            base_branch if name == "main" else target_branch
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
         )
-        mock_repo.get_contents.side_effect = GithubException(
-            404, {"message": "Not Found"}, {}
-        )
-        mock_repo.get_pulls.return_value = []
-        mock_repo.create_file = Mock()
 
         mock_pr = Mock()
         mock_pr.number = 456
@@ -996,16 +999,14 @@ class TestWorkflowSyncService:
             mock_ws_service.get_workspace.return_value = mock_workspace
             mock_ws_service_class.return_value = mock_ws_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
             )
 
             assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
             assert result.pr_reused is False
             assert result.pr_number == 456
             assert result.pr_url == "https://github.com/test-org/test-repo/pull/456"
@@ -1027,19 +1028,11 @@ class TestWorkflowSyncService:
             branch="feature/shared-workflow",
         )
 
-        mock_repo = Mock()
-        base_branch = Mock()
-        base_branch.commit.sha = "base123"
-        target_branch = Mock()
-        target_branch.commit.sha = "target123"
-        mock_repo.default_branch = "main"
-        mock_repo.get_branch.side_effect = lambda name: (
-            base_branch if name == "main" else target_branch
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
         )
-        mock_repo.get_contents.side_effect = GithubException(
-            404, {"message": "Not Found"}, {}
-        )
-        mock_repo.create_file = Mock()
 
         existing_pr = Mock()
         existing_pr.number = 789
@@ -1063,20 +1056,177 @@ class TestWorkflowSyncService:
             )
             mock_gh_service_class.return_value = mock_gh_service
 
-            async def mock_to_thread_impl(func, *args, **kwargs):
-                return func(*args, **kwargs)
-
-            mock_to_thread.side_effect = mock_to_thread_impl
+            mock_to_thread.side_effect = _mock_to_thread
 
             result = await workflow_sync_service.push(
                 objects=[push_obj], url=git_url, options=options
             )
 
             assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
             assert result.pr_reused is True
             assert result.pr_number == 789
             assert result.pr_url == "https://github.com/test-org/test-repo/pull/789"
             mock_repo.create_pull.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_multiple_objects_uses_single_commit(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode batches multiple workflow files into one commit."""
+        second_workflow = RemoteWorkflowDefinition(
+            id="wf_456def",
+            alias="another-workflow",
+            definition=sample_remote_workflow.definition.model_copy(
+                update={"title": "Another workflow"}
+            ),
+        )
+        push_objects = [
+            PushObject(
+                data=sample_remote_workflow, path="workflows/wf_123abc/definition.yml"
+            ),
+            PushObject(data=second_workflow, path="workflows/wf_456def/definition.yml"),
+        ]
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Push multiple workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/bulk-push",
+        )
+
+        mock_repo, branch_ref, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/bulk-push",
+            existing_file_contents={},
+            new_commit_sha="bulk-commit123",
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=push_objects, url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.message == "Committed changes for 2 workflow file(s)."
+            assert result.object_results is not None
+            assert [
+                object_result.status for object_result in result.object_results
+            ] == [
+                PushStatus.COMMITTED,
+                PushStatus.COMMITTED,
+            ]
+
+            mock_repo.get_git_ref.assert_called_once_with("heads/feature/bulk-push")
+            mock_repo.create_git_tree.assert_called_once()
+            mock_repo.create_git_commit.assert_called_once()
+            branch_ref.edit.assert_called_once_with(new_commit.sha)
+
+            tree_elements = mock_repo.create_git_tree.call_args.args[0]
+            assert len(tree_elements) == 2
+            assert {_tree_element_path(element) for element in tree_elements} == {
+                "workflows/wf_123abc/definition.yml",
+                "workflows/wf_456def/definition.yml",
+            }
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_multiple_objects_returns_no_op_when_unchanged(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode skips commit creation when all workflow files match."""
+        second_workflow = RemoteWorkflowDefinition(
+            id="wf_456def",
+            alias="another-workflow",
+            definition=sample_remote_workflow.definition.model_copy(
+                update={"title": "Another workflow"}
+            ),
+        )
+        push_objects = [
+            PushObject(
+                data=sample_remote_workflow, path="workflows/wf_123abc/definition.yml"
+            ),
+            PushObject(data=second_workflow, path="workflows/wf_456def/definition.yml"),
+        ]
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Push multiple workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/bulk-push",
+        )
+
+        first_yaml = yaml.dump(
+            sample_remote_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+        second_yaml = yaml.dump(
+            second_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/bulk-push",
+            existing_file_contents={
+                "workflows/wf_123abc/definition.yml": first_yaml,
+                "workflows/wf_456def/definition.yml": second_yaml,
+            },
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=push_objects, url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.NO_OP
+            assert result.sha is None
+            assert result.message == "No changes detected; nothing to commit."
+            assert result.object_results is not None
+            assert [
+                object_result.status for object_result in result.object_results
+            ] == [
+                PushStatus.NO_OP,
+                PushStatus.NO_OP,
+            ]
+            mock_repo.get_git_ref.assert_not_called()
+            mock_repo.get_git_commit.assert_not_called()
+            mock_repo.create_git_tree.assert_not_called()
+            mock_repo.create_git_commit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_list_branches_success(self, workflow_sync_service, git_url):

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -2,7 +2,7 @@
 
 import base64
 import uuid
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 import yaml
@@ -152,7 +152,6 @@ def _create_target_branch_repo(
     }
 
     def get_contents(path: str, ref: str):
-        assert ref == branch_name
         if path not in encoded_contents:
             raise GithubException(404, {"message": "Not Found"}, {})
         content_file = Mock()
@@ -598,9 +597,10 @@ class TestWorkflowSyncService:
             assert result.pr_reused is False
             assert result.object_results is not None
             mock_repo.create_git_ref.assert_not_called()
-            mock_repo.get_git_ref.assert_called_once_with(
-                "heads/feature/shared-workflow"
-            )
+            assert mock_repo.get_git_ref.call_args_list == [
+                call("heads/feature/shared-workflow"),
+                call("heads/feature/shared-workflow"),
+            ]
             mock_repo.create_git_tree.assert_called_once()
             mock_repo.create_git_commit.assert_called_once()
             branch_ref.edit.assert_called_once_with(new_commit.sha)
@@ -783,7 +783,9 @@ class TestWorkflowSyncService:
             assert result.object_results is not None
             assert len(result.object_results) == 1
             assert result.object_results[0].status == PushStatus.NO_OP
-            mock_repo.get_git_ref.assert_not_called()
+            mock_repo.get_git_ref.assert_called_once_with(
+                "heads/feature/shared-workflow"
+            )
             mock_repo.get_git_commit.assert_not_called()
             mock_repo.create_git_tree.assert_not_called()
             mock_repo.create_git_commit.assert_not_called()
@@ -943,6 +945,47 @@ class TestWorkflowSyncService:
         mock_repo.create_git_commit.assert_not_called()
 
     @pytest.mark.anyio
+    async def test_push_target_branch_rejects_concurrent_branch_changes(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Target-branch pushes should fail if the branch advances mid-prepare."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+        )
+        initial_ref = Mock()
+        initial_ref.object.sha = "snapshot123"
+        updated_ref = Mock()
+        updated_ref.object.sha = "snapshot456"
+        mock_repo.get_git_ref.side_effect = [initial_ref, updated_ref]
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="changed while preparing the bulk push",
+        ):
+            with patch("asyncio.to_thread") as mock_to_thread:
+                mock_to_thread.side_effect = _mock_to_thread
+                await workflow_sync_service._push_to_target_branch(
+                    repo=mock_repo,
+                    url=git_url,
+                    objects=[push_obj],
+                    options=options,
+                )
+
+        mock_repo.create_git_tree.assert_not_called()
+        mock_repo.create_git_commit.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_push_target_branch_noop_pr_failure_returns_no_op_result(
         self, workflow_sync_service, git_url, sample_remote_workflow
     ):
@@ -1009,7 +1052,9 @@ class TestWorkflowSyncService:
             assert result.pr_number is None
             assert result.pr_reused is False
             mock_upsert_pr.assert_awaited_once()
-            mock_repo.get_git_ref.assert_not_called()
+            mock_repo.get_git_ref.assert_called_once_with(
+                "heads/feature/shared-workflow"
+            )
             mock_repo.get_git_commit.assert_not_called()
             mock_repo.create_git_tree.assert_not_called()
             mock_repo.create_git_commit.assert_not_called()
@@ -1200,7 +1245,10 @@ class TestWorkflowSyncService:
                 PushStatus.COMMITTED,
             ]
 
-            mock_repo.get_git_ref.assert_called_once_with("heads/feature/bulk-push")
+            assert mock_repo.get_git_ref.call_args_list == [
+                call("heads/feature/bulk-push"),
+                call("heads/feature/bulk-push"),
+            ]
             mock_repo.create_git_tree.assert_called_once()
             mock_repo.create_git_commit.assert_called_once()
             branch_ref.edit.assert_called_once_with(new_commit.sha)
@@ -1290,7 +1338,7 @@ class TestWorkflowSyncService:
                 PushStatus.NO_OP,
                 PushStatus.NO_OP,
             ]
-            mock_repo.get_git_ref.assert_not_called()
+            mock_repo.get_git_ref.assert_called_once_with("heads/feature/bulk-push")
             mock_repo.get_git_commit.assert_not_called()
             mock_repo.create_git_tree.assert_not_called()
             mock_repo.create_git_commit.assert_not_called()

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -12,6 +12,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.dsl.common import DSLEntrypoint, DSLInput
 from tracecat.dsl.schemas import ActionStatement
+from tracecat.exceptions import TracecatValidationError
 from tracecat.git.types import GitUrl
 from tracecat.sync import Author, PushObject, PushOptions, PushStatus
 from tracecat.workflow.store.import_service import WorkflowImportService
@@ -903,6 +904,43 @@ class TestWorkflowSyncService:
             mock_upsert_pr.assert_awaited_once()
             mock_repo.create_git_tree.assert_called_once()
             mock_repo.create_git_commit.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_rejects_pr_to_same_branch(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Target-branch pushes should not commit directly to the PR base branch."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="main",
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="main",
+            base_branch_name="main",
+        )
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="branch must differ from the PR base branch",
+        ):
+            with patch("asyncio.to_thread") as mock_to_thread:
+                mock_to_thread.side_effect = _mock_to_thread
+                await workflow_sync_service._push_to_target_branch(
+                    repo=mock_repo,
+                    url=git_url,
+                    objects=[push_obj],
+                    options=options,
+                )
+
+        mock_repo.create_git_tree.assert_not_called()
+        mock_repo.create_git_commit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_push_target_branch_noop_pr_failure_returns_no_op_result(

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -405,15 +405,44 @@ class TestWorkflowSyncService:
             await workflow_sync_service.push(objects=[], url=git_url, options=options)
 
     @pytest.mark.anyio
-    async def test_push_objects_empty_objects(self, workflow_sync_service, git_url):
-        """Test push fails with empty objects list."""
+    async def test_push_legacy_rejects_multiple_objects(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test legacy publish mode rejects multi-object pushes."""
         author = Author(name="Test User", email="test@example.com")
         options = PushOptions(message="Update workflows", author=author)
+        push_objects = [
+            PushObject(data=sample_remote_workflow, path="workflows/test-workflow.yml"),
+            PushObject(
+                data=sample_remote_workflow, path="workflows/test-workflow-2.yml"
+            ),
+        ]
 
-        with pytest.raises(
-            ValueError, match="At least one workflow object is required"
+        mock_repo = Mock()
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
         ):
-            await workflow_sync_service.push(objects=[], url=git_url, options=options)
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+            mock_to_thread.side_effect = _mock_to_thread
+
+            with pytest.raises(
+                ValueError,
+                match="Legacy publish mode only supports pushing one workflow object at a time",
+            ):
+                await workflow_sync_service.push(
+                    objects=push_objects, url=git_url, options=options
+                )
 
     @pytest.mark.anyio
     async def test_push_workflows_github_failure(

--- a/tracecat/sync.py
+++ b/tracecat/sync.py
@@ -88,8 +88,22 @@ class PushOptions:
     pr_base_branch: str | None = None
     """Optional PR base branch override; defaults to repository default branch."""
 
+    pr_title: str | None = None
+    """Optional pull request title override."""
+
+    pr_body: str | None = None
+    """Optional pull request body override."""
+
     sign: bool = False
     """GPG signing if configured"""
+
+
+@dataclass(frozen=True)
+class PushObjectResult:
+    """Per-object result for a push operation."""
+
+    path: str
+    status: PushStatus
 
 
 @dataclass(frozen=True)
@@ -119,6 +133,9 @@ class CommitInfo:
 
     message: str = ""
     """Human-readable summary of the push outcome."""
+
+    object_results: list[PushObjectResult] | None = None
+    """Per-object outcomes for batch push operations."""
 
 
 @dataclass(frozen=True)

--- a/tracecat/workflow/management/folders/service.py
+++ b/tracecat/workflow/management/folders/service.py
@@ -680,6 +680,7 @@ class WorkflowFolderService(BaseWorkspaceService):
                     status=workflow.status,
                     latest_definition=latest_definition,
                     icon_url=workflow.icon_url,
+                    folder_path=path if path != "/" else None,
                     tags=[
                         TagRead.model_validate(tag, from_attributes=True)
                         for tag in workflow.tags

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -243,7 +243,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
             )
 
         # Add eager loading for tags since they're accessed in the router
-        stmt = stmt.options(selectinload(Workflow.tags))
+        stmt = stmt.options(selectinload(Workflow.tags), selectinload(Workflow.folder))
 
         results = await self.session.execute(stmt)
         res = []
@@ -434,7 +434,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
         stmt = stmt.limit(params.limit + 1)
 
         # Add eager loading for tags since they're accessed in the router
-        stmt = stmt.options(selectinload(Workflow.tags))
+        stmt = stmt.options(selectinload(Workflow.tags), selectinload(Workflow.folder))
 
         results = await self.session.execute(stmt)
         raw_items = list(results.all())

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -200,6 +200,7 @@ def wfs_and_defns_to_response(
                 error_handler=workflow.error_handler,
                 latest_definition=latest_defn,
                 folder_id=workflow.folder_id,
+                folder_path=workflow.folder.path if workflow.folder else None,
                 trigger_summary=trigger_summary_read,
             )
         )

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -91,6 +91,7 @@ class WorkflowReadMinimal(Schema):
     error_handler: str | None = None
     latest_definition: WorkflowDefinitionReadMinimal | None = None
     folder_id: uuid.UUID | None = None
+    folder_path: str | None = None
     trigger_summary: WorkflowTriggerSummary | None = None
 
 

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -18,6 +18,10 @@ from tracecat.sync import PullOptions, PullResult
 from tracecat.vcs.github.app import GitHubAppError
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.store.schemas import (
+    WorkflowBulkPushPreviewRequest,
+    WorkflowBulkPushPreviewResponse,
+    WorkflowBulkPushRequest,
+    WorkflowBulkPushResult,
     WorkflowDslPublish,
     WorkflowDslPublishResult,
     WorkflowSyncPullRequest,
@@ -62,6 +66,71 @@ async def publish_workflow(
             params=params,
             workflow=defn.workflow,
         )
+    except TracecatSettingsError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except TracecatCredentialsNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except GitHubAppError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.post(
+    "/push/preview",
+    response_model=WorkflowBulkPushPreviewResponse,
+)
+@require_scope("workflow:update")
+async def preview_bulk_push_workflows(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    params: WorkflowBulkPushPreviewRequest,
+) -> WorkflowBulkPushPreviewResponse:
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+    store_svc = WorkflowStoreService(session=session, role=role)
+    try:
+        return await store_svc.preview_bulk_push(params)
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.post(
+    "/push",
+    response_model=WorkflowBulkPushResult,
+)
+@require_scope("workflow:update")
+async def bulk_push_workflows(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    params: WorkflowBulkPushRequest,
+) -> WorkflowBulkPushResult:
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+    store_svc = WorkflowStoreService(session=session, role=role)
+    try:
+        return await store_svc.bulk_push(params)
     except TracecatSettingsError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime, timedelta
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import (
@@ -7,6 +8,7 @@ from pydantic import (
     ConfigDict,
     Field,
     field_serializer,
+    field_validator,
     model_validator,
 )
 
@@ -91,6 +93,106 @@ class WorkflowSyncPullRequest(BaseModel):
         default=False,
         description="Validate only, don't perform actual import",
     )
+
+
+class WorkflowBulkPushExclusionReason(StrEnum):
+    NOT_FOUND = "not_found"
+    NOT_PUBLISHED = "not_published"
+
+
+class WorkflowBulkPushWorkflowStatus(StrEnum):
+    COMMITTED = "committed"
+    NO_OP = "no_op"
+    EXCLUDED = "excluded"
+
+
+class WorkflowBulkPushWorkflowSummary(BaseModel):
+    workflow_id: WorkflowIDShort
+    title: str
+    alias: str | None = None
+    folder_path: str | None = None
+    latest_definition_version: int
+    latest_definition_created_at: datetime
+
+
+class WorkflowBulkPushExcludedWorkflow(BaseModel):
+    workflow_id: WorkflowIDShort | None = None
+    title: str | None = None
+    reason: WorkflowBulkPushExclusionReason
+    message: str
+
+
+class WorkflowBulkPushPreviewRequest(BaseModel):
+    workflow_ids: list[WorkflowIDShort] = Field(default_factory=list, max_length=500)
+    folder_paths: list[str] = Field(default_factory=list, max_length=100)
+
+    @field_validator("folder_paths", mode="before")
+    @classmethod
+    def validate_folder_paths(cls, value: list[str] | None) -> list[str]:
+        paths = [path.strip() for path in value or [] if path.strip()]
+        return list(dict.fromkeys(paths))
+
+    @model_validator(mode="after")
+    def validate_selection(self) -> "WorkflowBulkPushPreviewRequest":
+        if not self.workflow_ids and not self.folder_paths:
+            raise ValueError("At least one workflow or folder selection is required")
+        return self
+
+
+class WorkflowBulkPushPreviewResponse(BaseModel):
+    eligible_workflows: list[WorkflowBulkPushWorkflowSummary] = Field(
+        default_factory=list
+    )
+    excluded_workflows: list[WorkflowBulkPushExcludedWorkflow] = Field(
+        default_factory=list
+    )
+    resolved_workflow_ids: list[WorkflowIDShort] = Field(default_factory=list)
+    branch: str
+    commit_message: str
+    pr_title: str
+    pr_body: str
+    can_submit: bool = False
+
+
+class WorkflowBulkPushRequest(BaseModel):
+    workflow_ids: list[WorkflowIDShort] = Field(default_factory=list, min_length=1)
+    branch: str
+    commit_message: str = Field(min_length=1, max_length=512)
+    pr_title: str = Field(min_length=1, max_length=256)
+    pr_body: str = Field(default="")
+
+    @field_validator("branch")
+    @classmethod
+    def validate_branch(cls, value: str) -> str:
+        return validate_short_branch_name(value.strip(), field_name="branch")
+
+    @field_validator("commit_message", "pr_title", "pr_body")
+    @classmethod
+    def strip_text_fields(cls, value: str) -> str:
+        return value.strip()
+
+
+class WorkflowBulkPushWorkflowResult(BaseModel):
+    workflow_id: WorkflowIDShort
+    title: str
+    path: str
+    status: WorkflowBulkPushWorkflowStatus
+    message: str | None = None
+
+
+class WorkflowBulkPushResult(BaseModel):
+    status: Literal["committed", "no_op"]
+    commit_sha: str | None = None
+    branch: str
+    base_branch: str
+    pr_url: str | None = None
+    pr_number: int | None = None
+    pr_reused: bool = False
+    message: str
+    selected_count: int
+    eligible_count: int
+    excluded_count: int
+    workflow_results: list[WorkflowBulkPushWorkflowResult] = Field(default_factory=list)
 
 
 _SER_DSL_KEY_ORDER = (

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -98,6 +98,7 @@ class WorkflowSyncPullRequest(BaseModel):
 class WorkflowBulkPushExclusionReason(StrEnum):
     NOT_FOUND = "not_found"
     NOT_PUBLISHED = "not_published"
+    INVALID_CONFIGURATION = "invalid_configuration"
 
 
 class WorkflowBulkPushWorkflowStatus(StrEnum):
@@ -128,8 +129,18 @@ class WorkflowBulkPushPreviewRequest(BaseModel):
 
     @field_validator("folder_paths", mode="before")
     @classmethod
-    def validate_folder_paths(cls, value: list[str] | None) -> list[str]:
-        paths = [path.strip() for path in value or [] if path.strip()]
+    def validate_folder_paths(cls, value: object) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("folder_paths must be a list of strings")
+
+        paths: list[str] = []
+        for path in value:
+            if not isinstance(path, str):
+                raise ValueError("folder_paths must contain only strings")
+            if stripped := path.strip():
+                paths.append(stripped)
         return list(dict.fromkeys(paths))
 
     @model_validator(mode="after")
@@ -166,9 +177,16 @@ class WorkflowBulkPushRequest(BaseModel):
     def validate_branch(cls, value: str) -> str:
         return validate_short_branch_name(value.strip(), field_name="branch")
 
-    @field_validator("commit_message", "pr_title", "pr_body")
+    @field_validator("commit_message", "pr_title")
     @classmethod
-    def strip_text_fields(cls, value: str) -> str:
+    def validate_required_text_fields(cls, value: str) -> str:
+        if not (stripped := value.strip()):
+            raise ValueError("value cannot be empty")
+        return stripped
+
+    @field_validator("pr_body")
+    @classmethod
+    def strip_pr_body(cls, value: str) -> str:
         return value.strip()
 
 

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -394,15 +394,28 @@ class WorkflowStoreService(BaseWorkspaceService):
                 continue
 
             dsl = DSLInput.model_validate(definition.content)
+            try:
+                remote_definition = self._build_remote_workflow_definition(
+                    workflow_id=workflow_id,
+                    dsl=dsl,
+                    workflow=workflow,
+                )
+            except TracecatValidationError as e:
+                excluded_workflows.append(
+                    WorkflowBulkPushExcludedWorkflow(
+                        workflow_id=workflow_short_id,
+                        title=workflow.title,
+                        reason=WorkflowBulkPushExclusionReason.INVALID_CONFIGURATION,
+                        message=str(e),
+                    )
+                )
+                continue
+
             prepared_items.append(
                 PreparedBulkPushItem(
                     workflow=workflow,
                     definition=definition,
-                    remote_definition=self._build_remote_workflow_definition(
-                        workflow_id=workflow_id,
-                        dsl=dsl,
-                        workflow=workflow,
-                    ),
+                    remote_definition=remote_definition,
                     path=get_definition_path(workflow_id),
                 )
             )
@@ -436,7 +449,8 @@ class WorkflowStoreService(BaseWorkspaceService):
             )
         else:
             path_filters = [
-                WorkflowFolder.path.startswith(path) for path in normalized_paths
+                WorkflowFolder.path.startswith(path, autoescape=True)
+                for path in normalized_paths
             ]
             statement = (
                 select(Workflow.id)

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import cast
+from uuid import uuid4
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import selectinload
@@ -531,8 +532,8 @@ class WorkflowStoreService(BaseWorkspaceService):
         workspace_name: str,
         eligible_workflows: Sequence[WorkflowBulkPushWorkflowSummary],
     ) -> tuple[str, str, str, str]:
-        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        branch = f"tracecat/bulk-push-{timestamp}"
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        branch = f"tracecat/bulk-push-{timestamp}-{uuid4().hex[:8]}"
         workflow_count = len(eligible_workflows)
         if workflow_count == 1:
             workflow_label = eligible_workflows[0].title
@@ -632,7 +633,12 @@ class WorkflowStoreService(BaseWorkspaceService):
     def _to_workflow_uuids(
         self, workflow_ids: Sequence[WorkflowIDShort]
     ) -> list[WorkflowUUID]:
-        return [WorkflowUUID.new(workflow_id) for workflow_id in workflow_ids]
+        try:
+            return [WorkflowUUID.new(workflow_id) for workflow_id in workflow_ids]
+        except ValueError as e:
+            raise TracecatValidationError(
+                "workflow_ids contains an invalid workflow ID"
+            ) from e
 
 
 def get_definition_path(workflow_id: WorkflowUUID) -> Path:

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -1,16 +1,29 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import cast
 
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.orm import selectinload
+
 from tracecat.authz.controls import require_scope
 from tracecat.cases.enums import CaseEventType
-from tracecat.db.models import Workflow
+from tracecat.db.models import Workflow, WorkflowDefinition, WorkflowFolder, Workspace
 from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import TracecatSettingsError, TracecatValidationError
+from tracecat.git.types import GitUrl
 from tracecat.git.utils import parse_git_url
-from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.identifiers.workflow import WorkflowIDShort, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
-from tracecat.sync import Author, PushObject, PushOptions, PushStatus
+from tracecat.sync import (
+    Author,
+    PushObject,
+    PushObjectResult,
+    PushOptions,
+    PushStatus,
+)
 from tracecat.workflow.store.schemas import (
     RemoteCaseTrigger,
     RemoteWebhook,
@@ -18,12 +31,37 @@ from tracecat.workflow.store.schemas import (
     RemoteWorkflowSchedule,
     RemoteWorkflowTag,
     Status,
+    WorkflowBulkPushExcludedWorkflow,
+    WorkflowBulkPushExclusionReason,
+    WorkflowBulkPushPreviewRequest,
+    WorkflowBulkPushPreviewResponse,
+    WorkflowBulkPushRequest,
+    WorkflowBulkPushResult,
+    WorkflowBulkPushWorkflowResult,
+    WorkflowBulkPushWorkflowStatus,
+    WorkflowBulkPushWorkflowSummary,
     WorkflowDslPublish,
     WorkflowDslPublishResult,
     validate_short_branch_name,
 )
 from tracecat.workflow.store.sync import WorkflowSyncService
 from tracecat.workspaces.service import WorkspaceService
+
+
+@dataclass(frozen=True)
+class PreparedBulkPushItem:
+    workflow: Workflow
+    definition: WorkflowDefinition
+    remote_definition: RemoteWorkflowDefinition
+    path: Path
+
+
+@dataclass(frozen=True)
+class BulkPushSelectionResolution:
+    prepared_items: list[PreparedBulkPushItem]
+    eligible_workflows: list[WorkflowBulkPushWorkflowSummary]
+    excluded_workflows: list[WorkflowBulkPushExcludedWorkflow]
+    resolved_workflow_ids: list[WorkflowIDShort]
 
 
 class WorkflowStoreService(BaseWorkspaceService):
@@ -38,98 +76,30 @@ class WorkflowStoreService(BaseWorkspaceService):
         params: WorkflowDslPublish,
         workflow: Workflow,
     ) -> WorkflowDslPublishResult:
-        """Take the latest version of the workflow definition and publish it to the store."""
-        # Validate that workflow_id matches the provided workflow object
+        """Take the latest version of the workflow definition and publish it to GitHub."""
         if workflow.id != workflow_id:
             raise TracecatValidationError(
                 f"Workflow ID mismatch: provided {workflow_id} but workflow object has ID {workflow.id}"
             )
 
-        # Get workspace settings for git configuration
-
-        workspace_service = WorkspaceService(session=self.session, role=self.role)
-        workspace = await workspace_service.get_workspace(self.workspace_id)
-
-        if not workspace:
-            raise TracecatValidationError("Workspace not found")
-
-        # Extract git configuration from workspace settings
-        git_repo_url = workspace.settings.get("git_repo_url")
-        if not git_repo_url:
-            raise TracecatSettingsError(
-                "Git repository URL not configured for this workspace. "
-                "Please contact your administrator to configure it."
-            )
+        workspace, git_url = await self._get_workspace_and_git_url()
 
         logger.info(
             "Publishing workflow to store",
             workflow_title=dsl.title,
-            repo_url=git_repo_url,
+            repo_url=workspace.settings.get("git_repo_url"),
             workspace_id=self.workspace_id,
         )
 
-        # Parse the Git URL using workspace settings
-        try:
-            git_url = parse_git_url(git_repo_url, allowed_domains={"github.com"})
-        except ValueError as e:
-            raise TracecatSettingsError(
-                f"Invalid Git repository URL configured for this workspace: {e}. "
-                "Please contact your administrator to fix the configuration."
-            ) from e
-        # Note: We could add ref support later if needed via params or workspace settings
-
-        stable_path = get_definition_path(workflow_id)
-        webhook = workflow.webhook
-
-        await self.session.refresh(workflow, ["tags", "folder", "case_trigger"])
-
-        # Get folder path if workflow is in a folder
-        folder_path = None
-        if workflow.folder:
-            folder_path = workflow.folder.path
-
-        # Create PushObject with data and stable path
-        defn = RemoteWorkflowDefinition(
-            id=workflow_id.short(),
-            alias=workflow.alias,
-            folder_path=folder_path,
-            tags=[RemoteWorkflowTag(name=t.name) for t in workflow.tags],
-            # Convert Schedule ORM objects to RemoteWorkflowSchedule, handling type conversions and missing fields.
-            schedules=[
-                RemoteWorkflowSchedule(
-                    status=cast(Status, s.status),
-                    cron=s.cron,
-                    every=s.every,
-                    offset=s.offset,
-                    start_at=s.start_at,
-                    end_at=s.end_at,
-                    timeout=s.timeout,
-                )
-                for s in (workflow.schedules or [])
-            ],
-            webhook=RemoteWebhook(
-                methods=webhook.methods,
-                status=cast(Status, webhook.status),
-            ),
-            case_trigger=RemoteCaseTrigger(
-                status=cast(Status, workflow.case_trigger.status)
-                if workflow.case_trigger
-                else "offline",
-                event_types=[
-                    CaseEventType(event_type)
-                    for event_type in workflow.case_trigger.event_types
-                ]
-                if workflow.case_trigger
-                else [],
-                tag_filters=workflow.case_trigger.tag_filters
-                if workflow.case_trigger
-                else [],
-            )
-            if workflow.case_trigger
-            else None,
-            definition=dsl,
+        await self.session.refresh(
+            workflow, ["tags", "folder", "case_trigger", "schedules", "webhook"]
         )
-        push_obj = PushObject(data=defn, path=stable_path)
+        push_obj = PushObject(
+            data=self._build_remote_workflow_definition(
+                workflow_id=workflow_id, dsl=dsl, workflow=workflow
+            ),
+            path=get_definition_path(workflow_id),
+        )
 
         author = Author(name="Tracecat", email="noreply@tracecat.com")
         publish_message = params.message or f"Publish workflow: {dsl.title}"
@@ -170,7 +140,6 @@ class WorkflowStoreService(BaseWorkspaceService):
                 pr_base_branch=validated_pr_base_branch,
             )
 
-        # Use WorkflowSyncService to push the workflow with stable path
         sync_service = WorkflowSyncService(session=self.session, role=self.role)
         commit_info = await sync_service.push(
             objects=[push_obj],
@@ -182,9 +151,7 @@ class WorkflowStoreService(BaseWorkspaceService):
             PushStatus.COMMITTED,
             PushStatus.NO_OP,
         }:
-            workflow.git_sync_branch = validated_branch
-            self.session.add(workflow)
-            await self.session.commit()
+            await self._persist_git_sync_branch([workflow], validated_branch)
 
         logger.info(
             "Successfully published workflow",
@@ -208,6 +175,450 @@ class WorkflowStoreService(BaseWorkspaceService):
             pr_reused=commit_info.pr_reused,
             message=commit_info.message,
         )
+
+    @require_scope("workflow:update")
+    async def preview_bulk_push(
+        self, params: WorkflowBulkPushPreviewRequest
+    ) -> WorkflowBulkPushPreviewResponse:
+        workspace = await self._get_workspace()
+        selection = await self._resolve_bulk_push_selection(
+            workflow_ids=self._to_workflow_uuids(params.workflow_ids),
+            folder_paths=params.folder_paths,
+        )
+        branch, commit_message, pr_title, pr_body = self._build_bulk_push_defaults(
+            workspace_name=workspace.name,
+            eligible_workflows=selection.eligible_workflows,
+        )
+        return WorkflowBulkPushPreviewResponse(
+            eligible_workflows=selection.eligible_workflows,
+            excluded_workflows=selection.excluded_workflows,
+            resolved_workflow_ids=selection.resolved_workflow_ids,
+            branch=branch,
+            commit_message=commit_message,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            can_submit=bool(selection.prepared_items),
+        )
+
+    @require_scope("workflow:update")
+    async def bulk_push(
+        self, params: WorkflowBulkPushRequest
+    ) -> WorkflowBulkPushResult:
+        _, git_url = await self._get_workspace_and_git_url()
+        selection = await self._resolve_bulk_push_selection(
+            workflow_ids=self._to_workflow_uuids(params.workflow_ids),
+            folder_paths=[],
+        )
+        if not selection.prepared_items:
+            raise TracecatValidationError(
+                "No published workflows are available to push to GitHub."
+            )
+
+        author = Author(name="Tracecat", email="noreply@tracecat.com")
+        push_objects = [
+            PushObject(data=item.remote_definition, path=item.path)
+            for item in selection.prepared_items
+        ]
+        push_options = PushOptions(
+            message=params.commit_message,
+            author=author,
+            create_pr=True,
+            branch=params.branch,
+            pr_title=params.pr_title,
+            pr_body=params.pr_body,
+        )
+        sync_service = WorkflowSyncService(session=self.session, role=self.role)
+        commit_info = await sync_service.push(
+            objects=push_objects,
+            url=git_url,
+            options=push_options,
+        )
+
+        if commit_info.status in {PushStatus.COMMITTED, PushStatus.NO_OP}:
+            await self._persist_git_sync_branch(
+                [item.workflow for item in selection.prepared_items],
+                params.branch,
+            )
+
+        object_results = self._build_bulk_push_workflow_results(
+            selection=selection,
+            object_results=commit_info.object_results,
+            default_status=commit_info.status,
+        )
+        message = commit_info.message
+        if selection.excluded_workflows:
+            message = (
+                f"{message} Excluded {len(selection.excluded_workflows)} workflow(s)."
+            )
+
+        return WorkflowBulkPushResult(
+            status=commit_info.status.value,
+            commit_sha=commit_info.sha,
+            branch=commit_info.ref,
+            base_branch=commit_info.base_ref,
+            pr_url=commit_info.pr_url,
+            pr_number=commit_info.pr_number,
+            pr_reused=commit_info.pr_reused,
+            message=message,
+            selected_count=len(params.workflow_ids),
+            eligible_count=len(selection.prepared_items),
+            excluded_count=len(selection.excluded_workflows),
+            workflow_results=object_results,
+        )
+
+    async def _get_workspace(self) -> Workspace:
+        workspace_service = WorkspaceService(session=self.session, role=self.role)
+        workspace = await workspace_service.get_workspace(self.workspace_id)
+        if not workspace:
+            raise TracecatValidationError("Workspace not found")
+        return workspace
+
+    async def _get_workspace_and_git_url(self) -> tuple[Workspace, GitUrl]:
+        workspace = await self._get_workspace()
+        git_repo_url = workspace.settings.get("git_repo_url")
+        if not git_repo_url:
+            raise TracecatSettingsError(
+                "Git repository URL not configured for this workspace. "
+                "Please contact your administrator to configure it."
+            )
+        try:
+            git_url = parse_git_url(git_repo_url, allowed_domains={"github.com"})
+        except ValueError as e:
+            raise TracecatSettingsError(
+                f"Invalid Git repository URL configured for this workspace: {e}. "
+                "Please contact your administrator to fix the configuration."
+            ) from e
+        return workspace, git_url
+
+    def _build_remote_workflow_definition(
+        self,
+        *,
+        workflow_id: WorkflowUUID,
+        dsl: DSLInput,
+        workflow: Workflow,
+    ) -> RemoteWorkflowDefinition:
+        webhook = workflow.webhook
+        if webhook is None:
+            raise TracecatValidationError(
+                f"Workflow {workflow_id.short()} is missing a webhook configuration."
+            )
+
+        folder_path = workflow.folder.path if workflow.folder else None
+        return RemoteWorkflowDefinition(
+            id=workflow_id.short(),
+            alias=workflow.alias,
+            folder_path=folder_path,
+            tags=[RemoteWorkflowTag(name=tag.name) for tag in workflow.tags],
+            schedules=[
+                RemoteWorkflowSchedule(
+                    status=cast(Status, schedule.status),
+                    cron=schedule.cron,
+                    every=schedule.every,
+                    offset=schedule.offset,
+                    start_at=schedule.start_at,
+                    end_at=schedule.end_at,
+                    timeout=schedule.timeout,
+                )
+                for schedule in workflow.schedules or []
+            ],
+            webhook=RemoteWebhook(
+                methods=webhook.methods,
+                status=cast(Status, webhook.status),
+            ),
+            case_trigger=RemoteCaseTrigger(
+                status=cast(Status, workflow.case_trigger.status)
+                if workflow.case_trigger
+                else "offline",
+                event_types=[
+                    CaseEventType(event_type)
+                    for event_type in workflow.case_trigger.event_types
+                ]
+                if workflow.case_trigger
+                else [],
+                tag_filters=workflow.case_trigger.tag_filters
+                if workflow.case_trigger
+                else [],
+            )
+            if workflow.case_trigger
+            else None,
+            definition=dsl,
+        )
+
+    async def _resolve_bulk_push_selection(
+        self,
+        *,
+        workflow_ids: Sequence[WorkflowUUID],
+        folder_paths: Sequence[str],
+    ) -> BulkPushSelectionResolution:
+        folder_workflow_ids = await self._list_workflow_ids_in_selected_folders(
+            folder_paths
+        )
+        ordered_workflow_ids = self._dedupe_workflow_ids(
+            list(workflow_ids) + folder_workflow_ids
+        )
+        workflows_by_short = await self._get_workflows_by_short_id(ordered_workflow_ids)
+        definitions_by_short = await self._get_latest_definitions_by_short_id(
+            ordered_workflow_ids
+        )
+
+        prepared_items: list[PreparedBulkPushItem] = []
+        eligible_workflows: list[WorkflowBulkPushWorkflowSummary] = []
+        excluded_workflows: list[WorkflowBulkPushExcludedWorkflow] = []
+        resolved_workflow_ids = [
+            workflow_id.short() for workflow_id in ordered_workflow_ids
+        ]
+
+        for workflow_id in ordered_workflow_ids:
+            workflow_short_id = workflow_id.short()
+            workflow = workflows_by_short.get(workflow_short_id)
+            if workflow is None:
+                excluded_workflows.append(
+                    WorkflowBulkPushExcludedWorkflow(
+                        workflow_id=workflow_short_id,
+                        reason=WorkflowBulkPushExclusionReason.NOT_FOUND,
+                        message="Workflow not found in this workspace.",
+                    )
+                )
+                continue
+
+            definition = definitions_by_short.get(workflow_short_id)
+            if definition is None:
+                excluded_workflows.append(
+                    WorkflowBulkPushExcludedWorkflow(
+                        workflow_id=workflow_short_id,
+                        title=workflow.title,
+                        reason=WorkflowBulkPushExclusionReason.NOT_PUBLISHED,
+                        message="Workflow has no published definition to push.",
+                    )
+                )
+                continue
+
+            dsl = DSLInput.model_validate(definition.content)
+            prepared_items.append(
+                PreparedBulkPushItem(
+                    workflow=workflow,
+                    definition=definition,
+                    remote_definition=self._build_remote_workflow_definition(
+                        workflow_id=workflow_id,
+                        dsl=dsl,
+                        workflow=workflow,
+                    ),
+                    path=get_definition_path(workflow_id),
+                )
+            )
+            eligible_workflows.append(
+                WorkflowBulkPushWorkflowSummary(
+                    workflow_id=workflow_short_id,
+                    title=workflow.title,
+                    alias=workflow.alias,
+                    folder_path=workflow.folder.path if workflow.folder else None,
+                    latest_definition_version=definition.version,
+                    latest_definition_created_at=definition.created_at,
+                )
+            )
+
+        return BulkPushSelectionResolution(
+            prepared_items=prepared_items,
+            eligible_workflows=eligible_workflows,
+            excluded_workflows=excluded_workflows,
+            resolved_workflow_ids=resolved_workflow_ids,
+        )
+
+    async def _list_workflow_ids_in_selected_folders(
+        self, folder_paths: Sequence[str]
+    ) -> list[WorkflowUUID]:
+        normalized_paths = self._normalize_folder_paths(folder_paths)
+        if not normalized_paths:
+            return []
+        if "/" in normalized_paths:
+            statement = select(Workflow.id).where(
+                Workflow.workspace_id == self.workspace_id
+            )
+        else:
+            path_filters = [
+                WorkflowFolder.path.startswith(path) for path in normalized_paths
+            ]
+            statement = (
+                select(Workflow.id)
+                .join(WorkflowFolder, Workflow.folder_id == WorkflowFolder.id)
+                .where(
+                    Workflow.workspace_id == self.workspace_id,
+                    or_(*path_filters),
+                )
+            )
+        statement = statement.order_by(Workflow.created_at.desc(), Workflow.id.desc())
+        result = await self.session.execute(statement)
+        return [WorkflowUUID.new(workflow_id) for workflow_id in result.scalars().all()]
+
+    async def _get_workflows_by_short_id(
+        self, workflow_ids: Sequence[WorkflowUUID]
+    ) -> dict[WorkflowIDShort, Workflow]:
+        if not workflow_ids:
+            return {}
+        statement = (
+            select(Workflow)
+            .where(
+                Workflow.workspace_id == self.workspace_id,
+                Workflow.id.in_(workflow_ids),
+            )
+            .options(
+                selectinload(Workflow.tags),
+                selectinload(Workflow.folder),
+                selectinload(Workflow.schedules),
+                selectinload(Workflow.webhook),
+                selectinload(Workflow.case_trigger),
+            )
+        )
+        result = await self.session.execute(statement)
+        workflows = result.scalars().all()
+        return {
+            WorkflowUUID.new(workflow.id).short(): workflow for workflow in workflows
+        }
+
+    async def _get_latest_definitions_by_short_id(
+        self, workflow_ids: Sequence[WorkflowUUID]
+    ) -> dict[WorkflowIDShort, WorkflowDefinition]:
+        if not workflow_ids:
+            return {}
+        latest_versions = (
+            select(
+                WorkflowDefinition.workflow_id,
+                func.max(WorkflowDefinition.version).label("latest_version"),
+            )
+            .where(
+                WorkflowDefinition.workspace_id == self.workspace_id,
+                WorkflowDefinition.workflow_id.in_(workflow_ids),
+            )
+            .group_by(WorkflowDefinition.workflow_id)
+            .subquery()
+        )
+        statement = (
+            select(WorkflowDefinition)
+            .join(
+                latest_versions,
+                and_(
+                    WorkflowDefinition.workflow_id == latest_versions.c.workflow_id,
+                    WorkflowDefinition.version == latest_versions.c.latest_version,
+                ),
+            )
+            .where(WorkflowDefinition.workspace_id == self.workspace_id)
+        )
+        result = await self.session.execute(statement)
+        definitions = result.scalars().all()
+        return {
+            WorkflowUUID.new(definition.workflow_id).short(): definition
+            for definition in definitions
+            if definition.workflow_id is not None
+        }
+
+    def _build_bulk_push_defaults(
+        self,
+        *,
+        workspace_name: str,
+        eligible_workflows: Sequence[WorkflowBulkPushWorkflowSummary],
+    ) -> tuple[str, str, str, str]:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        branch = f"tracecat/bulk-push-{timestamp}"
+        workflow_count = len(eligible_workflows)
+        if workflow_count == 1:
+            workflow_label = eligible_workflows[0].title
+        else:
+            workflow_label = f"{workflow_count} workflows"
+
+        commit_message = f"Push {workflow_label} to GitHub"
+        pr_title = f"Push {workflow_label} from {workspace_name}"
+
+        workflow_lines = [
+            f"- {workflow.title} (`{workflow.workflow_id}`)"
+            for workflow in eligible_workflows
+        ]
+        pr_body = "\n".join(
+            [
+                "Automated bulk push from Tracecat.",
+                "",
+                f"**Workspace:** {workspace_name}",
+                "",
+                "**Workflows:**",
+                *workflow_lines,
+            ]
+        )
+        return branch, commit_message, pr_title, pr_body
+
+    async def _persist_git_sync_branch(
+        self, workflows: Sequence[Workflow], branch: str
+    ) -> None:
+        for workflow in workflows:
+            workflow.git_sync_branch = branch
+            self.session.add(workflow)
+        await self.session.commit()
+
+    def _build_bulk_push_workflow_results(
+        self,
+        *,
+        selection: BulkPushSelectionResolution,
+        object_results: Sequence[PushObjectResult] | None,
+        default_status: PushStatus,
+    ) -> list[WorkflowBulkPushWorkflowResult]:
+        object_status_by_path = (
+            {result.path: result.status for result in object_results}
+            if object_results
+            else {}
+        )
+        workflow_results = [
+            WorkflowBulkPushWorkflowResult(
+                workflow_id=item.remote_definition.id,
+                title=item.workflow.title,
+                path=str(item.path),
+                status=WorkflowBulkPushWorkflowStatus(
+                    object_status_by_path.get(str(item.path), default_status).value
+                ),
+            )
+            for item in selection.prepared_items
+        ]
+        for excluded in selection.excluded_workflows:
+            if excluded.workflow_id is None:
+                continue
+            workflow_results.append(
+                WorkflowBulkPushWorkflowResult(
+                    workflow_id=excluded.workflow_id,
+                    title=excluded.title or excluded.workflow_id,
+                    path=str(
+                        get_definition_path(WorkflowUUID.new(excluded.workflow_id))
+                    ),
+                    status=WorkflowBulkPushWorkflowStatus.EXCLUDED,
+                    message=excluded.message,
+                )
+            )
+        return workflow_results
+
+    def _dedupe_workflow_ids(
+        self, workflow_ids: Sequence[WorkflowUUID]
+    ) -> list[WorkflowUUID]:
+        unique_ids: dict[WorkflowIDShort, WorkflowUUID] = {}
+        for workflow_id in workflow_ids:
+            unique_ids.setdefault(workflow_id.short(), workflow_id)
+        return list(unique_ids.values())
+
+    def _normalize_folder_paths(self, folder_paths: Sequence[str]) -> list[str]:
+        normalized_paths: list[str] = []
+        for path in folder_paths:
+            stripped = path.strip()
+            if not stripped:
+                continue
+            if stripped == "/":
+                normalized = "/"
+            else:
+                normalized = stripped if stripped.startswith("/") else f"/{stripped}"
+                if not normalized.endswith("/"):
+                    normalized = f"{normalized}/"
+            if normalized not in normalized_paths:
+                normalized_paths.append(normalized)
+        return normalized_paths
+
+    def _to_workflow_uuids(
+        self, workflow_ids: Sequence[WorkflowIDShort]
+    ) -> list[WorkflowUUID]:
+        return [WorkflowUUID.new(workflow_id) for workflow_id in workflow_ids]
 
 
 def get_definition_path(workflow_id: WorkflowUUID) -> Path:

--- a/tracecat/workflow/store/sync.py
+++ b/tracecat/workflow/store/sync.py
@@ -399,6 +399,11 @@ class WorkflowSyncService(BaseWorkspaceService):
                 repo=f"{url.org}/{url.repo}",
             )
 
+        initial_branch_ref = await asyncio.to_thread(
+            repo.get_git_ref, f"heads/{branch_name}"
+        )
+        initial_branch_sha = initial_branch_ref.object.sha
+
         pr_url: str | None = None
         pr_number: int | None = None
         pr_reused = False
@@ -410,7 +415,7 @@ class WorkflowSyncService(BaseWorkspaceService):
             yaml_content = self._serialize_push_object(obj)
             try:
                 contents = await asyncio.to_thread(
-                    repo.get_contents, file_path, ref=branch_name
+                    repo.get_contents, file_path, ref=initial_branch_sha
                 )
                 if isinstance(contents, list):
                     raise GithubException(404, {"message": "Not a file"}, {})
@@ -444,8 +449,12 @@ class WorkflowSyncService(BaseWorkspaceService):
             branch_ref = await asyncio.to_thread(
                 repo.get_git_ref, f"heads/{branch_name}"
             )
+            if branch_ref.object.sha != initial_branch_sha:
+                raise TracecatValidationError(
+                    f"Branch '{branch_name}' changed while preparing the bulk push. Refresh and retry."
+                )
             parent_commit = await asyncio.to_thread(
-                repo.get_git_commit, branch_ref.object.sha
+                repo.get_git_commit, initial_branch_sha
             )
             new_tree = await asyncio.to_thread(
                 repo.create_git_tree,
@@ -461,7 +470,14 @@ class WorkflowSyncService(BaseWorkspaceService):
                 author=author,
                 committer=author,
             )
-            await asyncio.to_thread(branch_ref.edit, new_commit.sha)
+            try:
+                await asyncio.to_thread(branch_ref.edit, new_commit.sha)
+            except GithubException as e:
+                if e.status == 422:
+                    raise TracecatValidationError(
+                        f"Branch '{branch_name}' changed while preparing the bulk push. Refresh and retry."
+                    ) from e
+                raise
             commit_sha = new_commit.sha
 
         if options.create_pr:

--- a/tracecat/workflow/store/sync.py
+++ b/tracecat/workflow/store/sync.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 from pydantic import ValidationError
 
 from tracecat.db.models import User
-from tracecat.exceptions import TracecatNotFoundError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.git.utils import GitUrl
 from tracecat.logger import logger
 from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
@@ -376,6 +376,10 @@ class WorkflowSyncService(BaseWorkspaceService):
         base_branch_name = (
             options.pr_base_branch or url.ref or await self._get_default_branch(repo)
         )
+        if options.create_pr and branch_name == base_branch_name:
+            raise TracecatValidationError(
+                "branch must differ from the PR base branch when create_pr is enabled"
+            )
         base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
 
         try:

--- a/tracecat/workflow/store/sync.py
+++ b/tracecat/workflow/store/sync.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 from github.GithubException import GithubException
+from github.InputGitAuthor import InputGitAuthor
+from github.InputGitTreeElement import InputGitTreeElement
 
 if TYPE_CHECKING:
     from github.ContentFile import ContentFile
@@ -27,6 +29,7 @@ from tracecat.sync import (
     PullOptions,
     PullResult,
     PushObject,
+    PushObjectResult,
     PushOptions,
     PushStatus,
 )
@@ -317,10 +320,8 @@ class WorkflowSyncService(BaseWorkspaceService):
         Returns:
             CommitInfo with commit SHA and branch/PR details
         """
-        if len(objects) != 1:
-            raise ValueError("We only support pushing one workflow object at a time")
-
-        [obj] = objects
+        if not objects:
+            raise ValueError("At least one workflow object is required")
 
         gh_svc = GitHubAppService(session=self.session, role=self.role)
 
@@ -334,14 +335,19 @@ class WorkflowSyncService(BaseWorkspaceService):
                 return await self._push_to_target_branch(
                     repo=repo,
                     url=url,
-                    obj=obj,
+                    objects=objects,
                     options=options,
+                )
+
+            if len(objects) != 1:
+                raise ValueError(
+                    "Legacy publish mode only supports pushing one workflow object at a time"
                 )
 
             return await self._push_legacy(
                 repo=repo,
                 url=url,
-                obj=obj,
+                obj=objects[0],
                 options=options,
             )
 
@@ -361,13 +367,15 @@ class WorkflowSyncService(BaseWorkspaceService):
         *,
         repo: Any,
         url: GitUrl,
-        obj: PushObject[RemoteWorkflowDefinition],
+        objects: Sequence[PushObject[RemoteWorkflowDefinition]],
         options: PushOptions,
     ) -> CommitInfo:
         branch_name = options.branch
         if branch_name is None:
             raise ValueError("branch is required for target-branch push mode")
-        base_branch_name = options.pr_base_branch or url.ref or repo.default_branch
+        base_branch_name = (
+            options.pr_base_branch or url.ref or await self._get_default_branch(repo)
+        )
         base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
 
         try:
@@ -387,105 +395,107 @@ class WorkflowSyncService(BaseWorkspaceService):
                 repo=f"{url.org}/{url.repo}",
             )
 
-        file_path = obj.path_str
-        yaml_content = yaml.dump(
-            obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
-            sort_keys=False,
-        )
-
         pr_url: str | None = None
         pr_number: int | None = None
         pr_reused = False
+        tree_elements: list[InputGitTreeElement] = []
+        object_results: list[PushObjectResult] = []
 
-        try:
-            contents = await asyncio.to_thread(
-                repo.get_contents, file_path, ref=branch_name
-            )
-            if isinstance(contents, list):
-                raise GithubException(404, {"message": "Not a file"}, {})
-            existing_content = base64.b64decode(contents.content).decode("utf-8")
-            if existing_content == yaml_content:
-                if options.create_pr:
-                    pr_url, pr_number, pr_reused = await self._upsert_pull_request_safe(
-                        repo=repo,
-                        url=url,
-                        obj=obj,
-                        options=options,
-                        branch_name=branch_name,
-                        base_branch_name=base_branch_name,
-                    )
-                return CommitInfo(
-                    status=PushStatus.NO_OP,
-                    sha=None,
-                    ref=branch_name,
-                    base_ref=base_branch_name,
-                    pr_url=pr_url,
-                    pr_number=pr_number,
-                    pr_reused=pr_reused,
-                    message="No changes detected; nothing to commit.",
+        for obj in objects:
+            file_path = obj.path_str
+            yaml_content = self._serialize_push_object(obj)
+            try:
+                contents = await asyncio.to_thread(
+                    repo.get_contents, file_path, ref=branch_name
                 )
+                if isinstance(contents, list):
+                    raise GithubException(404, {"message": "Not a file"}, {})
+                existing_content = base64.b64decode(contents.content).decode("utf-8")
+                if existing_content == yaml_content:
+                    object_results.append(
+                        PushObjectResult(path=file_path, status=PushStatus.NO_OP)
+                    )
+                    continue
+            except GithubException as e:
+                if e.status != 404:
+                    raise
 
-            await asyncio.to_thread(
-                repo.update_file,
-                path=contents.path,
-                message=options.message,
-                content=yaml_content,
-                sha=contents.sha,
-                branch=branch_name,
+            tree_elements.append(
+                InputGitTreeElement(
+                    path=file_path,
+                    mode="100644",
+                    type="blob",
+                    content=yaml_content,
+                )
             )
-            logger.debug(
-                "Updated workflow file via API",
-                path=file_path,
-                branch=branch_name,
-            )
-        except GithubException as e:
-            if e.status != 404:
-                raise
-            await asyncio.to_thread(
-                repo.create_file,
-                path=file_path,
-                message=options.message,
-                content=yaml_content,
-                branch=branch_name,
-            )
-            logger.debug(
-                "Created workflow file via API",
-                path=file_path,
-                branch=branch_name,
+            object_results.append(
+                PushObjectResult(path=file_path, status=PushStatus.COMMITTED)
             )
 
-        branch = await asyncio.to_thread(repo.get_branch, branch_name)
-        commit_sha = branch.commit.sha
+        commit_sha: str | None = None
+        committed_count = sum(
+            1 for result in object_results if result.status == PushStatus.COMMITTED
+        )
+        if committed_count > 0:
+            branch_ref = await asyncio.to_thread(
+                repo.get_git_ref, f"heads/{branch_name}"
+            )
+            parent_commit = await asyncio.to_thread(
+                repo.get_git_commit, branch_ref.object.sha
+            )
+            new_tree = await asyncio.to_thread(
+                repo.create_git_tree,
+                tree_elements,
+                parent_commit.tree,
+            )
+            author = InputGitAuthor(options.author.name, options.author.email)
+            new_commit = await asyncio.to_thread(
+                repo.create_git_commit,
+                options.message,
+                new_tree,
+                [parent_commit],
+                author=author,
+                committer=author,
+            )
+            await asyncio.to_thread(branch_ref.edit, new_commit.sha)
+            commit_sha = new_commit.sha
 
         if options.create_pr:
             pr_url, pr_number, pr_reused = await self._upsert_pull_request_safe(
                 repo=repo,
                 url=url,
-                obj=obj,
+                obj=objects[0],
                 options=options,
                 branch_name=branch_name,
                 base_branch_name=base_branch_name,
             )
 
         logger.info(
-            "Successfully pushed workflow via GitHub API",
+            "Successfully pushed workflow definitions via GitHub API",
             branch=branch_name,
             base_branch=base_branch_name,
             commit_sha=commit_sha,
+            changed_objects=committed_count,
+            total_objects=len(object_results),
             pr_url=pr_url,
             pr_number=pr_number,
             pr_reused=pr_reused,
         )
 
         return CommitInfo(
-            status=PushStatus.COMMITTED,
+            status=PushStatus.COMMITTED if committed_count > 0 else PushStatus.NO_OP,
             sha=commit_sha,
             ref=branch_name,
             base_ref=base_branch_name,
             pr_url=pr_url,
             pr_number=pr_number,
             pr_reused=pr_reused,
-            message="Committed workflow changes.",
+            message=(
+                f"Committed changes for {committed_count} workflow file(s)."
+                if committed_count > 0
+                else "No changes detected; nothing to commit."
+            ),
+            object_results=object_results,
         )
 
     async def _push_legacy(
@@ -496,7 +506,7 @@ class WorkflowSyncService(BaseWorkspaceService):
         obj: PushObject[RemoteWorkflowDefinition],
         options: PushOptions,
     ) -> CommitInfo:
-        base_branch_name = url.ref or repo.default_branch
+        base_branch_name = url.ref or await self._get_default_branch(repo)
         base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
 
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -586,6 +596,9 @@ class WorkflowSyncService(BaseWorkspaceService):
             pr_number=pr_number,
             pr_reused=False,
             message="Committed workflow changes on a temporary legacy branch.",
+            object_results=[
+                PushObjectResult(path=obj.path_str, status=PushStatus.COMMITTED)
+            ],
         )
 
     async def _upsert_pull_request(
@@ -694,17 +707,19 @@ class WorkflowSyncService(BaseWorkspaceService):
                 current_user = None
 
         published_by = current_user.email if current_user else "<unknown>"
+        pr_title = options.pr_title or options.message
+        pr_body = options.pr_body or (
+            f"Automated workflow push from Tracecat\n\n"
+            f"**Workspace:** {workspace.name}\n"
+            f"**Published by:** {published_by}\n"
+            f"**Workflow Title:** {title}\n"
+            f"**Workflow Description:** {description}"
+        )
 
         pr = await asyncio.to_thread(
             repo.create_pull,
-            title=options.message,
-            body=(
-                f"Automated workflow sync from Tracecat\n\n"
-                f"**Workspace:** {workspace.name}\n"
-                f"**Published by:** {published_by}\n"
-                f"**Workflow Title:** {title}\n"
-                f"**Workflow Description:** {description}"
-            ),
+            title=pr_title,
+            body=pr_body,
             head=branch_name,
             base=base_branch_name,
         )
@@ -717,6 +732,20 @@ class WorkflowSyncService(BaseWorkspaceService):
             base_branch=base_branch_name,
         )
         return pr.html_url, pr.number, False
+
+    async def _get_default_branch(self, repo: Any) -> str:
+        default_branch = repo.default_branch
+        if not default_branch:
+            raise GitHubAppError(
+                "Target GitHub repository must be initialized with a default branch before pushing workflows."
+            )
+        return default_branch
+
+    def _serialize_push_object(self, obj: PushObject[RemoteWorkflowDefinition]) -> str:
+        return yaml.dump(
+            obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
+            sort_keys=False,
+        )
 
     async def list_commits(
         self,


### PR DESCRIPTION
## Screens

https://github.com/user-attachments/assets/10dc0ae5-eae2-4f21-a85c-57069917bb61




## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR adds bulk `Push to GitHub` support for workflows.

It introduces bulk preview and push endpoints that resolve selected workflow IDs and folder paths, export the latest published definition for each eligible workflow, and batch the resulting files into a single Git commit and pull request. On the frontend, the workflows dashboard now supports multi-select for workflows and folders, a bulk push dialog, and consistent `Push to GitHub` copy.

This update also polishes the frontend workflow selection and bulk-push UX: workflow row checkboxes now match the cases table style, the bulk-push dialog has a scrollable layout, included and excluded workflows are easier to scan, excluded workflow chips link directly to workflows, and folder metadata is clearer in the preview.

It also fixes workflow rename cache invalidation so returning to the workflows page refreshes renamed workflow titles, and updates the existing GitHub sync path so target-branch pushes can batch multiple workflow files into one commit while preserving PR reuse behavior.

## Related Issues

None.

## Screenshots / Recordings

N/A.

## Steps to QA

1. Open the workflows dashboard in a workspace with GitHub sync configured.
2. Select multiple workflows, or select a folder in folder view, then click `Push to GitHub`.
3. Confirm the dialog scrolls correctly, shows grouped excluded reasons, and renders included/excluded workflow links that open the workflow in a new tab.
4. Verify the created PR contains one commit with all changed workflow definition files.
5. Rename a workflow, return to the workflows page, and confirm the updated title is shown without a manual refresh.
6. Run `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_workflow_sync_service.py tests/unit/api/test_api_workflow_store_publish.py`.
7. Run `uv run ruff check tracecat/sync.py tracecat/workflow/management/folders/service.py tracecat/workflow/management/management.py tracecat/workflow/management/router.py tracecat/workflow/management/schemas.py tracecat/workflow/store/router.py tracecat/workflow/store/schemas.py tracecat/workflow/store/service.py tracecat/workflow/store/sync.py tests/unit/test_workflow_sync_service.py tests/unit/api/test_api_workflow_store_publish.py`.
8. Run `uv run basedpyright tests/unit/test_workflow_sync_service.py tests/unit/api/test_api_workflow_store_publish.py tracecat/sync.py tracecat/workflow/management/folders/service.py tracecat/workflow/management/management.py tracecat/workflow/management/router.py tracecat/workflow/management/schemas.py tracecat/workflow/store/router.py tracecat/workflow/store/schemas.py tracecat/workflow/store/service.py tracecat/workflow/store/sync.py`.
9. Run `pnpm -C frontend check` and `pnpm -C frontend run typecheck`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk Push to GitHub for workflows with a preview flow and single-PR batching. The workflows dashboard now supports multi-select for workflows and folders with a Bulk Push dialog.

- **New Features**
  - Preview lists eligible and excluded workflows (with reasons), resolved IDs (including folders), default branch/commit/PR title/body fields, a can_submit flag, and a branch picker that loads existing branches.
  - Push returns per-workflow status (committed/no_op/excluded) and per-file outcomes, plus commit SHA and branch/PR details.
  - Selection bar with select-all/deselect-all, selected count, and a bulk push action.

- **Refactors**
  - GitHub push supports multiple objects per push with per-object results and PR reuse; added optional PR title/body overrides.
  - Workflow responses include folder_path for folder-level selection; added unit tests for preview, push, batching, and sync.
  - Fixed workflow rename cache invalidation so workflow and folder lists refresh correctly after renames.

<sup>Written for commit 0c82136f136b7ee4f76d7a660d7cd63613f218d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



