### PR TITLE
feat(ui): Chat UI 2.0 @ mention and preset in prompt input

### DIFF
--- a/frontend/src/components/ai-elements/code-block-cache.ts
+++ b/frontend/src/components/ai-elements/code-block-cache.ts
@@ -1,0 +1,3 @@
+export function getTokensCacheKey(code: string, language: string): string {
+  return `${language}\u0000${code}`
+}

--- a/frontend/src/components/ai-elements/code-block.tsx
+++ b/frontend/src/components/ai-elements/code-block.tsx
@@ -12,6 +12,11 @@ import {
   useRef,
   useState,
 } from "react"
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
+import {
+  oneDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/esm/styles/prism"
 import type {
   BundledLanguage,
   BundledTheme,
@@ -273,6 +278,24 @@ const LINE_NUMBER_CLASSES = cn(
   "before:select-none"
 )
 
+const hasSyntaxColor = (tokenized: TokenizedCode) =>
+  tokenized.tokens.some((line) =>
+    line.some((token) => {
+      const htmlColor =
+        token.htmlStyle &&
+        typeof token.htmlStyle.color === "string" &&
+        token.htmlStyle.color.length > 0
+          ? token.htmlStyle.color
+          : undefined
+      const color = token.color ?? htmlColor
+      return (
+        typeof color === "string" &&
+        color !== "inherit" &&
+        color !== "currentColor"
+      )
+    })
+  )
+
 const CodeBlockBody = memo(
   ({
     tokenized,
@@ -432,9 +455,64 @@ export const CodeBlockContent = ({
     }
   }, [code, language, rawTokens])
 
+  const shouldUsePrismFallback = useMemo(
+    () => !hasSyntaxColor(tokenized),
+    [tokenized]
+  )
+
   return (
     <div className="relative overflow-auto">
-      <CodeBlockBody showLineNumbers={showLineNumbers} tokenized={tokenized} />
+      {shouldUsePrismFallback ? (
+        <>
+          <SyntaxHighlighter
+            className="overflow-hidden dark:hidden"
+            codeTagProps={{
+              className: "font-mono text-sm",
+            }}
+            customStyle={{
+              margin: 0,
+              padding: "1rem",
+              background: "transparent",
+            }}
+            language={language}
+            lineNumberStyle={{
+              color: "hsl(var(--muted-foreground))",
+              minWidth: "2.5rem",
+              paddingRight: "1rem",
+            }}
+            showLineNumbers={showLineNumbers}
+            style={oneLight}
+          >
+            {code}
+          </SyntaxHighlighter>
+          <SyntaxHighlighter
+            className="hidden overflow-hidden dark:block"
+            codeTagProps={{
+              className: "font-mono text-sm",
+            }}
+            customStyle={{
+              margin: 0,
+              padding: "1rem",
+              background: "transparent",
+            }}
+            language={language}
+            lineNumberStyle={{
+              color: "hsl(var(--muted-foreground))",
+              minWidth: "2.5rem",
+              paddingRight: "1rem",
+            }}
+            showLineNumbers={showLineNumbers}
+            style={oneDark}
+          >
+            {code}
+          </SyntaxHighlighter>
+        </>
+      ) : (
+        <CodeBlockBody
+          showLineNumbers={showLineNumbers}
+          tokenized={tokenized}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/ai-elements/code-block.tsx
+++ b/frontend/src/components/ai-elements/code-block.tsx
@@ -128,6 +128,26 @@ const tokensCache = new Map<string, TokenizedCode>()
 
 // Subscribers for async token updates
 const subscribers = new Map<string, Set<(result: TokenizedCode) => void>>()
+const inFlightTokenizations = new Map<string, Promise<void>>()
+
+const MAX_TOKENS_CACHE_ENTRIES = 500
+
+const setCachedTokens = (cacheKey: string, tokenized: TokenizedCode) => {
+  if (tokensCache.has(cacheKey)) {
+    tokensCache.delete(cacheKey)
+  }
+  tokensCache.set(cacheKey, tokenized)
+
+  while (tokensCache.size > MAX_TOKENS_CACHE_ENTRIES) {
+    const oldestCacheKey = tokensCache.keys().next().value as string | undefined
+    if (!oldestCacheKey) {
+      break
+    }
+    tokensCache.delete(oldestCacheKey)
+    subscribers.delete(oldestCacheKey)
+    inFlightTokenizations.delete(oldestCacheKey)
+  }
+}
 
 const getHighlighter = (
   language: BundledLanguage
@@ -174,6 +194,8 @@ export const highlightCode = (
   // Return cached result if available
   const cached = tokensCache.get(tokensCacheKey)
   if (cached) {
+    // Keep the most recently used entries hot.
+    setCachedTokens(tokensCacheKey, cached)
     return cached
   }
 
@@ -185,8 +207,12 @@ export const highlightCode = (
     subscribers.get(tokensCacheKey)?.add(callback)
   }
 
+  if (inFlightTokenizations.has(tokensCacheKey)) {
+    return null
+  }
+
   // Start highlighting in background - fire-and-forget async pattern
-  getHighlighter(language)
+  const tokenizationPromise = getHighlighter(language)
     // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then)
     .then((highlighter) => {
       const availableLangs = highlighter.getLoadedLanguages()
@@ -207,7 +233,7 @@ export const highlightCode = (
       }
 
       // Cache the result
-      tokensCache.set(tokensCacheKey, tokenized)
+      setCachedTokens(tokensCacheKey, tokenized)
 
       // Notify all subscribers
       const subs = subscribers.get(tokensCacheKey)
@@ -223,6 +249,12 @@ export const highlightCode = (
       console.error("Failed to highlight code:", error)
       subscribers.delete(tokensCacheKey)
     })
+    // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then)
+    .finally(() => {
+      inFlightTokenizations.delete(tokensCacheKey)
+    })
+
+  inFlightTokenizations.set(tokensCacheKey, tokenizationPromise)
 
   return null
 }
@@ -387,15 +419,13 @@ export const CodeBlockContent = ({
   useEffect(() => {
     let cancelled = false
 
-    // Reset to raw tokens when code changes (shows current code, not stale tokens)
-    setTokenized(highlightCode(code, language) ?? rawTokens)
-
-    // Subscribe to async highlighting result
-    highlightCode(code, language, (result) => {
+    const highlighted = highlightCode(code, language, (result) => {
       if (!cancelled) {
         setTokenized(result)
       }
     })
+    // Reset to raw tokens when code changes (shows current code, not stale tokens)
+    setTokenized(highlighted ?? rawTokens)
 
     return () => {
       cancelled = true

--- a/frontend/src/components/ai-elements/code-block.tsx
+++ b/frontend/src/components/ai-elements/code-block.tsx
@@ -1,29 +1,412 @@
 "use client"
 
 import { CheckIcon, CopyIcon } from "lucide-react"
-import type { ComponentProps, HTMLAttributes, ReactNode } from "react"
-import { createContext, useContext, useState } from "react"
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
+import type { ComponentProps, CSSProperties, HTMLAttributes } from "react"
 import {
-  oneDark,
-  oneLight,
-} from "react-syntax-highlighter/dist/esm/styles/prism"
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import type {
+  BundledLanguage,
+  BundledTheme,
+  HighlighterGeneric,
+  ThemedToken,
+} from "shiki"
+import { createHighlighter } from "shiki"
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { cn } from "@/lib/utils"
+import { getTokensCacheKey } from "./code-block-cache"
 
-type CodeBlockContextType = {
+// Shiki uses bitflags for font styles: 1=italic, 2=bold, 4=underline
+// eslint-disable-next-line no-bitwise -- shiki bitflag check
+const isItalic = (fontStyle: number | undefined) => fontStyle && fontStyle & 1
+// eslint-disable-next-line no-bitwise -- shiki bitflag check
+// oxlint-disable-next-line eslint(no-bitwise)
+const isBold = (fontStyle: number | undefined) => fontStyle && fontStyle & 2
+const isUnderline = (fontStyle: number | undefined) =>
+  // oxlint-disable-next-line eslint(no-bitwise)
+  fontStyle && fontStyle & 4
+
+// Transform tokens to include pre-computed keys to avoid noArrayIndexKey lint
+interface KeyedToken {
+  token: ThemedToken
+  key: string
+}
+interface KeyedLine {
+  tokens: KeyedToken[]
+  key: string
+}
+
+const addKeysToTokens = (lines: ThemedToken[][]): KeyedLine[] =>
+  lines.map((line, lineIdx) => ({
+    key: `line-${lineIdx}`,
+    tokens: line.map((token, tokenIdx) => ({
+      key: `line-${lineIdx}-${tokenIdx}`,
+      token,
+    })),
+  }))
+
+// Token rendering component
+const TokenSpan = ({ token }: { token: ThemedToken }) => (
+  <span
+    className="dark:!bg-[var(--shiki-dark-bg)] dark:!text-[var(--shiki-dark)]"
+    style={
+      {
+        backgroundColor: token.bgColor,
+        color: token.color,
+        fontStyle: isItalic(token.fontStyle) ? "italic" : undefined,
+        fontWeight: isBold(token.fontStyle) ? "bold" : undefined,
+        textDecoration: isUnderline(token.fontStyle) ? "underline" : undefined,
+        ...token.htmlStyle,
+      } as CSSProperties
+    }
+  >
+    {token.content}
+  </span>
+)
+
+// Line rendering component
+const LineSpan = ({
+  keyedLine,
+  showLineNumbers,
+}: {
+  keyedLine: KeyedLine
+  showLineNumbers: boolean
+}) => (
+  <span className={showLineNumbers ? LINE_NUMBER_CLASSES : "block"}>
+    {keyedLine.tokens.length === 0
+      ? "\n"
+      : keyedLine.tokens.map(({ token, key }) => (
+          <TokenSpan key={key} token={token} />
+        ))}
+  </span>
+)
+
+// Types
+type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
+  code: string
+  language: BundledLanguage
+  showLineNumbers?: boolean
+}
+
+interface TokenizedCode {
+  tokens: ThemedToken[][]
+  fg: string
+  bg: string
+}
+
+interface CodeBlockContextType {
   code: string
 }
 
+// Context
 const CodeBlockContext = createContext<CodeBlockContextType>({
   code: "",
 })
 
-export type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
+// Highlighter cache (singleton per language)
+const highlighterCache = new Map<
+  string,
+  Promise<HighlighterGeneric<BundledLanguage, BundledTheme>>
+>()
+
+// Token cache
+const tokensCache = new Map<string, TokenizedCode>()
+
+// Subscribers for async token updates
+const subscribers = new Map<string, Set<(result: TokenizedCode) => void>>()
+
+const getHighlighter = (
+  language: BundledLanguage
+): Promise<HighlighterGeneric<BundledLanguage, BundledTheme>> => {
+  const cached = highlighterCache.get(language)
+  if (cached) {
+    return cached
+  }
+
+  const highlighterPromise = createHighlighter({
+    langs: [language],
+    themes: ["github-light", "github-dark"],
+  })
+
+  highlighterCache.set(language, highlighterPromise)
+  return highlighterPromise
+}
+
+// Create raw tokens for immediate display while highlighting loads
+const createRawTokens = (code: string): TokenizedCode => ({
+  bg: "transparent",
+  fg: "inherit",
+  tokens: code.split("\n").map((line) =>
+    line === ""
+      ? []
+      : [
+          {
+            color: "inherit",
+            content: line,
+          } as ThemedToken,
+        ]
+  ),
+})
+
+// Synchronous highlight with callback for async results
+export const highlightCode = (
+  code: string,
+  language: BundledLanguage,
+  // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-callbacks)
+  callback?: (result: TokenizedCode) => void
+): TokenizedCode | null => {
+  const tokensCacheKey = getTokensCacheKey(code, language)
+
+  // Return cached result if available
+  const cached = tokensCache.get(tokensCacheKey)
+  if (cached) {
+    return cached
+  }
+
+  // Subscribe callback if provided
+  if (callback) {
+    if (!subscribers.has(tokensCacheKey)) {
+      subscribers.set(tokensCacheKey, new Set())
+    }
+    subscribers.get(tokensCacheKey)?.add(callback)
+  }
+
+  // Start highlighting in background - fire-and-forget async pattern
+  getHighlighter(language)
+    // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then)
+    .then((highlighter) => {
+      const availableLangs = highlighter.getLoadedLanguages()
+      const langToUse = availableLangs.includes(language) ? language : "text"
+
+      const result = highlighter.codeToTokens(code, {
+        lang: langToUse,
+        themes: {
+          dark: "github-dark",
+          light: "github-light",
+        },
+      })
+
+      const tokenized: TokenizedCode = {
+        bg: result.bg ?? "transparent",
+        fg: result.fg ?? "inherit",
+        tokens: result.tokens,
+      }
+
+      // Cache the result
+      tokensCache.set(tokensCacheKey, tokenized)
+
+      // Notify all subscribers
+      const subs = subscribers.get(tokensCacheKey)
+      if (subs) {
+        for (const sub of subs) {
+          sub(tokenized)
+        }
+        subscribers.delete(tokensCacheKey)
+      }
+    })
+    // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then), eslint-plugin-promise(prefer-await-to-callbacks)
+    .catch((error) => {
+      console.error("Failed to highlight code:", error)
+      subscribers.delete(tokensCacheKey)
+    })
+
+  return null
+}
+
+// Line number styles using CSS counters
+const LINE_NUMBER_CLASSES = cn(
+  "block",
+  "before:content-[counter(line)]",
+  "before:inline-block",
+  "before:[counter-increment:line]",
+  "before:w-8",
+  "before:mr-4",
+  "before:text-right",
+  "before:text-muted-foreground/50",
+  "before:font-mono",
+  "before:select-none"
+)
+
+const CodeBlockBody = memo(
+  ({
+    tokenized,
+    showLineNumbers,
+    className,
+  }: {
+    tokenized: TokenizedCode
+    showLineNumbers: boolean
+    className?: string
+  }) => {
+    const preStyle = useMemo(
+      () => ({
+        backgroundColor: tokenized.bg,
+        color: tokenized.fg,
+      }),
+      [tokenized.bg, tokenized.fg]
+    )
+
+    const keyedLines = useMemo(
+      () => addKeysToTokens(tokenized.tokens),
+      [tokenized.tokens]
+    )
+
+    return (
+      <pre
+        className={cn(
+          "dark:!bg-[var(--shiki-dark-bg)] dark:!text-[var(--shiki-dark)] m-0 p-4 text-sm",
+          className
+        )}
+        style={preStyle}
+      >
+        <code
+          className={cn(
+            "font-mono text-sm",
+            showLineNumbers && "[counter-increment:line_0] [counter-reset:line]"
+          )}
+        >
+          {keyedLines.map((keyedLine) => (
+            <LineSpan
+              key={keyedLine.key}
+              keyedLine={keyedLine}
+              showLineNumbers={showLineNumbers}
+            />
+          ))}
+        </code>
+      </pre>
+    )
+  },
+  (prevProps, nextProps) =>
+    prevProps.tokenized === nextProps.tokenized &&
+    prevProps.showLineNumbers === nextProps.showLineNumbers &&
+    prevProps.className === nextProps.className
+)
+
+CodeBlockBody.displayName = "CodeBlockBody"
+
+export const CodeBlockContainer = ({
+  className,
+  language,
+  style,
+  ...props
+}: HTMLAttributes<HTMLDivElement> & { language: string }) => (
+  <div
+    className={cn(
+      "group relative w-full overflow-hidden rounded-md border bg-background text-foreground",
+      className
+    )}
+    data-language={language}
+    style={{
+      containIntrinsicSize: "auto 200px",
+      contentVisibility: "auto",
+      ...style,
+    }}
+    {...props}
+  />
+)
+
+export const CodeBlockHeader = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex items-center justify-between border-b bg-muted/80 px-3 py-2 text-muted-foreground text-xs",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+)
+
+export const CodeBlockTitle = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex items-center gap-2", className)} {...props}>
+    {children}
+  </div>
+)
+
+export const CodeBlockFilename = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLSpanElement>) => (
+  <span className={cn("font-mono", className)} {...props}>
+    {children}
+  </span>
+)
+
+export const CodeBlockActions = ({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("-my-1 -mr-1 flex items-center gap-2", className)}
+    {...props}
+  >
+    {children}
+  </div>
+)
+
+export const CodeBlockContent = ({
+  code,
+  language,
+  showLineNumbers = false,
+}: {
   code: string
-  language: string
+  language: BundledLanguage
   showLineNumbers?: boolean
-  children?: ReactNode
+}) => {
+  // Memoized raw tokens for immediate display
+  const rawTokens = useMemo(() => createRawTokens(code), [code])
+
+  // Try to get cached result synchronously, otherwise use raw tokens
+  const [tokenized, setTokenized] = useState<TokenizedCode>(
+    () => highlightCode(code, language) ?? rawTokens
+  )
+
+  useEffect(() => {
+    let cancelled = false
+
+    // Reset to raw tokens when code changes (shows current code, not stale tokens)
+    setTokenized(highlightCode(code, language) ?? rawTokens)
+
+    // Subscribe to async highlighting result
+    highlightCode(code, language, (result) => {
+      if (!cancelled) {
+        setTokenized(result)
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [code, language, rawTokens])
+
+  return (
+    <div className="relative overflow-auto">
+      <CodeBlockBody showLineNumbers={showLineNumbers} tokenized={tokenized} />
+    </div>
+  )
 }
 
 export const CodeBlock = ({
@@ -33,71 +416,22 @@ export const CodeBlock = ({
   className,
   children,
   ...props
-}: CodeBlockProps) => (
-  <CodeBlockContext.Provider value={{ code }}>
-    <div
-      className={cn(
-        "relative w-full overflow-hidden rounded-md border bg-background text-foreground",
-        className
-      )}
-      {...props}
-    >
-      <div className="relative">
-        <SyntaxHighlighter
-          className="overflow-hidden dark:hidden"
-          codeTagProps={{
-            className: "font-mono text-sm",
-          }}
-          customStyle={{
-            margin: 0,
-            padding: "1rem",
-            fontSize: "0.875rem",
-            background: "hsl(var(--background))",
-            color: "hsl(var(--foreground))",
-          }}
+}: CodeBlockProps) => {
+  const contextValue = useMemo(() => ({ code }), [code])
+
+  return (
+    <CodeBlockContext.Provider value={contextValue}>
+      <CodeBlockContainer className={className} language={language} {...props}>
+        {children}
+        <CodeBlockContent
+          code={code}
           language={language}
-          lineNumberStyle={{
-            color: "hsl(var(--muted-foreground))",
-            paddingRight: "1rem",
-            minWidth: "2.5rem",
-          }}
           showLineNumbers={showLineNumbers}
-          style={oneLight}
-        >
-          {code}
-        </SyntaxHighlighter>
-        <SyntaxHighlighter
-          className="hidden overflow-hidden dark:block"
-          codeTagProps={{
-            className: "font-mono text-sm",
-          }}
-          customStyle={{
-            margin: 0,
-            padding: "1rem",
-            fontSize: "0.875rem",
-            background: "hsl(var(--background))",
-            color: "hsl(var(--foreground))",
-          }}
-          language={language}
-          lineNumberStyle={{
-            color: "hsl(var(--muted-foreground))",
-            paddingRight: "1rem",
-            minWidth: "2.5rem",
-          }}
-          showLineNumbers={showLineNumbers}
-          style={oneDark}
-        >
-          {code}
-        </SyntaxHighlighter>
-        {children && (
-          <div className="absolute top-2 right-2 flex items-center gap-2">
-            {children}
-          </div>
-        )}
-      </div>
-    </div>
-  </CodeBlockContext.Provider>
-)
+        />
+      </CodeBlockContainer>
+    </CodeBlockContext.Provider>
+  )
+}
 
 export type CodeBlockCopyButtonProps = ComponentProps<typeof Button> & {
   onCopy?: () => void
@@ -114,23 +448,36 @@ export const CodeBlockCopyButton = ({
   ...props
 }: CodeBlockCopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false)
+  const timeoutRef = useRef<number>(0)
   const { code } = useContext(CodeBlockContext)
 
-  const copyToClipboard = async () => {
-    if (typeof window === "undefined" || !navigator.clipboard.writeText) {
+  const copyToClipboard = useCallback(async () => {
+    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
       onError?.(new Error("Clipboard API not available"))
       return
     }
 
     try {
-      await navigator.clipboard.writeText(code)
-      setIsCopied(true)
-      onCopy?.()
-      setTimeout(() => setIsCopied(false), timeout)
+      if (!isCopied) {
+        await navigator.clipboard.writeText(code)
+        setIsCopied(true)
+        onCopy?.()
+        timeoutRef.current = window.setTimeout(
+          () => setIsCopied(false),
+          timeout
+        )
+      }
     } catch (error) {
       onError?.(error as Error)
     }
-  }
+  }, [code, onCopy, onError, timeout, isCopied])
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(timeoutRef.current)
+    },
+    []
+  )
 
   const Icon = isCopied ? CheckIcon : CopyIcon
 
@@ -146,3 +493,53 @@ export const CodeBlockCopyButton = ({
     </Button>
   )
 }
+
+export type CodeBlockLanguageSelectorProps = ComponentProps<typeof Select>
+
+export const CodeBlockLanguageSelector = (
+  props: CodeBlockLanguageSelectorProps
+) => <Select {...props} />
+
+export type CodeBlockLanguageSelectorTriggerProps = ComponentProps<
+  typeof SelectTrigger
+>
+
+export const CodeBlockLanguageSelectorTrigger = ({
+  className,
+  ...props
+}: CodeBlockLanguageSelectorTriggerProps) => (
+  <SelectTrigger
+    className={cn(
+      "h-7 border-none bg-transparent px-2 text-xs shadow-none",
+      className
+    )}
+    {...props}
+  />
+)
+
+export type CodeBlockLanguageSelectorValueProps = ComponentProps<
+  typeof SelectValue
+>
+
+export const CodeBlockLanguageSelectorValue = (
+  props: CodeBlockLanguageSelectorValueProps
+) => <SelectValue {...props} />
+
+export type CodeBlockLanguageSelectorContentProps = ComponentProps<
+  typeof SelectContent
+>
+
+export const CodeBlockLanguageSelectorContent = ({
+  align = "end",
+  ...props
+}: CodeBlockLanguageSelectorContentProps) => (
+  <SelectContent align={align} {...props} />
+)
+
+export type CodeBlockLanguageSelectorItemProps = ComponentProps<
+  typeof SelectItem
+>
+
+export const CodeBlockLanguageSelectorItem = (
+  props: CodeBlockLanguageSelectorItemProps
+) => <SelectItem {...props} />

--- a/frontend/src/components/ai-elements/model-selector.tsx
+++ b/frontend/src/components/ai-elements/model-selector.tsx
@@ -1,0 +1,212 @@
+import type { ComponentProps, ReactNode } from "react"
+
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command"
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
+
+export type ModelSelectorProps = ComponentProps<typeof Dialog>
+
+export const ModelSelector = (props: ModelSelectorProps) => (
+  <Dialog {...props} />
+)
+
+export type ModelSelectorTriggerProps = ComponentProps<typeof DialogTrigger>
+
+export const ModelSelectorTrigger = (props: ModelSelectorTriggerProps) => (
+  <DialogTrigger {...props} />
+)
+
+export type ModelSelectorContentProps = ComponentProps<typeof DialogContent> & {
+  title?: ReactNode
+}
+
+export const ModelSelectorContent = ({
+  className,
+  children,
+  title = "Model Selector",
+  ...props
+}: ModelSelectorContentProps) => (
+  <DialogContent
+    aria-describedby={undefined}
+    className={cn(
+      "border-none p-0 outline outline-1 outline-border",
+      className
+    )}
+    {...props}
+  >
+    <DialogTitle className="sr-only">{title}</DialogTitle>
+    <Command className="[&_[cmdk-input-wrapper]]:h-auto">{children}</Command>
+  </DialogContent>
+)
+
+export type ModelSelectorDialogProps = ComponentProps<typeof CommandDialog>
+
+export const ModelSelectorDialog = (props: ModelSelectorDialogProps) => (
+  <CommandDialog {...props} />
+)
+
+export type ModelSelectorInputProps = ComponentProps<typeof CommandInput>
+
+export const ModelSelectorInput = ({
+  className,
+  ...props
+}: ModelSelectorInputProps) => (
+  <CommandInput className={cn("h-auto py-3.5", className)} {...props} />
+)
+
+export type ModelSelectorListProps = ComponentProps<typeof CommandList>
+
+export const ModelSelectorList = (props: ModelSelectorListProps) => (
+  <CommandList {...props} />
+)
+
+export type ModelSelectorEmptyProps = ComponentProps<typeof CommandEmpty>
+
+export const ModelSelectorEmpty = (props: ModelSelectorEmptyProps) => (
+  <CommandEmpty {...props} />
+)
+
+export type ModelSelectorGroupProps = ComponentProps<typeof CommandGroup>
+
+export const ModelSelectorGroup = (props: ModelSelectorGroupProps) => (
+  <CommandGroup {...props} />
+)
+
+export type ModelSelectorItemProps = ComponentProps<typeof CommandItem>
+
+export const ModelSelectorItem = (props: ModelSelectorItemProps) => (
+  <CommandItem {...props} />
+)
+
+export type ModelSelectorShortcutProps = ComponentProps<typeof CommandShortcut>
+
+export const ModelSelectorShortcut = (props: ModelSelectorShortcutProps) => (
+  <CommandShortcut {...props} />
+)
+
+export type ModelSelectorSeparatorProps = ComponentProps<
+  typeof CommandSeparator
+>
+
+export const ModelSelectorSeparator = (props: ModelSelectorSeparatorProps) => (
+  <CommandSeparator {...props} />
+)
+
+export type ModelSelectorLogoProps = Omit<
+  ComponentProps<"img">,
+  "src" | "alt"
+> & {
+  provider:
+    | "moonshotai-cn"
+    | "lucidquery"
+    | "moonshotai"
+    | "zai-coding-plan"
+    | "alibaba"
+    | "xai"
+    | "vultr"
+    | "nvidia"
+    | "upstage"
+    | "groq"
+    | "github-copilot"
+    | "mistral"
+    | "vercel"
+    | "nebius"
+    | "deepseek"
+    | "alibaba-cn"
+    | "google-vertex-anthropic"
+    | "venice"
+    | "chutes"
+    | "cortecs"
+    | "github-models"
+    | "togetherai"
+    | "azure"
+    | "baseten"
+    | "huggingface"
+    | "opencode"
+    | "fastrouter"
+    | "google"
+    | "google-vertex"
+    | "cloudflare-workers-ai"
+    | "inception"
+    | "wandb"
+    | "openai"
+    | "zhipuai-coding-plan"
+    | "perplexity"
+    | "openrouter"
+    | "zenmux"
+    | "v0"
+    | "iflowcn"
+    | "synthetic"
+    | "deepinfra"
+    | "zhipuai"
+    | "submodel"
+    | "zai"
+    | "inference"
+    | "requesty"
+    | "morph"
+    | "lmstudio"
+    | "anthropic"
+    | "aihubmix"
+    | "fireworks-ai"
+    | "modelscope"
+    | "llama"
+    | "scaleway"
+    | "amazon-bedrock"
+    | "cerebras"
+    // oxlint-disable-next-line typescript-eslint(ban-types) -- intentional pattern for autocomplete-friendly string union
+    | (string & {})
+}
+
+export const ModelSelectorLogo = ({
+  provider,
+  className,
+  ...props
+}: ModelSelectorLogoProps) => (
+  <img
+    {...props}
+    alt={`${provider} logo`}
+    className={cn("size-3 dark:invert", className)}
+    height={12}
+    src={`https://models.dev/logos/${provider}.svg`}
+    width={12}
+  />
+)
+
+export type ModelSelectorLogoGroupProps = ComponentProps<"div">
+
+export const ModelSelectorLogoGroup = ({
+  className,
+  ...props
+}: ModelSelectorLogoGroupProps) => (
+  <div
+    className={cn(
+      "flex shrink-0 items-center -space-x-1 [&>img]:rounded-full [&>img]:bg-background [&>img]:p-px [&>img]:ring-1 dark:[&>img]:bg-foreground",
+      className
+    )}
+    {...props}
+  />
+)
+
+export type ModelSelectorNameProps = ComponentProps<"span">
+
+export const ModelSelectorName = ({
+  className,
+  ...props
+}: ModelSelectorNameProps) => (
+  <span className={cn("flex-1 truncate text-left", className)} {...props} />
+)

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -721,18 +721,16 @@ export const PromptInput = ({
       event.preventDefault()
 
       const form = event.currentTarget
+      const messageControl = form.elements.namedItem("message") as
+        | HTMLTextAreaElement
+        | HTMLInputElement
+        | null
       const text = usingProvider
         ? controller.textInput.value
         : (() => {
             const formData = new FormData(form)
             return (formData.get("message") as string) || ""
           })()
-
-      // Reset form immediately after capturing text to avoid race condition
-      // where user input during async blob conversion would be lost
-      if (!usingProvider) {
-        form.reset()
-      }
 
       try {
         // Convert blob URLs to data URLs asynchronously
@@ -759,6 +757,9 @@ export const PromptInput = ({
             clear()
             if (usingProvider) {
               controller.textInput.clear()
+            } else if (messageControl?.value === text) {
+              // Preserve edits made while submit was in-flight.
+              form.reset()
             }
           } catch {
             // Don't clear on error - user may want to retry
@@ -768,6 +769,9 @@ export const PromptInput = ({
           clear()
           if (usingProvider) {
             controller.textInput.clear()
+          } else if (messageControl?.value === text) {
+            // Preserve edits made while submit was in-flight.
+            form.reset()
           }
         }
       } catch {

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -1,36 +1,46 @@
 "use client"
 
-import type { ChatStatus, FileUIPart } from "ai"
+import type { ChatStatus, FileUIPart, SourceDocumentUIPart } from "ai"
 import {
-  ArrowUpIcon,
+  CornerDownLeftIcon,
   ImageIcon,
-  Loader2Icon,
-  PaperclipIcon,
   PlusIcon,
   SquareIcon,
   XIcon,
 } from "lucide-react"
 import { nanoid } from "nanoid"
+import type {
+  ChangeEvent,
+  ChangeEventHandler,
+  ClipboardEventHandler,
+  ComponentProps,
+  FormEvent,
+  FormEventHandler,
+  HTMLAttributes,
+  KeyboardEventHandler,
+  PropsWithChildren,
+  ReactNode,
+  RefObject,
+} from "react"
 import {
-  type ChangeEventHandler,
   Children,
-  type ClipboardEventHandler,
-  type ComponentProps,
   createContext,
-  Fragment,
-  type HTMLAttributes,
-  type KeyboardEventHandler,
-  type MouseEventHandler,
-  type RefObject,
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react"
-import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -38,130 +48,285 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupTextarea,
+} from "@/components/ui/input-group"
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { Textarea } from "@/components/ui/textarea"
+import { Spinner } from "@/components/ui/spinner"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 
-type AttachmentsContext = {
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
+  try {
+    const response = await fetch(url)
+    const blob = await response.blob()
+    // FileReader uses callback-based API, wrapping in Promise is necessary
+    // oxlint-disable-next-line eslint-plugin-promise(avoid-new)
+    return new Promise((resolve) => {
+      const reader = new FileReader()
+      // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
+      reader.onloadend = () => resolve(reader.result as string)
+      // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
+      reader.onerror = () => resolve(null)
+      reader.readAsDataURL(blob)
+    })
+  } catch {
+    return null
+  }
+}
+
+// ============================================================================
+// Provider Context & Types
+// ============================================================================
+
+export interface AttachmentsContext {
   files: (FileUIPart & { id: string })[]
   add: (files: File[] | FileList) => void
   remove: (id: string) => void
   clear: () => void
-  submit: () => void
   openFileDialog: () => void
   fileInputRef: RefObject<HTMLInputElement | null>
 }
 
-const AttachmentsContext = createContext<AttachmentsContext | null>(null)
+export interface TextInputContext {
+  value: string
+  setInput: (v: string) => void
+  clear: () => void
+}
 
-export const usePromptInputAttachments = () => {
-  const context = useContext(AttachmentsContext)
+export interface PromptInputControllerProps {
+  textInput: TextInputContext
+  attachments: AttachmentsContext
+  /** INTERNAL: Allows PromptInput to register its file textInput + "open" callback */
+  __registerFileInput: (
+    ref: RefObject<HTMLInputElement | null>,
+    open: () => void
+  ) => void
+}
 
-  if (!context) {
+const PromptInputController = createContext<PromptInputControllerProps | null>(
+  null
+)
+const ProviderAttachmentsContext = createContext<AttachmentsContext | null>(
+  null
+)
+
+export const usePromptInputController = () => {
+  const ctx = useContext(PromptInputController)
+  if (!ctx) {
     throw new Error(
-      "usePromptInputAttachments must be used within a PromptInput"
+      "Wrap your component inside <PromptInputProvider> to use usePromptInputController()."
     )
   }
+  return ctx
+}
 
+// Optional variants (do NOT throw). Useful for dual-mode components.
+const useOptionalPromptInputController = () => useContext(PromptInputController)
+
+export const useProviderAttachments = () => {
+  const ctx = useContext(ProviderAttachmentsContext)
+  if (!ctx) {
+    throw new Error(
+      "Wrap your component inside <PromptInputProvider> to use useProviderAttachments()."
+    )
+  }
+  return ctx
+}
+
+const useOptionalProviderAttachments = () =>
+  useContext(ProviderAttachmentsContext)
+
+export type PromptInputProviderProps = PropsWithChildren<{
+  initialInput?: string
+}>
+
+/**
+ * Optional global provider that lifts PromptInput state outside of PromptInput.
+ * If you don't use it, PromptInput stays fully self-managed.
+ */
+export const PromptInputProvider = ({
+  initialInput: initialTextInput = "",
+  children,
+}: PromptInputProviderProps) => {
+  // ----- textInput state
+  const [textInput, setTextInput] = useState(initialTextInput)
+  const clearInput = useCallback(() => setTextInput(""), [])
+
+  // ----- attachments state (global when wrapped)
+  const [attachmentFiles, setAttachmentFiles] = useState<
+    (FileUIPart & { id: string })[]
+  >([])
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  // oxlint-disable-next-line eslint(no-empty-function)
+  const openRef = useRef<() => void>(() => {})
+
+  const add = useCallback((files: File[] | FileList) => {
+    const incoming = [...files]
+    if (incoming.length === 0) {
+      return
+    }
+
+    setAttachmentFiles((prev) => [
+      ...prev,
+      ...incoming.map((file) => ({
+        filename: file.name,
+        id: nanoid(),
+        mediaType: file.type,
+        type: "file" as const,
+        url: URL.createObjectURL(file),
+      })),
+    ])
+  }, [])
+
+  const remove = useCallback((id: string) => {
+    setAttachmentFiles((prev) => {
+      const found = prev.find((f) => f.id === id)
+      if (found?.url) {
+        URL.revokeObjectURL(found.url)
+      }
+      return prev.filter((f) => f.id !== id)
+    })
+  }, [])
+
+  const clear = useCallback(() => {
+    setAttachmentFiles((prev) => {
+      for (const f of prev) {
+        if (f.url) {
+          URL.revokeObjectURL(f.url)
+        }
+      }
+      return []
+    })
+  }, [])
+
+  // Keep a ref to attachments for cleanup on unmount (avoids stale closure)
+  const attachmentsRef = useRef(attachmentFiles)
+
+  useEffect(() => {
+    attachmentsRef.current = attachmentFiles
+  }, [attachmentFiles])
+
+  // Cleanup blob URLs on unmount to prevent memory leaks
+  useEffect(
+    () => () => {
+      for (const f of attachmentsRef.current) {
+        if (f.url) {
+          URL.revokeObjectURL(f.url)
+        }
+      }
+    },
+    []
+  )
+
+  const openFileDialog = useCallback(() => {
+    openRef.current?.()
+  }, [])
+
+  const attachments = useMemo<AttachmentsContext>(
+    () => ({
+      add,
+      clear,
+      fileInputRef,
+      files: attachmentFiles,
+      openFileDialog,
+      remove,
+    }),
+    [attachmentFiles, add, remove, clear, openFileDialog]
+  )
+
+  const __registerFileInput = useCallback(
+    (ref: RefObject<HTMLInputElement | null>, open: () => void) => {
+      fileInputRef.current = ref.current
+      openRef.current = open
+    },
+    []
+  )
+
+  const controller = useMemo<PromptInputControllerProps>(
+    () => ({
+      __registerFileInput,
+      attachments,
+      textInput: {
+        clear: clearInput,
+        setInput: setTextInput,
+        value: textInput,
+      },
+    }),
+    [textInput, clearInput, attachments, __registerFileInput]
+  )
+
+  return (
+    <PromptInputController.Provider value={controller}>
+      <ProviderAttachmentsContext.Provider value={attachments}>
+        {children}
+      </ProviderAttachmentsContext.Provider>
+    </PromptInputController.Provider>
+  )
+}
+
+// ============================================================================
+// Component Context & Hooks
+// ============================================================================
+
+const LocalAttachmentsContext = createContext<AttachmentsContext | null>(null)
+
+export const usePromptInputAttachments = () => {
+  // Prefer local context (inside PromptInput) as it has validation, fall back to provider
+  const provider = useOptionalProviderAttachments()
+  const local = useContext(LocalAttachmentsContext)
+  const context = local ?? provider
+  if (!context) {
+    throw new Error(
+      "usePromptInputAttachments must be used within a PromptInput or PromptInputProvider"
+    )
+  }
   return context
 }
 
-export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
-  data: FileUIPart & { id: string }
-  className?: string
+// ============================================================================
+// Referenced Sources (Local to PromptInput)
+// ============================================================================
+
+export interface ReferencedSourcesContext {
+  sources: (SourceDocumentUIPart & { id: string })[]
+  add: (sources: SourceDocumentUIPart[] | SourceDocumentUIPart) => void
+  remove: (id: string) => void
+  clear: () => void
 }
 
-export function PromptInputAttachment({
-  data,
-  className,
-  ...props
-}: PromptInputAttachmentProps) {
-  const attachments = usePromptInputAttachments()
+export const LocalReferencedSourcesContext =
+  createContext<ReferencedSourcesContext | null>(null)
 
-  return (
-    <div
-      className={cn("group relative h-14 w-14 rounded-md border", className)}
-      key={data.id}
-      {...props}
-    >
-      {data.mediaType?.startsWith("image/") && data.url ? (
-        <img
-          alt={data.filename || "attachment"}
-          className="size-full rounded-md object-cover"
-          height={56}
-          src={data.url}
-          width={56}
-        />
-      ) : (
-        <div className="flex size-full items-center justify-center text-muted-foreground">
-          <PaperclipIcon className="size-4" />
-        </div>
-      )}
-      <Button
-        aria-label="Remove attachment"
-        className="-right-1.5 -top-1.5 absolute h-6 w-6 rounded-full opacity-0 group-hover:opacity-100"
-        onClick={() => attachments.remove(data.id)}
-        size="icon"
-        type="button"
-        variant="outline"
-      >
-        <XIcon className="h-3 w-3" />
-      </Button>
-    </div>
-  )
-}
-
-export type PromptInputAttachmentsProps = Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "children"
-> & {
-  children: (attachment: FileUIPart & { id: string }) => React.ReactNode
-}
-
-export function PromptInputAttachments({
-  className,
-  children,
-  ...props
-}: PromptInputAttachmentsProps) {
-  const attachments = usePromptInputAttachments()
-  const [height, setHeight] = useState(0)
-  const contentRef = useRef<HTMLDivElement>(null)
-
-  useLayoutEffect(() => {
-    const el = contentRef.current
-    if (!el) {
-      return
-    }
-    const ro = new ResizeObserver(() => {
-      setHeight(el.getBoundingClientRect().height)
-    })
-    ro.observe(el)
-    setHeight(el.getBoundingClientRect().height)
-    return () => ro.disconnect()
-  }, [])
-
-  return (
-    <div
-      aria-live="polite"
-      className={cn(
-        "overflow-hidden transition-[height] duration-200 ease-out",
-        className
-      )}
-      style={{ height: attachments.files.length ? height : 0 }}
-      {...props}
-    >
-      <div className="flex flex-wrap gap-2 p-3 pt-3" ref={contentRef}>
-        {attachments.files.map((file) => (
-          <Fragment key={file.id}>{children(file)}</Fragment>
-        ))}
-      </div>
-    </div>
-  )
+export const usePromptInputReferencedSources = () => {
+  const ctx = useContext(LocalReferencedSourcesContext)
+  if (!ctx) {
+    throw new Error(
+      "usePromptInputReferencedSources must be used within a LocalReferencedSourcesContext.Provider"
+    )
+  }
+  return ctx
 }
 
 export type PromptInputActionAddAttachmentsProps = ComponentProps<
@@ -176,29 +341,32 @@ export const PromptInputActionAddAttachments = ({
 }: PromptInputActionAddAttachmentsProps) => {
   const attachments = usePromptInputAttachments()
 
+  const handleSelect = useCallback(
+    (e: Event) => {
+      e.preventDefault()
+      attachments.openFileDialog()
+    },
+    [attachments]
+  )
+
   return (
-    <DropdownMenuItem
-      {...props}
-      onSelect={(e) => {
-        e.preventDefault()
-        attachments.openFileDialog()
-      }}
-    >
+    <DropdownMenuItem {...props} onSelect={handleSelect}>
       <ImageIcon className="mr-2 size-4" /> {label}
     </DropdownMenuItem>
   )
 }
 
-export type PromptInputMessage = {
-  text?: string
-  files?: FileUIPart[]
+export interface PromptInputMessage {
+  text: string
+  files: FileUIPart[]
 }
 
 export type PromptInputProps = Omit<
-  HTMLAttributes<HTMLDivElement>,
-  "onSubmit"
+  HTMLAttributes<HTMLFormElement>,
+  "onSubmit" | "onError"
 > & {
-  accept?: string // e.g., "image/*" or leave undefined for any
+  // e.g., "image/*" or leave undefined for any
+  accept?: string
   multiple?: boolean
   // When true, accepts drops anywhere on document. Default false (opt-in).
   globalDrop?: boolean
@@ -206,12 +374,16 @@ export type PromptInputProps = Omit<
   syncHiddenInput?: boolean
   // Minimal constraints
   maxFiles?: number
-  maxFileSize?: number // bytes
+  // bytes
+  maxFileSize?: number
   onError?: (err: {
     code: "max_files" | "max_file_size" | "accept"
     message: string
   }) => void
-  onSubmit: (message: PromptInputMessage) => void
+  onSubmit: (
+    message: PromptInputMessage,
+    event: FormEvent<HTMLFormElement>
+  ) => void | Promise<void>
 }
 
 export const PromptInput = ({
@@ -227,11 +399,31 @@ export const PromptInput = ({
   children,
   ...props
 }: PromptInputProps) => {
-  const [items, setItems] = useState<(FileUIPart & { id: string })[]>([])
-  const inputRef = useRef<HTMLInputElement | null>(null)
-  const rootRef = useRef<HTMLDivElement | null>(null)
+  // Try to use a provider controller if present
+  const controller = useOptionalPromptInputController()
+  const usingProvider = !!controller
 
-  const openFileDialog = useCallback(() => {
+  // Refs
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const formRef = useRef<HTMLFormElement | null>(null)
+
+  // ----- Local attachments (only used when no provider)
+  const [items, setItems] = useState<(FileUIPart & { id: string })[]>([])
+  const files = usingProvider ? controller.attachments.files : items
+
+  // ----- Local referenced sources (always local to PromptInput)
+  const [referencedSources, setReferencedSources] = useState<
+    (SourceDocumentUIPart & { id: string })[]
+  >([])
+
+  // Keep a ref to files for cleanup on unmount (avoids stale closure)
+  const filesRef = useRef(files)
+
+  useEffect(() => {
+    filesRef.current = files
+  }, [files])
+
+  const openFileDialogLocal = useCallback(() => {
     inputRef.current?.click()
   }, [])
 
@@ -240,20 +432,29 @@ export const PromptInput = ({
       if (!accept || accept.trim() === "") {
         return true
       }
-      // Simple check: if accept includes "image/*", filter to images; otherwise allow.
-      if (accept.includes("image/*")) {
-        return f.type.startsWith("image/")
-      }
-      return true
+
+      const patterns = accept
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+
+      return patterns.some((pattern) => {
+        if (pattern.endsWith("/*")) {
+          // e.g: image/* -> image/
+          const prefix = pattern.slice(0, -1)
+          return f.type.startsWith(prefix)
+        }
+        return f.type === pattern
+      })
     },
     [accept]
   )
 
-  const add = useCallback(
-    (files: File[] | FileList) => {
-      const incoming = Array.from(files)
+  const addLocal = useCallback(
+    (fileList: File[] | FileList) => {
+      const incoming = [...fileList]
       const accepted = incoming.filter((f) => matchesAccept(f))
-      if (accepted.length === 0) {
+      if (incoming.length && accepted.length === 0) {
         onError?.({
           code: "accept",
           message: "No files match the accepted types.",
@@ -263,13 +464,14 @@ export const PromptInput = ({
       const withinSize = (f: File) =>
         maxFileSize ? f.size <= maxFileSize : true
       const sized = accepted.filter(withinSize)
-      if (sized.length === 0 && accepted.length > 0) {
+      if (accepted.length > 0 && sized.length === 0) {
         onError?.({
           code: "max_file_size",
           message: "All files exceed the maximum size.",
         })
         return
       }
+
       setItems((prev) => {
         const capacity =
           typeof maxFiles === "number"
@@ -286,57 +488,132 @@ export const PromptInput = ({
         const next: (FileUIPart & { id: string })[] = []
         for (const file of capped) {
           next.push({
+            filename: file.name,
             id: nanoid(),
+            mediaType: file.type,
             type: "file",
             url: URL.createObjectURL(file),
-            mediaType: file.type,
-            filename: file.name,
           })
         }
-        return prev.concat(next)
+        return [...prev, ...next]
       })
     },
     [matchesAccept, maxFiles, maxFileSize, onError]
   )
 
-  const remove = useCallback((id: string) => {
-    setItems((prev) => {
-      const found = prev.find((file) => file.id === id)
-      if (found?.url) {
-        URL.revokeObjectURL(found.url)
+  const removeLocal = useCallback(
+    (id: string) =>
+      setItems((prev) => {
+        const found = prev.find((file) => file.id === id)
+        if (found?.url) {
+          URL.revokeObjectURL(found.url)
+        }
+        return prev.filter((file) => file.id !== id)
+      }),
+    []
+  )
+
+  // Wrapper that validates files before calling provider's add
+  const addWithProviderValidation = useCallback(
+    (fileList: File[] | FileList) => {
+      const incoming = [...fileList]
+      const accepted = incoming.filter((f) => matchesAccept(f))
+      if (incoming.length && accepted.length === 0) {
+        onError?.({
+          code: "accept",
+          message: "No files match the accepted types.",
+        })
+        return
       }
-      return prev.filter((file) => file.id !== id)
-    })
-  }, [])
+      const withinSize = (f: File) =>
+        maxFileSize ? f.size <= maxFileSize : true
+      const sized = accepted.filter(withinSize)
+      if (accepted.length > 0 && sized.length === 0) {
+        onError?.({
+          code: "max_file_size",
+          message: "All files exceed the maximum size.",
+        })
+        return
+      }
+
+      const currentCount = files.length
+      const capacity =
+        typeof maxFiles === "number"
+          ? Math.max(0, maxFiles - currentCount)
+          : undefined
+      const capped =
+        typeof capacity === "number" ? sized.slice(0, capacity) : sized
+      if (typeof capacity === "number" && sized.length > capacity) {
+        onError?.({
+          code: "max_files",
+          message: "Too many files. Some were not added.",
+        })
+      }
+
+      if (capped.length > 0) {
+        controller?.attachments.add(capped)
+      }
+    },
+    [matchesAccept, maxFileSize, maxFiles, onError, files.length, controller]
+  )
+
+  const clearAttachments = useCallback(
+    () =>
+      usingProvider
+        ? controller?.attachments.clear()
+        : setItems((prev) => {
+            for (const file of prev) {
+              if (file.url) {
+                URL.revokeObjectURL(file.url)
+              }
+            }
+            return []
+          }),
+    [usingProvider, controller]
+  )
+
+  const clearReferencedSources = useCallback(() => setReferencedSources([]), [])
+
+  const add = usingProvider ? addWithProviderValidation : addLocal
+  const remove = usingProvider ? controller.attachments.remove : removeLocal
+  const openFileDialog = usingProvider
+    ? controller.attachments.openFileDialog
+    : openFileDialogLocal
 
   const clear = useCallback(() => {
-    setItems((prev) => {
-      for (const file of prev) {
-        if (file.url) {
-          URL.revokeObjectURL(file.url)
-        }
-      }
-      return []
-    })
-  }, [])
+    clearAttachments()
+    clearReferencedSources()
+  }, [clearAttachments, clearReferencedSources])
+
+  const registerFileInput = controller?.__registerFileInput
+
+  // Let provider know about our hidden file input so external menus can call openFileDialog()
+  useEffect(() => {
+    if (!usingProvider || !registerFileInput) {
+      return
+    }
+    registerFileInput(inputRef, () => inputRef.current?.click())
+  }, [usingProvider, registerFileInput])
 
   // Note: File input cannot be programmatically set for security reasons
   // The syncHiddenInput prop is no longer functional
   useEffect(() => {
-    if (syncHiddenInput && inputRef.current) {
-      // Clear the input when items are cleared
-      if (items.length === 0) {
-        inputRef.current.value = ""
-      }
+    if (syncHiddenInput && inputRef.current && files.length === 0) {
+      inputRef.current.value = ""
     }
-  }, [items, syncHiddenInput])
+  }, [files, syncHiddenInput])
 
   // Attach drop handlers on nearest form and document (opt-in)
   useEffect(() => {
-    const root = rootRef.current
-    if (!root) {
+    const form = formRef.current
+    if (!form) {
       return
     }
+    if (globalDrop) {
+      // when global drop is on, let the document-level handler own drops
+      return
+    }
+
     const onDragOver = (e: DragEvent) => {
       if (e.dataTransfer?.types?.includes("Files")) {
         e.preventDefault()
@@ -350,18 +627,19 @@ export const PromptInput = ({
         add(e.dataTransfer.files)
       }
     }
-    root.addEventListener("dragover", onDragOver)
-    root.addEventListener("drop", onDrop)
+    form.addEventListener("dragover", onDragOver)
+    form.addEventListener("drop", onDrop)
     return () => {
-      root.removeEventListener("dragover", onDragOver)
-      root.removeEventListener("drop", onDrop)
+      form.removeEventListener("dragover", onDragOver)
+      form.removeEventListener("drop", onDrop)
     }
-  }, [add])
+  }, [add, globalDrop])
 
   useEffect(() => {
     if (!globalDrop) {
       return
     }
+
     const onDragOver = (e: DragEvent) => {
       if (e.dataTransfer?.types?.includes("Files")) {
         e.preventDefault()
@@ -383,80 +661,157 @@ export const PromptInput = ({
     }
   }, [add, globalDrop])
 
-  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    if (event.currentTarget.files) {
-      add(event.currentTarget.files)
-    }
-  }
-
-  const convertBlobUrlToDataUrl = async (url: string): Promise<string> => {
-    const response = await fetch(url)
-    const blob = await response.blob()
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onloadend = () => resolve(reader.result as string)
-      reader.onerror = reject
-      reader.readAsDataURL(blob)
-    })
-  }
-
-  const submit = useCallback(() => {
-    const messageField = rootRef.current?.querySelector<
-      HTMLTextAreaElement | HTMLInputElement
-    >("[name='message']")
-    const text = messageField?.value ?? ""
-    // Convert blob URLs to data URLs asynchronously
-    Promise.all(
-      items.map(async ({ id, ...item }) => {
-        if (item.url && item.url.startsWith("blob:")) {
-          return {
-            ...item,
-            url: await convertBlobUrlToDataUrl(item.url),
+  useEffect(
+    () => () => {
+      if (!usingProvider) {
+        for (const f of filesRef.current) {
+          if (f.url) {
+            URL.revokeObjectURL(f.url)
           }
         }
-        return item
-      })
-    ).then((files: FileUIPart[]) => {
-      onSubmit({ text, files })
-      clear()
-    })
-  }, [items, onSubmit, clear])
-
-  const ctx = useMemo<AttachmentsContext>(
-    () => ({
-      files: items.map((item) => ({ ...item, id: item.id })),
-      add,
-      remove,
-      clear,
-      submit,
-      openFileDialog,
-      fileInputRef: inputRef,
-    }),
-    [items, add, remove, clear, submit, openFileDialog]
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup only on unmount; filesRef always current
+    [usingProvider]
   )
 
-  return (
-    <AttachmentsContext.Provider value={ctx}>
+  const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      if (event.currentTarget.files) {
+        add(event.currentTarget.files)
+      }
+      // Reset input value to allow selecting files that were previously removed
+      event.currentTarget.value = ""
+    },
+    [add]
+  )
+
+  const attachmentsCtx = useMemo<AttachmentsContext>(
+    () => ({
+      add,
+      clear: clearAttachments,
+      fileInputRef: inputRef,
+      files: files.map((item) => ({ ...item, id: item.id })),
+      openFileDialog,
+      remove,
+    }),
+    [files, add, remove, clearAttachments, openFileDialog]
+  )
+
+  const refsCtx = useMemo<ReferencedSourcesContext>(
+    () => ({
+      add: (incoming: SourceDocumentUIPart[] | SourceDocumentUIPart) => {
+        const array = Array.isArray(incoming) ? incoming : [incoming]
+        setReferencedSources((prev) => [
+          ...prev,
+          ...array.map((s) => ({ ...s, id: nanoid() })),
+        ])
+      },
+      clear: clearReferencedSources,
+      remove: (id: string) => {
+        setReferencedSources((prev) => prev.filter((s) => s.id !== id))
+      },
+      sources: referencedSources,
+    }),
+    [referencedSources, clearReferencedSources]
+  )
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
+    async (event) => {
+      event.preventDefault()
+
+      const form = event.currentTarget
+      const text = usingProvider
+        ? controller.textInput.value
+        : (() => {
+            const formData = new FormData(form)
+            return (formData.get("message") as string) || ""
+          })()
+
+      // Reset form immediately after capturing text to avoid race condition
+      // where user input during async blob conversion would be lost
+      if (!usingProvider) {
+        form.reset()
+      }
+
+      try {
+        // Convert blob URLs to data URLs asynchronously
+        const convertedFiles: FileUIPart[] = await Promise.all(
+          files.map(async ({ id: _id, ...item }) => {
+            if (item.url?.startsWith("blob:")) {
+              const dataUrl = await convertBlobUrlToDataUrl(item.url)
+              // If conversion failed, keep the original blob URL
+              return {
+                ...item,
+                url: dataUrl ?? item.url,
+              }
+            }
+            return item
+          })
+        )
+
+        const result = onSubmit({ files: convertedFiles, text }, event)
+
+        // Handle both sync and async onSubmit
+        if (result instanceof Promise) {
+          try {
+            await result
+            clear()
+            if (usingProvider) {
+              controller.textInput.clear()
+            }
+          } catch {
+            // Don't clear on error - user may want to retry
+          }
+        } else {
+          // Sync function completed without throwing, clear inputs
+          clear()
+          if (usingProvider) {
+            controller.textInput.clear()
+          }
+        }
+      } catch {
+        // Don't clear on error - user may want to retry
+      }
+    },
+    [usingProvider, controller, files, onSubmit, clear]
+  )
+
+  // Render with or without local provider
+  const inner = (
+    <>
       <input
         accept={accept}
+        aria-label="Upload files"
         className="hidden"
         multiple={multiple}
         onChange={handleChange}
         ref={inputRef}
+        title="Upload files"
         type="file"
       />
-      <div
-        data-prompt-input="true"
-        ref={rootRef}
-        className={cn(
-          "w-full overflow-hidden rounded-xl border bg-background shadow-sm",
-          className
-        )}
+      <form
+        className={cn("w-full", className)}
+        onSubmit={handleSubmit}
+        ref={formRef}
         {...props}
       >
-        {children}
-      </div>
-    </AttachmentsContext.Provider>
+        <InputGroup className="overflow-hidden">{children}</InputGroup>
+      </form>
+    </>
+  )
+
+  const withReferencedSources = (
+    <LocalReferencedSourcesContext.Provider value={refsCtx}>
+      {inner}
+    </LocalReferencedSourcesContext.Provider>
+  )
+
+  // Always provide LocalAttachmentsContext so children get validated add function
+  return (
+    <LocalAttachmentsContext.Provider value={attachmentsCtx}>
+      {withReferencedSources}
+    </LocalAttachmentsContext.Provider>
   )
 }
 
@@ -466,111 +821,154 @@ export const PromptInputBody = ({
   className,
   ...props
 }: PromptInputBodyProps) => (
-  <div className={cn(className, "flex flex-col")} {...props} />
+  <div className={cn("contents", className)} {...props} />
 )
 
-export type PromptInputTextareaProps = ComponentProps<typeof Textarea>
+export type PromptInputTextareaProps = ComponentProps<typeof InputGroupTextarea>
 
 export const PromptInputTextarea = ({
   onChange,
+  onKeyDown,
   className,
   placeholder = "What would you like to know?",
   ...props
 }: PromptInputTextareaProps) => {
+  const controller = useOptionalPromptInputController()
   const attachments = usePromptInputAttachments()
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [isComposing, setIsComposing] = useState(false)
 
-  const syncHeight = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) {
-      return
-    }
-    const MIN_HEIGHT = 64 // matches min-h-16
-    const MAX_HEIGHT = 192 // matches max-h-48
-    textarea.style.height = "auto"
-    const nextHeight = textarea.scrollHeight
-    const clampedHeight = Math.min(Math.max(nextHeight, MIN_HEIGHT), MAX_HEIGHT)
-    textarea.style.height = `${clampedHeight}px`
-    textarea.style.overflowY = nextHeight > MAX_HEIGHT ? "auto" : "hidden"
-  }, [])
+  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
+    (e) => {
+      // Call the external onKeyDown handler first
+      onKeyDown?.(e)
 
-  useLayoutEffect(() => {
-    syncHeight()
-  }, [syncHeight, props.value, props.defaultValue])
-
-  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
-    if (e.key === "Enter") {
-      // Don't submit if IME composition is in progress
-      if (e.nativeEvent.isComposing) {
+      // If the external handler prevented default, don't run internal logic
+      if (e.defaultPrevented) {
         return
       }
 
-      if (e.shiftKey) {
-        // Allow newline
-        return
+      if (e.key === "Enter") {
+        if (isComposing || e.nativeEvent.isComposing) {
+          return
+        }
+        if (e.shiftKey) {
+          return
+        }
+        e.preventDefault()
+
+        // Check if the submit button is disabled before submitting
+        const { form } = e.currentTarget
+        const submitButton = form?.querySelector(
+          'button[type="submit"]'
+        ) as HTMLButtonElement | null
+        if (submitButton?.disabled) {
+          return
+        }
+
+        form?.requestSubmit()
       }
 
-      // Submit on Enter (without Shift)
-      e.preventDefault()
-      attachments.submit()
-    }
-  }
-
-  const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {
-    const items = event.clipboardData?.items
-
-    if (!items) {
-      return
-    }
-
-    const files: File[] = []
-
-    for (const item of items) {
-      if (item.kind === "file") {
-        const file = item.getAsFile()
-        if (file) {
-          files.push(file)
+      // Remove last attachment when Backspace is pressed and textarea is empty
+      if (
+        e.key === "Backspace" &&
+        e.currentTarget.value === "" &&
+        attachments.files.length > 0
+      ) {
+        e.preventDefault()
+        const lastAttachment = attachments.files.at(-1)
+        if (lastAttachment) {
+          attachments.remove(lastAttachment.id)
         }
       }
-    }
+    },
+    [onKeyDown, isComposing, attachments]
+  )
 
-    if (files.length > 0) {
-      event.preventDefault()
-      attachments.add(files)
-    }
-  }
+  const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      const items = event.clipboardData?.items
+
+      if (!items) {
+        return
+      }
+
+      const files: File[] = []
+
+      for (const item of items) {
+        if (item.kind === "file") {
+          const file = item.getAsFile()
+          if (file) {
+            files.push(file)
+          }
+        }
+      }
+
+      if (files.length > 0) {
+        event.preventDefault()
+        attachments.add(files)
+      }
+    },
+    [attachments]
+  )
+
+  const handleCompositionEnd = useCallback(() => setIsComposing(false), [])
+  const handleCompositionStart = useCallback(() => setIsComposing(true), [])
+
+  const controlledProps = controller
+    ? {
+        onChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
+          controller.textInput.setInput(e.currentTarget.value)
+          onChange?.(e)
+        },
+        value: controller.textInput.value,
+      }
+    : {
+        onChange,
+      }
 
   return (
-    <Textarea
-      className={cn(
-        "w-full resize-none rounded-none border-none p-3 shadow-none outline-none ring-0",
-        "field-sizing-content bg-transparent dark:bg-transparent",
-        "max-h-48 min-h-16",
-        "focus-visible:ring-0",
-        className
-      )}
+    <InputGroupTextarea
+      className={cn("field-sizing-content max-h-48 min-h-16", className)}
       name="message"
-      onChange={(e) => {
-        syncHeight()
-        onChange?.(e)
-      }}
+      onCompositionEnd={handleCompositionEnd}
+      onCompositionStart={handleCompositionStart}
       onKeyDown={handleKeyDown}
       onPaste={handlePaste}
       placeholder={placeholder}
-      ref={textareaRef}
       {...props}
+      {...controlledProps}
     />
   )
 }
 
-export type PromptInputToolbarProps = HTMLAttributes<HTMLDivElement>
+export type PromptInputHeaderProps = Omit<
+  ComponentProps<typeof InputGroupAddon>,
+  "align"
+>
 
-export const PromptInputToolbar = ({
+export const PromptInputHeader = ({
   className,
   ...props
-}: PromptInputToolbarProps) => (
-  <div
-    className={cn("flex items-center justify-between p-1", className)}
+}: PromptInputHeaderProps) => (
+  <InputGroupAddon
+    align="block-end"
+    className={cn("order-first flex-wrap gap-1", className)}
+    {...props}
+  />
+)
+
+export type PromptInputFooterProps = Omit<
+  ComponentProps<typeof InputGroupAddon>,
+  "align"
+>
+
+export const PromptInputFooter = ({
+  className,
+  ...props
+}: PromptInputFooterProps) => (
+  <InputGroupAddon
+    align="block-end"
+    className={cn("justify-between gap-1", className)}
     {...props}
   />
 )
@@ -582,39 +980,61 @@ export const PromptInputTools = ({
   ...props
 }: PromptInputToolsProps) => (
   <div
-    className={cn(
-      "flex items-center gap-1",
-      "[&_button:first-child]:rounded-bl-xl",
-      className
-    )}
+    className={cn("flex min-w-0 items-center gap-1", className)}
     {...props}
   />
 )
 
-export type PromptInputButtonProps = ComponentProps<typeof Button>
+export type PromptInputButtonTooltip =
+  | string
+  | {
+      content: ReactNode
+      shortcut?: string
+      side?: ComponentProps<typeof TooltipContent>["side"]
+    }
+
+export type PromptInputButtonProps = ComponentProps<typeof InputGroupButton> & {
+  tooltip?: PromptInputButtonTooltip
+}
 
 export const PromptInputButton = ({
   variant = "ghost",
   className,
   size,
+  tooltip,
   ...props
 }: PromptInputButtonProps) => {
   const newSize =
-    (size ?? Children.count(props.children) > 1) ? "default" : "icon"
+    size ?? (Children.count(props.children) > 1 ? "sm" : "icon-sm")
 
-  return (
-    <Button
-      className={cn(
-        "shrink-0 gap-1.5 rounded-lg",
-        variant === "ghost" && "text-muted-foreground",
-        newSize === "default" && "px-3",
-        className
-      )}
+  const button = (
+    <InputGroupButton
+      className={cn(className)}
       size={newSize}
       type="button"
       variant={variant}
       {...props}
     />
+  )
+
+  if (!tooltip) {
+    return button
+  }
+
+  const tooltipContent = typeof tooltip === "string" ? tooltip : tooltip.content
+  const shortcut = typeof tooltip === "string" ? undefined : tooltip.shortcut
+  const side = typeof tooltip === "string" ? "top" : (tooltip.side ?? "top")
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side={side}>
+        {tooltipContent}
+        {shortcut && (
+          <span className="ml-2 text-muted-foreground">{shortcut}</span>
+        )}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -623,9 +1043,8 @@ export const PromptInputActionMenu = (props: PromptInputActionMenuProps) => (
   <DropdownMenu {...props} />
 )
 
-export type PromptInputActionMenuTriggerProps = ComponentProps<
-  typeof Button
-> & {}
+export type PromptInputActionMenuTriggerProps = PromptInputButtonProps
+
 export const PromptInputActionMenuTrigger = ({
   className,
   children,
@@ -661,105 +1080,252 @@ export const PromptInputActionMenuItem = ({
 // Note: Actions that perform side-effects (like opening a file dialog)
 // are provided in opt-in modules (e.g., prompt-input-attachments).
 
-export type PromptInputSubmitProps = ComponentProps<typeof Button> & {
+export type PromptInputSubmitProps = ComponentProps<typeof InputGroupButton> & {
   status?: ChatStatus
+  onStop?: () => void
 }
 
 export const PromptInputSubmit = ({
   className,
   variant = "ghost",
-  size = "icon",
+  size = "icon-sm",
   status,
+  onStop,
   onClick,
   children,
   ...props
 }: PromptInputSubmitProps) => {
-  const attachments = usePromptInputAttachments()
+  const isGenerating = status === "submitted" || status === "streaming"
 
-  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
-    onClick?.(event)
-    if (!event.defaultPrevented) {
-      attachments.submit()
-    }
-  }
-
-  let Icon = <ArrowUpIcon className="size-3.5" />
+  let Icon = <CornerDownLeftIcon className="size-4" />
 
   if (status === "submitted") {
-    Icon = <Loader2Icon className="size-3.5 animate-spin" />
+    Icon = <Spinner />
   } else if (status === "streaming") {
-    Icon = <SquareIcon className="size-3.5" />
+    Icon = <SquareIcon className="size-4" />
   } else if (status === "error") {
-    Icon = <XIcon className="size-3.5" />
+    Icon = <XIcon className="size-4" />
   }
 
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (isGenerating && onStop) {
+        e.preventDefault()
+        onStop()
+        return
+      }
+      onClick?.(e)
+    },
+    [isGenerating, onStop, onClick]
+  )
+
   return (
-    <Button
-      aria-label="Send message"
-      className={cn("size-6 rounded-md hover:text-muted-foreground", className)}
-      size={size}
-      type="button"
-      variant={variant}
+    <InputGroupButton
+      aria-label={isGenerating ? "Stop" : "Submit"}
+      className={cn(className)}
       onClick={handleClick}
+      size={size}
+      type={isGenerating && onStop ? "button" : "submit"}
+      variant={variant}
       {...props}
     >
       {children ?? Icon}
-      <span className="sr-only">Send message</span>
-    </Button>
+    </InputGroupButton>
   )
 }
 
-export type PromptInputModelSelectProps = ComponentProps<typeof Select>
+export type PromptInputSelectProps = ComponentProps<typeof Select>
 
-export const PromptInputModelSelect = (props: PromptInputModelSelectProps) => (
+export const PromptInputSelect = (props: PromptInputSelectProps) => (
   <Select {...props} />
 )
 
-export type PromptInputModelSelectTriggerProps = ComponentProps<
-  typeof SelectTrigger
->
+export type PromptInputSelectTriggerProps = ComponentProps<typeof SelectTrigger>
 
-export const PromptInputModelSelectTrigger = ({
+export const PromptInputSelectTrigger = ({
   className,
   ...props
-}: PromptInputModelSelectTriggerProps) => (
+}: PromptInputSelectTriggerProps) => (
   <SelectTrigger
     className={cn(
       "border-none bg-transparent font-medium text-muted-foreground shadow-none transition-colors",
-      'hover:bg-accent hover:text-foreground [&[aria-expanded="true"]]:bg-accent [&[aria-expanded="true"]]:text-foreground',
+      "hover:bg-accent hover:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground",
       className
     )}
     {...props}
   />
 )
 
-export type PromptInputModelSelectContentProps = ComponentProps<
-  typeof SelectContent
->
+export type PromptInputSelectContentProps = ComponentProps<typeof SelectContent>
 
-export const PromptInputModelSelectContent = ({
+export const PromptInputSelectContent = ({
   className,
   ...props
-}: PromptInputModelSelectContentProps) => (
+}: PromptInputSelectContentProps) => (
   <SelectContent className={cn(className)} {...props} />
 )
 
-export type PromptInputModelSelectItemProps = ComponentProps<typeof SelectItem>
+export type PromptInputSelectItemProps = ComponentProps<typeof SelectItem>
 
-export const PromptInputModelSelectItem = ({
+export const PromptInputSelectItem = ({
   className,
   ...props
-}: PromptInputModelSelectItemProps) => (
+}: PromptInputSelectItemProps) => (
   <SelectItem className={cn(className)} {...props} />
 )
 
-export type PromptInputModelSelectValueProps = ComponentProps<
-  typeof SelectValue
->
+export type PromptInputSelectValueProps = ComponentProps<typeof SelectValue>
 
-export const PromptInputModelSelectValue = ({
+export const PromptInputSelectValue = ({
   className,
   ...props
-}: PromptInputModelSelectValueProps) => (
+}: PromptInputSelectValueProps) => (
   <SelectValue className={cn(className)} {...props} />
+)
+
+export type PromptInputHoverCardProps = ComponentProps<typeof HoverCard>
+
+export const PromptInputHoverCard = ({
+  openDelay = 0,
+  closeDelay = 0,
+  ...props
+}: PromptInputHoverCardProps) => (
+  <HoverCard closeDelay={closeDelay} openDelay={openDelay} {...props} />
+)
+
+export type PromptInputHoverCardTriggerProps = ComponentProps<
+  typeof HoverCardTrigger
+>
+
+export const PromptInputHoverCardTrigger = (
+  props: PromptInputHoverCardTriggerProps
+) => <HoverCardTrigger {...props} />
+
+export type PromptInputHoverCardContentProps = ComponentProps<
+  typeof HoverCardContent
+>
+
+export const PromptInputHoverCardContent = ({
+  align = "start",
+  ...props
+}: PromptInputHoverCardContentProps) => (
+  <HoverCardContent align={align} {...props} />
+)
+
+export type PromptInputTabsListProps = HTMLAttributes<HTMLDivElement>
+
+export const PromptInputTabsList = ({
+  className,
+  ...props
+}: PromptInputTabsListProps) => <div className={cn(className)} {...props} />
+
+export type PromptInputTabProps = HTMLAttributes<HTMLDivElement>
+
+export const PromptInputTab = ({
+  className,
+  ...props
+}: PromptInputTabProps) => <div className={cn(className)} {...props} />
+
+export type PromptInputTabLabelProps = HTMLAttributes<HTMLHeadingElement>
+
+export const PromptInputTabLabel = ({
+  className,
+  ...props
+}: PromptInputTabLabelProps) => (
+  // Content provided via children in props
+  // oxlint-disable-next-line eslint-plugin-jsx-a11y(heading-has-content)
+  <h3
+    className={cn(
+      "mb-2 px-3 font-medium text-muted-foreground text-xs",
+      className
+    )}
+    {...props}
+  />
+)
+
+export type PromptInputTabBodyProps = HTMLAttributes<HTMLDivElement>
+
+export const PromptInputTabBody = ({
+  className,
+  ...props
+}: PromptInputTabBodyProps) => (
+  <div className={cn("space-y-1", className)} {...props} />
+)
+
+export type PromptInputTabItemProps = HTMLAttributes<HTMLDivElement>
+
+export const PromptInputTabItem = ({
+  className,
+  ...props
+}: PromptInputTabItemProps) => (
+  <div
+    className={cn(
+      "flex items-center gap-2 px-3 py-2 text-xs hover:bg-accent",
+      className
+    )}
+    {...props}
+  />
+)
+
+export type PromptInputCommandProps = ComponentProps<typeof Command>
+
+export const PromptInputCommand = ({
+  className,
+  ...props
+}: PromptInputCommandProps) => <Command className={cn(className)} {...props} />
+
+export type PromptInputCommandInputProps = ComponentProps<typeof CommandInput>
+
+export const PromptInputCommandInput = ({
+  className,
+  ...props
+}: PromptInputCommandInputProps) => (
+  <CommandInput className={cn(className)} {...props} />
+)
+
+export type PromptInputCommandListProps = ComponentProps<typeof CommandList>
+
+export const PromptInputCommandList = ({
+  className,
+  ...props
+}: PromptInputCommandListProps) => (
+  <CommandList className={cn(className)} {...props} />
+)
+
+export type PromptInputCommandEmptyProps = ComponentProps<typeof CommandEmpty>
+
+export const PromptInputCommandEmpty = ({
+  className,
+  ...props
+}: PromptInputCommandEmptyProps) => (
+  <CommandEmpty className={cn(className)} {...props} />
+)
+
+export type PromptInputCommandGroupProps = ComponentProps<typeof CommandGroup>
+
+export const PromptInputCommandGroup = ({
+  className,
+  ...props
+}: PromptInputCommandGroupProps) => (
+  <CommandGroup className={cn(className)} {...props} />
+)
+
+export type PromptInputCommandItemProps = ComponentProps<typeof CommandItem>
+
+export const PromptInputCommandItem = ({
+  className,
+  ...props
+}: PromptInputCommandItemProps) => (
+  <CommandItem className={cn(className)} {...props} />
+)
+
+export type PromptInputCommandSeparatorProps = ComponentProps<
+  typeof CommandSeparator
+>
+
+export const PromptInputCommandSeparator = ({
+  className,
+  ...props
+}: PromptInputCommandSeparatorProps) => (
+  <CommandSeparator className={cn(className)} {...props} />
 )

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -291,6 +291,8 @@ export const PromptInputProvider = ({
 // ============================================================================
 
 const LocalAttachmentsContext = createContext<AttachmentsContext | null>(null)
+const PromptInputSubmitContext = createContext<(() => void) | null>(null)
+const useOptionalPromptInputSubmit = () => useContext(PromptInputSubmitContext)
 
 export const usePromptInputAttachments = () => {
   // Prefer local context (inside PromptInput) as it has validation, fall back to provider
@@ -382,7 +384,7 @@ export type PromptInputProps = Omit<
   }) => void
   onSubmit: (
     message: PromptInputMessage,
-    event: FormEvent<HTMLFormElement>
+    event?: FormEvent<HTMLFormElement>
   ) => void | Promise<void>
 }
 
@@ -719,6 +721,9 @@ export const PromptInput = ({
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     async (event) => {
       event.preventDefault()
+      // IMPORTANT: Chat prompt lives inside settings forms on /agents pages.
+      // Stop propagation so parent forms never treat Enter/Cmd+Enter as a save submit.
+      event.stopPropagation()
 
       const form = event.currentTarget
       const messageControl = form.elements.namedItem("message") as
@@ -781,6 +786,12 @@ export const PromptInput = ({
     [usingProvider, controller, files, onSubmit, clear]
   )
 
+  const submitPrompt = useCallback(() => {
+    // Do NOT use `textarea.form` from key handlers: in nested form layouts it can
+    // resolve to an ancestor form and trigger a page/navigation submit.
+    formRef.current?.requestSubmit()
+  }, [])
+
   // Render with or without local provider
   const inner = (
     <>
@@ -795,6 +806,7 @@ export const PromptInput = ({
         type="file"
       />
       <form
+        data-prompt-input-root="true"
         className={cn("w-full", className)}
         onSubmit={handleSubmit}
         ref={formRef}
@@ -814,7 +826,9 @@ export const PromptInput = ({
   // Always provide LocalAttachmentsContext so children get validated add function
   return (
     <LocalAttachmentsContext.Provider value={attachmentsCtx}>
-      {withReferencedSources}
+      <PromptInputSubmitContext.Provider value={submitPrompt}>
+        {withReferencedSources}
+      </PromptInputSubmitContext.Provider>
     </LocalAttachmentsContext.Provider>
   )
 }
@@ -839,6 +853,7 @@ export const PromptInputTextarea = ({
 }: PromptInputTextareaProps) => {
   const controller = useOptionalPromptInputController()
   const attachments = usePromptInputAttachments()
+  const submitPrompt = useOptionalPromptInputSubmit()
   const [isComposing, setIsComposing] = useState(false)
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
@@ -860,16 +875,22 @@ export const PromptInputTextarea = ({
         }
         e.preventDefault()
 
-        // Check if the submit button is disabled before submitting
-        const { form } = e.currentTarget
-        const submitButton = form?.querySelector(
-          'button[type="submit"]'
+        // Guard disabled state before submitting.
+        const root = e.currentTarget.closest('[data-prompt-input-root="true"]')
+        const submitButton = root?.querySelector(
+          'button[data-prompt-input-submit="true"]'
         ) as HTMLButtonElement | null
         if (submitButton?.disabled) {
           return
         }
 
-        form?.requestSubmit()
+        if (submitPrompt) {
+          submitPrompt()
+          return
+        }
+
+        // Fallback for isolated textarea usage outside PromptInput.
+        e.currentTarget.form?.requestSubmit()
       }
 
       // Remove last attachment when Backspace is pressed and textarea is empty
@@ -885,7 +906,7 @@ export const PromptInputTextarea = ({
         }
       }
     },
-    [onKeyDown, isComposing, attachments]
+    [onKeyDown, isComposing, attachments, submitPrompt]
   )
 
   const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = useCallback(
@@ -1099,6 +1120,7 @@ export const PromptInputSubmit = ({
   children,
   ...props
 }: PromptInputSubmitProps) => {
+  const submitPrompt = useOptionalPromptInputSubmit()
   const isGenerating = status === "submitted" || status === "streaming"
 
   let Icon = <CornerDownLeftIcon className="size-4" />
@@ -1119,17 +1141,21 @@ export const PromptInputSubmit = ({
         return
       }
       onClick?.(e)
+      if (!e.defaultPrevented && !isGenerating) {
+        submitPrompt?.()
+      }
     },
-    [isGenerating, onStop, onClick]
+    [isGenerating, onStop, onClick, submitPrompt]
   )
 
   return (
     <InputGroupButton
+      data-prompt-input-submit="true"
       aria-label={isGenerating ? "Stop" : "Submit"}
       className={cn(className)}
       onClick={handleClick}
       size={size}
-      type={isGenerating && onStop ? "button" : "submit"}
+      type="button"
       variant={variant}
       {...props}
     >

--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -214,7 +214,11 @@ function serializeToolPayload(payload: unknown): SerializedPayload {
   if (typeof payload === "string") {
     const trimmed = payload.trim()
     const looksLikeJson = trimmed.startsWith("{") || trimmed.startsWith("[")
-    if (looksLikeJson && payload.length <= MAX_INLINE_PAYLOAD_CHARS) {
+    if (looksLikeJson) {
+      if (payload.length > MAX_INLINE_PAYLOAD_CHARS) {
+        return { text: payload, extension: "json" }
+      }
+
       try {
         return {
           text: JSON.stringify(JSON.parse(payload), null, 2),

--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -2,162 +2,297 @@
 
 import type { DynamicToolUIPart, ToolUIPart } from "ai"
 import {
+  CheckCircleIcon,
   ChevronDownIcon,
-  CircleCheckIcon,
   CircleIcon,
   ClockIcon,
+  DownloadIcon,
   WrenchIcon,
   XCircleIcon,
 } from "lucide-react"
-import type { ComponentProps, ReactNode } from "react"
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import {
+  type ComponentProps,
+  isValidElement,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 import { CodeBlock, CodeBlockCopyButton } from "./code-block"
+
+const MAX_INLINE_PAYLOAD_CHARS = 12_000
 
 export type ToolProps = ComponentProps<typeof Collapsible>
 
 export const Tool = ({ className, ...props }: ToolProps) => (
   <Collapsible
-    className={cn("not-prose mb-4 w-full rounded-lg border-[0.5px]", className)}
+    className={cn("group not-prose mb-3 w-full rounded-md border", className)}
     {...props}
   />
 )
 
-type AnyToolUIPart = ToolUIPart | DynamicToolUIPart
+export type ToolPart = ToolUIPart | DynamicToolUIPart
 type LegacyToolState =
   | "approval-requested"
   | "approval-responded"
   | "output-denied"
-type ToolState = AnyToolUIPart["state"] | LegacyToolState
+type ToolState = ToolPart["state"] | LegacyToolState
 
 export type ToolHeaderProps = {
   title?: string
-  type: AnyToolUIPart["type"]
-  state: ToolState
   className?: string
   icon?: ReactNode
+  type: ToolPart["type"]
+  state: ToolState
+  toolName?: string
 }
 
-const getStatusBadge = (status: ToolState) => {
-  const labels: Record<ToolState, string> = {
-    "input-streaming": "Pending",
-    "input-available": "Running",
-    "approval-requested": "Needs approval",
-    "approval-responded": "Approval submitted",
-    "output-available": "Completed",
-    "output-error": "Error",
-    "output-denied": "Denied",
-  }
-
-  const icons: Record<ToolState, ReactNode> = {
-    "input-streaming": (
-      <CircleIcon className="size-3.5 text-muted-foreground animate-pulse" />
-    ),
-    "input-available": (
-      <ClockIcon className="size-3.5 text-amber-500 animate-pulse" />
-    ),
-    "approval-requested": (
-      <ClockIcon className="size-3.5 text-blue-500 animate-pulse" />
-    ),
-    "approval-responded": (
-      <CircleIcon className="size-3.5 text-blue-500 fill-blue-500" />
-    ),
-    "output-available": (
-      <CircleCheckIcon className="size-4 fill-emerald-500 stroke-white" />
-    ),
-    "output-error": (
-      <XCircleIcon className="size-4 fill-rose-500 stroke-white" />
-    ),
-    "output-denied": (
-      <XCircleIcon className="size-4 fill-amber-500 stroke-white" />
-    ),
-  }
-
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="inline-flex">{icons[status]}</div>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          <p>{labels[status]}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )
+const statusLabels: Record<ToolState, string> = {
+  "approval-requested": "Approval required",
+  "approval-responded": "Responded",
+  "input-available": "Running",
+  "input-streaming": "Pending",
+  "output-available": "Completed",
+  "output-denied": "Denied",
+  "output-error": "Error",
 }
+
+const statusIcons: Record<ToolState, ReactNode> = {
+  "approval-requested": <ClockIcon className="size-3.5 text-yellow-600" />,
+  "approval-responded": <CheckCircleIcon className="size-3.5 text-blue-600" />,
+  "input-available": <ClockIcon className="size-3.5 animate-pulse" />,
+  "input-streaming": <CircleIcon className="size-3.5" />,
+  "output-available": <CheckCircleIcon className="size-3.5 text-green-600" />,
+  "output-denied": <XCircleIcon className="size-3.5 text-orange-600" />,
+  "output-error": <XCircleIcon className="size-3.5 text-red-600" />,
+}
+
+export const getStatusBadge = (status: ToolState) => (
+  <Badge
+    className="h-6 gap-1 rounded-full px-2 py-0 text-[11px] font-medium"
+    variant="secondary"
+  >
+    {statusIcons[status]}
+    {statusLabels[status]}
+  </Badge>
+)
 
 export const ToolHeader = ({
   className,
   title,
   type,
   state,
+  toolName,
   icon,
   ...props
-}: ToolHeaderProps) => (
-  <CollapsibleTrigger
-    className={cn(
-      "flex w-full items-center justify-between gap-4 px-3 py-2",
-      className
-    )}
-    {...props}
-  >
-    <div className="flex items-center gap-2">
-      {icon ?? <WrenchIcon className="size-4 text-muted-foreground" />}
-      <span className="font-medium text-sm">
-        {title ?? type.split("-").slice(1).join("-")}
-      </span>
-      {getStatusBadge(state)}
-    </div>
-    <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-  </CollapsibleTrigger>
-)
+}: ToolHeaderProps) => {
+  const derivedName =
+    type === "dynamic-tool"
+      ? (toolName ?? "dynamic-tool")
+      : type.split("-").slice(1).join("-")
+
+  return (
+    <CollapsibleTrigger
+      className={cn(
+        "flex w-full items-center justify-between gap-3 px-3 py-2",
+        className
+      )}
+      {...props}
+    >
+      <div className="flex items-center gap-2.5">
+        {icon ?? <WrenchIcon className="size-5 text-muted-foreground" />}
+        <span className="font-medium text-sm">{title ?? derivedName}</span>
+        {getStatusBadge(state)}
+      </div>
+      <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+    </CollapsibleTrigger>
+  )
+}
 
 export type ToolContentProps = ComponentProps<typeof CollapsibleContent>
 
 export const ToolContent = ({ className, ...props }: ToolContentProps) => (
   <CollapsibleContent
     className={cn(
-      "text-popover-foreground outline-none",
-      "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-2",
-      "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2",
+      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 space-y-3 px-3 pb-3 pt-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
       className
     )}
     {...props}
   />
 )
 
+type SerializedPayload = {
+  text: string
+  extension: "json" | "txt"
+}
+
+function serializeToolPayload(payload: unknown): SerializedPayload {
+  if (typeof payload === "string") {
+    const trimmed = payload.trim()
+    const looksLikeJson = trimmed.startsWith("{") || trimmed.startsWith("[")
+    if (looksLikeJson && payload.length <= MAX_INLINE_PAYLOAD_CHARS) {
+      try {
+        return {
+          text: JSON.stringify(JSON.parse(payload), null, 2),
+          extension: "json",
+        }
+      } catch {
+        return { text: payload, extension: "txt" }
+      }
+    }
+    return { text: payload, extension: "txt" }
+  }
+
+  if (
+    payload &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    isValidElement(payload)
+  ) {
+    return { text: "", extension: "txt" }
+  }
+
+  if (payload && typeof payload === "object") {
+    try {
+      const compact = JSON.stringify(payload)
+      if (typeof compact !== "string") {
+        return { text: String(payload), extension: "txt" }
+      }
+
+      if (compact.length > MAX_INLINE_PAYLOAD_CHARS) {
+        return { text: compact, extension: "json" }
+      }
+
+      return {
+        text: JSON.stringify(payload, null, 2),
+        extension: "json",
+      }
+    } catch {
+      return { text: "[Unserializable payload]", extension: "txt" }
+    }
+  }
+
+  if (payload === null) {
+    return { text: "null", extension: "txt" }
+  }
+
+  if (payload === undefined) {
+    return { text: "", extension: "txt" }
+  }
+
+  return { text: String(payload), extension: "txt" }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+  const kb = bytes / 1024
+  if (kb < 1024) {
+    return `${kb.toFixed(1)} KB`
+  }
+  const mb = kb / 1024
+  return `${mb.toFixed(1)} MB`
+}
+
+function ToolPayload({
+  payload,
+  downloadName,
+}: {
+  payload: unknown
+  downloadName: string
+}) {
+  const serialized = useMemo(() => serializeToolPayload(payload), [payload])
+  const isLargePayload = serialized.text.length > MAX_INLINE_PAYLOAD_CHARS
+  const codeLanguage = serialized.extension === "json" ? "json" : "console"
+  const byteCount = useMemo(
+    () =>
+      isLargePayload ? new TextEncoder().encode(serialized.text).length : 0,
+    [isLargePayload, serialized.text]
+  )
+  const [downloadHref, setDownloadHref] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isLargePayload || !serialized.text) {
+      setDownloadHref(null)
+      return
+    }
+
+    const blob = new Blob([serialized.text], {
+      type: serialized.extension === "json" ? "application/json" : "text/plain",
+    })
+    const href = URL.createObjectURL(blob)
+    setDownloadHref(href)
+    return () => URL.revokeObjectURL(href)
+  }, [isLargePayload, serialized.extension, serialized.text])
+
+  if (!serialized.text) {
+    return null
+  }
+
+  if (isLargePayload) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-2 rounded-md border border-dashed bg-background/70 px-2.5 py-2 text-xs text-muted-foreground">
+          <span>Large payload ({formatBytes(byteCount)}). Preview hidden.</span>
+          {downloadHref && (
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="h-6 px-2 text-xs"
+            >
+              <a
+                href={downloadHref}
+                download={`${downloadName}.${serialized.extension}`}
+              >
+                <DownloadIcon className="mr-1.5 size-3" />
+                Download file
+              </a>
+            </Button>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <CodeBlock
+        code={serialized.text}
+        language={codeLanguage}
+        className="[&_code]:text-xs [&_pre]:text-xs"
+      >
+        <CodeBlockCopyButton className="absolute right-2 top-2 z-10 size-6" />
+      </CodeBlock>
+    </div>
+  )
+}
+
 export type ToolInputProps = ComponentProps<"div"> & {
-  input: AnyToolUIPart["input"]
+  input: ToolPart["input"]
 }
 
 export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
-  <div className={cn("space-y-2 overflow-hidden p-4", className)} {...props}>
-    <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+  <div className={cn("space-y-1.5 overflow-hidden", className)} {...props}>
+    <h4 className="font-medium text-muted-foreground text-xs tracking-wide">
       Parameters
     </h4>
-    <div className="rounded-md bg-muted/50">
-      <CodeBlock code={JSON.stringify(input, null, 2)} language="json">
-        <CodeBlockCopyButton />
-      </CodeBlock>
-    </div>
+    <ToolPayload payload={input} downloadName="tool-parameters" />
   </div>
 )
 
 export type ToolOutputProps = ComponentProps<"div"> & {
-  output: AnyToolUIPart["output"]
-  errorText: AnyToolUIPart["errorText"]
+  output: ToolPart["output"]
+  errorText: ToolPart["errorText"]
 }
 
 export const ToolOutput = ({
@@ -166,254 +301,29 @@ export const ToolOutput = ({
   errorText,
   ...props
 }: ToolOutputProps) => {
-  const { message, details } = extractErrorDetails(output, errorText)
-  const hasError = Boolean(message)
-
-  if (!(output || hasError)) {
+  const hasOutput = output !== undefined && output !== null
+  if (!hasOutput && !errorText) {
     return null
   }
 
-  const outputRecord =
-    output && typeof output === "object" && !Array.isArray(output)
-      ? (output as Record<string, unknown>)
-      : undefined
-  const outputIsOnlyErrorText =
-    hasError &&
-    outputRecord &&
-    Object.keys(outputRecord).every((key) => key === "errorText")
-
-  const shouldRenderRawOutput = output && !outputIsOnlyErrorText
-
-  let Output: ReactNode = null
-  if (shouldRenderRawOutput) {
-    if (
-      typeof output === "string" &&
-      hasError &&
-      message &&
-      output.trim() === message.trim()
-    ) {
-      Output = null
-    } else if (typeof output === "object") {
-      // Handle MCP content array format: [{"type": "text", "text": "..."}]
-      // Extract and parse the text content for pretty display
-      const displayOutput = extractMcpTextContent(output)
-      Output = (
-        <CodeBlock
-          code={JSON.stringify(displayOutput, null, 2)}
-          language="json"
-        >
-          <CodeBlockCopyButton />
-        </CodeBlock>
-      )
-    } else if (typeof output === "string") {
-      // Try to parse JSON strings for pretty display
-      let displayOutput: string
-      try {
-        displayOutput = JSON.stringify(JSON.parse(output), null, 2)
-      } catch {
-        displayOutput = output
-      }
-      Output = (
-        <CodeBlock code={displayOutput} language="json">
-          <CodeBlockCopyButton />
-        </CodeBlock>
-      )
-    } else {
-      Output = <div>{output as ReactNode}</div>
-    }
-  }
-
   return (
-    <div className={cn("space-y-2 p-4", className)} {...props}>
-      <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-        {hasError ? "Error" : "Result"}
+    <div className={cn("space-y-1.5", className)} {...props}>
+      <h4 className="font-medium text-muted-foreground text-xs tracking-wide">
+        {errorText ? "Error" : "Result"}
       </h4>
-      {hasError && (
-        <Alert
-          variant="destructive"
-          className="border-destructive/30 bg-destructive/10 py-3"
-        >
-          <AlertTitle className="text-sm font-semibold">
-            {details?.title ?? "Validation issue"}
-          </AlertTitle>
-          <AlertDescription className="mt-1 space-y-2 text-sm">
-            <p className="whitespace-pre-wrap text-destructive">
-              {details?.summary ?? message}
-            </p>
-            {details?.items && details.items.length > 0 && (
-              <ul className="list-disc space-y-1 pl-5 text-destructive">
-                {details.items.map((item, idx) => (
-                  <li key={`${item}-${idx}`}>{item}</li>
-                ))}
-              </ul>
-            )}
-          </AlertDescription>
-        </Alert>
-      )}
-      {Output && (
-        <div className="overflow-x-auto rounded-md bg-muted/50 text-foreground text-xs [&_table]:w-full">
-          {Output}
+      {errorText && (
+        <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-destructive text-xs">
+          {errorText}
         </div>
       )}
+      {hasOutput &&
+        (isValidElement(output) ? (
+          <div className="rounded-md bg-muted/50 p-1.5 text-xs text-foreground">
+            {output}
+          </div>
+        ) : (
+          <ToolPayload payload={output} downloadName="tool-result" />
+        ))}
     </div>
   )
-}
-
-type ErrorDetails = {
-  message?: string
-  details?: {
-    title: string
-    summary?: string
-    items?: string[]
-  }
-}
-
-function extractErrorDetails(
-  output: ToolUIPart["output"],
-  explicitErrorText: ToolUIPart["errorText"]
-): ErrorDetails {
-  const outputRecord =
-    output && typeof output === "object" && !Array.isArray(output)
-      ? (output as Record<string, unknown>)
-      : undefined
-  const derivedErrorText =
-    outputRecord && "errorText" in outputRecord
-      ? (outputRecord.errorText as string | undefined)
-      : undefined
-  const embeddedError =
-    (explicitErrorText ?? derivedErrorText)?.trim() || undefined
-
-  if (!embeddedError) {
-    return { message: undefined }
-  }
-
-  const parsed = parseValidationSummary(embeddedError)
-  if (parsed) {
-    return { message: embeddedError, details: parsed }
-  }
-
-  return {
-    message: embeddedError,
-    details: {
-      title: "Error",
-      summary: embeddedError,
-    },
-  }
-}
-
-function parseValidationSummary(message: string):
-  | {
-      title: string
-      summary?: string
-      items?: string[]
-    }
-  | undefined {
-  const trimmed = message.trim()
-  const validationMatch = trimmed.match(
-    /^(\d+)\s+validation errors:\s*(\[.*\])\s*Fix the errors and try again\.\s*$/s
-  )
-  if (validationMatch) {
-    const count = Number(validationMatch[1])
-    const title =
-      count === 1 ? "Validation error" : `${count} validation errors`
-    try {
-      const payload = JSON.parse(validationMatch[2]) as Array<{
-        loc?: string[] | string
-        msg?: string
-        input?: unknown
-      }>
-      const items = payload.map((error) => {
-        const path = Array.isArray(error.loc)
-          ? error.loc.join(" → ")
-          : (error.loc ?? "")
-        const prefix = path ? `${path}: ` : ""
-        const formattedInput =
-          error.input === undefined
-            ? ""
-            : ` (input: ${
-                typeof error.input === "string"
-                  ? error.input
-                  : JSON.stringify(error.input, null, 2)
-              })`
-        return `${prefix}${error.msg ?? "Invalid value"}${formattedInput}`
-      })
-      return {
-        title,
-        summary:
-          "The request couldn't be completed because some fields failed validation.",
-        items,
-      }
-    } catch {
-      return {
-        title,
-        summary: trimmed,
-      }
-    }
-  }
-
-  const feedbackMatch = trimmed.match(/^Validation feedback:\s*(.*)$/s)
-  if (feedbackMatch) {
-    return {
-      title: "Validation feedback",
-      summary: feedbackMatch[1].trim(),
-    }
-  }
-
-  return undefined
-}
-
-/**
- * Extract and parse text content from MCP content array format.
- * MCP returns: [{"type": "text", "text": "{...json...}"}, ...]
- * This extracts text from all blocks and parses JSON if possible.
- */
-function extractMcpTextContent(output: unknown): unknown {
-  if (!Array.isArray(output) || output.length === 0) {
-    return output
-  }
-
-  // Check if this looks like MCP content array format
-  const isMcpFormat = output.every(
-    (item) =>
-      item &&
-      typeof item === "object" &&
-      "type" in item &&
-      typeof item.type === "string"
-  )
-
-  if (!isMcpFormat) {
-    return output
-  }
-
-  // Extract text from all text blocks
-  const textBlocks = output.filter(
-    (item): item is { type: "text"; text: string } =>
-      item.type === "text" && "text" in item && typeof item.text === "string"
-  )
-
-  if (textBlocks.length === 0) {
-    // No text blocks, return original
-    return output
-  }
-
-  if (textBlocks.length === 1) {
-    // Single text block - try to parse as JSON
-    try {
-      return JSON.parse(textBlocks[0].text)
-    } catch {
-      return textBlocks[0].text
-    }
-  }
-
-  // Multiple text blocks - try to parse each as JSON, concatenate results
-  const parsed = textBlocks.map((block) => {
-    try {
-      return JSON.parse(block.text)
-    } catch {
-      return block.text
-    }
-  })
-
-  // If all parsed to the same type, return as array
-  return parsed
 }

--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -2,9 +2,8 @@
 
 import type { DynamicToolUIPart, ToolUIPart } from "ai"
 import {
-  CheckCircleIcon,
   ChevronDownIcon,
-  CircleIcon,
+  CircleCheckIcon,
   ClockIcon,
   DownloadIcon,
   WrenchIcon,
@@ -18,13 +17,18 @@ import {
   useMemo,
   useState,
 } from "react"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 import { CodeBlock, CodeBlockCopyButton } from "./code-block"
 
@@ -34,7 +38,10 @@ export type ToolProps = ComponentProps<typeof Collapsible>
 
 export const Tool = ({ className, ...props }: ToolProps) => (
   <Collapsible
-    className={cn("group not-prose mb-3 w-full rounded-md border", className)}
+    className={cn(
+      "group not-prose mb-2 w-full rounded-md border-[0.5px]",
+      className
+    )}
     {...props}
   />
 )
@@ -57,32 +64,54 @@ export type ToolHeaderProps = {
 
 const statusLabels: Record<ToolState, string> = {
   "approval-requested": "Approval required",
-  "approval-responded": "Responded",
-  "input-available": "Running",
-  "input-streaming": "Pending",
+  "approval-responded": "Completed",
+  "input-available": "In progress",
+  "input-streaming": "In progress",
   "output-available": "Completed",
-  "output-denied": "Denied",
+  "output-denied": "Error",
   "output-error": "Error",
 }
 
 const statusIcons: Record<ToolState, ReactNode> = {
-  "approval-requested": <ClockIcon className="size-3.5 text-yellow-600" />,
-  "approval-responded": <CheckCircleIcon className="size-3.5 text-blue-600" />,
-  "input-available": <ClockIcon className="size-3.5 animate-pulse" />,
-  "input-streaming": <CircleIcon className="size-3.5" />,
-  "output-available": <CheckCircleIcon className="size-3.5 text-green-600" />,
-  "output-denied": <XCircleIcon className="size-3.5 text-orange-600" />,
-  "output-error": <XCircleIcon className="size-3.5 text-red-600" />,
+  "approval-requested": (
+    <ClockIcon className="size-3.5 text-amber-500 animate-pulse" />
+  ),
+  "approval-responded": (
+    <CircleCheckIcon className="size-4 fill-emerald-500 stroke-background" />
+  ),
+  "input-available": (
+    <ClockIcon className="size-3.5 text-amber-500 animate-pulse" />
+  ),
+  "input-streaming": (
+    <ClockIcon className="size-3.5 text-amber-500 animate-pulse" />
+  ),
+  "output-available": (
+    <CircleCheckIcon className="size-4 fill-emerald-500 stroke-background" />
+  ),
+  "output-denied": (
+    <XCircleIcon className="size-4 fill-rose-500 stroke-background" />
+  ),
+  "output-error": (
+    <XCircleIcon className="size-4 fill-rose-500 stroke-background" />
+  ),
 }
 
 export const getStatusBadge = (status: ToolState) => (
-  <Badge
-    className="h-6 gap-1 rounded-full px-2 py-0 text-[11px] font-medium"
-    variant="secondary"
-  >
-    {statusIcons[status]}
-    {statusLabels[status]}
-  </Badge>
+  <TooltipProvider delayDuration={0}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          aria-label={statusLabels[status]}
+          className="inline-flex items-center"
+          role="img"
+        >
+          {statusIcons[status]}
+          <span className="sr-only">{statusLabels[status]}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{statusLabels[status]}</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
 )
 
 export const ToolHeader = ({
@@ -102,13 +131,13 @@ export const ToolHeader = ({
   return (
     <CollapsibleTrigger
       className={cn(
-        "flex w-full items-center justify-between gap-3 px-3 py-2",
+        "flex w-full items-center justify-between gap-3 px-2.5 py-1.5",
         className
       )}
       {...props}
     >
-      <div className="flex items-center gap-2.5">
-        {icon ?? <WrenchIcon className="size-5 text-muted-foreground" />}
+      <div className="flex items-center gap-2">
+        {icon ?? <WrenchIcon className="size-4 text-muted-foreground" />}
         <span className="font-medium text-sm">{title ?? derivedName}</span>
         {getStatusBadge(state)}
       </div>
@@ -122,7 +151,7 @@ export type ToolContentProps = ComponentProps<typeof CollapsibleContent>
 export const ToolContent = ({ className, ...props }: ToolContentProps) => (
   <CollapsibleContent
     className={cn(
-      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 space-y-3 px-3 pb-3 pt-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 space-y-3 px-2.5 pb-3 pt-2.5 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
       className
     )}
     {...props}
@@ -132,6 +161,53 @@ export const ToolContent = ({ className, ...props }: ToolContentProps) => (
 type SerializedPayload = {
   text: string
   extension: "json" | "txt"
+}
+
+/**
+ * Normalize MCP content arrays to the actual payload text when possible.
+ * Example: [{ type: "text", text: "[]" }] -> []
+ */
+function extractMcpTextContent(payload: unknown): unknown {
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return payload
+  }
+
+  const isMcpContentArray = payload.every(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      "type" in item &&
+      typeof item.type === "string"
+  )
+
+  if (!isMcpContentArray) {
+    return payload
+  }
+
+  const textBlocks = payload.filter(
+    (item): item is { type: "text"; text: string } =>
+      item.type === "text" && "text" in item && typeof item.text === "string"
+  )
+
+  if (textBlocks.length === 0) {
+    return payload
+  }
+
+  if (textBlocks.length === 1) {
+    try {
+      return JSON.parse(textBlocks[0].text)
+    } catch {
+      return textBlocks[0].text
+    }
+  }
+
+  return textBlocks.map((block) => {
+    try {
+      return JSON.parse(block.text)
+    } catch {
+      return block.text
+    }
+  })
 }
 
 function serializeToolPayload(payload: unknown): SerializedPayload {
@@ -145,7 +221,7 @@ function serializeToolPayload(payload: unknown): SerializedPayload {
           extension: "json",
         }
       } catch {
-        return { text: payload, extension: "txt" }
+        return { text: payload, extension: "json" }
       }
     }
     return { text: payload, extension: "txt" }
@@ -210,7 +286,14 @@ function ToolPayload({
   payload: unknown
   downloadName: string
 }) {
-  const serialized = useMemo(() => serializeToolPayload(payload), [payload])
+  const normalizedPayload = useMemo(
+    () => extractMcpTextContent(payload),
+    [payload]
+  )
+  const serialized = useMemo(
+    () => serializeToolPayload(normalizedPayload),
+    [normalizedPayload]
+  )
   const isLargePayload = serialized.text.length > MAX_INLINE_PAYLOAD_CHARS
   const codeLanguage = serialized.extension === "json" ? "json" : "console"
   const byteCount = useMemo(
@@ -269,9 +352,9 @@ function ToolPayload({
       <CodeBlock
         code={serialized.text}
         language={codeLanguage}
-        className="[&_code]:text-xs [&_pre]:text-xs"
+        className="[&_code]:text-[11px] [&_pre]:px-3 [&_pre]:py-2.5 [&_pre]:text-[11px]"
       >
-        <CodeBlockCopyButton className="absolute right-2 top-2 z-10 size-6" />
+        <CodeBlockCopyButton className="absolute right-1.5 top-1.5 z-10 size-5 [&_svg]:size-3" />
       </CodeBlock>
     </div>
   )
@@ -282,9 +365,9 @@ export type ToolInputProps = ComponentProps<"div"> & {
 }
 
 export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
-  <div className={cn("space-y-1.5 overflow-hidden", className)} {...props}>
-    <h4 className="font-medium text-muted-foreground text-xs tracking-wide">
-      Parameters
+  <div className={cn("space-y-2 overflow-hidden", className)} {...props}>
+    <h4 className="font-medium text-[11px] text-muted-foreground tracking-wide">
+      PARAMETERS
     </h4>
     <ToolPayload payload={input} downloadName="tool-parameters" />
   </div>
@@ -307,18 +390,18 @@ export const ToolOutput = ({
   }
 
   return (
-    <div className={cn("space-y-1.5", className)} {...props}>
-      <h4 className="font-medium text-muted-foreground text-xs tracking-wide">
-        {errorText ? "Error" : "Result"}
+    <div className={cn("space-y-2", className)} {...props}>
+      <h4 className="font-medium text-[11px] text-muted-foreground tracking-wide">
+        {errorText ? "Error" : "RESULT"}
       </h4>
       {errorText && (
-        <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-destructive text-xs">
+        <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-[11px] text-destructive">
           {errorText}
         </div>
       )}
       {hasOutput &&
         (isValidElement(output) ? (
-          <div className="rounded-md bg-muted/50 p-1.5 text-xs text-foreground">
+          <div className="rounded-md bg-muted/50 p-1.5 text-[11px] text-foreground">
             {output}
           </div>
         ) : (

--- a/frontend/src/components/chat/chat-history-dropdown.tsx
+++ b/frontend/src/components/chat/chat-history-dropdown.tsx
@@ -68,21 +68,22 @@ export function ChatHistoryDropdown({
           <div className="p-3 text-sm text-red-600">Failed to load chats</div>
         ) : (
           <Command>
-            <CommandInput placeholder="Search chats..." className="h-9" />
+            <CommandInput
+              placeholder="Search chats..."
+              className="h-8 text-xs"
+            />
             <CommandList className="max-h-64 overflow-y-auto">
-              <CommandEmpty>No chats found.</CommandEmpty>
+              <CommandEmpty className="text-xs">No chats found.</CommandEmpty>
               <CommandGroup>
                 {chats?.map((chat) => (
                   <CommandItem
                     key={chat.id}
                     value={`${chat.title} ${chat.id}`}
                     onSelect={() => handleSelect(chat.id)}
-                    className="flex items-start justify-between gap-2 py-2"
+                    className="flex items-start justify-between gap-2 py-2 text-xs"
                   >
                     <div className="flex min-w-0 flex-col">
-                      <span className="truncate text-sm font-medium">
-                        {chat.title}
-                      </span>
+                      <span className="truncate font-medium">{chat.title}</span>
                       <span className="text-xs text-muted-foreground">
                         {formatDistanceToNow(new Date(chat.created_at), {
                           addSuffix: true,

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -5,10 +5,10 @@ import Link from "next/link"
 import { useEffect, useState } from "react"
 import type {
   AgentPresetRead,
+  AgentPresetReadMinimal,
   AgentSessionEntity,
   AgentSessionsGetSessionVercelResponse,
 } from "@/client"
-import { AgentPresetMenu } from "@/components/chat/agent-preset-menu"
 import { ChatHistoryDropdown } from "@/components/chat/chat-history-dropdown"
 import { ChatSessionPane } from "@/components/chat/chat-session-pane"
 import { NoMessages } from "@/components/chat/messages"
@@ -201,7 +201,10 @@ export function ChatInterface({
     }
   }
 
-  const handleCreateCaseChatOnFirstSend = async (messageText: string) => {
+  const handleCreateCaseChatOnFirstSend = async (
+    messageText: string,
+    selectedTools?: string[]
+  ) => {
     if (entityType !== "case" || createChatPending) {
       return null
     }
@@ -211,6 +214,7 @@ export function ChatInterface({
         title: `Chat ${(chats?.length || 0) + 1}`,
         entity_type: "case",
         entity_id: entityId,
+        tools: selectedTools,
         agent_preset_id: effectivePresetId,
       })
 
@@ -269,21 +273,8 @@ export function ChatInterface({
             {/* (left-side plus removed) */}
           </div>
 
-          {/* Right-side controls: preset selector + actions */}
+          {/* Right-side actions */}
           <div className="flex items-center gap-1">
-            {presetsEnabled && (
-              <AgentPresetMenu
-                label={presetMenuLabel}
-                presets={presetOptions}
-                presetsIsLoading={presetsIsLoading}
-                presetsError={presetsError}
-                selectedPresetId={effectivePresetId}
-                disabled={presetMenuDisabled}
-                showSpinner={showPresetSpinner}
-                noPresetDescription="Use workspace default case agent instructions."
-                onSelect={(presetId) => void handlePresetChange(presetId)}
-              />
-            )}
             {/* New chat icon button with tooltip */}
             <AlertDialog
               open={newChatDialogOpen}
@@ -342,6 +333,22 @@ export function ChatInterface({
           draftMode={
             entityType === "case" && (isCaseDraftChat || chats?.length === 0)
           }
+          presetSelector={
+            presetsEnabled
+              ? {
+                  label: presetMenuLabel,
+                  presets: presetOptions,
+                  presetsError,
+                  presetsIsLoading,
+                  selectedPresetId: effectivePresetId,
+                  disabled: presetMenuDisabled,
+                  showSpinner: showPresetSpinner,
+                  noPresetDescription:
+                    "Use workspace default case agent instructions.",
+                  onSelect: (presetId) => void handlePresetChange(presetId),
+                }
+              : undefined
+          }
           onCreateSessionBeforeSend={
             entityType === "case" ? handleCreateCaseChatOnFirstSend : undefined
           }
@@ -373,7 +380,21 @@ interface ChatBodyProps {
   selectedPreset?: AgentPresetRead
   toolsEnabled: boolean
   draftMode: boolean
-  onCreateSessionBeforeSend?: (messageText: string) => Promise<string | null>
+  presetSelector?: {
+    label: string
+    presets?: AgentPresetReadMinimal[]
+    presetsIsLoading: boolean
+    presetsError: unknown
+    selectedPresetId: string | null
+    onSelect: (presetId: string | null) => void | Promise<void>
+    disabled?: boolean
+    showSpinner?: boolean
+    noPresetDescription?: string
+  }
+  onCreateSessionBeforeSend?: (
+    messageText: string,
+    selectedTools?: string[]
+  ) => Promise<string | null>
   draftInputDisabled: boolean
   pendingMessage: string | null
   onPendingMessageSent: () => void
@@ -390,6 +411,7 @@ function ChatBody({
   selectedPreset,
   toolsEnabled,
   draftMode,
+  presetSelector,
   onCreateSessionBeforeSend,
   draftInputDisabled,
   pendingMessage,
@@ -477,7 +499,8 @@ function ChatBody({
         placeholder={`Ask about this ${entityType}...`}
         className="flex-1 min-h-0"
         modelInfo={modelInfo}
-        toolsEnabled={false}
+        toolsEnabled={toolsEnabled}
+        presetSelector={presetSelector}
         onBeforeSend={onCreateSessionBeforeSend}
         inputDisabled={draftInputDisabled}
         inputDisabledPlaceholder="Creating chat..."
@@ -503,6 +526,7 @@ function ChatBody({
       className="flex-1 min-h-0"
       modelInfo={modelInfo}
       toolsEnabled={toolsEnabled}
+      presetSelector={presetSelector}
       pendingMessage={pendingMessage ?? undefined}
       onPendingMessageSent={onPendingMessageSent}
     />

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -11,15 +11,26 @@ import {
   type UITools,
 } from "ai"
 import {
+  BoxIcon,
   CheckIcon,
-  HammerIcon,
+  ChevronsUpDown,
+  Loader2,
   PencilIcon,
   RefreshCcwIcon,
   XIcon,
 } from "lucide-react"
 import { motion } from "motion/react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import type {
+  AgentPresetReadMinimal,
   AgentSessionEntity,
   AgentSessionReadVercel,
   ApprovalDecision,
@@ -33,13 +44,24 @@ import {
 } from "@/components/ai-elements/conversation"
 import { Message, MessageContent } from "@/components/ai-elements/message"
 import {
+  ModelSelector,
+  ModelSelectorContent,
+  ModelSelectorEmpty,
+  ModelSelectorGroup,
+  ModelSelectorInput,
+  ModelSelectorItem,
+  ModelSelectorList,
+  ModelSelectorTrigger,
+} from "@/components/ai-elements/model-selector"
+import {
   PromptInput,
   PromptInputBody,
   PromptInputButton,
+  PromptInputFooter,
+  PromptInputHeader,
   type PromptInputMessage,
   PromptInputSubmit,
   PromptInputTextarea,
-  PromptInputToolbar,
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input"
 import {
@@ -55,29 +77,27 @@ import {
   SourcesTrigger,
 } from "@/components/ai-elements/sources"
 import {
+  getStatusBadge,
   Tool,
   ToolContent,
   ToolHeader,
   ToolInput,
   ToolOutput,
 } from "@/components/ai-elements/tool"
-import { ChatToolsDialog } from "@/components/chat/chat-tools-dialog"
+import { CodeEditor } from "@/components/editor/codemirror/code-editor"
 import { getIcon } from "@/components/icons"
 import { JsonViewWithControls } from "@/components/json-viewer"
 import { Dots } from "@/components/loading/dots"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import {
   type ApprovalCard,
   makeContinueMessage,
+  parseChatError,
+  useUpdateChat,
   useVercelChat,
 } from "@/hooks/use-chat"
 import type { ModelInfo } from "@/lib/chat"
@@ -86,7 +106,66 @@ import {
   toUIMessage,
   transformMessages,
 } from "@/lib/chat"
+import { useBuilderRegistryActions } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
+
+const MAX_TOOL_MENTION_RESULTS = 40
+
+type ToolMentionToken = {
+  start: number
+  end: number
+  query: string
+}
+
+type ToolMentionState = ToolMentionToken & {
+  activeIndex: number
+}
+
+type ToolSuggestion = {
+  value: string
+  label: string
+  description?: string
+  group?: string
+}
+
+function getToolMentionToken(
+  text: string,
+  caret: number
+): ToolMentionToken | undefined {
+  const beforeCaret = text.slice(0, caret)
+  const atIndex = beforeCaret.lastIndexOf("@")
+  if (atIndex < 0) {
+    return undefined
+  }
+
+  const priorChar = atIndex === 0 ? " " : beforeCaret[atIndex - 1]
+  if (priorChar.trim() !== "") {
+    return undefined
+  }
+
+  const query = beforeCaret.slice(atIndex + 1)
+  if (/\s/.test(query)) {
+    return undefined
+  }
+
+  return {
+    start: atIndex,
+    end: caret,
+    query,
+  }
+}
+
+type ChatPresetSelector = {
+  label: string
+  presets?: AgentPresetReadMinimal[]
+  presetsIsLoading: boolean
+  presetsError: unknown
+  selectedPresetId: string | null
+  onSelect: (presetId: string | null) => void | Promise<void>
+  disabled?: boolean
+  showSpinner?: boolean
+  noPresetDescription?: string
+}
 
 export interface ChatSessionPaneProps {
   chat?: AgentSessionReadVercel | ChatReadVercel
@@ -106,7 +185,10 @@ export interface ChatSessionPaneProps {
    * new session ID to switch to, or null to cancel.
    * Used for inbox fork-on-send behavior.
    */
-  onBeforeSend?: (messageText: string) => Promise<string | null>
+  onBeforeSend?: (
+    messageText: string,
+    selectedTools?: string[]
+  ) => Promise<string | null>
   /**
    * Message to send immediately on mount. Used after forking a session
    * to send the user's message to the newly forked session.
@@ -126,6 +208,10 @@ export interface ChatSessionPaneProps {
    * Placeholder to show when input is disabled.
    */
   inputDisabledPlaceholder?: string
+  /**
+   * Optional preset selector rendered in the prompt footer.
+   */
+  presetSelector?: ChatPresetSelector
 }
 
 export function ChatSessionPane({
@@ -144,6 +230,7 @@ export function ChatSessionPane({
   onPendingMessageSent,
   inputDisabled = false,
   inputDisabledPlaceholder,
+  presetSelector,
 }: ChatSessionPaneProps) {
   const queryClient = useQueryClient()
   const processedMessageRef = useRef<
@@ -155,7 +242,11 @@ export function ChatSessionPane({
   >(undefined)
 
   const [input, setInput] = useState<string>("")
-  const [toolsDialogOpen, setToolsDialogOpen] = useState(false)
+  const [toolMention, setToolMention] = useState<ToolMentionState>()
+  const [selectedTools, setSelectedTools] = useState<string[]>([])
+  const { updateChat, isUpdating: isUpdatingTools } = useUpdateChat(workspaceId)
+  const { registryActions, registryActionsIsLoading } =
+    useBuilderRegistryActions()
 
   // Check if this is a legacy read-only session
   const isReadonly = chat ? "is_readonly" in chat && chat.is_readonly : false
@@ -222,7 +313,6 @@ export function ChatSessionPane({
   const handleSubmitApprovals = useCallback(
     async (decisionPayload: ApprovalDecision[]) => {
       if (!decisionPayload.length) return
-      console.log("decisionPayload", decisionPayload)
       try {
         clearError()
         await sendMessage(makeContinueMessage(decisionPayload))
@@ -243,6 +333,269 @@ export function ChatSessionPane({
   useEffect(() => {
     onMessagesChange?.(messages)
   }, [messages, onMessagesChange])
+
+  const toolSuggestions = useMemo<ToolSuggestion[]>(() => {
+    const actions = registryActions ?? []
+    return actions
+      .map((action) => ({
+        value: action.action,
+        label: action.default_title || action.action,
+        description: action.description ?? undefined,
+        group: action.namespace,
+      }))
+      .sort((left, right) => left.value.localeCompare(right.value))
+  }, [registryActions])
+
+  const toolSuggestionMap = useMemo(
+    () => new Map(toolSuggestions.map((tool) => [tool.value, tool])),
+    [toolSuggestions]
+  )
+
+  const persistToolsChainRef = useRef<Promise<void>>(Promise.resolve())
+
+  useEffect(() => {
+    setSelectedTools(chat?.tools ?? [])
+  }, [chat?.id, chat?.tools])
+
+  const queuePersistTools = useCallback(
+    (tools: string[]) => {
+      if (!chat || isReadonly) {
+        return
+      }
+
+      const chatId = chat.id
+      persistToolsChainRef.current = persistToolsChainRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          try {
+            await updateChat({
+              chatId,
+              update: { tools },
+            })
+          } catch (error) {
+            toast({
+              title: "Failed to update tools",
+              description: parseChatError(error),
+              variant: "destructive",
+            })
+          }
+        })
+    },
+    [chat, isReadonly, updateChat]
+  )
+
+  const addSelectedTool = useCallback(
+    (toolName: string) => {
+      setSelectedTools((current) => {
+        if (current.includes(toolName)) {
+          return current
+        }
+
+        const next = [...current, toolName]
+        queuePersistTools(next)
+        return next
+      })
+    },
+    [queuePersistTools]
+  )
+
+  const removeSelectedTool = useCallback(
+    (toolName: string) => {
+      setSelectedTools((current) => {
+        const next = current.filter((tool) => tool !== toolName)
+        queuePersistTools(next)
+        return next
+      })
+    },
+    [queuePersistTools]
+  )
+
+  const mentionEnabled =
+    toolsEnabled && !isReadonly && !inputDisabled && canSubmit
+
+  useEffect(() => {
+    if (!mentionEnabled) {
+      setToolMention(undefined)
+    }
+  }, [mentionEnabled])
+
+  const filteredToolSuggestions = useMemo(() => {
+    if (!toolMention) {
+      return []
+    }
+
+    const needle = toolMention.query.trim().toLowerCase()
+    const matches = toolSuggestions.filter((tool) => {
+      if (!needle) {
+        return true
+      }
+      return [tool.value, tool.label, tool.description ?? "", tool.group ?? ""]
+        .join(" ")
+        .toLowerCase()
+        .includes(needle)
+    })
+    return matches.slice(0, MAX_TOOL_MENTION_RESULTS)
+  }, [toolMention, toolSuggestions])
+
+  useEffect(() => {
+    if (!toolMention) {
+      return
+    }
+    if (filteredToolSuggestions.length === 0) {
+      setToolMention((current) => {
+        if (!current || current.activeIndex === 0) {
+          return current
+        }
+        return { ...current, activeIndex: 0 }
+      })
+      return
+    }
+
+    setToolMention((current) => {
+      if (!current) {
+        return current
+      }
+      const clampedIndex = Math.min(
+        current.activeIndex,
+        filteredToolSuggestions.length - 1
+      )
+      if (clampedIndex === current.activeIndex) {
+        return current
+      }
+      return { ...current, activeIndex: clampedIndex }
+    })
+  }, [filteredToolSuggestions.length, toolMention])
+
+  const handleSelectMentionTool = useCallback(
+    (toolName: string, textarea?: HTMLTextAreaElement) => {
+      const mention = toolMention
+      if (!mention) {
+        return
+      }
+
+      addSelectedTool(toolName)
+      setInput((current) => {
+        const before = current.slice(0, mention.start)
+        const after = current.slice(mention.end)
+        return `${before}${after}`
+      })
+      setToolMention(undefined)
+
+      if (!textarea) {
+        return
+      }
+
+      const caretPosition = mention.start
+      requestAnimationFrame(() => {
+        textarea.focus()
+        textarea.setSelectionRange(caretPosition, caretPosition)
+      })
+    },
+    [addSelectedTool, toolMention]
+  )
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const nextText = event.target.value
+      setInput(nextText)
+
+      if (!mentionEnabled) {
+        setToolMention(undefined)
+        return
+      }
+
+      const caret = event.target.selectionStart ?? nextText.length
+      const nextMention = getToolMentionToken(nextText, caret)
+      if (!nextMention) {
+        setToolMention(undefined)
+        return
+      }
+
+      setToolMention((current) => ({
+        ...nextMention,
+        activeIndex: current?.activeIndex ?? 0,
+      }))
+    },
+    [mentionEnabled]
+  )
+
+  const handleInputKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!toolMention) {
+        return
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault()
+        setToolMention(undefined)
+        return
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault()
+        if (filteredToolSuggestions.length === 0) {
+          return
+        }
+        setToolMention((current) => {
+          if (!current) {
+            return current
+          }
+          return {
+            ...current,
+            activeIndex:
+              (current.activeIndex + 1) % filteredToolSuggestions.length,
+          }
+        })
+        return
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault()
+        if (filteredToolSuggestions.length === 0) {
+          return
+        }
+        setToolMention((current) => {
+          if (!current) {
+            return current
+          }
+          const nextIndex =
+            (current.activeIndex - 1 + filteredToolSuggestions.length) %
+            filteredToolSuggestions.length
+          return { ...current, activeIndex: nextIndex }
+        })
+        return
+      }
+
+      if (
+        (event.key === "Enter" || event.key === "Tab") &&
+        filteredToolSuggestions.length > 0
+      ) {
+        event.preventDefault()
+        const selected =
+          filteredToolSuggestions[toolMention.activeIndex] ??
+          filteredToolSuggestions[0]
+        if (selected) {
+          handleSelectMentionTool(selected.value, event.currentTarget)
+        }
+      }
+    },
+    [filteredToolSuggestions, handleSelectMentionTool, toolMention]
+  )
+
+  const selectedToolBadges = useMemo(
+    () =>
+      selectedTools.map((toolName) => {
+        const suggestion = toolSuggestionMap.get(toolName)
+        return {
+          value: toolName,
+          label: suggestion?.label ?? toolName,
+          icon: getIcon(toolName, {
+            className: "size-5 shrink-0",
+          }),
+        }
+      }),
+    [selectedTools, toolSuggestionMap]
+  )
 
   const transformedMessages = useMemo(
     () => transformMessages(messages),
@@ -287,7 +640,6 @@ export function ChatSessionPane({
     const toolNames = lastMessage.parts.filter(isToolUIPart).map(getToolName)
 
     if (toolNames.length > 0) {
-      console.log("Invalidating entity queries for tools:", toolNames)
       invalidateEntityQueries(toolNames)
     }
 
@@ -307,7 +659,7 @@ export function ChatSessionPane({
     const messageText = message.text || ""
 
     if (onBeforeSend) {
-      const result = await onBeforeSend(messageText)
+      const result = await onBeforeSend(messageText, selectedTools)
       // Only clear input if onBeforeSend succeeded (non-null)
       // If null, the action was cancelled and user keeps their draft
       if (result !== null) {
@@ -432,11 +784,101 @@ export function ChatSessionPane({
           <ConversationScrollButton />
         </Conversation>
       </div>
-      <div className="px-4 pb-4">
+      <div className="relative px-2 pb-2">
+        {mentionEnabled && toolMention && (
+          <div className="absolute inset-x-2 bottom-full z-30 mb-2">
+            <div className="overflow-hidden rounded-md border bg-popover shadow-md">
+              {registryActionsIsLoading ? (
+                <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
+                  <Loader2 className="size-3 animate-spin" />
+                  Loading tools...
+                </div>
+              ) : null}
+              {!registryActionsIsLoading &&
+                filteredToolSuggestions.length === 0 && (
+                  <div className="px-3 py-2 text-xs text-muted-foreground">
+                    No tools found for
+                    {` "${toolMention.query}"`}.
+                  </div>
+                )}
+              {!registryActionsIsLoading &&
+                filteredToolSuggestions.length > 0 && (
+                  <div className="max-h-64 overflow-y-auto p-1">
+                    {filteredToolSuggestions.map((tool, index) => {
+                      const isActive = toolMention.activeIndex === index
+                      const isSelected = selectedTools.includes(tool.value)
+
+                      return (
+                        <button
+                          key={tool.value}
+                          type="button"
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={() => handleSelectMentionTool(tool.value)}
+                          className={cn(
+                            "flex w-full items-start justify-between gap-2 rounded-sm px-2 py-2 text-left",
+                            isActive && "bg-accent"
+                          )}
+                        >
+                          <div className="flex min-w-0 items-start gap-2">
+                            {getIcon(tool.value, {
+                              className: "mt-0.5 size-6 shrink-0",
+                            })}
+                            <div className="min-w-0">
+                              <p className="truncate text-xs font-medium text-foreground">
+                                {tool.label}
+                              </p>
+                              <p className="truncate text-[11px] text-muted-foreground">
+                                {tool.value}
+                              </p>
+                            </div>
+                          </div>
+                          {isSelected ? (
+                            <CheckIcon className="mt-0.5 size-3.5 text-muted-foreground" />
+                          ) : null}
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+            </div>
+          </div>
+        )}
         <PromptInput onSubmit={handleSubmit}>
+          {toolsEnabled && selectedToolBadges.length > 0 && (
+            <PromptInputHeader className="gap-1.5 px-2 pt-2">
+              {selectedToolBadges.map((tool) => (
+                <Badge
+                  key={tool.value}
+                  variant="secondary"
+                  className="h-7 gap-1.5 px-2.5 text-xs"
+                >
+                  <span className="inline-flex items-center justify-center text-foreground">
+                    {tool.icon}
+                  </span>
+                  <span className="truncate">{tool.label}</span>
+                  <button
+                    type="button"
+                    className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                    aria-label={`Remove ${tool.label}`}
+                    onClick={() => removeSelectedTool(tool.value)}
+                    disabled={
+                      isUpdatingTools ||
+                      isReadonly ||
+                      inputDisabled ||
+                      !toolsEnabled
+                    }
+                  >
+                    <XIcon className="size-3.5" />
+                  </button>
+                </Badge>
+              ))}
+            </PromptInputHeader>
+          )}
           <PromptInputBody>
             <PromptInputTextarea
-              onChange={(event) => setInput(event.target.value)}
+              onChange={handleInputChange}
+              onKeyDown={handleInputKeyDown}
+              onBlur={() => setToolMention(undefined)}
               placeholder={
                 isReadonly
                   ? "This is a legacy session (read-only)"
@@ -449,47 +891,173 @@ export function ChatSessionPane({
               disabled={isReadonly || inputDisabled || !canSubmit}
             />
           </PromptInputBody>
-          <PromptInputToolbar>
-            {toolsEnabled && !isReadonly && (
-              <PromptInputTools>
-                <TooltipProvider delayDuration={0}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <PromptInputButton
-                        aria-label="Configure tools"
-                        size="sm"
-                        onClick={() => setToolsDialogOpen(true)}
-                        className="h-7 gap-1 px-2"
-                        variant="ghost"
-                        disabled={!!status}
-                      >
-                        <HammerIcon className="size-4" />
-                        <span className="text-xs">Tools</span>
-                      </PromptInputButton>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">
-                      Configure tools for the agent
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </PromptInputTools>
-            )}
+          <PromptInputFooter>
+            <PromptInputTools>
+              {presetSelector && !isReadonly && (
+                <PromptPresetSelector
+                  selector={presetSelector}
+                  disabled={inputDisabled || !canSubmit}
+                />
+              )}
+            </PromptInputTools>
             <PromptInputSubmit
-              disabled={isReadonly || inputDisabled || !canSubmit || !input}
+              disabled={
+                isReadonly || inputDisabled || !canSubmit || !input.trim()
+              }
               status={status}
-              className="ml-auto text-muted-foreground/80"
+              className="text-muted-foreground/80"
             />
-          </PromptInputToolbar>
+          </PromptInputFooter>
         </PromptInput>
-        {chat && toolsEnabled && !isReadonly && (
-          <ChatToolsDialog
-            chatId={chat.id}
-            open={toolsDialogOpen}
-            onOpenChange={setToolsDialogOpen}
-          />
-        )}
       </div>
     </div>
+  )
+}
+
+function PromptPresetSelector({
+  selector,
+  disabled = false,
+}: {
+  selector: ChatPresetSelector
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+
+  const effectiveDisabled = Boolean(disabled || selector.disabled)
+
+  useEffect(() => {
+    if (effectiveDisabled) {
+      setOpen(false)
+    }
+  }, [effectiveDisabled])
+
+  const errorMessage = useMemo(() => {
+    if (typeof selector.presetsError === "string") {
+      return selector.presetsError
+    }
+    if (
+      selector.presetsError &&
+      typeof selector.presetsError === "object" &&
+      "body" in selector.presetsError &&
+      typeof (selector.presetsError as { body?: { detail?: unknown } }).body
+        ?.detail === "string"
+    ) {
+      return (selector.presetsError as { body?: { detail?: string } }).body
+        ?.detail
+    }
+    if (
+      selector.presetsError &&
+      typeof selector.presetsError === "object" &&
+      "message" in selector.presetsError &&
+      typeof (selector.presetsError as { message?: unknown }).message ===
+        "string"
+    ) {
+      return (selector.presetsError as { message: string }).message
+    }
+    return "Failed to load presets"
+  }, [selector.presetsError])
+
+  const noPresetValue = "__workspace_default_preset__"
+
+  const handleSelect = (value: string) => {
+    setOpen(false)
+    void selector.onSelect(value === noPresetValue ? null : value)
+  }
+
+  return (
+    <ModelSelector
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (effectiveDisabled) {
+          return
+        }
+        setOpen(nextOpen)
+      }}
+    >
+      <ModelSelectorTrigger asChild>
+        <PromptInputButton
+          size="sm"
+          variant="ghost"
+          disabled={effectiveDisabled}
+          className="h-7 max-w-[16rem] justify-between gap-1 px-2 text-xs"
+          aria-label="Select preset agent"
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <BoxIcon className="size-3 text-muted-foreground" />
+            <span className="truncate" title={selector.label}>
+              {selector.label}
+            </span>
+          </span>
+          {selector.showSpinner ? (
+            <Loader2 className="size-3 animate-spin text-muted-foreground" />
+          ) : (
+            <ChevronsUpDown className="size-3 text-muted-foreground" />
+          )}
+        </PromptInputButton>
+      </ModelSelectorTrigger>
+      <ModelSelectorContent title="Select preset agent" className="sm:max-w-lg">
+        {selector.presetsIsLoading ? (
+          <div className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
+            <Loader2 className="size-3 animate-spin" />
+            Loading presets...
+          </div>
+        ) : selector.presetsError ? (
+          <div className="p-3 text-xs text-red-600">{errorMessage}</div>
+        ) : (
+          <>
+            <ModelSelectorInput
+              placeholder="Search presets..."
+              className="text-xs"
+            />
+            <ModelSelectorList className="max-h-64 overflow-y-auto">
+              <ModelSelectorEmpty className="py-4 text-xs text-muted-foreground">
+                No presets found.
+              </ModelSelectorEmpty>
+              <ModelSelectorGroup>
+                <ModelSelectorItem
+                  value="no preset"
+                  onSelect={() => handleSelect(noPresetValue)}
+                  className="flex items-start justify-between gap-2 py-2 text-xs"
+                >
+                  <div className="flex flex-col">
+                    <span className="font-medium">No preset</span>
+                    <span className="text-muted-foreground">
+                      {selector.noPresetDescription ??
+                        "Use workspace default agent instructions."}
+                    </span>
+                  </div>
+                  {selector.selectedPresetId === null ? (
+                    <CheckIcon className="mt-0.5 size-3.5" />
+                  ) : null}
+                </ModelSelectorItem>
+                {(selector.presets ?? []).map((preset) => (
+                  <ModelSelectorItem
+                    key={preset.id}
+                    value={`${preset.name} ${preset.description ?? ""}`}
+                    onSelect={() => handleSelect(preset.id)}
+                    className="flex items-start justify-between gap-2 py-2 text-xs"
+                  >
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate font-medium">
+                        {preset.name}
+                      </span>
+                      {preset.description ? (
+                        <span className="text-muted-foreground">
+                          {preset.description}
+                        </span>
+                      ) : null}
+                    </div>
+                    {selector.selectedPresetId === preset.id ? (
+                      <CheckIcon className="mt-0.5 size-3.5" />
+                    ) : null}
+                  </ModelSelectorItem>
+                ))}
+              </ModelSelectorGroup>
+            </ModelSelectorList>
+          </>
+        )}
+      </ModelSelectorContent>
+    </ModelSelector>
   )
 }
 
@@ -575,7 +1143,7 @@ export function MessagePart({
           type={part.type}
           state={derivedState}
           icon={getIcon(toolName, {
-            className: "size-4 p-[3px]",
+            className: "size-5 p-[3px]",
           })}
         />
         <ToolContent>
@@ -693,16 +1261,12 @@ function ApprovalRequestPart({
 
   return (
     <div className="space-y-4">
-      <div>
-        <p className="text-xs font-medium uppercase text-muted-foreground">
-          Approvals required
-        </p>
-      </div>
       <div className="space-y-3">
-        {approvals.map((approval) => {
+        {approvals.map((approval, index) => {
           const actionId = approval.tool_name.replaceAll("__", ".")
           const decision = decisions[approval.tool_call_id]
-          const argsPreview = formatArgs(approval.args)
+          const initialOverrideArgs = formatArgs(approval.args)
+          const isLastApproval = index === approvals.length - 1
           return (
             <div
               key={approval.tool_call_id}
@@ -710,11 +1274,12 @@ function ApprovalRequestPart({
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <div className="flex items-center gap-1">
+                  <div className="flex items-center gap-2.5">
                     {getIcon(actionId, {
-                      className: "size-4 p-[3px]",
+                      className: "size-5 p-[3px]",
                     })}
-                    <p className="text-sm font-semibold">{actionId}</p>
+                    <p className="font-medium text-sm">{actionId}</p>
+                    {getStatusBadge("approval-requested")}
                   </div>
                 </div>
                 <JsonViewWithControls
@@ -725,11 +1290,8 @@ function ApprovalRequestPart({
                 />
                 <div className="flex w-full flex-wrap justify-start gap-1 sm:w-auto [&>button]:h-6 [&>button]:rounded-lg">
                   <Button
-                    type="button"
                     size="sm"
-                    variant={
-                      decision?.action === "approve" ? "default" : "outline"
-                    }
+                    variant="outline"
                     disabled={disabled || submitting}
                     onClick={() =>
                       setDecision(approval.tool_call_id, {
@@ -740,39 +1302,35 @@ function ApprovalRequestPart({
                     }
                     className={cn(
                       decision?.action === "approve" &&
-                        "bg-green-500/80 hover:bg-green-600/80"
+                        "border-success bg-background text-success hover:bg-success/10 hover:text-success"
                     )}
                   >
                     <CheckIcon className="mr-1 size-3" />
                     Approve
                   </Button>
                   <Button
-                    type="button"
                     size="sm"
-                    variant={
-                      decision?.action === "override" ? "default" : "outline"
-                    }
+                    variant="outline"
                     disabled={disabled || submitting}
                     onClick={() =>
                       setDecision(approval.tool_call_id, {
                         action: "override",
                         reason: undefined,
+                        overrideArgs:
+                          decision?.overrideArgs ?? initialOverrideArgs,
                       })
                     }
                     className={cn(
                       decision?.action === "override" &&
-                        "bg-green-500/80 hover:bg-green-600/80"
+                        "border-success bg-background text-success hover:bg-success/10 hover:text-success"
                     )}
                   >
                     <PencilIcon className="mr-1 size-3" />
-                    Approve + change
+                    Edit + approve
                   </Button>
                   <Button
-                    type="button"
                     size="sm"
-                    variant={
-                      decision?.action === "deny" ? "destructive" : "outline"
-                    }
+                    variant="outline"
                     disabled={disabled || submitting}
                     onClick={() =>
                       setDecision(approval.tool_call_id, {
@@ -780,6 +1338,10 @@ function ApprovalRequestPart({
                         overrideArgs: undefined,
                       })
                     }
+                    className={cn(
+                      decision?.action === "deny" &&
+                        "border-destructive bg-background text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    )}
                   >
                     <XIcon className="mr-1 size-3" />
                     Deny
@@ -787,20 +1349,25 @@ function ApprovalRequestPart({
                 </div>
               </div>
               {decision?.action === "override" && (
-                <Textarea
-                  className="text-xs"
-                  rows={4}
-                  spellCheck={false}
-                  value={decision.overrideArgs ?? ""}
-                  onChange={(event) =>
-                    setDecision(approval.tool_call_id, {
-                      ...decision,
-                      overrideArgs: event.target.value,
-                    })
-                  }
-                  placeholder={argsPreview}
-                  disabled={disabled || submitting}
-                />
+                <div
+                  data-testid={`approval-override-editor-${approval.tool_call_id}`}
+                >
+                  <CodeEditor
+                    value={decision.overrideArgs ?? initialOverrideArgs}
+                    language="json"
+                    onChange={(value) =>
+                      setDecision(approval.tool_call_id, {
+                        ...decision,
+                        overrideArgs: value,
+                      })
+                    }
+                    className={cn(
+                      "text-xs",
+                      "[&_.cm-editor]:!border [&_.cm-editor]:!border-input [&_.cm-editor]:!bg-background [&_.cm-editor]:rounded-md",
+                      "[&_.cm-scroller]:h-auto [&_.cm-scroller]:min-h-24 [&_.cm-scroller]:max-h-80 [&_.cm-scroller]:overflow-auto"
+                    )}
+                  />
+                </div>
               )}
               {decision?.action === "deny" && (
                 <Textarea
@@ -817,28 +1384,25 @@ function ApprovalRequestPart({
                   disabled={disabled || submitting}
                 />
               )}
+              {isLastApproval && (
+                <div className="flex flex-wrap justify-end gap-2 pt-1">
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={disabled || submitting || !readyToSubmit}
+                    className="h-6 gap-1 px-2 text-xs"
+                  >
+                    {submitting ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                      <CheckIcon className="size-3" />
+                    )}
+                    {submitting ? "Submitting..." : "Submit"}
+                  </Button>
+                </div>
+              )}
             </div>
           )
         })}
-      </div>
-      <div className="flex flex-wrap justify-end gap-2">
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={submitting}
-          onClick={() => setDecisions({})}
-          className="h-7 px-2 text-muted-foreground/80"
-        >
-          Reset
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSubmit}
-          disabled={disabled || submitting || !readyToSubmit}
-          className="h-7 px-2"
-        >
-          {submitting ? "Submitting..." : "Submit"}
-        </Button>
       </div>
       {disabled && (
         <p className="text-xs text-muted-foreground">

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -677,6 +677,7 @@ export function ChatSessionPane({
     setInput("")
 
     try {
+      await persistToolsChainRef.current.catch(() => undefined)
       clearError()
       sendMessage({
         text: messageText,

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -11,10 +11,10 @@ import {
   type UITools,
 } from "ai"
 import {
-  BoxIcon,
   CheckIcon,
-  ChevronsUpDown,
   Loader2,
+  MousePointer2OffIcon,
+  MousePointerClickIcon,
   PencilIcon,
   RefreshCcwIcon,
   XIcon,
@@ -773,6 +773,7 @@ export function ChatSessionPane({
             })}
             {isWaitingForResponse && (
               <motion.div
+                className="mt-3"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
@@ -785,9 +786,9 @@ export function ChatSessionPane({
           <ConversationScrollButton />
         </Conversation>
       </div>
-      <div className="relative px-2 pb-2">
+      <div className="relative px-3 pb-3">
         {mentionEnabled && toolMention && (
-          <div className="absolute inset-x-2 bottom-full z-30 mb-2">
+          <div className="absolute inset-x-3 bottom-full z-30 mb-2">
             <div className="overflow-hidden rounded-md border bg-popover shadow-md">
               {registryActionsIsLoading ? (
                 <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
@@ -846,7 +847,7 @@ export function ChatSessionPane({
         )}
         <PromptInput onSubmit={handleSubmit}>
           {toolsEnabled && selectedToolBadges.length > 0 && (
-            <PromptInputHeader className="gap-1.5 px-2 pt-2">
+            <PromptInputHeader className="gap-1.5 px-3 pt-3">
               {selectedToolBadges.map((tool) => (
                 <Badge
                   key={tool.value}
@@ -964,6 +965,10 @@ function PromptPresetSelector({
     setOpen(false)
     void selector.onSelect(value === noPresetValue ? null : value)
   }
+  const PresetIcon =
+    selector.selectedPresetId === null
+      ? MousePointer2OffIcon
+      : MousePointerClickIcon
 
   return (
     <ModelSelector
@@ -980,20 +985,20 @@ function PromptPresetSelector({
           size="sm"
           variant="ghost"
           disabled={effectiveDisabled}
-          className="h-7 max-w-[16rem] justify-between gap-1 px-2 text-xs"
+          className="h-7 max-w-[16rem] justify-start gap-1.5 px-2 text-xs"
           aria-label="Select preset agent"
         >
           <span className="flex min-w-0 items-center gap-1.5">
-            <BoxIcon className="size-3 text-muted-foreground" />
+            <PresetIcon className="size-3 text-muted-foreground" />
             <span className="truncate" title={selector.label}>
               {selector.label}
             </span>
           </span>
           {selector.showSpinner ? (
-            <Loader2 className="size-3 animate-spin text-muted-foreground" />
-          ) : (
-            <ChevronsUpDown className="size-3 text-muted-foreground" />
-          )}
+            <span className="ml-auto inline-flex items-center">
+              <Loader2 className="size-3 animate-spin text-muted-foreground" />
+            </span>
+          ) : null}
         </PromptInputButton>
       </ModelSelectorTrigger>
       <ModelSelectorContent title="Select preset agent" className="sm:max-w-lg">

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -128,6 +128,13 @@ type ToolSuggestion = {
   group?: string
 }
 
+function areToolListsEqual(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((tool, index) => tool === right[index])
+  )
+}
+
 function getToolMentionToken(
   text: string,
   caret: number
@@ -352,9 +359,41 @@ export function ChatSessionPane({
   )
 
   const persistToolsChainRef = useRef<Promise<void>>(Promise.resolve())
+  const selectedToolsRef = useRef<string[]>([])
+  const pendingPersistedToolsRef = useRef<string[] | null>(null)
+  const syncedChatIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    setSelectedTools(chat?.tools ?? [])
+    selectedToolsRef.current = selectedTools
+  }, [selectedTools])
+
+  useEffect(() => {
+    const nextChatId = chat?.id
+    const nextTools = chat?.tools ?? []
+
+    if (syncedChatIdRef.current !== nextChatId) {
+      syncedChatIdRef.current = nextChatId
+      pendingPersistedToolsRef.current = null
+      selectedToolsRef.current = nextTools
+      setSelectedTools(nextTools)
+      return
+    }
+
+    const pendingTools = pendingPersistedToolsRef.current
+    if (pendingTools) {
+      if (areToolListsEqual(nextTools, pendingTools)) {
+        pendingPersistedToolsRef.current = null
+      } else {
+        // Keep the optimistic selection visible until the invalidated chat query
+        // catches up, otherwise intermediate server echoes can flicker chips away.
+        return
+      }
+    }
+
+    if (!areToolListsEqual(selectedToolsRef.current, nextTools)) {
+      selectedToolsRef.current = nextTools
+      setSelectedTools(nextTools)
+    }
   }, [chat?.id, chat?.tools])
 
   const queuePersistTools = useCallback(
@@ -373,6 +412,12 @@ export function ChatSessionPane({
               update: { tools },
             })
           } catch (error) {
+            if (
+              pendingPersistedToolsRef.current &&
+              areToolListsEqual(pendingPersistedToolsRef.current, tools)
+            ) {
+              pendingPersistedToolsRef.current = null
+            }
             toast({
               title: "Failed to update tools",
               description: parseChatError(error),
@@ -384,30 +429,44 @@ export function ChatSessionPane({
     [chat, isReadonly, updateChat]
   )
 
+  const commitSelectedTools = useCallback(
+    (next: string[]) => {
+      if (areToolListsEqual(selectedToolsRef.current, next)) {
+        return
+      }
+
+      selectedToolsRef.current = next
+      setSelectedTools(next)
+
+      if (!chat || isReadonly) {
+        pendingPersistedToolsRef.current = null
+        return
+      }
+
+      pendingPersistedToolsRef.current = next
+      void queuePersistTools(next)
+    },
+    [chat, isReadonly, queuePersistTools]
+  )
+
   const addSelectedTool = useCallback(
     (toolName: string) => {
-      setSelectedTools((current) => {
-        if (current.includes(toolName)) {
-          return current
-        }
+      if (selectedToolsRef.current.includes(toolName)) {
+        return
+      }
 
-        const next = [...current, toolName]
-        queuePersistTools(next)
-        return next
-      })
+      commitSelectedTools([...selectedToolsRef.current, toolName])
     },
-    [queuePersistTools]
+    [commitSelectedTools]
   )
 
   const removeSelectedTool = useCallback(
     (toolName: string) => {
-      setSelectedTools((current) => {
-        const next = current.filter((tool) => tool !== toolName)
-        queuePersistTools(next)
-        return next
-      })
+      commitSelectedTools(
+        selectedToolsRef.current.filter((tool) => tool !== toolName)
+      )
     },
-    [queuePersistTools]
+    [commitSelectedTools]
   )
 
   const mentionEnabled =
@@ -749,6 +808,7 @@ export function ChatSessionPane({
                       // Render response actions for assistant messages and reveal them on hover for older messages.
                       <Actions
                         className={cn(
+                          "mt-4",
                           // Apply a smooth transition so the actions fade in and out gracefully.
                           "transition-opacity duration-200 ease-out",
                           // Hide actions by default for non-last messages and reveal them when the message group is hovered.
@@ -773,7 +833,7 @@ export function ChatSessionPane({
             })}
             {isWaitingForResponse && (
               <motion.div
-                className="mt-3"
+                className="mt-5"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}

--- a/frontend/src/components/ui/input-group.tsx
+++ b/frontend/src/components/ui/input-group.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import { cva, type VariantProps } from "class-variance-authority"
+import type * as React from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group border-input dark:bg-input/30 shadow-xs relative flex w-full items-center rounded-md border outline-none transition-[color,box-shadow]",
+        "h-9 has-[>textarea]:h-auto",
+
+        // Variants based on alignment.
+        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
+        "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
+
+        // Error state.
+        "has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
+
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "text-muted-foreground flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+        "inline-end":
+          "order-last pr-3 has-[>button]:mr-[-0.4rem] has-[>kbd]:mr-[-0.35rem]",
+        "block-start":
+          "[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5",
+        "block-end":
+          "[.border-t]:pt-3 order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        const control = e.currentTarget.parentElement?.querySelector<
+          HTMLInputElement | HTMLTextAreaElement
+        >("input, textarea")
+        control?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "text-muted-foreground flex items-center gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/frontend/src/components/ui/spinner.tsx
+++ b/frontend/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  )
+}
+
+export { Spinner }

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -32,6 +32,37 @@ import { type ModelInfo, toServerUIMessage } from "@/lib/chat"
 const DEFAULT_CHAT_ERROR_MESSAGE =
   "The assistant couldn't complete that request. Please try again."
 
+type UpdateableChatRecord =
+  | AgentSessionsGetSessionResponse
+  | AgentSessionsGetSessionVercelResponse
+  | AgentSessionsListSessionsResponse[number]
+
+type UpdateChatContext = {
+  previousChat?: AgentSessionsGetSessionResponse
+  previousChatVercel?: AgentSessionsGetSessionVercelResponse
+  previousChatLists: Array<
+    [readonly unknown[], AgentSessionsListSessionsResponse | undefined]
+  >
+}
+
+function applyOptimisticChatUpdate<T extends UpdateableChatRecord>(
+  chat: T,
+  update: AgentSessionUpdate
+): T {
+  return {
+    ...chat,
+    updated_at: new Date().toISOString(),
+    ...(typeof update.title === "string" ? { title: update.title } : {}),
+    ...(update.tools !== undefined ? { tools: update.tools ?? [] } : {}),
+    ...(update.agent_preset_id !== undefined
+      ? { agent_preset_id: update.agent_preset_id }
+      : {}),
+    ...("harness_type" in chat && update.harness_type !== undefined
+      ? { harness_type: update.harness_type }
+      : {}),
+  }
+}
+
 export function parseChatError(error: unknown): string {
   if (!error) {
     return DEFAULT_CHAT_ERROR_MESSAGE
@@ -176,7 +207,8 @@ export function useUpdateChat(workspaceId: string) {
   const mutation = useMutation<
     AgentSessionRead,
     ApiError,
-    { chatId: string; update: AgentSessionUpdate }
+    { chatId: string; update: AgentSessionUpdate },
+    UpdateChatContext
   >({
     mutationFn: ({ chatId, update }) =>
       agentSessionsUpdateSession({
@@ -184,7 +216,84 @@ export function useUpdateChat(workspaceId: string) {
         workspaceId,
         requestBody: update,
       }),
-    onSuccess: (_, variables) => {
+    onMutate: async ({ chatId, update }) => {
+      await Promise.all([
+        queryClient.cancelQueries({
+          queryKey: ["chat", chatId, workspaceId],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ["chat", chatId, workspaceId, "vercel"],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ["chats", workspaceId],
+        }),
+      ])
+
+      const previousChat =
+        queryClient.getQueryData<AgentSessionsGetSessionResponse>([
+          "chat",
+          chatId,
+          workspaceId,
+        ])
+      const previousChatVercel =
+        queryClient.getQueryData<AgentSessionsGetSessionVercelResponse>([
+          "chat",
+          chatId,
+          workspaceId,
+          "vercel",
+        ])
+      const previousChatLists =
+        queryClient.getQueriesData<AgentSessionsListSessionsResponse>({
+          queryKey: ["chats", workspaceId],
+        })
+
+      queryClient.setQueryData<AgentSessionsGetSessionResponse>(
+        ["chat", chatId, workspaceId],
+        (current) =>
+          current ? applyOptimisticChatUpdate(current, update) : current
+      )
+      queryClient.setQueryData<AgentSessionsGetSessionVercelResponse>(
+        ["chat", chatId, workspaceId, "vercel"],
+        (current) =>
+          current ? applyOptimisticChatUpdate(current, update) : current
+      )
+
+      for (const [queryKey] of previousChatLists) {
+        queryClient.setQueryData<AgentSessionsListSessionsResponse>(
+          queryKey,
+          (current) =>
+            current?.map((chatRecord) =>
+              chatRecord.id === chatId
+                ? applyOptimisticChatUpdate(chatRecord, update)
+                : chatRecord
+            ) ?? current
+        )
+      }
+
+      return {
+        previousChat,
+        previousChatVercel,
+        previousChatLists,
+      }
+    },
+    onError: (_, variables, context) => {
+      if (!context) {
+        return
+      }
+
+      queryClient.setQueryData(
+        ["chat", variables.chatId, workspaceId],
+        context.previousChat
+      )
+      queryClient.setQueryData(
+        ["chat", variables.chatId, workspaceId, "vercel"],
+        context.previousChatVercel
+      )
+      for (const [queryKey, previousData] of context.previousChatLists) {
+        queryClient.setQueryData(queryKey, previousData)
+      }
+    },
+    onSettled: (_, __, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["chat", variables.chatId, workspaceId],
       })

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -393,10 +393,5 @@ export function transformMessages(messages: ai.UIMessage[]): ai.UIMessage[] {
       finalMessages.push({ ...message, parts: newParts })
     }
   }
-  console.log({
-    states,
-    ignorePos,
-    finalMessages,
-  })
   return finalMessages
 }

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -449,4 +449,78 @@ describe("ChatSessionPane", () => {
 
     secondWrite.resolve()
   })
+
+  it("waits for pending tool persistence before sending a message", async () => {
+    const action = {
+      id: "action-1",
+      name: "core.cases.list_cases",
+      action: "core.cases.list_cases",
+      default_title: "List cases",
+      description: "List all cases",
+      namespace: "core.cases",
+      type: "template" as const,
+      origin: "tracecat://test",
+    }
+    mockUseBuilderRegistryActions.mockReturnValue({
+      registryActions: [action],
+      registryActionsIsLoading: false,
+      registryActionsError: null,
+      getRegistryAction: (key: string) =>
+        key === action.action ? action : undefined,
+    })
+
+    const toolWrite = createDeferred<void>()
+    const updateChat = jest.fn().mockImplementation(() => toolWrite.promise)
+    mockUseUpdateChat.mockReturnValue({
+      updateChat,
+      isUpdating: false,
+      updateError: null,
+    })
+
+    const sendMessage = jest.fn().mockResolvedValue(undefined)
+    mockUseVercelChat.mockReturnValue({
+      sendMessage,
+      regenerate: jest.fn(),
+      messages: [],
+      status: "ready",
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+            toolsEnabled
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const textarea = screen.getByRole("textbox")
+
+    fireEvent.change(textarea, { target: { value: "@li" } })
+    await screen.findByText("List cases")
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(updateChat).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(textarea, { target: { value: "hello" } })
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    expect(sendMessage).not.toHaveBeenCalled()
+
+    toolWrite.resolve()
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({ text: "hello" })
+    })
+  })
 })

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -2,12 +2,65 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import type { AgentSessionReadVercel } from "@/client"
 import { ChatSessionPane } from "@/components/chat/chat-session-pane"
-import { useVercelChat } from "@/hooks/use-chat"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { useUpdateChat, useVercelChat } from "@/hooks/use-chat"
+import { useBuilderRegistryActions } from "@/lib/hooks"
 
 jest.mock("@/hooks/use-chat", () => ({
   useVercelChat: jest.fn(),
   useGetChat: jest.fn(() => ({ chat: null })),
   useUpdateChat: jest.fn(() => ({ updateChat: jest.fn(), isUpdating: false })),
+  parseChatError: (error: unknown) =>
+    error instanceof Error ? error.message : "Chat error",
+  makeContinueMessage: (decisions: unknown) => ({
+    id: "continue-test",
+    role: "user",
+    parts: [
+      {
+        type: "data-continue",
+        data: { format: "continue", decisions },
+      },
+    ],
+  }),
+}))
+jest.mock("@/lib/hooks", () => ({
+  useBuilderRegistryActions: jest.fn(() => ({
+    registryActions: [],
+    registryActionsIsLoading: false,
+  })),
+}))
+jest.mock("@/components/ai-elements/code-block", () => ({
+  CodeBlock: ({
+    children,
+    code,
+  }: {
+    children?: React.ReactNode
+    code: string
+  }) => (
+    <div data-testid="mock-code-block">
+      {children}
+      <pre>{code}</pre>
+    </div>
+  ),
+  CodeBlockCopyButton: () => null,
+}))
+jest.mock("@/components/editor/codemirror/code-editor", () => ({
+  CodeEditor: ({
+    value,
+    onChange,
+    className,
+  }: {
+    value: string
+    onChange?: (value: string) => void
+    className?: string
+  }) => (
+    <textarea
+      data-testid="mock-code-editor"
+      className={className}
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
 }))
 jest.mock("@/providers/workspace-id", () => ({
   useWorkspaceId: () => "workspace-1",
@@ -16,6 +69,23 @@ jest.mock("@/providers/workspace-id", () => ({
 const mockUseVercelChat = useVercelChat as jest.MockedFunction<
   typeof useVercelChat
 >
+const mockUseUpdateChat = useUpdateChat as jest.MockedFunction<
+  typeof useUpdateChat
+>
+const mockUseBuilderRegistryActions =
+  useBuilderRegistryActions as jest.MockedFunction<
+    typeof useBuilderRegistryActions
+  >
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
 
 const createChatFixture = (
   overrides?: Partial<AgentSessionReadVercel>
@@ -42,6 +112,17 @@ describe("ChatSessionPane", () => {
 
   beforeEach(() => {
     jest.spyOn(console, "error").mockImplementation(() => undefined)
+    mockUseUpdateChat.mockReturnValue({
+      updateChat: jest.fn().mockResolvedValue(undefined),
+      isUpdating: false,
+      updateError: null,
+    })
+    mockUseBuilderRegistryActions.mockReturnValue({
+      registryActions: [],
+      registryActionsIsLoading: false,
+      registryActionsError: null,
+      getRegistryAction: () => undefined,
+    })
     queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -72,13 +153,15 @@ describe("ChatSessionPane", () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <ChatSessionPane
-          chat={createChatFixture()}
-          workspaceId="workspace-1"
-          entityType="case"
-          entityId="case-1"
-          modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
-        />
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
       </QueryClientProvider>
     )
 
@@ -113,16 +196,257 @@ describe("ChatSessionPane", () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <ChatSessionPane
-          chat={createChatFixture()}
-          workspaceId="workspace-1"
-          entityType="case"
-          entityId="case-1"
-          modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
-        />
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
       </QueryClientProvider>
     )
 
     expect(screen.getByTestId("dots-loader")).toBeInTheDocument()
+  })
+
+  it("submits approval decisions with continue payload", async () => {
+    const sendMessage = jest.fn().mockResolvedValue(undefined)
+    const clearError = jest.fn()
+
+    mockUseVercelChat.mockReturnValue({
+      sendMessage,
+      regenerate: jest.fn(),
+      messages: [
+        {
+          id: "msg-approval",
+          role: "assistant",
+          parts: [
+            {
+              type: "data-approval-request",
+              data: [
+                {
+                  tool_call_id: "tc-1",
+                  tool_name: "core__cases__list_cases",
+                  args: { limit: 100 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      status: "ready",
+      lastError: null,
+      clearError,
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByText("core.cases.list_cases")).toBeInTheDocument()
+    expect(screen.getByText("Approval required")).toBeInTheDocument()
+    const approvalSubmit = screen
+      .getAllByRole("button", { name: "Submit" })
+      .find((button) => button.textContent?.trim() === "Submit")
+    if (!approvalSubmit) {
+      throw new Error("Approval submit button not found")
+    }
+    expect(approvalSubmit).toBeDisabled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit + approve" }))
+    const overrideEditor = screen.getByTestId("mock-code-editor")
+    expect((overrideEditor as HTMLTextAreaElement).value).toContain(
+      '"limit": 100'
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }))
+    expect(approvalSubmit).toBeEnabled()
+
+    fireEvent.click(approvalSubmit)
+
+    await waitFor(() => {
+      expect(clearError).toHaveBeenCalled()
+    })
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "user",
+        parts: [
+          expect.objectContaining({
+            type: "data-continue",
+            data: expect.objectContaining({
+              format: "continue",
+              decisions: [
+                expect.objectContaining({
+                  tool_call_id: "tc-1",
+                  action: "approve",
+                }),
+              ],
+            }),
+          }),
+        ],
+      })
+    )
+  })
+
+  it("supports @ mention tools in draft mode and passes selected tools before first send", async () => {
+    const onBeforeSend = jest.fn().mockResolvedValue("chat-2")
+    const action = {
+      id: "action-1",
+      name: "core.cases.list_cases",
+      action: "core.cases.list_cases",
+      default_title: "List cases",
+      description: "List all cases",
+      namespace: "core.cases",
+      type: "template" as const,
+      origin: "tracecat://test",
+    }
+    mockUseBuilderRegistryActions.mockReturnValue({
+      registryActions: [action],
+      registryActionsIsLoading: false,
+      registryActionsError: null,
+      getRegistryAction: (key: string) =>
+        key === action.action ? action : undefined,
+    })
+
+    mockUseVercelChat.mockReturnValue({
+      sendMessage: jest.fn(),
+      regenerate: jest.fn(),
+      messages: [],
+      status: "ready",
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+            toolsEnabled
+            onBeforeSend={onBeforeSend}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const textarea = screen.getByRole("textbox")
+    fireEvent.change(textarea, { target: { value: "@li" } })
+
+    await screen.findByText("List cases")
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    expect(
+      screen.getByRole("button", { name: /remove list cases/i })
+    ).toBeInTheDocument()
+
+    fireEvent.change(textarea, { target: { value: "hello" } })
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(onBeforeSend).toHaveBeenCalledWith("hello", [
+        "core.cases.list_cases",
+      ])
+    })
+  })
+
+  it("serializes tool persistence updates to avoid stale writes", async () => {
+    const action = {
+      id: "action-1",
+      name: "core.cases.list_cases",
+      action: "core.cases.list_cases",
+      default_title: "List cases",
+      description: "List all cases",
+      namespace: "core.cases",
+      type: "template" as const,
+      origin: "tracecat://test",
+    }
+    mockUseBuilderRegistryActions.mockReturnValue({
+      registryActions: [action],
+      registryActionsIsLoading: false,
+      registryActionsError: null,
+      getRegistryAction: (key: string) =>
+        key === action.action ? action : undefined,
+    })
+
+    const firstWrite = createDeferred<void>()
+    const secondWrite = createDeferred<void>()
+    const updateChat = jest
+      .fn()
+      .mockImplementationOnce(() => firstWrite.promise)
+      .mockImplementationOnce(() => secondWrite.promise)
+    mockUseUpdateChat.mockReturnValue({
+      updateChat,
+      isUpdating: false,
+      updateError: null,
+    })
+
+    mockUseVercelChat.mockReturnValue({
+      sendMessage: jest.fn(),
+      regenerate: jest.fn(),
+      messages: [],
+      status: "ready",
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+            toolsEnabled
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const textarea = screen.getByRole("textbox")
+    fireEvent.change(textarea, { target: { value: "@li" } })
+    await screen.findByText("List cases")
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(updateChat).toHaveBeenCalledTimes(1)
+    })
+    expect(updateChat).toHaveBeenNthCalledWith(1, {
+      chatId: "chat-1",
+      update: { tools: ["core.cases.list_cases"] },
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /remove list cases/i }))
+    expect(updateChat).toHaveBeenCalledTimes(1)
+
+    firstWrite.resolve()
+    await waitFor(() => {
+      expect(updateChat).toHaveBeenCalledTimes(2)
+    })
+    expect(updateChat).toHaveBeenNthCalledWith(2, {
+      chatId: "chat-1",
+      update: { tools: [] },
+    })
+
+    secondWrite.resolve()
   })
 })

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { StrictMode } from "react"
 import type { AgentSessionReadVercel } from "@/client"
 import { ChatSessionPane } from "@/components/chat/chat-session-pane"
 import { TooltipProvider } from "@/components/ui/tooltip"
@@ -522,5 +523,212 @@ describe("ChatSessionPane", () => {
     await waitFor(() => {
       expect(sendMessage).toHaveBeenCalledWith({ text: "hello" })
     })
+  })
+
+  it("does not persist tool selection twice in StrictMode", async () => {
+    const action = {
+      id: "action-1",
+      name: "core.cases.list_cases",
+      action: "core.cases.list_cases",
+      default_title: "List cases",
+      description: "List all cases",
+      namespace: "core.cases",
+      type: "template" as const,
+      origin: "tracecat://test",
+    }
+    mockUseBuilderRegistryActions.mockReturnValue({
+      registryActions: [action],
+      registryActionsIsLoading: false,
+      registryActionsError: null,
+      getRegistryAction: (key: string) =>
+        key === action.action ? action : undefined,
+    })
+
+    const updateChat = jest.fn().mockResolvedValue(undefined)
+    mockUseUpdateChat.mockReturnValue({
+      updateChat,
+      isUpdating: false,
+      updateError: null,
+    })
+
+    mockUseVercelChat.mockReturnValue({
+      sendMessage: jest.fn(),
+      regenerate: jest.fn(),
+      messages: [],
+      status: "ready",
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    render(
+      <StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <ChatSessionPane
+              chat={createChatFixture()}
+              workspaceId="workspace-1"
+              entityType="case"
+              entityId="case-1"
+              modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+              toolsEnabled
+            />
+          </TooltipProvider>
+        </QueryClientProvider>
+      </StrictMode>
+    )
+
+    const textarea = screen.getByRole("textbox")
+    fireEvent.change(textarea, { target: { value: "@li" } })
+    await screen.findByText("List cases")
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(updateChat).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("keeps optimistic tool chips while queued persistence catches up", async () => {
+    const listCases = {
+      id: "action-1",
+      name: "core.cases.list_cases",
+      action: "core.cases.list_cases",
+      default_title: "List cases",
+      description: "List all cases",
+      namespace: "core.cases",
+      type: "template" as const,
+      origin: "tracecat://test",
+    }
+    const getCase = {
+      id: "action-2",
+      name: "core.cases.get_case",
+      action: "core.cases.get_case",
+      default_title: "Get case",
+      description: "Get a case",
+      namespace: "core.cases",
+      type: "template" as const,
+      origin: "tracecat://test",
+    }
+    mockUseBuilderRegistryActions.mockReturnValue({
+      registryActions: [listCases, getCase],
+      registryActionsIsLoading: false,
+      registryActionsError: null,
+      getRegistryAction: (key: string) =>
+        key === listCases.action
+          ? listCases
+          : key === getCase.action
+            ? getCase
+            : undefined,
+    })
+
+    const firstWrite = createDeferred<void>()
+    const secondWrite = createDeferred<void>()
+    const updateChat = jest
+      .fn()
+      .mockImplementationOnce(() => firstWrite.promise)
+      .mockImplementationOnce(() => secondWrite.promise)
+    mockUseUpdateChat.mockReturnValue({
+      updateChat,
+      isUpdating: false,
+      updateError: null,
+    })
+
+    mockUseVercelChat.mockReturnValue({
+      sendMessage: jest.fn(),
+      regenerate: jest.fn(),
+      messages: [],
+      status: "ready",
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+            toolsEnabled
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const textarea = screen.getByRole("textbox")
+    fireEvent.change(textarea, { target: { value: "@li" } })
+    await screen.findByText("List cases")
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(updateChat).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(textarea, { target: { value: "@ge" } })
+    await screen.findByText("Get case")
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    expect(
+      screen.getByRole("button", { name: /remove list cases/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /remove get case/i })
+    ).toBeInTheDocument()
+    expect(updateChat).toHaveBeenCalledTimes(1)
+
+    firstWrite.resolve()
+    await waitFor(() => {
+      expect(updateChat).toHaveBeenCalledTimes(2)
+    })
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture({ tools: ["core.cases.list_cases"] })}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+            toolsEnabled
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    expect(
+      screen.getByRole("button", { name: /remove list cases/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /remove get case/i })
+    ).toBeInTheDocument()
+
+    secondWrite.resolve()
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture({
+              tools: ["core.cases.list_cases", "core.cases.get_case"],
+            })}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+            toolsEnabled
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    expect(
+      screen.getByRole("button", { name: /remove list cases/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /remove get case/i })
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/tests/code-block-cache-key.test.ts
+++ b/frontend/tests/code-block-cache-key.test.ts
@@ -1,0 +1,21 @@
+import { getTokensCacheKey } from "@/components/ai-elements/code-block-cache"
+
+describe("getTokensCacheKey", () => {
+  it("does not collide for snippets that only differ in the middle", () => {
+    const prefix = "import x from 'pkg'\n".repeat(8)
+    const suffix = "\nexport default value\n".repeat(8)
+
+    const middleA = "A".repeat(200)
+    const middleB = "B".repeat(200)
+
+    const codeA = `${prefix}${middleA}${suffix}`
+    const codeB = `${prefix}${middleB}${suffix}`
+
+    expect(codeA.length).toBe(codeB.length)
+
+    const keyA = getTokensCacheKey(codeA, "javascript")
+    const keyB = getTokensCacheKey(codeB, "javascript")
+
+    expect(keyA).not.toBe(keyB)
+  })
+})

--- a/frontend/tests/code-block-highlight.test.ts
+++ b/frontend/tests/code-block-highlight.test.ts
@@ -1,0 +1,53 @@
+const codeToTokensMock = jest.fn(() => ({
+  bg: "transparent",
+  fg: "inherit",
+  tokens: [[{ content: "x", color: "#fff" }]],
+}))
+
+jest.mock("shiki", () => ({
+  createHighlighter: jest.fn(async () => ({
+    getLoadedLanguages: () => ["javascript"],
+    codeToTokens: codeToTokensMock,
+  })),
+}))
+
+import { highlightCode } from "@/components/ai-elements/code-block"
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("highlightCode", () => {
+  beforeEach(() => {
+    codeToTokensMock.mockClear()
+  })
+
+  it("dedupes in-flight tokenization for identical inputs", async () => {
+    const cb1 = jest.fn()
+    const cb2 = jest.fn()
+
+    expect(highlightCode("const a = 1", "javascript", cb1)).toBeNull()
+    expect(highlightCode("const a = 1", "javascript", cb2)).toBeNull()
+
+    await flushMicrotasks()
+
+    expect(codeToTokensMock).toHaveBeenCalledTimes(1)
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+  })
+
+  it("evicts old entries once cache exceeds max size", async () => {
+    for (let idx = 0; idx <= 500; idx += 1) {
+      highlightCode(`const value = ${idx}`, "javascript")
+    }
+
+    await flushMicrotasks()
+
+    const beforeRecall = codeToTokensMock.mock.calls.length
+    expect(highlightCode("const value = 0", "javascript")).toBeNull()
+    await flushMicrotasks()
+
+    expect(codeToTokensMock.mock.calls.length).toBeGreaterThan(beforeRecall)
+  })
+})

--- a/frontend/tests/input-group.test.tsx
+++ b/frontend/tests/input-group.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupTextarea,
+} from "@/components/ui/input-group"
+
+describe("InputGroupAddon", () => {
+  it("focuses textarea controls when clicked", () => {
+    render(
+      <InputGroup>
+        <InputGroupAddon data-testid="addon">Attach</InputGroupAddon>
+        <InputGroupTextarea data-testid="textarea" />
+      </InputGroup>
+    )
+
+    const addon = screen.getByTestId("addon")
+    const textarea = screen.getByTestId("textarea")
+
+    expect(textarea).not.toHaveFocus()
+    fireEvent.click(addon)
+    expect(textarea).toHaveFocus()
+  })
+})

--- a/frontend/tests/prompt-input.test.tsx
+++ b/frontend/tests/prompt-input.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from "@/components/ai-elements/prompt-input"
+
+describe("PromptInput", () => {
+  it("keeps local input text when async submit fails", async () => {
+    const onSubmit = jest.fn().mockRejectedValue(new Error("submit failed"))
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+        <PromptInputFooter>
+          <PromptInputSubmit status="ready" />
+        </PromptInputFooter>
+      </PromptInput>
+    )
+
+    const textarea = screen.getByRole("textbox")
+    fireEvent.change(textarea, { target: { value: "retry this" } })
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    expect(textarea).toHaveValue("retry this")
+  })
+})

--- a/frontend/tests/prompt-input.test.tsx
+++ b/frontend/tests/prompt-input.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { FormEvent } from "react"
 import {
   PromptInput,
   PromptInputBody,
@@ -8,6 +9,24 @@ import {
 } from "@/components/ai-elements/prompt-input"
 
 describe("PromptInput", () => {
+  beforeEach(() => {
+    const originalError = console.error
+    jest.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      const message = args[0]
+      if (
+        typeof message === "string" &&
+        message.includes("validateDOMNesting")
+      ) {
+        return
+      }
+      originalError(...args)
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it("keeps local input text when async submit fails", async () => {
     const onSubmit = jest.fn().mockRejectedValue(new Error("submit failed"))
 
@@ -31,5 +50,67 @@ describe("PromptInput", () => {
     })
 
     expect(textarea).toHaveValue("retry this")
+  })
+
+  it("submits prompt input inside agent settings forms without triggering outer form submit", async () => {
+    const promptSubmit = jest.fn().mockResolvedValue(undefined)
+    const outerSubmit = jest.fn((event: FormEvent<HTMLFormElement>) =>
+      event.preventDefault()
+    )
+
+    render(
+      <form onSubmit={outerSubmit}>
+        <PromptInput onSubmit={promptSubmit}>
+          <PromptInputBody>
+            <PromptInputTextarea />
+          </PromptInputBody>
+          <PromptInputFooter>
+            <PromptInputSubmit status="ready" />
+          </PromptInputFooter>
+        </PromptInput>
+      </form>
+    )
+
+    const textarea = screen.getByRole("textbox")
+    fireEvent.change(textarea, { target: { value: "send from agents" } })
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" })
+
+    await waitFor(() => {
+      expect(promptSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(outerSubmit).not.toHaveBeenCalled()
+  })
+
+  it("treats Cmd/Ctrl+Enter as prompt submit without outer form navigation", async () => {
+    const promptSubmit = jest.fn().mockResolvedValue(undefined)
+    const outerSubmit = jest.fn((event: FormEvent<HTMLFormElement>) =>
+      event.preventDefault()
+    )
+
+    render(
+      <form onSubmit={outerSubmit}>
+        <PromptInput onSubmit={promptSubmit}>
+          <PromptInputBody>
+            <PromptInputTextarea />
+          </PromptInputBody>
+          <PromptInputFooter>
+            <PromptInputSubmit status="ready" />
+          </PromptInputFooter>
+        </PromptInput>
+      </form>
+    )
+
+    const textarea = screen.getByRole("textbox")
+    fireEvent.change(textarea, { target: { value: "cmd enter" } })
+    fireEvent.keyDown(textarea, {
+      code: "Enter",
+      key: "Enter",
+      metaKey: true,
+    })
+
+    await waitFor(() => {
+      expect(promptSubmit).toHaveBeenCalledTimes(1)
+    })
+    expect(outerSubmit).not.toHaveBeenCalled()
   })
 })

--- a/frontend/tests/tool.test.tsx
+++ b/frontend/tests/tool.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, waitFor } from "@testing-library/react"
+
+jest.mock("@/components/ai-elements/code-block", () => ({
+  CodeBlock: ({
+    children,
+    code,
+  }: {
+    children?: React.ReactNode
+    code: string
+  }) => (
+    <div data-testid="mock-code-block">
+      {children}
+      <pre>{code}</pre>
+    </div>
+  ),
+  CodeBlockCopyButton: () => null,
+}))
+
+import { ToolInput } from "@/components/ai-elements/tool"
+
+describe("Tool payload downloads", () => {
+  beforeEach(() => {
+    URL.createObjectURL = jest.fn(() => "blob:tool-payload")
+    URL.revokeObjectURL = jest.fn()
+  })
+
+  it("keeps the json extension for large JSON string payloads", async () => {
+    render(<ToolInput input={`{"items":[${'"value",'.repeat(3000)}"done"]}`} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /download file/i })
+      ).toHaveAttribute("download", "tool-parameters.json")
+    })
+  })
+})

--- a/frontend/tests/use-chat.test.tsx
+++ b/frontend/tests/use-chat.test.tsx
@@ -1,0 +1,152 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type {
+  AgentSessionRead,
+  AgentSessionReadVercel,
+  AgentSessionReadWithMessages,
+} from "@/client"
+import { agentSessionsUpdateSession } from "@/client"
+import { useUpdateChat } from "@/hooks/use-chat"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    agentSessionsUpdateSession: jest.fn(),
+  }
+})
+
+const mockAgentSessionsUpdateSession =
+  agentSessionsUpdateSession as jest.MockedFunction<
+    typeof agentSessionsUpdateSession
+  >
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function createSessionRead(
+  overrides?: Partial<AgentSessionRead>
+): AgentSessionRead {
+  return {
+    id: "chat-1",
+    workspace_id: "workspace-1",
+    title: "Test chat",
+    created_by: "user-1",
+    entity_type: "case",
+    entity_id: "case-1",
+    channel_context: null,
+    tools: [],
+    agent_preset_id: null,
+    harness_type: null,
+    created_at: new Date("2024-01-01T00:00:00.000Z").toISOString(),
+    updated_at: new Date("2024-01-01T00:00:00.000Z").toISOString(),
+    ...overrides,
+  }
+}
+
+function createSessionReadWithMessages(
+  overrides?: Partial<AgentSessionReadWithMessages>
+): AgentSessionReadWithMessages {
+  return {
+    ...createSessionRead(),
+    messages: [],
+    ...overrides,
+  }
+}
+
+function createSessionReadVercel(
+  overrides?: Partial<AgentSessionReadVercel>
+): AgentSessionReadVercel {
+  return {
+    ...createSessionRead(),
+    messages: [],
+    ...overrides,
+  }
+}
+
+describe("useUpdateChat", () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    jest.clearAllMocks()
+  })
+
+  it("optimistically updates matching chat caches before the mutation resolves", async () => {
+    const deferred = createDeferred<AgentSessionRead>()
+    mockAgentSessionsUpdateSession.mockImplementation(
+      () =>
+        deferred.promise as unknown as ReturnType<
+          typeof agentSessionsUpdateSession
+        >
+    )
+
+    queryClient.setQueryData(
+      ["chat", "chat-1", "workspace-1"],
+      createSessionReadWithMessages()
+    )
+    queryClient.setQueryData(
+      ["chat", "chat-1", "workspace-1", "vercel"],
+      createSessionReadVercel()
+    )
+    queryClient.setQueryData(
+      ["chats", "workspace-1", "case", "case-1", 50],
+      [createSessionRead()]
+    )
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useUpdateChat("workspace-1"), {
+      wrapper,
+    })
+
+    const mutationPromise = result.current.updateChat({
+      chatId: "chat-1",
+      update: { tools: ["core.cases.list_cases"] },
+    })
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<AgentSessionReadWithMessages>([
+          "chat",
+          "chat-1",
+          "workspace-1",
+        ])?.tools
+      ).toEqual(["core.cases.list_cases"])
+    })
+    expect(
+      queryClient.getQueryData<AgentSessionReadVercel>([
+        "chat",
+        "chat-1",
+        "workspace-1",
+        "vercel",
+      ])?.tools
+    ).toEqual(["core.cases.list_cases"])
+    expect(
+      queryClient.getQueryData<AgentSessionRead[]>([
+        "chats",
+        "workspace-1",
+        "case",
+        "case-1",
+        50,
+      ])?.[0]?.tools
+    ).toEqual(["core.cases.list_cases"])
+
+    deferred.resolve(createSessionRead({ tools: ["core.cases.list_cases"] }))
+    await mutationPromise
+  })
+})


### PR DESCRIPTION
**Summary**
- Reapply the final UI/UX from PR #2260 with compact controls, tool badges, mention picker, and prompt footer layout while retaining backend-safe contracts
- Harden state paths: serialized tool persistence, prompt-input registration stability, addon focus support, and noiseless transformed message flows
- Refresh code/tool rendering with the redesigned tool cards, Shiki-powered code blocks, and collision-safe cache keys plus the new primitives (model selector, input group, spinner)

**Testing**
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the chat UI with a compact layout, `shiki` code blocks, a model selector, and new @-mention plus preset insertion in the prompt. Improves stability across input, tools, and message flow, and restores Enter-to-send.

- **New Features**
  - Switched code highlighting to `shiki` with token caching, in-flight dedupe, and better copy controls.
  - Added model selector dialog and primitives for quick model changes.
  - Updated prompt input with @-mentions and preset insertion; new `InputGroup`/`Spinner` and a compact footer.
  - Redesigned tool cards with badges, collapsible details, safe inline payload handling (with downloads for large payloads), and better spacing around call icons.

- **Bug Fixes**
  - Restored Enter-to-send in the prompt; Shift+Enter inserts a newline.
  - Prompt input is stable: addon focus works and input text is preserved on failed submit (tested).
  - Tool state persists and serializes across renders; chat updates apply optimistically for title, tools, and preset.
  - Collision-safe cache keys for code tokenization (tested); reduced noisy logs; first-send case chat creation supports passing selected tools.

<sup>Written for commit 8af33eebfcb4913a59ae35aa1a2cbfdfe5361154. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

