### PR TITLE
fix(auth): oidc redirect

### DIFF
--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -1,14 +1,9 @@
 "use client"
 
 import { type ComponentPropsWithoutRef, useState } from "react"
-import { authOauthOidcDatabaseAuthorize } from "@/client"
 import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
-import {
-  sanitizeReturnUrl,
-  serializeClearPostAuthReturnUrlCookie,
-  serializePostAuthReturnUrlCookie,
-} from "@/lib/auth-return-url"
+import { startOidcLogin } from "@/lib/auth-login"
 
 type OAuthButtonProps = ComponentPropsWithoutRef<typeof Button> & {
   returnUrl?: string | null
@@ -19,14 +14,6 @@ type OidcProviderIcon = "google" | "login"
 type OidcOAuthButtonProps = OAuthButtonProps & {
   providerLabel?: string
   providerIcon?: OidcProviderIcon
-}
-
-function setPostAuthReturnUrlCookie(returnUrl?: string | null): void {
-  const secure = window.location.protocol === "https:"
-  const sanitizedReturnUrl = sanitizeReturnUrl(returnUrl)
-  document.cookie = sanitizedReturnUrl
-    ? serializePostAuthReturnUrlCookie(sanitizedReturnUrl, secure)
-    : serializeClearPostAuthReturnUrlCookie(secure)
 }
 
 export function GithubOAuthButton({
@@ -68,9 +55,7 @@ export function OidcOAuthButton({
   const handleClick = async () => {
     try {
       setIsLoading(true)
-      const { authorization_url } = await authOauthOidcDatabaseAuthorize()
-      setPostAuthReturnUrlCookie(returnUrl)
-      window.location.href = authorization_url
+      await startOidcLogin(returnUrl)
     } catch (error) {
       console.error("Error authorizing with OIDC", error)
     } finally {

--- a/frontend/src/components/auth/saml.tsx
+++ b/frontend/src/components/auth/saml.tsx
@@ -4,22 +4,10 @@ import { type ComponentPropsWithoutRef, useState } from "react"
 import { authSamlDatabaseLogin } from "@/client"
 import { Icons } from "@/components/icons"
 import { Button } from "@/components/ui/button"
-import {
-  sanitizeReturnUrl,
-  serializeClearPostAuthReturnUrlCookie,
-  serializePostAuthReturnUrlCookie,
-} from "@/lib/auth-return-url"
+import { setPostAuthReturnUrlCookie } from "@/lib/auth-login"
 
 type SamlSSOButtonProps = ComponentPropsWithoutRef<typeof Button> & {
   returnUrl?: string | null
-}
-
-function setPostAuthReturnUrlCookie(returnUrl?: string | null): void {
-  const secure = window.location.protocol === "https:"
-  const sanitizedReturnUrl = sanitizeReturnUrl(returnUrl)
-  document.cookie = sanitizedReturnUrl
-    ? serializePostAuthReturnUrlCookie(sanitizedReturnUrl, secure)
-    : serializeClearPostAuthReturnUrlCookie(secure)
 }
 
 export function SamlSSOButton({ returnUrl, ...props }: SamlSSOButtonProps) {

--- a/frontend/src/components/auth/sign-in.tsx
+++ b/frontend/src/components/auth/sign-in.tsx
@@ -33,25 +33,14 @@ import {
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { useAuthActions } from "@/hooks/use-auth"
-import {
-  sanitizeReturnUrl,
-  serializeClearPostAuthReturnUrlCookie,
-  serializePostAuthReturnUrlCookie,
-} from "@/lib/auth-return-url"
+import { setPostAuthReturnUrlCookie, startOidcLogin } from "@/lib/auth-login"
+import { sanitizeReturnUrl } from "@/lib/auth-return-url"
 import { useAppInfo } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 
 interface SignInProps extends React.HTMLProps<HTMLDivElement> {
   returnUrl?: string | null
   organizationSlug?: string | null
-}
-
-function setPostAuthReturnUrlCookie(returnUrl?: string | null): void {
-  const secure = window.location.protocol === "https:"
-  const sanitizedReturnUrl = sanitizeReturnUrl(returnUrl)
-  document.cookie = sanitizedReturnUrl
-    ? serializePostAuthReturnUrlCookie(sanitizedReturnUrl, secure)
-    : serializeClearPostAuthReturnUrlCookie(secure)
 }
 
 function buildSignUpPath(
@@ -142,9 +131,7 @@ export function SignIn({
         if (!showOidcAuth) {
           throw new Error("OIDC login is not enabled")
         }
-        // Fall through — show OIDC buttons so user can click
-        // (OIDC requires user-initiated navigation for OAuth redirects)
-        setDiscoveredMethod(null)
+        await startOidcLogin(returnUrl)
         return
       }
       if (data.method === "saml") {

--- a/frontend/src/lib/auth-login.ts
+++ b/frontend/src/lib/auth-login.ts
@@ -1,0 +1,22 @@
+"use client"
+
+import { authOauthOidcDatabaseAuthorize } from "@/client"
+import {
+  sanitizeReturnUrl,
+  serializeClearPostAuthReturnUrlCookie,
+  serializePostAuthReturnUrlCookie,
+} from "@/lib/auth-return-url"
+
+export function setPostAuthReturnUrlCookie(returnUrl?: string | null): void {
+  const secure = window.location.protocol === "https:"
+  const sanitizedReturnUrl = sanitizeReturnUrl(returnUrl)
+  document.cookie = sanitizedReturnUrl
+    ? serializePostAuthReturnUrlCookie(sanitizedReturnUrl, secure)
+    : serializeClearPostAuthReturnUrlCookie(secure)
+}
+
+export async function startOidcLogin(returnUrl?: string | null): Promise<void> {
+  setPostAuthReturnUrlCookie(returnUrl)
+  const { authorization_url } = await authOauthOidcDatabaseAuthorize()
+  window.location.href = authorization_url
+}

--- a/frontend/tests/auth-ui-matrix.test.tsx
+++ b/frontend/tests/auth-ui-matrix.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { authDiscoverAuthMethod } from "@/client"
 import { SignIn } from "@/components/auth/sign-in"
 import { SignUp } from "@/components/auth/sign-up"
+import { startOidcLogin } from "@/lib/auth-login"
 
 type MockAppInfo = {
   version: string
@@ -66,6 +67,11 @@ jest.mock("@/lib/hooks", () => ({
   }),
 }))
 
+jest.mock("@/lib/auth-login", () => ({
+  startOidcLogin: jest.fn(),
+  setPostAuthReturnUrlCookie: jest.fn(),
+}))
+
 jest.mock("@/client", () => {
   class MockApiError extends Error {
     body: { detail: unknown }
@@ -100,6 +106,9 @@ function setMultiTenant(eeMultiTenant: boolean): void {
 describe("Auth UI matrix", () => {
   const mockDiscoverAuthMethod = authDiscoverAuthMethod as jest.MockedFunction<
     typeof authDiscoverAuthMethod
+  >
+  const mockStartOidcLogin = startOidcLogin as jest.MockedFunction<
+    typeof startOidcLogin
   >
   let consoleErrorSpy: jest.SpyInstance
 
@@ -192,6 +201,34 @@ describe("Auth UI matrix", () => {
     expect(
       screen.queryByRole("link", { name: "Sign up" })
     ).not.toBeInTheDocument()
+  })
+
+  it("starts OIDC login immediately when discovery resolves to oidc", async () => {
+    setAuthTypes(["oidc"])
+    mockDiscoverAuthMethod.mockResolvedValue({
+      method: "oidc",
+      next_url: null,
+      organization_slug: null,
+    })
+    mockStartOidcLogin.mockResolvedValue()
+
+    render(<SignIn returnUrl="/workspaces" />)
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "user@example.com" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+
+    await waitFor(() => {
+      expect(mockDiscoverAuthMethod).toHaveBeenCalledWith({
+        requestBody: {
+          email: "user@example.com",
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(mockStartOidcLogin).toHaveBeenCalledWith("/workspaces")
+    })
   })
 
   it.each([


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the OIDC redirect by auto-starting login after discovery in `SignIn` and moving redirect/return-url cookie handling to `@/lib/auth-login`. This saves the `returnUrl` before redirect so users land on the right page.

- **Bug Fixes**
  - Auto-start OIDC when discovery returns `oidc` via `startOidcLogin`.
  - Save the `returnUrl` cookie before redirect for correct post-auth navigation.
  - Added a test for the auto-start OIDC path.

- **Refactors**
  - Added `startOidcLogin` and `setPostAuthReturnUrlCookie` in `@/lib/auth-login`; updated `OidcOAuthButton`, `SignIn`, and `SamlSSOButton` to use them.

<sup>Written for commit 2ec675f15959f5d68a413bcef6425366f44a8c3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

