### PR TITLE
infra: Right-size fargate temporal resources

### DIFF
--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -33,6 +33,20 @@ Terraform stack for Tracecat on AWS ECS Fargate (`>1.0.0-beta.xx`).
 - `TRACECAT__DISABLE_NSJAIL=true`
 - `TRACECAT__EXECUTOR_BACKEND=direct` (executor + agent-executor)
 
+## Default sizing
+
+- `worker_desired_count=2`
+- `executor_desired_count=2`
+- `agent_executor_desired_count=1`
+- `tracecat_db_instance_class=db.t4g.medium`
+- `tracecat_db_allocated_storage=20`
+- `temporal_db_instance_class=db.t4g.2xlarge`
+- `temporal_db_allocated_storage=50`
+- `temporal_cpu=8192`
+- `temporal_memory=16384`
+
+Temporal PostgreSQL TLS is enabled by default for the Fargate auto-setup task because RDS for PostgreSQL 15 and later defaults `rds.force_ssl=1`. Host verification remains disabled in this stack until the task mounts the AWS RDS CA bundle; EKS and Helm already handle CA-backed verification explicitly.
+
 ## Quick start
 
 ```bash

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -5,6 +5,11 @@ terraform {
 locals {
   # Only set aws_role_arn if both aws_account_id and aws_role_name are provided
   aws_role_arn = var.aws_account_id != null && var.aws_role_name != null ? "arn:aws:iam::${var.aws_account_id}:role/${var.aws_role_name}" : null
+
+  tracecat_db_instance_class    = coalesce(var.tracecat_db_instance_class, var.db_instance_class, "db.t4g.medium")
+  temporal_db_instance_class    = coalesce(var.temporal_db_instance_class, var.db_instance_class, "db.t4g.2xlarge")
+  tracecat_db_allocated_storage = coalesce(var.tracecat_db_allocated_storage, var.db_allocated_storage, 20)
+  temporal_db_allocated_storage = coalesce(var.temporal_db_allocated_storage, var.db_allocated_storage, 50)
 }
 
 module "network" {
@@ -122,32 +127,36 @@ module "ecs" {
   temporal_api_key_arn = var.temporal_api_key_arn
 
   # Compute / memory
-  api_cpu                         = var.api_cpu
-  api_memory                      = var.api_memory
-  worker_cpu                      = var.worker_cpu
-  worker_memory                   = var.worker_memory
-  worker_desired_count            = var.worker_desired_count
-  executor_cpu                    = var.executor_cpu
-  executor_memory                 = var.executor_memory
-  executor_desired_count          = var.executor_desired_count
-  executor_client_timeout         = var.executor_client_timeout
-  executor_queue                  = var.executor_queue
-  executor_worker_pool_size       = var.executor_worker_pool_size
-  agent_executor_cpu              = var.agent_executor_cpu
-  agent_executor_memory           = var.agent_executor_memory
-  agent_executor_desired_count    = var.agent_executor_desired_count
-  agent_queue                     = var.agent_queue
-  agent_executor_worker_pool_size = var.agent_executor_worker_pool_size
-  ui_cpu                          = var.ui_cpu
-  ui_memory                       = var.ui_memory
-  temporal_cpu                    = var.temporal_cpu
-  temporal_memory                 = var.temporal_memory
-  temporal_num_history_shards     = var.temporal_num_history_shards
-  caddy_cpu                       = var.caddy_cpu
-  caddy_memory                    = var.caddy_memory
-  db_instance_class               = var.db_instance_class
-  db_allocated_storage            = var.db_allocated_storage
-  db_engine_version               = var.db_engine_version
+  api_cpu                                  = var.api_cpu
+  api_memory                               = var.api_memory
+  worker_cpu                               = var.worker_cpu
+  worker_memory                            = var.worker_memory
+  worker_desired_count                     = var.worker_desired_count
+  executor_cpu                             = var.executor_cpu
+  executor_memory                          = var.executor_memory
+  executor_desired_count                   = var.executor_desired_count
+  executor_client_timeout                  = var.executor_client_timeout
+  executor_queue                           = var.executor_queue
+  executor_worker_pool_size                = var.executor_worker_pool_size
+  agent_executor_cpu                       = var.agent_executor_cpu
+  agent_executor_memory                    = var.agent_executor_memory
+  agent_executor_desired_count             = var.agent_executor_desired_count
+  agent_queue                              = var.agent_queue
+  agent_executor_worker_pool_size          = var.agent_executor_worker_pool_size
+  ui_cpu                                   = var.ui_cpu
+  ui_memory                                = var.ui_memory
+  temporal_cpu                             = var.temporal_cpu
+  temporal_memory                          = var.temporal_memory
+  temporal_num_history_shards              = var.temporal_num_history_shards
+  temporal_db_tls_enabled                  = var.temporal_db_tls_enabled
+  temporal_db_tls_enable_host_verification = var.temporal_db_tls_enable_host_verification
+  caddy_cpu                                = var.caddy_cpu
+  caddy_memory                             = var.caddy_memory
+  tracecat_db_instance_class               = local.tracecat_db_instance_class
+  temporal_db_instance_class               = local.temporal_db_instance_class
+  tracecat_db_allocated_storage            = local.tracecat_db_allocated_storage
+  temporal_db_allocated_storage            = local.temporal_db_allocated_storage
+  db_engine_version                        = var.db_engine_version
 
   # Sentry configuration
   sentry_dsn = var.sentry_dsn

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -173,15 +173,25 @@ locals {
   ]
 
   temporal_env = [
+    # RDS for PostgreSQL 15+ defaults rds.force_ssl=1, so both Temporal server
+    # config generation and temporal-sql-tool bootstrap must opt into TLS.
     for k, v in {
-      DB                         = "postgres12"
-      DB_PORT                    = "5432"
-      POSTGRES_USER              = "postgres"
-      LOG_LEVEL                  = var.temporal_log_level
-      TEMPORAL_BROADCAST_ADDRESS = "0.0.0.0"
-      BIND_ON_IP                 = "0.0.0.0"
-      NUM_HISTORY_SHARDS         = var.temporal_num_history_shards
+      DB                                = "postgres12"
+      DBNAME                            = "temporal"
+      DB_PORT                           = "5432"
+      POSTGRES_USER                     = "postgres"
+      VISIBILITY_DBNAME                 = "temporal_visibility"
+      LOG_LEVEL                         = var.temporal_log_level
+      TEMPORAL_BROADCAST_ADDRESS        = "0.0.0.0"
+      BIND_ON_IP                        = "0.0.0.0"
+      NUM_HISTORY_SHARDS                = var.temporal_num_history_shards
+      SQL_TLS                           = var.temporal_db_tls_enabled
+      SQL_TLS_ENABLED                   = var.temporal_db_tls_enabled
+      SQL_TLS_DISABLE_HOST_VERIFICATION = !var.temporal_db_tls_enable_host_verification
+      SQL_HOST_VERIFICATION             = var.temporal_db_tls_enable_host_verification
+      SQL_HOST_NAME                     = local.temp_db_hostname
+      SQL_TLS_SERVER_NAME               = local.temp_db_hostname
     } :
-    { name = k, value = tostring(v) }
+    { name = k, value = tostring(v) } if v != null
   ]
 }

--- a/deployments/fargate/modules/ecs/rds.tf
+++ b/deployments/fargate/modules/ecs/rds.tf
@@ -64,8 +64,8 @@ resource "aws_db_instance" "core_database" {
   identifier                  = "core-database"
   engine                      = "postgres"
   engine_version              = var.db_engine_version
-  instance_class              = var.db_instance_class
-  allocated_storage           = var.db_allocated_storage
+  instance_class              = var.tracecat_db_instance_class
+  allocated_storage           = var.tracecat_db_allocated_storage
   storage_encrypted           = true
   storage_type                = "gp3"
   username                    = "postgres"
@@ -102,8 +102,8 @@ resource "aws_db_instance" "temporal_database" {
   identifier                  = "temporal-database"
   engine                      = "postgres"
   engine_version              = var.db_engine_version
-  instance_class              = var.db_instance_class
-  allocated_storage           = 5
+  instance_class              = var.temporal_db_instance_class
+  allocated_storage           = var.temporal_db_allocated_storage
   storage_encrypted           = true
   storage_type                = "gp3"
   username                    = "postgres"

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -484,7 +484,7 @@ variable "executor_memory" {
 variable "executor_desired_count" {
   type        = number
   description = "Desired number of executor instances to run"
-  default     = 1
+  default     = 2
 }
 
 variable "executor_client_timeout" {
@@ -542,6 +542,18 @@ variable "temporal_memory" {
   default = "16384"
 }
 
+variable "temporal_db_tls_enabled" {
+  type        = bool
+  description = "Enable TLS for Temporal's PostgreSQL connections and auto-setup schema bootstrap."
+  default     = true
+}
+
+variable "temporal_db_tls_enable_host_verification" {
+  type        = bool
+  description = "Enable TLS host verification for Temporal's PostgreSQL connections. Keep false unless you mount the RDS CA bundle into the Temporal task."
+  default     = false
+}
+
 variable "temporal_num_history_shards" {
   type        = string
   description = "Number of history shards for Temporal"
@@ -558,14 +570,28 @@ variable "caddy_memory" {
   default = "512"
 }
 
-variable "db_instance_class" {
-  type    = string
-  default = "db.t4g.2xlarge"
+variable "tracecat_db_instance_class" {
+  type        = string
+  description = "Instance class for the Tracecat application RDS instance."
+  default     = "db.t4g.medium"
 }
 
-variable "db_allocated_storage" {
-  type    = string
-  default = "5"
+variable "temporal_db_instance_class" {
+  type        = string
+  description = "Instance class for the Temporal RDS instance."
+  default     = "db.t4g.2xlarge"
+}
+
+variable "tracecat_db_allocated_storage" {
+  type        = number
+  description = "Allocated storage in GiB for the Tracecat application RDS instance."
+  default     = 20
+}
+
+variable "temporal_db_allocated_storage" {
+  type        = number
+  description = "Allocated storage in GiB for the Temporal RDS instance."
+  default     = 50
 }
 
 variable "db_engine_version" {

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -471,7 +471,7 @@ variable "agent_executor_memory" {
 variable "agent_executor_desired_count" {
   type        = number
   description = "Desired number of agent-executor instances to run"
-  default     = 2
+  default     = 1
 }
 
 variable "agent_queue" {
@@ -496,6 +496,18 @@ variable "temporal_memory" {
   default = "16384"
 }
 
+variable "temporal_db_tls_enabled" {
+  type        = bool
+  description = "Enable TLS for Temporal's PostgreSQL connections and auto-setup schema bootstrap."
+  default     = true
+}
+
+variable "temporal_db_tls_enable_host_verification" {
+  type        = bool
+  description = "Enable TLS host verification for Temporal's PostgreSQL connections. Keep false unless you mount the RDS CA bundle into the Temporal task."
+  default     = false
+}
+
 variable "temporal_num_history_shards" {
   type        = string
   description = "Number of history shards for Temporal"
@@ -512,14 +524,40 @@ variable "caddy_memory" {
   default = "512"
 }
 
+variable "tracecat_db_instance_class" {
+  type        = string
+  description = "Instance class for the Tracecat application RDS instance."
+  default     = null
+}
+
+variable "temporal_db_instance_class" {
+  type        = string
+  description = "Instance class for the Temporal RDS instance."
+  default     = null
+}
+
+variable "tracecat_db_allocated_storage" {
+  type        = number
+  description = "Allocated storage in GiB for the Tracecat application RDS instance."
+  default     = null
+}
+
+variable "temporal_db_allocated_storage" {
+  type        = number
+  description = "Allocated storage in GiB for the Temporal RDS instance."
+  default     = null
+}
+
 variable "db_instance_class" {
-  type    = string
-  default = "db.t4g.2xlarge"
+  type        = string
+  description = "Deprecated shared fallback for both RDS instance classes. Prefer tracecat_db_instance_class and temporal_db_instance_class."
+  default     = null
 }
 
 variable "db_allocated_storage" {
-  type    = string
-  default = "5"
+  type        = number
+  description = "Deprecated shared fallback for both RDS storage sizes in GiB. Prefer tracecat_db_allocated_storage and temporal_db_allocated_storage."
+  default     = null
 }
 
 variable "db_engine_version" {


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes several sizing and connectivity problems in the Fargate deployment. Worker and executor desired counts now default to `2` while `agent-executor` stays at `1`. The stack no longer reuses one DB sizing variable for both Postgres instances: Tracecat defaults to `db.t4g.medium` with `20` GiB, while Temporal defaults to `db.t4g.2xlarge` with `50` GiB. The change keeps the existing Temporal task sizing at `8192` CPU and `16384` MiB, which is already consistent with the current Retool self-hosted Temporal guidance to provision Temporal separately for production workloads.

The root cause was that the February refactor collapsed Tracecat and Temporal database sizing back onto the same Terraform variables, and the Fargate Temporal task was still starting without the SQL TLS environment that `temporalio/auto-setup` expects for RDS-backed Postgres. On newer RDS PostgreSQL versions, `rds.force_ssl` defaults to enabled, so Temporal schema setup and server startup would attempt a non-SSL connection and fail.

The fix introduces separate Tracecat and Temporal DB class and storage variables at the root and ECS module layers, rewires the two RDS instances to use them, updates the documented Fargate defaults, and enables the Temporal SQL TLS environment for both runtime and schema bootstrap. Host verification remains disabled for now because the Fargate task still does not mount the AWS RDS CA bundle the way the EKS and Helm deployments already do.

## Related Issues

## Screenshots / Recordings

Not applicable for Terraform-only changes.

## Steps to QA

1. Run `terraform fmt -check -recursive deployments/fargate`.
2. Run `terraform -chdir=deployments/fargate validate`.
3. Run `terraform -chdir=deployments/fargate plan` and confirm:
   - `worker_desired_count = 2`
   - `executor_desired_count = 2`
   - `agent_executor_desired_count = 1`
   - Tracecat RDS uses `db.t4g.medium` with `20` GiB
   - Temporal RDS uses `db.t4g.2xlarge` with `50` GiB
   - Temporal task env includes SQL TLS settings for schema setup and runtime


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Right-size ECS Fargate resources for Temporal and fix Postgres TLS so RDS-backed Temporal boots reliably. Sets sane defaults for service counts and separate DB sizing for Tracecat vs Temporal.

- **Bug Fixes**
  - Enable Postgres TLS for Temporal runtime and schema bootstrap to match RDS force-SSL defaults; add TLS env vars and keep host verification off until the RDS CA is mounted. This resolves non-SSL connection failures during `temporalio/auto-setup`.

- **Refactors**
  - Split RDS sizing for Tracecat and Temporal with new variables and defaults: Tracecat uses db.t4g.medium with 20 GiB; Temporal uses db.t4g.2xlarge with 50 GiB.
  - Update desired counts: worker=2, executor=2, agent-executor=1.
  - Keep the old shared DB vars as deprecated fallbacks and document the new defaults in the Fargate README.

<sup>Written for commit ffc1e27d9df2aa7659f18712f6263b11ba915ddb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

