### PR TITLE
feat(temporal): encrypt core workflow histories

### DIFF
--- a/tests/unit/test_dsl_converter.py
+++ b/tests/unit/test_dsl_converter.py
@@ -61,7 +61,8 @@ def test_from_payload_sanitizes_type_conversion_failures() -> None:
     assert "secret-token" not in message
 
 
-def test_agent_action_memo_logging_omits_raw_payload(
+@pytest.mark.anyio
+async def test_agent_action_memo_logging_omits_raw_payload(
     monkeypatch,
 ) -> None:
     """Memo parse warnings should not log the full protobuf payload."""
@@ -87,7 +88,7 @@ def test_agent_action_memo_logging_omits_raw_payload(
         }
     )
 
-    AgentActionMemo.from_temporal(memo)
+    await AgentActionMemo.from_temporal(memo)
 
     assert len(warnings) == 1
     warning = warnings[0]

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -72,6 +72,7 @@ from tracecat.interactions.schemas import ActionInteractionValidator
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import CollectionObject, InlineObject, StoredObject
+from tracecat.temporal.codec import decode_payloads
 from tracecat.workflow.actions.schemas import ActionControlFlow
 from tracecat.workflow.executions.enums import (
     ExecutionType,
@@ -1077,11 +1078,16 @@ class AgentActionMemo(BaseModel):
     )
 
     @classmethod
-    def from_temporal(cls, memo: temporalio.api.common.v1.Memo) -> AgentActionMemo:
+    async def from_temporal(
+        cls, memo: temporalio.api.common.v1.Memo
+    ) -> AgentActionMemo:
         data: dict[str, Any] = {}
         for key, value in memo.fields.items():
             try:
-                data[key] = _memo_payload_converter.from_payload(value)
+                decoded_value = (
+                    await decode_payloads([value], compression_enabled=True)
+                )[0]
+                data[key] = _memo_payload_converter.from_payload(decoded_value)
             except Exception as e:
                 logger.warning(
                     "Error parsing agent action memo field",
@@ -1117,25 +1123,34 @@ class ChildWorkflowMemo(BaseModel):
     )
 
     @staticmethod
-    def from_temporal(memo: temporalio.api.common.v1.Memo) -> ChildWorkflowMemo:
+    async def from_temporal(memo: temporalio.api.common.v1.Memo) -> ChildWorkflowMemo:
+        decoded_fields = dict(
+            zip(
+                memo.fields,
+                await decode_payloads(
+                    list(memo.fields.values()), compression_enabled=True
+                ),
+                strict=False,
+            )
+        )
         try:
-            action_ref = orjson.loads(memo.fields["action_ref"].data)
+            action_ref = orjson.loads(decoded_fields["action_ref"].data)
         except Exception as e:
             logger.warning("Error parsing child workflow memo action ref", error=e)
             action_ref = "Unknown Child Workflow"
-        if loop_index_data := memo.fields["loop_index"].data:
+        if loop_index_data := decoded_fields["loop_index"].data:
             loop_index = orjson.loads(loop_index_data)
         else:
             loop_index = None
         try:
             wait_strategy = WaitStrategy(
-                orjson.loads(memo.fields["wait_strategy"].data)
+                orjson.loads(decoded_fields["wait_strategy"].data)
             )
         except Exception as e:
             logger.warning("Error parsing child workflow memo wait strategy", error=e)
             wait_strategy = WaitStrategy.WAIT
         try:
-            stream_id = StreamID(orjson.loads(memo.fields["stream_id"].data))
+            stream_id = StreamID(orjson.loads(decoded_fields["stream_id"].data))
         except Exception as e:
             logger.warning("Error parsing child workflow memo stream id", error=e)
             stream_id = ROOT_STREAM

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -118,6 +118,7 @@ with workflow.unsafe.imports_passed_through():
         return_key,
         trigger_key,
     )
