### PR TITLE
fix: remove legacy org-scoped builtin registry repo

### DIFF
--- a/alembic/versions/0a1e3100a432_remove_legacy_org_scoped_builtin_.py
+++ b/alembic/versions/0a1e3100a432_remove_legacy_org_scoped_builtin_.py
@@ -1,0 +1,38 @@
+"""remove legacy org scoped builtin registry repository
+
+Revision ID: 0a1e3100a432
+Revises: 6171727be56a
+Create Date: 2026-03-11 18:26:36.376624
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0a1e3100a432"
+down_revision: str | None = "6171727be56a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Delete legacy org-scoped builtin registry repositories."""
+    op.execute(
+        sa.text(
+            "UPDATE registry_repository "
+            "SET current_version_id = NULL "
+            "WHERE origin = 'tracecat_registry'"
+        )
+    )
+    op.execute(
+        sa.text("DELETE FROM registry_repository WHERE origin = 'tracecat_registry'")
+    )
+
+
+def downgrade() -> None:
+    """Legacy data cleanup is not reversible."""
+    pass

--- a/alembic/versions/0a1e3100a432_remove_legacy_org_scoped_builtin_.py
+++ b/alembic/versions/0a1e3100a432_remove_legacy_org_scoped_builtin_.py
@@ -1,7 +1,7 @@
 """remove legacy org scoped builtin registry repository
 
 Revision ID: 0a1e3100a432
-Revises: 6171727be56a
+Revises: cd84c08340a5
 Create Date: 2026-03-11 18:26:36.376624
 
 """

