### PR TITLE
fix: Fix sign-in redirect loops and cluster URL leaks

### DIFF
--- a/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -5,19 +5,18 @@ import { Suspense, useEffect } from "react"
 import { SignIn } from "@/components/auth/sign-in"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useAuth } from "@/hooks/use-auth"
+import { sanitizeReturnUrl } from "@/lib/auth-return-url"
 
 function SignInContent() {
   const { user, userIsLoading } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const returnUrl = searchParams?.get("returnUrl") ?? null
+  const returnUrl = sanitizeReturnUrl(searchParams?.get("returnUrl") ?? null)
   const organizationSlug = searchParams?.get("org") ?? null
 
   useEffect(() => {
     if (user) {
-      // Redirect to returnUrl if provided, otherwise to workspaces
-      const redirectTo = returnUrl || "/workspaces"
-      router.push(redirectTo)
+      router.replace(returnUrl ?? "/workspaces")
     }
   }, [user, router, returnUrl])
 

--- a/frontend/src/components/auth/sign-in.tsx
+++ b/frontend/src/components/auth/sign-in.tsx
@@ -3,7 +3,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import Image from "next/image"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import TracecatIcon from "public/icon.png"
 import type React from "react"
 import { useEffect, useState } from "react"
@@ -33,7 +32,7 @@ import {
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
-import { useAuth, useAuthActions } from "@/hooks/use-auth"
+import { useAuthActions } from "@/hooks/use-auth"
 import {
   sanitizeReturnUrl,
   serializeClearPostAuthReturnUrlCookie,
@@ -60,8 +59,9 @@ function buildSignUpPath(
   organizationSlug?: string | null
 ): string {
   const params = new URLSearchParams()
-  if (returnUrl) {
-    params.set("returnUrl", returnUrl)
+  const sanitizedReturnUrl = sanitizeReturnUrl(returnUrl)
+  if (sanitizedReturnUrl) {
+    params.set("returnUrl", sanitizedReturnUrl)
   }
   if (organizationSlug) {
     params.set("org", organizationSlug)
@@ -91,17 +91,11 @@ export function SignIn({
   returnUrl,
   organizationSlug,
 }: SignInProps) {
-  const { user } = useAuth()
   const { appInfo, appInfoIsLoading, appInfoError } = useAppInfo()
   const [isDiscovering, setIsDiscovering] = useState(false)
   const [discoveredMethod, setDiscoveredMethod] = useState<"basic" | null>(null)
   const [discoveredEmail, setDiscoveredEmail] = useState("")
-  const router = useRouter()
   const signUpPath = buildSignUpPath(returnUrl, organizationSlug)
-
-  if (user) {
-    router.push("/workspaces")
-  }
 
   if (appInfoIsLoading) {
     return <CenteredSpinner />

--- a/frontend/src/lib/auth-return-url.test.ts
+++ b/frontend/src/lib/auth-return-url.test.ts
@@ -1,0 +1,48 @@
+import {
+  decodeAndSanitizeReturnUrl,
+  sanitizeReturnUrl,
+} from "@/lib/auth-return-url"
+
+describe("sanitizeReturnUrl", () => {
+  it.each([
+    "/sign-in",
+    "/sign-in/reset-password",
+    "/sign-up",
+    "/sign-up/invite",
+    "/auth",
+    "/auth/oauth/callback",
+  ])("rejects auth routes for %s", (value) => {
+    expect(sanitizeReturnUrl(value)).toBeNull()
+  })
+
+  it.each(["https://example.com/workspaces", "//example.com/workspaces"])(
+    "rejects external return targets for %s",
+    (value) => {
+      expect(sanitizeReturnUrl(value)).toBeNull()
+    }
+  )
+
+  it("keeps valid internal routes intact", () => {
+    expect(sanitizeReturnUrl("/workspaces/123?tab=members#activity")).toBe(
+      "/workspaces/123?tab=members#activity"
+    )
+  })
+
+  it("does not over-match unrelated internal routes", () => {
+    expect(sanitizeReturnUrl("/authentic/path")).toBe("/authentic/path")
+  })
+})
+
+describe("decodeAndSanitizeReturnUrl", () => {
+  it("rejects encoded auth routes", () => {
+    expect(
+      decodeAndSanitizeReturnUrl("%2Fsign-in%3FreturnUrl%3D%252Fsign-in")
+    ).toBeNull()
+  })
+
+  it("accepts encoded internal routes", () => {
+    expect(
+      decodeAndSanitizeReturnUrl("%2Fworkspaces%2Fabc%3Ftab%3Dmembers")
+    ).toBe("/workspaces/abc?tab=members")
+  })
+})

--- a/frontend/src/lib/auth-return-url.ts
+++ b/frontend/src/lib/auth-return-url.ts
@@ -2,10 +2,24 @@ export const POST_AUTH_RETURN_URL_COOKIE_NAME = "tracecat_post_auth_return_url"
 export const POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS = 60 * 15
 
 const APP_URL_PLACEHOLDER = "https://tracecat.local"
+const BLOCKED_POST_AUTH_RETURN_URL_PREFIXES = [
+  "/auth",
+  "/sign-in",
+  "/sign-up",
+] as const
 
 function getPostAuthReturnUrlCookieSameSite(secure: boolean): "None" | "Lax" {
   // Cross-site POSTs (SAML ACS) require SameSite=None; browsers require Secure with None.
   return secure ? "None" : "Lax"
+}
+
+function isBlockedPostAuthReturnPath(pathname: string): boolean {
+  const normalizedPathname = pathname.toLowerCase()
+  return BLOCKED_POST_AUTH_RETURN_URL_PREFIXES.some(
+    (prefix) =>
+      normalizedPathname === prefix ||
+      normalizedPathname.startsWith(`${prefix}/`)
+  )
 }
 
 export function sanitizeReturnUrl(
@@ -23,6 +37,9 @@ export function sanitizeReturnUrl(
   try {
     const parsed = new URL(trimmedValue, APP_URL_PLACEHOLDER)
     if (parsed.origin !== APP_URL_PLACEHOLDER) {
+      return null
+    }
+    if (isBlockedPostAuthReturnPath(parsed.pathname)) {
       return null
     }
     return `${parsed.pathname}${parsed.search}${parsed.hash}`

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -255,10 +255,19 @@ calculate_ports() {
 build_env() {
     local cluster_num=$1
     calculate_ports "$cluster_num"
+    local public_app_url_override="${CLUSTER_PUBLIC_APP_URL_OVERRIDE:-}"
+    local public_api_url_override="${CLUSTER_PUBLIC_API_URL_OVERRIDE:-}"
 
     # URLs that depend on ports
     local PUBLIC_APP_URL="http://localhost:${PUBLIC_APP_PORT}"
+    if [[ -n "$public_app_url_override" ]]; then
+        PUBLIC_APP_URL="${public_app_url_override%/}"
+    fi
+
     local PUBLIC_API_URL="${PUBLIC_APP_URL}/api"
+    if [[ -n "$public_api_url_override" ]]; then
+        PUBLIC_API_URL="${public_api_url_override%/}"
+    fi
 
     # Export all variables (include worktree ID for isolation)
     export COMPOSE_PROJECT_NAME="tracecat-${WORKTREE_ID}-${cluster_num}"
@@ -275,11 +284,13 @@ build_env() {
     export MINIO_CONSOLE_PORT
     export MCP_PORT
 
-    # URL variables that reference the public port (allow explicit env overrides, e.g. ngrok)
-    export TRACECAT__PUBLIC_APP_URL="${TRACECAT__PUBLIC_APP_URL:-${PUBLIC_APP_URL}}"
-    export TRACECAT__PUBLIC_API_URL="${TRACECAT__PUBLIC_API_URL:-${PUBLIC_API_URL}}"
-    export NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL:-${PUBLIC_APP_URL}}"
-    export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-${PUBLIC_API_URL}}"
+    # Always compute public URLs per cluster so `just`-loaded `.env` values from
+    # cluster 1 do not leak into other clusters. Use explicit override vars for
+    # tunnels or custom public hosts when needed.
+    export TRACECAT__PUBLIC_APP_URL="${PUBLIC_APP_URL}"
+    export TRACECAT__PUBLIC_API_URL="${PUBLIC_API_URL}"
+    export NEXT_PUBLIC_APP_URL="${PUBLIC_APP_URL}"
+    export NEXT_PUBLIC_API_URL="${PUBLIC_API_URL}"
 
     # Caddy configuration
     export BASE_DOMAIN=":${PUBLIC_APP_PORT}"


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes two related local auth regressions:

1. It removes conflicting `/sign-in` redirect paths and blocks auth-route `returnUrl` values so signed-in users cannot bounce back into `/sign-in`, `/sign-up`, or `/auth/*`.
2. It fixes `just cluster` leaking cluster-1 `.env` public URLs into other clusters, which caused the frontend on `http://localhost:180` to call `http://localhost/api` and trip CSP/network failures.

It also keeps explicit public URL overrides available for tunnel/custom-host workflows via `CLUSTER_PUBLIC_APP_URL_OVERRIDE` and `CLUSTER_PUBLIC_API_URL_OVERRIDE` instead of implicitly inheriting `NEXT_PUBLIC_*` or `TRACECAT__PUBLIC_*` from `.env`.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Run `just cluster 2 up -d --force-recreate api ui caddy`.
2. Open `http://localhost:180/sign-in` while logged out and confirm the sign-in form loads normally.
3. In DevTools, confirm the page calls `http://localhost:180/api/users/me` and `http://localhost:180/api/info`, not `http://localhost/api/...`.
4. Sign in and visit `http://localhost:180/sign-in?returnUrl=%2Fsign-in`; confirm the app settles on `/workspaces` instead of redirecting back into auth.
5. Optional: run `CLUSTER_PUBLIC_APP_URL_OVERRIDE=https://<your-ngrok-host> just cluster 2 up -d --force-recreate api ui caddy` and confirm generated public URLs use the tunnel host.

## Verification

- `pnpm -C frontend exec biome check --write 'src/app/sign-in/[[...sign-in]]/page.tsx' src/components/auth/sign-in.tsx src/lib/auth-return-url.ts src/lib/auth-return-url.test.ts`
- `pnpm -C frontend test -- --runTestsByPath src/lib/auth-return-url.test.ts --runInBand`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`
- DevTools MCP verification against `http://localhost:180/sign-in` after recreating `api`, `ui`, and `caddy`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sign-in redirect loops and stops per-cluster URL leaks by sanitizing auth return targets and computing public URLs per cluster with explicit override options.

- **Bug Fixes**
  - Auth: Block returnUrl values pointing to /sign-in, /sign-up, /auth, or external origins; apply sanitizeReturnUrl in the sign-in page and sign-up link; use router.replace after sign-in; add unit tests for sanitization/decoding.
  - Cluster: Compute TRACECAT__PUBLIC_* and NEXT_PUBLIC_* per cluster instead of inheriting from .env; support tunnels/custom hosts via CLUSTER_PUBLIC_APP_URL_OVERRIDE and CLUSTER_PUBLIC_API_URL_OVERRIDE.

<sup>Written for commit 18de16f749f919042e5365410a153f5504313c5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

