### PR TITLE
refactor(mcp): replace metadata app patch with route override

### DIFF
--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -19,19 +19,20 @@ from fastmcp.server.dependencies import get_access_token
 from key_value.aio.stores.redis import RedisStore
 from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 from key_value.aio.wrappers.prefix_collections import PrefixCollectionsWrapper
+from mcp.server.auth.handlers.metadata import MetadataHandler
 from mcp.server.auth.provider import (
     AuthorizationParams,
     TokenError,
 )
+from mcp.server.auth.routes import build_metadata, cors_middleware
+from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import BaseModel, Field
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy import select
-from starlette.datastructures import MutableHeaders
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
 from starlette.routing import Route
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from tracecat import config
 from tracecat.auth.credentials import compute_effective_scopes
@@ -103,52 +104,6 @@ def supports_refresh_scope(scopes_supported: Sequence[str] | None) -> bool:
         # If provider metadata omits scopes_supported, optimistically request.
         return True
     return _MCP_REFRESH_SCOPE in scopes_supported
-
-
-def _patch_oauth_metadata_route(app: ASGIApp) -> ASGIApp:
-    """Patch only the advertised token auth methods on discovery responses."""
-
-    async def patched_app(scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
-            await app(scope, receive, send)
-            return
-
-        start_message: Message | None = None
-        body_chunks: list[bytes] = []
-
-        async def capture(message: Message) -> None:
-            nonlocal start_message
-
-            match message["type"]:
-                case "http.response.start":
-                    start_message = dict(message)
-                case "http.response.body":
-                    body_chunks.append(message.get("body", b""))
-                case _:
-                    await send(message)
-
-        await app(scope, receive, capture)
-
-        if start_message is None:
-            return
-
-        body = b"".join(body_chunks)
-        try:
-            payload = json.loads(body)
-        except json.JSONDecodeError:
-            payload = None
-        if isinstance(payload, dict):
-            payload["token_endpoint_auth_methods_supported"] = (
-                _MCP_TOKEN_ENDPOINT_AUTH_METHODS
-            )
-            body = json.dumps(payload).encode("utf-8")
-
-        headers = MutableHeaders(raw=start_message["headers"])
-        headers["content-length"] = str(len(body))
-        await send(start_message)
-        await send({"type": "http.response.body", "body": body, "more_body": False})
-
-    return patched_app
 
 
 def _coerce_uuid(value: object) -> uuid.UUID | None:
@@ -749,21 +704,52 @@ def create_mcp_auth() -> AuthProvider:
             return response
 
         def get_routes(self, mcp_path: str | None = None) -> list[Route]:
-            """Patch OAuth metadata to advertise public-client auth (``"none"``)."""
+            """Replace OAuth metadata to advertise public-client auth."""
             routes = super().get_routes(mcp_path)
             if self.base_url is None:
                 return routes
 
+            custom_routes: list[Route] = []
             for route in routes:
                 if not (
                     isinstance(route, Route)
                     and route.path.startswith("/.well-known/oauth-authorization-server")
                 ):
+                    custom_routes.append(route)
                     continue
 
-                route.app = _patch_oauth_metadata_route(route.app)
+                # FastMCP builds this metadata via the SDK helper, which hardcodes
+                # only secret-based auth methods even though OAuthProxy registers
+                # MCP clients as public clients with token_endpoint_auth_method="none".
+                client_registration_options = (
+                    self.client_registration_options or ClientRegistrationOptions()
+                )
+                revocation_options = self.revocation_options or RevocationOptions()
+                metadata = build_metadata(
+                    self.base_url,
+                    self.service_documentation_url,
+                    client_registration_options,
+                    revocation_options,
+                )
+                metadata.token_endpoint_auth_methods_supported = (
+                    _MCP_TOKEN_ENDPOINT_AUTH_METHODS
+                )
+                handler = MetadataHandler(metadata)
+                methods = route.methods or ["GET", "OPTIONS"]
 
-            return routes
+                # Replace the route object directly instead of wrapping the ASGI app
+                # so the behavior stays aligned with FastMCP's own route overrides.
+                custom_routes.append(
+                    Route(
+                        path=route.path,
+                        endpoint=cors_middleware(handler.handle, ["GET", "OPTIONS"]),
+                        methods=methods,
+                        name=route.name,
+                        include_in_schema=route.include_in_schema,
+                    )
+                )
+
+            return custom_routes
 
     # Build Redis-backed storage for OAuth state (client registrations,
     # auth codes, tokens, transactions) so state survives restarts and


### PR DESCRIPTION
## Summary
- replace the OAuth metadata ASGI response patch with a route-level metadata override in `TracecatOIDCProxy`
- rebuild the discovery route with `MetadataHandler` so `token_endpoint_auth_methods_supported` correctly advertises public-client auth
- add inline comments documenting why the route replacement is needed

## Verification
- `uv run ruff check tracecat/mcp/auth.py`
- `uv run basedpyright tracecat/mcp/auth.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the ASGI response patch for OAuth discovery with a route-level override to rebuild metadata and correctly advertise public-client auth (`token_endpoint_auth_methods_supported` includes `none`). This aligns with FastMCP’s route override pattern and removes brittle response manipulation.

- **Refactors**
  - Swap the metadata patch with a direct route replacement in `TracecatOIDCProxy.get_routes` for `/.well-known/oauth-authorization-server`.
  - Build metadata via `build_metadata` and serve it with `MetadataHandler` wrapped by `cors_middleware`.
  - Explicitly set `token_endpoint_auth_methods_supported` to `_MCP_TOKEN_ENDPOINT_AUTH_METHODS` to include public-client auth.
  - Removed the `_patch_oauth_metadata_route` ASGI wrapper and added inline comments explaining the change.

<sup>Written for commit 1daedab935f6333f24a2dfff429a9537819f5224. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

