### PR TITLE
fix: register preset agent activities on workers

### DIFF
--- a/tests/integration/test_dsl_agent_wiring.py
+++ b/tests/integration/test_dsl_agent_wiring.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Generator, Iterator, Sequence
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from temporalio import activity
+from temporalio.client import Client
+from temporalio.worker import Worker
+from tracecat_ee.agent.activities import BuildToolDefsArgs, BuildToolDefsResult
+from tracecat_ee.agent.workflows.durable import DurableAgentWorkflow
+
+from tests.shared import to_data
+from tracecat import config
+from tracecat.agent.executor.activity import (
+    AgentExecutorInput,
+    AgentExecutorResult,
+    ExecuteApprovedToolsInput,
+    ExecuteApprovedToolsResult,
+)
+from tracecat.agent.session.activities import (
+    CreateSessionInput,
+    CreateSessionResult,
+    LoadSessionInput,
+    LoadSessionResult,
+)
+from tracecat.agent.worker import (
+    get_activities as get_agent_worker_activities,
+)
+from tracecat.agent.worker import (
+    new_sandbox_runner as new_agent_sandbox_runner,
+)
+from tracecat.auth.types import Role
+from tracecat.dsl.common import RETRY_POLICIES, DSLEntrypoint, DSLInput, DSLRunArgs
+from tracecat.dsl.schemas import ActionStatement
+from tracecat.dsl.worker import get_activities as get_dsl_worker_activities
+from tracecat.dsl.workflow import DSLWorkflow
+from tracecat.identifiers.workflow import WorkflowUUID, generate_exec_id
+from tracecat.registry.lock.types import RegistryLock
+
+
+def _activity_name(activity_def: object) -> str:
+    return getattr(activity_def, "__temporal_activity_definition").name
+
+
+@pytest.fixture(scope="session")
+def minio_server() -> Iterator[None]:
+    yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def workflow_bucket() -> Iterator[None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def disable_result_externalization(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(config, "TRACECAT__RESULT_EXTERNALIZATION_ENABLED", False)
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES",
+        1024 * 1024,
+    )
+    yield
+
+
+def _replace_activity(
+    activities: Sequence[Callable[..., Any]],
+    replacement: Callable[..., Any],
+) -> list[Callable[..., Any]]:
+    target_name = _activity_name(replacement)
+    replaced = False
+    updated: list[Callable[..., Any]] = []
+    for existing in activities:
+        if _activity_name(existing) == target_name:
+            updated.append(replacement)
+            replaced = True
+        else:
+            updated.append(existing)
+    if not replaced:
+        raise AssertionError(f"Activity {target_name!r} was not registered")
+    return updated
+
+
+def create_mock_create_session_activity(
+    captured_inputs: list[CreateSessionInput] | None = None,
+) -> Callable[..., Any]:
+    @activity.defn(name="create_session_activity")
+    async def mock_create_session_activity(
+        input: CreateSessionInput,
+    ) -> CreateSessionResult:
+        if captured_inputs is not None:
+            captured_inputs.append(input)
+        return CreateSessionResult(session_id=input.session_id, success=True)
+
+    return mock_create_session_activity
+
+
+def create_mock_load_session_activity() -> Callable[..., Any]:
+    @activity.defn(name="load_session_activity")
+    async def mock_load_session_activity(_: LoadSessionInput) -> LoadSessionResult:
+        return LoadSessionResult(
+            found=False,
+            sdk_session_id=None,
+            sdk_session_data=None,
+            is_fork=False,
+        )
+
+    return mock_load_session_activity
+
+
+def create_mock_build_tool_definitions_activity() -> Callable[..., Any]:
+    @activity.defn(name="build_tool_definitions")
+    async def mock_build_tool_definitions(
+        args: BuildToolDefsArgs,
+    ) -> BuildToolDefsResult:
+        del args
+        return BuildToolDefsResult(
+            tool_definitions={},
+            registry_lock=RegistryLock(
+                origins={"tracecat_registry": "test-version"},
+                actions={},
+            ),
+            user_mcp_claims=None,
+            allowed_internal_tools=None,
+        )
+
+    return mock_build_tool_definitions
+
+
+def create_mock_run_agent_activity(*, output: str) -> Callable[..., Any]:
+    @activity.defn(name="run_agent_activity")
+    async def mock_run_agent_activity(
+        input: AgentExecutorInput,
+    ) -> AgentExecutorResult:
+        del input
+        activity.heartbeat("Mock agent running")
+        return AgentExecutorResult(success=True, output=output)
+
+    return mock_run_agent_activity
+
+
+def create_mock_execute_approved_tools_activity() -> Callable[..., Any]:
+    @activity.defn(name="execute_approved_tools_activity")
+    async def mock_execute_approved_tools_activity(
+        input: ExecuteApprovedToolsInput,
+    ) -> ExecuteApprovedToolsResult:
+        del input
+        return ExecuteApprovedToolsResult(results=[], success=True)
+
+    return mock_execute_approved_tools_activity
+
+
+@pytest.fixture
+def agent_worker_factory(
+    threadpool: Any,
+) -> Generator[Callable[..., Worker], None, None]:
+    def create_agent_worker(
+        client: Client,
+        *,
+        task_queue: str,
+        activities: Sequence[Callable[..., Any]],
+    ) -> Worker:
+        return Worker(
+            client=client,
+            task_queue=task_queue,
+            activities=activities,
+            workflows=[DurableAgentWorkflow],
+            workflow_runner=new_agent_sandbox_runner(),
+            activity_executor=threadpool,
+        )
+
+    yield create_agent_worker
+
+
+class TestDSLAgentWiring:
+    @pytest.mark.anyio
+    @pytest.mark.integration
+    async def test_dsl_workflow_executes_ai_agent_on_agent_worker(
+        self,
+        test_role: Role,
+        temporal_client: Client,
+        test_worker_factory: Callable[..., Worker],
+        agent_worker_factory: Callable[..., Worker],
+    ) -> None:
+        agent_activities = list(get_agent_worker_activities())
+        for replacement in (
+            create_mock_create_session_activity(),
+            create_mock_load_session_activity(),
+            create_mock_build_tool_definitions_activity(),
+            create_mock_run_agent_activity(output="dsl-agent-wired"),
+            create_mock_execute_approved_tools_activity(),
+        ):
+            agent_activities = _replace_activity(agent_activities, replacement)
+
+        dsl = DSLInput(
+            title="DSL agent wiring",
+            description="Verify ai.agent spawns a child agent workflow",
+            entrypoint=DSLEntrypoint(ref="agent"),
+            actions=[
+                ActionStatement(
+                    ref="agent",
+                    action="ai.agent",
+                    args={
+                        "user_prompt": "Investigate this alert",
+                        "model_name": "gpt-4o-mini",
+                        "model_provider": "openai",
+                    },
+                )
+            ],
+            returns="${{ ACTIONS.agent.result }}",
+        )
+        wf_id = WorkflowUUID.new_uuid4()
+
+        async with test_worker_factory(
+            temporal_client,
+            activities=list(get_dsl_worker_activities()),
+        ):
+            async with agent_worker_factory(
+                temporal_client,
+                task_queue=config.TRACECAT__AGENT_QUEUE,
+                activities=agent_activities,
+            ):
+                result = await temporal_client.execute_workflow(
+                    DSLWorkflow.run,
+                    DSLRunArgs(
+                        dsl=dsl,
+                        role=test_role,
+                        wf_id=wf_id,
+                    ),
+                    id=generate_exec_id(wf_id),
+                    task_queue=config.TEMPORAL__CLUSTER_QUEUE,
+                    retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                    execution_timeout=timedelta(seconds=60),
+                )
+
+        data = await to_data(result)
+        assert data["output"] == "dsl-agent-wired"

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -22,6 +23,16 @@ class _AsyncContext:
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         return None
+
+
+@pytest.fixture(scope="session")
+def minio_server() -> Iterator[None]:
+    yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def workflow_bucket() -> Iterator[None]:
+    yield
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_worker_activity_registration.py
+++ b/tests/unit/test_worker_activity_registration.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+
+import pytest
+
+from tracecat.agent.preset.activities import (
+    resolve_agent_preset_config_activity,
+    resolve_agent_preset_version_ref_activity,
+)
+from tracecat.agent.worker import get_activities as get_agent_worker_activities
+from tracecat.dsl.worker import get_activities as get_dsl_worker_activities
+
+
+@pytest.fixture(scope="session")
+def minio_server() -> Iterator[None]:
+    yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def workflow_bucket() -> Iterator[None]:
+    yield
+
+
+def _activity_name(activity: object) -> str:
+    return getattr(activity, "__temporal_activity_definition").name
+
+
+def _activity_names(activities: Sequence[object]) -> set[str]:
+    return {_activity_name(activity) for activity in activities}
+
+
+def test_dsl_worker_registers_preset_version_resolution_activity() -> None:
+    names = _activity_names(get_dsl_worker_activities())
+    assert _activity_name(resolve_agent_preset_version_ref_activity) in names
+
+
+def test_agent_worker_registers_preset_resolution_activities() -> None:
+    names = _activity_names(get_agent_worker_activities())
+    assert _activity_name(resolve_agent_preset_config_activity) in names
+    assert _activity_name(resolve_agent_preset_version_ref_activity) in names

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -58,6 +58,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.mcp.trusted_server import app
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_config_activity,
+        resolve_agent_preset_version_ref_activity,
     )
     from tracecat.agent.session.activities import get_session_activities
     from tracecat.dsl.client import get_temporal_client
