### PR TITLE
fix(ui): prevent preset restore from submitting the builder form

### DIFF
--- a/frontend/src/components/agents/agent-preset-versions-panel.tsx
+++ b/frontend/src/components/agents/agent-preset-versions-panel.tsx
@@ -136,6 +136,7 @@ export function AgentPresetVersionsPanel({
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {view === "compare" ? (
             <Button
+              type="button"
               variant="ghost"
               size="sm"
               className="h-7 px-2 text-xs"
@@ -247,6 +248,7 @@ function VersionsHistoryView({
               </div>
               <div className="flex items-center gap-2">
                 <Button
+                  type="button"
                   variant="ghost"
                   size="sm"
                   className="h-8 px-2 text-xs"
@@ -257,6 +259,7 @@ function VersionsHistoryView({
                 </Button>
                 {!isCurrent ? (
                   <Button
+                    type="button"
                     variant="ghost"
                     size="sm"
                     className="h-8 px-2 text-xs"

--- a/frontend/tests/agent-preset-versions-panel.test.tsx
+++ b/frontend/tests/agent-preset-versions-panel.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { FormEvent } from "react"
+import type { AgentPresetRead, AgentPresetVersionReadMinimal } from "@/client"
+import { AgentPresetVersionsPanel } from "@/components/agents/agent-preset-versions-panel"
+import {
+  useAgentPresetVersions,
+  useCompareAgentPresetVersions,
+  useRestoreAgentPresetVersion,
+} from "@/hooks/use-agent-presets"
+
+jest.mock("@/hooks/use-agent-presets", () => ({
+  useAgentPresetVersions: jest.fn(),
+  useCompareAgentPresetVersions: jest.fn(),
+  useRestoreAgentPresetVersion: jest.fn(),
+}))
+
+jest.mock("@/lib/event-history", () => ({
+  getRelativeTime: () => "just now",
+}))
+
+const mockUseAgentPresetVersions =
+  useAgentPresetVersions as jest.MockedFunction<typeof useAgentPresetVersions>
+const mockUseCompareAgentPresetVersions =
+  useCompareAgentPresetVersions as jest.MockedFunction<
+    typeof useCompareAgentPresetVersions
+  >
+const mockUseRestoreAgentPresetVersion =
+  useRestoreAgentPresetVersion as jest.MockedFunction<
+    typeof useRestoreAgentPresetVersion
+  >
+
+const presetFixture: AgentPresetRead = {
+  id: "preset-1",
+  workspace_id: "workspace-1",
+  name: "Versioned QA agent",
+  slug: "versioned-qa-agent",
+  description: "Used to verify restore behavior.",
+  instructions: "v2 prompt",
+  model_name: "gpt-4o-mini",
+  model_provider: "openai",
+  base_url: null,
+  output_type: null,
+  actions: ["core.http_request"],
+  namespaces: null,
+  tool_approvals: null,
+  mcp_integrations: null,
+  retries: 3,
+  enable_internet_access: false,
+  current_version_id: "version-2",
+  created_at: "2026-03-07T00:00:00.000Z",
+  updated_at: "2026-03-07T00:00:00.000Z",
+}
+
+const versionsFixture: AgentPresetVersionReadMinimal[] = [
+  {
+    id: "version-2",
+    preset_id: "preset-1",
+    workspace_id: "workspace-1",
+    version: 2,
+    instructions: "v2 prompt",
+    model_name: "gpt-4o-mini",
+    model_provider: "openai",
+    base_url: null,
+    output_type: null,
+    actions: ["core.http_request"],
+    namespaces: null,
+    tool_approvals: null,
+    mcp_integrations: null,
+    retries: 3,
+    enable_internet_access: false,
+    created_at: "2026-03-07T00:00:02.000Z",
+    updated_at: "2026-03-07T00:00:02.000Z",
+  },
+  {
+    id: "version-1",
+    preset_id: "preset-1",
+    workspace_id: "workspace-1",
+    version: 1,
+    instructions: "v1 prompt",
+    model_name: "gpt-4o-mini",
+    model_provider: "openai",
+    base_url: null,
+    output_type: null,
+    actions: ["core.http_request"],
+    namespaces: null,
+    tool_approvals: null,
+    mcp_integrations: null,
+    retries: 3,
+    enable_internet_access: false,
+    created_at: "2026-03-07T00:00:01.000Z",
+    updated_at: "2026-03-07T00:00:01.000Z",
+  },
+]
+
+describe("AgentPresetVersionsPanel", () => {
+  beforeEach(() => {
+    global.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+
+    mockUseAgentPresetVersions.mockReturnValue({
+      versions: versionsFixture,
+      versionsIsLoading: false,
+      versionsError: null,
+      refetchVersions: jest.fn(),
+    })
+    mockUseCompareAgentPresetVersions.mockReturnValue({
+      diff: undefined,
+      diffIsLoading: false,
+      diffError: null,
+      refetchDiff: jest.fn(),
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("restores a version without submitting the parent form", async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+    })
+    const restoreAgentPresetVersion = jest.fn().mockResolvedValue(presetFixture)
+
+    mockUseRestoreAgentPresetVersion.mockReturnValue({
+      restoreAgentPresetVersion,
+      restoreAgentPresetVersionIsPending: false,
+      restoreAgentPresetVersionError: null,
+    })
+
+    render(
+      <form onSubmit={onSubmit}>
+        <AgentPresetVersionsPanel
+          workspaceId="workspace-1"
+          preset={presetFixture}
+        />
+      </form>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Restore" }))
+
+    expect(restoreAgentPresetVersion).toHaveBeenCalledWith({
+      presetId: "preset-1",
+      versionId: "version-1",
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Versions panel buttons from submitting the builder form. Prevents accidental submits when restoring or comparing versions.

- **Bug Fixes**
  - Set `type="button"` on Compare, Back, and Restore buttons in `AgentPresetVersionsPanel`.
  - Added a test to ensure restore calls the hook with correct IDs and does not submit the parent form.

<sup>Written for commit 82cb986b0bfb03f48b6f760fb6d0423a962fabf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

