### PR TITLE
chore(pre-commit): replace gitleaks with betterleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,10 @@ repos:
           - --verbose
       - id: ruff-format
         verbose: true
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.25.1
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.1.0
     hooks:
-      - id: gitleaks
+      - id: betterleaks
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.9.7
     hooks:


### PR DESCRIPTION
### Motivation
- Replace the repository secret-scanning pre-commit hook with a maintained alternative that provides improved detection and an official pre-commit hook entry.

### Description
- Updated `.pre-commit-config.yaml` to use the `betterleaks/betterleaks` repo and pinned it to `v1.1.0`.
- Replaced the hook id from `gitleaks` to `betterleaks` so the pre-commit hook uses the new runner.

### Testing
- Ran `uv run pre-commit validate-config` and the pre-commit configuration validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2fab6e09c833393eaeb82715a9d58)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the pre-commit secret scanner from `gitleaks` to `betterleaks` for better detection and a maintained, official hook. Config validated with `uv run pre-commit validate-config`.

- **Dependencies**
  - Switched to `https://github.com/betterleaks/betterleaks` pinned at `v1.1.0`.
  - Updated hook id from `gitleaks` to `betterleaks`.

<sup>Written for commit 8d212c35e7479234465187128e98f2133a4796c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

