### PR TITLE
feat(logging): sanitize worker and workflow runtime logs

### DIFF
--- a/tests/unit/test_dsl_workflow_logging.py
+++ b/tests/unit/test_dsl_workflow_logging.py
@@ -156,3 +156,24 @@ def test_safe_repr_handles_broken_repr() -> None:
     output = workflow_logging._format_fields({"bad": BrokenRepr()})
     assert output.startswith(" | ")
     assert "bad=<unrepresentable BrokenRepr>" in output
+
+
+def test_workflow_logger_sanitizes_messages_and_summarizes_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process_logger = MagicMock()
+    process_logger.opt.return_value = process_logger
+    monkeypatch.setattr(workflow_logging, "_in_workflow_context", lambda: False)
+    monkeypatch.setattr(workflow_logging, "process_logger", process_logger)
+
+    logger = workflow_logging.get_workflow_logger(service="dsl")
+    logger.info(
+        "Failure for alice@example.com",
+        params={"email": "alice@example.com", "token": "secret-token"},
+    )
+
+    [_, _, message_factory, suffix], _ = process_logger.log.call_args
+    assert message_factory() == "Failure for [REDACTED_EMAIL]"
+    formatted_suffix = suffix()
+    assert "params={'type': 'object'" in formatted_suffix
+    assert "secret-token" not in formatted_suffix

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -64,6 +64,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.interceptor import SentryInterceptor
     from tracecat.dsl.plugins import TracecatPydanticAIPlugin
     from tracecat.logger import logger
+    from tracecat.logger.security import configure_sentry
 
 
 def new_sandbox_runner() -> SandboxedWorkflowRunner:
@@ -313,10 +314,11 @@ async def main() -> None:
             sentry_environment = (
                 config.SENTRY_ENVIRONMENT_OVERRIDE or f"{app_env}-{temporal_namespace}"
             )
