### PR TITLE
fix(registry): resolve circular FK on repo delete

### DIFF
--- a/tracecat/registry/repositories/service.py
+++ b/tracecat/registry/repositories/service.py
@@ -80,6 +80,9 @@ class RegistryReposService(BaseOrgService):
 
     async def delete_repository(self, repository: RegistryRepository) -> None:
         """Delete a registry repository."""
+        if repository.current_version_id is not None:
+            repository.current_version_id = None
+            await self.session.flush()
         await self.session.delete(repository)
         await self.session.commit()
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

- Fix`sqlalchemy.exc.CircularDependencyError` when deleting a registry repository that has versions, caused by the bidirectional FK between `RegistryRepository.current_version_id` and `RegistryVersion.repository_id`
- Null out `current_version_id` and flush before cascading the delete to break the cycle

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

1. Add a custom registry repository and sync it so it has a version
2. Change organization remote repository to some other URL
3. Delete the original registry, actions should also be deleted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix repository deletion when versions exist by breaking the circular foreign key between `RegistryRepository.current_version_id` and `RegistryVersion.repository_id`. We now null `current_version_id` and flush before delete, preventing `sqlalchemy.exc.CircularDependencyError` and allowing cascading deletes to complete.

<sup>Written for commit bae524cb3d19b4d93264c777c231e396f40d1cfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

