### PR TITLE
test(registry): add delete regression coverage

### DIFF
--- a/tests/unit/test_registry_repositories_service.py
+++ b/tests/unit/test_registry_repositories_service.py
@@ -1,0 +1,67 @@
+"""Tests for registry repository service behavior."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.db.models import RegistryRepository
+from tracecat.registry.repositories.service import RegistryReposService
+
+
+@pytest.fixture
+def role() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"org:registry:delete"}),
+    )
+
+
+@pytest.mark.anyio
+async def test_delete_repository_clears_promoted_version_before_delete(
+    role: Role,
+) -> None:
+    """Deleting a promoted repository must clear the self-referential FK first."""
+    session = AsyncMock()
+    repository = RegistryRepository(
+        organization_id=role.organization_id,
+        origin="test_origin",
+    )
+    repository.current_version_id = uuid.uuid4()
+
+    service = RegistryReposService(session, role=role)
+    await service.delete_repository(repository)
+
+    assert repository.current_version_id is None
+    assert session.mock_calls == [
+        call.flush(),
+        call.delete(repository),
+        call.commit(),
+    ]
+
+
+@pytest.mark.anyio
+async def test_delete_repository_without_promoted_version_skips_flush(
+    role: Role,
+) -> None:
+    """Deleting an unpromoted repository should not emit the extra flush."""
+    session = AsyncMock()
+    repository = RegistryRepository(
+        organization_id=role.organization_id,
+        origin="test_origin",
+    )
+
+    service = RegistryReposService(session, role=role)
+    await service.delete_repository(repository)
+
+    assert session.mock_calls == [
+        call.delete(repository),
+        call.commit(),
+    ]


### PR DESCRIPTION
## Summary
- add a focused regression test for `RegistryReposService.delete_repository`
- verify a promoted repository clears `current_version_id` before delete and skips the extra flush when no promoted version exists

## Testing
- `uv run pytest --noconftest tests/unit/test_registry_repositories_service.py -q`
- `uv run ruff check tests/unit/test_registry_repositories_service.py`
- `uv run basedpyright tests/unit/test_registry_repositories_service.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests for `RegistryReposService.delete_repository` to enforce correct delete behavior.
Ensures promoted repos clear `current_version_id` before delete and skips the extra `flush` when no promoted version exists.

<sup>Written for commit a337235abd9007e00135509e4522b24d05feb254. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

