### PR TITLE
feat(ui): persist and hydrate cases list filters from localStorage

### DIFF
--- a/frontend/src/components/cases/case-sort.ts
+++ b/frontend/src/components/cases/case-sort.ts
@@ -1,0 +1,19 @@
+"use client"
+
+export type CaseSortField =
+  | "updated_at"
+  | "created_at"
+  | "priority"
+  | "severity"
+  | "status"
+  | "tasks"
+
+export interface CaseSortValue {
+  field: CaseSortField
+  direction: "asc" | "desc"
+}
+
+export const DEFAULT_CASE_SORT: CaseSortValue = {
+  field: "updated_at",
+  direction: "desc",
+}

--- a/frontend/src/components/cases/cases-header.tsx
+++ b/frontend/src/components/cases/cases-header.tsx
@@ -34,6 +34,11 @@ import {
   STATUSES,
 } from "@/components/cases/case-categories"
 import { UNASSIGNED } from "@/components/cases/case-panel-selectors"
+import {
+  type CaseSortField,
+  type CaseSortValue,
+  DEFAULT_CASE_SORT,
+} from "@/components/cases/case-sort"
 import { DynamicLucideIcon } from "@/components/dynamic-lucide-icon"
 import {
   type FilterMode,
@@ -257,24 +262,6 @@ function DateFilterSelect({
       </PopoverContent>
     </Popover>
   )
-}
-
-export type CaseSortField =
-  | "updated_at"
-  | "created_at"
-  | "priority"
-  | "severity"
-  | "status"
-  | "tasks"
-
-export interface CaseSortValue {
-  field: CaseSortField
-  direction: "asc" | "desc"
-}
-
-export const DEFAULT_CASE_SORT: CaseSortValue = {
-  field: "updated_at",
-  direction: "desc",
 }
 
 const CASE_SORT_OPTIONS: Array<{

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -15,12 +15,12 @@ import {
   type WorkspaceMember,
 } from "@/client"
 import { useCaseSelection } from "@/components/cases/case-selection-context"
-import { CasesAccordion } from "@/components/cases/cases-accordion"
 import {
   type CaseSortValue,
-  CasesHeader,
   DEFAULT_CASE_SORT,
-} from "@/components/cases/cases-header"
+} from "@/components/cases/case-sort"
+import { CasesAccordion } from "@/components/cases/cases-accordion"
+import { CasesHeader } from "@/components/cases/cases-header"
 import { DeleteCaseAlertDialog } from "@/components/cases/delete-case-dialog"
 import type {
   FilterMode,

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -15,6 +15,7 @@ import {
   casesSearchCases,
 } from "@/client"
 import {
+  type CaseSortField,
   type CaseSortValue,
   DEFAULT_CASE_SORT,
 } from "@/components/cases/case-sort"
@@ -270,25 +271,61 @@ function loadPersistedCasesFilterState(
 
     const parsed = JSON.parse(storedValue) as Partial<PersistedCasesFilters>
     return {
-      searchQuery: parsed.searchQuery ?? defaults.searchQuery,
-      sortBy: parsed.sortBy ?? defaults.sortBy,
-      statusFilter: parsed.statusFilter ?? defaults.statusFilter,
-      statusMode: parsed.statusMode ?? defaults.statusMode,
-      priorityFilter: parsed.priorityFilter ?? defaults.priorityFilter,
-      priorityMode: parsed.priorityMode ?? defaults.priorityMode,
-      prioritySortDirection:
-        parsed.prioritySortDirection ?? defaults.prioritySortDirection,
-      severityFilter: parsed.severityFilter ?? defaults.severityFilter,
-      severityMode: parsed.severityMode ?? defaults.severityMode,
-      severitySortDirection:
-        parsed.severitySortDirection ?? defaults.severitySortDirection,
-      assigneeFilter: parsed.assigneeFilter ?? defaults.assigneeFilter,
-      assigneeMode: parsed.assigneeMode ?? defaults.assigneeMode,
-      assigneeSortDirection:
-        parsed.assigneeSortDirection ?? defaults.assigneeSortDirection,
-      tagFilter: parsed.tagFilter ?? defaults.tagFilter,
-      tagMode: parsed.tagMode ?? defaults.tagMode,
-      tagSortDirection: parsed.tagSortDirection ?? defaults.tagSortDirection,
+      searchQuery: sanitizeSearchQuery(
+        parsed.searchQuery,
+        defaults.searchQuery
+      ),
+      sortBy: sanitizeSortBy(parsed.sortBy, defaults.sortBy),
+      statusFilter: sanitizeEnumArray(
+        parsed.statusFilter,
+        ALL_CASE_STATUSES,
+        defaults.statusFilter
+      ),
+      statusMode: sanitizeFilterMode(parsed.statusMode, defaults.statusMode),
+      priorityFilter: sanitizeEnumArray(
+        parsed.priorityFilter,
+        ALL_CASE_PRIORITIES,
+        defaults.priorityFilter
+      ),
+      priorityMode: sanitizeFilterMode(
+        parsed.priorityMode,
+        defaults.priorityMode
+      ),
+      prioritySortDirection: sanitizeSortDirection(
+        parsed.prioritySortDirection,
+        defaults.prioritySortDirection
+      ),
+      severityFilter: sanitizeEnumArray(
+        parsed.severityFilter,
+        ALL_CASE_SEVERITIES,
+        defaults.severityFilter
+      ),
+      severityMode: sanitizeFilterMode(
+        parsed.severityMode,
+        defaults.severityMode
+      ),
+      severitySortDirection: sanitizeSortDirection(
+        parsed.severitySortDirection,
+        defaults.severitySortDirection
+      ),
+      assigneeFilter: sanitizeStringArray(
+        parsed.assigneeFilter,
+        defaults.assigneeFilter
+      ),
+      assigneeMode: sanitizeFilterMode(
+        parsed.assigneeMode,
+        defaults.assigneeMode
+      ),
+      assigneeSortDirection: sanitizeSortDirection(
+        parsed.assigneeSortDirection,
+        defaults.assigneeSortDirection
+      ),
+      tagFilter: sanitizeStringArray(parsed.tagFilter, defaults.tagFilter),
+      tagMode: sanitizeFilterMode(parsed.tagMode, defaults.tagMode),
+      tagSortDirection: sanitizeSortDirection(
+        parsed.tagSortDirection,
+        defaults.tagSortDirection
+      ),
       dropdownFilters: sanitizeDropdownFilters(parsed.dropdownFilters),
       updatedAfter: parsePersistedDateFilter(
         parsed.updatedAfter,
@@ -341,6 +378,73 @@ function isFilterMode(value: unknown): value is FilterMode {
 
 function isSortDirection(value: unknown): value is SortDirection {
   return value === "asc" || value === "desc" || value === null
+}
+
+function isCaseSortField(value: unknown): value is CaseSortField {
+  return (
+    value === "updated_at" ||
+    value === "created_at" ||
+    value === "priority" ||
+    value === "severity" ||
+    value === "status" ||
+    value === "tasks"
+  )
+}
+
+function sanitizeSearchQuery(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback
+}
+
+function sanitizeStringArray(value: unknown, fallback: string[]): string[] {
+  return Array.isArray(value)
+    ? value.filter((item: unknown): item is string => typeof item === "string")
+    : fallback
+}
+
+function sanitizeEnumArray<T extends string>(
+  value: unknown,
+  allowedValues: ReadonlyArray<T>,
+  fallback: T[]
+): T[] {
+  if (!Array.isArray(value)) {
+    return fallback
+  }
+
+  const allowedSet = new Set(allowedValues)
+  return value.filter(
+    (item: unknown): item is T =>
+      typeof item === "string" && allowedSet.has(item as T)
+  )
+}
+
+function sanitizeFilterMode(value: unknown, fallback: FilterMode): FilterMode {
+  return isFilterMode(value) ? value : fallback
+}
+
+function sanitizeSortDirection(
+  value: unknown,
+  fallback: SortDirection
+): SortDirection {
+  return isSortDirection(value) ? value : fallback
+}
+
+function sanitizeSortBy(
+  value: unknown,
+  fallback: CaseSortValue
+): CaseSortValue {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return fallback
+  }
+
+  const candidate = value as {
+    field?: unknown
+    direction?: unknown
+  }
+
+  return isCaseSortField(candidate.field) &&
+    (candidate.direction === "asc" || candidate.direction === "desc")
+    ? { field: candidate.field, direction: candidate.direction }
+    : fallback
 }
 
 function sanitizeDropdownFilters(

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { DateRange } from "react-day-picker"
 import {
   type CasePriority,
@@ -27,6 +27,7 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 
 const CASES_PAGE_SIZE = 100
 const CASES_REFETCH_INTERVAL_MS = 120000
+const CASES_FILTER_STORAGE_KEY = "cases-filters:v1"
 const ALL_CASE_STATUSES: ReadonlyArray<CaseStatus> = [
   "unknown",
   "new",
@@ -141,6 +142,43 @@ export interface UseCasesResult {
   fetchNextPage: () => void
 }
 
+interface PersistedCaseDateRange {
+  from?: string
+  to?: string
+}
+
+type PersistedCaseDateFilter =
+  | {
+      type: "preset"
+      value: CaseDatePreset
+    }
+  | {
+      type: "range"
+      value: PersistedCaseDateRange
+    }
+
+interface PersistedCasesFilters {
+  searchQuery: string
+  sortBy: CaseSortValue
+  statusFilter: CaseStatus[]
+  statusMode: FilterMode
+  priorityFilter: CasePriority[]
+  priorityMode: FilterMode
+  prioritySortDirection: SortDirection
+  severityFilter: CaseSeverity[]
+  severityMode: FilterMode
+  severitySortDirection: SortDirection
+  assigneeFilter: string[]
+  assigneeMode: FilterMode
+  assigneeSortDirection: SortDirection
+  tagFilter: string[]
+  tagMode: FilterMode
+  tagSortDirection: SortDirection
+  dropdownFilters: Record<string, DropdownFilterState>
+  updatedAfter: PersistedCaseDateFilter
+  createdAfter: PersistedCaseDateFilter
+}
+
 // Helper to get Date from preset filter value
 function getDateFromPreset(preset: CaseDatePreset): Date | null {
   if (!preset) return null
@@ -190,6 +228,72 @@ export const DEFAULT_CREATED_PRESET: CaseDatePreset = "1m"
 export const DEFAULT_CREATED_FILTER: CaseDateFilterValue = {
   type: "preset",
   value: DEFAULT_CREATED_PRESET,
+}
+
+function parsePersistedDateFilter(
+  filter: PersistedCaseDateFilter | undefined,
+  fallback: CaseDateFilterValue
+): CaseDateFilterValue {
+  if (!filter) {
+    return fallback
+  }
+
+  if (filter.type === "preset") {
+    if (filter.value === null) {
+      return { type: "preset", value: null }
+    }
+
+    if (
+      filter.value === "1d" ||
+      filter.value === "3d" ||
+      filter.value === "1w" ||
+      filter.value === "1m"
+    ) {
+      return { type: "preset", value: filter.value }
+    }
+
+    return fallback
+  }
+
+  if (filter.type === "range" && typeof filter.value === "object") {
+    const from =
+      typeof filter.value.from === "string"
+        ? new Date(filter.value.from)
+        : undefined
+    const to =
+      typeof filter.value.to === "string"
+        ? new Date(filter.value.to)
+        : undefined
+
+    return {
+      type: "range",
+      value: {
+        from: from && !Number.isNaN(from.getTime()) ? from : undefined,
+        to: to && !Number.isNaN(to.getTime()) ? to : undefined,
+      },
+    }
+  }
+
+  return fallback
+}
+
+function serializeDateFilter(
+  filter: CaseDateFilterValue
+): PersistedCaseDateFilter {
+  if (filter.type === "preset") {
+    return {
+      type: "preset",
+      value: filter.value,
+    }
+  }
+
+  return {
+    type: "range",
+    value: {
+      from: filter.value.from?.toISOString(),
+      to: filter.value.to?.toISOString(),
+    },
+  }
 }
 
 function resolveEnumIncludeFilter<T extends string>(
@@ -287,6 +391,113 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
   const [createdAfter, setCreatedAfter] = useState<CaseDateFilterValue>(
     DEFAULT_CREATED_FILTER
   )
+  const hasHydratedFiltersRef = useRef(false)
+
+  useEffect(() => {
+    if (!workspaceId || typeof window === "undefined") {
+      return
+    }
+
+    const storedValue = window.localStorage.getItem(
+      `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`
+    )
+    if (!storedValue) {
+      hasHydratedFiltersRef.current = true
+      return
+    }
+
+    try {
+      const parsed = JSON.parse(storedValue) as Partial<PersistedCasesFilters>
+
+      setSearchQuery(parsed.searchQuery ?? "")
+      setSortByState(parsed.sortBy ?? DEFAULT_CASE_SORT)
+      setStatusFilter(parsed.statusFilter ?? [])
+      setStatusMode(parsed.statusMode ?? "include")
+      setPriorityFilter(parsed.priorityFilter ?? [])
+      setPriorityMode(parsed.priorityMode ?? "include")
+      setPrioritySortDirectionState(parsed.prioritySortDirection ?? null)
+      setSeverityFilter(parsed.severityFilter ?? [])
+      setSeverityMode(parsed.severityMode ?? "include")
+      setSeveritySortDirectionState(parsed.severitySortDirection ?? null)
+      setAssigneeFilter(parsed.assigneeFilter ?? [])
+      setAssigneeModeState(parsed.assigneeMode ?? "include")
+      setAssigneeSortDirectionState(parsed.assigneeSortDirection ?? null)
+      setTagFilter(parsed.tagFilter ?? [])
+      setTagModeState(parsed.tagMode ?? "include")
+      setTagSortDirectionState(parsed.tagSortDirection ?? null)
+      setDropdownFilters(parsed.dropdownFilters ?? {})
+      setUpdatedAfter(
+        parsePersistedDateFilter(parsed.updatedAfter, DEFAULT_DATE_FILTER)
+      )
+      setCreatedAfter(
+        parsePersistedDateFilter(parsed.createdAfter, DEFAULT_CREATED_FILTER)
+      )
+    } catch {
+      window.localStorage.removeItem(
+        `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`
+      )
+    }
+
+    hasHydratedFiltersRef.current = true
+  }, [workspaceId])
+
+  useEffect(() => {
+    if (
+      !workspaceId ||
+      !hasHydratedFiltersRef.current ||
+      typeof window === "undefined"
+    ) {
+      return
+    }
+
+    const persistedFilters: PersistedCasesFilters = {
+      searchQuery,
+      sortBy,
+      statusFilter,
+      statusMode,
+      priorityFilter,
+      priorityMode,
+      prioritySortDirection,
+      severityFilter,
+      severityMode,
+      severitySortDirection,
+      assigneeFilter,
+      assigneeMode,
+      assigneeSortDirection,
+      tagFilter,
+      tagMode,
+      tagSortDirection,
+      dropdownFilters,
+      updatedAfter: serializeDateFilter(updatedAfter),
+      createdAfter: serializeDateFilter(createdAfter),
+    }
+
+    window.localStorage.setItem(
+      `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`,
+      JSON.stringify(persistedFilters)
+    )
+  }, [
+    workspaceId,
+    searchQuery,
+    sortBy,
+    statusFilter,
+    statusMode,
+    priorityFilter,
+    priorityMode,
+    prioritySortDirection,
+    severityFilter,
+    severityMode,
+    severitySortDirection,
+    assigneeFilter,
+    assigneeMode,
+    assigneeSortDirection,
+    tagFilter,
+    tagMode,
+    tagSortDirection,
+    dropdownFilters,
+    updatedAfter,
+    createdAfter,
+  ])
 
   const setAssigneeMode = useCallback((_mode: FilterMode) => {
     setAssigneeModeState("include")

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -17,7 +17,7 @@ import {
 import {
   type CaseSortValue,
   DEFAULT_CASE_SORT,
-} from "@/components/cases/cases-header"
+} from "@/components/cases/case-sort"
 import type {
   FilterMode,
   SortDirection,

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -289,7 +289,7 @@ function loadPersistedCasesFilterState(
       tagFilter: parsed.tagFilter ?? defaults.tagFilter,
       tagMode: parsed.tagMode ?? defaults.tagMode,
       tagSortDirection: parsed.tagSortDirection ?? defaults.tagSortDirection,
-      dropdownFilters: parsed.dropdownFilters ?? defaults.dropdownFilters,
+      dropdownFilters: sanitizeDropdownFilters(parsed.dropdownFilters),
       updatedAfter: parsePersistedDateFilter(
         parsed.updatedAfter,
         defaults.updatedAfter
@@ -333,6 +333,52 @@ function serializePersistedCasesFilters(
     updatedAfter: serializeDateFilter(filters.updatedAfter),
     createdAfter: serializeDateFilter(filters.createdAfter),
   }
+}
+
+function isFilterMode(value: unknown): value is FilterMode {
+  return value === "include" || value === "exclude"
+}
+
+function isSortDirection(value: unknown): value is SortDirection {
+  return value === "asc" || value === "desc" || value === null
+}
+
+function sanitizeDropdownFilters(
+  dropdownFilters: unknown
+): Record<string, DropdownFilterState> {
+  if (
+    !dropdownFilters ||
+    typeof dropdownFilters !== "object" ||
+    Array.isArray(dropdownFilters)
+  ) {
+    return {}
+  }
+
+  const sanitized: Record<string, DropdownFilterState> = {}
+  for (const [definitionRef, state] of Object.entries(dropdownFilters)) {
+    if (!state || typeof state !== "object" || Array.isArray(state)) {
+      continue
+    }
+
+    const values = Array.isArray(state.values)
+      ? state.values.filter(
+          (value: unknown): value is string => typeof value === "string"
+        )
+      : null
+    if (!values || !isFilterMode(state.mode)) {
+      continue
+    }
+
+    sanitized[definitionRef] = {
+      values,
+      mode: state.mode,
+      sortDirection: isSortDirection(state.sortDirection)
+        ? state.sortDirection
+        : null,
+    }
+  }
+
+  return sanitized
 }
 
 function parsePersistedDateFilter(

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { DateRange } from "react-day-picker"
 import {
   type CasePriority,
@@ -157,26 +157,16 @@ type PersistedCaseDateFilter =
       value: PersistedCaseDateRange
     }
 
-interface PersistedCasesFilters {
-  searchQuery: string
-  sortBy: CaseSortValue
-  statusFilter: CaseStatus[]
-  statusMode: FilterMode
-  priorityFilter: CasePriority[]
-  priorityMode: FilterMode
-  prioritySortDirection: SortDirection
-  severityFilter: CaseSeverity[]
-  severityMode: FilterMode
-  severitySortDirection: SortDirection
-  assigneeFilter: string[]
-  assigneeMode: FilterMode
-  assigneeSortDirection: SortDirection
-  tagFilter: string[]
-  tagMode: FilterMode
-  tagSortDirection: SortDirection
-  dropdownFilters: Record<string, DropdownFilterState>
+type PersistedCasesFilters = Omit<
+  UseCasesFilters,
+  "updatedAfter" | "createdAfter"
+> & {
   updatedAfter: PersistedCaseDateFilter
   createdAfter: PersistedCaseDateFilter
+}
+
+type CasesFilterStateSnapshot = UseCasesFilters & {
+  hydratedWorkspaceId?: string
 }
 
 // Helper to get Date from preset filter value
@@ -228,6 +218,121 @@ export const DEFAULT_CREATED_PRESET: CaseDatePreset = "1m"
 export const DEFAULT_CREATED_FILTER: CaseDateFilterValue = {
   type: "preset",
   value: DEFAULT_CREATED_PRESET,
+}
+
+const DEFAULT_CASES_FILTERS: UseCasesFilters = {
+  searchQuery: "",
+  sortBy: DEFAULT_CASE_SORT,
+  statusFilter: [],
+  statusMode: "include",
+  priorityFilter: [],
+  priorityMode: "include",
+  prioritySortDirection: null,
+  severityFilter: [],
+  severityMode: "include",
+  severitySortDirection: null,
+  assigneeFilter: [],
+  assigneeMode: "include",
+  assigneeSortDirection: null,
+  tagFilter: [],
+  tagMode: "include",
+  tagSortDirection: null,
+  dropdownFilters: {},
+  updatedAfter: DEFAULT_DATE_FILTER,
+  createdAfter: DEFAULT_CREATED_FILTER,
+}
+
+function getCasesFilterStorageKey(workspaceId: string): string {
+  return `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`
+}
+
+function getDefaultCasesFilterState(): CasesFilterStateSnapshot {
+  return {
+    ...DEFAULT_CASES_FILTERS,
+    hydratedWorkspaceId: undefined,
+  }
+}
+
+function loadPersistedCasesFilterState(
+  workspaceId: string | undefined
+): CasesFilterStateSnapshot {
+  const defaults = getDefaultCasesFilterState()
+  if (!workspaceId || typeof window === "undefined") {
+    return defaults
+  }
+
+  const storageKey = getCasesFilterStorageKey(workspaceId)
+  try {
+    const storedValue = window.localStorage.getItem(storageKey)
+    if (!storedValue) {
+      return { ...defaults, hydratedWorkspaceId: workspaceId }
+    }
+
+    const parsed = JSON.parse(storedValue) as Partial<PersistedCasesFilters>
+    return {
+      searchQuery: parsed.searchQuery ?? defaults.searchQuery,
+      sortBy: parsed.sortBy ?? defaults.sortBy,
+      statusFilter: parsed.statusFilter ?? defaults.statusFilter,
+      statusMode: parsed.statusMode ?? defaults.statusMode,
+      priorityFilter: parsed.priorityFilter ?? defaults.priorityFilter,
+      priorityMode: parsed.priorityMode ?? defaults.priorityMode,
+      prioritySortDirection:
+        parsed.prioritySortDirection ?? defaults.prioritySortDirection,
+      severityFilter: parsed.severityFilter ?? defaults.severityFilter,
+      severityMode: parsed.severityMode ?? defaults.severityMode,
+      severitySortDirection:
+        parsed.severitySortDirection ?? defaults.severitySortDirection,
+      assigneeFilter: parsed.assigneeFilter ?? defaults.assigneeFilter,
+      assigneeMode: parsed.assigneeMode ?? defaults.assigneeMode,
+      assigneeSortDirection:
+        parsed.assigneeSortDirection ?? defaults.assigneeSortDirection,
+      tagFilter: parsed.tagFilter ?? defaults.tagFilter,
+      tagMode: parsed.tagMode ?? defaults.tagMode,
+      tagSortDirection: parsed.tagSortDirection ?? defaults.tagSortDirection,
+      dropdownFilters: parsed.dropdownFilters ?? defaults.dropdownFilters,
+      updatedAfter: parsePersistedDateFilter(
+        parsed.updatedAfter,
+        defaults.updatedAfter
+      ),
+      createdAfter: parsePersistedDateFilter(
+        parsed.createdAfter,
+        defaults.createdAfter
+      ),
+      hydratedWorkspaceId: workspaceId,
+    }
+  } catch (error) {
+    console.error(error)
+    try {
+      window.localStorage.removeItem(storageKey)
+    } catch (removeError) {
+      console.error(removeError)
+    }
+    return { ...defaults, hydratedWorkspaceId: workspaceId }
+  }
+}
+
+function persistCasesFilterState(
+  workspaceId: string,
+  filters: PersistedCasesFilters
+): void {
+  try {
+    window.localStorage.setItem(
+      getCasesFilterStorageKey(workspaceId),
+      JSON.stringify(filters)
+    )
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+function serializePersistedCasesFilters(
+  filters: UseCasesFilters
+): PersistedCasesFilters {
+  return {
+    ...filters,
+    updatedAfter: serializeDateFilter(filters.updatedAfter),
+    createdAfter: serializeDateFilter(filters.createdAfter),
+  }
 }
 
 function parsePersistedDateFilter(
@@ -319,27 +424,55 @@ function resolveEnumIncludeFilter<T extends string>(
 export function useCases(options: UseCasesOptions = {}): UseCasesResult {
   const { enabled = true, autoRefresh = true } = options
   const workspaceId = useWorkspaceId()
+  const initialFilterStateRef = useRef<CasesFilterStateSnapshot | null>(null)
+  if (initialFilterStateRef.current === null) {
+    initialFilterStateRef.current = loadPersistedCasesFilterState(workspaceId)
+  }
+  const initialFilterState = initialFilterStateRef.current
 
-  const [searchQuery, setSearchQuery] = useState("")
-  const [sortBy, setSortByState] = useState<CaseSortValue>(DEFAULT_CASE_SORT)
-  const [statusFilter, setStatusFilter] = useState<CaseStatus[]>([])
-  const [statusMode, setStatusMode] = useState<FilterMode>("include")
-  const [priorityFilter, setPriorityFilter] = useState<CasePriority[]>([])
-  const [priorityMode, setPriorityMode] = useState<FilterMode>("include")
+  const [searchQuery, setSearchQuery] = useState(initialFilterState.searchQuery)
+  const [sortBy, setSortByState] = useState<CaseSortValue>(
+    initialFilterState.sortBy
+  )
+  const [statusFilter, setStatusFilter] = useState<CaseStatus[]>(
+    initialFilterState.statusFilter
+  )
+  const [statusMode, setStatusMode] = useState<FilterMode>(
+    initialFilterState.statusMode
+  )
+  const [priorityFilter, setPriorityFilter] = useState<CasePriority[]>(
+    initialFilterState.priorityFilter
+  )
+  const [priorityMode, setPriorityMode] = useState<FilterMode>(
+    initialFilterState.priorityMode
+  )
   const [prioritySortDirection, setPrioritySortDirectionState] =
-    useState<SortDirection>(null)
-  const [severityFilter, setSeverityFilter] = useState<CaseSeverity[]>([])
-  const [severityMode, setSeverityMode] = useState<FilterMode>("include")
+    useState<SortDirection>(initialFilterState.prioritySortDirection)
+  const [severityFilter, setSeverityFilter] = useState<CaseSeverity[]>(
+    initialFilterState.severityFilter
+  )
+  const [severityMode, setSeverityMode] = useState<FilterMode>(
+    initialFilterState.severityMode
+  )
   const [severitySortDirection, setSeveritySortDirectionState] =
-    useState<SortDirection>(null)
-  const [assigneeFilter, setAssigneeFilter] = useState<string[]>([])
-  const [assigneeMode, setAssigneeModeState] = useState<FilterMode>("include")
+    useState<SortDirection>(initialFilterState.severitySortDirection)
+  const [assigneeFilter, setAssigneeFilter] = useState<string[]>(
+    initialFilterState.assigneeFilter
+  )
+  const [assigneeMode, setAssigneeModeState] = useState<FilterMode>(
+    initialFilterState.assigneeMode
+  )
   const [assigneeSortDirection, setAssigneeSortDirectionState] =
-    useState<SortDirection>(null)
-  const [tagFilter, setTagFilter] = useState<string[]>([])
-  const [tagMode, setTagModeState] = useState<FilterMode>("include")
-  const [tagSortDirection, setTagSortDirectionState] =
-    useState<SortDirection>(null)
+    useState<SortDirection>(initialFilterState.assigneeSortDirection)
+  const [tagFilter, setTagFilter] = useState<string[]>(
+    initialFilterState.tagFilter
+  )
+  const [tagMode, setTagModeState] = useState<FilterMode>(
+    initialFilterState.tagMode
+  )
+  const [tagSortDirection, setTagSortDirectionState] = useState<SortDirection>(
+    initialFilterState.tagSortDirection
+  )
 
   const setSortBy = useCallback((value: CaseSortValue) => {
     setSortByState(value)
@@ -385,15 +518,16 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
   }, [])
   const [dropdownFilters, setDropdownFilters] = useState<
     Record<string, DropdownFilterState>
-  >({})
-  const [updatedAfter, setUpdatedAfter] =
-    useState<CaseDateFilterValue>(DEFAULT_DATE_FILTER)
+  >(initialFilterState.dropdownFilters)
+  const [updatedAfter, setUpdatedAfter] = useState<CaseDateFilterValue>(
+    initialFilterState.updatedAfter
+  )
   const [createdAfter, setCreatedAfter] = useState<CaseDateFilterValue>(
-    DEFAULT_CREATED_FILTER
+    initialFilterState.createdAfter
   )
   const [hydratedWorkspaceId, setHydratedWorkspaceId] = useState<
     string | undefined
-  >(() => (typeof window === "undefined" ? workspaceId : undefined))
+  >(initialFilterState.hydratedWorkspaceId)
   const hasHydratedFilters = workspaceId
     ? hydratedWorkspaceId === workspaceId
     : false
@@ -408,79 +542,61 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
       return
     }
 
-    const storedValue = window.localStorage.getItem(
-      `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`
-    )
-    if (!storedValue) {
-      setHydratedWorkspaceId(workspaceId)
+    if (hydratedWorkspaceId === workspaceId) {
       return
     }
 
-    try {
-      const parsed = JSON.parse(storedValue) as Partial<PersistedCasesFilters>
-
-      setSearchQuery(parsed.searchQuery ?? "")
-      setSortByState(parsed.sortBy ?? DEFAULT_CASE_SORT)
-      setStatusFilter(parsed.statusFilter ?? [])
-      setStatusMode(parsed.statusMode ?? "include")
-      setPriorityFilter(parsed.priorityFilter ?? [])
-      setPriorityMode(parsed.priorityMode ?? "include")
-      setPrioritySortDirectionState(parsed.prioritySortDirection ?? null)
-      setSeverityFilter(parsed.severityFilter ?? [])
-      setSeverityMode(parsed.severityMode ?? "include")
-      setSeveritySortDirectionState(parsed.severitySortDirection ?? null)
-      setAssigneeFilter(parsed.assigneeFilter ?? [])
-      setAssigneeModeState(parsed.assigneeMode ?? "include")
-      setAssigneeSortDirectionState(parsed.assigneeSortDirection ?? null)
-      setTagFilter(parsed.tagFilter ?? [])
-      setTagModeState(parsed.tagMode ?? "include")
-      setTagSortDirectionState(parsed.tagSortDirection ?? null)
-      setDropdownFilters(parsed.dropdownFilters ?? {})
-      setUpdatedAfter(
-        parsePersistedDateFilter(parsed.updatedAfter, DEFAULT_DATE_FILTER)
-      )
-      setCreatedAfter(
-        parsePersistedDateFilter(parsed.createdAfter, DEFAULT_CREATED_FILTER)
-      )
-    } catch {
-      window.localStorage.removeItem(
-        `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`
-      )
-    }
-
-    setHydratedWorkspaceId(workspaceId)
-  }, [workspaceId])
+    const nextFilterState = loadPersistedCasesFilterState(workspaceId)
+    setSearchQuery(nextFilterState.searchQuery)
+    setSortByState(nextFilterState.sortBy)
+    setStatusFilter(nextFilterState.statusFilter)
+    setStatusMode(nextFilterState.statusMode)
+    setPriorityFilter(nextFilterState.priorityFilter)
+    setPriorityMode(nextFilterState.priorityMode)
+    setPrioritySortDirectionState(nextFilterState.prioritySortDirection)
+    setSeverityFilter(nextFilterState.severityFilter)
+    setSeverityMode(nextFilterState.severityMode)
+    setSeveritySortDirectionState(nextFilterState.severitySortDirection)
+    setAssigneeFilter(nextFilterState.assigneeFilter)
+    setAssigneeModeState(nextFilterState.assigneeMode)
+    setAssigneeSortDirectionState(nextFilterState.assigneeSortDirection)
+    setTagFilter(nextFilterState.tagFilter)
+    setTagModeState(nextFilterState.tagMode)
+    setTagSortDirectionState(nextFilterState.tagSortDirection)
+    setDropdownFilters(nextFilterState.dropdownFilters)
+    setUpdatedAfter(nextFilterState.updatedAfter)
+    setCreatedAfter(nextFilterState.createdAfter)
+    setHydratedWorkspaceId(nextFilterState.hydratedWorkspaceId)
+  }, [hydratedWorkspaceId, workspaceId])
 
   useEffect(() => {
     if (!workspaceId || !hasHydratedFilters || typeof window === "undefined") {
       return
     }
 
-    const persistedFilters: PersistedCasesFilters = {
-      searchQuery,
-      sortBy,
-      statusFilter,
-      statusMode,
-      priorityFilter,
-      priorityMode,
-      prioritySortDirection,
-      severityFilter,
-      severityMode,
-      severitySortDirection,
-      assigneeFilter,
-      assigneeMode,
-      assigneeSortDirection,
-      tagFilter,
-      tagMode,
-      tagSortDirection,
-      dropdownFilters,
-      updatedAfter: serializeDateFilter(updatedAfter),
-      createdAfter: serializeDateFilter(createdAfter),
-    }
-
-    window.localStorage.setItem(
-      `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`,
-      JSON.stringify(persistedFilters)
+    persistCasesFilterState(
+      workspaceId,
+      serializePersistedCasesFilters({
+        searchQuery,
+        sortBy,
+        statusFilter,
+        statusMode,
+        priorityFilter,
+        priorityMode,
+        prioritySortDirection,
+        severityFilter,
+        severityMode,
+        severitySortDirection,
+        assigneeFilter,
+        assigneeMode,
+        assigneeSortDirection,
+        tagFilter,
+        tagMode,
+        tagSortDirection,
+        dropdownFilters,
+        updatedAfter,
+        createdAfter,
+      })
     )
   }, [
     workspaceId,
@@ -734,8 +850,11 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     staleTime: 60000,
   })
 
+  const visibleRowsData = hasHydratedFilters ? rowsData : undefined
+  const visibleAggregateData = hasHydratedFilters ? aggregateData : undefined
+
   const flattenedCases = useMemo(() => {
-    const pages = rowsData?.pages ?? []
+    const pages = visibleRowsData?.pages ?? []
     const deduped: CaseReadMinimal[] = []
     const seenIds = new Set<string>()
 
@@ -750,7 +869,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     }
 
     return deduped
-  }, [rowsData?.pages])
+  }, [visibleRowsData?.pages])
 
   const sortedCases = useMemo(() => {
     if (assigneeSortDirection) {
@@ -780,7 +899,11 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
 
   const totalFilteredCaseEstimate = hasImpossibleEnumFilter
     ? 0
-    : (aggregateData?.total ?? rowsData?.pages[0]?.total_estimate ?? null)
+    : (visibleAggregateData?.total ??
+      visibleRowsData?.pages[0]?.total_estimate ??
+      null)
+  const isHydrationPending =
+    enabled && Boolean(workspaceId) && !hasHydratedFilters
 
   const refetch = useCallback(() => {
     void refetchRows()
@@ -796,7 +919,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
 
   return {
     cases,
-    isLoading,
+    isLoading: isHydrationPending ? true : isLoading,
     error: error ?? null,
     refetch,
     filters: {
@@ -844,11 +967,17 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     totalFilteredCaseEstimate,
     stageCounts: hasImpossibleEnumFilter
       ? EMPTY_STAGE_COUNTS
-      : (aggregateData?.status_groups ?? null),
-    isCountsLoading: hasImpossibleEnumFilter ? false : isCountsLoading,
-    isCountsFetching: hasImpossibleEnumFilter ? false : isCountsFetching,
+      : (visibleAggregateData?.status_groups ?? null),
+    isCountsLoading: hasImpossibleEnumFilter
+      ? false
+      : isHydrationPending || isCountsLoading,
+    isCountsFetching: hasImpossibleEnumFilter
+      ? false
+      : hasHydratedFilters && isCountsFetching,
     hasNextPage: hasImpossibleEnumFilter ? false : Boolean(hasNextPage),
-    isFetchingNextPage: hasImpossibleEnumFilter ? false : isFetchingNextPage,
+    isFetchingNextPage: hasImpossibleEnumFilter
+      ? false
+      : hasHydratedFilters && isFetchingNextPage,
     fetchNextPage: handleFetchNextPage,
   }
 }

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import type { DateRange } from "react-day-picker"
 import {
   type CasePriority,
@@ -391,10 +391,20 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
   const [createdAfter, setCreatedAfter] = useState<CaseDateFilterValue>(
     DEFAULT_CREATED_FILTER
   )
-  const hasHydratedFiltersRef = useRef(false)
+  const [hydratedWorkspaceId, setHydratedWorkspaceId] = useState<
+    string | undefined
+  >(() => (typeof window === "undefined" ? workspaceId : undefined))
+  const hasHydratedFilters = workspaceId
+    ? hydratedWorkspaceId === workspaceId
+    : false
 
   useEffect(() => {
-    if (!workspaceId || typeof window === "undefined") {
+    if (!workspaceId) {
+      setHydratedWorkspaceId(undefined)
+      return
+    }
+
+    if (typeof window === "undefined") {
       return
     }
 
@@ -402,7 +412,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
       `${workspaceId}:${CASES_FILTER_STORAGE_KEY}`
     )
     if (!storedValue) {
-      hasHydratedFiltersRef.current = true
+      setHydratedWorkspaceId(workspaceId)
       return
     }
 
@@ -438,15 +448,11 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
       )
     }
 
-    hasHydratedFiltersRef.current = true
+    setHydratedWorkspaceId(workspaceId)
   }, [workspaceId])
 
   useEffect(() => {
-    if (
-      !workspaceId ||
-      !hasHydratedFiltersRef.current ||
-      typeof window === "undefined"
-    ) {
+    if (!workspaceId || !hasHydratedFilters || typeof window === "undefined") {
       return
     }
 
@@ -497,6 +503,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
     dropdownFilters,
     updatedAfter,
     createdAfter,
+    hasHydratedFilters,
   ])
 
   const setAssigneeMode = useCallback((_mode: FilterMode) => {
@@ -686,7 +693,11 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
         limit: CASES_PAGE_SIZE,
         cursor: (pageParam as string | null) ?? undefined,
       }),
-    enabled: enabled && Boolean(workspaceId) && !hasImpossibleEnumFilter,
+    enabled:
+      enabled &&
+      Boolean(workspaceId) &&
+      hasHydratedFilters &&
+      !hasImpossibleEnumFilter,
     initialPageParam: null,
     getNextPageParam: (lastPage) => {
       if (!lastPage.has_more || !lastPage.next_cursor) {
@@ -712,7 +723,11 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
         workspaceId,
         ...apiQueryParams,
       }),
-    enabled: enabled && Boolean(workspaceId) && !hasImpossibleEnumFilter,
+    enabled:
+      enabled &&
+      Boolean(workspaceId) &&
+      hasHydratedFilters &&
+      !hasImpossibleEnumFilter,
     retry: retryHandler,
     refetchInterval: computeRefetchInterval(),
     refetchOnWindowFocus: false,

--- a/frontend/tests/use-cases.test.tsx
+++ b/frontend/tests/use-cases.test.tsx
@@ -133,6 +133,7 @@ function SortStateProbe() {
 describe("useCases", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    window.localStorage.clear()
   })
 
   it("uses paginated rows and separate global counts", async () => {
@@ -193,6 +194,92 @@ describe("useCases", () => {
     expect(mockSearchCaseAggregates).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: "workspace-1",
+      })
+    )
+  })
+
+  it("hydrates persisted filters before issuing case queries", async () => {
+    const firstPage: CasesSearchCasesResponse = {
+      items: [createCase(1)],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      total_estimate: 1,
+    }
+
+    const aggregate: CasesSearchCaseAggregatesResponse = {
+      total: 1,
+      status_groups: {
+        new: 1,
+        in_progress: 0,
+        on_hold: 0,
+        resolved: 0,
+        other: 0,
+      },
+    }
+
+    window.localStorage.setItem(
+      "workspace-1:cases-filters:v1",
+      JSON.stringify({
+        searchQuery: "persisted query",
+        sortBy: { field: "updated_at", direction: "desc" },
+        statusFilter: [],
+        statusMode: "include",
+        priorityFilter: [],
+        priorityMode: "include",
+        prioritySortDirection: null,
+        severityFilter: [],
+        severityMode: "include",
+        severitySortDirection: null,
+        assigneeFilter: [],
+        assigneeMode: "include",
+        assigneeSortDirection: null,
+        tagFilter: [],
+        tagMode: "include",
+        tagSortDirection: null,
+        dropdownFilters: {},
+        updatedAfter: { type: "preset", value: "1w" },
+        createdAfter: { type: "preset", value: "1m" },
+      })
+    )
+
+    mockSearchCases.mockResolvedValue(firstPage)
+    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookProbe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rows")).toHaveTextContent("1")
+    })
+
+    expect(mockSearchCases).toHaveBeenCalledTimes(1)
+    expect(mockSearchCases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        searchTerm: "persisted query",
+        updatedAfter: expect.stringContaining("T"),
+      })
+    )
+
+    expect(mockSearchCaseAggregates).toHaveBeenCalledTimes(1)
+    expect(mockSearchCaseAggregates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        searchTerm: "persisted query",
+        updatedAfter: expect.stringContaining("T"),
       })
     )
   })

--- a/frontend/tests/use-cases.test.tsx
+++ b/frontend/tests/use-cases.test.tsx
@@ -532,6 +532,84 @@ describe("useCases", () => {
     )
   })
 
+  it("sanitizes malformed persisted scalar filters", async () => {
+    const firstPage: CasesSearchCasesResponse = {
+      items: [createCase(1)],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      total_estimate: 1,
+    }
+
+    const aggregate: CasesSearchCaseAggregatesResponse = {
+      total: 1,
+      status_groups: {
+        new: 1,
+        in_progress: 0,
+        on_hold: 0,
+        resolved: 0,
+        other: 0,
+      },
+    }
+
+    window.localStorage.setItem(
+      "workspace-1:cases-filters:v1",
+      JSON.stringify(
+        createPersistedFilters({
+          searchQuery: 42,
+          sortBy: { field: "bad-field", direction: "up" },
+          statusFilter: ["new", "bad-status", 99],
+          statusMode: "bogus",
+          assigneeFilter: ["user-1", 123],
+          tagFilter: ["tag-1", null],
+        })
+      )
+    )
+
+    mockSearchCases.mockResolvedValue(firstPage)
+    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookProbe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rows")).toHaveTextContent("1")
+    })
+
+    expect(mockSearchCases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        searchTerm: undefined,
+        orderBy: "updated_at",
+        sort: "desc",
+        status: ["new"],
+        assigneeId: ["user-1"],
+        tags: ["tag-1"],
+      })
+    )
+    expect(mockSearchCaseAggregates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        searchTerm: undefined,
+        status: ["new"],
+        assigneeId: ["user-1"],
+        tags: ["tag-1"],
+      })
+    )
+  })
+
   it("clears rows when enum exclude filters match no records", async () => {
     const firstPage: CasesSearchCasesResponse = {
       items: [createCase(1)],

--- a/frontend/tests/use-cases.test.tsx
+++ b/frontend/tests/use-cases.test.tsx
@@ -450,6 +450,88 @@ describe("useCases", () => {
     consoleErrorSpy.mockRestore()
   })
 
+  it("sanitizes malformed persisted dropdown filters", async () => {
+    const firstPage: CasesSearchCasesResponse = {
+      items: [createCase(1)],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      total_estimate: 1,
+    }
+
+    const aggregate: CasesSearchCaseAggregatesResponse = {
+      total: 1,
+      status_groups: {
+        new: 1,
+        in_progress: 0,
+        on_hold: 0,
+        resolved: 0,
+        other: 0,
+      },
+    }
+
+    window.localStorage.setItem(
+      "workspace-1:cases-filters:v1",
+      JSON.stringify(
+        createPersistedFilters({
+          dropdownFilters: {
+            broken: null,
+            invalidMode: {
+              values: ["drop-me"],
+              mode: "bogus",
+              sortDirection: "asc",
+            },
+            invalidValues: {
+              values: "drop-me",
+              mode: "include",
+              sortDirection: "desc",
+            },
+            valid: {
+              values: ["keep-me"],
+              mode: "include",
+              sortDirection: "bogus",
+            },
+          },
+        })
+      )
+    )
+
+    mockSearchCases.mockResolvedValue(firstPage)
+    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookProbe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rows")).toHaveTextContent("1")
+    })
+
+    expect(mockSearchCases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        dropdown: ["valid:keep-me"],
+      })
+    )
+    expect(mockSearchCaseAggregates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        dropdown: ["valid:keep-me"],
+      })
+    )
+  })
+
   it("clears rows when enum exclude filters match no records", async () => {
     const firstPage: CasesSearchCasesResponse = {
       items: [createCase(1)],

--- a/frontend/tests/use-cases.test.tsx
+++ b/frontend/tests/use-cases.test.tsx
@@ -30,6 +30,31 @@ const mockSearchCaseAggregates =
     typeof casesSearchCaseAggregates
   >
 
+function createPersistedFilters(overrides: Record<string, unknown> = {}) {
+  return {
+    searchQuery: "",
+    sortBy: { field: "updated_at", direction: "desc" },
+    statusFilter: [],
+    statusMode: "include",
+    priorityFilter: [],
+    priorityMode: "include",
+    prioritySortDirection: null,
+    severityFilter: [],
+    severityMode: "include",
+    severitySortDirection: null,
+    assigneeFilter: [],
+    assigneeMode: "include",
+    assigneeSortDirection: null,
+    tagFilter: [],
+    tagMode: "include",
+    tagSortDirection: null,
+    dropdownFilters: {},
+    updatedAfter: { type: "preset", value: null },
+    createdAfter: { type: "preset", value: "1m" },
+    ...overrides,
+  }
+}
+
 function createCase(index: number): CaseReadMinimal {
   const id = `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`
   return {
@@ -136,6 +161,10 @@ describe("useCases", () => {
     window.localStorage.clear()
   })
 
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   it("uses paginated rows and separate global counts", async () => {
     const firstPage: CasesSearchCasesResponse = {
       items: Array.from({ length: 100 }, (_, index) => createCase(index + 1)),
@@ -221,27 +250,12 @@ describe("useCases", () => {
 
     window.localStorage.setItem(
       "workspace-1:cases-filters:v1",
-      JSON.stringify({
-        searchQuery: "persisted query",
-        sortBy: { field: "updated_at", direction: "desc" },
-        statusFilter: [],
-        statusMode: "include",
-        priorityFilter: [],
-        priorityMode: "include",
-        prioritySortDirection: null,
-        severityFilter: [],
-        severityMode: "include",
-        severitySortDirection: null,
-        assigneeFilter: [],
-        assigneeMode: "include",
-        assigneeSortDirection: null,
-        tagFilter: [],
-        tagMode: "include",
-        tagSortDirection: null,
-        dropdownFilters: {},
-        updatedAfter: { type: "preset", value: "1w" },
-        createdAfter: { type: "preset", value: "1m" },
-      })
+      JSON.stringify(
+        createPersistedFilters({
+          searchQuery: "persisted query",
+          updatedAfter: { type: "preset", value: "1w" },
+        })
+      )
     )
 
     mockSearchCases.mockResolvedValue(firstPage)
@@ -282,6 +296,158 @@ describe("useCases", () => {
         updatedAfter: expect.stringContaining("T"),
       })
     )
+  })
+
+  it("does not expose cached default-query rows before persisted filters hydrate", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-03-12T12:00:00Z"))
+
+    const cachedDefaultPage: CasesSearchCasesResponse = {
+      items: [createCase(1), createCase(2)],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      total_estimate: 2,
+    }
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const defaultFiltersKey = JSON.stringify({
+      apiQueryParams: {
+        startTime: new Date("2026-02-10T12:00:00.000Z").toISOString(),
+      },
+      hasImpossibleEnumFilter: false,
+    })
+    const defaultRowsKey = JSON.stringify({
+      filtersKey: defaultFiltersKey,
+      orderBy: "updated_at",
+      sort: "desc",
+    })
+
+    queryClient.setQueryData(["cases", "workspace-1", defaultRowsKey], {
+      pages: [cachedDefaultPage],
+      pageParams: [null],
+    })
+    queryClient.setQueryData(
+      ["cases", "aggregate", "workspace-1", defaultFiltersKey],
+      {
+        total: 2,
+        status_groups: {
+          new: 2,
+          in_progress: 0,
+          on_hold: 0,
+          resolved: 0,
+          other: 0,
+        },
+      } satisfies CasesSearchCaseAggregatesResponse
+    )
+
+    window.localStorage.setItem(
+      "workspace-1:cases-filters:v1",
+      JSON.stringify(
+        createPersistedFilters({
+          searchQuery: "persisted query",
+          updatedAfter: { type: "preset", value: "1w" },
+        })
+      )
+    )
+
+    mockSearchCases.mockImplementation(
+      () => new Promise(() => undefined) as ReturnType<typeof casesSearchCases>
+    )
+    mockSearchCaseAggregates.mockImplementation(
+      () =>
+        new Promise(() => undefined) as ReturnType<
+          typeof casesSearchCaseAggregates
+        >
+    )
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookProbe />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByTestId("rows")).toHaveTextContent("0")
+    expect(screen.getByTestId("total")).toHaveTextContent("-1")
+    expect(screen.getByTestId("new-count")).toHaveTextContent("-1")
+  })
+
+  it("falls back to defaults when localStorage access throws", async () => {
+    const firstPage: CasesSearchCasesResponse = {
+      items: [createCase(1)],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      total_estimate: 1,
+    }
+
+    const aggregate: CasesSearchCaseAggregatesResponse = {
+      total: 1,
+      status_groups: {
+        new: 1,
+        in_progress: 0,
+        on_hold: 0,
+        resolved: 0,
+        other: 0,
+      },
+    }
+
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new DOMException("Blocked", "SecurityError")
+      })
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("Blocked", "SecurityError")
+      })
+    const removeItemSpy = jest
+      .spyOn(Storage.prototype, "removeItem")
+      .mockImplementation(() => {
+        throw new DOMException("Blocked", "SecurityError")
+      })
+
+    mockSearchCases.mockResolvedValue(firstPage)
+    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookProbe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rows")).toHaveTextContent("1")
+    })
+
+    expect(mockSearchCases).toHaveBeenCalledTimes(1)
+    expect(mockSearchCaseAggregates).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).toHaveBeenCalled()
+
+    getItemSpy.mockRestore()
+    setItemSpy.mockRestore()
+    removeItemSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
   })
 
   it("clears rows when enum exclude filters match no records", async () => {


### PR DESCRIPTION
### Motivation
- Persist user filter state for the cases list across sessions so users keep their search, sort and filter settings.
- Support serializing and restoring both preset and explicit date range filters for `updatedAfter` and `createdAfter`.

### Description
- Add a `CASES_FILTER_STORAGE_KEY` and new persisted types (`PersistedCasesFilters`, `PersistedCaseDateFilter`, `PersistedCaseDateRange`) to model stored filter state.  
- Implement `parsePersistedDateFilter` and `serializeDateFilter` to safely convert date presets and range filters to/from JSON.  
- Hydrate filter state from `localStorage` on load using a `useEffect` that reads `window.localStorage` and sets state values, guarded by `workspaceId` and a `hasHydratedFiltersRef`.  
- Persist filter changes to `localStorage` in a second `useEffect` that serializes the current filters whenever relevant state values change, and add necessary imports (`useEffect`, `useRef`).

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab7ea4ef408320a141b9b647fb5edf)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist cases list filters in `localStorage` per workspace and restore them on load, including date presets and custom ranges. All queries, counts, and pagination wait for hydration to avoid default fetches or showing stale cached rows.

- **New Features**
  - Persist and hydrate search, sort, status/priority/severity/assignee/tag, dropdown filters, and `updatedAfter`/`createdAfter` with a hydration guard.
  - Support date presets (`1d`, `3d`, `1w`, `1m`) and custom ranges; extracted shared case sort types/default into `case-sort`.

- **Bug Fixes**
  - Hydrate filters before querying and gate rows/counts/pagination; hide cached default rows until hydration finishes.
  - Sanitize persisted filter state (dropdowns and scalars: search, `sortBy`, enum arrays, modes, directions, string arrays); ignore invalid JSON with safe fallbacks and handle `localStorage` errors; fix date filter typing/parsing (`null` presets, ISO ranges).

<sup>Written for commit 12b1e5b44a3d7dc87db677af2f4098f62fc38574. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

### QA
- Ran `uv run ruff check .`, `pnpm -C frontend check`, and `pnpm -C frontend run typecheck`.
- Verified locally with `just cluster up -d --seed` and Chrome DevTools against `http://localhost:480`.
- Confirmed workspace-scoped persistence under `<workspaceId>:cases-filters:v1`.
- Confirmed search, status, date, and sort filters survive reload and navigation away/back.
- Confirmed invalid JSON resets cleanly to defaults without breaking the page.
- Confirmed custom date ranges round-trip through localStorage hydration.
