### PR TITLE
fix(registry): handle StreamingBody in boto3 responses

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
@@ -204,13 +204,16 @@ def get_sync_session() -> boto3.Session:
     return session
 
 
+_STREAMING_BODY_MAX_BYTES = 100 * 1024 * 1024  # 100 MB
+
+
 async def _read_streaming_values(obj: Any) -> Any:
     """Recursively read StreamingBody and bytes values in a boto3 response.
 
     Content is decoded as UTF-8, falling back to base64 for binary data.
     """
     if isinstance(obj, StreamingBody):
-        content = await obj.read()
+        content = await obj.read(_STREAMING_BODY_MAX_BYTES)
         try:
             return content.decode("utf-8")
         except UnicodeDecodeError:
@@ -292,8 +295,8 @@ async def call_paginated_api(
         paginator = client.get_paginator(paginator_name)
         pages = paginator.paginate(**params)
 
-    results = []
-    async for page in pages:
-        results.append(await _read_streaming_values(page))
+        results = []
+        async for page in pages:
+            results.append(await _read_streaming_values(page))
 
     return results

--- a/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
@@ -4,11 +4,13 @@ Provides a interface to Boto3's Client and Paginator APIs.
 Supports role-based authentication and session management.
 """
 
+import base64
 from typing import TYPE_CHECKING, Annotated, Any
 from typing_extensions import Doc
 
 import boto3
 import aioboto3
+from aiobotocore.response import StreamingBody
 
 if TYPE_CHECKING:
     from types_aiobotocore_sts.type_defs import (
@@ -202,6 +204,29 @@ def get_sync_session() -> boto3.Session:
     return session
 
 
+async def _read_streaming_values(obj: Any) -> Any:
+    """Recursively read StreamingBody and bytes values in a boto3 response.
+
+    Content is decoded as UTF-8, falling back to base64 for binary data.
+    """
+    if isinstance(obj, StreamingBody):
+        content = await obj.read()
+        try:
+            return content.decode("utf-8")
+        except UnicodeDecodeError:
+            return base64.b64encode(content).decode("ascii")
+    if isinstance(obj, bytes):
+        try:
+            return obj.decode("utf-8")
+        except UnicodeDecodeError:
+            return base64.b64encode(obj).decode("ascii")
+    if isinstance(obj, dict):
+        return {k: await _read_streaming_values(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [await _read_streaming_values(item) for item in obj]
+    return obj
+
+
 @registry.register(
     default_title="Call method",
     description="Instantiate a Boto3 client and call an AWS Boto3 API method.",
@@ -232,7 +257,7 @@ async def call_api(
     session = await get_session()
     async with session.client(service_name, endpoint_url=endpoint_url) as client:  # type: ignore
         response = await getattr(client, method_name)(**params)
-        return response
+        return await _read_streaming_values(response)
 
 
 @registry.register(
@@ -269,6 +294,6 @@ async def call_paginated_api(
 
     results = []
     async for page in pages:
-        results.append(page)
+        results.append(await _read_streaming_values(page))
 
     return results


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

Previously, the AWS boto3 action was not handling `StreamingBody` response. For example, when calling a lambda:
```
There was an error in the executor when calling action 'tools.aws_boto3.call_api'.


SubprocessError: Subprocess exited with code 1: Traceback (most recent call last):
  File "/app/tracecat/executor/minimal_runner.py", line 477, in <module>
    result_bytes = json_dumps(result)
                   ^^^^^^^^^^^^^^^^^^
  File "/app/tracecat/executor/minimal_runner.py", line 36, in json_dumps
    return orjson.dumps(obj)
           ^^^^^^^^^^^^^^^^^
TypeError: Type is not JSON serializable: StreamingBody
```

- Add `_read_streaming_values` helper that reads `StreamingBody` and `bytes` values in boto3 responses before returning them
- Content is decoded as UTF-8, falling back to base64 encoding for binary data
- Applied to both `call_api` and `call_paginated_api` responses

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
Test `tools.aws_boto3.call_api` and `tools.aws_boto3.call_paginated_api` with streaming and non streaming calls, such as `invoke lambda`, or `list_buckets s3`, etc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON serialization errors when AWS `boto3` responses include streaming bodies by reading and decoding content in `call_api` and `call_paginated_api`. Adds a safe read cap and fixes a paginator session leak to prevent crashes and leaks.

- **Bug Fixes**
  - Added async `_read_streaming_values` to read `StreamingBody`/`bytes` (UTF-8 decode; base64 when binary), capped at 100 MB.
  - Applied to both `tools.aws_boto3.call_api` and `tools.aws_boto3.call_paginated_api`.
  - Fixed paginator session leak by consuming pages inside the client context.

<sup>Written for commit 2d90b63317dbaba917cfaa6726db9f824db43db2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