@@ -269,6 +270,7 @@ def get_activities() -> list[Callable[..., object]]:
     activities.extend(ApprovalManager.get_activities())
     # Preset resolution
     activities.append(resolve_agent_preset_config_activity)
+    activities.append(resolve_agent_preset_version_ref_activity)
 
     # Session management activities
     activities.extend(get_session_activities())

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -19,6 +19,9 @@ with workflow.unsafe.imports_passed_through():
     from tracecat_ee.agent.workflows.durable import DurableAgentWorkflow
 
     from tracecat import config
+    from tracecat.agent.preset.activities import (
+        resolve_agent_preset_version_ref_activity,
+    )
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.init_activities import (
@@ -87,6 +90,7 @@ def get_activities() -> list[Callable]:
     activities: list[Callable] = [
         *DSLActivities.load(),
         *CollectionActivities.get_activities(),
+        resolve_agent_preset_version_ref_activity,
         get_workflow_definition_activity,
         resolve_registry_lock_activity,
         get_workspace_organization_id_activity,


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes agent preset workflow execution failing with `NotFoundError` because `resolve_agent_preset_version_ref_activity` was referenced by `DSLWorkflow` but not registered on the Temporal workers that need it.

Changes:
- register `resolve_agent_preset_version_ref_activity` on the DSL worker and agent worker
- add a worker registration unit test so future activity wiring regressions fail fast
- add a focused integration test that runs `DSLWorkflow` and verifies `ai.agent` executes through the agent worker queue with a mocked agent runtime

## Related Issues

None.

## Screenshots / Recordings

N/A

## Steps to QA

1. Run `uv run pytest tests/unit/test_agent_preset_activities.py tests/unit/test_worker_activity_registration.py tests/integration/test_dsl_agent_wiring.py`.
2. Run `uv run ruff check tracecat/dsl/worker.py tracecat/agent/worker.py tests/unit/test_worker_activity_registration.py tests/unit/test_agent_preset_activities.py tests/integration/test_dsl_agent_wiring.py`.
3. Run `uv run pyright tracecat/dsl/worker.py tracecat/agent/worker.py tests/unit/test_worker_activity_registration.py tests/unit/test_agent_preset_activities.py tests/integration/test_dsl_agent_wiring.py`.
4. Optionally reproduce the original failure by running an `ai.preset_agent` workflow on `main`, then confirm this branch no longer hits the missing-activity error after restarting the workers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent preset workflow failures by registering the missing preset version resolution activity on both DSL and agent workers. Also adds tests to prevent regressions and verifies `ai.agent` runs on the agent worker.

- **Bug Fixes**
  - Register `resolve_agent_preset_version_ref_activity` in `tracecat/dsl/worker.py` and `tracecat/agent/worker.py` so `DSLWorkflow` can call it.
  - Add unit tests to assert workers register preset activities (`resolve_agent_preset_version_ref_activity`, `resolve_agent_preset_config_activity`).
  - Add integration test that executes `DSLWorkflow` and confirms `ai.agent` is handled by the agent worker queue with a mocked agent runtime.

<sup>Written for commit d9bb399a8c4f50dc55e5ffd6f27dd69ff0874c84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

