### PR TITLE
feat(mcp): Add workflow folder tools

### DIFF
--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -120,6 +120,7 @@ from tracecat.workflow.case_triggers.schemas import (
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
+from tracecat.workflow.management.folders.service import WorkflowFolderService
 from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.schemas import WorkflowCreate, WorkflowUpdate
 from tracecat.workflow.schedules.schemas import (
@@ -228,6 +229,28 @@ async def _resolve_workspace_role(workspace_id: str) -> tuple[uuid.UUID, Any]:
     except ValueError as exc:
         raise ToolError(str(exc)) from exc
     return ws_id, role
+
+
+def _normalize_folder_path_arg(path: str, *, allow_root: bool = True) -> str:
+    """Normalize a user-supplied folder path."""
+    raw = path.strip()
+    if not raw:
+        raise ToolError("Path is required")
+    if raw == "/":
+        if allow_root:
+            return raw
+        raise ToolError("Root path '/' is not valid for this operation")
+    if not raw.startswith("/"):
+        raise ToolError("Path must start with '/'")
+
+    parts = [part for part in raw.split("/") if part]
+    if any(part in {".", ".."} for part in parts):
+        raise ToolError("Path cannot contain '.' or '..' segments")
+    if not parts:
+        if allow_root:
+            return "/"
+        raise ToolError("Root path '/' is not valid for this operation")
+    return f"/{'/'.join(parts)}/"
 
 
 def _build_example_from_schema(schema: dict[str, Any]) -> dict[str, Any]:
@@ -1903,6 +1926,255 @@ async def list_workflows(
     except Exception as e:
         logger.error("Failed to list workflows", error=str(e))
         raise ToolError(f"Failed to list workflows: {e}") from None
+
+
+@mcp.tool()
+async def list_workflow_tree(
+    workspace_id: str,
+    path: str = "/",
+    depth: int = 1,
+    include_workflows: bool = True,
+) -> str:
+    """List workflow folders and workflows under a path.
+
+    Args:
+        workspace_id: The workspace ID.
+        path: Folder path to list from. Use "/" for the workspace root.
+        depth: Number of folder levels to traverse. Use 1 for direct children
+            only. Use 0 for unlimited depth.
+        include_workflows: Whether to include workflows alongside folders.
+
+    Returns JSON with the normalized root path and a flat list of items.
+    """
+
+    try:
+        if depth < 0:
+            raise ToolError("depth must be >= 0")
+
+        _, role = await _resolve_workspace_role(workspace_id)
+        root_path = _normalize_folder_path_arg(path)
+
+        async with WorkflowFolderService.with_session(role=role) as svc:
+            queue: deque[tuple[str, int]] = deque([(root_path, 1)])
+            items: list[dict[str, Any]] = []
+
+            while queue:
+                current_path, current_depth = queue.popleft()
+                for item in await svc.get_directory_items(
+                    current_path, order_by="desc"
+                ):
+                    payload = item.model_dump(mode="json")
+                    if payload["type"] == "folder":
+                        items.append(
+                            {
+                                "type": "folder",
+                                "path": payload["path"],
+                                "name": payload["name"],
+                                "depth": current_depth,
+                            }
+                        )
+                        if depth == 0 or current_depth < depth:
+                            queue.append((payload["path"], current_depth + 1))
+                    elif include_workflows:
+                        items.append(
+                            {
+                                "type": "workflow",
+                                "workflow_id": payload["id"],
+                                "title": payload["title"],
+                                "alias": payload["alias"],
+                                "status": payload["status"],
+                                "folder_path": current_path,
+                                "depth": current_depth,
+                                "tags": payload.get("tags") or [],
+                            }
+                        )
+
+            return _json(
+                {
+                    "root_path": root_path,
+                    "depth": "unlimited" if depth == 0 else depth,
+                    "items": items,
+                }
+            )
+    except ToolError:
+        raise
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to list workflow tree", error=str(e))
+        raise ToolError(f"Failed to list workflow tree: {e}") from None
+
+
+@mcp.tool()
+async def create_workflow_folder(
+    workspace_id: str,
+    path: str,
+    parents: bool = False,
+) -> str:
+    """Create a workflow folder by absolute path.
+
+    Args:
+        workspace_id: The workspace ID.
+        path: Absolute folder path to create, e.g. "/security/detections/".
+        parents: When true, create missing parent folders as needed.
+
+    Returns JSON describing the resulting folder and any created paths.
+    """
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+        parts = [part for part in normalized_path.strip("/").split("/") if part]
+
+        async with WorkflowFolderService.with_session(role=role) as svc:
+            if not parents:
+                parent_parts = parts[:-1]
+                parent_path = f"/{'/'.join(parent_parts)}/" if parent_parts else "/"
+                folder = await svc.create_folder(
+                    name=parts[-1], parent_path=parent_path
+                )
+                created_paths = [normalized_path]
+            else:
+                current_path = "/"
+                created_paths: list[str] = []
+                folder = None
+                for part in parts:
+                    next_path = (
+                        f"{current_path}{part}/" if current_path != "/" else f"/{part}/"
+                    )
+                    if existing := await svc.get_folder_by_path(next_path):
+                        folder = existing
+                    else:
+                        folder = await svc.create_folder(
+                            name=part,
+                            parent_path=current_path,
+                        )
+                        created_paths.append(next_path)
+                    current_path = next_path
+
+                if folder is None:
+                    raise ToolError(f"Failed to create folder {normalized_path}")
+
+            return _json(
+                {
+                    "path": normalized_path,
+                    "folder_id": str(folder.id),
+                    "created_paths": created_paths,
+                    "already_existed": not created_paths,
+                }
+            )
+    except ToolError:
+        raise
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to create workflow folder", error=str(e))
+        raise ToolError(f"Failed to create workflow folder: {e}") from None
+
+
+@mcp.tool()
+async def move_workflows(
+    workspace_id: str,
+    workflow_ids: list[str],
+    destination_path: str = "/",
+    dry_run: bool = False,
+) -> str:
+    """Move workflows into or out of a folder.
+
+    This tool is best-effort and non-atomic. If one workflow fails to move,
+    the remaining workflow moves still proceed.
+
+    Args:
+        workspace_id: The workspace ID.
+        workflow_ids: Workflow IDs in short or full format.
+        destination_path: Destination folder path, or "/" for root.
+        dry_run: When true, validate and report the move without mutating state.
+
+    Returns JSON with moved workflows and per-workflow errors.
+    """
+
+    try:
+        if not workflow_ids:
+            raise ToolError("workflow_ids must not be empty")
+
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_destination = _normalize_folder_path_arg(destination_path)
+
+        async with WorkflowsManagementService.with_session(role=role) as mgmt_svc:
+            folder_svc = WorkflowFolderService(mgmt_svc.session, role=role)
+            folder = None
+            if normalized_destination != "/":
+                folder = await folder_svc.get_folder_by_path(normalized_destination)
+                if folder is None:
+                    raise ToolError(f"Folder {normalized_destination} not found")
+
+            validated: list[dict[str, str]] = []
+            errors: list[dict[str, str]] = []
+            for raw_workflow_id in workflow_ids:
+                try:
+                    workflow_uuid = WorkflowUUID.new(raw_workflow_id)
+                except ValueError as e:
+                    errors.append({"workflow_id": raw_workflow_id, "error": str(e)})
+                    continue
+
+                workflow = await mgmt_svc.get_workflow(workflow_uuid)
+                if workflow is None:
+                    errors.append(
+                        {
+                            "workflow_id": raw_workflow_id,
+                            "error": f"Workflow {raw_workflow_id} not found",
+                        }
+                    )
+                    continue
+
+                validated.append(
+                    {
+                        "workflow_id": str(workflow_uuid),
+                        "title": workflow.title,
+                    }
+                )
+
+            if dry_run:
+                return _json(
+                    {
+                        "destination_path": normalized_destination,
+                        "requested_count": len(workflow_ids),
+                        "movable_count": len(validated),
+                        "movable_workflows": validated,
+                        "errors": errors,
+                    }
+                )
+
+            moved: list[dict[str, str]] = []
+            for workflow_info in validated:
+                try:
+                    workflow_uuid = WorkflowUUID.new(workflow_info["workflow_id"])
+                    await folder_svc.move_workflow(workflow_uuid, folder)
+                    moved.append(workflow_info)
+                except Exception as e:
+                    errors.append(
+                        {
+                            "workflow_id": workflow_info["workflow_id"],
+                            "error": str(e),
+                        }
+                    )
+
+            return _json(
+                {
+                    "destination_path": normalized_destination,
+                    "requested_count": len(workflow_ids),
+                    "moved_count": len(moved),
+                    "moved_workflows": moved,
+                    "errors": errors,
+                }
+            )
+    except ToolError:
+        raise
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to move workflows", error=str(e))
+        raise ToolError(f"Failed to move workflows: {e}") from None
 
 
 @mcp.tool()

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -58,7 +58,7 @@ from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
 from tracecat.chat.schemas import BasicChatRequest, ChatRequest
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.db.models import Action, WorkflowDefinition
+from tracecat.db.models import Action, Workflow, WorkflowDefinition
 from tracecat.dsl.common import (
     DSLInput,
     get_execution_type_from_search_attr,
@@ -2030,10 +2030,14 @@ async def create_workflow_folder(
             if not parents:
                 parent_parts = parts[:-1]
                 parent_path = f"/{'/'.join(parent_parts)}/" if parent_parts else "/"
-                folder = await svc.create_folder(
-                    name=parts[-1], parent_path=parent_path
-                )
-                created_paths = [normalized_path]
+                if existing := await svc.get_folder_by_path(normalized_path):
+                    folder = existing
+                    created_paths = []
+                else:
+                    folder = await svc.create_folder(
+                        name=parts[-1], parent_path=parent_path
+                    )
+                    created_paths = [normalized_path]
             else:
                 current_path = "/"
                 created_paths: list[str] = []
@@ -2100,8 +2104,7 @@ async def move_workflows(
         _, role = await _resolve_workspace_role(workspace_id)
         normalized_destination = _normalize_folder_path_arg(destination_path)
 
-        async with WorkflowsManagementService.with_session(role=role) as mgmt_svc:
-            folder_svc = WorkflowFolderService(mgmt_svc.session, role=role)
+        async with WorkflowFolderService.with_session(role=role) as folder_svc:
             folder = None
             if normalized_destination != "/":
                 folder = await folder_svc.get_folder_by_path(normalized_destination)
@@ -2117,22 +2120,25 @@ async def move_workflows(
                     errors.append({"workflow_id": raw_workflow_id, "error": str(e)})
                     continue
 
-                workflow = await mgmt_svc.get_workflow(workflow_uuid)
-                if workflow is None:
+                statement = select(Workflow.id, Workflow.title).where(
+                    Workflow.workspace_id == folder_svc.workspace_id,
+                    Workflow.id == workflow_uuid,
+                )
+                result = await folder_svc.session.execute(statement)
+                if row := result.one_or_none():
+                    validated.append(
+                        {
+                            "workflow_id": str(row.id),
+                            "title": row.title,
+                        }
+                    )
+                else:
                     errors.append(
                         {
                             "workflow_id": raw_workflow_id,
                             "error": f"Workflow {raw_workflow_id} not found",
                         }
                     )
-                    continue
-
-                validated.append(
-                    {
-                        "workflow_id": str(workflow_uuid),
-                        "title": workflow.title,
-                    }
-                )
 
             if dry_run:
                 return _json(
@@ -2152,6 +2158,7 @@ async def move_workflows(
                     await folder_svc.move_workflow(workflow_uuid, folder)
                     moved.append(workflow_info)
                 except Exception as e:
+                    await folder_svc.session.rollback()
                     errors.append(
                         {
                             "workflow_id": workflow_info["workflow_id"],


### PR DESCRIPTION
## Summary
This change adds a small MCP-only workflow folder management surface without changing the existing REST API, frontend, or workflow service contracts. Agents can now inspect folder structures, create folders by path, and move workflows into or out of folders in batches through the MCP server. The tree listing also returns workflow tag metadata so nested workflows can be tagged directly with the existing workflow tag MCP tools.

## Issue and user impact
Before this change, the MCP server exposed general workflow CRUD but not folder-oriented operations. That made agents inefficient at organizing workflows because they had to rely on UI-only or REST-only folder capabilities that were not available through MCP. In practice, an agent could not accurately inspect nested folder structure, create missing folders, or perform a multi-workflow reorganization flow over MCP.

## Root cause
Folder management primitives already existed in the application services and REST routers, but they were not surfaced in `tracecat/mcp/server.py`. The MCP surface also did not return folder-aware workflow metadata that would help an agent continue into tagging operations after locating a nested workflow.

## Fix
The MCP server now exposes three thin wrappers over the existing workflow folder services:

- `list_workflow_tree` lists folders and workflows under a path with bounded or unlimited depth.
- `create_workflow_folder` creates a folder from an absolute path and supports parent creation when requested.
- `move_workflows` performs best-effort, non-atomic batch moves into a destination folder or back to root, with a `dry_run` mode for validation.

A small path normalization helper was added to keep MCP path handling explicit and predictable. The tree listing now includes each workflow's `workflow_id`, `alias`, and current `tags` so agents can tag foldered or nested workflows directly using the existing tag tools.

## Safety and compatibility
This change is intentionally scoped to the MCP server. It does not modify the frontend, REST routes, or underlying service implementations, which keeps regression risk low for existing UI and API behavior. Batch moves are described and implemented as best-effort and non-atomic because the underlying single-workflow move service commits per workflow today; the MCP contract does not claim stronger guarantees than the current service layer provides.

## Validation
I validated the change with the existing repository checks that apply to the touched file:

- `uv run ruff check tracecat/mcp/server.py`
- `uv run basedpyright --warnings tracecat/mcp/server.py`
- pre-commit hooks during `git commit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MCP-only workflow folder tools so agents can list folders, create folders, and batch-move workflows via the MCP server. Hardened path and validation edge cases; tree listings include tag metadata for tagging nested workflows.

- **New Features**
  - `list_workflow_tree(path, depth, include_workflows)` lists folders and workflows from a path. Returns normalized `root_path` and items. Each workflow includes `workflow_id`, `alias`, `title`, `status`, `tags`, and `folder_path`. Depth `0` is unlimited.
  - `create_workflow_folder(path, parents)` creates a folder by absolute path. Optional `parents` creates missing ancestors. Rejects root paths and "."/".." segments. Returns `folder_id`, `created_paths`, and whether it already existed.
  - `move_workflows(workflow_ids, destination_path, dry_run)` moves workflows into a folder or back to root. Best-effort, non-atomic. Validates workflow IDs and destination folder; `dry_run` reports counts and per-item errors.
  - MCP-only change. No updates to REST, frontend, or underlying service contracts.

<sup>Written for commit 5c00ecfe6af13e2d981332cd7f44c1f05d622704. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