--- a/alembic/versions/0a1e3100a432_remove_legacy_org_scoped_builtin_.py
+++ b/alembic/versions/0a1e3100a432_remove_legacy_org_scoped_builtin_.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0a1e3100a432"
-down_revision: str | None = "6171727be56a"
+down_revision: str | None = "cd84c08340a5"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/tests/migration/test_remove_legacy_org_scoped_builtin_registry_repository.py
+++ b/tests/migration/test_remove_legacy_org_scoped_builtin_registry_repository.py
@@ -1,0 +1,241 @@
+"""Tests for removing legacy org-scoped builtin registry repositories."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+from tests.database import TEST_DB_CONFIG
+
+MIGRATION_REVISION = "0a1e3100a432"
+PREVIOUS_REVISION = "6171727be56a"
+
+
+def _run_alembic(db_url: str, *args: str) -> None:
+    env = os.environ.copy()
+    env["TRACECAT__DB_URI"] = db_url
+    result = subprocess.run(
+        ["uv", "run", "alembic", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Alembic command failed:\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+
+@pytest.fixture(scope="function")
+def migration_db_url() -> Iterator[str]:
+    default_engine = create_engine(
+        TEST_DB_CONFIG.sys_url_sync,
+        isolation_level="AUTOCOMMIT",
+        poolclass=NullPool,
+    )
+    db_name = f"test_registry_cleanup_{uuid.uuid4().hex[:8]}"
+    termination_query = text(
+        f"""
+        SELECT pg_terminate_backend(pg_stat_activity.pid)
+        FROM pg_stat_activity
+        WHERE pg_stat_activity.datname = '{db_name}'
+          AND pid <> pg_backend_pid();
+        """
+    )
+
+    try:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+        db_url = TEST_DB_CONFIG.test_url_sync.replace(
+            TEST_DB_CONFIG.test_db_name, db_name
+        )
+        _run_alembic(db_url, "upgrade", PREVIOUS_REVISION)
+        yield db_url
+    finally:
+        with default_engine.connect() as conn:
+            conn.execute(termination_query)
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        default_engine.dispose()
+
+
+def _seed_legacy_registry_rows(db_url: str) -> tuple[uuid.UUID, uuid.UUID]:
+    engine = create_engine(db_url, poolclass=NullPool)
+    organization_id = uuid.uuid4()
+    legacy_repo_id = uuid.uuid4()
+    legacy_version_id = uuid.uuid4()
+    platform_repo_id = uuid.uuid4()
+    platform_version_id = uuid.uuid4()
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO organization (id, name, slug, is_active)
+                    VALUES (:id, 'Test org', :slug, true)
+                    """
+                ),
+                {"id": organization_id, "slug": f"test-org-{organization_id.hex[:8]}"},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO registry_repository (id, organization_id, origin, current_version_id)
+                    VALUES (:id, :organization_id, 'tracecat_registry', NULL)
+                    """
+                ),
+                {
+                    "id": legacy_repo_id,
+                    "organization_id": organization_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO registry_version (
+                        id,
+                        organization_id,
+                        repository_id,
+                        version,
+                        manifest,
+                        tarball_uri
+                    )
+                    VALUES (
+                        :id,
+                        :organization_id,
+                        :repository_id,
+                        '1.0.0',
+                        CAST('{}' AS jsonb),
+                        's3://test-bucket/legacy.tar.gz'
+                    )
+                    """
+                ),
+                {
+                    "id": legacy_version_id,
+                    "organization_id": organization_id,
+                    "repository_id": legacy_repo_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    UPDATE registry_repository
+                    SET current_version_id = :version_id
+                    WHERE id = :repository_id
+                    """
+                ),
+                {
+                    "version_id": legacy_version_id,
+                    "repository_id": legacy_repo_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO platform_registry_repository (id, origin, current_version_id)
+                    VALUES (:id, 'tracecat_registry', NULL)
+                    """
+                ),
+                {"id": platform_repo_id},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO platform_registry_version (
+                        id,
+                        repository_id,
+                        version,
+                        manifest,
+                        tarball_uri
+                    )
+                    VALUES (
+                        :id,
+                        :repository_id,
+                        '1.0.0',
+                        CAST('{}' AS jsonb),
+                        's3://test-bucket/platform.tar.gz'
+                    )
+                    """
+                ),
+                {
+                    "id": platform_version_id,
+                    "repository_id": platform_repo_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    UPDATE platform_registry_repository
+                    SET current_version_id = :version_id
+                    WHERE id = :repository_id
+                    """
+                ),
+                {
+                    "version_id": platform_version_id,
+                    "repository_id": platform_repo_id,
+                },
+            )
+    finally:
+        engine.dispose()
+
+    return legacy_repo_id, platform_repo_id
+
+
+def test_upgrade_removes_legacy_org_scoped_builtin_registry_repository(
+    migration_db_url: str,
+) -> None:
+    db_url = migration_db_url
+    legacy_repo_id, platform_repo_id = _seed_legacy_registry_rows(db_url)
+    _run_alembic(db_url, "upgrade", MIGRATION_REVISION)
+
+    engine = create_engine(db_url, poolclass=NullPool)
+    try:
+        with engine.begin() as conn:
+            legacy_repo_count = conn.execute(
+                text(
+                    """
+                    SELECT COUNT(*)
+                    FROM registry_repository
+                    WHERE id = :repository_id
+                    """
+                ),
+                {"repository_id": legacy_repo_id},
+            ).scalar_one()
+            assert legacy_repo_count == 0
+
+            legacy_version_count = conn.execute(
+                text(
+                    """
+                    SELECT COUNT(*)
+                    FROM registry_version
+                    WHERE repository_id = :repository_id
+                    """
+                ),
+                {"repository_id": legacy_repo_id},
+            ).scalar_one()
+            assert legacy_version_count == 0
+
+            platform_repo_count = conn.execute(
+                text(
+                    """
+                    SELECT COUNT(*)
+                    FROM platform_registry_repository
+                    WHERE id = :repository_id
+                    """
+                ),
+                {"repository_id": platform_repo_id},
+            ).scalar_one()
+            assert platform_repo_count == 1
+    finally:
+        engine.dispose()

