### PR TITLE
feat(mcp): create preset agents via mcp

### DIFF
--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -286,3 +287,158 @@ async def test_list_workspaces_for_request_without_claimed_org_ids(
 
     assert captured["email"] == "user@example.com"
     assert captured["organization_ids"] is None
+
+
+@pytest.mark.anyio
+async def test_resolve_role_allows_superuser_without_org_membership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+
+    async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
+        return SimpleNamespace(id=user_id, is_superuser=True)
+
+    async def _resolve_workspace_org(_workspace_id: uuid.UUID) -> uuid.UUID:
+        assert _workspace_id == workspace_id
+        return organization_id
+
+    async def _compute_effective_scopes(_role) -> frozenset[str]:
+        return frozenset({"*"})
+
+    async def _resolve_workspace_membership(
+        _user_id: uuid.UUID, _workspace_id: uuid.UUID
+    ) -> None:
+        raise AssertionError("superusers should not require workspace membership")
+
+    monkeypatch.setattr(mcp_auth, "resolve_user_by_email", _resolve_user_by_email)
+    monkeypatch.setattr(mcp_auth, "resolve_workspace_org", _resolve_workspace_org)
+    monkeypatch.setattr(mcp_auth, "compute_effective_scopes", _compute_effective_scopes)
+    monkeypatch.setattr(
+        mcp_auth,
+        "resolve_workspace_membership",
+        _resolve_workspace_membership,
+    )
+
+    role = await mcp_auth.resolve_role("user@example.com", workspace_id)
+
+    assert role.user_id == user_id
+    assert role.workspace_id == workspace_id
+    assert role.organization_id == organization_id
+    assert role.scopes == frozenset({"*"})
+
+
+@pytest.mark.anyio
+async def test_resolve_role_allows_direct_workspace_membership_without_org_membership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    captured: dict[str, object] = {}
+
+    async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
+        return SimpleNamespace(id=user_id, is_superuser=False)
+
+    async def _resolve_workspace_org(_workspace_id: uuid.UUID) -> uuid.UUID:
+        return organization_id
+
+    async def _compute_effective_scopes(_role) -> frozenset[str]:
+        return frozenset()
+
+    async def _resolve_workspace_membership(
+        user_id_arg: uuid.UUID, workspace_id_arg: uuid.UUID
+    ) -> None:
+        captured["user_id"] = user_id_arg
+        captured["workspace_id"] = workspace_id_arg
+
+    monkeypatch.setattr(mcp_auth, "resolve_user_by_email", _resolve_user_by_email)
+    monkeypatch.setattr(mcp_auth, "resolve_workspace_org", _resolve_workspace_org)
+    monkeypatch.setattr(mcp_auth, "compute_effective_scopes", _compute_effective_scopes)
+    monkeypatch.setattr(
+        mcp_auth,
+        "resolve_workspace_membership",
+        _resolve_workspace_membership,
+    )
+
+    role = await mcp_auth.resolve_role("user@example.com", workspace_id)
+
+    assert captured == {"user_id": user_id, "workspace_id": workspace_id}
+    assert role.organization_id == organization_id
+    assert role.workspace_id == workspace_id
+    assert role.scopes == frozenset()
+
+
+@pytest.mark.anyio
+async def test_list_user_workspaces_includes_direct_memberships_without_org_membership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+
+    class _ScalarResult:
+        def __init__(self, values: list[uuid.UUID]) -> None:
+            self._values = values
+
+        def all(self) -> list[uuid.UUID]:
+            return self._values
+
+    class _TupleResult:
+        def __init__(self, values: list[tuple[uuid.UUID, str]]) -> None:
+            self._values = values
+
+        def all(self) -> list[tuple[uuid.UUID, str]]:
+            return self._values
+
+    class _Result:
+        def __init__(
+            self,
+            *,
+            scalars: list[uuid.UUID] | None = None,
+            tuples: list[tuple[uuid.UUID, str]] | None = None,
+        ) -> None:
+            self._scalars = scalars or []
+            self._tuples = tuples or []
+
+        def scalars(self) -> _ScalarResult:
+            return _ScalarResult(self._scalars)
+
+        def tuples(self) -> _TupleResult:
+            return _TupleResult(self._tuples)
+
+    class _Session:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        async def execute(self, _stmt):
+            self._calls += 1
+            if self._calls == 1:
+                return _Result(scalars=[])
+            if self._calls == 2:
+                return _Result(tuples=[(workspace_id, "Workspace A")])
+            raise AssertionError("unexpected extra query")
+
+    class _AsyncContext:
+        def __init__(self, session: _Session) -> None:
+            self._session = session
+
+        async def __aenter__(self) -> _Session:
+            return self._session
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
+        return SimpleNamespace(id=user_id, is_superuser=False)
+
+    monkeypatch.setattr(mcp_auth, "resolve_user_by_email", _resolve_user_by_email)
+    monkeypatch.setattr(
+        mcp_auth,
+        "get_async_session_context_manager",
+        lambda: _AsyncContext(_Session()),
+    )
+
+    workspaces = await mcp_auth.list_user_workspaces("user@example.com")
+
+    assert workspaces == [{"id": str(workspace_id), "name": "Workspace A"}]

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2135,11 +2135,19 @@ async def test_list_integrations_returns_mcp_and_provider_inventory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workspace_id = uuid.uuid4()
-    role = SimpleNamespace(workspace_id=workspace_id)
+    current_user_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id, user_id=current_user_id)
     oauth_integration = SimpleNamespace(
         provider_id="slack",
         grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        user_id=current_user_id,
         status=SimpleNamespace(value="connected"),
+    )
+    other_user_integration = SimpleNamespace(
+        provider_id="slack",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        user_id=uuid.uuid4(),
+        status=SimpleNamespace(value="configured"),
     )
     mcp_integration_id = uuid.uuid4()
     mcp_integration = SimpleNamespace(
@@ -2174,7 +2182,7 @@ async def test_list_integrations_returns_mcp_and_provider_inventory(
 
     class _IntegrationService:
         async def list_integrations(self):
-            return [oauth_integration]
+            return [other_user_integration, oauth_integration]
 
         async def list_mcp_integrations(self):
             return [mcp_integration]
@@ -2277,6 +2285,13 @@ async def test_get_agent_preset_authoring_context_includes_output_type_guidance(
     payload = _payload(result)
     assert payload["default_model"] == "gpt-4o-mini"
     assert payload["models"][0]["provider"] == "openai"
+    assert payload["agent_credentials"]["providers"][0]["provider"] == "openai"
+    assert payload["agent_credentials"]["providers"][0]["configured_org"] is True
+    assert payload["agent_credentials"]["providers"][0]["configured_workspace"] is False
+    assert (
+        payload["agent_credentials"]["providers"][0]["ready_for_agent_presets"] is False
+    )
+    assert payload["agent_credentials"]["default_model_workspace_ready"] is False
     assert payload["workspace_variables"][0]["name"] == "splunk"
     assert payload["workspace_secret_hints"][0]["name"] == "slack"
     assert "str" in payload["output_type_context"]["supported_literals"]
@@ -2302,6 +2317,10 @@ async def test_create_agent_preset_uses_default_model_and_passes_optional_fields
         async def get_model_config(self, model_name: str) -> SimpleNamespace:
             assert model_name == "gpt-4o-mini"
             return SimpleNamespace(name="gpt-4o-mini", provider="openai")
+
+        async def check_workspace_provider_credentials(self, provider: str) -> bool:
+            assert provider == "openai"
+            return True
 
     class _PresetService:
         async def create_preset(self, params: Any) -> SimpleNamespace:
@@ -2379,6 +2398,9 @@ async def test_create_agent_preset_requires_default_model_when_model_not_provide
         async def get_default_model(self) -> str | None:
             return None
 
+        async def check_workspace_provider_credentials(self, provider: str) -> bool:
+            return True
+
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     monkeypatch.setattr(
         mcp_server.AgentManagementService,
@@ -2411,6 +2433,10 @@ async def test_create_agent_preset_omitted_retry_fields_use_schema_defaults(
         async def get_model_config(self, model_name: str) -> SimpleNamespace:
             assert model_name == "gpt-4o-mini"
             return SimpleNamespace(name="gpt-4o-mini", provider="openai")
+
+        async def check_workspace_provider_credentials(self, provider: str) -> bool:
+            assert provider == "openai"
+            return True
 
     class _PresetService:
         async def create_preset(self, params: Any) -> SimpleNamespace:
@@ -2461,6 +2487,80 @@ async def test_create_agent_preset_omitted_retry_fields_use_schema_defaults(
     assert params.enable_internet_access is False
     assert payload["retries"] == 3
     assert payload["enable_internet_access"] is False
+
+
+@pytest.mark.anyio
+async def test_create_agent_preset_validates_explicit_model_provider_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _AgentManagementService:
+        async def get_model_config(self, model_name: str) -> SimpleNamespace:
+            assert model_name == "gpt-4o-mini"
+            return SimpleNamespace(name="gpt-4o-mini", provider="openai")
+
+        async def check_workspace_provider_credentials(self, provider: str) -> bool:
+            assert provider == "openai"
+            return True
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentManagementService,
+        "with_session",
+        lambda role: _AsyncContext(_AgentManagementService()),
+    )
+
+    with pytest.raises(ToolError, match="belongs to provider 'openai', not 'opneai'"):
+        await _tool(mcp_server.create_agent_preset)(
+            workspace_id=str(workspace_id),
+            name="Security triage",
+            model_name="gpt-4o-mini",
+            model_provider="opneai",
+        )
+
+
+@pytest.mark.anyio
+async def test_create_agent_preset_requires_workspace_credentials_for_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _AgentManagementService:
+        async def get_default_model(self) -> str | None:
+            return "gpt-4o-mini"
+
+        async def get_model_config(self, model_name: str) -> SimpleNamespace:
+            assert model_name == "gpt-4o-mini"
+            return SimpleNamespace(name="gpt-4o-mini", provider="openai")
+
+        async def check_workspace_provider_credentials(self, provider: str) -> bool:
+            assert provider == "openai"
+            return False
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentManagementService,
+        "with_session",
+        lambda role: _AsyncContext(_AgentManagementService()),
+    )
+
+    with pytest.raises(
+        ToolError,
+        match="Workspace credentials for provider 'openai' are not configured",
+    ):
+        await _tool(mcp_server.create_agent_preset)(
+            workspace_id=str(workspace_id),
+            name="Security triage",
+        )
 
 
 def test_mcp_instructions_include_agent_preset_authoring_tools() -> None:

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -804,19 +804,14 @@ async def resolve_workspace_membership(
 async def resolve_role(email: str, workspace_id: WorkspaceID) -> Role:
     """Resolve a user's Role for a given workspace from their OAuth email.
 
-    Pipeline: email -> User -> Workspace.organization_id -> OrganizationMembership -> Membership -> Role
-
-    The workspace's owning organization is resolved first, then the user's
-    membership in *that* organization is checked. This prevents an admin in
-    org A from gaining access to a workspace belonging to org B.
+    Pipeline: email -> User -> Workspace.organization_id -> scopes/membership -> Role
 
     Org admins/owners (users with ``org:workspace:read`` scope) bypass the
     workspace-level membership check, matching the behaviour of the main API.
+    Platform superusers also bypass direct membership checks.
     """
     user = await resolve_user_by_email(email)
     org_id = await resolve_workspace_org(workspace_id)
-    # Validate the user belongs to the organization (raises on missing membership)
-    await resolve_org_membership(user.id, org_id)
 
     # Compute scopes early so we can check for org-level workspace access
     role = Role(
@@ -829,8 +824,8 @@ async def resolve_role(email: str, workspace_id: WorkspaceID) -> Role:
     )
     scopes = await compute_effective_scopes(role)
 
-    # Org admins/owners can access any workspace in their org
-    if not has_scope(scopes, "org:workspace:read"):
+    # Platform superusers and org admins/owners can access any workspace.
+    if not user.is_superuser and not has_scope(scopes, "org:workspace:read"):
         await resolve_workspace_membership(user.id, workspace_id)
 
     role = role.model_copy(update={"scopes": scopes})
@@ -853,6 +848,25 @@ async def list_user_workspaces(
     user = await resolve_user_by_email(email)
 
     async with get_async_session_context_manager() as session:
+
+        async def _list_direct_membership_rows(
+            scoped_org_ids: set[OrganizationID] | None = None,
+        ) -> list[tuple[uuid.UUID, str]]:
+            member_stmt = (
+                select(Workspace.id, Workspace.name)
+                .join(Membership, Membership.workspace_id == Workspace.id)
+                .where(Membership.user_id == user.id)
+            )
+            if scoped_org_ids:
+                member_stmt = member_stmt.where(
+                    Workspace.organization_id.in_(scoped_org_ids)
+                )
+            member_result = await session.execute(member_stmt)
+            return sorted(
+                member_result.tuples().all(),
+                key=lambda item: (item[1], str(item[0])),
+            )
+
         # Platform superusers can see all workspaces without org memberships.
         if user.is_superuser:
             stmt = select(Workspace.id, Workspace.name)
@@ -869,12 +883,15 @@ async def list_user_workspaces(
         org_result = await session.execute(org_stmt)
         org_ids = set(org_result.scalars().all())
 
-        if not org_ids:
-            return []
         if organization_ids:
             org_ids &= set(organization_ids)
             if not org_ids:
-                return []
+                return [
+                    {"id": str(workspace_id), "name": name}
+                    for workspace_id, name in await _list_direct_membership_rows(
+                        set(organization_ids)
+                    )
+                ]
 
         # Determine org-admin visibility on a per-organization basis.
         org_admin_ids: set[OrganizationID] = set()
@@ -915,6 +932,10 @@ async def list_user_workspaces(
             )
             member_result = await session.execute(member_stmt)
             for workspace_id, workspace_name in member_result.tuples().all():
+                workspace_map[workspace_id] = workspace_name
+
+        if not org_ids:
+            for workspace_id, workspace_name in await _list_direct_membership_rows():
                 workspace_map[workspace_id] = workspace_name
 
         ordered = sorted(

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -11,7 +11,7 @@ import csv
 import json
 import re
 import uuid
-from collections import deque
+from collections import defaultdict, deque
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import Any, Literal, cast, get_args
@@ -384,9 +384,17 @@ def _build_output_type_context() -> dict[str, Any]:
 async def _build_integrations_inventory(role: Any) -> dict[str, Any]:
     """Build integration inventory for workflow and preset authoring."""
     async with IntegrationService.with_session(role=role) as svc:
+        user_id = getattr(role, "user_id", None)
+        integrations = await svc.list_integrations()
+        if user_id is not None:
+            integrations = [
+                integration
+                for integration in integrations
+                if getattr(integration, "user_id", None) == user_id
+            ]
         existing = {
             (integration.provider_id, integration.grant_type): integration
-            for integration in await svc.list_integrations()
+            for integration in integrations
         }
         mcp_integrations = await svc.list_mcp_integrations()
         oauth_providers: list[dict[str, Any]] = []
@@ -464,24 +472,35 @@ async def _resolve_agent_preset_model(
     model_provider: str | None,
 ) -> tuple[str, str]:
     """Resolve explicit or default model inputs for preset creation."""
-    if model_name is not None or model_provider is not None:
-        if not model_name or not model_provider:
-            raise ToolError(
-                "model_name and model_provider must both be provided when setting an explicit model"
-            )
-        return model_name, model_provider
-
     async with AgentManagementService.with_session(role=role) as svc:
-        if not (default_model := await svc.get_default_model()):
+        if model_name is not None or model_provider is not None:
+            if not model_name or not model_provider:
+                raise ToolError(
+                    "model_name and model_provider must both be provided when setting an explicit model"
+                )
+            try:
+                model_config = await svc.get_model_config(model_name)
+            except TracecatNotFoundError as exc:
+                raise ToolError(f"Model '{model_name}' not found") from exc
+            if model_config.provider != model_provider:
+                raise ToolError(
+                    f"Model '{model_name}' belongs to provider '{model_config.provider}', not '{model_provider}'"
+                )
+        else:
+            if not (default_model := await svc.get_default_model()):
+                raise ToolError(
+                    "No default model configured for this organization. Set one before creating a preset without explicit model fields."
+                )
+            try:
+                model_config = await svc.get_model_config(default_model)
+            except TracecatNotFoundError as exc:
+                raise ToolError(
+                    f"Default model '{default_model}' is configured but no longer exists"
+                ) from exc
+        if not await svc.check_workspace_provider_credentials(model_config.provider):
             raise ToolError(
-                "No default model configured for this organization. Set one before creating a preset without explicit model fields."
+                f"Workspace credentials for provider '{model_config.provider}' are not configured"
             )
-        try:
-            model_config = await svc.get_model_config(default_model)
-        except TracecatNotFoundError as exc:
-            raise ToolError(
-                f"Default model '{default_model}' is configured but no longer exists"
-            ) from exc
         return model_config.name, model_config.provider
 
 
@@ -4419,6 +4438,36 @@ async def _build_agent_preset_authoring_context(role: Any) -> dict[str, Any]:
         variables = await svc.list_variables(environment=DEFAULT_SECRETS_ENVIRONMENT)
 
     workspace_inventory = await _load_secret_inventory(role)
+    models_by_provider: dict[str, list[str]] = defaultdict(list)
+    for model_name, model in sorted(models.items(), key=lambda item: item[0]):
+        provider = cast(str, model.model_dump(mode="json")["provider"])
+        models_by_provider[provider].append(model_name)
+    agent_credentials = {
+        "providers": [
+            {
+                "provider": provider,
+                "configured_org": provider_status_org.get(provider, False),
+                "configured_workspace": provider_status_workspace.get(provider, False),
+                "ready_for_agent_presets": provider_status_workspace.get(
+                    provider, False
+                ),
+                "models": model_names,
+            }
+            for provider, model_names in sorted(models_by_provider.items())
+        ],
+        "default_model_workspace_ready": (
+            provider_status_workspace.get(
+                cast(str, models[default_model].model_dump(mode="json")["provider"]),
+                False,
+            )
+            if default_model in models
+            else None
+        ),
+        "notes": [
+            "Agent preset sessions require workspace-scoped credentials for the selected provider.",
+            "configured_org may still be useful for other agent flows, but it is not sufficient for run_agent_preset.",
+        ],
+    }
 
     return {
         "default_model": default_model,
@@ -4428,6 +4477,7 @@ async def _build_agent_preset_authoring_context(role: Any) -> dict[str, Any]:
         ],
         "provider_status_org": provider_status_org,
         "provider_status_workspace": provider_status_workspace,
+        "agent_credentials": agent_credentials,
         "workspace_variables": [
             {
                 "name": variable.name,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add MCP tools to author and create agent presets with model auto-resolution, agent credential connectivity checks, richer integration inventory, and clear output type guidance. Updates MCP instructions with a step-by-step preset authoring flow.

- **New Features**
  - Added `get_agent_preset_authoring_context` returning default model, models list, org/workspace provider status, agent credential readiness flags (`ready_for_agent_presets`, `default_model_workspace_ready`), workspace variables, secret hints, integrations, and `output_type` guidance (supported literals and a JSON Schema example).
  - Added `list_integrations` returning MCP integrations (with `attachable_to_agent_preset`, server/auth metadata) and OAuth providers (core and custom) with grant type, enabled/requires_config, and per-user connection status.
  - Added `create_agent_preset` with model auto-resolution from workspace default, strict validation for explicit model pairs, a check for workspace-scoped provider credentials, support for optional fields (slug, description, instructions, base_url, `output_type`, actions, namespaces, tool_approvals, `mcp_integration_ids`, retries, enable_internet_access), and schema defaults when omitted (e.g., retries=3, enable_internet_access=false).
  - Updated MCP instructions to include the preset authoring tools and flow.

- **Bug Fixes**
  - Superusers bypass org membership checks; direct workspace membership is allowed without org membership when resolving roles.
  - `list_user_workspaces` now includes direct workspace memberships even without org membership and when filtered orgs do not match.

<sup>Written for commit 87654c97264cf8e8c3558e2ea09b06b341cd6771. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

