### PR TITLE
feat(engine+ui): add a per-action secret masking toggle

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -105,6 +105,13 @@ export const $ActionControlFlow = {
       title: "Environment",
       description: "Override environment for this action's execution",
     },
+    disable_secrets_masking: {
+      type: "boolean",
+      title: "Disable Secrets Masking",
+      description:
+        "Disable secret masking for this action output. This is unsafe and should only be enabled when absolutely necessary.",
+      default: false,
+    },
   },
   type: "object",
   title: "ActionControlFlow",
@@ -606,6 +613,13 @@ export const $ActionStatement = {
       title: "Environment",
       description:
         "Override environment for this action's execution. Can be a template expression.",
+    },
+    disable_secrets_masking: {
+      type: "boolean",
+      title: "Disable Secrets Masking",
+      description:
+        "Disable secret masking for this action output. This is unsafe and should only be enabled when absolutely necessary.",
+      default: false,
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -29,6 +29,10 @@ export type ActionControlFlow = {
    * Override environment for this action's execution
    */
   environment?: string | null
+  /**
+   * Disable secret masking for this action output. This is unsafe and should only be enabled when absolutely necessary.
+   */
+  disable_secrets_masking?: boolean
 }
 
 export type ActionCreate = {
@@ -177,6 +181,10 @@ export type ActionStatement = {
    * Override environment for this action's execution. Can be a template expression.
    */
   environment?: string | null
+  /**
+   * Disable secret masking for this action output. This is unsafe and should only be enabled when absolutely necessary.
+   */
+  disable_secrets_masking?: boolean
 }
 
 export type ActionStep = {

--- a/frontend/src/components/builder/canvas/action-node.tsx
+++ b/frontend/src/components/builder/canvas/action-node.tsx
@@ -382,6 +382,9 @@ export default React.memo(function ActionNode({
               actionInputs={actionInputsObj}
               actionIsLoading={actionIsLoading}
               actionIsInteractive={action?.is_interactive}
+              disableSecretsMasking={
+                action?.control_flow?.disable_secrets_masking ?? false
+              }
               submitHandler={form.handleSubmit(onSubmit)}
               style={style}
               breakpoint={breakpoint}
@@ -430,6 +433,7 @@ function ActionNodeContent({
   Icon,
   workspaceId,
   childWorkflowInfo,
+  disableSecretsMasking,
   error,
   validationErrors,
 }: {
@@ -437,6 +441,7 @@ function ActionNodeContent({
   actionInputs?: Record<string, unknown>
   actionIsLoading: boolean
   actionIsInteractive?: boolean
+  disableSecretsMasking?: boolean
   submitHandler: () => void
   style: { fontSize: string; showContent: boolean }
   breakpoint: "small" | "large" | "medium"
@@ -534,6 +539,22 @@ function ActionNodeContent({
           {/* Child workflow */}
 
           <div className="flex items-start gap-1">
+            {disableSecretsMasking && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="outline"
+                    className="h-5 gap-1 border-amber-300/80 bg-amber-50 px-1.5 py-0 text-[10px] font-medium text-amber-800"
+                  >
+                    <AlertTriangleIcon className="size-3.5" />
+                    <span>Unmasked</span>
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent side="top" align="center" sideOffset={5}>
+                  <p>This action returns secrets without masking.</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
             {childWorkflowInfo.isChildWorkflow && (
               <ChildWorkflowLink
                 workspaceId={workspaceId}

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -71,6 +71,7 @@ import {
 } from "@/components/ui/accordion"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -189,6 +190,7 @@ const actionFormSchema = z.object({
     .max(1000, "Environment must be less than 1000 characters")
     .transform((val) => normalizeOptionalExpression(val))
     .optional(),
+  disable_secrets_masking: z.boolean().default(false),
   is_interactive: z.boolean().default(false),
   interaction: z
     .discriminatedUnion("type", [
@@ -327,6 +329,8 @@ function ActionPanelContent({
       join_strategy: actionControlFlow?.join_strategy,
       wait_until: actionControlFlow?.wait_until || undefined,
       environment: actionControlFlow?.environment || undefined,
+      disable_secrets_masking:
+        actionControlFlow?.disable_secrets_masking ?? false,
       is_interactive: action?.is_interactive ?? false,
       interaction: action?.interaction ?? undefined,
     }),
@@ -345,6 +349,7 @@ function ActionPanelContent({
       actionControlFlow?.join_strategy,
       actionControlFlow?.wait_until,
       actionControlFlow?.environment,
+      actionControlFlow?.disable_secrets_masking,
     ]
   )
 
@@ -589,6 +594,7 @@ function ActionPanelContent({
             join_strategy: values.join_strategy,
             wait_until: values.wait_until,
             environment: values.environment,
+            disable_secrets_masking: values.disable_secrets_masking,
           },
           is_interactive: values.is_interactive,
           interaction: values.interaction,
@@ -1460,6 +1466,31 @@ function ActionPanelContent({
                                   placeholder="Type @ to begin an expression..."
                                 />
                               </FormControl>
+                            </FormItem>
+                          )}
+                        />
+                      </ControlFlowField>
+
+                      <ControlFlowField
+                        label="Disable secrets masking"
+                        description="Allow this action to return unmasked secrets. Disabled by default and unsafe for production workflows."
+                      >
+                        <FormField
+                          name="disable_secrets_masking"
+                          control={methods.control}
+                          render={({ field }) => (
+                            <FormItem className="flex flex-row items-center gap-2 space-y-0">
+                              <FormControl>
+                                <Checkbox
+                                  checked={field.value}
+                                  onCheckedChange={(checked) =>
+                                    field.onChange(checked === true)
+                                  }
+                                />
+                              </FormControl>
+                              <FormLabel className="font-normal">
+                                Disable masking for this action
+                              </FormLabel>
                             </FormItem>
                           )}
                         />

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -533,7 +533,7 @@ function ActionPanelContent({
     async (values: ActionFormSchema) => {
       if (!registryAction || !action) {
         console.error("Action not found")
-        return
+        return false
       }
 
       setSaveState(SaveState.SAVING)
@@ -586,6 +586,7 @@ function ActionPanelContent({
         clearActionDraft(actionId)
         methods.reset(values)
         setTimeout(() => setSaveState(SaveState.SAVED), 300)
+        return true
       } catch (error) {
         if (error instanceof ApiError) {
           const apiError = error as TracecatApiError
@@ -621,6 +622,7 @@ function ActionPanelContent({
           console.error("Validation failed, unknown error", error)
         }
         setSaveState(SaveState.ERROR)
+        return false
       }
     },
     [
@@ -647,7 +649,7 @@ function ActionPanelContent({
   const onSubmit = useCallback(
     async (values: ActionFormSchema) => {
       try {
-        await handleSave(values)
+        return await handleSave(values)
       } catch (error) {
         console.error("Failed to save action", error)
         setSaveState(SaveState.ERROR)
@@ -664,6 +666,7 @@ function ActionPanelContent({
             ref: slugifyActionRef(action?.title ?? ""),
           },
         ])
+        return false
       }
     },
     [handleSave, action]
@@ -679,8 +682,7 @@ function ActionPanelContent({
 
     await methods.handleSubmit(
       async (values) => {
-        await onSubmit(values)
-        saveSucceeded = true
+        saveSucceeded = await onSubmit(values)
       },
       async () => {
         saveSucceeded = false

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -673,11 +673,8 @@ function ActionPanelContent({
   )
 
   const saveIfDirty = useCallback(async () => {
-    if (!methods.formState.isDirty) {
-      return true
-    }
-
     commitAllEditors()
+
     let saveSucceeded = false
 
     await methods.handleSubmit(

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -280,7 +280,7 @@ export interface ActionPanelRef extends ImperativePanelHandle {
   getActiveTab: () => ActionPanelTabs
   setOpen: (open: boolean) => void
   isOpen: () => boolean
-  saveIfDirty: () => Promise<boolean>
+  saveIfDirty?: () => Promise<boolean>
 }
 
 function ActionPanelContent({
@@ -691,23 +691,26 @@ function ActionPanelContent({
 
   // Set up the ref methods
   useEffect(() => {
-    if (actionPanelRef.current) {
-      actionPanelRef.current.setActiveTab = setActiveTab
-      actionPanelRef.current.getActiveTab = () => activeTab
-      actionPanelRef.current.setOpen = (newOpen: boolean) => {
+    const panelHandle = actionPanelRef.current
+
+    if (panelHandle) {
+      panelHandle.setActiveTab = setActiveTab
+      panelHandle.getActiveTab = () => activeTab
+      panelHandle.setOpen = (newOpen: boolean) => {
         setOpen(newOpen)
         // If the panel has a collapse method, use it
-        if (
-          actionPanelRef.current?.collapse &&
-          actionPanelRef.current?.expand
-        ) {
-          newOpen
-            ? actionPanelRef.current.expand()
-            : actionPanelRef.current.collapse()
+        if (panelHandle.collapse && panelHandle.expand) {
+          newOpen ? panelHandle.expand() : panelHandle.collapse()
         }
       }
-      actionPanelRef.current.isOpen = () => open
-      actionPanelRef.current.saveIfDirty = saveIfDirty
+      panelHandle.isOpen = () => open
+      panelHandle.saveIfDirty = saveIfDirty
+    }
+
+    return () => {
+      if (panelHandle?.saveIfDirty === saveIfDirty) {
+        panelHandle.saveIfDirty = undefined
+      }
     }
   }, [actionPanelRef, activeTab, setOpen, open, saveIfDirty])
 

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -280,6 +280,7 @@ export interface ActionPanelRef extends ImperativePanelHandle {
   getActiveTab: () => ActionPanelTabs
   setOpen: (open: boolean) => void
   isOpen: () => boolean
+  saveIfDirty: () => Promise<boolean>
 }
 
 function ActionPanelContent({
@@ -528,27 +529,6 @@ function ActionPanelContent({
     setInputMode(formModeEnabled ? "form" : "yaml")
   }, [formModeEnabled, actionId])
 
-  // Set up the ref methods
-  useEffect(() => {
-    if (actionPanelRef.current) {
-      actionPanelRef.current.setActiveTab = setActiveTab
-      actionPanelRef.current.getActiveTab = () => activeTab
-      actionPanelRef.current.setOpen = (newOpen: boolean) => {
-        setOpen(newOpen)
-        // If the panel has a collapse method, use it
-        if (
-          actionPanelRef.current?.collapse &&
-          actionPanelRef.current?.expand
-        ) {
-          newOpen
-            ? actionPanelRef.current.expand()
-            : actionPanelRef.current.collapse()
-        }
-      }
-      actionPanelRef.current.isOpen = () => open
-    }
-  }, [actionPanelRef, activeTab, setOpen, open])
-
   const handleSave = useCallback(
     async (values: ActionFormSchema) => {
       if (!registryAction || !action) {
@@ -689,6 +669,49 @@ function ActionPanelContent({
     [handleSave, action]
   )
 
+  const saveIfDirty = useCallback(async () => {
+    if (!methods.formState.isDirty) {
+      return true
+    }
+
+    commitAllEditors()
+    let saveSucceeded = false
+
+    await methods.handleSubmit(
+      async (values) => {
+        await onSubmit(values)
+        saveSucceeded = true
+      },
+      async () => {
+        saveSucceeded = false
+      }
+    )()
+
+    return saveSucceeded
+  }, [methods, onSubmit, commitAllEditors])
+
+  // Set up the ref methods
+  useEffect(() => {
+    if (actionPanelRef.current) {
+      actionPanelRef.current.setActiveTab = setActiveTab
+      actionPanelRef.current.getActiveTab = () => activeTab
+      actionPanelRef.current.setOpen = (newOpen: boolean) => {
+        setOpen(newOpen)
+        // If the panel has a collapse method, use it
+        if (
+          actionPanelRef.current?.collapse &&
+          actionPanelRef.current?.expand
+        ) {
+          newOpen
+            ? actionPanelRef.current.expand()
+            : actionPanelRef.current.collapse()
+        }
+      }
+      actionPanelRef.current.isOpen = () => open
+      actionPanelRef.current.saveIfDirty = saveIfDirty
+    }
+  }, [actionPanelRef, activeTab, setOpen, open, saveIfDirty])
+
   const panelRef = useRef<HTMLDivElement | null>(null)
 
   const onPanelBlur = useCallback(
@@ -709,11 +732,10 @@ function ActionPanelContent({
 
       // Only when focus actually leaves the panel do we auto-save.
       if (methods.formState.isDirty) {
-        commitAllEditors()
-        methods.handleSubmit(onSubmit)()
+        void saveIfDirty()
       }
     },
-    [methods, onSubmit, commitAllEditors]
+    [methods.formState.isDirty, saveIfDirty]
   )
 
   useEffect(() => {
@@ -721,15 +743,13 @@ function ActionPanelContent({
       // Save with Cmd+S (Mac) or Ctrl+S (Windows/Linux)
       if ((e.metaKey || e.ctrlKey) && e.key === "s") {
         e.preventDefault()
-        // Commit all YAML editors before form submission
-        commitAllEditors()
-        methods.handleSubmit(onSubmit)()
+        void saveIfDirty()
       }
     }
 
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [methods, onSubmit, action, commitAllEditors])
+  }, [saveIfDirty])
 
   // Handle mode switching with YAML preservation
   const handleModeChange = useCallback(
@@ -1488,7 +1508,7 @@ function ActionPanelContent({
                                   }
                                 />
                               </FormControl>
-                              <FormLabel className="font-normal">
+                              <FormLabel className="text-xs font-normal text-muted-foreground">
                                 Disable masking for this action
                               </FormLabel>
                             </FormItem>

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -485,30 +485,33 @@ function WorkflowManualTrigger({
     ValidationResult[] | null
   >(null)
   const [isTriggering, setIsTriggering] = React.useState(false)
+  const runInFlightRef = React.useRef(false)
 
   React.useEffect(() => {
     setManualTriggerErrors(null)
   }, [triggerPayload])
 
   const runWorkflow = async () => {
-    if (disabled || createDraftExecutionIsPending) return
-
-    const payloadError = validateTriggerPayload(triggerPayload)
-    if (payloadError) {
-      setManualTriggerErrors([toDslApiErrorResult(payloadError)])
+    if (disabled || createDraftExecutionIsPending || runInFlightRef.current)
       return
-    }
 
-    const didSaveSelectedAction =
-      (await actionPanelRef.current?.saveIfDirty?.()) ?? true
-    if (!didSaveSelectedAction) {
-      return
-    }
-
+    runInFlightRef.current = true
     setIsTriggering(true)
-    setTimeout(() => setIsTriggering(false), 1000)
-    setManualTriggerErrors(null)
+
     try {
+      const payloadError = validateTriggerPayload(triggerPayload)
+      if (payloadError) {
+        setManualTriggerErrors([toDslApiErrorResult(payloadError)])
+        return
+      }
+
+      const didSaveSelectedAction =
+        (await actionPanelRef.current?.saveIfDirty?.()) ?? true
+      if (!didSaveSelectedAction) {
+        return
+      }
+
+      setManualTriggerErrors(null)
       const result = await createDraftExecution({
         workflow_id: workflowId,
         inputs: parseTriggerPayload(triggerPayload),
@@ -540,6 +543,9 @@ function WorkflowManualTrigger({
           ])
         }
       }
+    } finally {
+      runInFlightRef.current = false
+      setIsTriggering(false)
     }
   }
 

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -472,8 +472,12 @@ function WorkflowManualTrigger({
   disabled: boolean
   workflowId: string
 }) {
-  const { expandSidebarAndFocusEvents, setCurrentExecutionId, triggerPayload } =
-    useWorkflowBuilder()
+  const {
+    actionPanelRef,
+    expandSidebarAndFocusEvents,
+    setCurrentExecutionId,
+    triggerPayload,
+  } = useWorkflowBuilder()
   // Always use draft execution endpoint - runs the current draft workflow graph
   const { createDraftExecution, createDraftExecutionIsPending } =
     useCreateDraftWorkflowExecution(workflowId)
@@ -488,11 +492,19 @@ function WorkflowManualTrigger({
 
   const runWorkflow = async () => {
     if (disabled || createDraftExecutionIsPending) return
+
     const payloadError = validateTriggerPayload(triggerPayload)
     if (payloadError) {
       setManualTriggerErrors([toDslApiErrorResult(payloadError)])
       return
     }
+
+    const didSaveSelectedAction =
+      (await actionPanelRef.current?.saveIfDirty?.()) ?? true
+    if (!didSaveSelectedAction) {
+      return
+    }
+
     setIsTriggering(true)
     setTimeout(() => setIsTriggering(false), 1000)
     setManualTriggerErrors(null)

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      `peer size-4 shrink-0 align-middle rounded-sm border border-border bg-muted/50 transition-colors
+      `peer size-4 shrink-0 align-middle rounded-sm border border-muted-foreground/40 bg-transparent transition-colors
      focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring
      disabled:cursor-not-allowed disabled:opacity-50
      data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground`,

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      `peer size-4 shrink-0 align-middle rounded-sm border border-muted-foreground shadow
+      `peer size-4 shrink-0 align-middle rounded-sm border border-border bg-muted/50 transition-colors
      focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring
      disabled:cursor-not-allowed disabled:opacity-50
      data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground`,

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -284,10 +284,15 @@ async def test_executor_respects_action_statement_secret_masking(
     test_role,
     db_session_with_repo,
     mock_run_context,
+    monkeypatch,
     disable_secrets_masking,
     expected_result,
 ):
     """Test that ActionStatement masking opt-out changes the final action result."""
+    from tracecat import config
+
+    monkeypatch.setattr(config, "TRACECAT__UNSAFE_DISABLE_SM_MASKING", False)
+
     session, db_repo_id = db_session_with_repo
 
     repo = Repository()

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -272,6 +272,78 @@ async def test_executor_can_run_udf_with_secrets(
 
 @pytest.mark.integration
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("disable_secrets_masking", "expected_result"),
+    [
+        pytest.param(False, "***", id="masked-by-default"),
+        pytest.param(True, "__SECRET_VALUE_UDF__", id="action-opt-out"),
+    ],
+)
+async def test_executor_respects_action_statement_secret_masking(
+    mock_package,
+    test_role,
+    db_session_with_repo,
+    mock_run_context,
+    disable_secrets_masking,
+    expected_result,
+):
+    """Test that ActionStatement masking opt-out changes the final action result."""
+    session, db_repo_id = db_session_with_repo
+
+    repo = Repository()
+    repo._register_udfs_from_package(mock_package)
+
+    sec_service = SecretsService(session, role=test_role)
+    try:
+        await sec_service.create_secret(
+            SecretCreate(
+                name="test",
+                environment="default",
+                keys=[
+                    SecretKeyValue(
+                        key="TEST_UDF_SECRET_KEY",
+                        value=SecretStr("__SECRET_VALUE_UDF__"),
+                    )
+                ],
+            )
+        )
+
+        ra_service = RegistryActionsService(session, role=test_role)
+        await ra_service.create_action(
+            RegistryActionCreate.from_bound(
+                repo.get("testing.fetch_secret"), db_repo_id
+            )
+        )
+
+        registry_lock = await create_manifest_for_actions(
+            session,
+            db_repo_id,
+            [repo.get("testing.fetch_secret")],
+            test_role.organization_id,
+        )
+
+        input = RunActionInput(
+            task=ActionStatement(
+                ref="test",
+                action="testing.fetch_secret",
+                args={"secret_key_name": "TEST_UDF_SECRET_KEY"},
+                disable_secrets_masking=disable_secrets_masking,
+            ),
+            exec_context=create_default_execution_context(),
+            run_context=mock_run_context,
+            registry_lock=registry_lock,
+        )
+
+        result = await run_action_test(input, test_role)
+
+        assert result == expected_result
+    finally:
+        secret = await sec_service.get_secret_by_name("test")
+        await sec_service.delete_secret(secret)
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
 async def test_executor_can_run_template_action_with_secret(
     mock_package, test_role, db_session_with_repo, mock_run_context
 ):

--- a/tests/unit/test_executor_manifest_resolution.py
+++ b/tests/unit/test_executor_manifest_resolution.py
@@ -314,3 +314,92 @@ async def test_prepare_resolved_context_includes_projected_secret_masks(
     assert "ASIA_TEMP_KEY" in prepared.resolved_context.secret_projection.mask_values
     assert "temp_secret" in prepared.resolved_context.secret_projection.mask_values
     assert "temp_token" in prepared.resolved_context.secret_projection.mask_values
+
+
+@pytest.mark.anyio
+async def test_prepare_resolved_context_disables_masking_for_action_opt_out(
+    db, session, test_role, session_test_organization, mocker
+):
+    origin = "core-registry"
+    version = "v1"
+    action_name = "core.echo"
+
+    repo = RegistryRepository(
+        id=uuid.uuid4(),
+        organization_id=test_role.organization_id,
+        origin=origin,
+    )
+    session.add(repo)
+    await session.commit()
+
+    manifest = {
+        "schema_version": "1.0",
+        "actions": {
+            action_name: _manifest_action(
+                action=action_name,
+                action_type="udf",
+                implementation=_udf_impl(
+                    origin=origin, module="manifest.module", name="manifest_fn"
+                ),
+            )
+        },
+    }
+    rv = RegistryVersion(
+        organization_id=test_role.organization_id,
+        repository_id=repo.id,
+        version=version,
+        manifest=manifest,
+        tarball_uri="s3://example/core-v1.tar.gz",
+    )
+    session.add(rv)
+    await session.commit()
+
+    versions_svc = RegistryVersionsService(session)
+    await versions_svc.populate_index_from_manifest(rv, commit=True)
+
+    wf_id = WorkflowUUID.new_uuid4()
+    run_ctx = RunContext(
+        wf_id=wf_id,
+        wf_exec_id=generate_exec_id(wf_id),
+        wf_run_id=uuid.uuid4(),
+        environment="default",
+        logical_time=datetime.now(UTC),
+    )
+    task = ActionStatement(
+        ref="a", action=action_name, args={}, disable_secrets_masking=True
+    )
+    input = RunActionInput(
+        task=task,
+        exec_context=create_default_execution_context(),
+        run_context=run_ctx,
+        registry_lock=RegistryLock(
+            origins={origin: version},
+            actions={action_name: origin},
+        ),
+    )
+
+    mocker.patch(
+        "tracecat.executor.service.secrets_manager.get_action_secrets",
+        return_value={"api": {"token": "super-secret-token"}},
+    )
+    mocker.patch("tracecat.executor.service.get_workspace_variables", return_value={})
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield session
+
+    mocker.patch(
+        "tracecat.executor.service.get_async_session_bypass_rls_context_manager",
+        _session_cm,
+    )
+    mocker.patch(
+        "tracecat.executor.registry_resolver.get_async_session_context_manager",
+        _session_cm,
+    )
+    mocker.patch(
+        "tracecat.executor.registry_resolver.get_async_session_bypass_rls_context_manager",
+        _session_cm,
+    )
+
+    prepared = await prepare_resolved_context(input=input, role=test_role)
+    assert prepared.mask_values is None

--- a/tests/unit/test_view.py
+++ b/tests/unit/test_view.py
@@ -1833,6 +1833,27 @@ def test_build_action_statements_simple_sequence():
     assert stmts_by_ref["action_c"].depends_on == ["action_b"]  # C depends on B
 
 
+def test_build_action_statements_preserves_disable_secrets_masking():
+    """Test that control_flow.disable_secrets_masking is carried to ActionStatement."""
+    trigger_id = f"trigger-{WORKFLOW_UUID}"
+
+    action = MockActionWithRef(
+        id=UUID_A,
+        type="udf",
+        title="Action A",
+        ref="action_a",
+        control_flow={"disable_secrets_masking": True},
+        upstream_edges=[
+            {"source_id": trigger_id, "source_type": "trigger"},
+        ],
+    )
+
+    stmts = build_action_statements_from_actions(cast("list[Action]", [action]))
+
+    assert len(stmts) == 1
+    assert stmts[0].disable_secrets_masking is True
+
+
 def test_build_action_statements_diamond():
     r"""Test build_action_statements_from_actions with diamond pattern.
 

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -1311,6 +1311,7 @@ def build_action_statements_from_actions(
             join_strategy=control_flow.join_strategy,
             interaction=interaction,
             environment=control_flow.environment,
+            disable_secrets_masking=control_flow.disable_secrets_masking,
         )
         statements.append(action_stmt)
     return statements

--- a/tracecat/dsl/schemas.py
+++ b/tracecat/dsl/schemas.py
@@ -363,6 +363,13 @@ class ActionStatement(BaseModel):
         default=None,
         description="Override environment for this action's execution. Can be a template expression.",
     )
+    disable_secrets_masking: bool = Field(
+        default=False,
+        description=(
+            "Disable secret masking for this action output. "
+            "This is unsafe and should only be enabled when absolutely necessary."
+        ),
+    )
 
     @property
     def title(self) -> str:

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -723,9 +723,15 @@ async def prepare_resolved_context(
 
     # Build root-level masks from the runtime projection so host-side credential
     # rewriting is also redacted from final outputs.
-    if config.TRACECAT__UNSAFE_DISABLE_SM_MASKING:
+    disable_secrets_masking = (
+        config.TRACECAT__UNSAFE_DISABLE_SM_MASKING or task.disable_secrets_masking
+    )
+    if disable_secrets_masking:
         logger.warning(
-            "Secrets masking is disabled. This is unsafe in production workflows."
+            "Secrets masking is disabled. This is unsafe in production workflows.",
+            task_ref=task.ref,
+            is_globally_disabled=config.TRACECAT__UNSAFE_DISABLE_SM_MASKING,
+            is_action_level_disabled=task.disable_secrets_masking,
         )
         mask_values = None
     else:

--- a/tracecat/workflow/actions/schemas.py
+++ b/tracecat/workflow/actions/schemas.py
@@ -58,6 +58,13 @@ class ActionControlFlow(Schema):
         default=None,
         description="Override environment for this action's execution",
     )
+    disable_secrets_masking: bool = Field(
+        default=False,
+        description=(
+            "Disable secret masking for this action output. "
+            "This is unsafe and should only be enabled when absolutely necessary."
+        ),
+    )
 
     @field_validator("wait_until", mode="before")
     def validate_wait_until(cls, v: str | None) -> str | None:

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1014,6 +1014,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 start_delay=act_stmt.start_delay,
                 wait_until=act_stmt.wait_until,
                 join_strategy=act_stmt.join_strategy,
+                disable_secrets_masking=act_stmt.disable_secrets_masking,
             )
             pos = (action_positions or {}).get(act_stmt.ref)
             new_action = Action(


### PR DESCRIPTION
### Motivation
- Provide an action-level opt-out for secret masking so individual actions can request unmasked outputs without relying solely on the global `TRACECAT__UNSAFE_DISABLE_SM_MASKING` toggle. 
- Surface the option in the action editor so authors can explicitly enable the unsafe behavior for troubleshooting or special cases.
- Ensure the DSL, persistence, and executor respect the per-action setting so behavior is consistent end-to-end.

### Description
- Add a new boolean field `disable_secrets_masking` to the client schemas/types and generated files so it is available in the TypeScript model and API payloads. 
- Add the field to the action form schema and editor UI as a checkbox labeled "Disable secrets masking", include it in `baseFormValues`, and send it as part of the `control_flow` when updating actions. 
- Extend DSL and workflow schemas by adding `disable_secrets_masking` to `ActionStatement` and `ActionControlFlow`, and propagate the flag when building `ActionStatement` instances in `build_action_statements_from_actions`. 
- Make the executor obey the action-level opt-out by reading `task.disable_secrets_masking` in `prepare_resolved_context` and disabling masking if either the global config or the action flag is set, while augmenting the executor log with contextual flags. 

### Testing
- Added `tests/unit/test_executor_manifest_resolution.py::test_prepare_resolved_context_disables_masking_for_action_opt_out` which verifies that `prepare_resolved_context` returns `mask_values is None` when an action sets `disable_secrets_masking`, and the test passed. 
- Added `tests/unit/test_view.py::test_build_action_statements_preserves_disable_secrets_masking` which verifies `build_action_statements_from_actions` preserves the flag into `ActionStatement`, and the test passed. 
- Ran the unit test suite for affected modules (`pytest tests/unit/test_executor_manifest_resolution.py tests/unit/test_view.py`) and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee4bdb6148320b52a9f60f72d4360)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-action `disable_secrets_masking` opt-out with end-to-end support and an “Unmasked” badge on action nodes. Builder manual runs now auto-save dirty edits (including YAML) and block concurrent runs; also adds PostgreSQL RLS and Caddy-based MCP routing.

- **New Features**
  - Per-action masking opt-out: checkbox in action panel; schemas/types updated; flag flows `ActionControlFlow` → `ActionStatement` → management; executor disables masking when global or action flags are set and logs both; canvas shows “Unmasked” badge.
  - Builder: `saveIfDirty` persists selected action before manual runs; manual trigger prevents concurrent runs and aborts on save errors.
  - Infra: PostgreSQL RLS via `TRACECAT__RLS_MODE` and tenant helpers; MCP via Caddy at `/mcp` with OAuth well-known and `TRACECAT_MCP__BASE_URL` default; Compose no longer exposes MCP port.

- **Bug Fixes**
  - Builder: commit YAML buffers before saving; auto-save on panel blur/Cmd+S; clear action panel `saveIfDirty` callback on unmount to avoid stale refs.
  - Registry: clear `current_version_id` before repo deletion to avoid circular FK failures.
  - Tests: add coverage to ensure the masking opt-out changes final results and that the flag propagates into `ActionStatement`.

<sup>Written for commit af7a7d8d0d90141a7ad751f4fd74da2c39d91c8f. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2313">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

