### PR TITLE
feat(fargate): Add MCP service deployment

### DIFF
--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -159,6 +159,18 @@ module "ecs" {
   temporal_db_allocated_storage            = local.temporal_db_allocated_storage
   db_engine_version                        = var.db_engine_version
 
+  # MCP Service
+  enable_mcp                      = var.enable_mcp
+  mcp_cpu                         = var.mcp_cpu
+  mcp_memory                      = var.mcp_memory
+  mcp_desired_count               = var.mcp_desired_count
+  mcp_rate_limit_rps              = var.mcp_rate_limit_rps
+  mcp_rate_limit_burst            = var.mcp_rate_limit_burst
+  mcp_tool_timeout_seconds        = var.mcp_tool_timeout_seconds
+  mcp_max_input_size_bytes        = var.mcp_max_input_size_bytes
+  mcp_startup_max_attempts        = var.mcp_startup_max_attempts
+  mcp_startup_retry_delay_seconds = var.mcp_startup_retry_delay_seconds
+
   # Sentry configuration
   sentry_dsn = var.sentry_dsn
 }

--- a/deployments/fargate/modules/ecs/alb.tf
+++ b/deployments/fargate/modules/ecs/alb.tf
@@ -120,6 +120,20 @@ resource "aws_wafv2_web_acl" "this" {
         }
 
         rule_action_override {
+          name = "EC2MetaDataSSRF_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
+          name = "EC2MetaDataSSRF_QUERYARGUMENTS"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
           name = "NoUserAgent_HEADER"
           action_to_use {
             count {}
@@ -336,10 +350,66 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
+  rule {
+    name     = "BlockSSRFExceptMcpOAuth"
+    priority = 8
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          or_statement {
+            statement {
+              label_match_statement {
+                scope = "LABEL"
+                key   = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_Body"
+              }
+            }
+
+            statement {
+              label_match_statement {
+                scope = "LABEL"
+                key   = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_QueryArguments"
+              }
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              regex_pattern_set_reference_statement {
+                arn = aws_wafv2_regex_pattern_set.mcp_oauth_endpoints[0].arn
+
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockSSRFExceptMcpOAuth"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # Custom rule to block oversized query strings except for attachment uploads
   rule {
     name     = "BlockQueryStringSizeExceptAttachments"
-    priority = 8
+    priority = 9
 
     action {
       block {}
@@ -396,6 +466,18 @@ resource "aws_wafv2_regex_pattern_set" "attachments_endpoint" {
 
   regular_expression {
     regex_string = "^/api/cases/[a-fA-F0-9-]+/attachments(\\?.*)?$"
+  }
+}
+
+resource "aws_wafv2_regex_pattern_set" "mcp_oauth_endpoints" {
+  count = var.enable_waf ? 1 : 0
+
+  name        = "mcp-oauth-endpoints-pattern"
+  description = "Matches MCP OAuth endpoints that carry localhost redirect URIs"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "^/(mcp/)?(register|authorize|consent|token|auth/callback)$"
   }
 }
 

--- a/deployments/fargate/modules/ecs/ecs-caddy.tf
+++ b/deployments/fargate/modules/ecs/ecs-caddy.tf
@@ -57,23 +57,50 @@ cat > /etc/caddy/Caddyfile <<'CONFIG'
     reverse_proxy http://temporal-ui-service:8080
   }
 
+${var.enable_mcp ? <<MCP
+  @mcp_routes {
+    path /mcp /mcp/*
+    path /.well-known/oauth-authorization-server
+    path /.well-known/oauth-protected-resource /.well-known/oauth-protected-resource/*
+    path /authorize /authorize/*
+    path /token
+    path /register
+    path /consent /consent/*
+    path /auth/callback /auth/callback/*
+  }
+  handle @mcp_routes {
+    reverse_proxy http://mcp-service:8099 {
+      flush_interval -1
+      header_up Connection "keep-alive"
+      header_up Keep-Alive "timeout=300"
+      header_down Connection "keep-alive"
+      header_down Keep-Alive "timeout=300"
+      header_up X-Forwarded-For {remote_host}
+      header_up X-Real-IP {remote_host}
+      header_up X-Forwarded-Proto {scheme}
+      header_up X-Forwarded-Host {host}
+    }
+  }
+MCP
+      : ""}
+
   reverse_proxy http://ui-service:3000
 }
 CONFIG
 
 caddy run --config /etc/caddy/Caddyfile
 EOT
-      ]
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
-          awslogs-region        = var.aws_region
-          awslogs-stream-prefix = "caddy"
-        }
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = "caddy"
       }
     }
-  ])
+    }
+])
 }
 
 resource "aws_ecs_service" "tracecat_caddy" {
@@ -125,6 +152,7 @@ resource "aws_ecs_service" "tracecat_caddy" {
   depends_on = [
     aws_ecs_service.tracecat_api,
     aws_ecs_service.tracecat_ui,
-    aws_ecs_service.tracecat_worker
+    aws_ecs_service.tracecat_worker,
+    aws_ecs_service.tracecat_mcp,
   ]
 }

--- a/deployments/fargate/modules/ecs/ecs-mcp.tf
+++ b/deployments/fargate/modules/ecs/ecs-mcp.tf
@@ -1,0 +1,104 @@
+# ECS Task Definition for MCP Service
+resource "aws_ecs_task_definition" "mcp_task_definition" {
+  count                    = var.enable_mcp ? 1 : 0
+  family                   = "TracecatMcpTaskDefinition"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.mcp_cpu
+  memory                   = var.mcp_memory
+  execution_role_arn       = aws_iam_role.mcp_execution[0].arn
+  task_role_arn            = aws_iam_role.mcp_task[0].arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "TracecatMcpContainer"
+      image     = "${var.tracecat_image}:${local.tracecat_image_tag}"
+      essential = true
+      portMappings = [
+        {
+          containerPort = 8099
+          hostPort      = 8099
+          name          = "mcp"
+          appProtocol   = "http"
+        }
+      ]
+      command = ["python", "-m", "tracecat.mcp"]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "mcp"
+        }
+      }
+      environment = local.mcp_env
+      secrets     = local.mcp_secrets
+      healthCheck = {
+        command     = ["CMD", "curl", "-f", "http://localhost:8099/.well-known/oauth-authorization-server"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 30
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "tracecat_mcp" {
+  count                = var.enable_mcp ? 1 : 0
+  name                 = "tracecat-mcp"
+  cluster              = aws_ecs_cluster.tracecat_cluster.id
+  task_definition      = aws_ecs_task_definition.mcp_task_definition[0].arn
+  desired_count        = var.mcp_desired_count
+  force_new_deployment = var.force_new_deployment
+
+  network_configuration {
+    subnets = var.private_subnet_ids
+    security_groups = [
+      aws_security_group.core.id,
+      aws_security_group.caddy.id,
+      aws_security_group.core_db.id,
+      aws_security_group.redis.id,
+    ]
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = local.local_dns_namespace
+    service {
+      port_name      = "mcp"
+      discovery_name = "mcp-service"
+      timeout {
+        per_request_timeout_seconds = 300
+      }
+      client_alias {
+        port     = 8099
+        dns_name = "mcp-service"
+      }
+    }
+
+    log_configuration {
+      log_driver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = "service-connect-mcp"
+      }
+    }
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+
+  depends_on = [
+    aws_ecs_service.tracecat_api
+  ]
+}

--- a/deployments/fargate/modules/ecs/iam.tf
+++ b/deployments/fargate/modules/ecs/iam.tf
@@ -387,6 +387,61 @@ resource "aws_iam_role_policy" "temporal_task_db_access" {
   })
 }
 
+# MCP execution role
+resource "aws_iam_role" "mcp_execution" {
+  count              = var.enable_mcp ? 1 : 0
+  name               = "TracecatMCPExecutionRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "mcp_execution_ecs_poll" {
+  count      = var.enable_mcp ? 1 : 0
+  policy_arn = aws_iam_policy.ecs_poll.arn
+  role       = aws_iam_role.mcp_execution[0].name
+}
+
+resource "aws_iam_role_policy_attachment" "mcp_execution_secrets" {
+  count      = var.enable_mcp ? 1 : 0
+  policy_arn = aws_iam_policy.secrets_access.arn
+  role       = aws_iam_role.mcp_execution[0].name
+}
+
+resource "aws_iam_role_policy_attachment" "mcp_execution_cloudwatch_logs" {
+  count      = var.enable_mcp ? 1 : 0
+  policy_arn = aws_iam_policy.cloudwatch_logs.arn
+  role       = aws_iam_role.mcp_execution[0].name
+}
+
+# MCP task role
+resource "aws_iam_role" "mcp_task" {
+  count              = var.enable_mcp ? 1 : 0
+  name               = "TracecatMCPTaskRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy" "mcp_task_db_access" {
+  count = var.enable_mcp ? 1 : 0
+  name  = "TracecatMCPDBAccessPolicy"
+  role  = aws_iam_role.mcp_task[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "rds-db:connect",
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          "${aws_db_instance.core_database.arn}/postgres",
+          aws_db_instance.core_database.master_user_secret[0].secret_arn,
+        ]
+      }
+    ]
+  })
+}
+
 # Caddy execution role
 resource "aws_iam_role" "caddy_execution" {
   name               = "TracecatCaddyExecutionRole"

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -148,6 +148,29 @@ locals {
     { name = k, value = tostring(v) } if v != null
   ]
 
+  mcp_env = [
+    for k, v in merge(
+      local.tracecat_common_env,
+      local.tracecat_db_configs,
+      {
+        TRACECAT__DB_ENDPOINT                     = local.core_db_hostname
+        OIDC_ISSUER                               = var.oidc_issuer
+        OIDC_SCOPES                               = var.oidc_scopes
+        TRACECAT_MCP__HOST                        = "0.0.0.0"
+        TRACECAT_MCP__PORT                        = "8099"
+        TRACECAT_MCP__BASE_URL                    = "https://${var.domain_name}"
+        TRACECAT_MCP__RATE_LIMIT_RPS              = var.mcp_rate_limit_rps
+        TRACECAT_MCP__RATE_LIMIT_BURST            = var.mcp_rate_limit_burst
+        TRACECAT_MCP__TOOL_TIMEOUT_SECONDS        = var.mcp_tool_timeout_seconds
+        TRACECAT_MCP__MAX_INPUT_SIZE_BYTES        = var.mcp_max_input_size_bytes
+        TRACECAT_MCP__STARTUP_MAX_ATTEMPTS        = var.mcp_startup_max_attempts
+        TRACECAT_MCP__STARTUP_RETRY_DELAY_SECONDS = var.mcp_startup_retry_delay_seconds
+        TEMPORAL__CLUSTER_QUEUE                   = local.temporal_cluster_queue
+      }
+    ) :
+    { name = k, value = tostring(v) } if v != null
+  ]
+
   migrations_env = [
     for k, v in merge(
       {

--- a/deployments/fargate/modules/ecs/secrets.tf
+++ b/deployments/fargate/modules/ecs/secrets.tf
@@ -310,4 +310,10 @@ locals {
   )
 
   executor_secrets = local.tracecat_base_secrets
+
+  mcp_secrets = concat(
+    local.tracecat_base_secrets,
+    local.oidc_client_id_secret,
+    local.oidc_client_secret_secret,
+  )
 }

--- a/deployments/fargate/modules/ecs/security_groups.tf
+++ b/deployments/fargate/modules/ecs/security_groups.tf
@@ -72,6 +72,14 @@ resource "aws_security_group" "caddy" {
     self        = true
   }
 
+  ingress {
+    description = "Allow Caddy to forward traffic to MCP service"
+    protocol    = "tcp"
+    from_port   = 8099
+    to_port     = 8099
+    self        = true
+  }
+
   egress {
     protocol    = "-1"
     from_port   = 0

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -576,6 +576,66 @@ variable "caddy_memory" {
   default = "512"
 }
 
+### MCP Service
+
+variable "enable_mcp" {
+  type        = bool
+  description = "Whether to enable the MCP server service in the deployment"
+  default     = false
+}
+
+variable "mcp_cpu" {
+  type    = string
+  default = "1024"
+}
+
+variable "mcp_memory" {
+  type    = string
+  default = "2048"
+}
+
+variable "mcp_desired_count" {
+  type        = number
+  description = "Desired number of MCP service instances to run"
+  default     = 1
+}
+
+variable "mcp_rate_limit_rps" {
+  type        = string
+  description = "Sustained requests per second per user for MCP rate limiting"
+  default     = "2.0"
+}
+
+variable "mcp_rate_limit_burst" {
+  type        = string
+  description = "Burst capacity for per-user MCP rate limiting"
+  default     = "10"
+}
+
+variable "mcp_tool_timeout_seconds" {
+  type        = string
+  description = "Maximum execution time in seconds for a single MCP tool call"
+  default     = "120"
+}
+
+variable "mcp_max_input_size_bytes" {
+  type        = string
+  description = "Maximum size in bytes for any single string argument to an MCP tool call"
+  default     = "524288"
+}
+
+variable "mcp_startup_max_attempts" {
+  type        = string
+  description = "Maximum MCP server startup attempts before failing"
+  default     = "3"
+}
+
+variable "mcp_startup_retry_delay_seconds" {
+  type        = string
+  description = "Seconds to wait between MCP startup retries"
+  default     = "2"
+}
+
 variable "tracecat_db_instance_class" {
   type        = string
   description = "Instance class for the Tracecat application RDS instance."

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -530,6 +530,66 @@ variable "caddy_memory" {
   default = "512"
 }
 
+### MCP Service
+
+variable "enable_mcp" {
+  type        = bool
+  description = "Whether to enable the MCP server service in the deployment"
+  default     = false
+}
+
+variable "mcp_cpu" {
+  type    = string
+  default = "1024"
+}
+
+variable "mcp_memory" {
+  type    = string
+  default = "2048"
+}
+
+variable "mcp_desired_count" {
+  type        = number
+  description = "Desired number of MCP service instances to run"
+  default     = 1
+}
+
+variable "mcp_rate_limit_rps" {
+  type        = string
+  description = "Sustained requests per second per user for MCP rate limiting"
+  default     = "2.0"
+}
+
+variable "mcp_rate_limit_burst" {
+  type        = string
+  description = "Burst capacity for per-user MCP rate limiting"
+  default     = "10"
+}
+
+variable "mcp_tool_timeout_seconds" {
+  type        = string
+  description = "Maximum execution time in seconds for a single MCP tool call"
+  default     = "120"
+}
+
+variable "mcp_max_input_size_bytes" {
+  type        = string
+  description = "Maximum size in bytes for any single string argument to an MCP tool call"
+  default     = "524288"
+}
+
+variable "mcp_startup_max_attempts" {
+  type        = string
+  description = "Maximum MCP server startup attempts before failing"
+  default     = "3"
+}
+
+variable "mcp_startup_retry_delay_seconds" {
+  type        = string
+  description = "Seconds to wait between MCP startup retries"
+  default     = "2"
+}
+
 variable "tracecat_db_instance_class" {
   type        = string
   description = "Instance class for the Tracecat application RDS instance."


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

- Add a new MCP service as an ECS Fargate task
- Configure Caddy reverse proxy to route MCP and OAuth endpoints to the new service on port 8099
- Add WAF rule to exempt MCP OAuth endpoints from AWS Core Rule Set SSRF

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
Deploy and ensure a connection can be established with the MCP server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MCP server as an ECS Fargate service behind `Caddy` (port 8099), with WAF SSRF exemptions for MCP OAuth and public bootstrap. Also exposes MCP tuning in root/ECS modules, bumps Helm chart/app images to 0.3.40/1.0.0-beta.30, and wires optional `sentry_dsn`.

- **New Features**
  - Fargate MCP: deploy `mcp-service` (port 8099) with IAM roles, OIDC client secrets, health checks, logs, Service Connect discovery, and a security group rule for `Caddy`→MCP; route `/mcp`, discovery (`/.well-known/...`) and OAuth endpoints via `Caddy` with keep‑alive/flush and `X‑Forwarded‑*` headers.
  - WAF: override CRS EC2 metadata SSRF labels to count; add regex pattern set and a rule to exempt MCP OAuth endpoints while blocking other SSRF; keep rule to block missing User‑Agent except MCP public paths.
  - Executor IAM/IRSA: add a dedicated executor task role for Fargate; pass `TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID` and `TRACECAT__AWS_ASSUME_ROLE_PRINCIPAL_ARN`; surface executor role ARN as an output; on EKS, create separate `executor` and `agentExecutor` service accounts bound via IRSA; update S3 bucket policies to include the executor role.
  - Helm/EKS: chart 0.3.40, app 1.0.0-beta.30; executor/agentExecutor service accounts with optional annotations; expose `tracecat.aws.assumeRoleAccountId` and `tracecat.aws.assumeRolePrincipalArn`; add optional `sentry_dsn`.
  - Tuning: expose MCP CPU/memory/count, per‑user RPS/burst, tool timeout, max input bytes, and startup retry settings in root/ECS modules.

- **Migration**
  - Enable MCP and set OIDC settings (issuer, scopes, client ID/secret); deploy and verify `/.well-known/oauth-authorization-server` responds.
  - For AWS cross‑account access, update trust to the new executor role ARN and set `TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID` and `TRACECAT__AWS_ASSUME_ROLE_PRINCIPAL_ARN` (Helm values or Compose env). Upgrade to chart 0.3.40 / image 1.0.0-beta.30.

<sup>Written for commit 85105adb8e18d010bbf38fb1c0144d135e53db1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

