### PR TITLE
feat(functions): Add FN.serialize expression function

### DIFF
--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,10 +1,12 @@
 from collections import Counter
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
 import orjson
 import pytest
+from pydantic import BaseModel
 
 from tracecat.contexts import ctx_logical_time
 from tracecat.expressions.functions import (
@@ -90,6 +92,7 @@ from tracecat.expressions.functions import (
     regex_match,
     regex_not_match,
     seconds_between,
+    serialize,
     serialize_json,
     set_timezone,
     slice_str,
@@ -116,6 +119,15 @@ from tracecat.expressions.functions import (
     weeks_between,
     zip_iterables,
 )
+
+
+class _SerializePydanticModel(BaseModel):
+    value: int
+
+
+@dataclass
+class _SerializeDataclassModel:
+    value: int
 
 
 @pytest.mark.parametrize(
@@ -767,6 +779,24 @@ def test_logical_operations(func, a: bool, b: Any, expected: bool) -> None:
         assert func(a) == expected
     else:
         assert func(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "input_data,expected",
+    [
+        ({"a": 1}, {"a": 1}),
+        (_SerializePydanticModel(value=42), {"value": 42}),
+        (_SerializeDataclassModel(value=7), {"value": 7}),
+    ],
+)
+def test_serialize(input_data: Any, expected: dict[str, Any]) -> None:
+    result = serialize(input_data)
+    assert orjson.loads(result) == expected
+
+
+def test_serialize_unsupported_type_raises() -> None:
+    with pytest.raises(TypeError):
+        serialize({"value": object()})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,12 +1,10 @@
 from collections import Counter
-from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
 import orjson
 import pytest
-from pydantic import BaseModel
 
 from tracecat.contexts import ctx_logical_time
 from tracecat.expressions.functions import (
@@ -119,15 +117,6 @@ from tracecat.expressions.functions import (
     weeks_between,
     zip_iterables,
 )
-
-
-class _SerializePydanticModel(BaseModel):
-    value: int
-
-
-@dataclass
-class _SerializeDataclassModel:
-    value: int
 
 
 @pytest.mark.parametrize(
@@ -785,11 +774,12 @@ def test_logical_operations(func, a: bool, b: Any, expected: bool) -> None:
     "input_data,expected",
     [
         ({"a": 1}, {"a": 1}),
-        (_SerializePydanticModel(value=42), {"value": 42}),
-        (_SerializeDataclassModel(value=7), {"value": 7}),
+        ([1, 2, 3], [1, 2, 3]),
+        ("test", "test"),
+        (123, 123),
     ],
 )
-def test_serialize(input_data: Any, expected: dict[str, Any]) -> None:
+def test_serialize(input_data: Any, expected: Any) -> None:
     result = serialize(input_data)
     assert orjson.loads(result) == expected
 

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import csv
+import dataclasses
 import hashlib
 import ipaddress
 import itertools
@@ -19,6 +20,7 @@ from uuid import uuid4
 
 import orjson
 import yaml
+from pydantic import BaseModel
 from slugify import slugify
 from tracecat_registry._internal.flatten import flatten_dict as _flatten_dict
 
@@ -525,6 +527,27 @@ def map_dict_keys(x: dict[str, Any], keys: dict[str, str]) -> dict[str, Any]:
 def serialize_json(x: Any) -> str:
     """Convert object to JSON string."""
     return orjson.dumps(x).decode()
+
+
+def serialize(x: Any) -> str:
+    """Serialize an object to string.
+
+    Uses `orjson` for performance and falls back to common model protocols
+    (pydantic/dataclass) for objects that need conversion before serialization.
+    """
+
+    def _default(value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.model_dump(mode="json")
+        if dataclasses.is_dataclass(value):
+            return dataclasses.asdict(value)
+        if hasattr(value, "model_dump") and callable(value.model_dump):
+            return value.model_dump(mode="json")
+        if hasattr(value, "dict") and callable(value.dict):
+            return value.dict()
+        raise TypeError
+
+    return orjson.dumps(x, default=_default).decode()
 
 
 def prettify_json(x: Any) -> str:
@@ -1147,6 +1170,7 @@ _FUNCTION_MAPPING = {
     "deserialize_ndjson": deserialize_ndjson,
     "deserialize_yaml": deserialize_yaml,
     "prettify_json": prettify_json,
+    "serialize": serialize,
     "serialize_json": serialize_json,
     "serialize_yaml": serialize_yaml,
     # Time related

--- a/tracecat/expressions/functions.py
+++ b/tracecat/expressions/functions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import csv
-import dataclasses
 import hashlib
 import ipaddress
 import itertools
@@ -20,7 +19,6 @@ from uuid import uuid4
 
 import orjson
 import yaml
-from pydantic import BaseModel
 from slugify import slugify
 from tracecat_registry._internal.flatten import flatten_dict as _flatten_dict
 
@@ -530,24 +528,8 @@ def serialize_json(x: Any) -> str:
 
 
 def serialize(x: Any) -> str:
-    """Serialize an object to string.
-
-    Uses `orjson` for performance and falls back to common model protocols
-    (pydantic/dataclass) for objects that need conversion before serialization.
-    """
-
-    def _default(value: Any) -> Any:
-        if isinstance(value, BaseModel):
-            return value.model_dump(mode="json")
-        if dataclasses.is_dataclass(value):
-            return dataclasses.asdict(value)
-        if hasattr(value, "model_dump") and callable(value.model_dump):
-            return value.model_dump(mode="json")
-        if hasattr(value, "dict") and callable(value.dict):
-            return value.dict()
-        raise TypeError
-
-    return orjson.dumps(x, default=_default).decode()
+    """Serialize a JSON-compatible value to string."""
+    return orjson.dumps(x).decode()
 
 
 def prettify_json(x: Any) -> str:


### PR DESCRIPTION
### Motivation
- Provide a generic, fast serialization function for expressions that can produce a compact string representation of common objects (plain data, Pydantic models, dataclasses, and model-like objects) for use in templates and workflows.

### Description
- Add `serialize` to `tracecat/expressions/functions.py` that uses `orjson` for performance and a `_default` converter to handle `pydantic.BaseModel` via `model_dump(mode="json")`, dataclasses via `dataclasses.asdict`, and model-like objects exposing `.model_dump()` or `.dict()`, raising `TypeError` for unsupported types.
- Add `dataclasses` and `pydantic.BaseModel` imports and register the function in the expressions mapping as `"serialize"` so it is available as `FN.serialize`.
- Extend `tests/unit/test_functions.py` with unit tests that validate serialization of plain dicts, a Pydantic model, a dataclass instance, and that unsupported types raise `TypeError`.

### Testing
- Ran `uv run ruff check --fix tracecat/expressions/functions.py tests/unit/test_functions.py` which completed and fixed formatting issues.
- Ran `uv run ruff format tracecat/expressions/functions.py tests/unit/test_functions.py` which completed successfully.
- Attempted `uv run pytest tests/unit/test_functions.py -k 'serialize'` but test collection/setup failed because a local PostgreSQL instance at `localhost:5432` was unavailable (connection refused), so pytest could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d5bedb388333a64d7751f4097ee8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `FN.serialize` to quickly stringify JSON-compatible values using `orjson`. The function now only supports JSON primitives and nested structures; non-JSON types raise `TypeError`.

- **New Features**
  - Registered as `"serialize"` in the expressions map for use as `FN.serialize`.
  - Added tests for dict, list, str, int, and an unsupported object case.

<sup>Written for commit 29bafaacb3782606c02aeedace38899926db357b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

