### PR TITLE
fix(registry): avoid double internal case row prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,6 +448,9 @@ Available predefined roles:
 ### Action Templates and Registry
 - **Templates**: `packages/tracecat-registry/tracecat_registry/templates/` - YAML-based integration templates
 - **Integrations**: `packages/tracecat-registry/tracecat_registry/integrations/` - Python client integrations
+- **Registry SDK client paths**: `packages/tracecat-registry/tracecat_registry/sdk/client.py` already appends `/internal` to the base URL. When adding methods in SDK subclients, pass paths relative to that prefix (for example, use `"/cases/{case_id}/rows"` rather than `"/internal/cases/{case_id}/rows"`).
+- **Check prefix ownership before adding endpoints**: Before introducing a new SDK helper, inspect the parent client's `base_url` normalization and existing call sites so you do not duplicate path segments such as `/internal/internal/...`.
+- **Add exact-path regression tests for SDK helpers**: When you add or change SDK subclient methods, add or update a mocked test that asserts the exact path passed to `self._client`, especially for internal routes.
 - **Reference file**: `tracecat/expressions/expectations.py` – Source of primitive type mappings (e.g., `str`, `int`, `Any`) used when defining `expects:` sections in templates.
 - **Naming**: `tools.{integration_name}` namespace, titles < 5 words
 

--- a/packages/tracecat-registry/tracecat_registry/sdk/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/cases.py
@@ -991,25 +991,25 @@ class CasesClient:
             params["cursor"] = cursor
         if is_set(reverse):
             params["reverse"] = reverse
-        return await self._client.get(f"/internal/cases/{case_id}/rows", params=params)
+        return await self._client.get(f"/cases/{case_id}/rows", params=params)
 
     async def link_case_row(
         self, case_id: str, *, table_id: str, row_id: str
     ) -> types.CaseTableRowRead:
         return await self._client.post(
-            f"/internal/cases/{case_id}/rows",
+            f"/cases/{case_id}/rows",
             json={"table_id": table_id, "row_id": row_id},
         )
 
     async def unlink_case_row(
         self, case_id: str, *, table_id: str, row_id: str
     ) -> None:
-        await self._client.delete(f"/internal/cases/{case_id}/rows/{table_id}/{row_id}")
+        await self._client.delete(f"/cases/{case_id}/rows/{table_id}/{row_id}")
 
     async def insert_case_row(
         self, case_id: str, *, table_id: str, row: dict[str, Any]
     ) -> types.CaseTableRowRead:
         return await self._client.post(
-            f"/internal/cases/{case_id}/rows/insert",
+            f"/cases/{case_id}/rows/insert",
             json={"table_id": table_id, "row": {"data": row}},
         )

--- a/tests/registry/test_cases_sdk.py
+++ b/tests/registry/test_cases_sdk.py
@@ -13,8 +13,10 @@ from tracecat_registry.sdk.cases import CasesClient
 def mock_tracecat_client() -> MagicMock:
     """Create a mock TracecatClient."""
     client = MagicMock()
+    client.get = AsyncMock()
     client.post = AsyncMock()
     client.patch = AsyncMock()
+    client.delete = AsyncMock()
     return client
 
 
@@ -78,4 +80,61 @@ async def test_update_case_simple_serializes_and_keeps_null_option(
                 {"definition_id": str(definition_id), "option_id": None},
             ]
         },
+    )
+
+
+@pytest.mark.anyio
+async def test_list_case_rows_uses_client_internal_prefix_once(
+    cases_client: CasesClient, mock_tracecat_client: MagicMock
+) -> None:
+    mock_tracecat_client.get.return_value = {"items": [], "next_cursor": None}
+
+    await cases_client.list_case_rows("case-id", limit=10)
+
+    mock_tracecat_client.get.assert_called_once_with(
+        "/cases/case-id/rows",
+        params={"limit": 10},
+    )
+
+
+@pytest.mark.anyio
+async def test_link_case_row_uses_client_internal_prefix_once(
+    cases_client: CasesClient, mock_tracecat_client: MagicMock
+) -> None:
+    mock_tracecat_client.post.return_value = {"case_id": "case-id"}
+
+    await cases_client.link_case_row("case-id", table_id="table-id", row_id="row-id")
+
+    mock_tracecat_client.post.assert_called_once_with(
+        "/cases/case-id/rows",
+        json={"table_id": "table-id", "row_id": "row-id"},
+    )
+
+
+@pytest.mark.anyio
+async def test_unlink_case_row_uses_client_internal_prefix_once(
+    cases_client: CasesClient, mock_tracecat_client: MagicMock
+) -> None:
+    await cases_client.unlink_case_row("case-id", table_id="table-id", row_id="row-id")
+
+    mock_tracecat_client.delete.assert_called_once_with(
+        "/cases/case-id/rows/table-id/row-id"
+    )
+
+
+@pytest.mark.anyio
+async def test_insert_case_row_uses_client_internal_prefix_once(
+    cases_client: CasesClient, mock_tracecat_client: MagicMock
+) -> None:
+    mock_tracecat_client.post.return_value = {"case_id": "case-id"}
+
+    await cases_client.insert_case_row(
+        "case-id",
+        table_id="table-id",
+        row={"customer": "acme"},
+    )
+
+    mock_tracecat_client.post.assert_called_once_with(
+        "/cases/case-id/rows/insert",
+        json={"table_id": "table-id", "row": {"data": {"customer": "acme"}}},
     )


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes the cases SDK paths for linked table row operations.

`TracecatClient` already appends `/internal` to the base URL, so the case row helpers in `CasesClient` should call `/cases/...`, not `/internal/cases/...`. Without that, linked table row actions can hit `/internal/internal/...` and 404.

This also adds regression coverage for:
- `list_case_rows`
- `link_case_row`
- `unlink_case_row`
- `insert_case_row`

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Run `uv run pytest --confcutdir=tests/registry tests/registry/test_cases_sdk.py`.
2. Run `uv run ruff check packages/tracecat-registry/tracecat_registry/sdk/cases.py tests/registry/test_cases_sdk.py`.
3. Run `uv run ruff format --check packages/tracecat-registry/tracecat_registry/sdk/cases.py tests/registry/test_cases_sdk.py`.
4. Run `uv run pyright packages/tracecat-registry/tracecat_registry/sdk/cases.py tests/registry/test_cases_sdk.py`.
5. Trigger a local linked case-row action and confirm the request path is `/internal/cases/{case_id}/rows`, not `/internal/internal/cases/{case_id}/rows`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double "/internal" prefix in cases SDK row endpoints and documents path rules to prevent duplication. Linked table row operations now call the correct paths and no longer 404.

- **Bug Fixes**
  - Updated CasesClient to use "/cases/..." for list/link/unlink/insert row methods, relying on TracecatClient to add "/internal".
  - Added regression tests and documented SDK path prefix rules to ensure only one internal prefix is used.

<sup>Written for commit 03c8e989c2b665a78d416bf9be652567885c48b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

