### PR TITLE
fix: Harden GitHub App credential recovery

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10410,6 +10410,11 @@ export const $GitHubAppCredentialsStatus = {
       type: "boolean",
       title: "Exists",
     },
+    is_corrupted: {
+      type: "boolean",
+      title: "Is Corrupted",
+      default: false,
+    },
     app_id: {
       anyOf: [
         {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3166,6 +3166,7 @@ export type GitHubAppCredentialsRequest = {
  */
 export type GitHubAppCredentialsStatus = {
   exists: boolean
+  is_corrupted?: boolean
   app_id?: string | null
   has_webhook_secret?: boolean
   webhook_secret_preview?: string | null

--- a/frontend/src/components/organization/org-vcs-github-manual-form.tsx
+++ b/frontend/src/components/organization/org-vcs-github-manual-form.tsx
@@ -43,12 +43,14 @@ type GitHubAppCredentialsFormData = z.infer<typeof gitHubAppCredentialsSchema>
 interface GitHubAppManualFormProps {
   onSuccess?: () => void
   existingAppId?: string
+  hasStoredCredentials?: boolean
   className?: string
 }
 
 export function GitHubAppManualForm({
   onSuccess,
   existingAppId,
+  hasStoredCredentials = false,
   className,
 }: GitHubAppManualFormProps) {
   const { saveCredentials } = useGitHubAppCredentials()
@@ -76,7 +78,7 @@ export function GitHubAppManualForm({
         client_id: data.client_id || undefined,
       })
 
-      const action = existingAppId ? "updated" : "registered"
+      const action = hasStoredCredentials ? "updated" : "registered"
       toast({
         title: `GitHub App ${action} successfully`,
         description: `Your GitHub App credentials have been ${action}.`,
@@ -104,7 +106,7 @@ export function GitHubAppManualForm({
     }
   }
 
-  const buttonLabel = existingAppId ? "Save changes" : "Save credentials"
+  const buttonLabel = hasStoredCredentials ? "Save changes" : "Save credentials"
 
   const containerClass = className ? `space-y-4 ${className}` : "space-y-4"
 

--- a/frontend/src/components/organization/org-vcs-github.tsx
+++ b/frontend/src/components/organization/org-vcs-github.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import {
+  AlertTriangleIcon,
   CheckCircle2Icon,
   ExternalLinkIcon,
   GithubIcon,
@@ -104,6 +105,7 @@ export function GitHubAppSetup() {
   }, [])
 
   const isConfigured = credentialsStatus?.exists ?? false
+  const isCorrupted = credentialsStatus?.is_corrupted ?? false
 
   const handleFormSuccess = () => {
     setDialogOpen(false)
@@ -143,7 +145,9 @@ export function GitHubAppSetup() {
     <>
       <div className="flex items-center justify-between rounded-lg border p-4">
         <div className="flex items-center gap-3">
-          {isConfigured ? (
+          {isCorrupted ? (
+            <AlertTriangleIcon className="size-5 text-amber-500" />
+          ) : isConfigured ? (
             <CheckCircle2Icon className="size-5 text-green-500" />
           ) : (
             <GithubIcon className="size-5 text-muted-foreground" />
@@ -151,7 +155,9 @@ export function GitHubAppSetup() {
           <div>
             <p className="text-sm font-medium">GitHub</p>
             <p className="text-xs text-muted-foreground">
-              {isConfigured ? (
+              {isCorrupted ? (
+                "Stored credentials are unreadable. Re-enter the GitHub App credentials to reconnect."
+              ) : isConfigured ? (
                 <>
                   App ID: {credentialsStatus?.app_id}
                   {credentialsStatus?.has_webhook_secret
@@ -175,7 +181,7 @@ export function GitHubAppSetup() {
                 size="sm"
                 onClick={() => setDialogOpen(true)}
               >
-                Update
+                {isCorrupted ? "Reconnect" : "Update"}
               </Button>
               <Button
                 variant="destructive"
@@ -198,6 +204,7 @@ export function GitHubAppSetup() {
         onOpenChange={setDialogOpen}
         manifest={manifest}
         onFormSuccess={handleFormSuccess}
+        hasStoredCredentials={isConfigured}
         existingAppId={
           isConfigured ? credentialsStatus?.app_id || undefined : undefined
         }
@@ -235,12 +242,14 @@ function GitHubConnectionDialog({
   onOpenChange,
   manifest,
   onFormSuccess,
+  hasStoredCredentials,
   existingAppId,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   manifest: { manifest: Record<string, unknown> } | undefined
   onFormSuccess: () => void
+  hasStoredCredentials: boolean
   existingAppId?: string
 }) {
   const { toast } = useToast()
@@ -316,7 +325,7 @@ function GitHubConnectionDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            {existingAppId ? "Update GitHub App" : "Connect GitHub App"}
+            {hasStoredCredentials ? "Update GitHub App" : "Connect GitHub App"}
           </DialogTitle>
         </DialogHeader>
         <Tabs defaultValue="create" className="w-full">
@@ -378,6 +387,7 @@ function GitHubConnectionDialog({
             <GitHubAppManualForm
               onSuccess={onFormSuccess}
               existingAppId={existingAppId}
+              hasStoredCredentials={hasStoredCredentials}
             />
           </TabsContent>
         </Tabs>

--- a/frontend/src/types/react-diff-viewer-continued.d.ts
+++ b/frontend/src/types/react-diff-viewer-continued.d.ts
@@ -1,0 +1,33 @@
+declare module "react-diff-viewer-continued" {
+  import type { CSSProperties, JSX } from "react"
+
+  export enum DiffMethod {
+    CHARS = "diffChars",
+    WORDS = "diffWords",
+    WORDS_WITH_SPACE = "diffWordsWithSpace",
+    LINES = "diffLines",
+    TRIMMED_LINES = "diffTrimmedLines",
+    SENTENCES = "diffSentences",
+    CSS = "diffCss",
+  }
+
+  export type ReactDiffViewerStylesOverride = Record<string, unknown>
+
+  export interface ReactDiffViewerProps {
+    oldValue: string
+    newValue: string
+    splitView?: boolean
+    compareMethod?: DiffMethod
+    showDiffOnly?: boolean
+    hideSummary?: boolean
+    leftTitle?: string
+    rightTitle?: string
+    styles?: ReactDiffViewerStylesOverride
+    className?: string
+    lineNumberStyle?: CSSProperties
+  }
+
+  export default function ReactDiffViewer(
+    props: ReactDiffViewerProps
+  ): JSX.Element
+}

--- a/tests/unit/test_github_app.py
+++ b/tests/unit/test_github_app.py
@@ -17,6 +17,7 @@ from tracecat.exceptions import TracecatNotFoundError
 from tracecat.git.types import GitUrl
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import SecretKeyValue
+from tracecat.secrets.service import SecretsService
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.vcs.github.schemas import (
     GitHubAppConfig,
@@ -26,6 +27,17 @@ from tracecat.vcs.github.schemas import (
 )
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture(autouse=True)
+def mock_git_sync_entitlement():
+    """These tests exercise GitHub logic, not tier resolution."""
+    with patch.object(
+        GitHubAppService,
+        "has_entitlement",
+        new=AsyncMock(return_value=True),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -175,6 +187,31 @@ class TestGitHubAppService:
                 await github_admin_service.get_github_app_credentials()
 
     @pytest.mark.anyio
+    async def test_get_github_app_credentials_corrupted_secret(
+        self, github_admin_service, mock_credentials
+    ) -> None:
+        """Corrupted encrypted_keys should raise a recoverable GitHubAppError."""
+        await github_admin_service.register_app(
+            app_id=mock_credentials.app_id,
+            private_key_pem=mock_credentials.private_key,
+            webhook_secret=mock_credentials.webhook_secret,
+            client_id=mock_credentials.client_id,
+        )
+        secrets_service = SecretsService(
+            session=github_admin_service.session, role=github_admin_service.role
+        )
+        secret = await secrets_service.get_org_secret_by_name("github-app-credentials")
+        secret.encrypted_keys = b"not-a-valid-fernet-token"
+        github_admin_service.session.add(secret)
+        await github_admin_service.session.commit()
+
+        with pytest.raises(
+            GitHubAppError,
+            match="Failed to retrieve GitHub App credentials: invalid credential data",
+        ):
+            await github_admin_service.get_github_app_credentials()
+
+    @pytest.mark.anyio
     async def test_update_github_app_credentials_success(
         self, github_admin_service, mock_credentials, mock_secret
     ):
@@ -221,39 +258,139 @@ class TestGitHubAppService:
         self, github_service, mock_credentials, mock_secret
     ):
         """Test getting credentials status when they exist."""
-        with patch.object(
-            github_service, "get_github_app_credentials", return_value=mock_credentials
-        ):
-            with patch(
-                "tracecat.vcs.github.app.SecretsService"
-            ) as mock_secrets_service:
-                mock_service = AsyncMock()
-                mock_service.get_org_secret_by_name.return_value = mock_secret
-                mock_secrets_service.return_value = mock_service
+        with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
+            mock_service = Mock()
+            mock_service.get_org_secret_by_name = AsyncMock(return_value=mock_secret)
+            mock_service.decrypt_keys = Mock(
+                return_value=[
+                    SecretKeyValue(
+                        key="app_id", value=SecretStr(mock_credentials.app_id)
+                    ),
+                    SecretKeyValue(
+                        key="private_key", value=mock_credentials.private_key
+                    ),
+                    SecretKeyValue(
+                        key="webhook_secret", value=mock_credentials.webhook_secret
+                    ),
+                    SecretKeyValue(
+                        key="client_id", value=SecretStr(mock_credentials.client_id)
+                    ),
+                ]
+            )
+            mock_secrets_service.return_value = mock_service
 
-                status = await github_service.get_github_app_credentials_status()
-
-                assert status["exists"] is True
-                assert status["app_id"] == mock_credentials.app_id
-                assert status["has_webhook_secret"] is True
-                assert status["webhook_secret_preview"] == "webh****"
-                assert status["client_id"] == mock_credentials.client_id
-
-    @pytest.mark.anyio
-    async def test_get_github_app_credentials_status_not_exists(self, github_service):
-        """Test getting credentials status when they don't exist."""
-        with patch.object(
-            github_service,
-            "get_github_app_credentials",
-            side_effect=GitHubAppError("Not found"),
-        ):
             status = await github_service.get_github_app_credentials_status()
 
-            assert status["exists"] is False
-            assert status["app_id"] is None
-            assert status["has_webhook_secret"] is False
-            assert status["webhook_secret_preview"] is None
-            assert status["client_id"] is None
+            assert status["exists"] is True
+            assert status["is_corrupted"] is False
+            assert status["app_id"] == mock_credentials.app_id
+            assert status["has_webhook_secret"] is True
+            assert status["webhook_secret_preview"] == "webh****"
+            assert status["client_id"] == mock_credentials.client_id
+
+    @pytest.mark.anyio
+    async def test_get_github_app_credentials_status_corrupted_secret(
+        self, github_admin_service, mock_credentials
+    ) -> None:
+        """Corrupted stored credentials should degrade to reconfiguration status."""
+        await github_admin_service.register_app(
+            app_id=mock_credentials.app_id,
+            private_key_pem=mock_credentials.private_key,
+            webhook_secret=mock_credentials.webhook_secret,
+            client_id=mock_credentials.client_id,
+        )
+        secrets_service = SecretsService(
+            session=github_admin_service.session, role=github_admin_service.role
+        )
+        secret = await secrets_service.get_org_secret_by_name("github-app-credentials")
+        created_at = secret.created_at
+        secret.encrypted_keys = b"not-a-valid-fernet-token"
+        github_admin_service.session.add(secret)
+        await github_admin_service.session.commit()
+
+        status = await github_admin_service.get_github_app_credentials_status()
+
+        assert status["exists"] is True
+        assert status["is_corrupted"] is True
+        assert status["app_id"] is None
+        assert status["has_webhook_secret"] is False
+        assert status["webhook_secret_preview"] is None
+        assert status["client_id"] is None
+        assert status["created_at"] == (
+            created_at.isoformat() if created_at is not None else None
+        )
+
+    @pytest.mark.anyio
+    async def test_get_github_app_credentials_status_not_exists(
+        self, github_admin_service
+    ):
+        """Test getting credentials status when they don't exist."""
+        status = await github_admin_service.get_github_app_credentials_status()
+
+        assert status["exists"] is False
+        assert status["is_corrupted"] is False
+        assert status["app_id"] is None
+        assert status["has_webhook_secret"] is False
+        assert status["webhook_secret_preview"] is None
+        assert status["client_id"] is None
+
+    @pytest.mark.anyio
+    async def test_save_github_app_credentials_recovers_corrupted_secret(
+        self, github_admin_service, mock_credentials
+    ) -> None:
+        """Saving full credentials should repair a corrupted stored org secret."""
+        await github_admin_service.register_app(
+            app_id=mock_credentials.app_id,
+            private_key_pem=mock_credentials.private_key,
+            webhook_secret=mock_credentials.webhook_secret,
+            client_id=mock_credentials.client_id,
+        )
+        secrets_service = SecretsService(
+            session=github_admin_service.session, role=github_admin_service.role
+        )
+        secret = await secrets_service.get_org_secret_by_name("github-app-credentials")
+        original_secret_id = secret.id
+        secret.encrypted_keys = b"not-a-valid-fernet-token"
+        github_admin_service.session.add(secret)
+        await github_admin_service.session.commit()
+
+        updated_private_key = SecretStr(
+            "-----BEGIN RSA PRIVATE KEY-----\nrecovered-key\n-----END RSA PRIVATE KEY-----"
+        )
+        (
+            recovered_config,
+            was_created,
+        ) = await github_admin_service.save_github_app_credentials(
+            app_id="654321",
+            private_key_pem=updated_private_key,
+            webhook_secret=SecretStr("new-webhook-secret"),
+            client_id="client-456",
+        )
+
+        recovered_secret = await secrets_service.get_org_secret_by_name(
+            "github-app-credentials"
+        )
+        recovered_credentials = await github_admin_service.get_github_app_credentials()
+        recovered_status = (
+            await github_admin_service.get_github_app_credentials_status()
+        )
+
+        assert was_created is False
+        assert recovered_config.app_id == "654321"
+        assert recovered_secret.id == original_secret_id
+        assert recovered_credentials.app_id == "654321"
+        assert (
+            recovered_credentials.private_key.get_secret_value()
+            == updated_private_key.get_secret_value()
+        )
+        assert (
+            recovered_credentials.webhook_secret
+            and recovered_credentials.webhook_secret.get_secret_value()
+            == "new-webhook-secret"
+        )
+        assert recovered_credentials.client_id == "client-456"
+        assert recovered_status["exists"] is True
+        assert recovered_status["is_corrupted"] is False
 
     # ============================================================================
     # Installation Management Tests

--- a/tracecat/vcs/github/app.py
+++ b/tracecat/vcs/github/app.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+from enum import StrEnum
 from typing import Any
 
+from cryptography.fernet import InvalidToken
 from github import Auth, Github, GithubIntegration
 from github.GithubException import GithubException, UnknownObjectException
 from pydantic import SecretStr
 from pydantic import ValidationError as PydanticValidationError
 
 from tracecat.authz.controls import require_scope
+from tracecat.db.models import OrganizationSecret
 from tracecat.exceptions import TracecatException, TracecatNotFoundError
 from tracecat.git.types import GitUrl
 from tracecat.secrets.enums import SecretType
@@ -26,6 +29,14 @@ from tracecat.vcs.github.schemas import (
 
 class GitHubAppError(TracecatException):
     """GitHub App operation error."""
+
+
+class GitHubAppSecretState(StrEnum):
+    """State of the stored GitHub App org secret."""
+
+    MISSING = "missing"
+    VALID = "valid"
+    CORRUPTED = "corrupted"
 
 
 class GitHubAppService(BaseOrgService):
@@ -135,21 +146,73 @@ class GitHubAppService(BaseOrgService):
         Raises:
             GitHubAppError: If credentials already exist or are invalid
         """
-        # Check if credentials already exist
-        try:
-            await self.get_github_app_credentials()
+        secret_state, _secret, _credentials = await self._get_github_app_secret_state()
+        if secret_state is not GitHubAppSecretState.MISSING:
             raise GitHubAppError(
                 "GitHub App credentials already exist. Use update_github_app_credentials() to modify them."
             )
-        except GitHubAppError as e:
-            if "Failed to retrieve GitHub App credentials" not in str(e):
-                # Re-raise if it's not a "not found" error
-                raise
 
         # Delegate to the main register_app method
         return await self.register_app(
             app_id, private_key_pem, webhook_secret, client_id
         )
+
+    def _build_secret_update(
+        self,
+        *,
+        app_id: str,
+        private_key_pem: SecretStr,
+        webhook_secret: SecretStr | None,
+        client_id: str | None,
+    ) -> SecretUpdate:
+        """Build a full replacement key payload for the GitHub App secret."""
+        secret_keys = [
+            SecretKeyValue(key="app_id", value=SecretStr(app_id)),
+            SecretKeyValue(key="private_key", value=private_key_pem),
+        ]
+
+        if webhook_secret:
+            secret_keys.append(
+                SecretKeyValue(key="webhook_secret", value=webhook_secret)
+            )
+
+        if client_id:
+            secret_keys.append(
+                SecretKeyValue(key="client_id", value=SecretStr(client_id))
+            )
+
+        return SecretUpdate(keys=secret_keys)
+
+    async def _get_github_app_secret_state(
+        self,
+    ) -> tuple[
+        GitHubAppSecretState,
+        OrganizationSecret | None,
+        GitHubAppCredentials | None,
+    ]:
+        """Classify the stored GitHub App secret without failing on corruption."""
+        secrets_service = SecretsService(session=self.session, role=self.role)
+        try:
+            secret = await secrets_service.get_org_secret_by_name(
+                "github-app-credentials"
+            )
+        except TracecatNotFoundError:
+            return GitHubAppSecretState.MISSING, None, None
+
+        try:
+            decrypted_keys = secrets_service.decrypt_keys(secret.encrypted_keys)
+            key_dict = {kv.key: kv.value.get_secret_value() for kv in decrypted_keys}
+            credentials = GitHubAppCredentials.model_validate(key_dict)
+        except (InvalidToken, PydanticValidationError, ValueError) as e:
+            self.logger.warning(
+                "Stored GitHub App credentials are corrupted; allowing reconfiguration",
+                secret_id=str(secret.id),
+                error_type=type(e).__name__,
+                error=str(e),
+            )
+            return GitHubAppSecretState.CORRUPTED, secret, None
+
+        return GitHubAppSecretState.VALID, secret, credentials
 
     @requires_entitlement(Entitlement.GIT_SYNC)
     @require_scope("org:settings:update")
@@ -174,13 +237,19 @@ class GitHubAppService(BaseOrgService):
         Raises:
             GitHubAppError: If no credentials exist or update fails
         """
-        # Get existing credentials
-        try:
-            existing_credentials = await self.get_github_app_credentials()
-        except GitHubAppError as e:
+        (
+            secret_state,
+            secret,
+            existing_credentials,
+        ) = await self._get_github_app_secret_state()
+        if secret_state is GitHubAppSecretState.MISSING or secret is None:
             raise GitHubAppError(
                 "No existing GitHub App credentials found. Use register_existing_app() first."
-            ) from e
+            )
+        if existing_credentials is None:
+            raise GitHubAppError(
+                "Stored GitHub App credentials are corrupted. Re-enter all values to recover them."
+            )
 
         # Use existing values if new ones aren't provided
         updated_credentials = GitHubAppCredentials(
@@ -196,31 +265,14 @@ class GitHubAppService(BaseOrgService):
             else existing_credentials.client_id,
         )
 
-        # Prepare secret keys for storage
-        secret_keys = [
-            SecretKeyValue(key="app_id", value=SecretStr(updated_credentials.app_id)),
-            SecretKeyValue(key="private_key", value=updated_credentials.private_key),
-        ]
-
-        if updated_credentials.webhook_secret:
-            secret_keys.append(
-                SecretKeyValue(
-                    key="webhook_secret", value=updated_credentials.webhook_secret
-                )
-            )
-
-        if updated_credentials.client_id:
-            secret_keys.append(
-                SecretKeyValue(
-                    key="client_id", value=SecretStr(updated_credentials.client_id)
-                )
-            )
-
         # Update the organization secret
         secrets_service = SecretsService(session=self.session, role=self.role)
-        secret = await secrets_service.get_org_secret_by_name("github-app-credentials")
-
-        secret_update = SecretUpdate(keys=secret_keys)
+        secret_update = self._build_secret_update(
+            app_id=updated_credentials.app_id,
+            private_key_pem=updated_credentials.private_key,
+            webhook_secret=updated_credentials.webhook_secret,
+            client_id=updated_credentials.client_id,
+        )
         await secrets_service.update_org_secret(secret, secret_update)
 
         # Create config with basic info
@@ -263,30 +315,14 @@ class GitHubAppService(BaseOrgService):
         Raises:
             GitHubAppError: If operation fails
         """
-        try:
-            # Try to get existing credentials to determine if this is an update
-            existing_credentials = await self.get_github_app_credentials()
-
-            # Update existing credentials
-            config = await self.update_github_app_credentials(
-                app_id=app_id,
-                private_key_pem=private_key_pem,
-                webhook_secret=webhook_secret,
-                client_id=client_id,
-            )
-
-            self.logger.info(
-                "Updated existing GitHub App credentials",
-                app_id=app_id,
-                previous_app_id=existing_credentials.app_id,
-            )
-
-            return config, False  # was_created = False (updated)
-
-        except GitHubAppError as e:
-            if "Failed to retrieve GitHub App credentials" in str(e):
-                # No existing credentials, create new ones
-                config = await self.register_existing_app(
+        (
+            secret_state,
+            secret,
+            existing_credentials,
+        ) = await self._get_github_app_secret_state()
+        match secret_state:
+            case GitHubAppSecretState.MISSING:
+                config = await self.register_app(
                     app_id=app_id,
                     private_key_pem=private_key_pem,
                     webhook_secret=webhook_secret,
@@ -298,10 +334,50 @@ class GitHubAppService(BaseOrgService):
                     app_id=app_id,
                 )
 
-                return config, True  # was_created = True (new)
-            else:
-                # Re-raise other GitHubAppErrors
-                raise
+                return config, True
+            case GitHubAppSecretState.CORRUPTED:
+                if secret is None:
+                    raise GitHubAppError(
+                        "Stored GitHub App credentials could not be recovered."
+                    )
+                secrets_service = SecretsService(session=self.session, role=self.role)
+                secret_update = self._build_secret_update(
+                    app_id=app_id,
+                    private_key_pem=private_key_pem,
+                    webhook_secret=webhook_secret,
+                    client_id=client_id,
+                )
+                await secrets_service.update_org_secret(secret, secret_update)
+                config = GitHubAppConfig(
+                    installation_id=0,
+                    app_id=app_id,
+                    client_id=client_id,
+                )
+                self.logger.info(
+                    "Recovered corrupted GitHub App credentials",
+                    app_id=app_id,
+                    secret_id=str(secret.id),
+                )
+                return config, False
+            case GitHubAppSecretState.VALID:
+                config = await self.update_github_app_credentials(
+                    app_id=app_id,
+                    private_key_pem=private_key_pem,
+                    webhook_secret=webhook_secret,
+                    client_id=client_id,
+                )
+
+                self.logger.info(
+                    "Updated existing GitHub App credentials",
+                    app_id=app_id,
+                    previous_app_id=existing_credentials.app_id
+                    if existing_credentials
+                    else None,
+                )
+
+                return config, False
+
+        raise GitHubAppError("Failed to save GitHub App credentials")
 
     @requires_entitlement(Entitlement.GIT_SYNC)
     @require_scope("org:settings:delete")
@@ -334,40 +410,50 @@ class GitHubAppService(BaseOrgService):
         Returns:
             Dictionary with credentials status information
         """
-        try:
-            credentials = await self.get_github_app_credentials()
+        secret_state, secret, credentials = await self._get_github_app_secret_state()
+        match secret_state:
+            case GitHubAppSecretState.VALID if secret and credentials:
+                has_webhook_secret = credentials.webhook_secret is not None
+                webhook_secret_preview = None
+                if credentials.webhook_secret is not None:
+                    raw = credentials.webhook_secret.get_secret_value()
+                    webhook_secret_preview = (
+                        raw[:4] + "****" if len(raw) >= 4 else "****"
+                    )
 
-            # Get the secret to find when it was created
-            secrets_service = SecretsService(session=self.session, role=self.role)
-            secret = await secrets_service.get_org_secret_by_name(
-                "github-app-credentials"
-            )
-
-            has_webhook_secret = credentials.webhook_secret is not None
-            webhook_secret_preview = None
-            if credentials.webhook_secret is not None:
-                raw = credentials.webhook_secret.get_secret_value()
-                webhook_secret_preview = raw[:4] + "****" if len(raw) >= 4 else "****"
-
-            return {
-                "exists": True,
-                "app_id": credentials.app_id,
-                "has_webhook_secret": has_webhook_secret,
-                "webhook_secret_preview": webhook_secret_preview,
-                "client_id": credentials.client_id,
-                "created_at": secret.created_at.isoformat()
-                if secret.created_at
-                else None,
-            }
-        except GitHubAppError:
-            return {
-                "exists": False,
-                "app_id": None,
-                "has_webhook_secret": False,
-                "webhook_secret_preview": None,
-                "client_id": None,
-                "created_at": None,
-            }
+                return {
+                    "exists": True,
+                    "is_corrupted": False,
+                    "app_id": credentials.app_id,
+                    "has_webhook_secret": has_webhook_secret,
+                    "webhook_secret_preview": webhook_secret_preview,
+                    "client_id": credentials.client_id,
+                    "created_at": secret.created_at.isoformat()
+                    if secret.created_at
+                    else None,
+                }
+            case GitHubAppSecretState.CORRUPTED if secret:
+                return {
+                    "exists": True,
+                    "is_corrupted": True,
+                    "app_id": None,
+                    "has_webhook_secret": False,
+                    "webhook_secret_preview": None,
+                    "client_id": None,
+                    "created_at": secret.created_at.isoformat()
+                    if secret.created_at
+                    else None,
+                }
+            case _:
+                return {
+                    "exists": False,
+                    "is_corrupted": False,
+                    "app_id": None,
+                    "has_webhook_secret": False,
+                    "webhook_secret_preview": None,
+                    "client_id": None,
+                    "created_at": None,
+                }
 
     @requires_entitlement(Entitlement.GIT_SYNC)
     @require_scope("org:settings:read")
@@ -380,36 +466,23 @@ class GitHubAppService(BaseOrgService):
         Raises:
             GitHubAppError: If credentials are not found or invalid
         """
-        try:
-            secrets_service = SecretsService(session=self.session, role=self.role)
-            secret = await secrets_service.get_org_secret_by_name(
-                "github-app-credentials"
-            )
+        secret_state, _secret, credentials = await self._get_github_app_secret_state()
+        match secret_state:
+            case GitHubAppSecretState.MISSING:
+                raise GitHubAppError(
+                    "Failed to retrieve GitHub App credentials: credentials not found"
+                )
+            case GitHubAppSecretState.CORRUPTED:
+                raise GitHubAppError(
+                    "Failed to retrieve GitHub App credentials: invalid credential data"
+                )
+            case GitHubAppSecretState.VALID if credentials:
+                self.logger.debug(
+                    "Retrieved GitHub App credentials from organization secret"
+                )
+                return credentials
 
-            # Decrypt the secret keys
-            decrypted_keys = secrets_service.decrypt_keys(secret.encrypted_keys)
-
-            # Convert to dictionary for easier access
-            key_dict = {kv.key: kv.value.get_secret_value() for kv in decrypted_keys}
-
-            # Validate and construct the credentials model
-            credentials = GitHubAppCredentials.model_validate(key_dict)
-
-            self.logger.debug(
-                "Retrieved GitHub App credentials from organization secret"
-            )
-            return credentials
-
-        except TracecatNotFoundError as e:
-            self.logger.debug("Failed to retrieve GitHub App credentials", error=str(e))
-            raise GitHubAppError(
-                "Failed to retrieve GitHub App credentials: credentials not found"
-            ) from e
-        except PydanticValidationError as e:
-            self.logger.debug("Failed to retrieve GitHub App credentials", error=str(e))
-            raise GitHubAppError(
-                "Failed to retrieve GitHub App credentials: invalid credential data"
-            ) from e
+        raise GitHubAppError("Failed to retrieve GitHub App credentials")
 
     @requires_entitlement(Entitlement.GIT_SYNC)
     async def get_github_client_for_repo(self, repo_url: GitUrl) -> Github:

--- a/tracecat/vcs/router.py
+++ b/tracecat/vcs/router.py
@@ -154,13 +154,21 @@ async def save_github_app_credentials(
         }
 
     except GitHubAppError as e:
-        logger.error("Failed to save GitHub App credentials", error=str(e))
+        logger.error(
+            "Failed to save GitHub App credentials",
+            error_type=type(e).__name__,
+            error=str(e),
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to save GitHub App credentials: {str(e)}",
         ) from e
     except Exception as e:
-        logger.error("Error saving GitHub App credentials", error=str(e))
+        logger.error(
+            "Error saving GitHub App credentials",
+            error_type=type(e).__name__,
+            error=str(e),
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error while saving credentials",
@@ -208,7 +216,11 @@ async def get_github_app_credentials_status(
         return GitHubAppCredentialsStatus(**status_data)
 
     except Exception as e:
-        logger.error("Error getting GitHub App credentials status", error=str(e))
+        logger.error(
+            "Error getting GitHub App credentials status",
+            error_type=type(e).__name__,
+            error=str(e),
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error while getting credentials status",

--- a/tracecat/vcs/schemas.py
+++ b/tracecat/vcs/schemas.py
@@ -30,6 +30,7 @@ class GitHubAppCredentialsStatus(BaseModel):
     """Status of GitHub App credentials."""
 
     exists: bool
+    is_corrupted: bool = False
     app_id: str | None = None
     has_webhook_secret: bool = False
     webhook_secret_preview: str | None = None


### PR DESCRIPTION
Summary
- add a secret-state classifier in `tracecat/vcs/github/app.py` so corrupted `github-app-credentials` rows log the issue, allow a full overwrite, and keep the save path from creating duplicate records
- extend the status schema/client with `is_corrupted`, return detailed metadata for corrupted/missing rows, and log richer router errors when save attempts fail
- tweak the org GitHub UI and form labels to treat `is_corrupted` as needing reconnection while keeping the save workflow identical to repair credentials

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens GitHub App credential storage and recovery. Detects corrupted org secrets, avoids duplicate records, and lets users repair credentials through the same save flow. The UI now flags corruption and prompts a quick reconnect.

- New Features
  - Added secret-state classifier (missing/valid/corrupted) to handle recovery without crashes.
  - Extended credentials status with `is_corrupted` and created metadata for corrupted/missing states.
  - Updated org GitHub UI: warning state, “Reconnect” CTA, and labels while keeping the same save workflow.

- Bug Fixes
  - Save behavior: create when missing, in-place overwrite when corrupted, and update when valid (no duplicate secrets).
  - Improved router error logging with error types and richer details.
  - Added unit tests for corrupted secret detection, status responses, and successful recovery.

<sup>Written for commit 3be1eaebf4233b2e5367ac21415d9a949f630171. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

