### PR TITLE
fix(agents): stopgap resolution of tracecat registry alias

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -6,7 +6,6 @@ Tests the runtime execution with mocked Claude SDK.
 from __future__ import annotations
 
 import uuid
-from dataclasses import replace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -261,24 +260,18 @@ class TestClaudeAgentRuntimeRun:
         mock_socket_writer.send_done.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_adds_registry_mcp_alias_on_resume(
+    async def test_adds_registry_mcp_alias(
         self,
         mock_socket_writer: MagicMock,
         mock_claude_sdk_client: MagicMock,
         sample_init_payload: RuntimeInitPayload,
     ) -> None:
-        """Test that resumed sessions include the registry MCP alias."""
+        """Test that fresh sessions include both registry MCP aliases."""
         captured_options: list[Any] = []
 
         def _mock_client_ctor(*_args: Any, **kwargs: Any) -> MagicMock:
             captured_options.append(kwargs["options"])
             return mock_claude_sdk_client
-
-        resumed_payload = replace(
-            sample_init_payload,
-            sdk_session_id="eed8297f-26fb-4e00-905f-a10f0cf20704",
-            sdk_session_data='{"type":"user","message":{"content":"test"}}\n',
-        )
 
         with (
             patch(
@@ -291,7 +284,7 @@ class TestClaudeAgentRuntimeRun:
             ),
         ):
             runtime = ClaudeAgentRuntime(mock_socket_writer)
-            await runtime.run(resumed_payload)
+            await runtime.run(sample_init_payload)
 
         assert captured_options
         mcp_servers = captured_options[0].mcp_servers

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -474,9 +474,8 @@ class ClaudeAgentRuntime:
                     auth_token=payload.mcp_auth_token,
                 )
                 mcp_servers[REGISTRY_MCP_SERVER_NAME] = proxy_config
-                # Guard against alias drift in resumed session history/tool calls.
-                if payload.sdk_session_id:
-                    mcp_servers[REGISTRY_MCP_SERVER_NAME_ALIAS] = proxy_config
+                # Guard against alias drift across fresh and resumed sessions.
+                mcp_servers[REGISTRY_MCP_SERVER_NAME_ALIAS] = proxy_config
 
             stderr_queue: asyncio.Queue[str] = asyncio.Queue()
             if payload.config.mcp_servers:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Always register the Tracecat registry MCP under both its canonical name and alias to prevent alias drift from breaking tool calls in fresh and resumed sessions. Updated tests to verify both aliases are present in new sessions.

- **Bug Fixes**
  - Always add `REGISTRY_MCP_SERVER_NAME_ALIAS` to `mcp_servers` (not only when `sdk_session_id` is set).
  - Simplified unit test to use a fresh `sample_init_payload` and assert both aliases.

<sup>Written for commit eed3bc118a75ce3e300455562ac4bdb14d763eda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

