### PR TITLE
fix(credentials): default connection filter to Connected when available

### DIFF
--- a/frontend/src/components/workspaces/workspace-credentials-inventory.tsx
+++ b/frontend/src/components/workspaces/workspace-credentials-inventory.tsx
@@ -7,7 +7,7 @@ import {
   SquareAsterisk,
   Unlink2,
 } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type { SecretDefinition } from "@/client"
 import {
   CatalogHeader,
@@ -86,6 +86,8 @@ export function WorkspaceCredentialsInventory() {
   const [searchQuery, setSearchQuery] = useState("")
   const [connectionFilter, setConnectionFilter] =
     useState<CredentialConnectionFilter>("all")
+  const [hasInitializedConnectionFilter, setHasInitializedConnectionFilter] =
+    useState(false)
   const [environmentFilter, setEnvironmentFilter] = useState("all")
   const [secretTypeFilter, setSecretTypeFilter] =
     useState<CredentialSecretTypeFilter>("all")
@@ -105,6 +107,18 @@ export function WorkspaceCredentialsInventory() {
     () => buildCredentialGroups(allSecretDefinitions, allSecrets),
     [allSecretDefinitions, allSecrets]
   )
+
+  useEffect(() => {
+    if (hasInitializedConnectionFilter) {
+      return
+    }
+
+    if (credentialGroups.some((group) => group.isConnected)) {
+      setConnectionFilter("connected")
+    }
+
+    setHasInitializedConnectionFilter(true)
+  }, [credentialGroups, hasInitializedConnectionFilter])
 
   const availableEnvironments = useMemo(
     () =>


### PR DESCRIPTION
### Motivation
- The credentials inventory is overcrowded by default; when at least one credential group is already connected the page should default the connection filter to `connected` so users immediately see active connections.

### Description
- Initialize the connection filter in `frontend/src/components/workspaces/workspace-credentials-inventory.tsx` by importing `useEffect` and adding a one-time effect that sets `connectionFilter` to `"connected"` if any `credentialGroups` are connected, while preserving `all` when none are connected.

### Testing
- Ran frontend checks and typechecking: `pnpm install --dir frontend` (install), `pnpm -C frontend check` (biome lint/format) and `pnpm -C frontend run typecheck` (`tsc`) which all completed successfully; Playwright navigation attempt to capture a screenshot failed with `ERR_EMPTY_RESPONSE` when reaching the local app endpoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08c41880483339265d9c9a0bfaf74)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the workspace credentials inventory to the Connected filter when any credential group is connected, so users see active connections first. If none are connected, it stays on All and the default is applied only on first render.

<sup>Written for commit 3551b50cc5c73f618f66a7efc32b44070a4f5905. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

