### PR TITLE
fix(mcp): MCP AWS external ID for Bedrock UDFs

### DIFF
--- a/tests/unit/test_agent_management_service.py
+++ b/tests/unit/test_agent_management_service.py
@@ -12,6 +12,7 @@ from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
+from tracecat.integrations.aws_assume_role import build_workspace_external_id
 from tracecat.secrets import secrets_manager
 
 
@@ -76,3 +77,56 @@ async def test_with_preset_config_sets_registry_and_env_context(role: Role) -> N
 
     assert registry_secrets.get_or_default("ANTHROPIC_API_KEY") is None
     assert secrets_manager.get("ANTHROPIC_API_KEY") is None
+
+
+@pytest.mark.anyio
+async def test_get_runtime_provider_credentials_injects_bedrock_external_id(
+    role: Role,
+) -> None:
+    service = AgentManagementService(AsyncMock(), role=role)
+    service.get_workspace_provider_credentials = AsyncMock(
+        return_value={
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
+            "AWS_REGION": "us-east-1",
+            "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        }
+    )
+
+    credentials = await service.get_runtime_provider_credentials("bedrock")
+    assert role.workspace_id is not None
+
+    assert credentials is not None
+    assert credentials["TRACECAT_AWS_EXTERNAL_ID"] == build_workspace_external_id(
+        role.workspace_id
+    )
+
+
+@pytest.mark.anyio
+async def test_with_model_config_injects_bedrock_external_id(role: Role) -> None:
+    service = AgentManagementService(AsyncMock(), role=role)
+    service.get_default_model = AsyncMock(return_value="bedrock")
+    service.get_provider_credentials = AsyncMock(
+        return_value={
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
+            "AWS_REGION": "us-east-1",
+            "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        }
+    )
+    assert role.workspace_id is not None
+
+    assert registry_secrets.get_or_default("TRACECAT_AWS_EXTERNAL_ID") is None
+    assert secrets_manager.get("TRACECAT_AWS_EXTERNAL_ID") is None
+
+    async with service.with_model_config(
+        use_workspace_credentials=False
+    ) as model_config:
+        assert model_config.name == "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        assert registry_secrets.get("TRACECAT_AWS_EXTERNAL_ID") == (
+            build_workspace_external_id(role.workspace_id)
+        )
+        assert secrets_manager.get("TRACECAT_AWS_EXTERNAL_ID") == (
+            build_workspace_external_id(role.workspace_id)
+        )
+
+    assert registry_secrets.get_or_default("TRACECAT_AWS_EXTERNAL_ID") is None
+    assert secrets_manager.get("TRACECAT_AWS_EXTERNAL_ID") is None

--- a/tracecat/agent/internal_router.py
+++ b/tracecat/agent/internal_router.py
@@ -74,7 +74,7 @@ async def _provider_secrets_context(
             registry_secrets.reset_context(secrets_token)
         return
 
-    credentials = await agent_svc.get_workspace_provider_credentials(model_provider)
+    credentials = await agent_svc.get_runtime_provider_credentials(model_provider)
     if not credentials:
         raise ValueError(
             f"No credentials found for provider '{model_provider}'. "

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -22,6 +22,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import OrganizationSecret, Secret
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
+from tracecat.integrations.aws_assume_role import build_workspace_external_id
 from tracecat.logger import logger
 from tracecat.secrets import secrets_manager
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
@@ -31,6 +32,8 @@ from tracecat.secrets.service import SecretsService
 from tracecat.service import BaseOrgService
 from tracecat.settings.schemas import SettingCreate, SettingUpdate, ValueType
 from tracecat.settings.service import SettingsService
+
+_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY = "TRACECAT_AWS_EXTERNAL_ID"
 
 
 class AgentManagementService(BaseOrgService):
@@ -166,6 +169,37 @@ class AgentManagementService(BaseOrgService):
             return {kv.key: kv.value.get_secret_value() for kv in secret_keys}
         except TracecatNotFoundError:
             return None
+
+    def _augment_runtime_provider_credentials(
+        self, provider: str, credentials: dict[str, str]
+    ) -> dict[str, str]:
+        """Augment provider credentials with runtime-only values when required."""
+        if (
+            provider != "bedrock"
+            or "AWS_ROLE_ARN" not in credentials
+            or self.role.workspace_id is None
+            or _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY in credentials
+        ):
+            return credentials
+
+        runtime_credentials = credentials.copy()
+        runtime_credentials[_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY] = (
+            build_workspace_external_id(self.role.workspace_id)
+        )
+        return runtime_credentials
+
+    async def get_runtime_provider_credentials(
+        self, provider: str, *, use_workspace_credentials: bool = True
+    ) -> dict[str, str] | None:
+        """Get provider credentials augmented for runtime consumers."""
+        if use_workspace_credentials:
+            credentials = await self.get_workspace_provider_credentials(provider)
+        else:
+            credentials = await self.get_provider_credentials(provider)
+
+        if credentials is None:
+            return None
+        return self._augment_runtime_provider_credentials(provider, credentials)
 
     @require_scope("agent:update")
     async def delete_provider_credentials(self, provider: str) -> None:
@@ -305,10 +339,9 @@ class AgentManagementService(BaseOrgService):
         )
 
         # Fetch credentials from appropriate scope
-        if use_workspace_credentials:
-            credentials = await self.get_workspace_provider_credentials(provider)
-        else:
-            credentials = await self.get_provider_credentials(provider)
+        credentials = await self.get_runtime_provider_credentials(
+            provider, use_workspace_credentials=use_workspace_credentials
+        )
 
         if not credentials:
             scope = "workspace" if use_workspace_credentials else "organization"
@@ -398,14 +431,10 @@ class AgentManagementService(BaseOrgService):
         )
 
         # Get credentials from appropriate scope
-        if use_workspace_credentials:
-            credentials = await self.get_workspace_provider_credentials(
-                preset_config.model_provider
-            )
-        else:
-            credentials = await self.get_provider_credentials(
-                preset_config.model_provider
-            )
+        credentials = await self.get_runtime_provider_credentials(
+            preset_config.model_provider,
+            use_workspace_credentials=use_workspace_credentials,
+        )
 
         if not credentials:
             raise TracecatNotFoundError(


### PR DESCRIPTION
## Summary
This fixes a regression in the PydanticAI-backed MCP UDF path when a workspace is configured to use Bedrock through `AWS_ROLE_ARN`. GitHub, Linear, and Notion MCP UDFs all call `ctx.agents.run`, which routes through `/internal/agent/run` rather than the normal registry action secret-loading path. After the AWS assume-role changes from `#2310`, those MCP UDF runs could fail with `AWS role assumption requires a Tracecat-provided workspace External ID`, which surfaced to users as a 500 `Agent run did not complete successfully`.

## Root cause
The Bedrock assume-role change added runtime `TRACECAT_AWS_EXTERNAL_ID` injection in the registry action secret path, but the internal agent runtime used by MCP UDFs was loading workspace provider credentials directly from `AgentManagementService`. That meant the Bedrock credential could include `AWS_ROLE_ARN` without the workspace-scoped external ID ever being added before `aws_boto3` attempted `AssumeRole`.

## Fix
This change adds a runtime provider-credential augmentation step in `AgentManagementService` for Bedrock credentials that use `AWS_ROLE_ARN`. When that shape is detected, Tracecat now derives the external ID from the workspace ID and injects it into the runtime credential map before those credentials are exposed to the registry secret context and env sandbox. The internal `/internal/agent/run` path now uses that runtime-augmented provider credential loader so MCP UDFs behave the same way as standard registry actions.

The change is intentionally narrow: it only augments runtime credentials for Bedrock assume-role use, and it leaves deployment-level AWS assume-role account/principal configuration unchanged.

## Validation
I ran the repository verification steps required before push:

- `uv run ruff check --fix .`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings --threads 4`
- `pnpm -C frontend exec biome check --write .`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`

I also added focused unit coverage for the runtime Bedrock external-ID injection and ran:

- `uv run pytest tests/unit/test_agent_management_service.py`

For the focused pytest run, I supplied temporary local values for the required `TRACECAT__SERVICE_KEY` and `TRACECAT__DB_ENCRYPTION_KEY` test environment variables.
