### PR TITLE
feat(temporal): encrypt durable agent histories

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
@@ -33,6 +33,7 @@ from tracecat.identifiers import WorkflowID
 from tracecat.identifiers.workflow import exec_id_to_parts
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
+from tracecat.temporal.visibility import tokenize_visibility_value
 from tracecat.workflow.executions.enums import TemporalSearchAttr
 from tracecat_ee.agent.activities import (
     ApplyApprovalResultsActivityInputs,
@@ -328,7 +329,9 @@ class ApprovalService(BaseWorkspaceService):
                 session_id=session_id,
             )
             return []
-        alias = build_agent_alias(session.parent_workflow_id, session.action_ref)
+        alias = tokenize_visibility_value(
+            build_agent_alias(session.parent_workflow_id, session.action_ref)
+        )
 
         query = " AND ".join(
             [

--- a/tests/unit/test_approvals_service.py
+++ b/tests/unit/test_approvals_service.py
@@ -1,6 +1,9 @@
 """Tests for ApprovalService CRUD operations."""
 
 import uuid
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -8,9 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_ee.agent.approvals.schemas import ApprovalCreate, ApprovalUpdate
 from tracecat_ee.agent.approvals.service import ApprovalService, SessionInfo
 
+from tracecat.agent.aliases import build_agent_alias
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentSession, User
+from tracecat.identifiers import WorkflowID
+from tracecat.temporal.visibility import tokenize_visibility_value
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -263,6 +269,47 @@ class TestApprovalService:
         """Test batch update with empty dict returns empty list."""
         updated = await approvals_service.update_approvals({})
         assert updated == []
+
+    async def test_list_session_history_uses_tokenized_alias_query(
+        self,
+        approvals_service: ApprovalService,
+    ) -> None:
+        session_id = uuid.uuid4()
+        parent_workflow_id = WorkflowID(str(uuid.uuid4()))
+        action_ref = "tools.some_action"
+        expected_alias = tokenize_visibility_value(
+            build_agent_alias(parent_workflow_id, action_ref)
+        )
+        captured_query: str | None = None
+
+        class FakeTemporalClient:
+            async def list_workflows(self, **kwargs: str) -> AsyncIterator[object]:
+                nonlocal captured_query
+                captured_query = kwargs["query"]
+                if False:
+                    yield object()
+
+        with (
+            patch.object(
+                approvals_service,
+                "get_session",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        parent_workflow_id=parent_workflow_id,
+                        action_ref=action_ref,
+                    )
+                ),
+            ),
+            patch(
+                "tracecat_ee.agent.approvals.service.get_temporal_client",
+                AsyncMock(return_value=FakeTemporalClient()),
+            ),
+        ):
+            history = await approvals_service.list_session_history(session_id)
+
+        assert history == []
+        assert captured_query is not None
+        assert expected_alias in captured_query
 
     async def test_delete_approval(
         self,

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -55,6 +55,7 @@ from tracecat.chat.schemas import (
 )
 from tracecat.chat.service import ChatService
 from tracecat.chat.tools import get_default_tools
+from tracecat.contexts import with_temporal_workspace_id
 from tracecat.db.models import AgentSession, AgentSessionHistory, Approval, Chat
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import RETRY_POLICIES
@@ -891,15 +892,16 @@ class AgentSessionService(BaseWorkspaceService):
                 task_queue=config.TRACECAT__AGENT_QUEUE,
             )
 
-            await client.start_workflow(
-                DurableAgentWorkflow.run,
-                workflow_args,
-                id=str(workflow_id),
-                task_queue=config.TRACECAT__AGENT_QUEUE,
-                execution_timeout=timedelta(hours=1),
-                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-                search_attributes=self._build_direct_agent_search_attributes(),
-            )
+            with with_temporal_workspace_id(self.role.workspace_id):
+                await client.start_workflow(
+                    DurableAgentWorkflow.run,
+                    workflow_args,
+                    id=str(workflow_id),
+                    task_queue=config.TRACECAT__AGENT_QUEUE,
+                    execution_timeout=timedelta(hours=1),
+                    retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                    search_attributes=self._build_direct_agent_search_attributes(),
+                )
 
         # Return ChatResponse with session_id for streaming
         stream_url = f"/api/agent/sessions/{session_id}/stream"
@@ -1029,14 +1031,15 @@ class AgentSessionService(BaseWorkspaceService):
         )
 
         try:
-            await handle.execute_update(
-                DurableAgentWorkflow.set_approvals,
-                WorkflowApprovalSubmission(
-                    approvals=approval_map,
-                    approved_by=self.role.user_id,
-                    decision_metadata=decision_metadata or None,
-                ),
-            )
+            with with_temporal_workspace_id(self.role.workspace_id):
+                await handle.execute_update(
+                    DurableAgentWorkflow.set_approvals,
+                    WorkflowApprovalSubmission(
+                        approvals=approval_map,
+                        approved_by=self.role.user_id,
+                        decision_metadata=decision_metadata or None,
+                    ),
+                )
         except Exception:
             # Allow retriable failures to be resubmitted by clearing dedup marker.
             if dedup_client is not None and dedup_key is not None:


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts Temporal durable agent histories and uses tokenized visibility values in approvals history queries. Binds workflow starts and approval updates to the workspace ID to ensure tenant-scoped encryption.

- **New Features**
  - Use `tokenize_visibility_value` for the agent alias in approvals history queries.
  - Wrap `DurableAgentWorkflow` starts and approval updates with `with_temporal_workspace_id`.
  - Add a unit test to verify the tokenized alias is included in the Temporal visibility query.

<sup>Written for commit 2ad828bca8513b0c73553be0cc485309012bd2e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

