### PR TITLE
fix: Cascade workspace membership deletes

### DIFF
--- a/alembic/versions/cd84c08340a5_add_cascade_delete_to_membership_.py
+++ b/alembic/versions/cd84c08340a5_add_cascade_delete_to_membership_.py
@@ -1,0 +1,48 @@
+"""add cascade delete to membership workspace fk.
+
+Revision ID: cd84c08340a5
+Revises: 6171727be56a
+Create Date: 2026-03-11 13:50:36.124118
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "cd84c08340a5"
+down_revision: str | None = "6171727be56a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "fk_membership_workspace_id_workspace",
+        "membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("fk_membership_workspace_id_workspace"),
+        "membership",
+        "workspace",
+        ["workspace_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_membership_workspace_id_workspace"),
+        "membership",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_membership_workspace_id_workspace",
+        "membership",
+        "workspace",
+        ["workspace_id"],
+        ["id"],
+    )

--- a/tests/integration/test_syncv2_execv2_e2e.py
+++ b/tests/integration/test_syncv2_execv2_e2e.py
@@ -276,7 +276,8 @@ async def test_bucket(minio_client: Minio, mock_org_id: uuid.UUID):
         if not minio_client.bucket_exists(bucket_name):
             minio_client.make_bucket(bucket_name)
     except S3Error as e:
-        pytest.fail(f"Failed to ensure test MinIO bucket '{bucket_name}': {e}")
+        if e.code not in {"BucketAlreadyOwnedByYou", "BucketAlreadyExists"}:
+            pytest.fail(f"Failed to ensure test MinIO bucket '{bucket_name}': {e}")
 
     yield bucket_name
 

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -94,6 +94,66 @@ class TestWorkspaceService:
         # Verify settings are preserved through validation
         assert workspace.settings is not None
 
+    async def test_delete_workspace_removes_memberships(
+        self,
+        session: AsyncSession,
+        svc_organization: Organization,
+    ) -> None:
+        """Deleting a workspace should cascade to membership rows."""
+        workspace = Workspace(
+            name="test-workspace",
+            organization_id=svc_organization.id,
+        )
+        other_workspace = Workspace(
+            name="other-workspace",
+            organization_id=svc_organization.id,
+        )
+        member = User(
+            id=uuid.uuid4(),
+            email=f"member-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="hashed",
+            role=UserRole.BASIC,
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        session.add_all([workspace, other_workspace, member])
+        await session.flush()
+
+        session.add(
+            Membership(
+                user_id=member.id,
+                workspace_id=workspace.id,
+            )
+        )
+        await session.commit()
+
+        service = WorkspaceService(
+            session=session,
+            role=Role(
+                type="user",
+                workspace_id=workspace.id,
+                organization_id=svc_organization.id,
+                user_id=uuid.uuid4(),
+                service_id="tracecat-api",
+                scopes=ADMIN_SCOPES,
+            ),
+        )
+        await service.delete_workspace(workspace.id)
+
+        membership = await session.scalar(
+            select(Membership).where(
+                Membership.workspace_id == workspace.id,
+                Membership.user_id == member.id,
+            )
+        )
+        deleted_workspace = await session.scalar(
+            select(Workspace).where(Workspace.id == workspace.id)
+        )
+
+        assert membership is None
+        assert deleted_workspace is None
+
 
 @pytest.mark.parametrize(
     "valid_url",

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -350,7 +350,7 @@ class Membership(Base):
     )
     workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
-        ForeignKey("workspace.id"),
+        ForeignKey("workspace.id", ondelete="CASCADE"),
         primary_key=True,
     )
 


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes workspace deletion when `membership` rows still exist by adding `ON DELETE CASCADE` to `membership.workspace_id`.

It also adds a regression test for deleting a workspace with an existing membership and includes an Alembic migration for the foreign key change.

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Run `uv run pytest tests/unit/test_workspace_service.py -k delete_workspace_removes_memberships`.
2. Run `uv run pytest tests/unit/test_invitation.py -k workspace_invitation_cascade_delete`.
3. Delete a workspace that still has memberships and confirm the delete succeeds without manually removing memberships first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cascade workspace deletes to related `membership` rows so deleting a workspace no longer fails when members exist. Also fixes a MinIO integration test race when creating buckets; includes a DB migration and a regression test.

- **Bug Fixes**
  - Workspace deletion cascades `membership` via FK `ondelete="CASCADE"`; regression test added.
  - MinIO test tolerates "BucketAlreadyOwnedByYou"/"BucketAlreadyExists" to prevent flakes.

<sup>Written for commit 9323f8c62f528ebf52719f38bb9e42de8b3ad8af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

