### PR TITLE
fix(auth): scope SAML login gate to resolved organization

### DIFF
--- a/tests/unit/api/test_api_saml.py
+++ b/tests/unit/api/test_api_saml.py
@@ -1,0 +1,110 @@
+"""HTTP-level tests for SAML login routing and gating."""
+
+from __future__ import annotations
+
+import uuid
+from typing import cast
+from unittest.mock import ANY, AsyncMock, Mock, patch
+
+import pytest
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+
+import tracecat.auth.saml as saml_module
+from tracecat.api.common import bootstrap_role
+from tracecat.auth.enums import AuthType
+
+
+def _override_saml_db_session(client: TestClient) -> Mock:
+    db_session = Mock()
+    db_session.add = Mock()
+    db_session.commit = AsyncMock()
+
+    async def override_get_async_session() -> Mock:
+        return db_session
+
+    app = cast(FastAPI, client.app)
+    app.dependency_overrides[saml_module.get_async_session] = override_get_async_session
+    return db_session
+
+
+@pytest.mark.anyio
+async def test_saml_login_uses_resolved_org_for_auth_gate(
+    client: TestClient,
+) -> None:
+    organization_id = uuid.uuid4()
+    _override_saml_db_session(client)
+    saml_client = Mock()
+    saml_client.prepare_for_authenticate.return_value = (
+        "req-123",
+        {"headers": [("Location", "https://idp.example.com/sso")]},
+    )
+
+    with (
+        patch.object(
+            saml_module,
+            "resolve_auth_organization_id",
+            AsyncMock(return_value=organization_id),
+        ) as resolve_org_mock,
+        patch.object(
+            saml_module,
+            "verify_auth_type",
+            AsyncMock(),
+        ) as verify_auth_type_mock,
+        patch.object(
+            saml_module,
+            "get_org_saml_metadata_url",
+            AsyncMock(return_value="https://metadata.example.com"),
+        ),
+        patch.object(
+            saml_module,
+            "create_saml_client",
+            AsyncMock(return_value=saml_client),
+        ),
+    ):
+        response = client.get("/auth/saml/login?org=example-org")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"redirect_url": "https://idp.example.com/sso"}
+    resolve_org_mock.assert_awaited_once()
+    verify_auth_type_mock.assert_awaited_once_with(
+        AuthType.SAML,
+        role=bootstrap_role(organization_id),
+        session=ANY,
+    )
+
+
+@pytest.mark.anyio
+async def test_saml_login_stops_before_handler_when_org_scoped_gate_fails(
+    client: TestClient,
+) -> None:
+    organization_id = uuid.uuid4()
+    _override_saml_db_session(client)
+
+    with (
+        patch.object(
+            saml_module,
+            "resolve_auth_organization_id",
+            AsyncMock(return_value=organization_id),
+        ),
+        patch.object(
+            saml_module,
+            "verify_auth_type",
+            AsyncMock(
+                side_effect=saml_module.HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Auth type saml is not enabled",
+                )
+            ),
+        ),
+        patch.object(
+            saml_module,
+            "get_org_saml_metadata_url",
+            AsyncMock(),
+        ) as get_metadata_mock,
+    ):
+        response = client.get("/auth/saml/login?org=example-org")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json()["detail"] == "Auth type saml is not enabled"
+    get_metadata_mock.assert_not_awaited()

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,7 +1,10 @@
+import uuid
+
 import pytest
 from fastapi import HTTPException, status
 from pytest_mock import MockerFixture
 
