### PR TITLE
fix(mcp): Handle nested MCP email claims in auth identity extraction

### DIFF
--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -410,6 +410,29 @@ def test_get_token_identity_extracts_ids_from_claims_and_scopes(
     assert identity.workspace_ids == frozenset({ws_id, extra_ws_id})
 
 
+def test_get_token_identity_reads_email_from_upstream_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = type(
+        "T",
+        (),
+        {
+            "client_id": "tracecat-client",
+            "scopes": [],
+            "claims": {
+                "client_id": "tracecat-client",
+                "upstream_claims": {"email": " user@example.com "},
+            },
+        },
+    )()
+    monkeypatch.setattr(mcp_auth, "get_access_token", lambda: token)
+
+    identity = mcp_auth.get_token_identity()
+
+    assert identity.client_id == "tracecat-client"
+    assert identity.email == "user@example.com"
+
+
 def test_get_token_identity_prefers_token_client_id_over_sub(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -523,6 +546,41 @@ async def test_list_workspaces_for_request_without_claimed_org_ids(
         return []
 
     monkeypatch.setattr(mcp_auth, "get_token_identity", lambda: identity)
+    monkeypatch.setattr(mcp_auth, "list_user_workspaces", _list_user_workspaces)
+
+    await mcp_auth.list_workspaces_for_request()
+
+    assert captured["email"] == "user@example.com"
+    assert captured["organization_ids"] is None
+
+
+@pytest.mark.anyio
+async def test_list_workspaces_for_request_reads_email_from_upstream_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    token = type(
+        "T",
+        (),
+        {
+            "client_id": "tracecat-client",
+            "scopes": [],
+            "claims": {
+                "client_id": "tracecat-client",
+                "upstream_claims": {"email": " user@example.com "},
+            },
+        },
+    )()
+
+    async def _list_user_workspaces(
+        email: str,
+        organization_ids: frozenset[uuid.UUID] | None = None,
+    ) -> list[dict[str, str]]:
+        captured["email"] = email
+        captured["organization_ids"] = organization_ids
+        return []
+
+    monkeypatch.setattr(mcp_auth, "get_access_token", lambda: token)
     monkeypatch.setattr(mcp_auth, "list_user_workspaces", _list_user_workspaces)
 
     await mcp_auth.list_workspaces_for_request()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1468,6 +1468,22 @@ async def test_get_mcp_client_id_extracts_email():
 
 
 @pytest.mark.anyio
+async def test_get_mcp_client_id_extracts_email_from_upstream_claims():
+    from fastmcp.server.context import Context
+
+    from tracecat.mcp.middleware import get_mcp_client_id
+
+    token = SimpleNamespace(claims={"upstream_claims": {"email": " user@example.com "}})
+    fastmcp_ctx = SimpleNamespace(get_access_token=lambda: token)
+    ctx = MiddlewareContext(
+        message=CallToolRequestParams(name="t", arguments=None),
+        fastmcp_context=cast(Context, fastmcp_ctx),
+        method="tools/call",
+    )
+    assert get_mcp_client_id(ctx) == "user@example.com"
+
+
+@pytest.mark.anyio
 async def test_get_mcp_client_id_returns_anonymous_without_token():
     from fastmcp.server.context import Context
 

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -8,7 +8,7 @@ import re
 import time
 import uuid
 from base64 import urlsafe_b64decode
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -210,6 +210,19 @@ def _extract_scope_uuids(scopes: list[str], resource: str) -> set[uuid.UUID]:
     return ids
 
 
+def get_email_claim(claims: Mapping[str, object]) -> str | None:
+    """Extract an email claim from FastMCP token claims."""
+    match claims:
+        case {"email": str(raw_email)} if email := raw_email.strip():
+            return email
+        case {"upstream_claims": {"email": str(raw_email)}} if (
+            email := raw_email.strip()
+        ):
+            return email
+        case _:
+            return None
+
+
 def _decode_unverified_id_token_claims(id_token: str) -> dict[str, object]:
     """Decode a JWT payload without signature verification.
 
@@ -231,8 +244,7 @@ def get_token_identity() -> MCPTokenIdentity:
         raise ValueError("Authentication required")
 
     claims = access_token.claims
-    raw_email = claims.get("email")
-    email = raw_email.strip() if isinstance(raw_email, str) else None
+    email = get_email_claim(claims)
     raw_client_ids = [
         claims.get("client_id"),
         claims.get("azp"),

--- a/tracecat/mcp/middleware.py
+++ b/tracecat/mcp/middleware.py
@@ -15,7 +15,7 @@ from fastmcp.server.middleware.middleware import CallNext, Middleware, Middlewar
 from fastmcp.tools.tool import ToolResult
 
 from tracecat.logger import logger
-from tracecat.mcp.auth import MCPTokenIdentity, get_token_identity
+from tracecat.mcp.auth import MCPTokenIdentity, get_email_claim, get_token_identity
 from tracecat.mcp.config import (
     TRACECAT_MCP__MAX_INPUT_SIZE_BYTES,
     TRACECAT_MCP__TOOL_TIMEOUT_SECONDS,
@@ -27,6 +27,7 @@ class AccessTokenClaims(TypedDict, total=False):
     client_id: str
     azp: str
     sub: str
+    upstream_claims: dict[str, str]
 
 
 class AccessTokenLike(Protocol):
@@ -351,9 +352,9 @@ def get_mcp_client_id(context: MiddlewareContext) -> str:  # type: ignore[type-a
         if access_token is None:
             access_token = cast(AccessTokenLike | None, get_access_token())
         if access_token is not None:
-            email = access_token.claims.get("email")
+            email = get_email_claim(access_token.claims)
             if email:
-                return str(email)
+                return email
             client_id = (
                 access_token.claims.get("client_id")
                 or access_token.claims.get("azp")


### PR DESCRIPTION

## Problem
Tracecat’s MCP identity extraction assumed the access token would always expose `email` as a top-level claim. In our cloud environment that is still true, but the reported failure shows at least one other
  environment where `list_workspaces` reached Tracecat without a usable root `email`; FastMCP’s proxy auth stack also defines `upstream_claims` as the container for preserved upstream identity claims, so that is the only
  alternate claim path we can justify from source.

## Solution
Keep root `email` as the primary path and add `upstream_claims.email` as a defensive compatibility fallback, with regression coverage for the nested-only case.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MCP auth to read email from nested `upstream_claims.email`, ensuring identity and client ID are extracted correctly for `fastmcp` tokens. Prevents users being marked anonymous when email isn’t at the top level.

- **Bug Fixes**
  - Added `get_email_claim` to parse email from `email` or `upstream_claims.email` and trim whitespace.
  - Wired the helper into `get_token_identity` and middleware `get_mcp_client_id`.
  - Expanded tests to cover nested email claims and workspace listing with `upstream_claims`.

<sup>Written for commit 12bc0c764df607982035ca24e5bb675f3db61273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

