### PR TITLE
refactor(frontend): rename org settings from `git` to `custom-registry` (files & route)

### DIFF
--- a/frontend/src/app/organization/page.tsx
+++ b/frontend/src/app/organization/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation"
 
 export default function OrganizationPage() {
-  return redirect("/organization/settings/git")
+  return redirect("/organization/settings/custom-registry")
 }

--- a/frontend/src/app/organization/settings/custom-registry/layout.tsx
+++ b/frontend/src/app/organization/settings/custom-registry/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Custom registry | Organization",
+}
+
+export default function CustomRegistryLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/organization/settings/custom-registry/page.tsx
+++ b/frontend/src/app/organization/settings/custom-registry/page.tsx
@@ -3,11 +3,11 @@
 import { ArrowUpRight } from "lucide-react"
 import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { CenteredSpinner } from "@/components/loading/spinner"
-import { OrgSettingsGitForm } from "@/components/organization/org-settings-git"
+import { OrgSettingsCustomRegistryForm } from "@/components/organization/org-settings-custom-registry"
 import { Button } from "@/components/ui/button"
 import { useEntitlements } from "@/hooks/use-entitlements"
 
-export default function GitSettingsPage() {
+export default function CustomRegistrySettingsPage() {
   const { hasEntitlement, isLoading } = useEntitlements()
   const customRegistryEnabled = hasEntitlement("custom_registry")
 
@@ -19,16 +19,16 @@ export default function GitSettingsPage() {
         <div className="flex w-full">
           <div className="items-start space-y-3 text-left">
             <h2 className="text-2xl font-semibold tracking-tight">
-              Git repository
+              Custom registry
             </h2>
             <p className="text-md text-muted-foreground">
-              View and manage your organization Git settings here.
+              View and manage your organization's custom registry settings here.
             </p>
           </div>
         </div>
 
         {customRegistryEnabled ? (
-          <OrgSettingsGitForm />
+          <OrgSettingsCustomRegistryForm />
         ) : (
           <div className="flex flex-1 items-center justify-center pb-8">
             <EntitlementRequiredEmptyState

--- a/frontend/src/app/organization/settings/git/layout.tsx
+++ b/frontend/src/app/organization/settings/git/layout.tsx
@@ -1,9 +1,0 @@
-import type { Metadata } from "next"
-
-export const metadata: Metadata = {
-  title: "Git repository | Organization",
-}
-
-export default function GitLayout({ children }: { children: React.ReactNode }) {
-  return children
-}

--- a/frontend/src/components/organization/org-settings-custom-registry.tsx
+++ b/frontend/src/components/organization/org-settings-custom-registry.tsx
@@ -42,7 +42,7 @@ export const gitFormSchema = z.object({
 
 type GitFormValues = z.infer<typeof gitFormSchema>
 
-export function OrgSettingsGitForm() {
+export function OrgSettingsCustomRegistryForm() {
   const {
     gitSettings,
     gitSettingsIsLoading,

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -50,10 +50,10 @@ export function OrganizationSidebar({
 
   const navSettings = [
     {
-      title: "Git repository",
-      url: "/organization/settings/git",
+      title: "Custom registry",
+      url: "/organization/settings/custom-registry",
       icon: GitBranchIcon,
-      isActive: pathname?.includes("/organization/settings/git"),
+      isActive: pathname?.includes("/organization/settings/custom-registry"),
       visible: canViewSettings === true,
       locked: !customRegistryEnabled,
     },

--- a/frontend/tests/org-settings-custom-registry-form.test.ts
+++ b/frontend/tests/org-settings-custom-registry-form.test.ts
@@ -1,4 +1,5 @@
-import { gitFormSchema } from "@/components/organization/org-settings-git"
+import type { ZodIssue } from "zod"
+import { gitFormSchema as customRegistryFormSchema } from "@/components/organization/org-settings-custom-registry"
 
 const baseFormData = {
   git_allowed_domains: [{ id: "0", text: "github.com" }],
@@ -8,7 +9,7 @@ const baseFormData = {
 
 describe("gitFormSchema git_repo_url superRefine", () => {
   it("accepts a valid git+ssh URL with nested groups", () => {
-    const result = gitFormSchema.safeParse({
+    const result = customRegistryFormSchema.safeParse({
       ...baseFormData,
       git_repo_url: "git+ssh://git@gitlab.example.com/group/subgroup/repo.git",
     })
@@ -53,28 +54,30 @@ describe("gitFormSchema git_repo_url superRefine", () => {
       "Repository path must have at least 2 segments (e.g., org/repo)",
     ],
   ])("returns specific error when %s", (_, url, message) => {
-    const result = gitFormSchema.safeParse({
+    const result = customRegistryFormSchema.safeParse({
       ...baseFormData,
       git_repo_url: url,
     })
 
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error.issues.map((issue) => issue.message)).toContain(
-        message
-      )
+      expect(
+        result.error.issues.map((issue: ZodIssue) => issue.message)
+      ).toContain(message)
     }
   })
 
   it("falls back to generic error when validation fails for other reasons", () => {
-    const result = gitFormSchema.safeParse({
+    const result = customRegistryFormSchema.safeParse({
       ...baseFormData,
       git_repo_url: "git+ssh://git@github.com/org/repo.git@@",
     })
 
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error.issues.map((issue) => issue.message)).toContain(
+      expect(
+        result.error.issues.map((issue: ZodIssue) => issue.message)
+      ).toContain(
         "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"
       )
     }


### PR DESCRIPTION
### Motivation
- Align on the new "Custom registry" naming by renaming route directories and component files so the URL, sidebar and component names are consistent.

### Description
- Moved the route directory `frontend/src/app/organization/settings/git` to `frontend/src/app/organization/settings/custom-registry` and created `CustomRegistryLayout`/`CustomRegistrySettingsPage` with updated metadata and copy.
- Renamed the settings form component `frontend/src/components/organization/org-settings-git.tsx` to `frontend/src/components/organization/org-settings-custom-registry.tsx` and exported `OrgSettingsCustomRegistryForm` to match the new page.
- Updated the organization root redirect in `frontend/src/app/organization/page.tsx` to point to `/organization/settings/custom-registry` and updated the sidebar navigation in `frontend/src/components/sidebar/organization-sidebar.tsx` to use the new URL and `isActive` check.
- Removed the old `git` layout file and adjusted imports; generated client files referencing the backend API path `/settings/git` were left unchanged (these are codegen artifacts and reflect the backend API path, not the frontend route).

### Testing
- Ran `pnpm -C frontend check` which auto-fixed one file on the first run and reported no remaining fixes on a subsequent run (success).
- Attempted a Playwright page screenshot to validate the UI at `http://127.0.0.1:3000/organization/settings/custom-registry`, but the local app was not reachable (`ERR_EMPTY_RESPONSE`), so the runtime screenshot check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab4d41e1bc8320921da1e101450c2c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the organization settings from “Git repository” to “Custom registry” across the frontend. This updates the URL to /organization/settings/custom-registry, adjusts the page/layout and sidebar, and keeps backend API/codegen paths unchanged.

- **Refactors**
  - Moved route to `organization/settings/custom-registry` with new layout metadata and `CustomRegistrySettingsPage`.
  - Renamed form to `OrgSettingsCustomRegistryForm` and updated imports.
  - Updated org root redirect and sidebar item (title, URL, active check).
  - Removed old `organization/settings/git` layout; generated client still targets `/settings/git`.

- **Bug Fixes**
  - Updated the custom registry form test to import the schema from `org-settings-custom-registry` and added explicit `ZodIssue` typing.

<sup>Written for commit d1b9c34c0b284872aa1580ba8daa473db518ed59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