--- a/tests/unit/test_registry_repositories_router.py
+++ b/tests/unit/test_registry_repositories_router.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from inspect import unwrap
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Organization, RegistryRepository
+from tracecat.registry.constants import (
+    DEFAULT_LOCAL_REGISTRY_ORIGIN,
+    DEFAULT_REGISTRY_ORIGIN,
+)
+from tracecat.registry.repositories import router as registry_repos_router
+from tracecat.registry.repositories.schemas import (
+    RegistryRepositoryCreate,
+    RegistryRepositoryUpdate,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.mark.anyio
+async def test_create_registry_repository_rejects_platform_builtin_origin(
+    session: AsyncSession,
+    test_role: Role,
+) -> None:
+    """Org-scoped registry API must not recreate the platform builtin origin."""
+    create_repository = unwrap(registry_repos_router.create_registry_repository)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_repository(
+            role=test_role,
+            session=session,
+            params=RegistryRepositoryCreate(origin=DEFAULT_REGISTRY_ORIGIN),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "platform-scoped" in str(exc_info.value.detail)
+
+
+@pytest.mark.anyio
+async def test_update_registry_repository_rejects_platform_builtin_origin(
+    session: AsyncSession,
+    test_role: Role,
+) -> None:
+    """Org-scoped registry API must not mutate a repo into the builtin origin."""
+    update_repository = unwrap(registry_repos_router.update_registry_repository)
+
+    session.add(
+        Organization(
+            id=test_role.organization_id,
+            name="Registry router test org",
+            slug="registry-router-test-org",
+            is_active=True,
+        )
+    )
+    await session.flush()
+
+    repository = RegistryRepository(
+        organization_id=test_role.organization_id,
+        origin=DEFAULT_LOCAL_REGISTRY_ORIGIN,
+    )
+    session.add(repository)
+    await session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await update_repository(
+            role=test_role,
+            session=session,
+            repository_id=repository.id,
+            params=RegistryRepositoryUpdate(origin=DEFAULT_REGISTRY_ORIGIN),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "platform-scoped" in str(exc_info.value.detail)

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -454,9 +454,17 @@ async def create_registry_repository(
     params: RegistryRepositoryCreate,
 ) -> RegistryRepositoryRead:
     """Create a new registry repository."""
+    if params.origin == DEFAULT_REGISTRY_ORIGIN:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"The {DEFAULT_REGISTRY_ORIGIN!r} repository is platform-scoped. "
+                "Use the admin registry API instead."
+            ),
+        )
+
     # Check entitlement for custom registry (non-system repositories)
-    if params.origin != DEFAULT_REGISTRY_ORIGIN:
-        await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
+    await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
 
     service = RegistryReposService(session, role=role)
     try:
@@ -512,10 +520,18 @@ async def update_registry_repository(
 
     # Check entitlement for custom registry repositories.
     # Also gate attempts to mutate a default repo into a custom origin.
-    if repository.origin != DEFAULT_REGISTRY_ORIGIN or (
-        params.origin is not None and params.origin != DEFAULT_REGISTRY_ORIGIN
+    if repository.origin == DEFAULT_REGISTRY_ORIGIN or (
+        params.origin is not None and params.origin == DEFAULT_REGISTRY_ORIGIN
     ):
-        await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"The {DEFAULT_REGISTRY_ORIGIN!r} repository is platform-scoped. "
+                "Use the admin registry API instead."
+            ),
+        )
+
+    await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
 
     updated_repository = await repos_service.update_repository(repository, params)
     actions = await actions_service.list_actions_from_index_by_repository(repository_id)


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR removes legacy org-scoped `tracecat_registry` rows from `registry_repository` now that the builtin registry is platform-scoped.

It adds a data migration that clears `current_version_id` and deletes org-scoped builtin repository rows, and it adds an org API guard so clients cannot recreate or retarget a repository to `tracecat_registry` through the org-scoped registry endpoints.

It also adds:
- a migration test that seeds both org-scoped and platform-scoped builtin registry rows and verifies only the org-scoped rows are removed on upgrade
- route tests that verify org-scoped create/update reject the platform builtin origin

## Related Issues


## Screenshots / Recordings

N/A

## Steps to QA

1. Run `export TRACECAT__DB_URI=postgresql+psycopg://postgres:postgres@localhost:5732/postgres`.
2. Run `uv run alembic upgrade head` and verify it completes successfully.
3. Seed a legacy org-scoped `registry_repository` row with `origin = 'tracecat_registry'` on a pre-migration database, then upgrade to `0a1e3100a432` and verify the org-scoped repo and its `registry_version` rows are deleted while `platform_registry_repository` rows remain.
4. Run `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/migration/test_remove_legacy_org_scoped_builtin_registry_repository.py tests/unit/test_registry_repositories_router.py`.
5. Verify org-scoped registry create/update calls reject `tracecat_registry` with a `400` and direct callers to the admin registry API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed legacy org‑scoped builtin registry repos and blocked org‑scoped APIs from targeting the platform builtin `tracecat_registry`. Also fixed Alembic head divergence.

- **Migration**
  - Added Alembic `cd84c08340a5` to set `ON DELETE CASCADE` on `membership.workspace_id` and align migration heads.
  - Added `0a1e3100a432` to clear `current_version_id` and delete org-scoped `registry_repository` rows where `origin='tracecat_registry'` (platform-scoped rows remain). Run `uv run alembic upgrade head`.

- **Bug Fixes**
  - Org-scoped create/update now reject `tracecat_registry` with a 400. Use the admin registry API instead.

<sup>Written for commit 7a13e4e9437e379dbe4968812cf66809ef85c341. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

