### PR TITLE
fix(tests): serialize shared xdist db setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from dotenv import load_dotenv
 from minio import Minio
 from minio.error import S3Error
 from sqlalchemy import create_engine, select, text
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.pool import NullPool
@@ -125,6 +126,15 @@ def _install_case_number_allocator(conn: Any) -> None:
             EXECUTE FUNCTION assign_workspace_case_number()
             """
         )
+    )
+
+
+def _lock_test_db_setup(conn: Any, db_uri: str) -> None:
+    """Serialize shared test DB setup across xdist workers."""
+    db_name = make_url(db_uri).database or "postgres"
+    conn.execute(
+        text("SELECT pg_advisory_xact_lock(hashtext(:lock_key)::bigint)"),
+        {"lock_key": f"tests:db-setup:{db_name}"},
     )
 
 
@@ -331,6 +341,7 @@ def default_org(db: None, env_sandbox: None) -> Iterator[None]:
 
         # Ensure schema exists for service sessions that target the default DB.
         with sync_engine.begin() as conn:
+            _lock_test_db_setup(conn, sync_db_uri)
             Base.metadata.create_all(conn)
             _install_case_number_allocator(conn)
 


### PR DESCRIPTION
## Summary
- serialize shared default-db schema setup in `tests/conftest.py` with a Postgres advisory transaction lock keyed by database name
- keep the existing split between the worker-local test DB and the shared default DB used by `with_session()` fixtures
- prevent parallel `CREATE OR REPLACE FUNCTION assign_workspace_case_number()` calls from pytest-xdist workers, which were causing `tuple concurrently updated` in CI

## Testing
- `uv run pytest tests/integration/test_syncv2_execv2_e2e.py::TestSyncv2MinioIntegration::test_sync_creates_registry_version_with_manifest tests/integration/test_syncv2_execv2_e2e.py::TestExecuteWithSyncedRegistry::test_execute_action_with_ephemeral_backend tests/integration/test_syncv2_execv2_e2e.py::TestFailureScenarios::test_execute_raises_when_tarball_missing tests/integration/test_syncv2_execv2_e2e.py::TestMultitenantWorkloads::test_workspace_specific_registry_locks -n 4 -ra -v`
- `uv run ruff check tests/conftest.py tests/integration/test_syncv2_execv2_e2e.py`
- `uv run basedpyright tests/conftest.py tests/integration/test_syncv2_execv2_e2e.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize the shared test DB setup across pytest-xdist workers to remove CI race conditions and “tuple concurrently updated” errors. Adds a Postgres advisory transaction lock keyed by DB name around schema creation and function install in tests/conftest.py.

- **Bug Fixes**
  - Added _lock_test_db_setup using pg_advisory_xact_lock(hashtext(key)::bigint).
  - Serialized Base.metadata.create_all and assign_workspace_case_number installation for the shared default DB.
  - No changes to worker-local test DBs or existing fixtures.

<sup>Written for commit cdf3359001a02581c0b7bc420d0339ad86e5ddc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

