### PR TITLE
Expose MCP custom credentials endpoint and add secure UI for showing/redacting them

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -336,6 +336,8 @@ import type {
   McpIntegrationsCreateMcpIntegrationResponse,
   McpIntegrationsDeleteMcpIntegrationData,
   McpIntegrationsDeleteMcpIntegrationResponse,
+  McpIntegrationsGetMcpCustomCredentialsData,
+  McpIntegrationsGetMcpCustomCredentialsResponse,
   McpIntegrationsGetMcpIntegrationData,
   McpIntegrationsGetMcpIntegrationResponse,
   McpIntegrationsListMcpIntegrationsData,
@@ -9338,6 +9340,33 @@ export const mcpIntegrationsGetMcpIntegration = (
   return __request(OpenAPI, {
     method: "GET",
     url: "/mcp-integrations/{mcp_integration_id}",
+    path: {
+      mcp_integration_id: data.mcpIntegrationId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Mcp Custom Credentials
+ * Get decrypted custom credentials for an MCP integration.
+ * @param data The data for the request.
+ * @param data.mcpIntegrationId
+ * @param data.workspaceId
+ * @returns MCPCustomCredentialsRead Successful Response
+ * @throws ApiError
+ */
+export const mcpIntegrationsGetMcpCustomCredentials = (
+  data: McpIntegrationsGetMcpCustomCredentialsData
+): CancelablePromise<McpIntegrationsGetMcpCustomCredentialsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/mcp-integrations/{mcp_integration_id}/custom-credentials",
     path: {
       mcp_integration_id: data.mcpIntegrationId,
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3853,12 +3853,23 @@ export type MCPIntegrationRead = {
   server_uri: string | null
   auth_type: MCPAuthType
   oauth_integration_id: string | null
+  has_custom_credentials?: boolean
   stdio_command: string | null
   stdio_args: Array<string> | null
   has_stdio_env?: boolean
   timeout: number | null
   created_at: string
   updated_at: string
+}
+
+/**
+ * Decrypted MCP custom credentials payload.
+ */
+export type MCPCustomCredentialsRead = {
+  /**
+   * Decrypted custom credentials JSON headers.
+   */
+  custom_credentials?: string | null
 }
 
 /**
@@ -10457,6 +10468,14 @@ export type McpIntegrationsGetMcpIntegrationData = {
 }
 
 export type McpIntegrationsGetMcpIntegrationResponse = MCPIntegrationRead
+
+export type McpIntegrationsGetMcpCustomCredentialsData = {
+  mcpIntegrationId: string
+  workspaceId: string
+}
+
+export type McpIntegrationsGetMcpCustomCredentialsResponse =
+  MCPCustomCredentialsRead
 
 export type McpIntegrationsUpdateMcpIntegrationData = {
   mcpIntegrationId: string

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Loader2, Plus, Trash2 } from "lucide-react"
+import { Eye, EyeOff, Loader2, Plus, Trash2 } from "lucide-react"
 import React, { useState } from "react"
 import { useFieldArray, useForm } from "react-hook-form"
 import { z } from "zod"
@@ -42,6 +42,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import {
   useCreateMcpIntegration,
+  useGetMcpCustomCredentials,
   useGetMcpIntegration,
   useIntegrations,
   useUpdateMcpIntegration,
@@ -81,6 +82,9 @@ const AUTH_TYPES = [
 ] as const
 
 const ALLOWED_COMMANDS = ["npx", "uvx", "python", "python3", "node"] as const
+const REDACTED_CUSTOM_CREDENTIALS_JSON = `{
+  "******": "******"
+}`
 
 function isAllowedCommand(
   command: string
@@ -304,6 +308,12 @@ export function MCPIntegrationDialog({
   )
   const [internalOpen, setInternalOpen] = useState(false)
   const [isEditHydrated, setIsEditHydrated] = useState(false)
+  const [showCustomCredentials, setShowCustomCredentials] = useState(false)
+  const { mcpCustomCredentials } = useGetMcpCustomCredentials(
+    workspaceId,
+    mcpIntegrationId ?? null,
+    isEditMode && showCustomCredentials
+  )
   const open = controlledOpen ?? internalOpen
   const { className: triggerClassName, ...restTriggerProps } =
     triggerProps ?? {}
@@ -331,14 +341,19 @@ export function MCPIntegrationDialog({
 
   const serverType = form.watch("server_type")
   const authType = form.watch("auth_type")
+  const hasConfiguredCredentials = Boolean(
+    isEditMode && mcpIntegration?.has_custom_credentials
+  )
 
   React.useEffect(() => {
     if (!isEditMode) {
       setIsEditHydrated(true)
+      setShowCustomCredentials(false)
       return
     }
     if (open) {
       setIsEditHydrated(false)
+      setShowCustomCredentials(false)
     }
   }, [isEditMode, open, mcpIntegrationId])
 
@@ -357,7 +372,9 @@ export function MCPIntegrationDialog({
         server_uri: mcpIntegration.server_uri || "",
         auth_type: mcpIntegration.auth_type,
         oauth_integration_id: mcpIntegration.oauth_integration_id || "",
-        custom_credentials: "", // Don't populate for security
+        custom_credentials: mcpIntegration.has_custom_credentials
+          ? REDACTED_CUSTOM_CREDENTIALS_JSON
+          : "",
         stdio_command: mcpIntegration.stdio_command || "",
         stdio_args: hydratedStdioArgs,
         stdio_env: "", // Env vars are not returned from API for security
@@ -366,6 +383,7 @@ export function MCPIntegrationDialog({
       // Explicitly sync field-array state; reset() can lag on first mount.
       replaceStdioArgs(hydratedStdioArgs)
       setIsEditHydrated(true)
+      setShowCustomCredentials(false)
     }
   }, [
     isEditMode,
@@ -375,6 +393,19 @@ export function MCPIntegrationDialog({
     form,
     replaceStdioArgs,
   ])
+
+  React.useEffect(() => {
+    if (!showCustomCredentials || !isEditMode) {
+      return
+    }
+    if (mcpCustomCredentials?.custom_credentials !== undefined) {
+      form.setValue(
+        "custom_credentials",
+        mcpCustomCredentials.custom_credentials ?? "",
+        { shouldDirty: false }
+      )
+    }
+  }, [form, isEditMode, mcpCustomCredentials, showCustomCredentials])
 
   const resetForm = () => {
     if (
@@ -391,7 +422,9 @@ export function MCPIntegrationDialog({
         server_uri: mcpIntegration.server_uri || "",
         auth_type: mcpIntegration.auth_type,
         oauth_integration_id: mcpIntegration.oauth_integration_id || "",
-        custom_credentials: "",
+        custom_credentials: mcpIntegration.has_custom_credentials
+          ? REDACTED_CUSTOM_CREDENTIALS_JSON
+          : "",
         stdio_command: mcpIntegration.stdio_command || "",
         stdio_args: hydratedStdioArgs,
         stdio_env: "", // Env vars are not returned from API for security
@@ -399,10 +432,12 @@ export function MCPIntegrationDialog({
       })
       replaceStdioArgs(hydratedStdioArgs)
       setIsEditHydrated(true)
+      setShowCustomCredentials(false)
     } else {
       form.reset(DEFAULT_VALUES)
       replaceStdioArgs([])
       setIsEditHydrated(false)
+      setShowCustomCredentials(false)
     }
   }
 
@@ -414,6 +449,7 @@ export function MCPIntegrationDialog({
     if (!nextOpen) {
       resetForm()
       setIsEditHydrated(false)
+      setShowCustomCredentials(false)
     }
   }
 
@@ -446,13 +482,10 @@ export function MCPIntegrationDialog({
       }
 
       let customCredentialsForUpdate: string | undefined
-      if (values.auth_type !== "NONE") {
-        if (trimmedCustomCredentials !== "") {
-          customCredentialsForUpdate = trimmedCustomCredentials
-        } else if (customCredentialsWasEdited) {
-          // Explicitly send an empty string when a user clears the editor in edit mode.
-          customCredentialsForUpdate = ""
-        }
+      if (values.auth_type !== "NONE" && customCredentialsWasEdited) {
+        // Only send credentials updates when the editor was actually modified.
+        // This avoids persisting the redacted placeholder value in edit mode.
+        customCredentialsForUpdate = trimmedCustomCredentials
       }
 
       if (isEditMode && mcpIntegrationId) {
@@ -1016,20 +1049,69 @@ export function MCPIntegrationDialog({
                               : "Custom credentials (JSON)"}
                           </FormLabel>
                           <FormControl>
-                            <CodeEditor
-                              value={field.value || ""}
-                              onChange={field.onChange}
-                              language="json"
-                              className="font-mono text-xs [&_.cm-content]:text-xs [&_.cm-editor]:min-h-[120px]"
-                            />
+                            <div className="space-y-2">
+                              {isEditMode && hasConfiguredCredentials && (
+                                <div className="flex items-center justify-end">
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 px-2 text-xs"
+                                    onClick={() => {
+                                      const willShow = !showCustomCredentials
+                                      setShowCustomCredentials(willShow)
+                                      if (
+                                        !isEditMode ||
+                                        !hasConfiguredCredentials
+                                      ) {
+                                        return
+                                      }
+                                      if (!willShow) {
+                                        form.setValue(
+                                          "custom_credentials",
+                                          REDACTED_CUSTOM_CREDENTIALS_JSON,
+                                          { shouldDirty: false }
+                                        )
+                                      }
+                                    }}
+                                  >
+                                    {showCustomCredentials ? (
+                                      <EyeOff className="mr-1 h-3.5 w-3.5" />
+                                    ) : (
+                                      <Eye className="mr-1 h-3.5 w-3.5" />
+                                    )}
+                                    {showCustomCredentials ? "Hide" : "Show"}{" "}
+                                    secret
+                                  </Button>
+                                </div>
+                              )}
+                              <CodeEditor
+                                value={field.value || ""}
+                                onChange={field.onChange}
+                                language="json"
+                                readOnly={
+                                  isEditMode &&
+                                  hasConfiguredCredentials &&
+                                  !showCustomCredentials
+                                }
+                                className="font-mono text-xs [&_.cm-content]:text-xs [&_.cm-editor]:min-h-[120px]"
+                              />
+                            </div>
                           </FormControl>
-                          <FormDescription className="text-xs">
-                            {authType === "OAUTH2"
-                              ? "Optional: add extra request headers as JSON. Authorization is set from OAuth and cannot be overridden."
-                              : "Enter headers as a JSON object, for example "}
-                            {authType !== "OAUTH2" && (
-                              <code>{`{"Authorization":"Bearer token123"}`}</code>
+                          <FormDescription className="space-y-1 text-xs">
+                            {isEditMode && hasConfiguredCredentials && (
+                              <p>
+                                Configured credentials are redacted by default.
+                              </p>
                             )}
+                            <p>
+                              {authType === "OAUTH2"
+                                ? "Optional: add extra request headers as JSON. Authorization is set from OAuth and cannot be overridden."
+                                : "Enter headers as a JSON object, for example "}
+                              {authType !== "OAUTH2" && (
+                                <code>{`{"Authorization":"Bearer token123"}`}</code>
+                              )}
+                            </p>
                           </FormDescription>
                           <FormMessage />
                         </FormItem>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -136,6 +136,7 @@ import {
   integrationsListIntegrations,
   integrationsTestConnection,
   integrationsUpdateIntegration,
+  type MCPCustomCredentialsRead,
   type MCPIntegrationCreate,
   type MCPIntegrationRead,
   type MCPIntegrationUpdate,
@@ -143,6 +144,7 @@ import {
   type ModelCredentialUpdate,
   mcpIntegrationsCreateMcpIntegration,
   mcpIntegrationsDeleteMcpIntegration,
+  mcpIntegrationsGetMcpCustomCredentials,
   mcpIntegrationsGetMcpIntegration,
   mcpIntegrationsListMcpIntegrations,
   mcpIntegrationsUpdateMcpIntegration,
@@ -4605,6 +4607,34 @@ export function useGetMcpIntegration(
     mcpIntegration,
     mcpIntegrationIsLoading,
     mcpIntegrationError,
+  }
+}
+
+export function useGetMcpCustomCredentials(
+  workspaceId: string,
+  mcpIntegrationId: string | null,
+  enabled = true
+) {
+  const {
+    data: mcpCustomCredentials,
+    isLoading: mcpCustomCredentialsIsLoading,
+    error: mcpCustomCredentialsError,
+  } = useQuery<MCPCustomCredentialsRead, TracecatApiError>({
+    queryKey: ["mcp-custom-credentials", workspaceId, mcpIntegrationId],
+    queryFn: async () =>
+      await mcpIntegrationsGetMcpCustomCredentials({
+        workspaceId,
+        mcpIntegrationId: mcpIntegrationId!,
+      }),
+    enabled: Boolean(workspaceId && mcpIntegrationId && enabled),
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+  })
+
+  return {
+    mcpCustomCredentials,
+    mcpCustomCredentialsIsLoading,
+    mcpCustomCredentialsError,
   }
 }
 

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -37,6 +37,7 @@ from tracecat.integrations.schemas import (
     IntegrationReadMinimal,
     IntegrationTestConnectionResponse,
     IntegrationUpdate,
+    MCPCustomCredentialsRead,
     MCPIntegrationCreate,
     MCPIntegrationRead,
     MCPIntegrationUpdate,
@@ -837,6 +838,7 @@ async def create_mcp_integration(
         server_uri=mcp_integration.server_uri,
         auth_type=mcp_integration.auth_type,
         oauth_integration_id=mcp_integration.oauth_integration_id,
+        has_custom_credentials=bool(mcp_integration.encrypted_headers),
         created_at=mcp_integration.created_at,
         updated_at=mcp_integration.updated_at,
         server_type=cast(MCPServerType, mcp_integration.server_type),
@@ -873,6 +875,7 @@ async def list_mcp_integrations(
             server_uri=integration.server_uri,
             auth_type=integration.auth_type,
             oauth_integration_id=integration.oauth_integration_id,
+            has_custom_credentials=bool(integration.encrypted_headers),
             created_at=integration.created_at,
             updated_at=integration.updated_at,
             server_type=cast(MCPServerType, integration.server_type),
@@ -916,6 +919,7 @@ async def get_mcp_integration(
         server_uri=integration.server_uri,
         auth_type=integration.auth_type,
         oauth_integration_id=integration.oauth_integration_id,
+        has_custom_credentials=bool(integration.encrypted_headers),
         created_at=integration.created_at,
         updated_at=integration.updated_at,
         server_type=cast(MCPServerType, integration.server_type),
@@ -966,6 +970,7 @@ async def update_mcp_integration(
         server_uri=integration.server_uri,
         auth_type=integration.auth_type,
         oauth_integration_id=integration.oauth_integration_id,
+        has_custom_credentials=bool(integration.encrypted_headers),
         created_at=integration.created_at,
         updated_at=integration.updated_at,
         server_type=cast(MCPServerType, integration.server_type),
@@ -974,6 +979,35 @@ async def update_mcp_integration(
         has_stdio_env=bool(integration.encrypted_stdio_env),
         timeout=integration.timeout,
     )
+
+
+@mcp_router.get("/{mcp_integration_id}/custom-credentials")
+@require_scope("integration:read")
+async def get_mcp_custom_credentials(
+    role: WorkspaceUserRole,
+    session: AsyncDBSession,
+    mcp_integration_id: uuid.UUID,
+) -> MCPCustomCredentialsRead:
+    """Get decrypted custom credentials for an MCP integration."""
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+
+    svc = IntegrationService(session, role=role)
+    integration = await svc.get_mcp_integration(mcp_integration_id=mcp_integration_id)
+    if integration is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="MCP integration not found",
+        )
+
+    custom_credentials = None
+    if integration.encrypted_headers:
+        custom_credentials = svc.get_decrypted_mcp_custom_credentials(integration)
+
+    return MCPCustomCredentialsRead(custom_credentials=custom_credentials)
 
 
 @mcp_router.delete("/{mcp_integration_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -538,6 +538,8 @@ class MCPIntegrationRead(BaseModel):
     server_uri: str | None
     auth_type: MCPAuthType
     oauth_integration_id: UUID4 | None
+    has_custom_credentials: bool = False
+    """Whether encrypted custom credentials are configured."""
     # Stdio-type server fields
     stdio_command: str | None
     stdio_args: list[str] | None
@@ -548,3 +550,12 @@ class MCPIntegrationRead(BaseModel):
     timeout: int | None
     created_at: datetime
     updated_at: datetime
+
+
+class MCPCustomCredentialsRead(BaseModel):
+    """Decrypted MCP custom credentials payload."""
+
+    custom_credentials: str | None = Field(
+        default=None,
+        description="Decrypted custom credentials JSON headers.",
+    )

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1242,6 +1242,15 @@ class IntegrationService(BaseWorkspaceService):
         result = await self.session.execute(statement)
         return result.scalars().first()
 
+
+    def get_decrypted_mcp_custom_credentials(
+        self, mcp_integration: MCPIntegration
+    ) -> str | None:
+        """Get decrypted custom MCP header credentials."""
+        if not mcp_integration.encrypted_headers:
+            return None
+        return self._decrypt_token(mcp_integration.encrypted_headers)
+
     @require_scope("integration:update")
     async def update_mcp_integration(
         self, *, mcp_integration_id: uuid.UUID, params: MCPIntegrationUpdate


### PR DESCRIPTION
### Motivation
- Allow operators to retrieve decrypted custom header credentials for MCP integrations while keeping secrets redacted by default in the UI.
- Avoid accidentally persisting a redacted placeholder value back to the API when editing an integration.

### Description
- Added a new backend API endpoint `GET /mcp-integrations/{mcp_integration_id}/custom-credentials` that returns a `MCPCustomCredentialsRead` payload with decrypted custom credentials when present; implemented in `tracecat/integrations/router.py` and exposed by `IntegrationService.get_decrypted_mcp_custom_credentials` in `tracecat/integrations/service.py` and the new Pydantic schema in `tracecat/integrations/schemas.py`.
- Added a `has_custom_credentials` boolean to the `MCPIntegrationRead` response to indicate configured (redacted) credentials in list/get/update responses.
- Updated client SDK types and generated services in `frontend/src/client/types.gen.ts` and `frontend/src/client/services.gen.ts` to include the new types and `mcpIntegrationsGetMcpCustomCredentials` service function.
- Implemented a frontend hook `useGetMcpCustomCredentials` in `frontend/src/lib/hooks.tsx` and integrated a secure UI in `MCPIntegrationDialog` (`frontend/src/components/integrations/mcp-integration-dialog.tsx`) that shows a redacted placeholder (`REDACTED_CUSTOM_CREDENTIALS_JSON`), provides a Show/Hide secret toggle, only fetches credentials when requested, and only sends custom credentials updates when the editor was actually modified to avoid persisting the redaction placeholder.

### Testing
- Ran backend unit tests (`pytest`) against the integrations module and they passed.
- Ran frontend type checking and build (`pnpm -w -C frontend build` / `tsc`) and the build/typecheck succeeded.
- Ran the client test suite and hooks integration smoke checks and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b084fab92c83338ff279ed8d0acd59)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a secure way to reveal MCP custom header credentials on demand and a new API to fetch them decrypted. Secrets are masked by default and are never overwritten by a placeholder when editing.

- New Features
  - Backend: `GET /mcp-integrations/{mcp_integration_id}/custom-credentials` returns `MCPCustomCredentialsRead` with decrypted headers.
  - Backend: `MCPIntegrationRead` now includes `has_custom_credentials`.
  - SDK: Generated types and `mcpIntegrationsGetMcpCustomCredentials` service.
  - Frontend: `useGetMcpCustomCredentials` hook and dialog Show/Hide control with `Eye`/`EyeOff`. Redacted placeholder shown by default; editor is read-only until revealed; fetch occurs only on reveal.

- Bug Fixes
  - Prevent saving the redacted placeholder by sending custom credentials only when the editor was modified.

<sup>Written for commit c07f52fcb6610614e2a84267ae276874d9d616b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