+    from tracecat.temporal.visibility import tokenize_visibility_value
     from tracecat.tiers.activities import (
         AcquireActionPermitInput,
         AcquireWorkflowPermitInput,
@@ -163,7 +164,7 @@ def _inherit_search_attributes_with_alias(
     alias: str,
 ) -> TypedSearchAttributes:
     pairs: list[SearchAttributePair[Any]] = [
-        TemporalSearchAttr.ALIAS.create_pair(alias)
+        TemporalSearchAttr.ALIAS.create_pair(tokenize_visibility_value(alias))
     ]
     if base_attrs:
         pairs.extend(

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -16,7 +16,7 @@ from temporalio.service import RPCError
 
 from tracecat import config
 from tracecat.concurrency import cooperative
-from tracecat.contexts import ctx_role
+from tracecat.contexts import ctx_role, with_temporal_workspace_id
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.workflow import DSLWorkflow
@@ -471,10 +471,12 @@ async def receive_interaction(
         # Get temporal client and workflow handle
         client = await get_temporal_client()
         handle = client.get_workflow_handle_for(DSLWorkflow.run, input.execution_id)
+        role = ctx_role.get()
 
         # Convert to internal interaction format
         # Execute workflow interaction handler
-        result = await handle.execute_update(DSLWorkflow.interaction_handler, input)
+        with with_temporal_workspace_id(role.workspace_id if role else None):
+            result = await handle.execute_update(DSLWorkflow.interaction_handler, input)
         logger.info("Interaction processed", result=result)
 
         return ReceiveInteractionResponse(

--- a/tracecat/workflow/executions/common.py
+++ b/tracecat/workflow/executions/common.py
@@ -9,7 +9,6 @@ from temporalio.api.enums.v1 import EventType
 from temporalio.api.history.v1 import HistoryEvent
 
 from tracecat.dsl.action import DSLActivities
-from tracecat.dsl.compression import get_compression_payload_codec
 from tracecat.executor.activities import ExecutorActivities
 from tracecat.identifiers import UserID, WorkflowID, WorkspaceID
 from tracecat.logger import logger
@@ -19,6 +18,7 @@ from tracecat.storage.object import (
     InlineObject,
     StoredObject,
 )
+from tracecat.temporal.codec import decode_payloads
 from tracecat.workflow.executions.enums import (
     ExecutionType,
     TemporalSearchAttr,
@@ -248,11 +248,8 @@ async def extract_payload(
     payload: temporalio.api.common.v1.Payloads, index: int = 0
 ) -> Any:
     """Extract the first payload from a workflow history event."""
-    # Always call the decoder. It will return the original payload if it's not compressed.
-    # This enables backwards compatibility of newer payloads with older clients.
-    codec = get_compression_payload_codec()
-    decompressed_payload = await codec.decode(payload.payloads)
-    payload_obj = decompressed_payload[index]
+    decoded_payloads = await decode_payloads(payload.payloads, compression_enabled=True)
+    payload_obj = decoded_payloads[index]
     encoding = payload_obj.metadata.get("encoding", b"").decode()
     # Temporal's NullPayloadConverter encodes `None` as binary/null with no data.
     if encoding == "binary/null":

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -46,6 +46,7 @@ from tracecat.storage.object import (
     StoredObjectValidator,
 )
 from tracecat.storage.utils import serialize_object
+from tracecat.temporal.visibility import is_tokenized_visibility_value
 from tracecat.validation.service import validate_dsl
 from tracecat.workflow.executions.dependencies import UnquotedExecutionID
 from tracecat.workflow.executions.enums import (
@@ -341,6 +342,8 @@ def _to_workflow_run_read_minimal(
     workflow_alias: str | None = execution.typed_search_attributes.get(
         TemporalSearchAttr.ALIAS.key
     )
+    if is_tokenized_visibility_value(workflow_alias):
+        workflow_alias = None
     try:
         wf_id, _ = exec_id_to_parts(execution.id)
         workflow_id = wf_id.short()

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -738,7 +738,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
         match attrs.workflow_type.name:
             case "DSLWorkflow":
                 try:
-                    memo = ChildWorkflowMemo.from_temporal(attrs.memo)
+                    memo = await ChildWorkflowMemo.from_temporal(attrs.memo)
                 except Exception as e:
                     logger.error("Error parsing child workflow memo", error=e)
                     raise e
@@ -776,7 +776,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                 )
             case "DurableAgentWorkflow":
                 try:
-                    memo = AgentActionMemo.from_temporal(attrs.memo)
+                    memo = await AgentActionMemo.from_temporal(attrs.memo)
                 except Exception as e:
                     logger.error("Error parsing agent action memo", error=e)
                     raise e

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -32,7 +32,7 @@ from temporalio.service import RPCError
 from tracecat import config
 from tracecat.audit.logger import audit_log
 from tracecat.auth.types import Role
-from tracecat.contexts import ctx_role
+from tracecat.contexts import ctx_role, with_temporal_workspace_id
 from tracecat.db.models import Interaction
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import RETRY_POLICIES, DSLInput, DSLRunArgs
@@ -1426,23 +1426,24 @@ class WorkflowExecutionsService:
         pairs.append(execution_type.to_temporal_search_attr_pair())
         search_attrs = TypedSearchAttributes(search_attributes=pairs)
         try:
-            result = await self._client.execute_workflow(
-                DSLWorkflow.run,
-                DSLRunArgs(
-                    dsl=dsl,
-                    role=self.role,
-                    wf_id=wf_id,
-                    trigger_inputs=trigger_inputs_ref,
-                    execution_type=execution_type,
-                    time_anchor=time_anchor,
-                    registry_lock=registry_lock,
-                ),
-                id=wf_exec_id,
-                task_queue=config.TEMPORAL__CLUSTER_QUEUE,
-                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-                search_attributes=search_attrs,
-                **kwargs,
-            )
+            with with_temporal_workspace_id(self.role.workspace_id):
+                result = await self._client.execute_workflow(
+                    DSLWorkflow.run,
+                    DSLRunArgs(
+                        dsl=dsl,
+                        role=self.role,
+                        wf_id=wf_id,
+                        trigger_inputs=trigger_inputs_ref,
+                        execution_type=execution_type,
+                        time_anchor=time_anchor,
+                        registry_lock=registry_lock,
+                    ),
+                    id=wf_exec_id,
+                    task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+                    retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                    search_attributes=search_attrs,
+                    **kwargs,
+                )
         except WorkflowFailureError as e:
             if isinstance(e.cause, TerminatedError):
                 self.logger.info(
@@ -1578,26 +1579,27 @@ class WorkflowExecutionsService:
         search_attrs = TypedSearchAttributes(search_attributes=pairs)
 
         try:
-            await asyncio.wait_for(
-                self._client.start_workflow(
-                    DSLWorkflow.run,
-                    DSLRunArgs(
-                        dsl=dsl,
-                        role=self.role,
-                        wf_id=wf_id,
-                        trigger_inputs=trigger_inputs_ref,
-                        execution_type=execution_type,
-                        time_anchor=time_anchor,
-                        registry_lock=registry_lock,
+            with with_temporal_workspace_id(self.role.workspace_id):
+                await asyncio.wait_for(
+                    self._client.start_workflow(
+                        DSLWorkflow.run,
+                        DSLRunArgs(
+                            dsl=dsl,
+                            role=self.role,
+                            wf_id=wf_id,
+                            trigger_inputs=trigger_inputs_ref,
+                            execution_type=execution_type,
+                            time_anchor=time_anchor,
+                            registry_lock=registry_lock,
+                        ),
+                        id=wf_exec_id,
+                        task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+                        retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                        search_attributes=search_attrs,
+                        **kwargs,
                     ),
-                    id=wf_exec_id,
-                    task_queue=config.TEMPORAL__CLUSTER_QUEUE,
-                    retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-                    search_attributes=search_attrs,
-                    **kwargs,
-                ),
-                timeout=start_timeout,
-            )
+                    timeout=start_timeout,
+                )
         except TimeoutError as e:
             self.logger.error(
                 "Timed out while dispatching workflow start",

--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -9,6 +9,7 @@ from temporalio.exceptions import TemporalError
 from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.contexts import with_temporal_workspace_id
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import DSLRunArgs
 from tracecat.identifiers import ScheduleUUID, WorkflowID
@@ -83,28 +84,28 @@ async def create_schedule(
             temporalio.client.ScheduleIntervalSpec(every=every, offset=offset)
         ]
 
-    return await client.create_schedule(
-        id=temporal_schedule_id,
-        schedule=temporalio.client.Schedule(
-            action=temporalio.client.ScheduleActionStartWorkflow(
-                DSLWorkflow.run,
-                # Scheduled workflow only needs to know the workflow ID
-                # and the role of the user who scheduled it. Everything else
-                # is pulled inside the workflow itself.
-                # Pass the native ScheduleUUID (UUID) - it will be serialized as UUID string
-                DSLRunArgs(role=role, wf_id=workflow_id, schedule_id=schedule_uuid),
-                id=workflow_schedule_id,
-                task_queue=config.TEMPORAL__CLUSTER_QUEUE,
-                typed_search_attributes=build_schedule_search_attributes(role),
-                **schedule_kwargs,
+    with with_temporal_workspace_id(role.workspace_id):
+        return await client.create_schedule(
+            id=temporal_schedule_id,
+            schedule=temporalio.client.Schedule(
+                action=temporalio.client.ScheduleActionStartWorkflow(
+                    DSLWorkflow.run,
+                    # Scheduled workflow only needs to know the workflow ID
+                    # and the role of the user who scheduled it. Everything else
+                    # is pulled inside the workflow itself.
+                    # Pass the native ScheduleUUID (UUID) - it will be serialized as UUID string
+                    DSLRunArgs(role=role, wf_id=workflow_id, schedule_id=schedule_uuid),
+                    id=workflow_schedule_id,
+                    task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+                    typed_search_attributes=build_schedule_search_attributes(role),
+                    **schedule_kwargs,
+                ),
+                spec=temporalio.client.ScheduleSpec(**spec_kwargs),
+                policy=temporalio.client.SchedulePolicy(
+                    overlap=temporalio.client.ScheduleOverlapPolicy.ALLOW_ALL,
+                ),
             ),
-            spec=temporalio.client.ScheduleSpec(**spec_kwargs),
-            policy=temporalio.client.SchedulePolicy(
-                # Allow overlapping workflows to run in parallel
-                overlap=temporalio.client.ScheduleOverlapPolicy.ALLOW_ALL,
-            ),
-        ),
-    )
+        )
 
 
 async def delete_schedule(schedule_id: AnyScheduleID) -> None:
@@ -128,7 +129,12 @@ async def delete_schedule(schedule_id: AnyScheduleID) -> None:
     return None
 
 
-async def update_schedule(schedule_id: AnyScheduleID, params: ScheduleUpdate) -> None:
+async def update_schedule(
+    schedule_id: AnyScheduleID,
+    params: ScheduleUpdate,
+    *,
+    role: Role | None = None,
+) -> None:
     async def _update_schedule(
         input: temporalio.client.ScheduleUpdateInput,
     ) -> temporalio.client.ScheduleUpdate:
@@ -146,18 +152,20 @@ async def update_schedule(schedule_id: AnyScheduleID, params: ScheduleUpdate) ->
             try:
                 raw_args = await extract_first(Payloads(payloads=[action.args[0]]))
                 run_args = DSLRunArgs.model_validate(raw_args)
-                role = run_args.role
+                effective_role = run_args.role
             except Exception as e:
                 logger.warning(
                     "Error extracting role from schedule action",
                     error=e,
                 )
-                role = Role(
+                effective_role = Role(
                     type="service",
                     service_id="tracecat-schedule-runner",
                     scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-schedule-runner"],
                 )
-            action.typed_search_attributes = build_schedule_search_attributes(role)
+            action.typed_search_attributes = build_schedule_search_attributes(
+                role or effective_role
+            )
             if "inputs" in set_fields:
                 action.args[0].dsl.trigger_inputs = set_fields["inputs"]  # type: ignore
         else:
@@ -199,4 +207,5 @@ async def update_schedule(schedule_id: AnyScheduleID, params: ScheduleUpdate) ->
         return temporalio.client.ScheduleUpdate(schedule=input.description.schedule)
 
     handle = await _get_handle(schedule_id)
-    return await handle.update(_update_schedule)
+    with with_temporal_workspace_id(role.workspace_id if role else None):
+        return await handle.update(_update_schedule)

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -209,7 +209,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         # After-commit callback to update Temporal schedule
         async def _update_schedule():
             try:
-                await bridge.update_schedule(schedule_id, params)
+                await bridge.update_schedule(schedule_id, params, role=self.role)
                 logger.info(
                     "Updated schedule",
                     schedule_id=schedule_id,


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts Temporal workflow histories and transparently decodes memo/payload data via a centralized codec. Also tokenizes workflow alias visibility and enforces workspace scoping for executions, updates, schedules, and interactions.

- **New Features**
  - Added encrypted history support with centralized decoding via `tracecat.temporal.codec.decode_payloads` for histories and memos; backward compatible.
  - Tokenized `ALIAS` search attribute on write and hide tokenized values on read.
  - Scoped workflow executions, updates, schedules, and webhook interactions with `with_temporal_workspace_id`.

- **Bug Fixes**
  - Stopped logging raw memo payloads on parse warnings.
  - Made memo parsing async and resilient for `AgentActionMemo` and `ChildWorkflowMemo`; updated tests.
  - Ensured workflow interaction and schedule updates execute within the correct workspace context.

<sup>Written for commit daf88fab72886b8febc9a205a5994930c9ffbc67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