+from tracecat.api.common import bootstrap_role
 from tracecat.auth.dependencies import (
     require_any_auth_type_enabled,
     require_auth_type_enabled,
@@ -50,7 +53,6 @@ async def test_verify_auth_type_not_allowed(
 async def test_verify_auth_type_setting_disabled(mocker: MockerFixture):
     """Test that disabled SAML setting raises HTTPException."""
     mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
-    mocker.patch("tracecat.auth.dependencies.get_setting_override", return_value=None)
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=False)
 
     with pytest.raises(HTTPException) as exc:
@@ -64,7 +66,6 @@ async def test_verify_auth_type_setting_disabled(mocker: MockerFixture):
 async def test_verify_auth_type_invalid_setting(mocker: MockerFixture):
     """Test that invalid settings raise HTTPException."""
     mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
-    mocker.patch("tracecat.auth.dependencies.get_setting_override", return_value=None)
     mocker.patch("tracecat.auth.dependencies.get_setting", return_value=None)
 
     with pytest.raises(HTTPException) as exc:
@@ -93,6 +94,28 @@ async def test_verify_auth_type_non_saml_is_platform_controlled(
 
     # No DB calls needed for non-SAML auth types
     get_setting_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_verify_auth_type_uses_provided_org_role(
+    mocker: MockerFixture,
+) -> None:
+    """SAML checks should honor the caller's resolved organization context."""
+    mocker.patch("tracecat.config.TRACECAT__AUTH_TYPES", [AuthType.SAML])
+    get_setting_mock = mocker.patch(
+        "tracecat.auth.dependencies.get_setting",
+        return_value=True,
+    )
+    org_id = uuid.uuid4()
+    role = bootstrap_role(org_id)
+
+    await verify_auth_type(AuthType.SAML, role=role)
+
+    get_setting_mock.assert_awaited_once_with(
+        key="saml_enabled",
+        role=role,
+        session=None,
+    )
 
 
 @pytest.mark.anyio

--- a/tracecat/auth/dependencies.py
+++ b/tracecat/auth/dependencies.py
@@ -2,15 +2,15 @@ from collections.abc import Sequence
 from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
 from tracecat.api.common import bootstrap_role
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.enums import AuthType
 from tracecat.auth.types import Role
-from tracecat.logger import logger
 from tracecat.settings.constants import AUTH_TYPE_TO_SETTING_KEY
-from tracecat.settings.service import get_setting, get_setting_override
+from tracecat.settings.service import get_setting
 
 WorkspaceUserRole = Annotated[
     Role,
@@ -58,11 +58,18 @@ Sets the `ctx_role` context variable.
 """
 
 
-async def verify_auth_type(auth_type: AuthType) -> None:
+async def verify_auth_type(
+    auth_type: AuthType,
+    *,
+    role: Role | None = None,
+    session: AsyncSession | None = None,
+) -> None:
     """Verify if an auth type is enabled and properly configured.
 
     Args:
         auth_type: The authentication type to verify
+        role: Optional role to use for org-scoped setting lookups
+        session: Optional database session to reuse for setting lookups
 
     Raises:
         HTTPException: If the auth type is not allowed or not enabled
@@ -83,19 +90,10 @@ async def verify_auth_type(auth_type: AuthType) -> None:
 
     # 2. Check that the setting is enabled
     key = AUTH_TYPE_TO_SETTING_KEY[auth_type]
-    # 2.5. Check for overrides
-    override = get_setting_override(key)
-    if override is not None:
-        logger.warning(
-            "Overriding auth setting from environment variables. "
-            "This is not recommended for production environments.",
-            key=key,
-            override=override,
-        )
-        return
+    setting_role = role or bootstrap_role()
     # NOTE: These settings were introduced after org settings implemented
     # so no defaults required
-    setting = await get_setting(key=key, role=bootstrap_role())
+    setting = await get_setting(key=key, role=setting_role, session=session)
     if setting is None or not isinstance(setting, bool):
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -58,7 +58,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.api.common import bootstrap_role, get_default_organization_id
-from tracecat.auth.dependencies import ServiceRole, require_auth_type_enabled
+from tracecat.auth.dependencies import ServiceRole, verify_auth_type
 from tracecat.auth.enums import AuthType
 from tracecat.auth.org_context import resolve_auth_organization_id
 from tracecat.auth.users import (
@@ -199,6 +199,20 @@ class SAMLParser:
             attributes[saml_attr.name] = asdict(saml_attr)
 
         return attributes
+
+
+async def require_saml_login_organization(
+    request: Request,
+    db_session: Annotated[AsyncSession, Depends(get_async_session)],
+) -> OrganizationID:
+    """Resolve the target org and enforce org-scoped SAML enablement."""
+    organization_id = await resolve_auth_organization_id(request, session=db_session)
+    await verify_auth_type(
+        AuthType.SAML,
+        role=bootstrap_role(organization_id),
+        session=db_session,
+    )
+    return organization_id
 
 
 @contextmanager
@@ -630,16 +644,14 @@ async def create_saml_client(
 @router.get(
     "/login",
     name=f"saml:{auth_backend.name}.login",
-    dependencies=[require_auth_type_enabled(AuthType.SAML)],
 )
 async def login(
-    request: Request,
+    organization_id: Annotated[
+        OrganizationID, Depends(require_saml_login_organization)
+    ],
     db_session: Annotated[AsyncSession, Depends(get_async_session)],
 ) -> SAMLDatabaseLoginResponse:
     """Initiate SAML login flow"""
-    # Org resolution is explicit in multi-tenant mode and default-org in
-    # single-tenant mode. This keeps login org-scoped before we contact the IdP.
-    organization_id = await resolve_auth_organization_id(request, session=db_session)
     saml_idp_metadata_url = await get_org_saml_metadata_url(db_session, organization_id)
     client = await create_saml_client(saml_idp_metadata_url)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scope SAML login gating to the resolved organization and enforce org-level SAML enablement before redirecting to the IdP. Prevents cross-org logins when SAML is disabled for the target org.

- **Bug Fixes**
  - Gate SAML login using the resolved organization (verify_auth_type now accepts role and session).
  - Added require_saml_login_organization dependency to resolve org and validate SAML before contacting the IdP.
  - Removed environment-based auth setting override to ensure org settings are respected.

- **Tests**
  - Added HTTP tests for /auth/saml/login covering success and org-scoped 403.
  - Added unit test to ensure verify_auth_type uses the provided org role.

<sup>Written for commit 7396fbc0aa720222a32794681453c20293fa6818. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

