### PR TITLE
feat(workflows): backport bulk github push to 0.53.25

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -15625,6 +15625,17 @@ export const $WorkflowBulkPushPreviewResponse = {
       type: "string",
       title: "Branch",
     },
+    base_branch: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Base Branch",
+    },
     commit_message: {
       type: "string",
       title: "Commit Message",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6868,6 +6868,35 @@ export const $GetWorkflowDefinitionActivityInputs = {
   title: "GetWorkflowDefinitionActivityInputs",
 } as const
 
+export const $GitBranchInfo = {
+  properties: {
+    name: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Name",
+      description: "The branch name",
+    },
+    sha: {
+      type: "string",
+      maxLength: 40,
+      minLength: 40,
+      title: "Sha",
+      description: "The latest commit SHA for the branch",
+    },
+    is_default: {
+      type: "boolean",
+      title: "Is Default",
+      description: "Whether this is the repository default branch",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["name", "sha"],
+  title: "GitBranchInfo",
+  description: "Git branch information for repository management.",
+} as const
+
 export const $GitCommitInfo = {
   properties: {
     sha: {
@@ -15500,6 +15529,347 @@ export const $WorkflowAlias = {
   title: "WorkflowAlias",
 } as const
 
+export const $WorkflowBulkPushExcludedWorkflow = {
+  properties: {
+    workflow_id: {
+      anyOf: [
+        {
+          type: "string",
+          pattern: "wf_[0-9a-zA-Z]+",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Workflow Id",
+    },
+    title: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Title",
+    },
+    reason: {
+      $ref: "#/components/schemas/WorkflowBulkPushExclusionReason",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+  },
+  type: "object",
+  required: ["reason", "message"],
+  title: "WorkflowBulkPushExcludedWorkflow",
+} as const
+
+export const $WorkflowBulkPushExclusionReason = {
+  type: "string",
+  enum: ["not_found", "not_published", "invalid_configuration"],
+  title: "WorkflowBulkPushExclusionReason",
+} as const
+
+export const $WorkflowBulkPushPreviewRequest = {
+  properties: {
+    workflow_ids: {
+      items: {
+        type: "string",
+        pattern: "wf_[0-9a-zA-Z]+",
+      },
+      type: "array",
+      maxItems: 500,
+      title: "Workflow Ids",
+    },
+    folder_paths: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      maxItems: 100,
+      title: "Folder Paths",
+    },
+  },
+  type: "object",
+  title: "WorkflowBulkPushPreviewRequest",
+} as const
+
+export const $WorkflowBulkPushPreviewResponse = {
+  properties: {
+    eligible_workflows: {
+      items: {
+        $ref: "#/components/schemas/WorkflowBulkPushWorkflowSummary",
+      },
+      type: "array",
+      title: "Eligible Workflows",
+    },
+    excluded_workflows: {
+      items: {
+        $ref: "#/components/schemas/WorkflowBulkPushExcludedWorkflow",
+      },
+      type: "array",
+      title: "Excluded Workflows",
+    },
+    resolved_workflow_ids: {
+      items: {
+        type: "string",
+        pattern: "wf_[0-9a-zA-Z]+",
+      },
+      type: "array",
+      title: "Resolved Workflow Ids",
+    },
+    branch: {
+      type: "string",
+      title: "Branch",
+    },
+    commit_message: {
+      type: "string",
+      title: "Commit Message",
+    },
+    pr_title: {
+      type: "string",
+      title: "Pr Title",
+    },
+    pr_body: {
+      type: "string",
+      title: "Pr Body",
+    },
+    can_submit: {
+      type: "boolean",
+      title: "Can Submit",
+      default: false,
+    },
+  },
+  type: "object",
+  required: ["branch", "commit_message", "pr_title", "pr_body"],
+  title: "WorkflowBulkPushPreviewResponse",
+} as const
+
+export const $WorkflowBulkPushRequest = {
+  properties: {
+    workflow_ids: {
+      items: {
+        type: "string",
+        pattern: "wf_[0-9a-zA-Z]+",
+      },
+      type: "array",
+      minItems: 1,
+      title: "Workflow Ids",
+    },
+    branch: {
+      type: "string",
+      title: "Branch",
+    },
+    commit_message: {
+      type: "string",
+      maxLength: 512,
+      minLength: 1,
+      title: "Commit Message",
+    },
+    pr_title: {
+      type: "string",
+      maxLength: 256,
+      minLength: 1,
+      title: "Pr Title",
+    },
+    pr_body: {
+      type: "string",
+      title: "Pr Body",
+      default: "",
+    },
+  },
+  type: "object",
+  required: ["branch", "commit_message", "pr_title"],
+  title: "WorkflowBulkPushRequest",
+} as const
+
+export const $WorkflowBulkPushResult = {
+  properties: {
+    status: {
+      type: "string",
+      enum: ["committed", "no_op"],
+      title: "Status",
+    },
+    commit_sha: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Commit Sha",
+    },
+    branch: {
+      type: "string",
+      title: "Branch",
+    },
+    base_branch: {
+      type: "string",
+      title: "Base Branch",
+    },
+    pr_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Url",
+    },
+    pr_number: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Number",
+    },
+    pr_reused: {
+      type: "boolean",
+      title: "Pr Reused",
+      default: false,
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+    selected_count: {
+      type: "integer",
+      title: "Selected Count",
+    },
+    eligible_count: {
+      type: "integer",
+      title: "Eligible Count",
+    },
+    excluded_count: {
+      type: "integer",
+      title: "Excluded Count",
+    },
+    workflow_results: {
+      items: {
+        $ref: "#/components/schemas/WorkflowBulkPushWorkflowResult",
+      },
+      type: "array",
+      title: "Workflow Results",
+    },
+  },
+  type: "object",
+  required: [
+    "status",
+    "branch",
+    "base_branch",
+    "message",
+    "selected_count",
+    "eligible_count",
+    "excluded_count",
+  ],
+  title: "WorkflowBulkPushResult",
+} as const
+
+export const $WorkflowBulkPushWorkflowResult = {
+  properties: {
+    workflow_id: {
+      type: "string",
+      pattern: "wf_[0-9a-zA-Z]+",
+      title: "Workflow Id",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+    },
+    path: {
+      type: "string",
+      title: "Path",
+    },
+    status: {
+      $ref: "#/components/schemas/WorkflowBulkPushWorkflowStatus",
+    },
+    message: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Message",
+    },
+  },
+  type: "object",
+  required: ["workflow_id", "title", "path", "status"],
+  title: "WorkflowBulkPushWorkflowResult",
+} as const
+
+export const $WorkflowBulkPushWorkflowStatus = {
+  type: "string",
+  enum: ["committed", "no_op", "excluded"],
+  title: "WorkflowBulkPushWorkflowStatus",
+} as const
+
+export const $WorkflowBulkPushWorkflowSummary = {
+  properties: {
+    workflow_id: {
+      type: "string",
+      pattern: "wf_[0-9a-zA-Z]+",
+      title: "Workflow Id",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+    },
+    alias: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Alias",
+    },
+    folder_path: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Path",
+    },
+    latest_definition_version: {
+      type: "integer",
+      title: "Latest Definition Version",
+    },
+    latest_definition_created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Latest Definition Created At",
+    },
+  },
+  type: "object",
+  required: [
+    "workflow_id",
+    "title",
+    "latest_definition_version",
+    "latest_definition_created_at",
+  ],
+  title: "WorkflowBulkPushWorkflowSummary",
+} as const
+
 export const $WorkflowCommitResponse = {
   properties: {
     workflow_id: {
@@ -15775,6 +16145,33 @@ export const $WorkflowDslPublish = {
         },
       ],
       title: "Message",
+    },
+    branch: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Branch",
+    },
+    create_pr: {
+      type: "boolean",
+      title: "Create Pr",
+      default: false,
+    },
+    pr_base_branch: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pr Base Branch",
     },
   },
   type: "object",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -411,6 +411,8 @@ import type {
   WorkflowExecutionsTerminateWorkflowExecutionResponse,
   WorkflowsAddTagData,
   WorkflowsAddTagResponse,
+  WorkflowsBulkPushWorkflowsData,
+  WorkflowsBulkPushWorkflowsResponse,
   WorkflowsCommitWorkflowData,
   WorkflowsCommitWorkflowResponse,
   WorkflowsCreateWorkflowData,
@@ -427,6 +429,8 @@ import type {
   WorkflowsGetWorkflowResponse,
   WorkflowsListTagsData,
   WorkflowsListTagsResponse,
+  WorkflowsListWorkflowBranchesData,
+  WorkflowsListWorkflowBranchesResponse,
   WorkflowsListWorkflowCommitsData,
   WorkflowsListWorkflowCommitsResponse,
   WorkflowsListWorkflowDefinitionsData,
@@ -435,6 +439,8 @@ import type {
   WorkflowsListWorkflowsResponse,
   WorkflowsMoveWorkflowToFolderData,
   WorkflowsMoveWorkflowToFolderResponse,
+  WorkflowsPreviewBulkPushWorkflowsData,
+  WorkflowsPreviewBulkPushWorkflowsResponse,
   WorkflowsPublishWorkflowData,
   WorkflowsPublishWorkflowResponse,
   WorkflowsPullWorkflowsData,
@@ -1859,6 +1865,56 @@ export const workflowsPublishWorkflow = (
 }
 
 /**
+ * Preview Bulk Push Workflows
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns WorkflowBulkPushPreviewResponse Successful Response
+ * @throws ApiError
+ */
+export const workflowsPreviewBulkPushWorkflows = (
+  data: WorkflowsPreviewBulkPushWorkflowsData
+): CancelablePromise<WorkflowsPreviewBulkPushWorkflowsResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workflows/push/preview",
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Bulk Push Workflows
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns WorkflowBulkPushResult Successful Response
+ * @throws ApiError
+ */
+export const workflowsBulkPushWorkflows = (
+  data: WorkflowsBulkPushWorkflowsData
+): CancelablePromise<WorkflowsBulkPushWorkflowsResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workflows/push",
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * List Workflow Commits
  * Get commit list for workflow repository via GitHub App.
  *
@@ -1879,6 +1935,31 @@ export const workflowsListWorkflowCommits = (
     url: "/workflows/sync/commits",
     query: {
       branch: data.branch,
+      limit: data.limit,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Workflow Branches
+ * Get branch list for workflow repository via GitHub App.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.limit Maximum number of branches to return
+ * @returns GitBranchInfo Successful Response
+ * @throws ApiError
+ */
+export const workflowsListWorkflowBranches = (
+  data: WorkflowsListWorkflowBranchesData
+): CancelablePromise<WorkflowsListWorkflowBranchesResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workflows/sync/branches",
+    query: {
       limit: data.limit,
       workspace_id: data.workspaceId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4924,6 +4924,7 @@ export type WorkflowBulkPushPreviewResponse = {
   excluded_workflows?: Array<WorkflowBulkPushExcludedWorkflow>
   resolved_workflow_ids?: Array<string>
   branch: string
+  base_branch?: string | null
   commit_message: string
   pr_title: string
   pr_body: string

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2106,6 +2106,24 @@ export type GetWorkflowDefinitionActivityInputs = {
 }
 
 /**
+ * Git branch information for repository management.
+ */
+export type GitBranchInfo = {
+  /**
+   * The branch name
+   */
+  name: string
+  /**
+   * The latest commit SHA for the branch
+   */
+  sha: string
+  /**
+   * Whether this is the repository default branch
+   */
+  is_default?: boolean
+}
+
+/**
  * Git commit information for repository management.
  */
 export type GitCommitInfo = {
@@ -4884,6 +4902,78 @@ export type WorkflowAlias = {
   component_id?: "workflow-alias"
 }
 
+export type WorkflowBulkPushExcludedWorkflow = {
+  workflow_id?: string | null
+  title?: string | null
+  reason: WorkflowBulkPushExclusionReason
+  message: string
+}
+
+export type WorkflowBulkPushExclusionReason =
+  | "not_found"
+  | "not_published"
+  | "invalid_configuration"
+
+export type WorkflowBulkPushPreviewRequest = {
+  workflow_ids?: Array<string>
+  folder_paths?: Array<string>
+}
+
+export type WorkflowBulkPushPreviewResponse = {
+  eligible_workflows?: Array<WorkflowBulkPushWorkflowSummary>
+  excluded_workflows?: Array<WorkflowBulkPushExcludedWorkflow>
+  resolved_workflow_ids?: Array<string>
+  branch: string
+  commit_message: string
+  pr_title: string
+  pr_body: string
+  can_submit?: boolean
+}
+
+export type WorkflowBulkPushRequest = {
+  workflow_ids?: Array<string>
+  branch: string
+  commit_message: string
+  pr_title: string
+  pr_body?: string
+}
+
+export type WorkflowBulkPushResult = {
+  status: "committed" | "no_op"
+  commit_sha?: string | null
+  branch: string
+  base_branch: string
+  pr_url?: string | null
+  pr_number?: number | null
+  pr_reused?: boolean
+  message: string
+  selected_count: number
+  eligible_count: number
+  excluded_count: number
+  workflow_results?: Array<WorkflowBulkPushWorkflowResult>
+}
+
+export type status3 = "committed" | "no_op"
+
+export type WorkflowBulkPushWorkflowResult = {
+  workflow_id: string
+  title: string
+  path: string
+  status: WorkflowBulkPushWorkflowStatus
+  message?: string | null
+}
+
+export type WorkflowBulkPushWorkflowStatus = "committed" | "no_op" | "excluded"
+
+export type WorkflowBulkPushWorkflowSummary = {
+  workflow_id: string
+  title: string
+  alias?: string | null
+  folder_path?: string | null
+  latest_definition_version: number
+  latest_definition_created_at: string
+}
+
 export type WorkflowCommitResponse = {
   workflow_id: string
   status: "success" | "failure"
@@ -4894,7 +4984,7 @@ export type WorkflowCommitResponse = {
   } | null
 }
 
-export type status3 = "success" | "failure"
+export type status4 = "success" | "failure"
 
 /**
  * API response model for persisted workflow definitions.
@@ -4936,6 +5026,9 @@ export type WorkflowDirectoryItem = {
 
 export type WorkflowDslPublish = {
   message?: string | null
+  branch?: string | null
+  create_pr?: boolean
+  pr_base_branch?: string | null
 }
 
 export type WorkflowEntrypointValidationRequest = {
@@ -5084,7 +5177,7 @@ export type WorkflowExecutionRead = {
   interactions?: Array<InteractionRead>
 }
 
-export type status4 =
+export type status5 =
   | "RUNNING"
   | "COMPLETED"
   | "FAILED"
@@ -5815,6 +5908,21 @@ export type WorkflowsPublishWorkflowData = {
 
 export type WorkflowsPublishWorkflowResponse = void
 
+export type WorkflowsPreviewBulkPushWorkflowsData = {
+  requestBody: WorkflowBulkPushPreviewRequest
+  workspaceId: string
+}
+
+export type WorkflowsPreviewBulkPushWorkflowsResponse =
+  WorkflowBulkPushPreviewResponse
+
+export type WorkflowsBulkPushWorkflowsData = {
+  requestBody: WorkflowBulkPushRequest
+  workspaceId: string
+}
+
+export type WorkflowsBulkPushWorkflowsResponse = WorkflowBulkPushResult
+
 export type WorkflowsListWorkflowCommitsData = {
   /**
    * Branch name to fetch commits from
@@ -5828,6 +5936,16 @@ export type WorkflowsListWorkflowCommitsData = {
 }
 
 export type WorkflowsListWorkflowCommitsResponse = Array<GitCommitInfo>
+
+export type WorkflowsListWorkflowBranchesData = {
+  /**
+   * Maximum number of branches to return
+   */
+  limit?: number
+  workspaceId: string
+}
+
+export type WorkflowsListWorkflowBranchesResponse = Array<GitBranchInfo>
 
 export type WorkflowsPullWorkflowsData = {
   requestBody: WorkflowSyncPullRequest
@@ -7996,6 +8114,36 @@ export type $OpenApiTs = {
       }
     }
   }
+  "/workflows/push/preview": {
+    post: {
+      req: WorkflowsPreviewBulkPushWorkflowsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowBulkPushPreviewResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workflows/push": {
+    post: {
+      req: WorkflowsBulkPushWorkflowsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowBulkPushResult
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
   "/workflows/sync/commits": {
     get: {
       req: WorkflowsListWorkflowCommitsData
@@ -8004,6 +8152,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: Array<GitCommitInfo>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workflows/sync/branches": {
+    get: {
+      req: WorkflowsListWorkflowBranchesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<GitBranchInfo>
         /**
          * Validation Error
          */

--- a/frontend/src/components/dashboard/dashboard-table.tsx
+++ b/frontend/src/components/dashboard/dashboard-table.tsx
@@ -5,7 +5,7 @@ import type { Row } from "@tanstack/react-table"
 import { format, formatDistanceToNow } from "date-fns"
 import { CircleDot } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import type { WorkflowReadMinimal } from "@/client"
 import { DeleteWorkflowAlertDialog } from "@/components/dashboard/delete-workflow-dialog"
 import { ViewMode } from "@/components/dashboard/folder-view-toggle"
@@ -51,6 +51,12 @@ export function WorkflowsTagsDashboardTable({
   })
   const [selectedWorkflow, setSelectedWorkflow] =
     useState<WorkflowReadMinimal | null>(null)
+  const handleSelectionChange = useCallback(
+    (selectedRows: Row<WorkflowReadMinimal>[]) => {
+      onSelectionChange?.(selectedRows.map((row) => row.original))
+    },
+    [onSelectionChange]
+  )
 
   const handleOnClickRow = (row: Row<WorkflowReadMinimal>) => () => {
     // Link to workflow detail page
@@ -77,9 +83,7 @@ export function WorkflowsTagsDashboardTable({
           getRowHref={(row) =>
             `/workspaces/${workspaceId}/workflows/${row.original.id}`
           }
-          onSelectionChange={(selectedRows) => {
-            onSelectionChange?.(selectedRows.map((row) => row.original))
-          }}
+          onSelectionChange={handleSelectionChange}
           columns={[
             {
               id: "select",

--- a/frontend/src/components/dashboard/dashboard-table.tsx
+++ b/frontend/src/components/dashboard/dashboard-table.tsx
@@ -38,8 +38,10 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 
 export function WorkflowsTagsDashboardTable({
   onSelectionChange,
+  clearSelectionTrigger,
 }: {
   onSelectionChange?: (workflows: WorkflowReadMinimal[]) => void
+  clearSelectionTrigger?: number
 }) {
   const router = useRouter()
   const workspaceId = useWorkspaceId()
@@ -70,7 +72,7 @@ export function WorkflowsTagsDashboardTable({
     >
       <TooltipProvider>
         <DataTable
-          tableId={`${workspaceId}-${user?.id}:workflows-table`}
+          tableId={`${workspaceId}-${user?.id}:workflows-table:tags`}
           initialColumnVisibility={{
             created_at: false,
           }}
@@ -83,7 +85,9 @@ export function WorkflowsTagsDashboardTable({
           getRowHref={(row) =>
             `/workspaces/${workspaceId}/workflows/${row.original.id}`
           }
+          getRowId={(workflow) => workflow.id}
           onSelectionChange={handleSelectionChange}
+          clearSelectionTrigger={clearSelectionTrigger}
           columns={[
             {
               id: "select",
@@ -125,6 +129,7 @@ export function WorkflowsTagsDashboardTable({
                   "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
                 cellClassName:
                   "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
+                disableRowLink: true,
               },
             },
             {

--- a/frontend/src/components/dashboard/dashboard-table.tsx
+++ b/frontend/src/components/dashboard/dashboard-table.tsx
@@ -19,6 +19,7 @@ import {
 import { TagBadge } from "@/components/tag-badge"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,7 +36,11 @@ import { useWorkflowManager } from "@/lib/hooks"
 import { capitalizeFirst } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-export function WorkflowsTagsDashboardTable() {
+export function WorkflowsTagsDashboardTable({
+  onSelectionChange,
+}: {
+  onSelectionChange?: (workflows: WorkflowReadMinimal[]) => void
+}) {
   const router = useRouter()
   const workspaceId = useWorkspaceId()
   const { user } = useAuth()
@@ -72,7 +77,52 @@ export function WorkflowsTagsDashboardTable() {
           getRowHref={(row) =>
             `/workspaces/${workspaceId}/workflows/${row.original.id}`
           }
+          onSelectionChange={(selectedRows) => {
+            onSelectionChange?.(selectedRows.map((row) => row.original))
+          }}
           columns={[
+            {
+              id: "select",
+              header: ({ table }) => (
+                <div className="flex w-full justify-center">
+                  <Checkbox
+                    className="border-foreground/50"
+                    checked={
+                      table.getIsAllPageRowsSelected() ||
+                      (table.getIsSomePageRowsSelected() && "indeterminate")
+                    }
+                    onCheckedChange={(value) =>
+                      table.toggleAllPageRowsSelected(!!value)
+                    }
+                    aria-label="Select all workflows"
+                  />
+                </div>
+              ),
+              cell: ({ row }) => (
+                <div
+                  className="flex w-full justify-center"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    event.preventDefault()
+                  }}
+                >
+                  <Checkbox
+                    className="border-foreground/50"
+                    checked={row.getIsSelected()}
+                    onCheckedChange={(value) => row.toggleSelected(!!value)}
+                    aria-label={`Select workflow ${row.original.title}`}
+                  />
+                </div>
+              ),
+              enableSorting: false,
+              enableHiding: false,
+              meta: {
+                headerClassName:
+                  "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
+                cellClassName:
+                  "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
+              },
+            },
             {
               accessorKey: "title",
               header: ({ column }) => (

--- a/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
@@ -1,0 +1,702 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  FolderIcon,
+  GitBranchIcon,
+  GitPullRequestIcon,
+  WorkflowIcon,
+} from "lucide-react"
+import Link from "next/link"
+import { useEffect, useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import {
+  type ApiError,
+  type GitBranchInfo,
+  type WorkflowBulkPushExcludedWorkflow,
+  type WorkflowBulkPushPreviewResponse,
+  workflowsBulkPushWorkflows,
+  workflowsListWorkflowBranches,
+  workflowsPreviewBulkPushWorkflows,
+} from "@/client"
+import { Spinner } from "@/components/loading/spinner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { ToastAction } from "@/components/ui/toast"
+import { toast } from "@/components/ui/use-toast"
+import type { TracecatApiError } from "@/lib/errors"
+
+const CREATE_NEW_BRANCH_VALUE = "__create_new_branch__"
+
+const bulkPushFormSchema = z.object({
+  branch: z.string().trim().min(1, "Target branch is required"),
+  commitMessage: z.string().trim().min(1, "Commit message is required"),
+  prTitle: z.string().trim().min(1, "Pull request title is required"),
+  prBody: z.string().trim(),
+})
+
+type BulkPushFormValues = z.infer<typeof bulkPushFormSchema>
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  const apiError = error as TracecatApiError<unknown>
+  const detail =
+    typeof apiError === "object" && apiError !== null
+      ? apiError.body?.detail
+      : undefined
+  if (typeof detail === "string" && detail.trim()) {
+    return detail
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message
+  }
+  return fallback
+}
+
+function getPushToastTitle(result: {
+  status: "committed" | "no_op"
+  pr_url?: string | null
+  pr_reused?: boolean
+}): string {
+  if (result.status === "no_op") {
+    if (result.pr_url && result.pr_reused) {
+      return "No changes (PR reused)"
+    }
+    if (result.pr_url) {
+      return "No changes (PR created)"
+    }
+    return "No changes to push"
+  }
+
+  if (result.pr_url && result.pr_reused) {
+    return "Workflows pushed (PR reused)"
+  }
+  if (result.pr_url) {
+    return "Workflows pushed (PR created)"
+  }
+  return "Workflows pushed"
+}
+
+function getDisplayFolderPath(folderPath?: string | null): string {
+  if (!folderPath || folderPath === "/") {
+    return "/"
+  }
+
+  return folderPath.endsWith("/") ? folderPath.slice(0, -1) : folderPath
+}
+
+function SelectedWorkflowList({
+  workspaceId,
+  preview,
+}: {
+  workspaceId: string
+  preview: WorkflowBulkPushPreviewResponse
+}) {
+  const eligibleWorkflows = preview.eligible_workflows ?? []
+  const excludedWorkflows = preview.excluded_workflows ?? []
+  const excludedWorkflowGroups = excludedWorkflows.reduce<
+    Array<{
+      message: string
+      workflows: WorkflowBulkPushExcludedWorkflow[]
+    }>
+  >((groups, workflow) => {
+    const message = workflow.message || "Unknown exclusion reason"
+    const existingGroup = groups.find((group) => group.message === message)
+
+    if (existingGroup) {
+      existingGroup.workflows.push(workflow)
+      return groups
+    }
+
+    groups.push({ message, workflows: [workflow] })
+    return groups
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <div className="text-xs font-medium text-foreground">Included</div>
+          <span className="text-xs text-muted-foreground">
+            {eligibleWorkflows.length}
+          </span>
+        </div>
+        <div className="max-h-44 overflow-auto rounded-md border">
+          {eligibleWorkflows.length > 0 ? (
+            <div className="divide-y">
+              {eligibleWorkflows.map((workflow, index) => {
+                const content = (
+                  <div className="flex items-center justify-between gap-3 px-3 py-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <WorkflowIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                        <p className="truncate text-sm font-medium">
+                          {workflow.title}
+                        </p>
+                      </div>
+                      <span className="inline-flex shrink-0 items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] text-foreground">
+                        <FolderIcon className="size-3 shrink-0 text-muted-foreground" />
+                        <span>
+                          {getDisplayFolderPath(workflow.folder_path)}
+                        </span>
+                      </span>
+                    </div>
+                    <Badge
+                      variant="secondary"
+                      className="h-5 shrink-0 rounded-sm px-2 text-[10px] font-normal"
+                    >
+                      v{workflow.latest_definition_version}
+                    </Badge>
+                  </div>
+                )
+
+                return workflow.workflow_id ? (
+                  <Link
+                    key={workflow.workflow_id}
+                    href={`/workspaces/${workspaceId}/workflows/${workflow.workflow_id}`}
+                    title={workflow.workflow_id}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block transition-colors hover:bg-muted/40"
+                  >
+                    {content}
+                  </Link>
+                ) : (
+                  <div
+                    key={`included-${workflow.title ?? "workflow"}-${index}`}
+                    title={workflow.workflow_id ?? undefined}
+                  >
+                    {content}
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="px-3 py-4 text-sm text-muted-foreground">
+              No published workflows are eligible to push.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <div className="text-xs font-medium text-foreground">Excluded</div>
+          <span className="text-xs text-muted-foreground">
+            {excludedWorkflows.length}
+          </span>
+        </div>
+        <div className="max-h-36 overflow-auto rounded-md border">
+          {excludedWorkflowGroups.length > 0 ? (
+            <div className="divide-y">
+              {excludedWorkflowGroups.map((group) => (
+                <ExcludedWorkflowGroupRow
+                  key={group.message}
+                  message={group.message}
+                  workspaceId={workspaceId}
+                  workflows={group.workflows}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="px-3 py-4 text-sm text-muted-foreground">
+              Nothing excluded from this push.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ExcludedWorkflowGroupRow({
+  message,
+  workspaceId,
+  workflows,
+}: {
+  message: string
+  workspaceId: string
+  workflows: WorkflowBulkPushExcludedWorkflow[]
+}) {
+  return (
+    <div className="space-y-1 px-3 py-2">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-xs text-muted-foreground">{message}</p>
+        <Badge
+          variant="secondary"
+          className="h-5 shrink-0 rounded-sm px-2 text-[10px] font-normal"
+        >
+          {workflows.length}
+        </Badge>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {workflows.map((workflow, index) => {
+          const label =
+            workflow.title || workflow.workflow_id || "Unknown workflow"
+          const workflowId = workflow.workflow_id
+
+          if (workflowId) {
+            return (
+              <Link
+                key={workflowId}
+                href={`/workspaces/${workspaceId}/workflows/${workflowId}`}
+                title={workflowId}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] text-foreground transition-colors hover:bg-muted/80"
+              >
+                <WorkflowIcon className="size-3 text-muted-foreground" />
+                <span>{label}</span>
+              </Link>
+            )
+          }
+
+          return (
+            <span
+              key={`excluded-${label}-${index}`}
+              className="inline-flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] text-foreground"
+            >
+              <WorkflowIcon className="size-3 text-muted-foreground" />
+              <span>{label}</span>
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export function WorkflowBulkPushDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  selectedWorkflowIds,
+  selectedFolderPaths,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  selectedWorkflowIds: string[]
+  selectedFolderPaths: string[]
+  onSuccess?: () => void
+}) {
+  const queryClient = useQueryClient()
+  const [isCreatingBranch, setIsCreatingBranch] = useState(false)
+
+  const sortedWorkflowIds = useMemo(
+    () => [...selectedWorkflowIds].sort(),
+    [selectedWorkflowIds]
+  )
+  const sortedFolderPaths = useMemo(
+    () => [...selectedFolderPaths].sort(),
+    [selectedFolderPaths]
+  )
+  const hasSelection =
+    sortedWorkflowIds.length > 0 || sortedFolderPaths.length > 0
+
+  const form = useForm<BulkPushFormValues>({
+    resolver: zodResolver(bulkPushFormSchema),
+    defaultValues: {
+      branch: "",
+      commitMessage: "",
+      prTitle: "",
+      prBody: "",
+    },
+  })
+
+  const previewQuery = useQuery<WorkflowBulkPushPreviewResponse, ApiError>({
+    queryKey: [
+      "workflow-bulk-push-preview",
+      workspaceId,
+      sortedWorkflowIds,
+      sortedFolderPaths,
+    ],
+    queryFn: async () =>
+      await workflowsPreviewBulkPushWorkflows({
+        workspaceId,
+        requestBody: {
+          workflow_ids: sortedWorkflowIds,
+          folder_paths: sortedFolderPaths,
+        },
+      }),
+    enabled: open && hasSelection,
+    refetchOnWindowFocus: false,
+  })
+
+  const {
+    data: repoBranches,
+    isLoading: branchesLoading,
+    error: branchesError,
+  } = useQuery<Array<GitBranchInfo>, ApiError>({
+    queryKey: ["workflow-sync-branches", workspaceId],
+    queryFn: async () =>
+      await workflowsListWorkflowBranches({
+        workspaceId,
+        limit: 200,
+      }),
+    enabled: open,
+    refetchOnWindowFocus: false,
+  })
+
+  const hasBranches = (repoBranches?.length ?? 0) > 0
+
+  useEffect(() => {
+    if (!open || !previewQuery.data) {
+      return
+    }
+
+    form.reset({
+      branch: previewQuery.data.branch,
+      commitMessage: previewQuery.data.commit_message,
+      prTitle: previewQuery.data.pr_title,
+      prBody: previewQuery.data.pr_body,
+    })
+  }, [form, open, previewQuery.data])
+
+  const selectedBranch = form.watch("branch")
+
+  useEffect(() => {
+    if (!open || !repoBranches || repoBranches.length === 0) {
+      return
+    }
+
+    const branchNames = new Set(repoBranches.map((branch) => branch.name))
+    setIsCreatingBranch(!selectedBranch || !branchNames.has(selectedBranch))
+  }, [open, repoBranches, selectedBranch])
+
+  const pushMutation = useMutation({
+    mutationFn: async (values: BulkPushFormValues) => {
+      if (!previewQuery.data) {
+        throw new Error("Bulk push preview has not loaded.")
+      }
+      return await workflowsBulkPushWorkflows({
+        workspaceId,
+        requestBody: {
+          workflow_ids: previewQuery.data.resolved_workflow_ids ?? [],
+          branch: values.branch,
+          commit_message: values.commitMessage,
+          pr_title: values.prTitle,
+          pr_body: values.prBody || undefined,
+        },
+      })
+    },
+    onSuccess: (result) => {
+      toast({
+        title: getPushToastTitle(result),
+        description: result.message,
+        action: result.pr_url ? (
+          <ToastAction
+            altText="Open pull request"
+            onClick={() =>
+              window.open(result.pr_url ?? "", "_blank", "noopener,noreferrer")
+            }
+          >
+            View PR
+          </ToastAction>
+        ) : undefined,
+      })
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["directory-items"] })
+      queryClient.invalidateQueries({ queryKey: ["workflow-sync-branches"] })
+      onSuccess?.()
+      onOpenChange(false)
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Failed to push workflows",
+        description: getErrorMessage(
+          error,
+          "The workflows could not be pushed to GitHub."
+        ),
+      })
+    },
+  })
+
+  const selectedBranchInfo = repoBranches?.find(
+    (branch) => branch.name === selectedBranch
+  )
+  const isSelectedDefaultBranch = selectedBranchInfo?.is_default ?? false
+  const previewErrorMessage = previewQuery.error
+    ? getErrorMessage(
+        previewQuery.error,
+        "The bulk push preview could not be loaded."
+      )
+    : null
+  const branchesErrorMessage = branchesError
+    ? getErrorMessage(
+        branchesError,
+        "The GitHub branches could not be loaded for this workspace."
+      )
+    : null
+
+  const canSubmit =
+    hasSelection &&
+    previewQuery.isSuccess &&
+    (previewQuery.data.can_submit ?? false) &&
+    hasBranches &&
+    !branchesLoading &&
+    !isSelectedDefaultBranch &&
+    !pushMutation.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-[760px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitBranchIcon className="size-4" />
+            Push to GitHub
+          </DialogTitle>
+          <DialogDescription>
+            Push the latest published definitions for the selected workflows to
+            one branch and one pull request.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!hasSelection ? (
+          <div className="rounded-md border px-3 py-4 text-sm text-muted-foreground">
+            Select at least one workflow or folder to continue.
+          </div>
+        ) : previewQuery.isLoading ? (
+          <div className="flex min-h-[280px] items-center justify-center">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner className="size-4" segmentColor="currentColor" />
+              Loading preview...
+            </div>
+          </div>
+        ) : previewErrorMessage ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-4 text-sm text-destructive">
+            {previewErrorMessage}
+          </div>
+        ) : previewQuery.data ? (
+          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit((values) =>
+                  pushMutation.mutateAsync(values)
+                )}
+                className="flex min-h-0 flex-col"
+              >
+                <div className="space-y-5">
+                  <SelectedWorkflowList
+                    workspaceId={workspaceId}
+                    preview={previewQuery.data}
+                  />
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <FormField
+                      control={form.control}
+                      name="branch"
+                      render={({ field }) => (
+                        <FormItem className="md:col-span-2">
+                          <FormLabel>Target branch</FormLabel>
+                          <Select
+                            value={
+                              isCreatingBranch ||
+                              !repoBranches?.some(
+                                (branch) => branch.name === field.value
+                              )
+                                ? CREATE_NEW_BRANCH_VALUE
+                                : field.value
+                            }
+                            onValueChange={(value) => {
+                              if (value === CREATE_NEW_BRANCH_VALUE) {
+                                setIsCreatingBranch(true)
+                                field.onChange("")
+                                return
+                              }
+                              setIsCreatingBranch(false)
+                              field.onChange(value)
+                            }}
+                            disabled={branchesLoading || !hasBranches}
+                          >
+                            <FormControl>
+                              <SelectTrigger className="h-9">
+                                <SelectValue placeholder="Select branch" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {hasBranches ? (
+                                <>
+                                  <SelectItem value={CREATE_NEW_BRANCH_VALUE}>
+                                    Create new branch...
+                                  </SelectItem>
+                                  <SelectSeparator />
+                                  {(repoBranches ?? []).map((branch) => (
+                                    <SelectItem
+                                      key={branch.name}
+                                      value={branch.name}
+                                      disabled={branch.is_default}
+                                    >
+                                      <div className="flex items-center gap-2">
+                                        <span>{branch.name}</span>
+                                        {branch.is_default && (
+                                          <Badge
+                                            variant="secondary"
+                                            className="h-4 rounded-sm px-1 text-[10px] font-normal"
+                                          >
+                                            default
+                                          </Badge>
+                                        )}
+                                      </div>
+                                    </SelectItem>
+                                  ))}
+                                </>
+                              ) : (
+                                <SelectItem value="__no_branches" disabled>
+                                  No branches found
+                                </SelectItem>
+                              )}
+                            </SelectContent>
+                          </Select>
+                          {isCreatingBranch ? (
+                            <div className="mt-2">
+                              <Input
+                                value={field.value}
+                                onChange={field.onChange}
+                                placeholder="tracecat/bulk-push"
+                              />
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                The branch will be created from the repository
+                                default branch if it does not exist.
+                              </p>
+                            </div>
+                          ) : null}
+                          {branchesErrorMessage ? (
+                            <p className="text-xs text-destructive">
+                              {branchesErrorMessage}
+                            </p>
+                          ) : null}
+                          {!branchesLoading && !hasBranches ? (
+                            <p className="text-xs text-muted-foreground">
+                              No branches are available from the configured
+                              repository.
+                            </p>
+                          ) : null}
+                          {isSelectedDefaultBranch ? (
+                            <p className="text-xs text-destructive">
+                              Bulk pushes always open a pull request, so select
+                              or create a branch other than the default branch.
+                            </p>
+                          ) : null}
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="commitMessage"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Commit message</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="prTitle"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Pull request title</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  <FormField
+                    control={form.control}
+                    name="prBody"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Pull request description</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            {...field}
+                            className="min-h-32 resize-y"
+                            placeholder="Describe this workflow push"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {!previewQuery.data.can_submit ? (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                      Nothing eligible to push. Only published workflows can be
+                      included in the pull request.
+                    </div>
+                  ) : null}
+                </div>
+
+                <DialogFooter className="mt-5 gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => onOpenChange(false)}
+                    disabled={pushMutation.isPending}
+                  >
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={!canSubmit}>
+                    {pushMutation.isPending ? (
+                      <>
+                        <Spinner
+                          className="mr-2 size-4"
+                          segmentColor="currentColor"
+                        />
+                        Pushing to GitHub...
+                      </>
+                    ) : (
+                      <>
+                        <GitPullRequestIcon className="mr-2 size-4" />
+                        Push to GitHub
+                      </>
+                    )}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
+++ b/frontend/src/components/dashboard/workflow-bulk-push-dialog.tsx
@@ -440,10 +440,12 @@ export function WorkflowBulkPushDialog({
     },
   })
 
-  const selectedBranchInfo = repoBranches?.find(
-    (branch) => branch.name === selectedBranch
-  )
-  const isSelectedDefaultBranch = selectedBranchInfo?.is_default ?? false
+  const effectiveBaseBranch =
+    previewQuery.data?.base_branch ??
+    repoBranches?.find((branch) => branch.is_default)?.name ??
+    null
+  const isSelectedBaseBranch =
+    Boolean(effectiveBaseBranch) && selectedBranch === effectiveBaseBranch
   const previewErrorMessage = previewQuery.error
     ? getErrorMessage(
         previewQuery.error,
@@ -463,7 +465,7 @@ export function WorkflowBulkPushDialog({
     (previewQuery.data.can_submit ?? false) &&
     hasBranches &&
     !branchesLoading &&
-    !isSelectedDefaultBranch &&
+    !isSelectedBaseBranch &&
     !pushMutation.isPending
 
   return (
@@ -553,7 +555,9 @@ export function WorkflowBulkPushDialog({
                                     <SelectItem
                                       key={branch.name}
                                       value={branch.name}
-                                      disabled={branch.is_default}
+                                      disabled={
+                                        branch.name === effectiveBaseBranch
+                                      }
                                     >
                                       <div className="flex items-center gap-2">
                                         <span>{branch.name}</span>
@@ -600,10 +604,11 @@ export function WorkflowBulkPushDialog({
                               repository.
                             </p>
                           ) : null}
-                          {isSelectedDefaultBranch ? (
+                          {isSelectedBaseBranch ? (
                             <p className="text-xs text-destructive">
                               Bulk pushes always open a pull request, so select
-                              or create a branch other than the default branch.
+                              or create a branch other than the PR base branch (
+                              {effectiveBaseBranch}).
                             </p>
                           ) : null}
                           <FormMessage />

--- a/frontend/src/components/dashboard/workflow-folders-table.tsx
+++ b/frontend/src/components/dashboard/workflow-folders-table.tsx
@@ -51,9 +51,11 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 export function WorkflowFoldersTable({
   view,
   onSelectionChange,
+  clearSelectionTrigger,
 }: {
   view: ViewMode
   onSelectionChange?: (items: DirectoryItem[]) => void
+  clearSelectionTrigger?: number
 }) {
   const workspaceId = useWorkspaceId()
   const searchParams = useSearchParams()
@@ -72,6 +74,7 @@ export function WorkflowFoldersTable({
       directoryItemsIsLoading={directoryItemsIsLoading}
       directoryItemsError={directoryItemsError}
       onSelectionChange={onSelectionChange}
+      clearSelectionTrigger={clearSelectionTrigger}
     />
   )
 }
@@ -82,12 +85,14 @@ export function WorkflowsDashboardTable({
   directoryItemsIsLoading,
   directoryItemsError,
   onSelectionChange,
+  clearSelectionTrigger,
 }: {
   view: ViewMode
   directoryItems: DirectoryItem[] | undefined
   directoryItemsIsLoading: boolean
   directoryItemsError: ApiError | null
   onSelectionChange?: (items: DirectoryItem[]) => void
+  clearSelectionTrigger?: number
 }) {
   const router = useRouter()
   const workspaceId = useWorkspaceId()
@@ -123,7 +128,7 @@ export function WorkflowsDashboardTable({
     >
       <TooltipProvider>
         <DataTable<DirectoryItem, unknown>
-          tableId={`${workspaceId}-${user?.id}:workflows-table`}
+          tableId={`${workspaceId}-${user?.id}:workflows-table:folders`}
           initialColumnVisibility={{
             created_at: false,
           }}
@@ -140,7 +145,11 @@ export function WorkflowsDashboardTable({
             }
             return undefined
           }}
+          getRowId={(item) =>
+            item.type === "workflow" ? item.id : `folder:${item.path}`
+          }
           onSelectionChange={handleSelectionChange}
+          clearSelectionTrigger={clearSelectionTrigger}
           columns={[
             {
               id: "select",
@@ -186,6 +195,7 @@ export function WorkflowsDashboardTable({
                   "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
                 cellClassName:
                   "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
+                disableRowLink: true,
               },
             },
             {

--- a/frontend/src/components/dashboard/workflow-folders-table.tsx
+++ b/frontend/src/components/dashboard/workflow-folders-table.tsx
@@ -5,7 +5,7 @@ import type { Row } from "@tanstack/react-table"
 import { format, formatDistanceToNow } from "date-fns"
 import { CircleDot, FolderIcon, WorkflowIcon } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import type {
   ApiError,
   FolderDirectoryItem,
@@ -97,6 +97,12 @@ export function WorkflowsDashboardTable({
     useState<WorkflowReadMinimal | null>(null)
   const [selectedFolder, setSelectedFolder] =
     useState<FolderDirectoryItem | null>(null)
+  const handleSelectionChange = useCallback(
+    (selectedRows: Row<DirectoryItem>[]) => {
+      onSelectionChange?.(selectedRows.map((row) => row.original))
+    },
+    [onSelectionChange]
+  )
 
   const handleOnClickRow = (row: Row<DirectoryItem>) => () => {
     // Link to workflow detail page
@@ -134,9 +140,7 @@ export function WorkflowsDashboardTable({
             }
             return undefined
           }}
-          onSelectionChange={(selectedRows) => {
-            onSelectionChange?.(selectedRows.map((row) => row.original))
-          }}
+          onSelectionChange={handleSelectionChange}
           columns={[
             {
               id: "select",

--- a/frontend/src/components/dashboard/workflow-folders-table.tsx
+++ b/frontend/src/components/dashboard/workflow-folders-table.tsx
@@ -31,6 +31,7 @@ import {
 import { TagBadge } from "@/components/tag-badge"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -47,7 +48,13 @@ import { type DirectoryItem, useGetDirectoryItems } from "@/lib/hooks"
 import { capitalizeFirst } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-export function WorkflowFoldersTable({ view }: { view: ViewMode }) {
+export function WorkflowFoldersTable({
+  view,
+  onSelectionChange,
+}: {
+  view: ViewMode
+  onSelectionChange?: (items: DirectoryItem[]) => void
+}) {
   const workspaceId = useWorkspaceId()
   const searchParams = useSearchParams()
   const path = searchParams?.get("path") || "/"
@@ -64,6 +71,7 @@ export function WorkflowFoldersTable({ view }: { view: ViewMode }) {
       directoryItems={directoryItems}
       directoryItemsIsLoading={directoryItemsIsLoading}
       directoryItemsError={directoryItemsError}
+      onSelectionChange={onSelectionChange}
     />
   )
 }
@@ -73,11 +81,13 @@ export function WorkflowsDashboardTable({
   directoryItems,
   directoryItemsIsLoading,
   directoryItemsError,
+  onSelectionChange,
 }: {
   view: ViewMode
   directoryItems: DirectoryItem[] | undefined
   directoryItemsIsLoading: boolean
   directoryItemsError: ApiError | null
+  onSelectionChange?: (items: DirectoryItem[]) => void
 }) {
   const router = useRouter()
   const workspaceId = useWorkspaceId()
@@ -124,7 +134,56 @@ export function WorkflowsDashboardTable({
             }
             return undefined
           }}
+          onSelectionChange={(selectedRows) => {
+            onSelectionChange?.(selectedRows.map((row) => row.original))
+          }}
           columns={[
+            {
+              id: "select",
+              header: ({ table }) => (
+                <div className="flex w-full justify-center">
+                  <Checkbox
+                    className="border-foreground/50"
+                    checked={
+                      table.getIsAllPageRowsSelected() ||
+                      (table.getIsSomePageRowsSelected() && "indeterminate")
+                    }
+                    onCheckedChange={(value) =>
+                      table.toggleAllPageRowsSelected(!!value)
+                    }
+                    aria-label="Select all rows"
+                  />
+                </div>
+              ),
+              cell: ({ row }) => (
+                <div
+                  className="flex w-full justify-center"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    event.preventDefault()
+                  }}
+                >
+                  <Checkbox
+                    className="border-foreground/50"
+                    checked={row.getIsSelected()}
+                    onCheckedChange={(value) => row.toggleSelected(!!value)}
+                    aria-label={`Select ${row.original.type} ${
+                      row.original.type === "workflow"
+                        ? row.original.title
+                        : row.original.name
+                    }`}
+                  />
+                </div>
+              ),
+              enableSorting: false,
+              enableHiding: false,
+              meta: {
+                headerClassName:
+                  "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
+                cellClassName:
+                  "w-12 min-w-[3rem] max-w-[3rem] px-2 text-center",
+              },
+            },
             {
               accessorKey: "type",
               header: ({ column }) => (

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -20,6 +20,7 @@ export function WorkflowsDashboard() {
   const [bulkPushOpen, setBulkPushOpen] = useState(false)
   const [selectedWorkflowIds, setSelectedWorkflowIds] = useState<string[]>([])
   const [selectedFolderPaths, setSelectedFolderPaths] = useState<string[]>([])
+  const selectionResetKey = workflowView === ViewMode.Folders ? 1 : 0
 
   const selectedCount = selectedWorkflowIds.length + selectedFolderPaths.length
   const sortedSelectedWorkflowIds = useMemo(
@@ -71,6 +72,12 @@ export function WorkflowsDashboard() {
     []
   )
 
+  useEffect(() => {
+    setSelectedWorkflowIds([])
+    setSelectedFolderPaths([])
+    setBulkPushOpen(false)
+  }, [workflowView])
+
   if (workflowView === ViewMode.Folders) {
     return (
       <div className="size-full overflow-auto">
@@ -88,6 +95,7 @@ export function WorkflowsDashboard() {
           <WorkflowFoldersTable
             view={workflowView}
             onSelectionChange={handleDirectorySelectionChange}
+            clearSelectionTrigger={selectionResetKey}
           />
         </div>
         <WorkflowBulkPushDialog
@@ -109,6 +117,7 @@ export function WorkflowsDashboard() {
       selectedWorkflowIds={sortedSelectedWorkflowIds}
       selectedFolderPaths={sortedSelectedFolderPaths}
       onSelectionChange={handleWorkflowSelectionChange}
+      clearSelectionTrigger={selectionResetKey}
     />
   )
 }
@@ -120,6 +129,7 @@ function WorkflowTagsDashboard({
   selectedWorkflowIds,
   selectedFolderPaths,
   onSelectionChange,
+  clearSelectionTrigger,
 }: {
   workspaceId: string
   bulkPushOpen: boolean
@@ -127,6 +137,7 @@ function WorkflowTagsDashboard({
   selectedWorkflowIds: string[]
   selectedFolderPaths: string[]
   onSelectionChange: (workflows: WorkflowReadMinimal[]) => void
+  clearSelectionTrigger: number
 }) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -160,7 +171,10 @@ function WorkflowTagsDashboard({
               {selectedCount > 0 ? ` (${selectedCount})` : ""}
             </Button>
           </div>
-          <WorkflowsTagsDashboardTable onSelectionChange={onSelectionChange} />
+          <WorkflowsTagsDashboardTable
+            onSelectionChange={onSelectionChange}
+            clearSelectionTrigger={clearSelectionTrigger}
+          />
         </div>
       </div>
       <WorkflowBulkPushDialog

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -2,7 +2,7 @@
 
 import { GitBranchIcon } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import type { WorkflowReadMinimal } from "@/client"
 import { WorkflowsTagsDashboardTable } from "@/components/dashboard/dashboard-table"
 import { ViewMode } from "@/components/dashboard/folder-view-toggle"
@@ -31,39 +31,45 @@ export function WorkflowsDashboard() {
     [selectedFolderPaths]
   )
 
-  const handleWorkflowSelectionChange = (workflows: WorkflowReadMinimal[]) => {
-    setSelectedWorkflowIds(
-      Array.from(new Set(workflows.map((workflow) => workflow.id)))
-    )
-    setSelectedFolderPaths([])
-  }
+  const handleWorkflowSelectionChange = useCallback(
+    (workflows: WorkflowReadMinimal[]) => {
+      setSelectedWorkflowIds(
+        Array.from(new Set(workflows.map((workflow) => workflow.id)))
+      )
+      setSelectedFolderPaths([])
+    },
+    []
+  )
 
-  const handleDirectorySelectionChange = (items: DirectoryItem[]) => {
-    setSelectedWorkflowIds(
-      Array.from(
-        new Set(
-          items
-            .filter(
-              (item): item is Extract<DirectoryItem, { type: "workflow" }> =>
-                item.type === "workflow"
-            )
-            .map((item) => item.id)
+  const handleDirectorySelectionChange = useCallback(
+    (items: DirectoryItem[]) => {
+      setSelectedWorkflowIds(
+        Array.from(
+          new Set(
+            items
+              .filter(
+                (item): item is Extract<DirectoryItem, { type: "workflow" }> =>
+                  item.type === "workflow"
+              )
+              .map((item) => item.id)
+          )
         )
       )
-    )
-    setSelectedFolderPaths(
-      Array.from(
-        new Set(
-          items
-            .filter(
-              (item): item is Extract<DirectoryItem, { type: "folder" }> =>
-                item.type === "folder"
-            )
-            .map((item) => item.path)
+      setSelectedFolderPaths(
+        Array.from(
+          new Set(
+            items
+              .filter(
+                (item): item is Extract<DirectoryItem, { type: "folder" }> =>
+                  item.type === "folder"
+              )
+              .map((item) => item.path)
+          )
         )
       )
-    )
-  }
+    },
+    []
+  )
 
   if (workflowView === ViewMode.Folders) {
     return (

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -1,34 +1,127 @@
 "use client"
 
+import { GitBranchIcon } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useEffect } from "react"
+import { useEffect, useMemo, useState } from "react"
+import type { WorkflowReadMinimal } from "@/client"
 import { WorkflowsTagsDashboardTable } from "@/components/dashboard/dashboard-table"
 import { ViewMode } from "@/components/dashboard/folder-view-toggle"
+import { WorkflowBulkPushDialog } from "@/components/dashboard/workflow-bulk-push-dialog"
 import { WorkflowFoldersTable } from "@/components/dashboard/workflow-folders-table"
 import { WorkflowTagsSidebar } from "@/components/dashboard/workflow-tags-sidebar"
+import { Button } from "@/components/ui/button"
 import { useLocalStorage } from "@/hooks/use-local-storage"
-import { useWorkflowTags } from "@/lib/hooks"
+import { type DirectoryItem, useWorkflowTags } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 export function WorkflowsDashboard() {
   const workspaceId = useWorkspaceId()
-
   const [workflowView, _] = useLocalStorage("folder-view", ViewMode.Tags)
+  const [bulkPushOpen, setBulkPushOpen] = useState(false)
+  const [selectedWorkflowIds, setSelectedWorkflowIds] = useState<string[]>([])
+  const [selectedFolderPaths, setSelectedFolderPaths] = useState<string[]>([])
+
+  const selectedCount = selectedWorkflowIds.length + selectedFolderPaths.length
+  const sortedSelectedWorkflowIds = useMemo(
+    () => [...selectedWorkflowIds].sort(),
+    [selectedWorkflowIds]
+  )
+  const sortedSelectedFolderPaths = useMemo(
+    () => [...selectedFolderPaths].sort(),
+    [selectedFolderPaths]
+  )
+
+  const handleWorkflowSelectionChange = (workflows: WorkflowReadMinimal[]) => {
+    setSelectedWorkflowIds(
+      Array.from(new Set(workflows.map((workflow) => workflow.id)))
+    )
+    setSelectedFolderPaths([])
+  }
+
+  const handleDirectorySelectionChange = (items: DirectoryItem[]) => {
+    setSelectedWorkflowIds(
+      Array.from(
+        new Set(
+          items
+            .filter(
+              (item): item is Extract<DirectoryItem, { type: "workflow" }> =>
+                item.type === "workflow"
+            )
+            .map((item) => item.id)
+        )
+      )
+    )
+    setSelectedFolderPaths(
+      Array.from(
+        new Set(
+          items
+            .filter(
+              (item): item is Extract<DirectoryItem, { type: "folder" }> =>
+                item.type === "folder"
+            )
+            .map((item) => item.path)
+        )
+      )
+    )
+  }
 
   if (workflowView === ViewMode.Folders) {
     return (
       <div className="size-full overflow-auto">
-        <div className="container h-full gap-8 py-8">
-          <WorkflowFoldersTable view={workflowView} />
+        <div className="container flex h-full flex-col gap-4 py-8">
+          <div className="flex items-center justify-end">
+            <Button
+              onClick={() => setBulkPushOpen(true)}
+              disabled={selectedCount === 0}
+            >
+              <GitBranchIcon className="mr-2 size-4" />
+              Push selected to GitHub
+              {selectedCount > 0 ? ` (${selectedCount})` : ""}
+            </Button>
+          </div>
+          <WorkflowFoldersTable
+            view={workflowView}
+            onSelectionChange={handleDirectorySelectionChange}
+          />
         </div>
+        <WorkflowBulkPushDialog
+          open={bulkPushOpen}
+          onOpenChange={setBulkPushOpen}
+          workspaceId={workspaceId}
+          selectedWorkflowIds={sortedSelectedWorkflowIds}
+          selectedFolderPaths={sortedSelectedFolderPaths}
+        />
       </div>
     )
   }
 
-  return <WorkflowTagsDashboard workspaceId={workspaceId} />
+  return (
+    <WorkflowTagsDashboard
+      workspaceId={workspaceId}
+      bulkPushOpen={bulkPushOpen}
+      onBulkPushOpenChange={setBulkPushOpen}
+      selectedWorkflowIds={sortedSelectedWorkflowIds}
+      selectedFolderPaths={sortedSelectedFolderPaths}
+      onSelectionChange={handleWorkflowSelectionChange}
+    />
+  )
 }
 
-function WorkflowTagsDashboard({ workspaceId }: { workspaceId: string }) {
+function WorkflowTagsDashboard({
+  workspaceId,
+  bulkPushOpen,
+  onBulkPushOpenChange,
+  selectedWorkflowIds,
+  selectedFolderPaths,
+  onSelectionChange,
+}: {
+  workspaceId: string
+  bulkPushOpen: boolean
+  onBulkPushOpenChange: (open: boolean) => void
+  selectedWorkflowIds: string[]
+  selectedFolderPaths: string[]
+  onSelectionChange: (workflows: WorkflowReadMinimal[]) => void
+}) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const queryTag = searchParams?.get("tag")
@@ -41,6 +134,9 @@ function WorkflowTagsDashboard({ workspaceId }: { workspaceId: string }) {
       router.push(`/workspaces/${workspaceId}/workflows`)
     }
   }, [queryTag, tags, router, workspaceId])
+
+  const selectedCount = selectedWorkflowIds.length + selectedFolderPaths.length
+
   return (
     <div className="size-full overflow-auto">
       <div className="container grid h-full grid-cols-6 gap-8 py-8">
@@ -48,9 +144,26 @@ function WorkflowTagsDashboard({ workspaceId }: { workspaceId: string }) {
           <WorkflowTagsSidebar workspaceId={workspaceId} />
         </div>
         <div className="col-span-5 flex flex-col space-y-8">
-          <WorkflowsTagsDashboardTable />
+          <div className="flex items-center justify-end">
+            <Button
+              onClick={() => onBulkPushOpenChange(true)}
+              disabled={selectedCount === 0}
+            >
+              <GitBranchIcon className="mr-2 size-4" />
+              Push selected to GitHub
+              {selectedCount > 0 ? ` (${selectedCount})` : ""}
+            </Button>
+          </div>
+          <WorkflowsTagsDashboardTable onSelectionChange={onSelectionChange} />
         </div>
       </div>
+      <WorkflowBulkPushDialog
+        open={bulkPushOpen}
+        onOpenChange={onBulkPushOpenChange}
+        workspaceId={workspaceId}
+        selectedWorkflowIds={selectedWorkflowIds}
+        selectedFolderPaths={selectedFolderPaths}
+      />
     </div>
   )
 }

--- a/frontend/src/components/data-table/table.tsx
+++ b/frontend/src/components/data-table/table.tsx
@@ -47,6 +47,7 @@ type ColumnMeta = {
   headerStyle?: React.CSSProperties
   cellClassName?: string
   cellStyle?: React.CSSProperties
+  disableRowLink?: boolean
 }
 
 export type TableCol<TData> = {
@@ -72,6 +73,7 @@ interface DataTableProps<TData, TValue> {
   onSelectionChange?: (selectedRows: Row<TData>[]) => void
   serverSidePagination?: ServerSidePaginationProps
   clearSelectionTrigger?: number
+  getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string
 }
 
 export function DataTable<TData, TValue>({
@@ -93,6 +95,7 @@ export function DataTable<TData, TValue>({
   onSelectionChange,
   serverSidePagination,
   clearSelectionTrigger,
+  getRowId,
 }: DataTableProps<TData, TValue>) {
   const [tableState, setTableState] = useLocalStorage<Partial<TableState>>(
     `table-state:${tableId}`,
@@ -152,6 +155,7 @@ export function DataTable<TData, TValue>({
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,
+    getRowId,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -362,6 +366,7 @@ function TableContents<TData>({
               const columnMeta = cell.column.columnDef.meta as
                 | ColumnMeta
                 | undefined
+              const disableRowLink = columnMeta?.disableRowLink ?? false
               const cellClassName = cn(
                 columnMeta?.cellClassName,
                 isActionsCol && "p-2"
@@ -373,7 +378,7 @@ function TableContents<TData>({
               )
 
               // For action columns, don't wrap in Link
-              if (isActionsCol || !href) {
+              if (isActionsCol || disableRowLink || !href) {
                 return (
                   <TableCell
                     key={cell.id}

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -1,0 +1,452 @@
+"""HTTP-level tests for workflow publish API endpoint."""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatValidationError
+from tracecat.registry.repositories.schemas import GitBranchInfo
+from tracecat.vcs.github.app import GitHubAppError
+from tracecat.workflow.store.schemas import (
+    WorkflowBulkPushExcludedWorkflow,
+    WorkflowBulkPushExclusionReason,
+    WorkflowBulkPushPreviewResponse,
+    WorkflowBulkPushResult,
+    WorkflowBulkPushWorkflowResult,
+    WorkflowBulkPushWorkflowStatus,
+    WorkflowBulkPushWorkflowSummary,
+    WorkflowDslPublishResult,
+)
+
+
+def _sample_dsl_content() -> dict[str, object]:
+    return {
+        "title": "Test workflow",
+        "description": "A test workflow",
+        "entrypoint": {"ref": "start", "expects": {}},
+        "actions": [
+            {
+                "ref": "start",
+                "action": "core.transform.passthrough",
+                "args": {"value": "test"},
+            }
+        ],
+    }
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/{workflow_id}/publish keeps legacy 204 behavior."""
+    workflow_id = str(uuid.uuid4())
+    workflow = Mock()
+    workflow.id = uuid.UUID(workflow_id)
+
+    definition = Mock()
+    definition.content = _sample_dsl_content()
+    definition.workflow = workflow
+
+    with (
+        patch(
+            "tracecat.workflow.store.router.WorkflowDefinitionsService"
+        ) as mock_defn_cls,
+        patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls,
+    ):
+        mock_defn_svc = AsyncMock()
+        mock_defn_svc.get_definition_by_workflow_id.return_value = definition
+        mock_defn_cls.return_value = mock_defn_svc
+
+        mock_store_svc = AsyncMock()
+        mock_store_svc.publish_workflow_dsl.return_value = WorkflowDslPublishResult(
+            status="committed",
+            commit_sha="abc123",
+            branch="feature/shared-workflow",
+            base_branch="main",
+            pr_url="https://github.com/test-org/test-repo/pull/123",
+            pr_number=123,
+            pr_reused=False,
+            message="Committed workflow changes.",
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            f"/workflows/{workflow_id}/publish",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "message": "Update workflow",
+                "branch": "feature/shared-workflow",
+                "create_pr": True,
+            },
+        )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    called_params = mock_store_svc.publish_workflow_dsl.call_args.kwargs["params"]
+    assert called_params.branch == "feature/shared-workflow"
+    assert called_params.create_pr is True
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_invalid_branch_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test branch validation errors from service return 400."""
+    workflow_id = str(uuid.uuid4())
+    workflow = Mock()
+    workflow.id = uuid.UUID(workflow_id)
+
+    definition = Mock()
+    definition.content = _sample_dsl_content()
+    definition.workflow = workflow
+
+    with (
+        patch(
+            "tracecat.workflow.store.router.WorkflowDefinitionsService"
+        ) as mock_defn_cls,
+        patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls,
+    ):
+        mock_defn_svc = AsyncMock()
+        mock_defn_svc.get_definition_by_workflow_id.return_value = definition
+        mock_defn_cls.return_value = mock_defn_svc
+
+        mock_store_svc = AsyncMock()
+        mock_store_svc.publish_workflow_dsl.side_effect = TracecatValidationError(
+            "branch must be a short branch name, not a full ref (refs/...)"
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            f"/workflows/{workflow_id}/publish",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "branch": "refs/heads/feature/shared-workflow",
+                "create_pr": False,
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "short branch name" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_definition_not_found_returns_404(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test publish returns 404 when workflow definition does not exist."""
+    workflow_id = str(uuid.uuid4())
+
+    with patch(
+        "tracecat.workflow.store.router.WorkflowDefinitionsService"
+    ) as mock_defn_cls:
+        mock_defn_svc = AsyncMock()
+        mock_defn_svc.get_definition_by_workflow_id.return_value = None
+        mock_defn_cls.return_value = mock_defn_svc
+
+        response = client.post(
+            f"/workflows/{workflow_id}/publish",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"branch": "feature/shared-workflow", "create_pr": False},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Workflow definition not found"
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_invalid_create_pr_type_returns_422(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test request validation rejects invalid create_pr type."""
+    workflow_id = str(uuid.uuid4())
+    response = client.post(
+        f"/workflows/{workflow_id}/publish",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={
+            "branch": "feature/shared-workflow",
+            "create_pr": {"invalid": True},
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+@pytest.mark.anyio
+async def test_preview_bulk_push_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push/preview returns preview data."""
+    with patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls:
+        mock_store_svc = AsyncMock()
+        mock_store_svc.preview_bulk_push.return_value = WorkflowBulkPushPreviewResponse(
+            eligible_workflows=[
+                WorkflowBulkPushWorkflowSummary(
+                    workflow_id="wf_123abc",
+                    title="Workflow 1",
+                    alias="workflow-1",
+                    folder_path="/security",
+                    latest_definition_version=3,
+                    latest_definition_created_at=datetime(2026, 3, 6, 12, 0, 0),
+                )
+            ],
+            excluded_workflows=[
+                WorkflowBulkPushExcludedWorkflow(
+                    workflow_id="wf_missing",
+                    title="Missing workflow",
+                    reason=WorkflowBulkPushExclusionReason.NOT_PUBLISHED,
+                    message="Workflow has not been published yet",
+                )
+            ],
+            resolved_workflow_ids=["wf_123abc"],
+            branch="tracecat/bulk-push-20260306-120000",
+            commit_message="Push workflows to GitHub",
+            pr_title="Push workflows to GitHub",
+            pr_body="Bulk push preview",
+            can_submit=True,
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            "/workflows/push/preview",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "workflow_ids": ["wf_123abc"],
+                "folder_paths": ["/security"],
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["branch"] == "tracecat/bulk-push-20260306-120000"
+    assert payload["commit_message"] == "Push workflows to GitHub"
+    assert payload["pr_title"] == "Push workflows to GitHub"
+    assert payload["can_submit"] is True
+    assert payload["resolved_workflow_ids"] == ["wf_123abc"]
+    assert payload["eligible_workflows"][0]["workflow_id"] == "wf_123abc"
+    assert payload["excluded_workflows"][0]["reason"] == "not_published"
+
+    called_params = mock_store_svc.preview_bulk_push.call_args.args[0]
+    assert called_params.workflow_ids == ["wf_123abc"]
+    assert called_params.folder_paths == ["/security"]
+
+
+@pytest.mark.anyio
+async def test_preview_bulk_push_invalid_folder_paths_type_returns_422(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push/preview rejects non-list folder_paths."""
+    response = client.post(
+        "/workflows/push/preview",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={
+            "workflow_ids": ["wf_123abc"],
+            "folder_paths": "/security",
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+@pytest.mark.anyio
+async def test_bulk_push_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push returns structured bulk push result."""
+    with patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls:
+        mock_store_svc = AsyncMock()
+        mock_store_svc.bulk_push.return_value = WorkflowBulkPushResult(
+            status="committed",
+            commit_sha="abc123",
+            branch="feature/bulk-push",
+            base_branch="main",
+            pr_url="https://github.com/test-org/test-repo/pull/456",
+            pr_number=456,
+            pr_reused=False,
+            message="Committed changes for 2 workflow file(s).",
+            selected_count=2,
+            eligible_count=2,
+            excluded_count=0,
+            workflow_results=[
+                WorkflowBulkPushWorkflowResult(
+                    workflow_id="wf_123abc",
+                    title="Workflow 1",
+                    path="workflows/wf_123abc/definition.yml",
+                    status=WorkflowBulkPushWorkflowStatus.COMMITTED,
+                    message="Committed",
+                ),
+                WorkflowBulkPushWorkflowResult(
+                    workflow_id="wf_456def",
+                    title="Workflow 2",
+                    path="workflows/wf_456def/definition.yml",
+                    status=WorkflowBulkPushWorkflowStatus.NO_OP,
+                    message="Already up to date",
+                ),
+            ],
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            "/workflows/push",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "workflow_ids": ["wf_123abc", "wf_456def"],
+                "branch": "feature/bulk-push",
+                "commit_message": "Push workflows to GitHub",
+                "pr_title": "Push workflows to GitHub",
+                "pr_body": "Bulk push body",
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["status"] == "committed"
+    assert payload["commit_sha"] == "abc123"
+    assert payload["branch"] == "feature/bulk-push"
+    assert payload["base_branch"] == "main"
+    assert payload["pr_number"] == 456
+    assert payload["selected_count"] == 2
+    assert payload["eligible_count"] == 2
+    assert payload["excluded_count"] == 0
+    assert payload["workflow_results"][0]["workflow_id"] == "wf_123abc"
+    assert payload["workflow_results"][1]["status"] == "no_op"
+
+    called_params = mock_store_svc.bulk_push.call_args.args[0]
+    assert called_params.workflow_ids == ["wf_123abc", "wf_456def"]
+    assert called_params.branch == "feature/bulk-push"
+    assert called_params.commit_message == "Push workflows to GitHub"
+    assert called_params.pr_title == "Push workflows to GitHub"
+    assert called_params.pr_body == "Bulk push body"
+
+
+@pytest.mark.anyio
+async def test_bulk_push_whitespace_required_fields_return_422(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test POST /workflows/push rejects whitespace-only required text fields."""
+    response = client.post(
+        "/workflows/push",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={
+            "workflow_ids": ["wf_123abc"],
+            "branch": "feature/bulk-push",
+            "commit_message": "   ",
+            "pr_title": "   ",
+            "pr_body": "body",
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+@pytest.mark.anyio
+async def test_list_workflow_branches_success(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workflows/sync/branches returns branch list."""
+    with (
+        patch("tracecat.workflow.store.router.WorkspaceService") as mock_workspace_cls,
+        patch("tracecat.workflow.store.router.WorkflowSyncService") as mock_sync_cls,
+    ):
+        mock_workspace_svc = AsyncMock()
+        mock_workspace = Mock()
+        mock_workspace.settings = {
+            "git_repo_url": "git+ssh://git@github.com/test-org/test-repo.git"
+        }
+        mock_workspace_svc.get_workspace.return_value = mock_workspace
+        mock_workspace_cls.return_value = mock_workspace_svc
+
+        mock_sync_svc = AsyncMock()
+        mock_sync_svc.list_branches.return_value = [
+            GitBranchInfo(name="main", sha="a" * 40, is_default=True),
+            GitBranchInfo(
+                name="feature/workflow-publish",
+                sha="b" * 40,
+                is_default=False,
+            ),
+        ]
+        mock_sync_cls.return_value = mock_sync_svc
+
+        response = client.get(
+            "/workflows/sync/branches",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload == [
+        {"name": "main", "sha": "a" * 40, "is_default": True},
+        {
+            "name": "feature/workflow-publish",
+            "sha": "b" * 40,
+            "is_default": False,
+        },
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_workflow_branches_missing_repo_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workflows/sync/branches returns 400 when repo URL is missing."""
+    with patch("tracecat.workflow.store.router.WorkspaceService") as mock_workspace_cls:
+        mock_workspace_svc = AsyncMock()
+        mock_workspace = Mock()
+        mock_workspace.settings = {}
+        mock_workspace_svc.get_workspace.return_value = mock_workspace
+        mock_workspace_cls.return_value = mock_workspace_svc
+
+        response = client.get(
+            "/workflows/sync/branches",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Git repository URL not configured" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_list_workflow_branches_github_error_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /workflows/sync/branches maps GitHub errors to 400."""
+    with (
+        patch("tracecat.workflow.store.router.WorkspaceService") as mock_workspace_cls,
+        patch("tracecat.workflow.store.router.WorkflowSyncService") as mock_sync_cls,
+    ):
+        mock_workspace_svc = AsyncMock()
+        mock_workspace = Mock()
+        mock_workspace.settings = {
+            "git_repo_url": "git+ssh://git@github.com/test-org/test-repo.git"
+        }
+        mock_workspace_svc.get_workspace.return_value = mock_workspace
+        mock_workspace_cls.return_value = mock_workspace_svc
+
+        mock_sync_svc = AsyncMock()
+        mock_sync_svc.list_branches.side_effect = GitHubAppError(
+            "Unable to access repository"
+        )
+        mock_sync_cls.return_value = mock_sync_svc
+
+        response = client.get(
+            "/workflows/sync/branches",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Unable to access repository" in response.json()["detail"]

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -209,6 +209,7 @@ async def test_preview_bulk_push_success(
             ],
             resolved_workflow_ids=["wf_123abc"],
             branch="tracecat/bulk-push-20260306-120000",
+            base_branch="release",
             commit_message="Push workflows to GitHub",
             pr_title="Push workflows to GitHub",
             pr_body="Bulk push preview",
@@ -228,6 +229,7 @@ async def test_preview_bulk_push_success(
     assert response.status_code == status.HTTP_200_OK
     payload = response.json()
     assert payload["branch"] == "tracecat/bulk-push-20260306-120000"
+    assert payload["base_branch"] == "release"
     assert payload["commit_message"] == "Push workflows to GitHub"
     assert payload["pr_title"] == "Push workflows to GitHub"
     assert payload["can_submit"] is True

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tracecat.expressions.common import eval_jsonpath
 from tracecat.parse import (
     get_pyproject_toml_required_deps,
+    safe_url,
     traverse_expressions,
     traverse_leaves,
     unescape_string,
@@ -219,3 +220,16 @@ def test_unescape_string_no_escapes() -> None:
 def test_unescape_string_empty() -> None:
     """Test that empty strings are handled correctly."""
     assert unescape_string("") == ""
+
+
+def test_safe_url_strips_credentials() -> None:
+    assert (
+        safe_url("https://user:pass@example.com/foo/bar?token=secret#frag")
+        == "https://example.com/foo/bar"
+    )
+
+
+def test_safe_url_preserves_port() -> None:
+    assert safe_url("https://user:pass@example.com:8443/foo") == (
+        "https://example.com:8443/foo"
+    )

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -222,6 +222,27 @@ def test_unescape_string_empty() -> None:
     assert unescape_string("") == ""
 
 
+def test_safe_url_removes_credentials() -> None:
+    assert (
+        safe_url("https://user:token@example.com/org/repo.git?x=1")
+        == "https://example.com/org/repo.git"
+    )
+
+
+def test_safe_url_preserves_port_without_credentials() -> None:
+    assert (
+        safe_url("https://user:token@example.com:8443/org/repo.git")
+        == "https://example.com:8443/org/repo.git"
+    )
+
+
+def test_safe_url_handles_malformed_port_without_raising() -> None:
+    assert (
+        safe_url("https://user:token@example.com:notaport/org/repo.git?x=1")
+        == "https://example.com:notaport/org/repo.git"
+    )
+
+
 def test_safe_url_strips_credentials() -> None:
     assert (
         safe_url("https://user:pass@example.com/foo/bar?token=secret#frag")

--- a/tests/unit/test_workflow_store_service.py
+++ b/tests/unit/test_workflow_store_service.py
@@ -101,6 +101,55 @@ async def test_resolve_bulk_push_selection_excludes_invalid_configuration(
 
 
 @pytest.mark.anyio
+async def test_resolve_bulk_push_selection_excludes_invalid_stored_dsl(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Bulk preview should exclude workflows with malformed stored DSL content."""
+    workflow_id = WorkflowUUID.new(uuid.uuid4())
+    workflow = SimpleNamespace(
+        title="Corrupt workflow",
+        alias="corrupt-workflow",
+        webhook=None,
+        folder=None,
+        tags=[],
+        schedules=[],
+        case_trigger=None,
+    )
+    definition = SimpleNamespace(
+        content={"title": "Corrupt workflow"},
+        version=7,
+        created_at=datetime(2026, 3, 6, 12, 0, 0),
+    )
+
+    with (
+        patch.object(
+            workflow_store_service,
+            "_get_workflows_by_short_id",
+            AsyncMock(return_value={workflow_id.short(): workflow}),
+        ),
+        patch.object(
+            workflow_store_service,
+            "_get_latest_definitions_by_short_id",
+            AsyncMock(return_value={workflow_id.short(): definition}),
+        ),
+    ):
+        resolution = await workflow_store_service._resolve_bulk_push_selection(
+            workflow_ids=[workflow_id],
+            folder_paths=[],
+        )
+
+    assert resolution.prepared_items == []
+    assert resolution.eligible_workflows == []
+    assert resolution.resolved_workflow_ids == [workflow_id.short()]
+    assert len(resolution.excluded_workflows) == 1
+    assert (
+        resolution.excluded_workflows[0].reason
+        == WorkflowBulkPushExclusionReason.INVALID_CONFIGURATION
+    )
+    assert "Field required" in resolution.excluded_workflows[0].message
+
+
+@pytest.mark.anyio
 async def test_list_workflow_ids_in_selected_folders_autoescapes_like_wildcards(
     workflow_store_service: WorkflowStoreService,
 ) -> None:

--- a/tests/unit/test_workflow_store_service.py
+++ b/tests/unit/test_workflow_store_service.py
@@ -1,0 +1,194 @@
+"""Unit tests for WorkflowStoreService bulk push behavior."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
+
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatValidationError
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.store.schemas import (
+    WorkflowBulkPushExclusionReason,
+    WorkflowBulkPushPreviewRequest,
+    WorkflowBulkPushWorkflowSummary,
+)
+from tracecat.workflow.store.service import WorkflowStoreService
+
+
+def _sample_dsl_content() -> dict[str, object]:
+    return {
+        "title": "Test workflow",
+        "description": "A test workflow",
+        "entrypoint": {"ref": "start", "expects": {}},
+        "actions": [
+            {
+                "ref": "start",
+                "action": "core.transform.passthrough",
+                "args": {"value": "test"},
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def workflow_store_service() -> WorkflowStoreService:
+    workspace_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+    organization_id = uuid.UUID("550e8400-e29b-41d4-a716-446655440001")
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+    )
+    return WorkflowStoreService(session=AsyncMock(), role=role)
+
+
+@pytest.mark.anyio
+async def test_resolve_bulk_push_selection_excludes_invalid_configuration(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Bulk preview should exclude workflows that fail remote export validation."""
+    workflow_id = WorkflowUUID.new(uuid.uuid4())
+    workflow = SimpleNamespace(
+        title="Broken workflow",
+        alias="broken-workflow",
+        webhook=None,
+        folder=None,
+        tags=[],
+        schedules=[],
+        case_trigger=None,
+    )
+    definition = SimpleNamespace(
+        content=_sample_dsl_content(),
+        version=3,
+        created_at=datetime(2026, 3, 6, 12, 0, 0),
+    )
+
+    with (
+        patch.object(
+            workflow_store_service,
+            "_get_workflows_by_short_id",
+            AsyncMock(return_value={workflow_id.short(): workflow}),
+        ),
+        patch.object(
+            workflow_store_service,
+            "_get_latest_definitions_by_short_id",
+            AsyncMock(return_value={workflow_id.short(): definition}),
+        ),
+    ):
+        resolution = await workflow_store_service._resolve_bulk_push_selection(
+            workflow_ids=[workflow_id],
+            folder_paths=[],
+        )
+
+    assert resolution.prepared_items == []
+    assert resolution.eligible_workflows == []
+    assert resolution.resolved_workflow_ids == [workflow_id.short()]
+    assert len(resolution.excluded_workflows) == 1
+    assert (
+        resolution.excluded_workflows[0].reason
+        == WorkflowBulkPushExclusionReason.INVALID_CONFIGURATION
+    )
+    assert workflow_id.short() in resolution.excluded_workflows[0].message
+
+
+@pytest.mark.anyio
+async def test_list_workflow_ids_in_selected_folders_autoescapes_like_wildcards(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Folder selection SQL should escape wildcard characters in user paths."""
+    result = Mock()
+    result.scalars.return_value.all.return_value = []
+    with patch.object(
+        workflow_store_service.session,
+        "execute",
+        AsyncMock(return_value=result),
+    ) as mock_execute:
+        await workflow_store_service._list_workflow_ids_in_selected_folders(
+            ["/sec_ur/%ops"]
+        )
+
+    statement = mock_execute.call_args.args[0]
+    compiled = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+    assert "ESCAPE '/'" in compiled
+    assert "LIKE" in compiled
+
+
+def test_bulk_push_preview_request_rejects_non_list_folder_paths() -> None:
+    """Schema should reject malformed folder_paths values before normalization."""
+    with pytest.raises(ValidationError, match="folder_paths must be a list of strings"):
+        WorkflowBulkPushPreviewRequest.model_validate(
+            {
+                "workflow_ids": ["wf_123abc"],
+                "folder_paths": "/security",
+            }
+        )
+
+
+def test_to_workflow_uuids_rejects_invalid_short_ids(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Malformed short IDs should be translated into a validation error."""
+    with patch(
+        "tracecat.workflow.store.service.WorkflowUUID.new",
+        side_effect=ValueError("bad workflow id"),
+    ):
+        with pytest.raises(
+            TracecatValidationError,
+            match="workflow_ids contains an invalid workflow ID",
+        ):
+            workflow_store_service._to_workflow_uuids(["wf_badbadbad"])
+
+
+def test_build_bulk_push_defaults_adds_entropy_to_branch_names(
+    workflow_store_service: WorkflowStoreService,
+) -> None:
+    """Default bulk branch names should not collide within the same timestamp."""
+    eligible_workflows = [
+        WorkflowBulkPushWorkflowSummary(
+            workflow_id="wf_123abc",
+            title="Workflow 1",
+            alias="workflow-1",
+            folder_path="/security",
+            latest_definition_version=3,
+            latest_definition_created_at=datetime(2026, 3, 6, 12, 0, 0),
+        )
+    ]
+
+    with (
+        patch("tracecat.workflow.store.service.datetime") as mock_datetime,
+        patch("tracecat.workflow.store.service.uuid4") as mock_uuid4,
+    ):
+        mock_datetime.now.return_value.strftime.return_value = "20260306-120000-123456"
+        mock_uuid4.side_effect = [
+            SimpleNamespace(hex="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            SimpleNamespace(hex="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        ]
+
+        first_branch, *_ = workflow_store_service._build_bulk_push_defaults(
+            workspace_name="Test workspace",
+            eligible_workflows=eligible_workflows,
+        )
+        second_branch, *_ = workflow_store_service._build_bulk_push_defaults(
+            workspace_name="Test workspace",
+            eligible_workflows=eligible_workflows,
+        )
+
+    assert first_branch == "tracecat/bulk-push-20260306-120000-123456-aaaaaaaa"
+    assert second_branch == "tracecat/bulk-push-20260306-120000-123456-bbbbbbbb"
+    assert first_branch != second_branch
+    assert re.match(r"^tracecat/bulk-push-\d{8}-\d{6}-\d{6}-[0-9a-f]{8}$", first_branch)

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -780,12 +780,65 @@ class TestWorkflowSyncService:
             assert result.object_results is not None
             assert len(result.object_results) == 1
             assert result.object_results[0].status == PushStatus.NO_OP
-            mock_repo.get_git_ref.assert_called_once_with(
-                "heads/feature/shared-workflow"
-            )
+            assert mock_repo.get_git_ref.call_args_list == [
+                call("heads/feature/shared-workflow"),
+                call("heads/feature/shared-workflow"),
+            ]
             mock_repo.get_git_commit.assert_not_called()
             mock_repo.create_git_tree.assert_not_called()
             mock_repo.create_git_commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_noop_rejects_concurrent_branch_changes(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Target-branch no-op pushes should fail if the branch advances mid-prepare."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/shared-workflow",
+        )
+
+        expected_yaml = yaml.dump(
+            sample_remote_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={
+                "workflows/test-workflow.yml": expected_yaml,
+            },
+        )
+        initial_ref = Mock()
+        initial_ref.object.sha = "snapshot123"
+        updated_ref = Mock()
+        updated_ref.object.sha = "snapshot456"
+        mock_repo.get_git_ref.side_effect = [initial_ref, updated_ref]
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="changed while preparing the bulk push",
+        ):
+            with patch("asyncio.to_thread") as mock_to_thread:
+                mock_to_thread.side_effect = _mock_to_thread
+                await workflow_sync_service._push_to_target_branch(
+                    repo=mock_repo,
+                    url=git_url,
+                    objects=[push_obj],
+                    options=options,
+                )
+
+        mock_repo.get_git_commit.assert_not_called()
+        mock_repo.create_git_tree.assert_not_called()
+        mock_repo.create_git_commit.assert_not_called()
 
     @pytest.mark.anyio
     async def test_push_empty_branch_still_uses_target_branch_mode(
@@ -1049,9 +1102,10 @@ class TestWorkflowSyncService:
             assert result.pr_number is None
             assert result.pr_reused is False
             mock_upsert_pr.assert_awaited_once()
-            mock_repo.get_git_ref.assert_called_once_with(
-                "heads/feature/shared-workflow"
-            )
+            assert mock_repo.get_git_ref.call_args_list == [
+                call("heads/feature/shared-workflow"),
+                call("heads/feature/shared-workflow"),
+            ]
             mock_repo.get_git_commit.assert_not_called()
             mock_repo.create_git_tree.assert_not_called()
             mock_repo.create_git_commit.assert_not_called()
@@ -1335,7 +1389,10 @@ class TestWorkflowSyncService:
                 PushStatus.NO_OP,
                 PushStatus.NO_OP,
             ]
-            mock_repo.get_git_ref.assert_called_once_with("heads/feature/bulk-push")
+            assert mock_repo.get_git_ref.call_args_list == [
+                call("heads/feature/bulk-push"),
+                call("heads/feature/bulk-push"),
+            ]
             mock_repo.get_git_commit.assert_not_called()
             mock_repo.create_git_tree.assert_not_called()
             mock_repo.create_git_commit.assert_not_called()

--- a/tests/unit/test_workflow_sync_service.py
+++ b/tests/unit/test_workflow_sync_service.py
@@ -1,16 +1,19 @@
 """Tests for WorkflowSyncService functionality."""
 
+import base64
 import uuid
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
+import yaml
 from github.GithubException import GithubException
 
 from tracecat.auth.types import Role
 from tracecat.dsl.common import DSLEntrypoint, DSLInput
 from tracecat.dsl.schemas import ActionStatement
+from tracecat.exceptions import TracecatValidationError
 from tracecat.git.types import GitUrl
-from tracecat.sync import Author, PushObject, PushOptions
+from tracecat.sync import Author, PushObject, PushOptions, PushStatus
 from tracecat.workflow.store.import_service import WorkflowImportService
 from tracecat.workflow.store.schemas import RemoteWorkflowDefinition
 from tracecat.workflow.store.sync import WorkflowSyncService
@@ -67,7 +70,13 @@ def sample_remote_workflow_with_folder(sample_workflow):
 
 
 @pytest.fixture
-def workflow_sync_service(workspace_id):
+def organization_id():
+    """Test organization ID."""
+    return uuid.UUID("550e8400-e29b-41d4-a716-446655440001")
+
+
+@pytest.fixture
+def workflow_sync_service(workspace_id, organization_id):
     """WorkflowSyncService instance for testing."""
     # Use a mock session for unit tests
     mock_session = AsyncMock()
@@ -75,12 +84,13 @@ def workflow_sync_service(workspace_id):
         type="service",
         service_id="tracecat-api",
         workspace_id=workspace_id,
+        organization_id=organization_id,
     )
     return WorkflowSyncService(session=mock_session, role=role)
 
 
 @pytest.fixture
-def workflow_import_service(workspace_id):
+def workflow_import_service(workspace_id, organization_id):
     """WorkflowImportService instance for testing."""
     # Use a mock session for unit tests
     mock_session = AsyncMock()
@@ -88,8 +98,90 @@ def workflow_import_service(workspace_id):
         type="service",
         service_id="tracecat-api",
         workspace_id=workspace_id,
+        organization_id=organization_id,
     )
     return WorkflowImportService(session=mock_session, role=role)
+
+
+async def _mock_to_thread(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def _tree_element_path(tree_element: object) -> str:
+    return vars(tree_element)["_InputGitTreeElement__path"]
+
+
+def _create_target_branch_repo(
+    *,
+    branch_name: str,
+    base_branch_name: str = "main",
+    default_branch: str = "main",
+    branch_exists: bool = True,
+    existing_file_contents: dict[str, str] | None = None,
+    base_commit_sha: str = "base123",
+    branch_head_sha: str = "branch-head123",
+    parent_commit_sha: str = "parent123",
+    new_commit_sha: str = "new-commit123",
+) -> tuple[Mock, Mock, Mock, Mock]:
+    mock_repo = Mock()
+    mock_repo.default_branch = default_branch
+
+    base_branch = Mock()
+    base_branch.commit.sha = base_commit_sha
+
+    target_branch = Mock()
+    target_branch.commit.sha = branch_head_sha
+
+    def get_branch(name: str):
+        if name == base_branch_name:
+            return base_branch
+        if name == branch_name:
+            if not branch_exists:
+                raise GithubException(404, {"message": "Not Found"}, {})
+            return target_branch
+        raise AssertionError(f"Unexpected branch lookup: {name}")
+
+    mock_repo.get_branch.side_effect = get_branch
+
+    encoded_contents = {
+        path: base64.b64encode(content.encode("utf-8")).decode("utf-8")
+        for path, content in (existing_file_contents or {}).items()
+    }
+
+    def get_contents(path: str, ref: str):
+        if path not in encoded_contents:
+            raise GithubException(404, {"message": "Not Found"}, {})
+        content_file = Mock()
+        content_file.path = path
+        content_file.sha = f"sha-{path}"
+        content_file.content = encoded_contents[path]
+        return content_file
+
+    mock_repo.get_contents.side_effect = get_contents
+
+    branch_ref = Mock()
+    branch_ref.object.sha = parent_commit_sha
+    branch_ref.edit = Mock()
+
+    parent_commit = Mock()
+    parent_commit.sha = parent_commit_sha
+    parent_commit.tree = Mock()
+
+    new_tree = Mock()
+    new_tree.sha = "tree123"
+
+    new_commit = Mock()
+    new_commit.sha = new_commit_sha
+
+    mock_repo.get_git_ref.return_value = branch_ref
+    mock_repo.get_git_commit.return_value = parent_commit
+    mock_repo.create_git_tree.return_value = new_tree
+    mock_repo.create_git_commit.return_value = new_commit
+    mock_repo.create_git_ref = Mock()
+    mock_repo.get_pulls.return_value = []
+    mock_repo.create_pull = Mock()
+
+    return mock_repo, branch_ref, parent_commit, new_commit
 
 
 class TestWorkflowSyncService:
@@ -160,6 +252,7 @@ class TestWorkflowSyncService:
                 objects=[push_obj], url=git_url, options=options
             )
 
+            assert result.status == PushStatus.COMMITTED
             assert result.sha == "abc123def"
             assert result.ref.startswith("tracecat-sync-")
 
@@ -217,6 +310,7 @@ class TestWorkflowSyncService:
                 objects=[push_item], url=git_url, options=options
             )
 
+            assert result.status == PushStatus.COMMITTED
             assert result.sha == "abc123def"
             assert result.ref.startswith("tracecat-sync-")
 
@@ -289,6 +383,7 @@ class TestWorkflowSyncService:
                 objects=[push_obj], url=git_url, options=options
             )
 
+            assert result.status == PushStatus.COMMITTED
             assert result.sha == "abc123def"
             assert result.ref.startswith("tracecat-sync-")
 
@@ -302,20 +397,49 @@ class TestWorkflowSyncService:
         options = PushOptions(message="Update workflows", author=author)
 
         with pytest.raises(
-            ValueError, match="We only support pushing one workflow object at a time"
+            ValueError, match="At least one workflow object is required"
         ):
             await workflow_sync_service.push(objects=[], url=git_url, options=options)
 
     @pytest.mark.anyio
-    async def test_push_objects_empty_objects(self, workflow_sync_service, git_url):
-        """Test push fails with empty objects list."""
+    async def test_push_legacy_rejects_multiple_objects(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test legacy publish mode rejects multi-object pushes."""
         author = Author(name="Test User", email="test@example.com")
         options = PushOptions(message="Update workflows", author=author)
+        push_objects = [
+            PushObject(data=sample_remote_workflow, path="workflows/test-workflow.yml"),
+            PushObject(
+                data=sample_remote_workflow, path="workflows/test-workflow-2.yml"
+            ),
+        ]
 
-        with pytest.raises(
-            ValueError, match="We only support pushing one workflow object at a time"
+        mock_repo = Mock()
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
         ):
-            await workflow_sync_service.push(objects=[], url=git_url, options=options)
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+            mock_to_thread.side_effect = _mock_to_thread
+
+            with pytest.raises(
+                ValueError,
+                match="Legacy publish mode only supports pushing one workflow object at a time",
+            ):
+                await workflow_sync_service.push(
+                    objects=push_objects, url=git_url, options=options
+                )
 
     @pytest.mark.anyio
     async def test_push_workflows_github_failure(
@@ -416,6 +540,850 @@ class TestWorkflowSyncService:
             call_args = mock_repo.create_file.call_args
             file_path = call_args.kwargs["path"]
             assert file_path == "workflows/my-test-workflow.yaml"
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_commits_to_existing_branch(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode commits directly to an existing branch."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo, branch_ref, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.ref == "feature/shared-workflow"
+            assert result.base_ref == "main"
+            assert result.pr_url is None
+            assert result.pr_number is None
+            assert result.pr_reused is False
+            assert result.object_results is not None
+            mock_repo.create_git_ref.assert_not_called()
+            assert mock_repo.get_git_ref.call_args_list == [
+                call("heads/feature/shared-workflow"),
+                call("heads/feature/shared-workflow"),
+            ]
+            mock_repo.create_git_tree.assert_called_once()
+            mock_repo.create_git_commit.assert_called_once()
+            branch_ref.edit.assert_called_once_with(new_commit.sha)
+
+            object_results = result.object_results or []
+            assert len(object_results) == 1
+            assert object_results[0].path == "workflows/test-workflow.yml"
+            assert object_results[0].status == PushStatus.COMMITTED
+
+            tree_elements = mock_repo.create_git_tree.call_args.args[0]
+            assert len(tree_elements) == 1
+            assert _tree_element_path(tree_elements[0]) == "workflows/test-workflow.yml"
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_creates_missing_branch_from_base(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode creates target branch when it is missing."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/new-workflow",
+        )
+
+        mock_repo, branch_ref, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/new-workflow",
+            branch_exists=False,
+            existing_file_contents={},
+            new_commit_sha="target123",
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.ref == "feature/new-workflow"
+            assert result.base_ref == "main"
+            mock_repo.create_git_ref.assert_called_once_with(
+                ref="refs/heads/feature/new-workflow",
+                sha="base123",
+            )
+            mock_repo.create_git_tree.assert_called_once()
+            branch_ref.edit.assert_called_once_with(new_commit.sha)
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_defaults_base_to_url_ref(
+        self, workflow_sync_service, sample_remote_workflow
+    ):
+        """Test branch-target mode uses URL ref as base when pr_base_branch is unset."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/new-workflow",
+        )
+        git_url = GitUrl(
+            host="github.com", org="test-org", repo="test-repo", ref="release"
+        )
+
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/new-workflow",
+            base_branch_name="release",
+            existing_file_contents={},
+            base_commit_sha="release123",
+            new_commit_sha="target123",
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.base_ref == "release"
+            mock_repo.create_git_ref.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_noop_returns_no_op(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode returns no_op on identical file contents."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/shared-workflow",
+        )
+
+        expected_yaml = yaml.dump(
+            sample_remote_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={
+                "workflows/test-workflow.yml": expected_yaml,
+            },
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.NO_OP
+            assert result.sha is None
+            assert result.ref == "feature/shared-workflow"
+            assert result.base_ref == "main"
+            assert result.object_results is not None
+            assert len(result.object_results) == 1
+            assert result.object_results[0].status == PushStatus.NO_OP
+            mock_repo.get_git_ref.assert_called_once_with(
+                "heads/feature/shared-workflow"
+            )
+            mock_repo.get_git_commit.assert_not_called()
+            mock_repo.create_git_tree.assert_not_called()
+            mock_repo.create_git_commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_empty_branch_still_uses_target_branch_mode(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test empty-string branch does not fall back to legacy mode."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="",
+        )
+
+        mock_repo = Mock()
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        target_mode_result = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+            patch.object(
+                workflow_sync_service,
+                "_push_to_target_branch",
+                new=AsyncMock(return_value=target_mode_result),
+            ) as mock_target_mode,
+            patch.object(
+                workflow_sync_service,
+                "_push_legacy",
+                new=AsyncMock(return_value=Mock()),
+            ) as mock_legacy_mode,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result is target_mode_result
+            mock_target_mode.assert_awaited_once()
+            mock_legacy_mode.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_create_pr_failure_returns_committed_result(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test successful commits are returned even when PR creation fails."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+            patch.object(
+                workflow_sync_service,
+                "_upsert_pull_request",
+                new=AsyncMock(
+                    side_effect=GithubException(
+                        422, {"message": "Validation Failed"}, {}
+                    )
+                ),
+            ) as mock_upsert_pr,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.pr_url is None
+            assert result.pr_number is None
+            assert result.pr_reused is False
+            mock_upsert_pr.assert_awaited_once()
+            mock_repo.create_git_tree.assert_called_once()
+            mock_repo.create_git_commit.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_rejects_pr_to_same_branch(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Target-branch pushes should not commit directly to the PR base branch."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="main",
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="main",
+            base_branch_name="main",
+        )
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="branch must differ from the PR base branch",
+        ):
+            with patch("asyncio.to_thread") as mock_to_thread:
+                mock_to_thread.side_effect = _mock_to_thread
+                await workflow_sync_service._push_to_target_branch(
+                    repo=mock_repo,
+                    url=git_url,
+                    objects=[push_obj],
+                    options=options,
+                )
+
+        mock_repo.create_git_tree.assert_not_called()
+        mock_repo.create_git_commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_rejects_concurrent_branch_changes(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Target-branch pushes should fail if the branch advances mid-prepare."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+        )
+        initial_ref = Mock()
+        initial_ref.object.sha = "snapshot123"
+        updated_ref = Mock()
+        updated_ref.object.sha = "snapshot456"
+        mock_repo.get_git_ref.side_effect = [initial_ref, updated_ref]
+
+        with pytest.raises(
+            TracecatValidationError,
+            match="changed while preparing the bulk push",
+        ):
+            with patch("asyncio.to_thread") as mock_to_thread:
+                mock_to_thread.side_effect = _mock_to_thread
+                await workflow_sync_service._push_to_target_branch(
+                    repo=mock_repo,
+                    url=git_url,
+                    objects=[push_obj],
+                    options=options,
+                )
+
+        mock_repo.create_git_tree.assert_not_called()
+        mock_repo.create_git_commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_noop_pr_failure_returns_no_op_result(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test no-op publish still succeeds when PR creation fails."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="feature/shared-workflow",
+        )
+
+        expected_yaml = yaml.dump(
+            sample_remote_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={
+                "workflows/test-workflow.yml": expected_yaml,
+            },
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+            patch.object(
+                workflow_sync_service,
+                "_upsert_pull_request",
+                new=AsyncMock(
+                    side_effect=GithubException(
+                        422, {"message": "Validation Failed"}, {}
+                    )
+                ),
+            ) as mock_upsert_pr,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.NO_OP
+            assert result.sha is None
+            assert result.pr_url is None
+            assert result.pr_number is None
+            assert result.pr_reused is False
+            mock_upsert_pr.assert_awaited_once()
+            mock_repo.get_git_ref.assert_called_once_with(
+                "heads/feature/shared-workflow"
+            )
+            mock_repo.get_git_commit.assert_not_called()
+            mock_repo.create_git_tree.assert_not_called()
+            mock_repo.create_git_commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_create_pr_creates_new_pull_request(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode creates a PR when requested and none exists."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
+        )
+
+        mock_pr = Mock()
+        mock_pr.number = 456
+        mock_pr.html_url = "https://github.com/test-org/test-repo/pull/456"
+        mock_repo.create_pull.return_value = mock_pr
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+            patch(
+                "tracecat.workflow.store.sync.WorkspaceService"
+            ) as mock_ws_service_class,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_ws_service = AsyncMock()
+            mock_workspace = Mock()
+            mock_workspace.name = "Test Workspace"
+            mock_ws_service.get_workspace.return_value = mock_workspace
+            mock_ws_service_class.return_value = mock_ws_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.pr_reused is False
+            assert result.pr_number == 456
+            assert result.pr_url == "https://github.com/test-org/test-repo/pull/456"
+            mock_repo.create_pull.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_create_pr_reuses_existing_pull_request(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode reuses existing open PR for same head/base."""
+        push_obj = PushObject(
+            data=sample_remote_workflow, path="workflows/test-workflow.yml"
+        )
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Update workflows",
+            author=author,
+            create_pr=True,
+            branch="feature/shared-workflow",
+        )
+
+        mock_repo, _, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/shared-workflow",
+            existing_file_contents={},
+            new_commit_sha="target123",
+        )
+
+        existing_pr = Mock()
+        existing_pr.number = 789
+        existing_pr.html_url = "https://github.com/test-org/test-repo/pull/789"
+        mock_repo.get_pulls.return_value = [existing_pr]
+        mock_repo.create_pull = Mock()
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=[push_obj], url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.pr_reused is True
+            assert result.pr_number == 789
+            assert result.pr_url == "https://github.com/test-org/test-repo/pull/789"
+            mock_repo.create_pull.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_multiple_objects_uses_single_commit(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode batches multiple workflow files into one commit."""
+        second_workflow = RemoteWorkflowDefinition(
+            id="wf_456def",
+            alias="another-workflow",
+            definition=sample_remote_workflow.definition.model_copy(
+                update={"title": "Another workflow"}
+            ),
+        )
+        push_objects = [
+            PushObject(
+                data=sample_remote_workflow, path="workflows/wf_123abc/definition.yml"
+            ),
+            PushObject(data=second_workflow, path="workflows/wf_456def/definition.yml"),
+        ]
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Push multiple workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/bulk-push",
+        )
+
+        mock_repo, branch_ref, _, new_commit = _create_target_branch_repo(
+            branch_name="feature/bulk-push",
+            existing_file_contents={},
+            new_commit_sha="bulk-commit123",
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=push_objects, url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.COMMITTED
+            assert result.sha == new_commit.sha
+            assert result.message == "Committed changes for 2 workflow file(s)."
+            assert result.object_results is not None
+            assert [
+                object_result.status for object_result in result.object_results
+            ] == [
+                PushStatus.COMMITTED,
+                PushStatus.COMMITTED,
+            ]
+
+            assert mock_repo.get_git_ref.call_args_list == [
+                call("heads/feature/bulk-push"),
+                call("heads/feature/bulk-push"),
+            ]
+            mock_repo.create_git_tree.assert_called_once()
+            mock_repo.create_git_commit.assert_called_once()
+            branch_ref.edit.assert_called_once_with(new_commit.sha)
+
+            tree_elements = mock_repo.create_git_tree.call_args.args[0]
+            assert len(tree_elements) == 2
+            assert {_tree_element_path(element) for element in tree_elements} == {
+                "workflows/wf_123abc/definition.yml",
+                "workflows/wf_456def/definition.yml",
+            }
+
+    @pytest.mark.anyio
+    async def test_push_target_branch_multiple_objects_returns_no_op_when_unchanged(
+        self, workflow_sync_service, git_url, sample_remote_workflow
+    ):
+        """Test branch-target mode skips commit creation when all workflow files match."""
+        second_workflow = RemoteWorkflowDefinition(
+            id="wf_456def",
+            alias="another-workflow",
+            definition=sample_remote_workflow.definition.model_copy(
+                update={"title": "Another workflow"}
+            ),
+        )
+        push_objects = [
+            PushObject(
+                data=sample_remote_workflow, path="workflows/wf_123abc/definition.yml"
+            ),
+            PushObject(data=second_workflow, path="workflows/wf_456def/definition.yml"),
+        ]
+        author = Author(name="Test User", email="test@example.com")
+        options = PushOptions(
+            message="Push multiple workflows",
+            author=author,
+            create_pr=False,
+            branch="feature/bulk-push",
+        )
+
+        first_yaml = yaml.dump(
+            sample_remote_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+        second_yaml = yaml.dump(
+            second_workflow.model_dump(
+                mode="json", exclude_none=True, exclude_unset=True
+            ),
+            sort_keys=False,
+        )
+
+        mock_repo, _, _, _ = _create_target_branch_repo(
+            branch_name="feature/bulk-push",
+            existing_file_contents={
+                "workflows/wf_123abc/definition.yml": first_yaml,
+                "workflows/wf_456def/definition.yml": second_yaml,
+            },
+        )
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+            mock_to_thread.side_effect = _mock_to_thread
+
+            result = await workflow_sync_service.push(
+                objects=push_objects, url=git_url, options=options
+            )
+
+            assert result.status == PushStatus.NO_OP
+            assert result.sha is None
+            assert result.message == "No changes detected; nothing to commit."
+            assert result.object_results is not None
+            assert [
+                object_result.status for object_result in result.object_results
+            ] == [
+                PushStatus.NO_OP,
+                PushStatus.NO_OP,
+            ]
+            mock_repo.get_git_ref.assert_called_once_with("heads/feature/bulk-push")
+            mock_repo.get_git_commit.assert_not_called()
+            mock_repo.create_git_tree.assert_not_called()
+            mock_repo.create_git_commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_list_branches_success(self, workflow_sync_service, git_url):
+        """Test branch listing from GitHub repository."""
+        mock_repo = Mock()
+        mock_repo.default_branch = "main"
+
+        main_branch = Mock()
+        main_branch.name = "main"
+        main_branch.commit.sha = "a" * 40
+        feature_branch = Mock()
+        feature_branch.name = "feature/workflow-sync"
+        feature_branch.commit.sha = "b" * 40
+        mock_repo.get_branches.return_value = [main_branch, feature_branch]
+
+        mock_github_client = Mock()
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github_client.close = Mock()
+
+        with (
+            patch(
+                "tracecat.workflow.store.sync.GitHubAppService"
+            ) as mock_gh_service_class,
+            patch("asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_gh_service = AsyncMock()
+            mock_gh_service.get_github_client_for_repo = AsyncMock(
+                return_value=mock_github_client
+            )
+            mock_gh_service_class.return_value = mock_gh_service
+
+            async def mock_to_thread_impl(func, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            mock_to_thread.side_effect = mock_to_thread_impl
+
+            branches = await workflow_sync_service.list_branches(url=git_url, limit=10)
+
+        assert len(branches) == 2
+        assert branches[0].name == "main"
+        assert branches[0].sha == "a" * 40
+        assert branches[0].is_default is True
+        assert branches[1].name == "feature/workflow-sync"
+        assert branches[1].sha == "b" * 40
+        assert branches[1].is_default is False
 
 
 class TestWorkflowImportServiceFolders:
@@ -520,6 +1488,7 @@ class TestWorkflowImportServiceFolders:
         )
         workflow_import_service._create_schedules = AsyncMock()
         workflow_import_service._update_webhook = AsyncMock()
+        workflow_import_service._update_case_trigger = AsyncMock()
         workflow_import_service._create_tags = AsyncMock()
 
         with patch(
@@ -558,6 +1527,7 @@ class TestWorkflowImportServiceFolders:
         workflow_import_service._ensure_folder_exists = AsyncMock()
         workflow_import_service._create_schedules = AsyncMock()
         workflow_import_service._update_webhook = AsyncMock()
+        workflow_import_service._update_case_trigger = AsyncMock()
         workflow_import_service._create_tags = AsyncMock()
 
         with patch(

--- a/tracecat/dsl/validation.py
+++ b/tracecat/dsl/validation.py
@@ -140,7 +140,13 @@ def format_input_schema_validation_error(details: list[ValidationDetail]) -> str
 
 
 PYDANTIC_ERR_TYPE_HANDLER: dict[str, Callable[[Sequence[int | str]], str]] = {
-    "pydantic.extra_forbidden": lambda loc: f"The attribute '{'.'.join(str(s) for s in loc)}' is not allowed in the input schema.",
-    "pydantic.missing": lambda loc: f"Missing required field(s): '{'.'.join(str(s) for s in loc)}'.",
-    "pydantic.invalid_type": lambda loc: f"Invalid type at '{'.'.join(str(s) for s in loc)}'.",
+    "pydantic.extra_forbidden": lambda loc: (
+        f"The attribute '{'.'.join(str(s) for s in loc)}' is not allowed in the input schema."
+    ),
+    "pydantic.missing": lambda loc: (
+        f"Missing required field(s): '{'.'.join(str(s) for s in loc)}'."
+    ),
+    "pydantic.invalid_type": lambda loc: (
+        f"Invalid type at '{'.'.join(str(s) for s in loc)}'."
+    ),
 }

--- a/tracecat/parse.py
+++ b/tracecat/parse.py
@@ -75,9 +75,15 @@ def traverse_expressions(obj: Any) -> Iterator[str]:
 def safe_url(url: str) -> str:
     """Remove credentials from a url."""
     url_obj = urlparse(url)
+    hostname = url_obj.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    netloc = hostname
+    if url_obj.port is not None:
+        netloc = f"{hostname}:{url_obj.port}"
     # XXX(safety): Reconstruct url without credentials.
     # Note that we do not recommend passing credentials in the url.
-    cleaned_url = urlunparse((url_obj.scheme, url_obj.netloc, url_obj.path, "", "", ""))
+    cleaned_url = urlunparse((url_obj.scheme, netloc, url_obj.path, "", "", ""))
     return cleaned_url
 
 

--- a/tracecat/parse.py
+++ b/tracecat/parse.py
@@ -75,12 +75,15 @@ def traverse_expressions(obj: Any) -> Iterator[str]:
 def safe_url(url: str) -> str:
     """Remove credentials from a url."""
     url_obj = urlparse(url)
-    hostname = url_obj.hostname or ""
-    if ":" in hostname and not hostname.startswith("["):
-        hostname = f"[{hostname}]"
-    netloc = hostname
-    if url_obj.port is not None:
-        netloc = f"{hostname}:{url_obj.port}"
+    try:
+        hostname = url_obj.hostname or ""
+        if ":" in hostname and not hostname.startswith("["):
+            hostname = f"[{hostname}]"
+        netloc = hostname
+        if (port := url_obj.port) is not None:
+            netloc = f"{hostname}:{port}"
+    except ValueError:
+        netloc = url_obj.netloc.rsplit("@", 1)[-1]
     # XXX(safety): Reconstruct url without credentials.
     # Note that we do not recommend passing credentials in the url.
     cleaned_url = urlunparse((url_obj.scheme, netloc, url_obj.path, "", "", ""))

--- a/tracecat/registry/actions/schemas.py
+++ b/tracecat/registry/actions/schemas.py
@@ -382,9 +382,9 @@ class RegistryActionRead(RegistryActionBase):
             options=RegistryActionOptions(**action.options),
             secrets=sorted(
                 secrets,
-                key=lambda x: x.provider_id
-                if isinstance(x, RegistryOAuthSecret)
-                else x.name,
+                key=lambda x: (
+                    x.provider_id if isinstance(x, RegistryOAuthSecret) else x.name
+                ),
             ),
         )
 

--- a/tracecat/registry/repositories/schemas.py
+++ b/tracecat/registry/repositories/schemas.py
@@ -119,6 +119,27 @@ class GitCommitInfo(BaseModel):
     )
 
 
+class GitBranchInfo(BaseModel):
+    """Git branch information for repository management."""
+
+    name: str = Field(
+        ...,
+        description="The branch name",
+        min_length=1,
+        max_length=255,
+    )
+    sha: str = Field(
+        ...,
+        description="The latest commit SHA for the branch",
+        min_length=40,
+        max_length=40,
+    )
+    is_default: bool = Field(
+        default=False,
+        description="Whether this is the repository default branch",
+    )
+
+
 class RegistryRepositorySync(BaseModel):
     """Parameters for syncing a repository to a specific commit."""
 

--- a/tracecat/sync.py
+++ b/tracecat/sync.py
@@ -44,6 +44,13 @@ class ConflictStrategy(StrEnum):
     """Overwrite existing workflows with new definitions"""
 
 
+class PushStatus(StrEnum):
+    """Status of a push/commit operation."""
+
+    COMMITTED = "committed"
+    NO_OP = "no_op"
+
+
 @dataclass(frozen=True)
 class PullOptions:
     """Options controlling pull/checkout behavior."""
@@ -75,19 +82,60 @@ class PushOptions:
     create_pr: bool = False
     """Create a pull request if supported"""
 
+    branch: str | None = None
+    """Target branch for branch-target publish mode; None enables legacy temp-branch flow."""
+
+    pr_base_branch: str | None = None
+    """Optional PR base branch override; defaults to repository default branch."""
+
+    pr_title: str | None = None
+    """Optional pull request title override."""
+
+    pr_body: str | None = None
+    """Optional pull request body override."""
+
     sign: bool = False
     """GPG signing if configured"""
+
+
+@dataclass(frozen=True)
+class PushObjectResult:
+    """Per-object result for a push operation."""
+
+    path: str
+    status: PushStatus
 
 
 @dataclass(frozen=True)
 class CommitInfo:
     """Result of a push/commit operation."""
 
-    sha: str
-    """SHA of the commit"""
+    status: PushStatus
+    """Outcome status for the push operation."""
+
+    sha: str | None
+    """SHA of the commit; None for no-op pushes."""
 
     ref: str
     """Resolved ref after push (e.g., branch)"""
+
+    base_ref: str
+    """Resolved base branch used for branch creation and PR operations."""
+
+    pr_url: str | None = None
+    """Created or reused pull request URL if available."""
+
+    pr_number: int | None = None
+    """Created or reused pull request number if available."""
+
+    pr_reused: bool = False
+    """Whether an existing PR was reused instead of creating a new one."""
+
+    message: str = ""
+    """Human-readable summary of the push outcome."""
+
+    object_results: list[PushObjectResult] | None = None
+    """Per-object outcomes for batch push operations."""
 
 
 @dataclass(frozen=True)
@@ -184,7 +232,8 @@ class SyncService[T: BaseModel](Protocol):
             options: Commit metadata and optional provider hints.
 
         Returns:
-            CommitInfo containing the resulting commit SHA and ref.
+            CommitInfo containing push outcome details (status, commit SHA, branch,
+            PR metadata).
 
         Raises:
             RuntimeError: Transport or push errors (conflicts, auth).

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -11,6 +11,7 @@ from tracecat.exceptions import (
 from tracecat.git.utils import parse_git_url
 from tracecat.identifiers.workflow import AnyWorkflowIDPath
 from tracecat.logger import logger
+from tracecat.parse import safe_url
 from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.sync import PullOptions, PullResult
 from tracecat.vcs.github.app import GitHubAppError
@@ -28,6 +29,12 @@ from tracecat.workflow.store.sync import WorkflowSyncService
 from tracecat.workspaces.service import WorkspaceService
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
+
+
+def _safe_repository_url(repository_url: str | None) -> str | None:
+    if repository_url is None:
+        return None
+    return safe_url(repository_url)
 
 
 @router.post(
@@ -213,14 +220,20 @@ async def list_workflow_commits(
     except HTTPException:
         raise
     except ValueError as e:
-        logger.error(f"Invalid repository URL: {repository_url}", exc_info=True)
+        logger.error(
+            "Invalid repository URL",
+            repository_url=_safe_repository_url(repository_url),
+            exc_info=True,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid repository URL: {str(e)}",
         ) from e
     except GitHubAppError as e:
         logger.error(
-            f"GitHub App error accessing repository: {repository_url}", exc_info=True
+            "GitHub App error accessing repository",
+            repository_url=_safe_repository_url(repository_url),
+            exc_info=True,
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -229,7 +242,7 @@ async def list_workflow_commits(
     except Exception as e:
         logger.error(
             "Error fetching commits from repository",
-            repository_url=repository_url,
+            repository_url=_safe_repository_url(repository_url),
             error=str(e),
         )
         raise HTTPException(
@@ -282,14 +295,20 @@ async def list_workflow_branches(
     except HTTPException:
         raise
     except ValueError as e:
-        logger.error(f"Invalid repository URL: {repository_url}", exc_info=True)
+        logger.error(
+            "Invalid repository URL",
+            repository_url=_safe_repository_url(repository_url),
+            exc_info=True,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid repository URL: {str(e)}",
         ) from e
     except GitHubAppError as e:
         logger.error(
-            f"GitHub App error accessing repository: {repository_url}", exc_info=True
+            "GitHub App error accessing repository",
+            repository_url=_safe_repository_url(repository_url),
+            exc_info=True,
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -298,7 +317,7 @@ async def list_workflow_branches(
     except Exception as e:
         logger.error(
             "Error fetching branches from repository",
-            repository_url=repository_url,
+            repository_url=_safe_repository_url(repository_url),
             error=str(e),
         )
         raise HTTPException(
@@ -369,7 +388,8 @@ async def pull_workflows(
         ) from e
     except GitHubAppError as e:
         logger.error(
-            f"GitHub App error during workflow pull: {repository_url}",
+            "GitHub App error during workflow pull",
+            repository_url=_safe_repository_url(repository_url),
             exc_info=True,
         )
         raise HTTPException(
@@ -378,7 +398,8 @@ async def pull_workflows(
         ) from e
     except Exception as e:
         logger.error(
-            f"Error pulling workflows from repository: {repository_url}",
+            "Error pulling workflows from repository",
+            repository_url=_safe_repository_url(repository_url),
             exc_info=True,
         )
         raise HTTPException(

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -6,15 +6,23 @@ from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import (
     TracecatCredentialsNotFoundError,
     TracecatSettingsError,
+    TracecatValidationError,
 )
 from tracecat.git.utils import parse_git_url
 from tracecat.identifiers.workflow import AnyWorkflowIDPath
 from tracecat.logger import logger
-from tracecat.registry.repositories.schemas import GitCommitInfo
+from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.sync import PullOptions, PullResult
 from tracecat.vcs.github.app import GitHubAppError
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
-from tracecat.workflow.store.schemas import WorkflowDslPublish, WorkflowSyncPullRequest
+from tracecat.workflow.store.schemas import (
+    WorkflowBulkPushPreviewRequest,
+    WorkflowBulkPushPreviewResponse,
+    WorkflowBulkPushRequest,
+    WorkflowBulkPushResult,
+    WorkflowDslPublish,
+    WorkflowSyncPullRequest,
+)
 from tracecat.workflow.store.service import WorkflowStoreService
 from tracecat.workflow.store.sync import WorkflowSyncService
 from tracecat.workspaces.service import WorkspaceService
@@ -22,7 +30,10 @@ from tracecat.workspaces.service import WorkspaceService
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 
 
-@router.post("/{workflow_id}/publish", status_code=status.HTTP_204_NO_CONTENT)
+@router.post(
+    "/{workflow_id}/publish",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
 async def publish_workflow(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
@@ -56,7 +67,80 @@ async def publish_workflow(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         ) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except TracecatCredentialsNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except GitHubAppError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.post(
+    "/push/preview",
+    response_model=WorkflowBulkPushPreviewResponse,
+)
+async def preview_bulk_push_workflows(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    params: WorkflowBulkPushPreviewRequest,
+) -> WorkflowBulkPushPreviewResponse:
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+    store_svc = WorkflowStoreService(session=session, role=role)
+    try:
+        return await store_svc.preview_bulk_push(params)
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.post(
+    "/push",
+    response_model=WorkflowBulkPushResult,
+)
+async def bulk_push_workflows(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    params: WorkflowBulkPushRequest,
+) -> WorkflowBulkPushResult:
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+    store_svc = WorkflowStoreService(session=session, role=role)
+    try:
+        return await store_svc.bulk_push(params)
+    except TracecatSettingsError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except TracecatCredentialsNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except GitHubAppError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -126,6 +210,8 @@ async def list_workflow_commits(
 
         return commits
 
+    except HTTPException:
+        raise
     except ValueError as e:
         logger.error(f"Invalid repository URL: {repository_url}", exc_info=True)
         raise HTTPException(
@@ -141,12 +227,83 @@ async def list_workflow_commits(
             detail=f"Unable to access repository: {str(e)}",
         ) from e
     except Exception as e:
-        logger.exception(
-            f"Error fetching commits from repository: {repository_url}", exc_info=True
+        logger.error(
+            "Error fetching commits from repository",
+            repository_url=repository_url,
+            error=str(e),
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to fetch repository commits",
+        ) from e
+
+
+@router.get("/sync/branches", response_model=list[GitBranchInfo])
+async def list_workflow_branches(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    limit: int = Query(
+        default=100,
+        description="Maximum number of branches to return",
+        ge=1,
+        le=200,
+    ),
+) -> list[GitBranchInfo]:
+    """Get branch list for workflow repository via GitHub App."""
+    if not role.workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+
+    repository_url = None
+    try:
+        workspace_service = WorkspaceService(session=session, role=role)
+        workspace = await workspace_service.get_workspace(role.workspace_id)
+
+        if not workspace:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Workspace not found",
+            )
+
+        repository_url = workspace.settings.get("git_repo_url")
+
+        if not repository_url:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Git repository URL not configured in workspace settings",
+            )
+
+        git_url = parse_git_url(repository_url)
+        sync_service = WorkflowSyncService(session=session, role=role)
+        branches = await sync_service.list_branches(url=git_url, limit=limit)
+        return branches
+    except HTTPException:
+        raise
+    except ValueError as e:
+        logger.error(f"Invalid repository URL: {repository_url}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid repository URL: {str(e)}",
+        ) from e
+    except GitHubAppError as e:
+        logger.error(
+            f"GitHub App error accessing repository: {repository_url}", exc_info=True
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unable to access repository: {str(e)}",
+        ) from e
+    except Exception as e:
+        logger.error(
+            "Error fetching branches from repository",
+            repository_url=repository_url,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch repository branches",
         ) from e
 
 

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -159,6 +159,7 @@ class WorkflowBulkPushPreviewResponse(BaseModel):
     )
     resolved_workflow_ids: list[WorkflowIDShort] = Field(default_factory=list)
     branch: str
+    base_branch: str | None = None
     commit_message: str
     pr_title: str
     pr_body: str

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -1,8 +1,18 @@
+import re
 from datetime import datetime, timedelta
+from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
+from tracecat.cases.enums import CaseEventType
 from tracecat.dsl.common import DSLInput
 from tracecat.identifiers.workflow import WorkflowID, WorkflowIDShort
 from tracecat.store import Source
@@ -11,8 +21,62 @@ from tracecat.store import Source
 WorkflowSource = Source[WorkflowID]
 
 
+_INVALID_GIT_REF_CHARS_RE = re.compile(r"[\x00-\x20\x7f~^:?*\[\\]")
+
+
+def validate_short_branch_name(value: str, *, field_name: str) -> str:
+    """Validate Git-safe short branch names."""
+    if value == "":
+        raise ValueError(f"{field_name} cannot be empty")
+    if value.startswith("refs/"):
+        raise ValueError(
+            f"{field_name} must be a short branch name, not a full ref (refs/...)"
+        )
+    if value in {".", "..", "@", "HEAD"}:
+        raise ValueError(f"{field_name} must be a valid branch name")
+    if value.startswith("/") or value.endswith("/"):
+        raise ValueError(f"{field_name} cannot start or end with '/'")
+    if value.startswith("-"):
+        raise ValueError(f"{field_name} cannot start with '-'")
+    if value.endswith("."):
+        raise ValueError(f"{field_name} cannot end with '.'")
+    if any(part.endswith(".lock") for part in value.split("/")):
+        raise ValueError(
+            f"{field_name} cannot contain path segments ending with '.lock'"
+        )
+    if ".." in value:
+        raise ValueError(f"{field_name} cannot contain '..'")
+    if "//" in value:
+        raise ValueError(f"{field_name} cannot contain '//'")
+    if "@{" in value:
+        raise ValueError(f"{field_name} cannot contain '@{{'")
+    if _INVALID_GIT_REF_CHARS_RE.search(value):
+        raise ValueError(
+            f"{field_name} contains invalid characters for a Git branch name"
+        )
+    if any(part.startswith(".") or part.endswith(".") for part in value.split("/")):
+        raise ValueError(
+            f"{field_name} contains invalid path segments for a Git branch name"
+        )
+    return value
+
+
 class WorkflowDslPublish(BaseModel):
     message: str | None = None
+    branch: str | None = None
+    create_pr: bool = False
+    pr_base_branch: str | None = None
+
+
+class WorkflowDslPublishResult(BaseModel):
+    status: Literal["committed", "no_op"]
+    commit_sha: str | None = None
+    branch: str
+    base_branch: str
+    pr_url: str | None = None
+    pr_number: int | None = None
+    pr_reused: bool = False
+    message: str
 
 
 class WorkflowSyncPullRequest(BaseModel):
@@ -29,6 +93,124 @@ class WorkflowSyncPullRequest(BaseModel):
         default=False,
         description="Validate only, don't perform actual import",
     )
+
+
+class WorkflowBulkPushExclusionReason(StrEnum):
+    NOT_FOUND = "not_found"
+    NOT_PUBLISHED = "not_published"
+    INVALID_CONFIGURATION = "invalid_configuration"
+
+
+class WorkflowBulkPushWorkflowStatus(StrEnum):
+    COMMITTED = "committed"
+    NO_OP = "no_op"
+    EXCLUDED = "excluded"
+
+
+class WorkflowBulkPushWorkflowSummary(BaseModel):
+    workflow_id: WorkflowIDShort
+    title: str
+    alias: str | None = None
+    folder_path: str | None = None
+    latest_definition_version: int
+    latest_definition_created_at: datetime
+
+
+class WorkflowBulkPushExcludedWorkflow(BaseModel):
+    workflow_id: WorkflowIDShort | None = None
+    title: str | None = None
+    reason: WorkflowBulkPushExclusionReason
+    message: str
+
+
+class WorkflowBulkPushPreviewRequest(BaseModel):
+    workflow_ids: list[WorkflowIDShort] = Field(default_factory=list, max_length=500)
+    folder_paths: list[str] = Field(default_factory=list, max_length=100)
+
+    @field_validator("folder_paths", mode="before")
+    @classmethod
+    def validate_folder_paths(cls, value: object) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("folder_paths must be a list of strings")
+
+        paths: list[str] = []
+        for path in value:
+            if not isinstance(path, str):
+                raise ValueError("folder_paths must contain only strings")
+            if stripped := path.strip():
+                paths.append(stripped)
+        return list(dict.fromkeys(paths))
+
+    @model_validator(mode="after")
+    def validate_selection(self) -> "WorkflowBulkPushPreviewRequest":
+        if not self.workflow_ids and not self.folder_paths:
+            raise ValueError("At least one workflow or folder selection is required")
+        return self
+
+
+class WorkflowBulkPushPreviewResponse(BaseModel):
+    eligible_workflows: list[WorkflowBulkPushWorkflowSummary] = Field(
+        default_factory=list
+    )
+    excluded_workflows: list[WorkflowBulkPushExcludedWorkflow] = Field(
+        default_factory=list
+    )
+    resolved_workflow_ids: list[WorkflowIDShort] = Field(default_factory=list)
+    branch: str
+    commit_message: str
+    pr_title: str
+    pr_body: str
+    can_submit: bool = False
+
+
+class WorkflowBulkPushRequest(BaseModel):
+    workflow_ids: list[WorkflowIDShort] = Field(default_factory=list, min_length=1)
+    branch: str
+    commit_message: str = Field(min_length=1, max_length=512)
+    pr_title: str = Field(min_length=1, max_length=256)
+    pr_body: str = Field(default="")
+
+    @field_validator("branch")
+    @classmethod
+    def validate_branch(cls, value: str) -> str:
+        return validate_short_branch_name(value.strip(), field_name="branch")
+
+    @field_validator("commit_message", "pr_title")
+    @classmethod
+    def validate_required_text_fields(cls, value: str) -> str:
+        if not (stripped := value.strip()):
+            raise ValueError("value cannot be empty")
+        return stripped
+
+    @field_validator("pr_body")
+    @classmethod
+    def strip_pr_body(cls, value: str) -> str:
+        return value.strip()
+
+
+class WorkflowBulkPushWorkflowResult(BaseModel):
+    workflow_id: WorkflowIDShort
+    title: str
+    path: str
+    status: WorkflowBulkPushWorkflowStatus
+    message: str | None = None
+
+
+class WorkflowBulkPushResult(BaseModel):
+    status: Literal["committed", "no_op"]
+    commit_sha: str | None = None
+    branch: str
+    base_branch: str
+    pr_url: str | None = None
+    pr_number: int | None = None
+    pr_reused: bool = False
+    message: str
+    selected_count: int
+    eligible_count: int
+    excluded_count: int
+    workflow_results: list[WorkflowBulkPushWorkflowResult] = Field(default_factory=list)
 
 
 _SER_DSL_KEY_ORDER = (
@@ -63,6 +245,20 @@ class RemoteWebhook(BaseModel):
     """The methods of the webhook."""
     status: Status = Field(default="online")
     """Status of the webhook, either 'online' or 'offline'."""
+
+
+class RemoteCaseTrigger(BaseModel):
+    """Represents a case trigger configuration in a remote store."""
+
+    status: Status = Field(default="offline")
+    event_types: list[CaseEventType] = Field(default_factory=list)
+    tag_filters: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_event_types(self) -> "RemoteCaseTrigger":
+        if self.status == "online" and not self.event_types:
+            raise ValueError("event_types must be non-empty when status is online")
+        return self
 
 
 class RemoteWorkflowSchedule(BaseModel):
@@ -134,6 +330,9 @@ class RemoteWorkflowDefinition(BaseModel):
 
     webhook: RemoteWebhook | None = None
     """Webhook for the workflow."""
+
+    case_trigger: RemoteCaseTrigger | None = None
+    """Case trigger configuration for the workflow."""
 
     definition: DSLInput
 

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import cast
 from uuid import uuid4
 
+from pydantic import ValidationError
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import selectinload
 
@@ -389,14 +390,14 @@ class WorkflowStoreService(BaseWorkspaceService):
                 )
                 continue
 
-            dsl = DSLInput.model_validate(definition.content)
             try:
+                dsl = DSLInput.model_validate(definition.content)
                 remote_definition = self._build_remote_workflow_definition(
                     workflow_id=workflow_id,
                     dsl=dsl,
                     workflow=workflow,
                 )
-            except TracecatValidationError as e:
+            except (TracecatValidationError, ValidationError) as e:
                 excluded_workflows.append(
                     WorkflowBulkPushExcludedWorkflow(
                         workflow_id=workflow_short_id,

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -182,7 +182,7 @@ class WorkflowStoreService(BaseWorkspaceService):
     async def preview_bulk_push(
         self, params: WorkflowBulkPushPreviewRequest
     ) -> WorkflowBulkPushPreviewResponse:
-        workspace = await self._get_workspace()
+        workspace, git_url = await self._get_workspace_and_git_url()
         selection = await self._resolve_bulk_push_selection(
             workflow_ids=self._to_workflow_uuids(params.workflow_ids),
             folder_paths=params.folder_paths,
@@ -196,6 +196,7 @@ class WorkflowStoreService(BaseWorkspaceService):
             excluded_workflows=selection.excluded_workflows,
             resolved_workflow_ids=selection.resolved_workflow_ids,
             branch=branch,
+            base_branch=git_url.ref,
             commit_message=commit_message,
             pr_title=pr_title,
             pr_body=pr_body,

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -1,24 +1,67 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import cast
+from uuid import uuid4
 
-from tracecat.db.models import Workflow
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.orm import selectinload
+
+from tracecat.cases.enums import CaseEventType
+from tracecat.db.models import Workflow, WorkflowDefinition, WorkflowFolder, Workspace
 from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import TracecatSettingsError, TracecatValidationError
+from tracecat.git.types import GitUrl
 from tracecat.git.utils import parse_git_url
-from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.identifiers.workflow import WorkflowIDShort, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
-from tracecat.sync import Author, PushObject, PushOptions
+from tracecat.sync import (
+    Author,
+    PushObject,
+    PushObjectResult,
+    PushOptions,
+    PushStatus,
+)
 from tracecat.workflow.store.schemas import (
+    RemoteCaseTrigger,
     RemoteWebhook,
     RemoteWorkflowDefinition,
     RemoteWorkflowSchedule,
     RemoteWorkflowTag,
     Status,
+    WorkflowBulkPushExcludedWorkflow,
+    WorkflowBulkPushExclusionReason,
+    WorkflowBulkPushPreviewRequest,
+    WorkflowBulkPushPreviewResponse,
+    WorkflowBulkPushRequest,
+    WorkflowBulkPushResult,
+    WorkflowBulkPushWorkflowResult,
+    WorkflowBulkPushWorkflowStatus,
+    WorkflowBulkPushWorkflowSummary,
     WorkflowDslPublish,
+    WorkflowDslPublishResult,
+    validate_short_branch_name,
 )
 from tracecat.workflow.store.sync import WorkflowSyncService
 from tracecat.workspaces.service import WorkspaceService
+
+
+@dataclass(frozen=True)
+class PreparedBulkPushItem:
+    workflow: Workflow
+    definition: WorkflowDefinition
+    remote_definition: RemoteWorkflowDefinition
+    path: Path
+
+
+@dataclass(frozen=True)
+class BulkPushSelectionResolution:
+    prepared_items: list[PreparedBulkPushItem]
+    eligible_workflows: list[WorkflowBulkPushWorkflowSummary]
+    excluded_workflows: list[WorkflowBulkPushExcludedWorkflow]
+    resolved_workflow_ids: list[WorkflowIDShort]
 
 
 class WorkflowStoreService(BaseWorkspaceService):
@@ -31,92 +74,69 @@ class WorkflowStoreService(BaseWorkspaceService):
         dsl: DSLInput,
         params: WorkflowDslPublish,
         workflow: Workflow,
-    ) -> None:
-        """Take the latest version of the workflow definition and publish it to the store."""
-        # Validate that workflow_id matches the provided workflow object
+    ) -> WorkflowDslPublishResult:
+        """Take the latest version of the workflow definition and publish it to GitHub."""
         if workflow.id != workflow_id:
             raise TracecatValidationError(
                 f"Workflow ID mismatch: provided {workflow_id} but workflow object has ID {workflow.id}"
             )
 
-        # Get workspace settings for git configuration
-
-        workspace_service = WorkspaceService(session=self.session, role=self.role)
-        workspace = await workspace_service.get_workspace(self.workspace_id)
-
-        if not workspace:
-            raise TracecatValidationError("Workspace not found")
-
-        # Extract git configuration from workspace settings
-        git_repo_url = workspace.settings.get("git_repo_url")
-        if not git_repo_url:
-            raise TracecatSettingsError(
-                "Git repository URL not configured for this workspace. "
-                "Please contact your administrator to configure it."
-            )
+        workspace, git_url = await self._get_workspace_and_git_url()
 
         logger.info(
             "Publishing workflow to store",
             workflow_title=dsl.title,
-            repo_url=git_repo_url,
+            repo_url=workspace.settings.get("git_repo_url"),
             workspace_id=self.workspace_id,
         )
 
-        # Parse the Git URL using workspace settings
-        try:
-            git_url = parse_git_url(git_repo_url, allowed_domains={"github.com"})
-        except ValueError as e:
-            raise TracecatSettingsError(
-                f"Invalid Git repository URL configured for this workspace: {e}. "
-                "Please contact your administrator to fix the configuration."
-            ) from e
-        # Note: We could add ref support later if needed via params or workspace settings
-
-        stable_path = get_definition_path(workflow_id)
-        webhook = workflow.webhook
-
-        await self.session.refresh(workflow, ["tags", "folder"])
-
-        # Get folder path if workflow is in a folder
-        folder_path = None
-        if workflow.folder:
-            folder_path = workflow.folder.path
-
-        # Create PushObject with data and stable path
-        defn = RemoteWorkflowDefinition(
-            id=workflow_id.short(),
-            alias=workflow.alias,
-            folder_path=folder_path,
-            tags=[RemoteWorkflowTag(name=t.name) for t in workflow.tags],
-            # Convert Schedule ORM objects to RemoteWorkflowSchedule, handling type conversions and missing fields.
-            schedules=[
-                RemoteWorkflowSchedule(
-                    status=cast(Status, s.status),
-                    cron=s.cron,
-                    every=s.every,
-                    offset=s.offset,
-                    start_at=s.start_at,
-                    end_at=s.end_at,
-                    timeout=s.timeout,
-                )
-                for s in (workflow.schedules or [])
-            ],
-            webhook=RemoteWebhook(
-                methods=webhook.methods,
-                status=cast(Status, webhook.status),
+        await self.session.refresh(workflow, ["tags", "folder", "schedules", "webhook"])
+        push_obj = PushObject(
+            data=self._build_remote_workflow_definition(
+                workflow_id=workflow_id, dsl=dsl, workflow=workflow
             ),
-            definition=dsl,
+            path=get_definition_path(workflow_id),
         )
-        push_obj = PushObject(data=defn, path=stable_path)
 
         author = Author(name="Tracecat", email="noreply@tracecat.com")
-        push_options = PushOptions(
-            message=params.message or f"Publish workflow: {dsl.title}",
-            author=author,
-            create_pr=True,  # Create PR for review
-        )
+        publish_message = params.message or f"Publish workflow: {dsl.title}"
+        validated_branch: str | None = None
+        validated_pr_base_branch: str | None = None
 
-        # Use WorkflowSyncService to push the workflow with stable path
+        if params.branch is not None:
+            try:
+                validated_branch = validate_short_branch_name(
+                    params.branch,
+                    field_name="branch",
+                )
+                if params.pr_base_branch is not None:
+                    validated_pr_base_branch = validate_short_branch_name(
+                        params.pr_base_branch,
+                        field_name="pr_base_branch",
+                    )
+            except ValueError as e:
+                raise TracecatValidationError(str(e)) from e
+
+        if params.branch is None:
+            logger.warning(
+                "workflow_publish_legacy_mode_used",
+                workflow_id=str(workflow_id),
+                workspace_id=str(self.workspace_id),
+            )
+            push_options = PushOptions(
+                message=publish_message,
+                author=author,
+                create_pr=True,
+            )
+        else:
+            push_options = PushOptions(
+                message=publish_message,
+                author=author,
+                create_pr=params.create_pr,
+                branch=validated_branch,
+                pr_base_branch=validated_pr_base_branch,
+            )
+
         sync_service = WorkflowSyncService(session=self.session, role=self.role)
         commit_info = await sync_service.push(
             objects=[push_obj],
@@ -124,12 +144,492 @@ class WorkflowStoreService(BaseWorkspaceService):
             options=push_options,
         )
 
+        if validated_branch is not None and commit_info.status in {
+            PushStatus.COMMITTED,
+            PushStatus.NO_OP,
+        }:
+            await self._persist_git_sync_branch([workflow], validated_branch)
+
         logger.info(
             "Successfully published workflow",
             workflow_title=dsl.title,
+            status=commit_info.status.value,
             commit_sha=commit_info.sha,
             ref=commit_info.ref,
+            base_ref=commit_info.base_ref,
+            pr_url=commit_info.pr_url,
+            pr_number=commit_info.pr_number,
+            pr_reused=commit_info.pr_reused,
         )
+
+        return WorkflowDslPublishResult(
+            status=commit_info.status.value,
+            commit_sha=commit_info.sha,
+            branch=commit_info.ref,
+            base_branch=commit_info.base_ref,
+            pr_url=commit_info.pr_url,
+            pr_number=commit_info.pr_number,
+            pr_reused=commit_info.pr_reused,
+            message=commit_info.message,
+        )
+
+    async def preview_bulk_push(
+        self, params: WorkflowBulkPushPreviewRequest
+    ) -> WorkflowBulkPushPreviewResponse:
+        workspace = await self._get_workspace()
+        selection = await self._resolve_bulk_push_selection(
+            workflow_ids=self._to_workflow_uuids(params.workflow_ids),
+            folder_paths=params.folder_paths,
+        )
+        branch, commit_message, pr_title, pr_body = self._build_bulk_push_defaults(
+            workspace_name=workspace.name,
+            eligible_workflows=selection.eligible_workflows,
+        )
+        return WorkflowBulkPushPreviewResponse(
+            eligible_workflows=selection.eligible_workflows,
+            excluded_workflows=selection.excluded_workflows,
+            resolved_workflow_ids=selection.resolved_workflow_ids,
+            branch=branch,
+            commit_message=commit_message,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            can_submit=bool(selection.prepared_items),
+        )
+
+    async def bulk_push(
+        self, params: WorkflowBulkPushRequest
+    ) -> WorkflowBulkPushResult:
+        _, git_url = await self._get_workspace_and_git_url()
+        selection = await self._resolve_bulk_push_selection(
+            workflow_ids=self._to_workflow_uuids(params.workflow_ids),
+            folder_paths=[],
+        )
+        if not selection.prepared_items:
+            raise TracecatValidationError(
+                "No published workflows are available to push to GitHub."
+            )
+
+        author = Author(name="Tracecat", email="noreply@tracecat.com")
+        push_objects = [
+            PushObject(data=item.remote_definition, path=item.path)
+            for item in selection.prepared_items
+        ]
+        push_options = PushOptions(
+            message=params.commit_message,
+            author=author,
+            create_pr=True,
+            branch=params.branch,
+            pr_title=params.pr_title,
+            pr_body=params.pr_body,
+        )
+        sync_service = WorkflowSyncService(session=self.session, role=self.role)
+        commit_info = await sync_service.push(
+            objects=push_objects,
+            url=git_url,
+            options=push_options,
+        )
+
+        if commit_info.status in {PushStatus.COMMITTED, PushStatus.NO_OP}:
+            await self._persist_git_sync_branch(
+                [item.workflow for item in selection.prepared_items],
+                params.branch,
+            )
+
+        object_results = self._build_bulk_push_workflow_results(
+            selection=selection,
+            object_results=commit_info.object_results,
+            default_status=commit_info.status,
+        )
+        message = commit_info.message
+        if selection.excluded_workflows:
+            message = (
+                f"{message} Excluded {len(selection.excluded_workflows)} workflow(s)."
+            )
+
+        return WorkflowBulkPushResult(
+            status=commit_info.status.value,
+            commit_sha=commit_info.sha,
+            branch=commit_info.ref,
+            base_branch=commit_info.base_ref,
+            pr_url=commit_info.pr_url,
+            pr_number=commit_info.pr_number,
+            pr_reused=commit_info.pr_reused,
+            message=message,
+            selected_count=len(params.workflow_ids),
+            eligible_count=len(selection.prepared_items),
+            excluded_count=len(selection.excluded_workflows),
+            workflow_results=object_results,
+        )
+
+    async def _get_workspace(self) -> Workspace:
+        workspace_service = WorkspaceService(session=self.session, role=self.role)
+        workspace = await workspace_service.get_workspace(self.workspace_id)
+        if not workspace:
+            raise TracecatValidationError("Workspace not found")
+        return workspace
+
+    async def _get_workspace_and_git_url(self) -> tuple[Workspace, GitUrl]:
+        workspace = await self._get_workspace()
+        git_repo_url = workspace.settings.get("git_repo_url")
+        if not git_repo_url:
+            raise TracecatSettingsError(
+                "Git repository URL not configured for this workspace. "
+                "Please contact your administrator to configure it."
+            )
+        try:
+            git_url = parse_git_url(git_repo_url, allowed_domains={"github.com"})
+        except ValueError as e:
+            raise TracecatSettingsError(
+                f"Invalid Git repository URL configured for this workspace: {e}. "
+                "Please contact your administrator to fix the configuration."
+            ) from e
+        return workspace, git_url
+
+    def _build_remote_workflow_definition(
+        self,
+        *,
+        workflow_id: WorkflowUUID,
+        dsl: DSLInput,
+        workflow: Workflow,
+    ) -> RemoteWorkflowDefinition:
+        webhook = workflow.webhook
+        if webhook is None:
+            raise TracecatValidationError(
+                f"Workflow {workflow_id.short()} is missing a webhook configuration."
+            )
+        case_trigger = getattr(workflow, "case_trigger", None)
+
+        folder_path = workflow.folder.path if workflow.folder else None
+        return RemoteWorkflowDefinition(
+            id=workflow_id.short(),
+            alias=workflow.alias,
+            folder_path=folder_path,
+            tags=[RemoteWorkflowTag(name=tag.name) for tag in workflow.tags],
+            schedules=[
+                RemoteWorkflowSchedule(
+                    status=cast(Status, schedule.status),
+                    cron=schedule.cron,
+                    every=schedule.every,
+                    offset=schedule.offset,
+                    start_at=schedule.start_at,
+                    end_at=schedule.end_at,
+                    timeout=schedule.timeout,
+                )
+                for schedule in workflow.schedules or []
+            ],
+            webhook=RemoteWebhook(
+                methods=webhook.methods,
+                status=cast(Status, webhook.status),
+            ),
+            case_trigger=RemoteCaseTrigger(
+                status=cast(Status, case_trigger.status) if case_trigger else "offline",
+                event_types=[
+                    CaseEventType(event_type) for event_type in case_trigger.event_types
+                ]
+                if case_trigger
+                else [],
+                tag_filters=case_trigger.tag_filters if case_trigger else [],
+            )
+            if case_trigger
+            else None,
+            definition=dsl,
+        )
+
+    async def _resolve_bulk_push_selection(
+        self,
+        *,
+        workflow_ids: Sequence[WorkflowUUID],
+        folder_paths: Sequence[str],
+    ) -> BulkPushSelectionResolution:
+        folder_workflow_ids = await self._list_workflow_ids_in_selected_folders(
+            folder_paths
+        )
+        ordered_workflow_ids = self._dedupe_workflow_ids(
+            list(workflow_ids) + folder_workflow_ids
+        )
+        workflows_by_short = await self._get_workflows_by_short_id(ordered_workflow_ids)
+        definitions_by_short = await self._get_latest_definitions_by_short_id(
+            ordered_workflow_ids
+        )
+
+        prepared_items: list[PreparedBulkPushItem] = []
+        eligible_workflows: list[WorkflowBulkPushWorkflowSummary] = []
+        excluded_workflows: list[WorkflowBulkPushExcludedWorkflow] = []
+        resolved_workflow_ids = [
+            workflow_id.short() for workflow_id in ordered_workflow_ids
+        ]
+
+        for workflow_id in ordered_workflow_ids:
+            workflow_short_id = workflow_id.short()
+            workflow = workflows_by_short.get(workflow_short_id)
+            if workflow is None:
+                excluded_workflows.append(
+                    WorkflowBulkPushExcludedWorkflow(
+                        workflow_id=workflow_short_id,
+                        reason=WorkflowBulkPushExclusionReason.NOT_FOUND,
+                        message="Workflow not found in this workspace.",
+                    )
+                )
+                continue
+
+            definition = definitions_by_short.get(workflow_short_id)
+            if definition is None:
+                excluded_workflows.append(
+                    WorkflowBulkPushExcludedWorkflow(
+                        workflow_id=workflow_short_id,
+                        title=workflow.title,
+                        reason=WorkflowBulkPushExclusionReason.NOT_PUBLISHED,
+                        message="Workflow has no published definition to push.",
+                    )
+                )
+                continue
+
+            dsl = DSLInput.model_validate(definition.content)
+            try:
+                remote_definition = self._build_remote_workflow_definition(
+                    workflow_id=workflow_id,
+                    dsl=dsl,
+                    workflow=workflow,
+                )
+            except TracecatValidationError as e:
+                excluded_workflows.append(
+                    WorkflowBulkPushExcludedWorkflow(
+                        workflow_id=workflow_short_id,
+                        title=workflow.title,
+                        reason=WorkflowBulkPushExclusionReason.INVALID_CONFIGURATION,
+                        message=str(e),
+                    )
+                )
+                continue
+
+            prepared_items.append(
+                PreparedBulkPushItem(
+                    workflow=workflow,
+                    definition=definition,
+                    remote_definition=remote_definition,
+                    path=get_definition_path(workflow_id),
+                )
+            )
+            eligible_workflows.append(
+                WorkflowBulkPushWorkflowSummary(
+                    workflow_id=workflow_short_id,
+                    title=workflow.title,
+                    alias=workflow.alias,
+                    folder_path=workflow.folder.path if workflow.folder else None,
+                    latest_definition_version=definition.version,
+                    latest_definition_created_at=definition.created_at,
+                )
+            )
+
+        return BulkPushSelectionResolution(
+            prepared_items=prepared_items,
+            eligible_workflows=eligible_workflows,
+            excluded_workflows=excluded_workflows,
+            resolved_workflow_ids=resolved_workflow_ids,
+        )
+
+    async def _list_workflow_ids_in_selected_folders(
+        self, folder_paths: Sequence[str]
+    ) -> list[WorkflowUUID]:
+        normalized_paths = self._normalize_folder_paths(folder_paths)
+        if not normalized_paths:
+            return []
+        if "/" in normalized_paths:
+            statement = select(Workflow.id).where(
+                Workflow.workspace_id == self.workspace_id
+            )
+        else:
+            path_filters = [
+                WorkflowFolder.path.startswith(path, autoescape=True)
+                for path in normalized_paths
+            ]
+            statement = (
+                select(Workflow.id)
+                .join(WorkflowFolder, Workflow.folder_id == WorkflowFolder.id)
+                .where(
+                    Workflow.workspace_id == self.workspace_id,
+                    or_(*path_filters),
+                )
+            )
+        statement = statement.order_by(Workflow.created_at.desc(), Workflow.id.desc())
+        result = await self.session.execute(statement)
+        return [WorkflowUUID.new(workflow_id) for workflow_id in result.scalars().all()]
+
+    async def _get_workflows_by_short_id(
+        self, workflow_ids: Sequence[WorkflowUUID]
+    ) -> dict[WorkflowIDShort, Workflow]:
+        if not workflow_ids:
+            return {}
+        statement = (
+            select(Workflow)
+            .where(
+                Workflow.workspace_id == self.workspace_id,
+                Workflow.id.in_(workflow_ids),
+            )
+            .options(
+                selectinload(Workflow.tags),
+                selectinload(Workflow.folder),
+                selectinload(Workflow.schedules),
+                selectinload(Workflow.webhook),
+            )
+        )
+        result = await self.session.execute(statement)
+        workflows = result.scalars().all()
+        return {
+            WorkflowUUID.new(workflow.id).short(): workflow for workflow in workflows
+        }
+
+    async def _get_latest_definitions_by_short_id(
+        self, workflow_ids: Sequence[WorkflowUUID]
+    ) -> dict[WorkflowIDShort, WorkflowDefinition]:
+        if not workflow_ids:
+            return {}
+        latest_versions = (
+            select(
+                WorkflowDefinition.workflow_id,
+                func.max(WorkflowDefinition.version).label("latest_version"),
+            )
+            .where(
+                WorkflowDefinition.workspace_id == self.workspace_id,
+                WorkflowDefinition.workflow_id.in_(workflow_ids),
+            )
+            .group_by(WorkflowDefinition.workflow_id)
+            .subquery()
+        )
+        statement = (
+            select(WorkflowDefinition)
+            .join(
+                latest_versions,
+                and_(
+                    WorkflowDefinition.workflow_id == latest_versions.c.workflow_id,
+                    WorkflowDefinition.version == latest_versions.c.latest_version,
+                ),
+            )
+            .where(WorkflowDefinition.workspace_id == self.workspace_id)
+        )
+        result = await self.session.execute(statement)
+        definitions = result.scalars().all()
+        return {
+            WorkflowUUID.new(definition.workflow_id).short(): definition
+            for definition in definitions
+            if definition.workflow_id is not None
+        }
+
+    def _build_bulk_push_defaults(
+        self,
+        *,
+        workspace_name: str,
+        eligible_workflows: Sequence[WorkflowBulkPushWorkflowSummary],
+    ) -> tuple[str, str, str, str]:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        branch = f"tracecat/bulk-push-{timestamp}-{uuid4().hex[:8]}"
+        workflow_count = len(eligible_workflows)
+        if workflow_count == 1:
+            workflow_label = eligible_workflows[0].title
+        else:
+            workflow_label = f"{workflow_count} workflows"
+
+        commit_message = f"Push {workflow_label} to GitHub"
+        pr_title = f"Push {workflow_label} from {workspace_name}"
+
+        workflow_lines = [
+            f"- {workflow.title} (`{workflow.workflow_id}`)"
+            for workflow in eligible_workflows
+        ]
+        pr_body = "\n".join(
+            [
+                "Automated bulk push from Tracecat.",
+                "",
+                f"**Workspace:** {workspace_name}",
+                "",
+                "**Workflows:**",
+                *workflow_lines,
+            ]
+        )
+        return branch, commit_message, pr_title, pr_body
+
+    async def _persist_git_sync_branch(
+        self, workflows: Sequence[Workflow], branch: str
+    ) -> None:
+        if not workflows or not hasattr(workflows[0], "git_sync_branch"):
+            return
+        for workflow in workflows:
+            workflow.git_sync_branch = branch
+            self.session.add(workflow)
+        await self.session.commit()
+
+    def _build_bulk_push_workflow_results(
+        self,
+        *,
+        selection: BulkPushSelectionResolution,
+        object_results: Sequence[PushObjectResult] | None,
+        default_status: PushStatus,
+    ) -> list[WorkflowBulkPushWorkflowResult]:
+        object_status_by_path = (
+            {result.path: result.status for result in object_results}
+            if object_results
+            else {}
+        )
+        workflow_results = [
+            WorkflowBulkPushWorkflowResult(
+                workflow_id=item.remote_definition.id,
+                title=item.workflow.title,
+                path=str(item.path),
+                status=WorkflowBulkPushWorkflowStatus(
+                    object_status_by_path.get(str(item.path), default_status).value
+                ),
+            )
+            for item in selection.prepared_items
+        ]
+        for excluded in selection.excluded_workflows:
+            if excluded.workflow_id is None:
+                continue
+            workflow_results.append(
+                WorkflowBulkPushWorkflowResult(
+                    workflow_id=excluded.workflow_id,
+                    title=excluded.title or excluded.workflow_id,
+                    path=str(
+                        get_definition_path(WorkflowUUID.new(excluded.workflow_id))
+                    ),
+                    status=WorkflowBulkPushWorkflowStatus.EXCLUDED,
+                    message=excluded.message,
+                )
+            )
+        return workflow_results
+
+    def _dedupe_workflow_ids(
+        self, workflow_ids: Sequence[WorkflowUUID]
+    ) -> list[WorkflowUUID]:
+        unique_ids: dict[WorkflowIDShort, WorkflowUUID] = {}
+        for workflow_id in workflow_ids:
+            unique_ids.setdefault(workflow_id.short(), workflow_id)
+        return list(unique_ids.values())
+
+    def _normalize_folder_paths(self, folder_paths: Sequence[str]) -> list[str]:
+        normalized_paths: list[str] = []
+        for path in folder_paths:
+            stripped = path.strip()
+            if not stripped:
+                continue
+            if stripped == "/":
+                normalized = "/"
+            else:
+                normalized = stripped if stripped.startswith("/") else f"/{stripped}"
+                if not normalized.endswith("/"):
+                    normalized = f"{normalized}/"
+            if normalized not in normalized_paths:
+                normalized_paths.append(normalized)
+        return normalized_paths
+
+    def _to_workflow_uuids(
+        self, workflow_ids: Sequence[WorkflowIDShort]
+    ) -> list[WorkflowUUID]:
+        try:
+            return [WorkflowUUID.new(workflow_id) for workflow_id in workflow_ids]
+        except ValueError as e:
+            raise TracecatValidationError(
+                "workflow_ids contains an invalid workflow ID"
+            ) from e
 
 
 def get_definition_path(workflow_id: WorkflowUUID) -> Path:

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -16,6 +16,7 @@ from tracecat.git.types import GitUrl
 from tracecat.git.utils import parse_git_url
 from tracecat.identifiers.workflow import WorkflowIDShort, WorkflowUUID
 from tracecat.logger import logger
+from tracecat.parse import safe_url
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import (
     Author,
@@ -82,11 +83,15 @@ class WorkflowStoreService(BaseWorkspaceService):
             )
 
         workspace, git_url = await self._get_workspace_and_git_url()
+        raw_git_repo_url = workspace.settings.get("git_repo_url")
+        safe_git_repo_url = (
+            safe_url(raw_git_repo_url) if isinstance(raw_git_repo_url, str) else None
+        )
 
         logger.info(
             "Publishing workflow to store",
             workflow_title=dsl.title,
-            repo_url=workspace.settings.get("git_repo_url"),
+            repo_url=safe_git_repo_url,
             workspace_id=self.workspace_id,
         )
 
@@ -553,8 +558,9 @@ class WorkflowStoreService(BaseWorkspaceService):
     ) -> None:
         if not workflows or not hasattr(workflows[0], "git_sync_branch"):
             return
+        branch_attr = "git_sync_branch"
         for workflow in workflows:
-            workflow.git_sync_branch = branch
+            setattr(workflow, branch_attr, branch)
             self.session.add(workflow)
         await self.session.commit()
 

--- a/tracecat/workflow/store/sync.py
+++ b/tracecat/workflow/store/sync.py
@@ -445,14 +445,12 @@ class WorkflowSyncService(BaseWorkspaceService):
         committed_count = sum(
             1 for result in object_results if result.status == PushStatus.COMMITTED
         )
-        if committed_count > 0:
-            branch_ref = await asyncio.to_thread(
-                repo.get_git_ref, f"heads/{branch_name}"
+        branch_ref = await asyncio.to_thread(repo.get_git_ref, f"heads/{branch_name}")
+        if branch_ref.object.sha != initial_branch_sha:
+            raise TracecatValidationError(
+                f"Branch '{branch_name}' changed while preparing the bulk push. Refresh and retry."
             )
-            if branch_ref.object.sha != initial_branch_sha:
-                raise TracecatValidationError(
-                    f"Branch '{branch_name}' changed while preparing the bulk push. Refresh and retry."
-                )
+        if committed_count > 0:
             parent_commit = await asyncio.to_thread(
                 repo.get_git_commit, initial_branch_sha
             )

--- a/tracecat/workflow/store/sync.py
+++ b/tracecat/workflow/store/sync.py
@@ -6,17 +6,22 @@ import asyncio
 import base64
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from github.GithubException import GithubException
+from github.InputGitAuthor import InputGitAuthor
+from github.InputGitTreeElement import InputGitTreeElement
+
+if TYPE_CHECKING:
+    from github.ContentFile import ContentFile
 from pydantic import ValidationError
 
 from tracecat.db.models import User
-from tracecat.exceptions import TracecatNotFoundError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.git.utils import GitUrl
 from tracecat.logger import logger
-from tracecat.registry.repositories.schemas import GitCommitInfo
+from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import (
     CommitInfo,
@@ -24,7 +29,9 @@ from tracecat.sync import (
     PullOptions,
     PullResult,
     PushObject,
+    PushObjectResult,
     PushOptions,
+    PushStatus,
 )
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.workflow.store.import_service import WorkflowImportService
@@ -191,6 +198,7 @@ class WorkflowSyncService(BaseWorkspaceService):
                 content_map = {}
 
                 for item in workflows_contents:
+                    item: ContentFile = item  # type hint for GitHub API object
                     # Look for workflow directories
                     if item.type == "dir":
                         # Get definition.yml from each workflow directory
@@ -312,10 +320,8 @@ class WorkflowSyncService(BaseWorkspaceService):
         Returns:
             CommitInfo with commit SHA and branch/PR details
         """
-        if len(objects) != 1:
-            raise ValueError("We only support pushing one workflow object at a time")
-
-        [obj] = objects
+        if not objects:
+            raise ValueError("At least one workflow object is required")
 
         gh_svc = GitHubAppService(session=self.session, role=self.role)
 
@@ -325,147 +331,24 @@ class WorkflowSyncService(BaseWorkspaceService):
         try:
             repo = await asyncio.to_thread(gh.get_repo, f"{url.org}/{url.repo}")
 
-            # Get base branch
-            base_branch_name = url.ref or repo.default_branch
-            base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
-
-            # Create feature branch
-            timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-            branch_name = f"tracecat-sync-{timestamp}"
-
-            logger.info(
-                "Creating branch via GitHub API",
-                branch=branch_name,
-                base_branch=base_branch_name,
-                repo=f"{url.org}/{url.repo}",
-            )
-
-            await asyncio.to_thread(
-                repo.create_git_ref,
-                ref=f"refs/heads/{branch_name}",
-                sha=base_branch.commit.sha,
-            )
-
-            # Create/update workflow files via API
-            file_path = obj.path_str
-
-            yaml_content = yaml.dump(
-                obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
-                sort_keys=False,
-            )
-
-            # NOTE: We intentionally omit author/committer parameters to enable
-            # GitHub's automatic commit signing for GitHub Apps. Per GitHub docs:
-            # "Signature verification for bots will only work if the request
-            # contains no custom author information, custom committer information"
-            # https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-
-            try:
-                # Try to get existing file to update it
-                contents = await asyncio.to_thread(
-                    repo.get_contents, file_path, ref=branch_name
+            if options.branch is not None:
+                return await self._push_to_target_branch(
+                    repo=repo,
+                    url=url,
+                    objects=objects,
+                    options=options,
                 )
-                # get_contents returns ContentFile for files, or list for directories
-                if isinstance(contents, list):
-                    raise GithubException(404, {"message": "Not a file"}, {})
 
-                await asyncio.to_thread(
-                    repo.update_file,
-                    path=contents.path,
-                    message=options.message,
-                    content=yaml_content,
-                    sha=contents.sha,
-                    branch=branch_name,
+            if len(objects) != 1:
+                raise ValueError(
+                    "Legacy publish mode only supports pushing one workflow object at a time"
                 )
-                logger.debug(
-                    "Updated workflow file via API",
-                    path=file_path,
-                    branch=branch_name,
-                )
-            except GithubException as e:
-                if e.status == 404:
-                    # File doesn't exist, create it
-                    await asyncio.to_thread(
-                        repo.create_file,
-                        path=file_path,
-                        message=options.message,
-                        content=yaml_content,
-                        branch=branch_name,
-                    )
-                    logger.debug(
-                        "Created workflow file via API",
-                        path=file_path,
-                        branch=branch_name,
-                    )
 
-            # Get the latest commit SHA from the branch
-            branch = await asyncio.to_thread(repo.get_branch, branch_name)
-            commit_sha = branch.commit.sha
-
-            # Create PR if requested
-            pr_url = None
-            if options.create_pr:
-                try:
-                    ws_svc = WorkspaceService(session=self.session)
-                    workspace = await ws_svc.get_workspace(self.workspace_id)
-                    if not workspace:
-                        raise TracecatNotFoundError("Workspace not found")
-
-                    try:
-                        title = obj.data.definition.title
-                        description = obj.data.definition.description
-                    except ValueError:
-                        title = "<An error occurred while determining the title>"
-                        description = (
-                            "<An error occurred while determining the description>"
-                        )
-
-                    try:
-                        current_user = await self.session.get(User, self.role.user_id)
-                    except Exception:
-                        current_user = None
-
-                    published_by = current_user.email if current_user else "<unknown>"
-
-                    pr = await asyncio.to_thread(
-                        repo.create_pull,
-                        title=options.message,
-                        body=(
-                            f"Automated workflow sync from Tracecat\n\n"
-                            f"**Workspace:** {workspace.name}\n"
-                            f"**Published by:** {published_by}\n"
-                            f"**Workflow Title:** {title}\n"
-                            f"**Workflow Description:** {description}"
-                        ),
-                        head=branch_name,
-                        base=base_branch_name,
-                    )
-                    pr_url = pr.html_url
-
-                    logger.info(
-                        "Created PR via GitHub API",
-                        pr_number=pr.number,
-                        pr_url=pr_url,
-                    )
-                except GithubException as e:
-                    logger.error(
-                        "Failed to create PR via GitHub API",
-                        error=str(e),
-                        branch=branch_name,
-                    )
-                    # Don't fail the entire operation if PR creation fails
-
-            logger.info(
-                "Successfully pushed workflows via GitHub API",
-                count=1,
-                branch=branch_name,
-                commit_sha=commit_sha,
-                pr_created=pr_url is not None,
-            )
-
-            return CommitInfo(
-                sha=commit_sha,
-                ref=branch_name,
+            return await self._push_legacy(
+                repo=repo,
+                url=url,
+                obj=objects[0],
+                options=options,
             )
 
         except GithubException as e:
@@ -478,6 +361,411 @@ class WorkflowSyncService(BaseWorkspaceService):
             raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
         finally:
             gh.close()
+
+    async def _push_to_target_branch(
+        self,
+        *,
+        repo: Any,
+        url: GitUrl,
+        objects: Sequence[PushObject[RemoteWorkflowDefinition]],
+        options: PushOptions,
+    ) -> CommitInfo:
+        branch_name = options.branch
+        if branch_name is None:
+            raise ValueError("branch is required for target-branch push mode")
+        base_branch_name = (
+            options.pr_base_branch or url.ref or await self._get_default_branch(repo)
+        )
+        if options.create_pr and branch_name == base_branch_name:
+            raise TracecatValidationError(
+                "branch must differ from the PR base branch when create_pr is enabled"
+            )
+        base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
+
+        try:
+            await asyncio.to_thread(repo.get_branch, branch_name)
+        except GithubException as e:
+            if e.status != 404:
+                raise
+            await asyncio.to_thread(
+                repo.create_git_ref,
+                ref=f"refs/heads/{branch_name}",
+                sha=base_branch.commit.sha,
+            )
+            logger.info(
+                "Created target branch via GitHub API",
+                branch=branch_name,
+                base_branch=base_branch_name,
+                repo=f"{url.org}/{url.repo}",
+            )
+
+        initial_branch_ref = await asyncio.to_thread(
+            repo.get_git_ref, f"heads/{branch_name}"
+        )
+        initial_branch_sha = initial_branch_ref.object.sha
+
+        pr_url: str | None = None
+        pr_number: int | None = None
+        pr_reused = False
+        tree_elements: list[InputGitTreeElement] = []
+        object_results: list[PushObjectResult] = []
+
+        for obj in objects:
+            file_path = obj.path_str
+            yaml_content = self._serialize_push_object(obj)
+            try:
+                contents = await asyncio.to_thread(
+                    repo.get_contents, file_path, ref=initial_branch_sha
+                )
+                if isinstance(contents, list):
+                    raise GithubException(404, {"message": "Not a file"}, {})
+                existing_content = base64.b64decode(contents.content).decode("utf-8")
+                if existing_content == yaml_content:
+                    object_results.append(
+                        PushObjectResult(path=file_path, status=PushStatus.NO_OP)
+                    )
+                    continue
+            except GithubException as e:
+                if e.status != 404:
+                    raise
+
+            tree_elements.append(
+                InputGitTreeElement(
+                    path=file_path,
+                    mode="100644",
+                    type="blob",
+                    content=yaml_content,
+                )
+            )
+            object_results.append(
+                PushObjectResult(path=file_path, status=PushStatus.COMMITTED)
+            )
+
+        commit_sha: str | None = None
+        committed_count = sum(
+            1 for result in object_results if result.status == PushStatus.COMMITTED
+        )
+        if committed_count > 0:
+            branch_ref = await asyncio.to_thread(
+                repo.get_git_ref, f"heads/{branch_name}"
+            )
+            if branch_ref.object.sha != initial_branch_sha:
+                raise TracecatValidationError(
+                    f"Branch '{branch_name}' changed while preparing the bulk push. Refresh and retry."
+                )
+            parent_commit = await asyncio.to_thread(
+                repo.get_git_commit, initial_branch_sha
+            )
+            new_tree = await asyncio.to_thread(
+                repo.create_git_tree,
+                tree_elements,
+                parent_commit.tree,
+            )
+            author = InputGitAuthor(options.author.name, options.author.email)
+            new_commit = await asyncio.to_thread(
+                repo.create_git_commit,
+                options.message,
+                new_tree,
+                [parent_commit],
+                author=author,
+                committer=author,
+            )
+            try:
+                await asyncio.to_thread(branch_ref.edit, new_commit.sha)
+            except GithubException as e:
+                if e.status == 422:
+                    raise TracecatValidationError(
+                        f"Branch '{branch_name}' changed while preparing the bulk push. Refresh and retry."
+                    ) from e
+                raise
+            commit_sha = new_commit.sha
+
+        if options.create_pr:
+            pr_url, pr_number, pr_reused = await self._upsert_pull_request_safe(
+                repo=repo,
+                url=url,
+                obj=objects[0],
+                options=options,
+                branch_name=branch_name,
+                base_branch_name=base_branch_name,
+            )
+
+        logger.info(
+            "Successfully pushed workflow definitions via GitHub API",
+            branch=branch_name,
+            base_branch=base_branch_name,
+            commit_sha=commit_sha,
+            changed_objects=committed_count,
+            total_objects=len(object_results),
+            pr_url=pr_url,
+            pr_number=pr_number,
+            pr_reused=pr_reused,
+        )
+
+        return CommitInfo(
+            status=PushStatus.COMMITTED if committed_count > 0 else PushStatus.NO_OP,
+            sha=commit_sha,
+            ref=branch_name,
+            base_ref=base_branch_name,
+            pr_url=pr_url,
+            pr_number=pr_number,
+            pr_reused=pr_reused,
+            message=(
+                f"Committed changes for {committed_count} workflow file(s)."
+                if committed_count > 0
+                else "No changes detected; nothing to commit."
+            ),
+            object_results=object_results,
+        )
+
+    async def _push_legacy(
+        self,
+        *,
+        repo: Any,
+        url: GitUrl,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+    ) -> CommitInfo:
+        base_branch_name = url.ref or await self._get_default_branch(repo)
+        base_branch = await asyncio.to_thread(repo.get_branch, base_branch_name)
+
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        branch_name = f"tracecat-sync-{timestamp}"
+
+        logger.info(
+            "Creating legacy temp branch via GitHub API",
+            branch=branch_name,
+            base_branch=base_branch_name,
+            repo=f"{url.org}/{url.repo}",
+        )
+
+        await asyncio.to_thread(
+            repo.create_git_ref,
+            ref=f"refs/heads/{branch_name}",
+            sha=base_branch.commit.sha,
+        )
+
+        file_path = obj.path_str
+        yaml_content = yaml.dump(
+            obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
+            sort_keys=False,
+        )
+
+        try:
+            contents = await asyncio.to_thread(
+                repo.get_contents, file_path, ref=branch_name
+            )
+            if isinstance(contents, list):
+                raise GithubException(404, {"message": "Not a file"}, {})
+            await asyncio.to_thread(
+                repo.update_file,
+                path=contents.path,
+                message=options.message,
+                content=yaml_content,
+                sha=contents.sha,
+                branch=branch_name,
+            )
+            logger.debug(
+                "Updated workflow file via API (legacy)",
+                path=file_path,
+                branch=branch_name,
+            )
+        except GithubException as e:
+            if e.status != 404:
+                raise
+            await asyncio.to_thread(
+                repo.create_file,
+                path=file_path,
+                message=options.message,
+                content=yaml_content,
+                branch=branch_name,
+            )
+            logger.debug(
+                "Created workflow file via API (legacy)",
+                path=file_path,
+                branch=branch_name,
+            )
+
+        branch = await asyncio.to_thread(repo.get_branch, branch_name)
+        commit_sha = branch.commit.sha
+
+        pr_url: str | None = None
+        pr_number: int | None = None
+        if options.create_pr:
+            try:
+                pr_url, pr_number, _ = await self._create_pull_request(
+                    repo=repo,
+                    obj=obj,
+                    options=options,
+                    branch_name=branch_name,
+                    base_branch_name=base_branch_name,
+                )
+            except GithubException as e:
+                logger.error(
+                    "Failed to create PR via GitHub API (legacy)",
+                    error=str(e),
+                    branch=branch_name,
+                )
+
+        return CommitInfo(
+            status=PushStatus.COMMITTED,
+            sha=commit_sha,
+            ref=branch_name,
+            base_ref=base_branch_name,
+            pr_url=pr_url,
+            pr_number=pr_number,
+            pr_reused=False,
+            message="Committed workflow changes on a temporary legacy branch.",
+            object_results=[
+                PushObjectResult(path=obj.path_str, status=PushStatus.COMMITTED)
+            ],
+        )
+
+    async def _upsert_pull_request(
+        self,
+        *,
+        repo: Any,
+        url: GitUrl,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+        branch_name: str,
+        base_branch_name: str,
+    ) -> tuple[str | None, int | None, bool]:
+        def _first_open_pull_request() -> Any | None:
+            pulls = repo.get_pulls(
+                state="open",
+                head=f"{url.org}:{branch_name}",
+                base=base_branch_name,
+            )
+            return next(iter(pulls), None)
+
+        try:
+            existing_pr = await asyncio.to_thread(_first_open_pull_request)
+        except GithubException as e:
+            logger.error(
+                "Failed to search for open pull requests",
+                error=str(e),
+                branch=branch_name,
+                base_branch=base_branch_name,
+            )
+            existing_pr = None
+
+        if existing_pr is not None:
+            logger.info(
+                "Reused existing pull request",
+                pr_number=existing_pr.number,
+                pr_url=existing_pr.html_url,
+                branch=branch_name,
+                base_branch=base_branch_name,
+            )
+            return existing_pr.html_url, existing_pr.number, True
+
+        return await self._create_pull_request(
+            repo=repo,
+            obj=obj,
+            options=options,
+            branch_name=branch_name,
+            base_branch_name=base_branch_name,
+        )
+
+    async def _upsert_pull_request_safe(
+        self,
+        *,
+        repo: Any,
+        url: GitUrl,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+        branch_name: str,
+        base_branch_name: str,
+    ) -> tuple[str | None, int | None, bool]:
+        try:
+            return await self._upsert_pull_request(
+                repo=repo,
+                url=url,
+                obj=obj,
+                options=options,
+                branch_name=branch_name,
+                base_branch_name=base_branch_name,
+            )
+        except GithubException as e:
+            logger.error(
+                "Failed to create or reuse pull request via GitHub API",
+                status=e.status,
+                data=e.data,
+                branch=branch_name,
+                base_branch=base_branch_name,
+                repo=f"{url.org}/{url.repo}",
+            )
+            return None, None, False
+
+    async def _create_pull_request(
+        self,
+        *,
+        repo: Any,
+        obj: PushObject[RemoteWorkflowDefinition],
+        options: PushOptions,
+        branch_name: str,
+        base_branch_name: str,
+    ) -> tuple[str, int, bool]:
+        ws_svc = WorkspaceService(session=self.session, role=self.role)
+        workspace = await ws_svc.get_workspace(self.workspace_id)
+        if not workspace:
+            raise TracecatNotFoundError("Workspace not found")
+
+        try:
+            title = obj.data.definition.title
+            description = obj.data.definition.description
+        except ValueError:
+            title = "<An error occurred while determining the title>"
+            description = "<An error occurred while determining the description>"
+
+        current_user = None
+        if self.role.user_id is not None:
+            try:
+                current_user = await self.session.get(User, self.role.user_id)
+            except Exception:
+                current_user = None
+
+        published_by = current_user.email if current_user else "<unknown>"
+        pr_title = options.pr_title or options.message
+        pr_body = options.pr_body or (
+            f"Automated workflow push from Tracecat\n\n"
+            f"**Workspace:** {workspace.name}\n"
+            f"**Published by:** {published_by}\n"
+            f"**Workflow Title:** {title}\n"
+            f"**Workflow Description:** {description}"
+        )
+
+        pr = await asyncio.to_thread(
+            repo.create_pull,
+            title=pr_title,
+            body=pr_body,
+            head=branch_name,
+            base=base_branch_name,
+        )
+
+        logger.info(
+            "Created PR via GitHub API",
+            pr_number=pr.number,
+            pr_url=pr.html_url,
+            branch=branch_name,
+            base_branch=base_branch_name,
+        )
+        return pr.html_url, pr.number, False
+
+    async def _get_default_branch(self, repo: Any) -> str:
+        default_branch = repo.default_branch
+        if not default_branch:
+            raise GitHubAppError(
+                "Target GitHub repository must be initialized with a default branch before pushing workflows."
+            )
+        return default_branch
+
+    def _serialize_push_object(self, obj: PushObject[RemoteWorkflowDefinition]) -> str:
+        return yaml.dump(
+            obj.data.model_dump(mode="json", exclude_none=True, exclude_unset=True),
+            sort_keys=False,
+        )
 
     async def list_commits(
         self,
@@ -563,5 +851,46 @@ class WorkflowSyncService(BaseWorkspaceService):
                 data=e.data,
                 repo=f"{url.org}/{url.repo}",
                 branch=branch,
+            )
+            raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
+
+    async def list_branches(
+        self,
+        *,
+        url: GitUrl,
+        limit: int = 100,
+    ) -> list[GitBranchInfo]:
+        """List branches from a Git repository using GitHub App API."""
+        try:
+            gh_svc = GitHubAppService(session=self.session, role=self.role)
+            gh = await gh_svc.get_github_client_for_repo(url)
+
+            try:
+                repo = await asyncio.to_thread(gh.get_repo, f"{url.org}/{url.repo}")
+                branches_paginated = await asyncio.to_thread(repo.get_branches)
+
+                branches: list[GitBranchInfo] = []
+                count = 0
+                for branch_obj in branches_paginated:
+                    if count >= limit:
+                        break
+                    branches.append(
+                        GitBranchInfo(
+                            name=branch_obj.name,
+                            sha=branch_obj.commit.sha,
+                            is_default=branch_obj.name == repo.default_branch,
+                        )
+                    )
+                    count += 1
+
+                return branches
+            finally:
+                gh.close()
+        except GithubException as e:
+            logger.error(
+                "GitHub API error during branch listing",
+                status=e.status,
+                data=e.data,
+                repo=f"{url.org}/{url.repo}",
             )
             raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e


### PR DESCRIPTION
## Summary
- backport bulk GitHub workflow push support to the `0.53.25` line
- add the minimal old-dashboard UI needed to select workflows/folders and open the bulk push dialog
- preserve the legacy single publish contract on `0.53` while adding the new bulk preview, bulk push, and branch listing endpoints
- fix a frontend render loop in the old workflows dashboard by stabilizing selection callbacks

## What changed
- backend
  - added `POST /workflows/push/preview`
  - added `POST /workflows/push`
  - added `GET /workflows/sync/branches`
  - backported branch-target push support and bulk selection/defaulting logic
  - kept `POST /workflows/{workflow_id}/publish` on the old `204` response contract
- frontend
  - added selection checkboxes to the old tags and folders workflows tables
  - added a `Push selected to GitHub` action in the old workflows dashboard
  - reused the bulk push dialog against the `0.53` UI surfaces instead of backporting the newer dashboard rewrite

## Validation
- `just gen-client-ci`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- `uv run pytest tests/unit/test_workflow_sync_service.py tests/unit/test_workflow_store_service.py -x`
- `uv run ruff check tracecat/registry/repositories/schemas.py tracecat/sync.py tracecat/workflow/store/router.py tracecat/workflow/store/schemas.py tracecat/workflow/store/service.py tracecat/workflow/store/sync.py tests/unit/test_workflow_sync_service.py tests/unit/test_workflow_store_service.py tests/unit/api/test_api_workflow_store_publish.py`
- Chrome DevTools MCP QA against local `0.53.25` stack
  - workflows page loads in tags and folders view
  - selection checkboxes render in both tables
  - button count updates as selections change
  - dialog preview shows included vs excluded unpublished workflows correctly
  - preview defaults are populated
  - missing GitHub workspace config is surfaced cleanly and submit remains disabled

## Notes
- `tests/unit/api/test_api_workflow_store_publish.py` was updated for the `0.53` compatibility contract but was not run in the earlier isolated pass because it required a live PostgreSQL fixture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backported bulk GitHub workflow push to 0.53.25 with preview, branch listing, and a minimal old-dashboard bulk push UI. Adds branch-target publishing while preserving the legacy single publish contract, tightens branch validation, and skips PRs when there are no changes.

- **New Features**
  - API: added POST `/workflows/push/preview`, POST `/workflows/push`, and GET `/workflows/sync/branches` returning `GitBranchInfo` with default-branch flag.
  - Supports branch-target publish with optional PR metadata (base, title, body), sensible defaults in bulk preview, and a no-op push status to avoid empty PRs.
  - Old dashboard: selection checkboxes for tags and folders, “Push selected to GitHub” action, and a reusable bulk push dialog with branch selection and preview of included/excluded items.

- **Bug Fixes**
  - Tightened branch handling: strict short branch name rules for both target and base (no `refs/*`, invalid chars, empty), clearer errors, and safer PR options to prevent invalid ref issues.
  - Fixed a render loop in the old workflows dashboard by stabilizing selection callbacks and kept submit disabled when workspace GitHub config is missing.
  - Sanitized URLs in router/service logs by stripping credentials while preserving host and port via `safe_url`.
  - Aligned Python formatting with CI ruff.

<sup>Written for commit 70508806ae3cc5798ca6b5ca0f2748af081b7fbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

