### PR TITLE
fix(ui): Unknown case status counts

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5796,6 +5796,11 @@ export const $CaseStatusGroupCounts = {
       title: "Closed",
       default: 0,
     },
+    unknown: {
+      type: "integer",
+      title: "Unknown",
+      default: 0,
+    },
     other: {
       type: "integer",
       title: "Other",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1642,6 +1642,7 @@ export type CaseStatusGroupCounts = {
   on_hold?: number
   resolved?: number
   closed?: number
+  unknown?: number
   other?: number
 }
 

--- a/frontend/src/components/cases/cases-accordion.tsx
+++ b/frontend/src/components/cases/cases-accordion.tsx
@@ -94,6 +94,7 @@ const STATUS_GROUPS: Record<StatusGroup, StatusGroupConfig> = {
     icon: CircleHelpIcon,
     statuses: ["unknown"],
     iconColor: "text-slate-600",
+    aggregateKey: "unknown",
   },
 }
 

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -59,6 +59,8 @@ const EMPTY_STAGE_COUNTS: CaseSearchAggregateRead["status_groups"] = {
   in_progress: 0,
   on_hold: 0,
   resolved: 0,
+  closed: 0,
+  unknown: 0,
   other: 0,
 }
 

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -852,6 +852,7 @@ async def test_search_case_aggregates_success(
                 on_hold=4,
                 resolved=18,
                 closed=4,
+                unknown=6,
                 other=2,
             ),
         )
@@ -876,6 +877,7 @@ async def test_search_case_aggregates_success(
         assert data["status_groups"]["new"] == 10
         assert data["status_groups"]["resolved"] == 18
         assert data["status_groups"]["closed"] == 4
+        assert data["status_groups"]["unknown"] == 6
         mock_svc.get_search_case_aggregates.assert_called_once()
 
 

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1195,7 +1195,53 @@ class TestCasesService:
         assert aggregates.status_groups.on_hold == 0
         assert aggregates.status_groups.resolved == 1
         assert aggregates.status_groups.closed == 0
+        assert aggregates.status_groups.unknown == 0
         assert aggregates.status_groups.other == 0
+
+    async def test_get_search_case_aggregates_excludes_unknown_from_other(
+        self, cases_service: CasesService, session: AsyncSession
+    ) -> None:
+        """`other` aggregate should not include cases with `unknown` status."""
+
+        now = datetime.now(UTC)
+        session.add_all(
+            [
+                Case(
+                    workspace_id=cases_service.workspace_id,
+                    case_number=1,
+                    summary="Other status case",
+                    description="Other",
+                    status=CaseStatus.OTHER,
+                    priority=CasePriority.MEDIUM,
+                    severity=CaseSeverity.MEDIUM,
+                    created_at=now,
+                    updated_at=now,
+                ),
+                Case(
+                    workspace_id=cases_service.workspace_id,
+                    case_number=2,
+                    summary="Unknown status case",
+                    description="Unknown",
+                    status=CaseStatus.UNKNOWN,
+                    priority=CasePriority.MEDIUM,
+                    severity=CaseSeverity.MEDIUM,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            ]
+        )
+        await session.commit()
+
+        aggregates = await cases_service.get_search_case_aggregates()
+
+        assert aggregates.total == 2
+        assert aggregates.status_groups.new == 0
+        assert aggregates.status_groups.in_progress == 0
+        assert aggregates.status_groups.on_hold == 0
+        assert aggregates.status_groups.resolved == 0
+        assert aggregates.status_groups.closed == 0
+        assert aggregates.status_groups.unknown == 1
+        assert aggregates.status_groups.other == 1
 
     async def test_create_case_with_nonexistent_field(
         self, cases_service: CasesService

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -58,6 +58,7 @@ class CaseStatusGroupCounts(Schema):
     on_hold: int = 0
     resolved: int = 0
     closed: int = 0
+    unknown: int = 0
     other: int = 0
 
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -689,12 +689,13 @@ class CasesService(BaseWorkspaceService):
                 0,
             ).label("closed"),
             func.coalesce(
+                func.sum(sa.case((Case.status == CaseStatus.UNKNOWN, 1), else_=0)),
+                0,
+            ).label("unknown"),
+            func.coalesce(
                 func.sum(
                     sa.case(
-                        (
-                            Case.status.in_([CaseStatus.OTHER, CaseStatus.UNKNOWN]),
-                            1,
-                        ),
+                        (Case.status == CaseStatus.OTHER, 1),
                         else_=0,
                     )
                 ),
@@ -715,6 +716,7 @@ class CasesService(BaseWorkspaceService):
                 on_hold=int(row.on_hold or 0),
                 resolved=int(row.resolved or 0),
                 closed=int(row.closed or 0),
+                unknown=int(row.unknown or 0),
                 other=int(row.other or 0),
             ),
         )


### PR DESCRIPTION
Summary
- add explicit unknown status aggregate across schemas, client types, and case service so “other” no longer mixes in unknown cases
- ensure case accordion and hooks treat unknown status separately and update generated clients accordingly
- simplify OAuth/oidc authorize flow to use direct fetch and drop unused generated endpoints

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separate the “unknown” case status from “other” across API and UI to fix incorrect aggregate counts, and simplify OIDC authorize with a direct fetch. This makes status totals accurate and removes reliance on an unused generated endpoint.

- **Bug Fixes**
  - API: added `unknown` to `CaseStatusGroupCounts`; aggregation counts `unknown` separately and `other` only for OTHER; response maps the new field. Tests cover excluding `unknown` from `other`.
  - Frontend: updated generated schemas/types to include `unknown`; cases accordion uses `aggregateKey: "unknown"`; default status counts now include `closed` and `unknown`.

<sup>Written for commit 5b75765854b2aa829d1c6a9874b85368468c5ba9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