-            sentry_sdk.init(
+            configure_sentry(
                 dsn=sentry_dsn,
                 environment=sentry_environment,
                 release=f"tracecat@{APP_VERSION}",
+                sentry_sdk_module=sentry_sdk,
             )
             interceptors.append(SentryInterceptor())
 

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -30,6 +30,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.workflow import DSLWorkflow
     from tracecat.ee.interactions.service import InteractionService
     from tracecat.logger import logger
+    from tracecat.logger.security import configure_sentry
     from tracecat.storage.collection import CollectionActivities
     from tracecat.tiers.activities import TierActivities
     from tracecat.workflow.management.definitions import (
@@ -116,10 +117,11 @@ async def main() -> None:
         sentry_environment: str = (
             config.SENTRY_ENVIRONMENT_OVERRIDE or f"{app_env}-{temporal_namespace}"
         )
-        sentry_sdk.init(
+        configure_sentry(
             dsn=sentry_dsn,
             environment=sentry_environment,
             release=f"tracecat@{APP_VERSION}",
+            sentry_sdk_module=sentry_sdk,
         )
         logger.info(
             "Sentry initialized",

--- a/tracecat/dsl/workflow_logging.py
+++ b/tracecat/dsl/workflow_logging.py
@@ -7,6 +7,7 @@ from typing import Any
 from temporalio import workflow
 
 from tracecat.logger import logger as process_logger
+from tracecat.logger.security import sanitize_log_fields, sanitize_text
 
 
 def _in_workflow_context() -> bool:
@@ -101,18 +102,21 @@ class WorkflowRuntimeLogger:
             temporal_level = "debug" if level == "trace" else level
             if not _workflow_level_enabled(temporal_level):
                 return
-            merged_fields = {**self._bound_fields, **fields}
-            formatted_message = f"{message}{_format_fields(merged_fields)}"
+            merged_fields = sanitize_log_fields({**self._bound_fields, **fields})
+            formatted_message = (
+                f"{sanitize_text(message) or ''}{_format_fields(merged_fields)}"
+            )
             getattr(workflow.logger, temporal_level)(formatted_message)
             return
 
-        bound_fields = self._bound_fields
-        dynamic_fields = fields
+        bound_fields = sanitize_log_fields(self._bound_fields)
+        dynamic_fields = sanitize_log_fields(fields)
+        sanitized_message = sanitize_text(message) or ""
 
         process_logger.opt(lazy=True).log(
             _LOGURU_LEVEL_BY_NAME[level],
             "{}{}",
-            lambda: message,
+            lambda: sanitized_message,
             lambda: _format_fields({**bound_fields, **dynamic_fields}),
         )
 

--- a/tracecat/executor/backends/pool/worker.py
+++ b/tracecat/executor/backends/pool/worker.py
@@ -26,6 +26,7 @@ import signal
 import sys
 import time
 import traceback
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -41,7 +42,7 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 # =============================================================================
 from tracecat import config  # noqa: E402
 from tracecat.auth.types import Role  # noqa: E402
-from tracecat.contexts import ctx_role  # noqa: E402
+from tracecat.contexts import ctx_log_masks, ctx_role  # noqa: E402
 from tracecat.executor.minimal_runner import run_action_minimal_async  # noqa: E402
 from tracecat.executor.schemas import (  # noqa: E402
     ExecutorActionErrorInfo,
@@ -82,6 +83,27 @@ _connection_counter = 0
 _active_connections = 0
 _worker_id = int(os.environ.get("TRACECAT_WORKER_ID", "0"))
 _test_mode = os.environ.get("TRACECAT__POOL_WORKER_TEST_MODE", "").lower() == "true"
+
+
+def _collect_log_masks(value: Any) -> set[str]:
+    masks: set[str] = set()
+    stack: list[Any] = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            stack.extend(current.values())
+            continue
+        if isinstance(current, Sequence) and not isinstance(
+            current, str | bytes | bytearray
+        ):
+            stack.extend(current)
+            continue
+        if current is None:
+            continue
+        current_str = str(current)
+        if current_str and len(current_str) > 1:
+            masks.add(current_str)
+    return masks
 
 
 async def handle_task(request: dict[str, Any]) -> dict[str, Any]:
@@ -137,19 +159,25 @@ async def handle_task(request: dict[str, Any]) -> dict[str, Any]:
 
         # Set the role context for actions that need it (e.g., core.cases, core.table)
         ctx_role.set(role)
+        log_masks_token = ctx_log_masks.set(
+            tuple(_collect_log_masks(resolved_context.secrets))
+        )
 
         # Execute action using minimal runner (no DB access, explicit context)
-        start = time.monotonic()
-        result = await run_action_minimal_async(
-            action_impl=resolved_context.action_impl.model_dump(),
-            args=resolved_context.evaluated_args,
-            secrets=resolved_context.secrets,
-            workspace_id=resolved_context.workspace_id,
-            workflow_id=resolved_context.workflow_id,
-            run_id=resolved_context.run_id,
-            executor_token=resolved_context.executor_token,
-        )
-        timing["action_ms"] = (time.monotonic() - start) * 1000
+        try:
+            start = time.monotonic()
+            result = await run_action_minimal_async(
+                action_impl=resolved_context.action_impl.model_dump(),
+                args=resolved_context.evaluated_args,
+                secrets=resolved_context.secrets,
+                workspace_id=resolved_context.workspace_id,
+                workflow_id=resolved_context.workflow_id,
+                run_id=resolved_context.run_id,
+                executor_token=resolved_context.executor_token,
+            )
+            timing["action_ms"] = (time.monotonic() - start) * 1000
+        finally:
+            ctx_log_masks.reset(log_masks_token)
 
         timing["total_ms"] = (time.monotonic() - start_total) * 1000
 

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -284,7 +284,7 @@ class SettingsService(BaseOrgService):
     @require_scope("org:settings:update")
     @audit_log(resource_type="organization_setting", action="update")
     async def update_git_settings(self, params: GitSettingsUpdate) -> None:
-        self.logger.info(f"Updating Git settings: {params}")
+        self.logger.info("Updating Git settings", params=params)
         # Ignore read-only fields
         git_settings = await self.list_org_settings(keys=GitSettingsUpdate.keys())
         await self._update_grouped_settings(git_settings, params)


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime log sanitization for workers and workflows to prevent secrets and PII from leaking. Sanitizes messages and fields, scopes masks per task, and centralizes secure Sentry setup.

- **New Features**
  - Sanitizes workflow and process logger messages and fields via `sanitize_text` and `sanitize_log_fields`; summarizes large params.
  - Scopes masking in pool workers using `ctx_log_masks` populated from nested action secrets via `_collect_log_masks`; resets after execution.
  - Initializes Sentry via `configure_sentry` in agent and DSL workers.
  - Uses structured params for Git settings logs; adds a unit test covering email redaction, token masking, and payload summarization.

<sup>Written for commit e80637fc017c3ca508689d93fc258a1e6e82160b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

