### PR TITLE
fix(mcp): provide oauth metadata

### DIFF
--- a/deployments/eks/modules/eks/waf.tf
+++ b/deployments/eks/modules/eks/waf.tf
@@ -35,6 +35,22 @@ resource "aws_wafv2_regex_pattern_set" "mcp_oauth_endpoints" {
   tags = var.tags
 }
 
+# Regex pattern set for MCP public endpoints that must remain reachable even
+# when clients omit a User-Agent header during connection bootstrapping.
+resource "aws_wafv2_regex_pattern_set" "mcp_public_endpoints" {
+  count = var.enable_waf ? 1 : 0
+
+  name        = "${var.cluster_name}-mcp-public-endpoints"
+  description = "Matches MCP discovery, transport, and OAuth endpoints"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "^/(mcp|\\.well-known/oauth-(protected-resource|authorization-server)(/mcp)?|(mcp/)?(register|authorize|consent|token|auth/callback))$"
+  }
+
+  tags = var.tags
+}
+
 resource "aws_wafv2_web_acl" "main" {
   count = var.enable_waf ? 1 : 0
 
@@ -106,6 +122,13 @@ resource "aws_wafv2_web_acl" "main" {
 
         rule_action_override {
           name = "GenericLFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
+          name = "NoUserAgent_HEADER"
           action_to_use {
             count {}
           }
@@ -203,12 +226,60 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  # Priority 5: Block XSS except on attachment upload endpoints
+  # Priority 5: Block missing User-Agent except on MCP public endpoints.
+  # Some MCP clients bootstrap OAuth without a User-Agent header. Keep WAF
+  # protection in place globally, but carve out the MCP public surface.
+  rule {
+    name     = "BlockMissingUserAgentExceptMcpPublic"
+    priority = 5
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          label_match_statement {
+            scope = "LABEL"
+            key   = "awswaf:managed:aws:core-rule-set:NoUserAgent_Header"
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              regex_pattern_set_reference_statement {
+                arn = aws_wafv2_regex_pattern_set.mcp_public_endpoints[0].arn
+
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.cluster_name}-missing-ua-except-mcp"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Priority 6: Block XSS except on attachment upload endpoints
   # The CommonRuleSet sets CrossSiteScripting_BODY to count mode above,
   # and this rule re-blocks it unless the request is to an attachment endpoint.
   rule {
     name     = "BlockXSSExceptAttachments"
-    priority = 5
+    priority = 6
 
     action {
       block {}
@@ -251,12 +322,12 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  # Priority 6: Block LFI except on attachment upload endpoints
+  # Priority 7: Block LFI except on attachment upload endpoints
   # Same pattern as XSS - CommonRuleSet GenericLFI_BODY is set to count,
   # and this rule re-blocks unless the request targets an attachment endpoint.
   rule {
     name     = "BlockLFIExceptAttachments"
-    priority = 6
+    priority = 7
 
     action {
       block {}
@@ -299,14 +370,14 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  # Priority 7: Block SSRF except on MCP OAuth endpoints
+  # Priority 8: Block SSRF except on MCP OAuth endpoints
   # The CommonRuleSet sets EC2MetaDataSSRF_BODY and _QUERYARGUMENTS to count
   # mode above, and this rule re-blocks them unless the request targets an MCP
   # OAuth endpoint. Local MCP clients legitimately send localhost redirect URIs
   # in register bodies and authorize/consent query strings.
   rule {
     name     = "BlockSSRFExceptMcpOAuth"
-    priority = 7
+    priority = 8
 
     action {
       block {}
@@ -360,10 +431,10 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  # Priority 8: IP Reputation List - blocks known bad IPs (botnets, scanners)
+  # Priority 9: IP Reputation List - blocks known bad IPs (botnets, scanners)
   rule {
     name     = "AWSManagedRulesAmazonIpReputationList"
-    priority = 8
+    priority = 9
 
     override_action {
       none {}

--- a/deployments/fargate/modules/ecs/alb.tf
+++ b/deployments/fargate/modules/ecs/alb.tf
@@ -119,6 +119,13 @@ resource "aws_wafv2_web_acl" "this" {
           }
         }
 
+        rule_action_override {
+          name = "NoUserAgent_HEADER"
+          action_to_use {
+            count {}
+          }
+        }
+
       }
     }
 
@@ -198,10 +205,55 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
+  # Custom rule to block missing User-Agent except for MCP public endpoints.
+  # Some MCP clients bootstrap OAuth without a User-Agent header. Keep the
+  # managed rule active everywhere else.
+  rule {
+    name     = "BlockMissingUserAgentExceptMcpPublic"
+    priority = 5
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          label_match_statement {
+            scope = "LABEL"
+            key   = "awswaf:managed:aws:core-rule-set:NoUserAgent_Header"
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              regex_pattern_set_reference_statement {
+                arn = aws_wafv2_regex_pattern_set.mcp_public_endpoints[0].arn
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockMissingUserAgentExceptMcpPublic"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # Custom rule to block XSS threats except for attachment uploads
   rule {
     name     = "BlockXSSExceptAttachments"
-    priority = 5
+    priority = 6
 
     action {
       block {}
@@ -244,7 +296,7 @@ resource "aws_wafv2_web_acl" "this" {
   # Custom rule to block LFI threats except for attachment uploads
   rule {
     name     = "BlockLFIExceptAttachments"
-    priority = 6
+    priority = 7
 
     action {
       block {}
@@ -287,7 +339,7 @@ resource "aws_wafv2_web_acl" "this" {
   # Custom rule to block oversized query strings except for attachment uploads
   rule {
     name     = "BlockQueryStringSizeExceptAttachments"
-    priority = 7
+    priority = 8
 
     action {
       block {}
@@ -344,6 +396,20 @@ resource "aws_wafv2_regex_pattern_set" "attachments_endpoint" {
 
   regular_expression {
     regex_string = "^/api/cases/[a-fA-F0-9-]+/attachments(\\?.*)?$"
+  }
+}
+
+# Regex pattern set for MCP public endpoints that must remain reachable even
+# when clients omit a User-Agent header during connection bootstrapping.
+resource "aws_wafv2_regex_pattern_set" "mcp_public_endpoints" {
+  count = var.enable_waf ? 1 : 0
+
+  name        = "mcp-public-endpoint-pattern"
+  description = "Matches MCP discovery, transport, and OAuth endpoints"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "^/(mcp|\\.well-known/oauth-(protected-resource|authorization-server)(/mcp)?|(mcp/)?(register|authorize|consent|token|auth/callback))$"
   }
 }
 

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -8,6 +8,7 @@ from fastmcp import FastMCP
 from mcp.server.auth.provider import AuthorizationParams
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
+from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from tracecat.mcp import auth as mcp_auth
@@ -100,6 +101,33 @@ def test_create_mcp_auth_metadata_advertises_public_client_auth(
     assert payload["token_endpoint"] == "https://mcp.example.com/token"
     assert payload["registration_endpoint"] == "https://mcp.example.com/register"
     assert "none" in payload["token_endpoint_auth_methods_supported"]
+
+
+def test_create_mcp_auth_metadata_preserves_upstream_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = _build_test_auth(monkeypatch)
+    upstream_app = Starlette(routes=mcp_auth.OIDCProxy.get_routes(auth))
+    upstream_client = TestClient(upstream_app)
+    client = TestClient(
+        FastMCP("test", auth=auth).http_app(path="/mcp", transport="streamable-http")
+    )
+
+    upstream_metadata = upstream_client.get("/.well-known/oauth-authorization-server")
+    metadata_response = client.get("/.well-known/oauth-authorization-server")
+
+    assert upstream_metadata.status_code == 200
+    assert metadata_response.status_code == 200
+
+    upstream_payload = upstream_metadata.json()
+    payload = metadata_response.json()
+    assert payload["client_id_metadata_document_supported"] is True
+    assert payload == {
+        **upstream_payload,
+        "token_endpoint_auth_methods_supported": (
+            mcp_auth._MCP_TOKEN_ENDPOINT_AUTH_METHODS
+        ),
+    }
 
 
 def test_create_mcp_auth_protected_resource_metadata_uses_mcp_path(

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -19,20 +19,19 @@ from fastmcp.server.dependencies import get_access_token
 from key_value.aio.stores.redis import RedisStore
 from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 from key_value.aio.wrappers.prefix_collections import PrefixCollectionsWrapper
-from mcp.server.auth.handlers.metadata import MetadataHandler
 from mcp.server.auth.provider import (
     AuthorizationParams,
     TokenError,
 )
-from mcp.server.auth.routes import build_metadata, cors_middleware
-from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import BaseModel, Field
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy import select
+from starlette.datastructures import MutableHeaders
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
 from starlette.routing import Route
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from tracecat import config
 from tracecat.auth.credentials import compute_effective_scopes
@@ -104,6 +103,52 @@ def supports_refresh_scope(scopes_supported: Sequence[str] | None) -> bool:
         # If provider metadata omits scopes_supported, optimistically request.
         return True
     return _MCP_REFRESH_SCOPE in scopes_supported
+
+
+def _patch_oauth_metadata_route(app: ASGIApp) -> ASGIApp:
+    """Patch only the advertised token auth methods on discovery responses."""
+
+    async def patched_app(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        start_message: Message | None = None
+        body_chunks: list[bytes] = []
+
+        async def capture(message: Message) -> None:
+            nonlocal start_message
+
+            match message["type"]:
+                case "http.response.start":
+                    start_message = dict(message)
+                case "http.response.body":
+                    body_chunks.append(message.get("body", b""))
+                case _:
+                    await send(message)
+
+        await app(scope, receive, capture)
+
+        if start_message is None:
+            return
+
+        body = b"".join(body_chunks)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict):
+            payload["token_endpoint_auth_methods_supported"] = (
+                _MCP_TOKEN_ENDPOINT_AUTH_METHODS
+            )
+            body = json.dumps(payload).encode("utf-8")
+
+        headers = MutableHeaders(raw=start_message["headers"])
+        headers["content-length"] = str(len(body))
+        await send(start_message)
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+
+    return patched_app
 
 
 def _coerce_uuid(value: object) -> uuid.UUID | None:
@@ -716,17 +761,7 @@ def create_mcp_auth() -> AuthProvider:
                 ):
                     continue
 
-                metadata = build_metadata(
-                    self.base_url,
-                    self.service_documentation_url,
-                    self.client_registration_options or ClientRegistrationOptions(),
-                    self.revocation_options or RevocationOptions(),
-                )
-                metadata.token_endpoint_auth_methods_supported = (
-                    _MCP_TOKEN_ENDPOINT_AUTH_METHODS
-                )
-                handler = MetadataHandler(metadata)
-                route.app = cors_middleware(handler.handle, ["GET", "OPTIONS"])
+                route.app = _patch_oauth_metadata_route(route.app)
 
             return routes
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose OAuth/OIDC discovery and public-client registration for MCP, and relax edge WAF to allow OAuth bootstrapping without a User-Agent. This lets MCP clients auto-discover endpoints and complete authorization reliably.

- **Bug Fixes**
  - Advertise public-client auth by patching discovery to include token_endpoint_auth_methods_supported = ["none", "client_secret_post", "client_secret_basic"] and preserve all upstream fields; include registration_endpoint and support public-client registration at `/register`.
  - Serve protected-resource discovery at `/.well-known/oauth-protected-resource/mcp` with accurate `resource` and `authorization_servers`.
  - Merge platform OIDC scopes into requested scopes (order-preserving, no duplicates) and add/remove `offline_access` based on provider support.
  - Update AWS WAF to allow missing User-Agent on MCP public endpoints (discovery, transport, OAuth) while blocking elsewhere; add regex pattern set and a targeted rule, and adjust rule priorities.
  - Expand tests for metadata endpoints, protected-resource metadata, public-client registration, and scope merging.

<sup>Written for commit bbf5932f091bc16e4673a8b2b0103a14c8b9ec88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

