### PR TITLE
fix(agents): bump llm proxy timeout and make configurable

### DIFF
--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -143,6 +143,7 @@ module "ecs" {
   agent_executor_desired_count             = var.agent_executor_desired_count
   agent_queue                              = var.agent_queue
   agent_executor_worker_pool_size          = var.agent_executor_worker_pool_size
+  llm_proxy_read_timeout                   = var.llm_proxy_read_timeout
   ui_cpu                                   = var.ui_cpu
   ui_memory                                = var.ui_memory
   temporal_cpu                             = var.temporal_cpu

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -137,6 +137,7 @@ locals {
         TRACECAT__EXECUTOR_BACKEND          = "direct"
         TRACECAT__AGENT_QUEUE               = var.agent_queue
         TRACECAT__EXECUTOR_WORKER_POOL_SIZE = var.agent_executor_worker_pool_size
+        TRACECAT__LLM_PROXY_READ_TIMEOUT    = var.llm_proxy_read_timeout
         TRACECAT__UNSAFE_DISABLE_SM_MASKING = "false"
         TRACECAT__DISABLE_NSJAIL            = "true"
         TRACECAT__SANDBOX_NSJAIL_PATH       = "/usr/local/bin/nsjail"

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -532,6 +532,12 @@ variable "agent_executor_worker_pool_size" {
   default     = null
 }
 
+variable "llm_proxy_read_timeout" {
+  type        = string
+  description = "LLM proxy read timeout in seconds (default: 300)"
+  default     = "300"
+}
+
 variable "temporal_cpu" {
   type    = string
   default = "8192"

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -486,6 +486,12 @@ variable "agent_executor_worker_pool_size" {
   default     = null
 }
 
+variable "llm_proxy_read_timeout" {
+  type        = string
+  description = "LLM proxy read timeout in seconds (default: 300)"
+  default     = "300"
+}
+
 variable "temporal_cpu" {
   type    = string
   default = "8192"

--- a/deployments/helm/tracecat/templates/_helpers.tpl
+++ b/deployments/helm/tracecat/templates/_helpers.tpl
@@ -819,6 +819,8 @@ Merges: common + temporal + postgres + redis + agent-executor-specific
   value: {{ .Values.agentExecutor.queue | quote }}
 - name: TRACECAT__EXECUTOR_WORKER_POOL_SIZE
   value: {{ .Values.agentExecutor.workerPoolSize | quote }}
+- name: TRACECAT__LLM_PROXY_READ_TIMEOUT
+  value: {{ .Values.agentExecutor.llmProxyReadTimeout | quote }}
 {{- end }}
 
 {{/*

--- a/deployments/helm/tracecat/values.yaml
+++ b/deployments/helm/tracecat/values.yaml
@@ -326,6 +326,7 @@ agentExecutor:
       memory: "4096Mi"
   queue: "shared-agent-queue"
   workerPoolSize: ""
+  llmProxyReadTimeout: "300"
   contextCompression:
     enabled: false
     thresholdKb: 16

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -278,6 +278,7 @@ services:
       TEMPORAL__API_KEY: ${TEMPORAL__API_KEY}
       # Agent Worker configuration
       TRACECAT__AGENT_QUEUE: ${TRACECAT__AGENT_QUEUE:-shared-agent-queue}
+      TRACECAT__LLM_PROXY_READ_TIMEOUT: ${TRACECAT__LLM_PROXY_READ_TIMEOUT:-300}
       # Pool size auto-scales based on available CPUs if not set
       TRACECAT__EXECUTOR_WORKER_POOL_SIZE: ${TRACECAT__EXECUTOR_WORKER_POOL_SIZE:-}
       # Redis

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -300,6 +300,7 @@ services:
       TEMPORAL__API_KEY: ${TEMPORAL__API_KEY}
       # Agent Worker configuration
       TRACECAT__AGENT_QUEUE: ${TRACECAT__AGENT_QUEUE:-shared-agent-queue}
+      TRACECAT__LLM_PROXY_READ_TIMEOUT: ${TRACECAT__LLM_PROXY_READ_TIMEOUT:-300}
       # Pool size auto-scales based on available CPUs if not set
       TRACECAT__EXECUTOR_WORKER_POOL_SIZE: ${TRACECAT__EXECUTOR_WORKER_POOL_SIZE:-}
       # Redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -290,6 +290,7 @@ services:
         TEMPORAL__API_KEY: ${TEMPORAL__API_KEY}
         # Agent Worker configuration
         TRACECAT__AGENT_QUEUE: ${TRACECAT__AGENT_QUEUE:-shared-agent-queue}
+        TRACECAT__LLM_PROXY_READ_TIMEOUT: ${TRACECAT__LLM_PROXY_READ_TIMEOUT:-300}
         # Pool size auto-scales based on available CPUs if not set
         TRACECAT__EXECUTOR_WORKER_POOL_SIZE: ${TRACECAT__EXECUTOR_WORKER_POOL_SIZE:-}
         # Redis

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import httpx
 
+from tracecat.config import TRACECAT__LLM_PROXY_READ_TIMEOUT
 from tracecat.logger import logger
 
 # LiteLLM proxy runs on localhost:4000
@@ -103,8 +104,8 @@ class LLMSocketProxy:
             self.socket_path.unlink()
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(
-                connect=10.0,
-                read=120.0,
+                connect=20.0,
+                read=TRACECAT__LLM_PROXY_READ_TIMEOUT,
                 write=30.0,
                 pool=10.0,
             )

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -621,6 +621,11 @@ TRACECAT__AGENT_SANDBOX_MEMORY_MB = int(
 )
 """Default memory limit for agent sandbox execution in megabytes (4 GiB)."""
 
+TRACECAT__LLM_PROXY_READ_TIMEOUT = float(
+    os.environ.get("TRACECAT__LLM_PROXY_READ_TIMEOUT") or 300.0
+)
+"""Read timeout for the LLM socket proxy in seconds (default: 5 minutes)."""
+
 TRACECAT__AGENT_QUEUE = os.environ.get("TRACECAT__AGENT_QUEUE", "shared-agent-queue")
 """Task queue for the AgentWorker (Temporal workflow queue).
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the agent LLM proxy read timeout to 300s and make it configurable to reduce timeouts on long responses. Adds `TRACECAT__LLM_PROXY_READ_TIMEOUT` across Docker, Helm, and ECS; also raises the connect timeout to 20s.

- **Migration**
  - Default is 300s; no action needed unless you want to change it.
  - Docker Compose: set `TRACECAT__LLM_PROXY_READ_TIMEOUT`.
  - Helm: set `agentExecutor.llmProxyReadTimeout`.
  - ECS (Terraform): set `llm_proxy_read_timeout`.

<sup>Written for commit 630851c6bd15dc5806c5012f1eec813e370f7357. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

