### PR TITLE
fix: workflow export/import regressions

### DIFF
--- a/frontend/src/app/admin/tiers/page.tsx
+++ b/frontend/src/app/admin/tiers/page.tsx
@@ -1,10 +1,12 @@
 "use client"
 
+import { AlertTriangleIcon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
 import { AdminTiersTable } from "@/components/admin/admin-tiers-table"
 import { CreateTierDialog } from "@/components/admin/create-tier-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { useAdminTiers } from "@/hooks/use-admin"
 import { useAppInfo } from "@/lib/hooks"
 
@@ -52,6 +54,14 @@ export default function AdminTiersPage() {
             <CreateTierDialog />
           </div>
         </div>
+        <Alert variant="warning">
+          <AlertTriangleIcon className="size-4" />
+          <AlertTitle>Enterprise license required</AlertTitle>
+          <AlertDescription>
+            All tier settings on this page are Enterprise-only and will be gated
+            behind a license key in a future release.
+          </AlertDescription>
+        </Alert>
         <AdminTiersTable />
       </div>
     </div>

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -1,7 +1,9 @@
 """HTTP-level tests for workflow management API endpoints."""
 
+import json
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -389,6 +391,91 @@ async def test_get_workflow_not_found(
         # Should return 404
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.anyio
+async def test_export_workflow_includes_layout(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    mock_workflow.trigger_position_x = 12.0
+    mock_workflow.trigger_position_y = 24.0
+    mock_workflow.viewport_x = 30.0
+    mock_workflow.viewport_y = 40.0
+    mock_workflow.viewport_zoom = 1.5
+    mock_workflow.actions = [
+        Action(
+            id=uuid.uuid4(),
+            workflow_id=mock_workflow.id,
+            workspace_id=mock_workflow.workspace_id,
+            type="core.transform.reshape",
+            title="entrypoint_1",
+            description="",
+            status="offline",
+            inputs="{}",
+            control_flow={},
+            is_interactive=False,
+            interaction=None,
+            position_x=100.0,
+            position_y=200.0,
+            upstream_edges=[],
+        )
+    ]
+
+    with (
+        patch(
+            "tracecat.workflow.management.router.get_setting",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "tracecat.workflow.management.router.WorkflowDefinitionsService"
+        ) as MockDefinitionsService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.get_definition_by_workflow_id.return_value = SimpleNamespace(
+            workspace_id=mock_workflow.workspace_id,
+            workflow_id=mock_workflow.id,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+            version=1,
+            content={
+                "title": "Test Workflow",
+                "description": "Test workflow description",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "entrypoint_1",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_1"},
+                    }
+                ],
+            },
+            workflow=mock_workflow,
+        )
+        MockDefinitionsService.return_value = mock_svc
+
+        response = client.get(
+            f"/workflows/{mock_workflow.id}/export",
+            params={
+                "workspace_id": str(test_admin_role.workspace_id),
+                "format": "json",
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = json.loads(response.text)
+    assert payload["layout"] == {
+        "trigger": {"x": 12.0, "y": 24.0},
+        "viewport": {"x": 30.0, "y": 40.0, "zoom": 1.5},
+        "actions": [
+            {
+                "ref": "entrypoint_1",
+                "x": 100.0,
+                "y": 200.0,
+            }
+        ],
+    }
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -303,3 +303,52 @@ async def test_workflow_import_applies_layout(test_role: Role):
         assert len(workflow.actions) == 1
         assert workflow.actions[0].position_x == 100.0
         assert workflow.actions[0].position_y == 200.0
+
+
+@pytest.mark.anyio
+async def test_workflow_import_prefers_explicit_layout_over_exported_layout(
+    test_role: Role,
+):
+    dsl = ExternalWorkflowDefinition(
+        definition=DSLInput(
+            **{
+                "title": "layout_override_import",
+                "description": "Workflow import with explicit layout override",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "entrypoint_1",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_1"},
+                    }
+                ],
+                "returns": "${{ ACTIONS.entrypoint_1.result }}",
+            }
+        ),
+        layout=WorkflowLayout(
+            trigger=WorkflowLayoutPosition(x=12.0, y=24.0),
+            viewport=WorkflowLayoutViewport(x=30.0, y=40.0, zoom=1.5),
+            actions=[
+                WorkflowLayoutActionPosition(ref="entrypoint_1", x=100.0, y=200.0)
+            ],
+        ),
+    )
+
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await service.create_workflow_from_external_definition(
+            dsl.model_dump(mode="json"),
+            trigger_position=(1.0, 2.0),
+            viewport=(3.0, 4.0, 0.75),
+            action_positions={"entrypoint_1": (5.0, 6.0)},
+        )
+        await service.session.refresh(workflow, ["actions"])
+
+        assert workflow.trigger_position_x == 1.0
+        assert workflow.trigger_position_y == 2.0
+        assert workflow.viewport_x == 3.0
+        assert workflow.viewport_y == 4.0
+        assert workflow.viewport_zoom == 0.75
+        assert workflow.actions is not None
+        assert len(workflow.actions) == 1
+        assert workflow.actions[0].position_x == 5.0
+        assert workflow.actions[0].position_y == 6.0

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,15 +1,25 @@
-from typing import Any
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import select
 
 from tracecat.auth.types import Role
-from tracecat.db.models import CaseTag, CaseTrigger
+from tracecat.db.models import CaseTag, CaseTrigger, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
 from tracecat.workflow.management.management import WorkflowsManagementService
-from tracecat.workflow.management.schemas import ExternalWorkflowDefinition
+from tracecat.workflow.management.schemas import (
+    ExternalWorkflowDefinition,
+    WorkflowLayout,
+    WorkflowLayoutActionPosition,
+    WorkflowLayoutPosition,
+    WorkflowLayoutViewport,
+)
 
 pytestmark = pytest.mark.usefixtures("registry_version_with_manifest")
 
@@ -115,3 +125,181 @@ async def test_workflow_import_case_trigger_creates_tags(test_role: Role):
         )
         tag_result = await service.session.execute(tag_stmt)
         assert tag_result.scalar_one().ref == "phishing"
+
+
+def test_external_workflow_definition_omits_empty_case_trigger():
+    workflow_id = WorkflowUUID.new_uuid4()
+    external = ExternalWorkflowDefinition.from_database(
+        cast(
+            WorkflowDefinition,
+            SimpleNamespace(
+                workspace_id=uuid.uuid4(),
+                workflow_id=workflow_id,
+                created_at=datetime(2024, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+                version=1,
+                content={
+                    "title": "empty_case_trigger",
+                    "description": "Export should omit inert case triggers",
+                    "entrypoint": {"expects": {}, "ref": None},
+                    "actions": [
+                        {
+                            "ref": "entrypoint_1",
+                            "action": "core.transform.reshape",
+                            "args": {"value": "ENTRYPOINT_1"},
+                        }
+                    ],
+                },
+                workflow=SimpleNamespace(
+                    trigger_position_x=0.0,
+                    trigger_position_y=0.0,
+                    viewport_x=0.0,
+                    viewport_y=0.0,
+                    viewport_zoom=1.0,
+                    actions=[],
+                    case_trigger=SimpleNamespace(
+                        status="offline",
+                        event_types=[],
+                        tag_filters=[],
+                    ),
+                ),
+            ),
+        )
+    )
+
+    assert external.case_trigger is None
+
+
+def test_external_workflow_definition_includes_layout():
+    workflow_id = WorkflowUUID.new_uuid4()
+    external = ExternalWorkflowDefinition.from_database(
+        cast(
+            WorkflowDefinition,
+            SimpleNamespace(
+                workspace_id=uuid.uuid4(),
+                workflow_id=workflow_id,
+                created_at=datetime(2024, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+                version=1,
+                content={
+                    "title": "layout_export",
+                    "description": "Export should preserve layout",
+                    "entrypoint": {"expects": {}, "ref": None},
+                    "actions": [
+                        {
+                            "ref": "entrypoint_1",
+                            "action": "core.transform.reshape",
+                            "args": {"value": "ENTRYPOINT_1"},
+                        }
+                    ],
+                },
+                workflow=SimpleNamespace(
+                    trigger_position_x=12.0,
+                    trigger_position_y=24.0,
+                    viewport_x=30.0,
+                    viewport_y=40.0,
+                    viewport_zoom=1.5,
+                    actions=[
+                        SimpleNamespace(
+                            ref="entrypoint_1",
+                            position_x=100.0,
+                            position_y=200.0,
+                        )
+                    ],
+                    case_trigger=SimpleNamespace(
+                        status="offline",
+                        event_types=[],
+                        tag_filters=[],
+                    ),
+                ),
+            ),
+        )
+    )
+
+    assert external.layout is not None
+    assert external.layout.trigger == WorkflowLayoutPosition(x=12.0, y=24.0)
+    assert external.layout.viewport == WorkflowLayoutViewport(x=30.0, y=40.0, zoom=1.5)
+    assert external.layout.actions == [
+        WorkflowLayoutActionPosition(ref="entrypoint_1", x=100.0, y=200.0)
+    ]
+
+
+@pytest.mark.anyio
+async def test_workflow_import_ignores_empty_case_trigger(test_role: Role):
+    dsl = ExternalWorkflowDefinition(
+        definition=DSLInput(
+            **{
+                "title": "empty_case_trigger_import",
+                "description": "Workflow import with inert case trigger",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "entrypoint_1",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_1"},
+                    }
+                ],
+                "returns": "${{ ACTIONS.entrypoint_1.result }}",
+            }
+        ),
+        case_trigger=CaseTriggerConfig(
+            status="offline",
+            event_types=[],
+            tag_filters=[],
+        ),
+    )
+
+    with patch(
+        "tracecat.workflow.management.management.CaseTriggersService"
+    ) as case_trigger_service_cls:
+        async with WorkflowsManagementService.with_session(test_role) as service:
+            workflow = await service.create_workflow_from_external_definition(
+                dsl.model_dump(mode="json")
+            )
+
+        assert workflow.id is not None
+        case_trigger_service_cls.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_workflow_import_applies_layout(test_role: Role):
+    dsl = ExternalWorkflowDefinition(
+        definition=DSLInput(
+            **{
+                "title": "layout_import",
+                "description": "Workflow import with layout",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "entrypoint_1",
+                        "action": "core.transform.reshape",
+                        "args": {"value": "ENTRYPOINT_1"},
+                    }
+                ],
+                "returns": "${{ ACTIONS.entrypoint_1.result }}",
+            }
+        ),
+        layout=WorkflowLayout(
+            trigger=WorkflowLayoutPosition(x=12.0, y=24.0),
+            viewport=WorkflowLayoutViewport(x=30.0, y=40.0, zoom=1.5),
+            actions=[
+                WorkflowLayoutActionPosition(ref="entrypoint_1", x=100.0, y=200.0)
+            ],
+        ),
+    )
+
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await service.create_workflow_from_external_definition(
+            dsl.model_dump(mode="json")
+        )
+        await service.session.refresh(workflow, ["actions"])
+
+        assert workflow.trigger_position_x == 12.0
+        assert workflow.trigger_position_y == 24.0
+        assert workflow.viewport_x == 30.0
+        assert workflow.viewport_y == 40.0
+        assert workflow.viewport_zoom == 1.5
+        assert workflow.actions is not None
+        assert len(workflow.actions) == 1
+        assert workflow.actions[0].position_x == 100.0
+        assert workflow.actions[0].position_y == 200.0

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
+from tracecat.cases.enums import CaseEventType
 from tracecat.db.models import (
     Schedule,
     Workflow,
@@ -20,6 +21,8 @@ from tracecat.dsl.common import DSLConfig, DSLEntrypoint, DSLInput
 from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import ActionStatement
 from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
+from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.store.import_service import WorkflowImportService
 from tracecat.workflow.store.schemas import (
     RemoteCaseTrigger,
@@ -188,25 +191,55 @@ class TestWorkflowImportService:
         assert tag_names == {"test", "import"}
 
     @pytest.mark.anyio
-    async def test_update_case_trigger_ignores_empty_remote_block(
+    async def test_update_case_trigger_ignores_missing_remote_block(
         self,
         import_service: WorkflowImportService,
     ) -> None:
-        remote_case_trigger = RemoteCaseTrigger(
-            status="offline",
-            event_types=[],
-            tag_filters=[],
-        )
-
         with patch(
             "tracecat.workflow.store.import_service.CaseTriggersService"
         ) as case_trigger_service_cls:
             await import_service._update_case_trigger(
                 cast(Workflow, SimpleNamespace(id=WorkflowUUID.new_uuid4())),
-                remote_case_trigger,
+                None,
             )
 
         case_trigger_service_cls.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_update_case_trigger_clears_existing_trigger_from_inert_remote_block(
+        self,
+        import_service: WorkflowImportService,
+        sample_dsl: DSLInput,
+    ) -> None:
+        workflow = await import_service.wf_mgmt.create_db_workflow_from_dsl(
+            sample_dsl, workflow_id=WorkflowUUID.new_uuid4()
+        )
+        case_trigger_service = CaseTriggersService(
+            import_service.session, role=import_service.role
+        )
+        await case_trigger_service.upsert_case_trigger(
+            WorkflowUUID.new(workflow.id),
+            CaseTriggerConfig(
+                status="online",
+                event_types=[CaseEventType.CASE_CREATED],
+                tag_filters=[],
+            ),
+        )
+
+        await import_service._update_case_trigger(
+            workflow,
+            RemoteCaseTrigger(
+                status="offline",
+                event_types=[],
+                tag_filters=[],
+            ),
+        )
+        await import_service.session.refresh(workflow, ["case_trigger"])
+
+        assert workflow.case_trigger is not None
+        assert workflow.case_trigger.status == "offline"
+        assert workflow.case_trigger.event_types == []
+        assert workflow.case_trigger.tag_filters == []
 
     @pytest.mark.anyio
     async def test_import_workflow_overwrite_behavior(

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -1,8 +1,6 @@
 """Tests for WorkflowImportService functionality."""
 
-from types import SimpleNamespace
-from typing import cast
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import select
@@ -191,19 +189,33 @@ class TestWorkflowImportService:
         assert tag_names == {"test", "import"}
 
     @pytest.mark.anyio
-    async def test_update_case_trigger_ignores_missing_remote_block(
+    async def test_update_case_trigger_clears_existing_trigger_when_remote_block_missing(
         self,
         import_service: WorkflowImportService,
+        sample_dsl: DSLInput,
     ) -> None:
-        with patch(
-            "tracecat.workflow.store.import_service.CaseTriggersService"
-        ) as case_trigger_service_cls:
-            await import_service._update_case_trigger(
-                cast(Workflow, SimpleNamespace(id=WorkflowUUID.new_uuid4())),
-                None,
-            )
+        workflow = await import_service.wf_mgmt.create_db_workflow_from_dsl(
+            sample_dsl, workflow_id=WorkflowUUID.new_uuid4()
+        )
+        case_trigger_service = CaseTriggersService(
+            import_service.session, role=import_service.role
+        )
+        await case_trigger_service.upsert_case_trigger(
+            WorkflowUUID.new(workflow.id),
+            CaseTriggerConfig(
+                status="online",
+                event_types=[CaseEventType.CASE_CREATED],
+                tag_filters=[],
+            ),
+        )
 
-        case_trigger_service_cls.assert_not_called()
+        await import_service._update_case_trigger(workflow, None)
+        await import_service.session.refresh(workflow, ["case_trigger"])
+
+        assert workflow.case_trigger is not None
+        assert workflow.case_trigger.status == "offline"
+        assert workflow.case_trigger.event_types == []
+        assert workflow.case_trigger.tag_filters == []
 
     @pytest.mark.anyio
     async def test_update_case_trigger_clears_existing_trigger_from_inert_remote_block(
@@ -226,14 +238,20 @@ class TestWorkflowImportService:
             ),
         )
 
-        await import_service._update_case_trigger(
-            workflow,
-            RemoteCaseTrigger(
-                status="offline",
-                event_types=[],
-                tag_filters=[],
-            ),
-        )
+        with patch(
+            "tracecat.workflow.store.import_service.CaseTriggersService.upsert_case_trigger",
+            new_callable=AsyncMock,
+        ) as mock_upsert:
+            await import_service._update_case_trigger(
+                workflow,
+                RemoteCaseTrigger(
+                    status="offline",
+                    event_types=[],
+                    tag_filters=[],
+                ),
+            )
+
+        mock_upsert.assert_not_awaited()
         await import_service.session.refresh(workflow, ["case_trigger"])
 
         assert workflow.case_trigger is not None

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -1,5 +1,9 @@
 """Tests for WorkflowImportService functionality."""
 
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
+
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +22,7 @@ from tracecat.dsl.schemas import ActionStatement
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.store.import_service import WorkflowImportService
 from tracecat.workflow.store.schemas import (
+    RemoteCaseTrigger,
     RemoteWebhook,
     RemoteWorkflowDefinition,
     RemoteWorkflowSchedule,
@@ -181,6 +186,27 @@ class TestWorkflowImportService:
         tags = result.scalars().all()
         tag_names = {tag.name for tag in tags}
         assert tag_names == {"test", "import"}
+
+    @pytest.mark.anyio
+    async def test_update_case_trigger_ignores_empty_remote_block(
+        self,
+        import_service: WorkflowImportService,
+    ) -> None:
+        remote_case_trigger = RemoteCaseTrigger(
+            status="offline",
+            event_types=[],
+            tag_filters=[],
+        )
+
+        with patch(
+            "tracecat.workflow.store.import_service.CaseTriggersService"
+        ) as case_trigger_service_cls:
+            await import_service._update_case_trigger(
+                cast(Workflow, SimpleNamespace(id=WorkflowUUID.new_uuid4())),
+                remote_case_trigger,
+            )
+
+        case_trigger_service_cls.assert_not_called()
 
     @pytest.mark.anyio
     async def test_import_workflow_overwrite_behavior(

--- a/tests/unit/test_workflow_store_service.py
+++ b/tests/unit/test_workflow_store_service.py
@@ -1,0 +1,167 @@
+"""Tests for WorkflowStoreService publishing behavior."""
+
+import uuid
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.cases.enums import CaseEventType
+from tracecat.db.models import Workflow
+from tracecat.dsl.common import DSLEntrypoint, DSLInput
+from tracecat.dsl.schemas import ActionStatement
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.sync import PushStatus
+from tracecat.workflow.store.schemas import WorkflowDslPublish
+from tracecat.workflow.store.service import WorkflowStoreService
+
+
+@pytest.fixture
+def workflow_store_service() -> WorkflowStoreService:
+    session = AsyncMock()
+    session.add = Mock()
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-api"],
+    )
+    return WorkflowStoreService(session=session, role=role)
+
+
+@pytest.fixture
+def sample_dsl() -> DSLInput:
+    return DSLInput(
+        title="Test workflow",
+        description="A workflow for store publish tests",
+        entrypoint=DSLEntrypoint(ref="start", expects={}),
+        actions=[
+            ActionStatement(
+                ref="start",
+                action="core.transform.passthrough",
+                args={"value": "test"},
+            )
+        ],
+    )
+
+
+def _workflow_fixture(
+    workflow_id: WorkflowUUID,
+    *,
+    case_trigger: SimpleNamespace | None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=workflow_id,
+        alias="test-workflow",
+        tags=[],
+        folder=None,
+        schedules=[],
+        webhook=SimpleNamespace(methods=["POST"], status="online"),
+        case_trigger=case_trigger,
+        git_sync_branch=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_omits_inert_case_trigger(
+    workflow_store_service: WorkflowStoreService,
+    sample_dsl: DSLInput,
+) -> None:
+    workflow_id = WorkflowUUID.new_uuid4()
+    workflow = _workflow_fixture(
+        workflow_id,
+        case_trigger=SimpleNamespace(
+            status="offline",
+            event_types=[],
+            tag_filters=[],
+        ),
+    )
+
+    with (
+        patch("tracecat.workflow.store.service.WorkspaceService") as workspace_cls,
+        patch("tracecat.workflow.store.service.WorkflowSyncService") as sync_cls,
+    ):
+        workspace_service = AsyncMock()
+        workspace_service.get_workspace.return_value = SimpleNamespace(
+            settings={"git_repo_url": "git+ssh://git@github.com/test-org/test-repo.git"}
+        )
+        workspace_cls.return_value = workspace_service
+
+        sync_service = AsyncMock()
+        sync_service.push.return_value = SimpleNamespace(
+            status=PushStatus.NO_OP,
+            sha="abc123",
+            ref="feature/test",
+            base_ref="main",
+            pr_url=None,
+            pr_number=None,
+            pr_reused=False,
+            message="No changes",
+        )
+        sync_cls.return_value = sync_service
+
+        await workflow_store_service.publish_workflow_dsl(
+            workflow_id=workflow_id,
+            dsl=sample_dsl,
+            params=WorkflowDslPublish(branch="feature/test", create_pr=False),
+            workflow=cast(Workflow, workflow),
+        )
+
+    push_obj = sync_service.push.call_args.kwargs["objects"][0]
+    assert push_obj.data.case_trigger is None
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_includes_configured_case_trigger(
+    workflow_store_service: WorkflowStoreService,
+    sample_dsl: DSLInput,
+) -> None:
+    workflow_id = WorkflowUUID.new_uuid4()
+    workflow = _workflow_fixture(
+        workflow_id,
+        case_trigger=SimpleNamespace(
+            status="online",
+            event_types=[CaseEventType.CASE_CREATED.value],
+            tag_filters=["phishing"],
+        ),
+    )
+
+    with (
+        patch("tracecat.workflow.store.service.WorkspaceService") as workspace_cls,
+        patch("tracecat.workflow.store.service.WorkflowSyncService") as sync_cls,
+    ):
+        workspace_service = AsyncMock()
+        workspace_service.get_workspace.return_value = SimpleNamespace(
+            settings={"git_repo_url": "git+ssh://git@github.com/test-org/test-repo.git"}
+        )
+        workspace_cls.return_value = workspace_service
+
+        sync_service = AsyncMock()
+        sync_service.push.return_value = SimpleNamespace(
+            status=PushStatus.NO_OP,
+            sha="abc123",
+            ref="feature/test",
+            base_ref="main",
+            pr_url=None,
+            pr_number=None,
+            pr_reused=False,
+            message="No changes",
+        )
+        sync_cls.return_value = sync_service
+
+        await workflow_store_service.publish_workflow_dsl(
+            workflow_id=workflow_id,
+            dsl=sample_dsl,
+            params=WorkflowDslPublish(branch="feature/test", create_pr=False),
+            workflow=cast(Workflow, workflow),
+        )
+
+    push_obj = sync_service.push.call_args.kwargs["objects"][0]
+    assert push_obj.data.case_trigger is not None
+    assert push_obj.data.case_trigger.status == "online"
+    assert push_obj.data.case_trigger.event_types == [CaseEventType.CASE_CREATED]
+    assert push_obj.data.case_trigger.tag_filters == ["phishing"]

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -116,6 +116,7 @@ from tracecat.workflow.case_triggers.schemas import (
     CaseTriggerConfig,
     CaseTriggerRead,
     CaseTriggerUpdate,
+    is_case_trigger_configured,
 )
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.executions.service import WorkflowExecutionsService
@@ -1683,11 +1684,19 @@ async def get_workflow(
                 case_trigger = await CaseTriggersService(
                     svc.session, role=role
                 ).get_case_trigger(wf_id)
-                payload["case_trigger"] = {
-                    "status": case_trigger.status,
-                    "event_types": case_trigger.event_types,
-                    "tag_filters": case_trigger.tag_filters,
-                }
+                payload["case_trigger"] = (
+                    {
+                        "status": case_trigger.status,
+                        "event_types": case_trigger.event_types,
+                        "tag_filters": case_trigger.tag_filters,
+                    }
+                    if is_case_trigger_configured(
+                        status=case_trigger.status,
+                        event_types=case_trigger.event_types,
+                        tag_filters=case_trigger.tag_filters,
+                    )
+                    else None
+                )
             except TracecatNotFoundError:
                 payload["case_trigger"] = None
             except Exception as e:

--- a/tracecat/workflow/case_triggers/schemas.py
+++ b/tracecat/workflow/case_triggers/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -21,6 +22,19 @@ def _dedupe_items[T](items: list[T]) -> list[T]:
         seen.add(item)
         deduped.append(item)
     return deduped
+
+
+def is_case_trigger_configured(
+    *,
+    status: str | None,
+    event_types: Sequence[CaseEventType | str] | None,
+    tag_filters: Sequence[str] | None,
+) -> bool:
+    if status == "online":
+        return True
+    if event_types:
+        return True
+    return any(ref.strip() for ref in tag_filters or [])
 
 
 class CaseTriggerConfig(BaseModel):
@@ -44,6 +58,13 @@ class CaseTriggerConfig(BaseModel):
         if self.status == "online" and not self.event_types:
             raise ValueError("event_types must be non-empty when status is online")
         return self
+
+    def is_configured(self) -> bool:
+        return is_case_trigger_configured(
+            status=self.status,
+            event_types=self.event_types,
+            tag_filters=self.tag_filters,
+        )
 
 
 class CaseTriggerCreate(CaseTriggerConfig):

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -34,8 +34,9 @@ class WorkflowDefinitionsService(BaseWorkspaceService):
                 WorkflowDefinition.workflow_id == workflow_id,
             )
             .options(
-                selectinload(WorkflowDefinition.workflow).selectinload(
-                    Workflow.case_trigger
+                selectinload(WorkflowDefinition.workflow).options(
+                    selectinload(Workflow.case_trigger),
+                    selectinload(Workflow.actions),
                 )
             )
         )

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -844,6 +844,9 @@ class WorkflowsManagementService(BaseWorkspaceService):
         # NOTE: We do not support adding invalid workflows
 
         dsl = external_defn.definition
+        trigger_position, viewport, action_positions = (
+            external_defn.extract_layout_positions()
+        )
         self.logger.trace("Constructed DSL from external definition", dsl=dsl)
         # We need to be able to control:
         # 1. The workspace the workflow is imported into
@@ -859,9 +862,9 @@ class WorkflowsManagementService(BaseWorkspaceService):
             viewport=viewport,
             action_positions=action_positions,
         )
-        if external_defn.case_trigger is not None:
-            from tracecat.workflow.case_triggers.service import CaseTriggersService
-
+        if external_defn.case_trigger is not None and (
+            external_defn.case_trigger.is_configured()
+        ):
             case_trigger_service = CaseTriggersService(self.session, role=self.role)
             await case_trigger_service.upsert_case_trigger(
                 WorkflowUUID.new(workflow.id),

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -844,8 +844,19 @@ class WorkflowsManagementService(BaseWorkspaceService):
         # NOTE: We do not support adding invalid workflows
 
         dsl = external_defn.definition
-        trigger_position, viewport, action_positions = (
+        imported_trigger_position, imported_viewport, imported_action_positions = (
             external_defn.extract_layout_positions()
+        )
+        trigger_position = (
+            trigger_position
+            if trigger_position is not None
+            else imported_trigger_position
+        )
+        viewport = viewport if viewport is not None else imported_viewport
+        action_positions = (
+            action_positions
+            if action_positions is not None
+            else imported_action_positions
         )
         self.logger.trace("Constructed DSL from external definition", dsl=dsl)
         # We need to be able to control:

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -56,6 +56,7 @@ from tracecat.workflow.case_triggers.schemas import (
     CaseTriggerCreate,
     CaseTriggerRead,
     CaseTriggerUpdate,
+    is_case_trigger_configured,
 )
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
@@ -69,6 +70,7 @@ from tracecat.workflow.management.schemas import (
     WorkflowDefinitionReadMinimal,
     WorkflowEntrypointValidationRequest,
     WorkflowEntrypointValidationResponse,
+    WorkflowLayout,
     WorkflowMoveToFolder,
     WorkflowRead,
     WorkflowReadMinimal,
@@ -595,19 +597,26 @@ async def export_workflow(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Cannot export draft: {e}",
             ) from e
-        external_defn = ExternalWorkflowDefinition(
-            workspace_id=workflow.workspace_id,
-            workflow_id=WorkflowUUID.new(workflow.id),
-            definition=dsl,
-            case_trigger=CaseTriggerConfig.model_validate(
+        case_trigger = None
+        if workflow.case_trigger and is_case_trigger_configured(
+            status=workflow.case_trigger.status,
+            event_types=workflow.case_trigger.event_types,
+            tag_filters=workflow.case_trigger.tag_filters,
+        ):
+            case_trigger = CaseTriggerConfig.model_validate(
                 {
                     "status": workflow.case_trigger.status,
                     "event_types": workflow.case_trigger.event_types,
                     "tag_filters": workflow.case_trigger.tag_filters,
                 }
             )
-            if workflow.case_trigger
-            else None,
+
+        external_defn = ExternalWorkflowDefinition(
+            workspace_id=workflow.workspace_id,
+            workflow_id=WorkflowUUID.new(workflow.id),
+            definition=dsl,
+            layout=WorkflowLayout.from_workflow(workflow),
+            case_trigger=case_trigger,
         )
     else:
         # Existing behavior: fetch from WorkflowDefinition

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Literal
@@ -22,7 +23,10 @@ from tracecat.tags.schemas import TagRead
 from tracecat.validation.schemas import ValidationResult
 from tracecat.webhooks.schemas import WebhookRead
 from tracecat.workflow.actions.schemas import ActionRead
-from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
+from tracecat.workflow.case_triggers.schemas import (
+    CaseTriggerConfig,
+    is_case_trigger_configured,
+)
 from tracecat.workflow.schedules.schemas import ScheduleRead
 
 
@@ -204,6 +208,7 @@ class ExternalWorkflowDefinition(BaseModel):
     )
     version: int = Field(default=1, gt=0)
     definition: DSLInput
+    layout: WorkflowLayout | None = None
     case_trigger: CaseTriggerConfig | None = None
 
     @staticmethod
@@ -213,13 +218,19 @@ class ExternalWorkflowDefinition(BaseModel):
         case_trigger: CaseTriggerConfig | None = None,
     ) -> ExternalWorkflowDefinition:
         if case_trigger is None and defn.workflow and defn.workflow.case_trigger:
-            case_trigger = CaseTriggerConfig.model_validate(
-                {
-                    "status": defn.workflow.case_trigger.status,
-                    "event_types": defn.workflow.case_trigger.event_types,
-                    "tag_filters": defn.workflow.case_trigger.tag_filters,
-                }
-            )
+            workflow_case_trigger = defn.workflow.case_trigger
+            if is_case_trigger_configured(
+                status=workflow_case_trigger.status,
+                event_types=workflow_case_trigger.event_types,
+                tag_filters=workflow_case_trigger.tag_filters,
+            ):
+                case_trigger = CaseTriggerConfig.model_validate(
+                    {
+                        "status": workflow_case_trigger.status,
+                        "event_types": workflow_case_trigger.event_types,
+                        "tag_filters": workflow_case_trigger.tag_filters,
+                    }
+                )
         return ExternalWorkflowDefinition(
             workspace_id=defn.workspace_id,
             workflow_id=WorkflowUUID.new(defn.workflow_id),
@@ -227,6 +238,9 @@ class ExternalWorkflowDefinition(BaseModel):
             updated_at=defn.updated_at,
             version=defn.version,
             definition=DSLInput.model_validate(defn.content),
+            layout=WorkflowLayout.from_workflow(defn.workflow)
+            if defn.workflow
+            else None,
             case_trigger=case_trigger,
         )
 
@@ -237,6 +251,117 @@ class ExternalWorkflowDefinition(BaseModel):
         if v is None:
             return None
         return WorkflowUUID.new(v)
+
+    def extract_layout_positions(
+        self,
+    ) -> tuple[
+        tuple[float, float] | None,
+        tuple[float, float, float] | None,
+        dict[str, tuple[float, float]] | None,
+    ]:
+        if self.layout is None:
+            return None, None, None
+        return self.layout.extract_positions()
+
+
+class WorkflowLayoutPosition(BaseModel):
+    x: float | None = None
+    y: float | None = None
+    position: dict[str, float] | None = None
+
+    @field_validator("position")
+    @classmethod
+    def validate_position(
+        cls, value: dict[str, float] | None
+    ) -> dict[str, float] | None:
+        if value is None:
+            return None
+        return {
+            key: coordinate for key, coordinate in value.items() if key in {"x", "y"}
+        }
+
+    @field_validator("x", "y", mode="before")
+    @classmethod
+    def coerce_coordinate(cls, value: Any) -> float | None:
+        if value is None:
+            return None
+        return float(value)
+
+    def resolved(self) -> tuple[float, float]:
+        x = self.x
+        y = self.y
+        if self.position is not None:
+            if x is None:
+                x = self.position.get("x")
+            if y is None:
+                y = self.position.get("y")
+        return (x if x is not None else 0.0, y if y is not None else 0.0)
+
+
+class WorkflowLayoutViewport(BaseModel):
+    x: float | None = None
+    y: float | None = None
+    zoom: float | None = None
+
+
+class WorkflowLayoutActionPosition(WorkflowLayoutPosition):
+    ref: str
+
+
+class WorkflowLayout(BaseModel):
+    trigger: WorkflowLayoutPosition | None = None
+    viewport: WorkflowLayoutViewport | None = None
+    actions: list[WorkflowLayoutActionPosition] = Field(default_factory=list)
+
+    @classmethod
+    def from_workflow(cls, workflow: Workflow) -> WorkflowLayout:
+        return cls(
+            trigger=WorkflowLayoutPosition(
+                x=workflow.trigger_position_x,
+                y=workflow.trigger_position_y,
+            ),
+            viewport=WorkflowLayoutViewport(
+                x=workflow.viewport_x,
+                y=workflow.viewport_y,
+                zoom=workflow.viewport_zoom,
+            ),
+            actions=[
+                WorkflowLayoutActionPosition(
+                    ref=action.ref,
+                    x=action.position_x,
+                    y=action.position_y,
+                )
+                for action in _iter_sorted_actions(workflow.actions or [])
+            ],
+        )
+
+    def extract_positions(
+        self,
+    ) -> tuple[
+        tuple[float, float] | None,
+        tuple[float, float, float] | None,
+        dict[str, tuple[float, float]] | None,
+    ]:
+        trigger_position = self.trigger.resolved() if self.trigger is not None else None
+        viewport = (
+            (
+                self.viewport.x if self.viewport.x is not None else 0.0,
+                self.viewport.y if self.viewport.y is not None else 0.0,
+                self.viewport.zoom if self.viewport.zoom is not None else 1.0,
+            )
+            if self.viewport is not None
+            else None
+        )
+        action_positions = (
+            {action.ref: action.resolved() for action in self.actions}
+            if self.actions
+            else None
+        )
+        return trigger_position, viewport, action_positions
+
+
+def _iter_sorted_actions(actions: Iterable[Any]) -> list[Any]:
+    return sorted(actions, key=lambda action: action.ref)
 
 
 class WorkflowCommitResponse(BaseModel):

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -15,10 +15,7 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import PullDiagnostic, PullResult
-from tracecat.workflow.case_triggers.schemas import (
-    CaseTriggerConfig,
-    is_case_trigger_configured,
-)
+from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.folders.service import WorkflowFolderService
@@ -434,14 +431,8 @@ class WorkflowImportService(BaseWorkspaceService):
     ) -> None:
         if not remote_case_trigger:
             return
-        if not is_case_trigger_configured(
-            status=remote_case_trigger.status,
-            event_types=remote_case_trigger.event_types,
-            tag_filters=remote_case_trigger.tag_filters,
-        ):
-            return
         service = CaseTriggersService(session=self.session, role=self.role)
-        config = CaseTriggerConfig.model_validate(remote_case_trigger)
+        config = CaseTriggerConfig.model_validate(remote_case_trigger.model_dump())
         await service.upsert_case_trigger(
             WorkflowUUID.new(workflow.id),
             config,

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -15,7 +15,10 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import PullDiagnostic, PullResult
-from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
+from tracecat.workflow.case_triggers.schemas import (
+    CaseTriggerConfig,
+    is_case_trigger_configured,
+)
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.folders.service import WorkflowFolderService
@@ -430,6 +433,12 @@ class WorkflowImportService(BaseWorkspaceService):
         self, workflow: Workflow, remote_case_trigger: RemoteCaseTrigger | None
     ) -> None:
         if not remote_case_trigger:
+            return
+        if not is_case_trigger_configured(
+            status=remote_case_trigger.status,
+            event_types=remote_case_trigger.event_types,
+            tag_filters=remote_case_trigger.tag_filters,
+        ):
             return
         service = CaseTriggersService(session=self.session, role=self.role)
         config = CaseTriggerConfig.model_validate(remote_case_trigger)

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -15,7 +15,10 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import PullDiagnostic, PullResult
-from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
+from tracecat.workflow.case_triggers.schemas import (
+    CaseTriggerConfig,
+    is_case_trigger_configured,
+)
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.folders.service import WorkflowFolderService
@@ -429,7 +432,15 @@ class WorkflowImportService(BaseWorkspaceService):
     async def _update_case_trigger(
         self, workflow: Workflow, remote_case_trigger: RemoteCaseTrigger | None
     ) -> None:
-        if not remote_case_trigger:
+        if remote_case_trigger is None:
+            await self._clear_case_trigger(workflow)
+            return
+        if not is_case_trigger_configured(
+            status=remote_case_trigger.status,
+            event_types=remote_case_trigger.event_types,
+            tag_filters=remote_case_trigger.tag_filters,
+        ):
+            await self._clear_case_trigger(workflow)
             return
         service = CaseTriggersService(session=self.session, role=self.role)
         config = CaseTriggerConfig.model_validate(remote_case_trigger.model_dump())
@@ -439,6 +450,21 @@ class WorkflowImportService(BaseWorkspaceService):
             create_missing_tags=True,
             commit=False,
         )
+
+    async def _clear_case_trigger(self, workflow: Workflow) -> None:
+        await self.session.refresh(workflow, ["case_trigger"])
+        case_trigger = workflow.case_trigger
+        if case_trigger is None:
+            case_trigger = await CaseTriggersService(
+                session=self.session, role=self.role
+            )._ensure_case_trigger_exists(WorkflowUUID.new(workflow.id), commit=False)
+            workflow.case_trigger = case_trigger
+
+        case_trigger.status = "offline"
+        case_trigger.event_types = []
+        case_trigger.tag_filters = []
+        self.session.add(case_trigger)
+        await self.session.flush()
 
     async def _update_tags(
         self, workflow: Workflow, remote_tags: list[RemoteWorkflowTag] | None = None

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -11,7 +11,6 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import Author, PushObject, PushOptions, PushStatus
-from tracecat.workflow.case_triggers.schemas import is_case_trigger_configured
 from tracecat.workflow.store.schemas import (
     RemoteCaseTrigger,
     RemoteWebhook,
@@ -90,21 +89,6 @@ class WorkflowStoreService(BaseWorkspaceService):
             folder_path = workflow.folder.path
 
         # Create PushObject with data and stable path
-        case_trigger = None
-        if workflow.case_trigger and is_case_trigger_configured(
-            status=workflow.case_trigger.status,
-            event_types=workflow.case_trigger.event_types,
-            tag_filters=workflow.case_trigger.tag_filters,
-        ):
-            case_trigger = RemoteCaseTrigger(
-                status=cast(Status, workflow.case_trigger.status),
-                event_types=[
-                    CaseEventType(event_type)
-                    for event_type in workflow.case_trigger.event_types
-                ],
-                tag_filters=workflow.case_trigger.tag_filters,
-            )
-
         defn = RemoteWorkflowDefinition(
             id=workflow_id.short(),
             alias=workflow.alias,
@@ -127,7 +111,22 @@ class WorkflowStoreService(BaseWorkspaceService):
                 methods=webhook.methods,
                 status=cast(Status, webhook.status),
             ),
-            case_trigger=case_trigger,
+            case_trigger=RemoteCaseTrigger(
+                status=cast(Status, workflow.case_trigger.status)
+                if workflow.case_trigger
+                else "offline",
+                event_types=[
+                    CaseEventType(event_type)
+                    for event_type in workflow.case_trigger.event_types
+                ]
+                if workflow.case_trigger
+                else [],
+                tag_filters=workflow.case_trigger.tag_filters
+                if workflow.case_trigger
+                else [],
+            )
+            if workflow.case_trigger
+            else None,
             definition=dsl,
         )
         push_obj = PushObject(data=defn, path=stable_path)

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -11,6 +11,7 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import Author, PushObject, PushOptions, PushStatus
+from tracecat.workflow.case_triggers.schemas import is_case_trigger_configured
 from tracecat.workflow.store.schemas import (
     RemoteCaseTrigger,
     RemoteWebhook,
@@ -89,6 +90,21 @@ class WorkflowStoreService(BaseWorkspaceService):
             folder_path = workflow.folder.path
 
         # Create PushObject with data and stable path
+        case_trigger = None
+        if workflow.case_trigger and is_case_trigger_configured(
+            status=workflow.case_trigger.status,
+            event_types=workflow.case_trigger.event_types,
+            tag_filters=workflow.case_trigger.tag_filters,
+        ):
+            case_trigger = RemoteCaseTrigger(
+                status=cast(Status, workflow.case_trigger.status),
+                event_types=[
+                    CaseEventType(event_type)
+                    for event_type in workflow.case_trigger.event_types
+                ],
+                tag_filters=workflow.case_trigger.tag_filters,
+            )
+
         defn = RemoteWorkflowDefinition(
             id=workflow_id.short(),
             alias=workflow.alias,
@@ -111,22 +127,7 @@ class WorkflowStoreService(BaseWorkspaceService):
                 methods=webhook.methods,
                 status=cast(Status, webhook.status),
             ),
-            case_trigger=RemoteCaseTrigger(
-                status=cast(Status, workflow.case_trigger.status)
-                if workflow.case_trigger
-                else "offline",
-                event_types=[
-                    CaseEventType(event_type)
-                    for event_type in workflow.case_trigger.event_types
-                ]
-                if workflow.case_trigger
-                else [],
-                tag_filters=workflow.case_trigger.tag_filters
-                if workflow.case_trigger
-                else [],
-            )
-            if workflow.case_trigger
-            else None,
+            case_trigger=case_trigger,
             definition=dsl,
         )
         push_obj = PushObject(data=defn, path=stable_path)


### PR DESCRIPTION
## Summary

This PR fixes two workflow export/import regressions and adds a clearer warning on the admin tiers page.

First, workflow exports were serializing an inert `case_trigger` block even when no case trigger was actually configured. In OSS deployments that do not have the `case_addons` entitlement, importing that export attempted to upsert the case trigger anyway, which returned a 403 and made the import modal look like it failed even though the workflow itself had been created.

Second, workflow file exports did not include canvas layout data. Imports rebuilt the workflow definition but lost the trigger position, viewport, and action coordinates, so imported workflows appeared jumbled in the top-left of the builder.

## Root cause

The `case_trigger` regression came from the workflow model always having a default offline case trigger row. Export treated the presence of that row as a real configuration and serialized it. Import then treated any `case_trigger` payload as actionable.

The layout regression existed because the external workflow interchange format only carried the DSL and optional case trigger data. The file import path already supported applying layout tuples internally, but the export format never emitted layout and the file import path never derived positions from the uploaded payload.

## Fix

The workflow export/import path now distinguishes between a real case trigger configuration and the inert default placeholder. Exports omit the placeholder block, and import skips legacy inert case trigger payloads instead of hitting the entitlement-gated case trigger service.

The external workflow definition now includes a `layout` section containing trigger coordinates, viewport state, and per-action positions. Export populates that section from the persisted workflow graph, and file import extracts those positions and passes them into workflow creation so imported workflows retain their original layout.

For consistency, the MCP workflow export path also omits inert case trigger payloads.

The admin tiers page now includes a shadcn alert making it explicit that the settings on that page are Enterprise-only and will be gated by a license key in a future release.

## Validation

I validated the changes with the following checks:

- `uv run ruff check --fix ...`
- `uv run ruff format --check ...`
- `uv run basedpyright --warnings --threads 4 ...`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_export.py tests/unit/test_workflow_import_service.py -q`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_export.py tests/unit/api/test_api_workflows.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow export/import to treat unconfigured case triggers as absent, adds layout to exports, and updates repo sync to clear or omit inert triggers to avoid entitlement errors. Also adds an Enterprise-only notice to the Admin Tiers page.

- **Bug Fixes**
  - Case triggers: Exports and repo publish omit inert triggers; MCP/API return case_trigger: null when not configured.
  - Import/sync: Skip upserting unconfigured triggers and clear local triggers to offline when the remote block is missing or inert.
  - Layout: Export includes trigger, viewport, and per-action positions; import applies them and prefers explicit overrides.

- **New Features**
  - Warning alert on Admin → Tiers stating these settings are Enterprise-only and will require a license key.

<sup>Written for commit a41593764dbb9ce435a61d49c5d63b8894b277fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

