### PR TITLE
ci: add API governance for OpenAPI spec changes

### DIFF
--- a/.github/workflows/api-governance.yml
+++ b/.github/workflows/api-governance.yml
@@ -1,0 +1,39 @@
+name: API Governance
+on:
+  pull_request:
+    paths:
+      - 'docs/openapi.yml'
+      - '**/*.py'
+
+jobs:
+  api-governance:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+
+      - name: Checkout base branch spec
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: _base
+
+      - name: Check for spec changes
+        id: check
+        run: |
+          if [ -f "docs/openapi.yml" ] && [ -f "_base/docs/openapi.yml" ]; then
+            echo "old_spec=_base/docs/openapi.yml" >> "$GITHUB_OUTPUT"
+            echo "new_spec=docs/openapi.yml" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      - name: Delimit — Lint API changes
+        if: steps.check.outputs.skip != 'true'
+        uses: delimit-ai/delimit@v1
+        with:
+          old_spec: ${{ steps.check.outputs.old_spec }}
+          new_spec: ${{ steps.check.outputs.new_spec }}
+          mode: advisory


### PR DESCRIPTION
## Add API governance to CI

Adds a GitHub Actions workflow that automatically detects breaking API changes on pull requests that modify `docs/openapi.yml`.

### What it does
- Compares the OpenAPI spec on the PR branch against the base branch
- Comments on PRs with a summary: semver classification, breaking changes, migration guide
- Runs in **advisory mode** (non-blocking) — will never fail your CI
- Only triggers when `docs/openapi.yml` or Python source files change

### Why
API breaking changes are the #1 cause of downstream integration failures. With a 249KB OpenAPI spec and active development, this catches regressions before merge — zero configuration needed.

### Details
- Uses [Delimit](https://github.com/marketplace/actions/delimit-api-governance) (open-source, MIT)
- Single workflow file, no dependencies to install
- Non-blocking — purely informational PR comments

Happy to adjust the configuration if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an API governance CI workflow that checks OpenAPI spec changes on pull requests and comments with breaking-change analysis. Runs in advisory mode, so CI never fails.

- **New Features**
  - Compares `docs/openapi.yml` on the PR to the base branch to detect breaking changes.
  - Posts a PR comment with semver classification and migration notes.
  - Triggers only when `docs/openapi.yml` or `**/*.py` files change.
  - Uses `delimit-ai/delimit@v1`; single workflow file, no new runtime dependencies.

<sup>Written for commit 4d6fe6a70f705ce9d5114df7c6166bf89a30ff4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

