### PR TITLE
feat(ui): Add workflow and agent duplication

### DIFF
--- a/frontend/src/components/agents/agent-preset-delete-dialog.tsx
+++ b/frontend/src/components/agents/agent-preset-delete-dialog.tsx
@@ -27,6 +27,8 @@ export function AgentPresetDeleteDialog({
   onConfirm: () => Promise<void> | void
 }) {
   const [confirmationValue, setConfirmationValue] = useState("")
+  const normalizedPresetName = presetName.trim()
+  const confirmationTarget = normalizedPresetName || "DELETE"
 
   useEffect(() => {
     if (!open) {
@@ -38,7 +40,7 @@ export function AgentPresetDeleteDialog({
     setConfirmationValue("")
   }, [presetName])
 
-  const isConfirmationValid = confirmationValue === presetName
+  const isConfirmationValid = confirmationValue === confirmationTarget
 
   return (
     <AlertDialog
@@ -58,16 +60,17 @@ export function AgentPresetDeleteDialog({
           <AlertDialogTitle>Delete this agent?</AlertDialogTitle>
           <AlertDialogDescription>
             This action permanently removes{" "}
-            {presetName ? `"${presetName}"` : "the agent"} and cannot be undone.
+            {normalizedPresetName ? `"${normalizedPresetName}"` : "the agent"}{" "}
+            and cannot be undone.
           </AlertDialogDescription>
           <AlertDialogDescription>
-            Type <b>{presetName}</b> to confirm deletion.
+            Type <b>{confirmationTarget}</b> to confirm deletion.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <Input
           value={confirmationValue}
           onChange={(event) => setConfirmationValue(event.target.value)}
-          placeholder={`Type "${presetName}" to confirm`}
+          placeholder={`Type "${confirmationTarget}" to confirm`}
           disabled={isDeleting}
         />
         <AlertDialogFooter>

--- a/frontend/src/components/agents/agent-preset-delete-dialog.tsx
+++ b/frontend/src/components/agents/agent-preset-delete-dialog.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Input } from "@/components/ui/input"
+
+export function AgentPresetDeleteDialog({
+  open,
+  onOpenChange,
+  presetName,
+  isDeleting,
+  onConfirm,
+}: {
+  open: boolean
+  onOpenChange: (nextOpen: boolean) => void
+  presetName: string
+  isDeleting: boolean
+  onConfirm: () => Promise<void> | void
+}) {
+  const [confirmationValue, setConfirmationValue] = useState("")
+
+  useEffect(() => {
+    if (!open) {
+      setConfirmationValue("")
+    }
+  }, [open])
+
+  useEffect(() => {
+    setConfirmationValue("")
+  }, [presetName])
+
+  const isConfirmationValid = confirmationValue === presetName
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (isDeleting) {
+          return
+        }
+        if (!nextOpen) {
+          setConfirmationValue("")
+        }
+        onOpenChange(nextOpen)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this agent?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action permanently removes{" "}
+            {presetName ? `"${presetName}"` : "the agent"} and cannot be undone.
+          </AlertDialogDescription>
+          <AlertDialogDescription>
+            Type <b>{presetName}</b> to confirm deletion.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          value={confirmationValue}
+          onChange={(event) => setConfirmationValue(event.target.value)}
+          placeholder={`Type "${presetName}" to confirm`}
+          disabled={isDeleting}
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={(event) => {
+              event.preventDefault()
+              void onConfirm()
+            }}
+            disabled={isDeleting || !isConfirmationValid}
+          >
+            {isDeleting ? "Deleting..." : "Delete agent"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Braces,
   Brackets,
+  CopyPlus,
   Hash,
   History,
   List,
@@ -26,14 +27,7 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import {
-  type MouseEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   type FieldErrors,
   type UseFormReturn,
@@ -46,6 +40,7 @@ import type {
   AgentPresetRead,
   AgentPresetUpdate,
 } from "@/client"
+import { AgentPresetDeleteDialog } from "@/components/agents/agent-preset-delete-dialog"
 import { AgentPresetVersionSelect } from "@/components/agents/agent-preset-version-select"
 import { AgentPresetVersionsPanel } from "@/components/agents/agent-preset-versions-panel"
 import { SlackChannelPanel } from "@/components/agents/external-channels/slack-channel-panel"
@@ -58,22 +53,12 @@ import { CenteredSpinner } from "@/components/loading/spinner"
 import { MultiTagCommandInput, type Suggestion } from "@/components/tags-input"
 import { SimpleEditor } from "@/components/tiptap-templates/simple/simple-editor"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
@@ -127,6 +112,7 @@ import { useEntitlements } from "@/hooks/use-entitlements"
 import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import {
   type AgentPresetFormMode,
+  buildDuplicateAgentPresetPayload,
   canSubmitAgentPresetForm,
 } from "@/lib/agent-presets"
 import type { ModelInfo } from "@/lib/chat"
@@ -502,6 +488,25 @@ export function AgentPresetsBuilder({
           handleSetSelectedPresetId(updated.id)
           return updated
         }}
+        onDuplicate={
+          selectedPreset
+            ? async () => {
+                const existingSlugs =
+                  presets
+                    ?.map((preset) => preset.slug)
+                    .filter(
+                      (slug): slug is string => typeof slug === "string"
+                    ) ?? []
+                const created = await createAgentPreset(
+                  buildDuplicateAgentPresetPayload(
+                    selectedPreset,
+                    existingSlugs
+                  )
+                )
+                handleSetSelectedPresetId(created.id)
+              }
+            : undefined
+        }
         onDelete={
           selectedPreset
             ? async () => {
@@ -906,6 +911,7 @@ type AgentPresetFormProps = {
     presetId: string,
     payload: AgentPresetUpdate
   ) => Promise<AgentPresetRead>
+  onDuplicate?: () => Promise<void>
   onDelete?: () => Promise<void>
   isSaving: boolean
   isDeleting: boolean
@@ -924,6 +930,7 @@ function AgentPresetForm({
   builderPrompt,
   onCreate,
   onUpdate,
+  onDuplicate,
   onDelete,
   isSaving,
   isDeleting,
@@ -945,8 +952,7 @@ function AgentPresetForm({
     defaultValues: preset ? presetToFormValues(preset) : DEFAULT_FORM_VALUES,
   })
 
-  const handleConfirmDelete = async (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault()
+  const handleConfirmDelete = async () => {
     if (!onDelete) {
       return
     }
@@ -1068,6 +1074,8 @@ function AgentPresetForm({
               isSaving={isSaving}
               isDeleting={isDeleting}
               canSubmit={canSubmit}
+              presetName={preset?.name ?? ""}
+              onDuplicate={onDuplicate}
               onDelete={onDelete}
               deleteDialogOpen={deleteDialogOpen}
               onDeleteDialogChange={handleDeleteDialogChange}
@@ -1110,6 +1118,8 @@ function AgentPresetDocumentPanel({
   isSaving,
   isDeleting,
   canSubmit,
+  presetName,
+  onDuplicate,
   onDelete,
   deleteDialogOpen,
   onDeleteDialogChange,
@@ -1120,10 +1130,12 @@ function AgentPresetDocumentPanel({
   isSaving: boolean
   isDeleting: boolean
   canSubmit: boolean
+  presetName: string
+  onDuplicate?: () => Promise<void>
   onDelete?: () => Promise<void>
   deleteDialogOpen: boolean
   onDeleteDialogChange: (nextOpen: boolean) => void
-  onConfirmDelete: (event: MouseEvent<HTMLButtonElement>) => Promise<void>
+  onConfirmDelete: () => Promise<void>
 }) {
   return (
     <ScrollArea className="h-full">
@@ -1198,10 +1210,7 @@ function AgentPresetDocumentPanel({
               )}
             </Button>
             {mode === "edit" && onDelete ? (
-              <AlertDialog
-                open={deleteDialogOpen}
-                onOpenChange={onDeleteDialogChange}
-              >
+              <>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button
@@ -1216,51 +1225,37 @@ function AgentPresetDocumentPanel({
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    <AlertDialogTrigger asChild>
+                    {onDuplicate ? (
                       <DropdownMenuItem
-                        className="text-destructive focus:text-destructive"
-                        onSelect={(e) => {
-                          e.preventDefault()
-                          onDeleteDialogChange(true)
+                        onSelect={() => {
+                          void onDuplicate()
                         }}
                       >
-                        <Trash2 className="mr-2 size-4" />
-                        Delete agent
+                        <CopyPlus className="mr-2 size-4" />
+                        Duplicate agent
                       </DropdownMenuItem>
-                    </AlertDialogTrigger>
+                    ) : null}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onSelect={(event) => {
+                        event.preventDefault()
+                        onDeleteDialogChange(true)
+                      }}
+                    >
+                      <Trash2 className="mr-2 size-4" />
+                      Delete agent
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      Delete this agent preset?
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This action permanently removes the preset and cannot be
-                      undone.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel disabled={isDeleting}>
-                      Cancel
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      variant="destructive"
-                      onClick={onConfirmDelete}
-                      disabled={isDeleting}
-                    >
-                      {isDeleting ? (
-                        <span className="flex items-center">
-                          <Loader2 className="mr-2 size-4 animate-spin" />
-                          Deleting...
-                        </span>
-                      ) : (
-                        "Delete agent"
-                      )}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+                <AgentPresetDeleteDialog
+                  open={deleteDialogOpen}
+                  onOpenChange={onDeleteDialogChange}
+                  presetName={presetName}
+                  isDeleting={isDeleting}
+                  onConfirm={onConfirmDelete}
+                />
+              </>
             ) : null}
           </div>
         </div>

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -94,6 +94,7 @@ import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/use-toast"
 import {
   useAgentPreset,
   useAgentPresets,
@@ -942,6 +943,8 @@ function AgentPresetForm({
   mcpIntegrationsIsLoading,
 }: AgentPresetFormProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [isDuplicating, setIsDuplicating] = useState(false)
+  const isDuplicatingRef = useRef(false)
   const [activeTab, setActiveTab] = useState<AgentPresetSideTab>("live-chat")
   const { isFeatureEnabled: isFeatureEnabledFlag } = useFeatureFlag()
   const channelsEnabled = isFeatureEnabledFlag("agent-channels")
@@ -1046,6 +1049,28 @@ function AgentPresetForm({
     [isDeleting]
   )
 
+  const handleDuplicate = useCallback(async () => {
+    if (!onDuplicate || isDuplicatingRef.current) {
+      return
+    }
+
+    isDuplicatingRef.current = true
+    setIsDuplicating(true)
+    try {
+      await onDuplicate()
+    } catch (error) {
+      console.error("Failed to duplicate agent preset", error)
+      toast({
+        title: "Duplicate failed",
+        description: "Could not duplicate agent. Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      isDuplicatingRef.current = false
+      setIsDuplicating(false)
+    }
+  }, [onDuplicate])
+
   const handleAddToolApproval = useCallback(() => {
     appendToolApproval({
       tool: "",
@@ -1075,7 +1100,8 @@ function AgentPresetForm({
               isDeleting={isDeleting}
               canSubmit={canSubmit}
               presetName={preset?.name ?? ""}
-              onDuplicate={onDuplicate}
+              onDuplicate={onDuplicate ? handleDuplicate : undefined}
+              isDuplicating={isDuplicating}
               onDelete={onDelete}
               deleteDialogOpen={deleteDialogOpen}
               onDeleteDialogChange={handleDeleteDialogChange}
@@ -1120,6 +1146,7 @@ function AgentPresetDocumentPanel({
   canSubmit,
   presetName,
   onDuplicate,
+  isDuplicating,
   onDelete,
   deleteDialogOpen,
   onDeleteDialogChange,
@@ -1132,6 +1159,7 @@ function AgentPresetDocumentPanel({
   canSubmit: boolean
   presetName: string
   onDuplicate?: () => Promise<void>
+  isDuplicating: boolean
   onDelete?: () => Promise<void>
   deleteDialogOpen: boolean
   onDeleteDialogChange: (nextOpen: boolean) => void
@@ -1227,12 +1255,13 @@ function AgentPresetDocumentPanel({
                   <DropdownMenuContent align="end">
                     {onDuplicate ? (
                       <DropdownMenuItem
+                        disabled={isDuplicating}
                         onSelect={() => {
                           void onDuplicate()
                         }}
                       >
                         <CopyPlus className="mr-2 size-4" />
-                        Duplicate agent
+                        {isDuplicating ? "Duplicating..." : "Duplicate agent"}
                       </DropdownMenuItem>
                     ) : null}
                     <DropdownMenuSeparator />

--- a/frontend/src/components/agents/agents-table.tsx
+++ b/frontend/src/components/agents/agents-table.tsx
@@ -6,7 +6,7 @@ import type { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
 import { Copy, CopyPlus, Trash2 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import type { AgentPresetRead, AgentPresetReadMinimal } from "@/client"
 import {
   agentPresetsGetAgentPreset,
@@ -248,11 +248,13 @@ function AgentActionsMenu({
   onCopy,
   onDuplicate,
   onDelete,
+  isDuplicating,
 }: {
   preset: AgentPresetTableRow
   onCopy: (preset: AgentPresetTableRow) => void
   onDuplicate: (preset: AgentPresetTableRow) => void
   onDelete: (preset: AgentPresetTableRow) => void
+  isDuplicating: boolean
 }) {
   return (
     <DropdownMenu>
@@ -277,10 +279,11 @@ function AgentActionsMenu({
         </DropdownMenuItem>
         <DropdownMenuItem
           className="text-xs"
+          disabled={isDuplicating}
           onClick={() => onDuplicate(preset)}
         >
           <CopyPlus className="mr-2 size-3.5" />
-          Duplicate agent
+          {isDuplicating ? "Duplicating..." : "Duplicate agent"}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
@@ -302,6 +305,10 @@ export function AgentsTable() {
   const [selectedPreset, setSelectedPreset] =
     useState<AgentPresetTableRow | null>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [duplicatingPresetId, setDuplicatingPresetId] = useState<string | null>(
+    null
+  )
+  const duplicatingPresetIdRef = useRef<string | null>(null)
   const { createAgentPreset } = useCreateAgentPreset(workspaceId)
   const { deleteAgentPreset, deleteAgentPresetIsPending } =
     useDeleteAgentPreset(workspaceId)
@@ -399,6 +406,12 @@ export function AgentsTable() {
 
   const handleDuplicate = useCallback(
     async (preset: AgentPresetTableRow) => {
+      if (duplicatingPresetIdRef.current === preset.id) {
+        return
+      }
+
+      duplicatingPresetIdRef.current = preset.id
+      setDuplicatingPresetId(preset.id)
       try {
         const sourcePreset = toDuplicateSourcePreset(preset)
         const fullPreset =
@@ -417,6 +430,14 @@ export function AgentsTable() {
         router.push(`/workspaces/${workspaceId}/agents/${createdPreset.id}`)
       } catch (error) {
         console.error("Failed to duplicate agent preset:", error)
+        toast({
+          title: "Duplicate failed",
+          description: "Could not duplicate agent. Please try again.",
+          variant: "destructive",
+        })
+      } finally {
+        duplicatingPresetIdRef.current = null
+        setDuplicatingPresetId(null)
       }
     },
     [createAgentPreset, presets, router, workspaceId]
@@ -675,6 +696,7 @@ export function AgentsTable() {
             onCopy={handleCopy}
             onDuplicate={handleDuplicate}
             onDelete={handleDeleteRequest}
+            isDuplicating={duplicatingPresetId === row.original.id}
           />
         ),
       },

--- a/frontend/src/components/agents/agents-table.tsx
+++ b/frontend/src/components/agents/agents-table.tsx
@@ -4,29 +4,21 @@ import { DotsHorizontalIcon } from "@radix-ui/react-icons"
 import { useQuery } from "@tanstack/react-query"
 import type { ColumnDef } from "@tanstack/react-table"
 import { format } from "date-fns"
-import { Copy, Trash2 } from "lucide-react"
+import { Copy, CopyPlus, Trash2 } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useCallback, useMemo, useState } from "react"
 import type { AgentPresetRead, AgentPresetReadMinimal } from "@/client"
 import {
   agentPresetsGetAgentPreset,
   agentPresetsListAgentPresets,
 } from "@/client"
+import { AgentPresetDeleteDialog } from "@/components/agents/agent-preset-delete-dialog"
 import {
   DataTable,
   DataTableColumnHeader,
   type DataTableToolbarProps,
 } from "@/components/data-table"
 import { getIcon, ProviderIcon } from "@/components/icons"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -43,8 +35,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
-import { useDeleteAgentPreset } from "@/hooks/use-agent-presets"
+import {
+  useCreateAgentPreset,
+  useDeleteAgentPreset,
+} from "@/hooks/use-agent-presets"
 import { useAuth } from "@/hooks/use-auth"
+import { buildDuplicateAgentPresetPayload } from "@/lib/agent-presets"
 import { retryHandler, type TracecatApiError } from "@/lib/errors"
 import { useListMcpIntegrations } from "@/lib/hooks"
 import {
@@ -190,6 +186,40 @@ const buildMcpBadges = (
 const hasToolsConfig = (preset: AgentPresetTableRow) =>
   preset.actions !== undefined || preset.namespaces !== undefined
 
+function toDuplicateSourcePreset(
+  preset: AgentPresetTableRow
+): AgentPresetRead | null {
+  if (
+    typeof preset.slug !== "string" ||
+    typeof preset.model_name !== "string" ||
+    typeof preset.model_provider !== "string"
+  ) {
+    return null
+  }
+
+  return {
+    id: preset.id,
+    workspace_id: preset.workspace_id,
+    name: preset.name,
+    slug: preset.slug,
+    description: preset.description ?? null,
+    current_version_id: preset.current_version_id ?? null,
+    created_at: preset.created_at,
+    updated_at: preset.updated_at,
+    instructions: preset.instructions ?? null,
+    model_name: preset.model_name,
+    model_provider: preset.model_provider,
+    base_url: preset.base_url ?? null,
+    output_type: preset.output_type ?? null,
+    actions: preset.actions ?? null,
+    namespaces: preset.namespaces ?? null,
+    tool_approvals: preset.tool_approvals ?? null,
+    mcp_integrations: preset.mcp_integrations ?? null,
+    retries: preset.retries,
+    enable_internet_access: preset.enable_internet_access,
+  }
+}
+
 const renderRelativeDate = (value?: string) => {
   if (!value) {
     return <span className="text-xs text-muted-foreground">-</span>
@@ -216,10 +246,12 @@ const renderRelativeDate = (value?: string) => {
 function AgentActionsMenu({
   preset,
   onCopy,
+  onDuplicate,
   onDelete,
 }: {
   preset: AgentPresetTableRow
   onCopy: (preset: AgentPresetTableRow) => void
+  onDuplicate: (preset: AgentPresetTableRow) => void
   onDelete: (preset: AgentPresetTableRow) => void
 }) {
   return (
@@ -243,6 +275,13 @@ function AgentActionsMenu({
           <Copy className="mr-2 size-3.5" />
           Copy agent ID
         </DropdownMenuItem>
+        <DropdownMenuItem
+          className="text-xs"
+          onClick={() => onDuplicate(preset)}
+        >
+          <CopyPlus className="mr-2 size-3.5" />
+          Duplicate agent
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="text-xs text-rose-500 focus:text-rose-600"
@@ -257,11 +296,13 @@ function AgentActionsMenu({
 }
 
 export function AgentsTable() {
+  const router = useRouter()
   const workspaceId = useWorkspaceId()
   const { user } = useAuth()
   const [selectedPreset, setSelectedPreset] =
     useState<AgentPresetTableRow | null>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const { createAgentPreset } = useCreateAgentPreset(workspaceId)
   const { deleteAgentPreset, deleteAgentPresetIsPending } =
     useDeleteAgentPreset(workspaceId)
   const { mcpIntegrations } = useListMcpIntegrations(workspaceId)
@@ -355,6 +396,31 @@ export function AgentsTable() {
     setSelectedPreset(preset)
     setDeleteDialogOpen(true)
   }, [])
+
+  const handleDuplicate = useCallback(
+    async (preset: AgentPresetTableRow) => {
+      try {
+        const sourcePreset = toDuplicateSourcePreset(preset)
+        const fullPreset =
+          sourcePreset ??
+          (await agentPresetsGetAgentPreset({
+            workspaceId,
+            presetId: preset.id,
+          }))
+        const existingSlugs =
+          presets
+            ?.map((item) => item.slug)
+            .filter((slug): slug is string => typeof slug === "string") ?? []
+        const createdPreset = await createAgentPreset(
+          buildDuplicateAgentPresetPayload(fullPreset, existingSlugs)
+        )
+        router.push(`/workspaces/${workspaceId}/agents/${createdPreset.id}`)
+      } catch (error) {
+        console.error("Failed to duplicate agent preset:", error)
+      }
+    },
+    [createAgentPreset, presets, router, workspaceId]
+  )
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!selectedPreset) {
@@ -607,12 +673,13 @@ export function AgentsTable() {
           <AgentActionsMenu
             preset={row.original}
             onCopy={handleCopy}
+            onDuplicate={handleDuplicate}
             onDelete={handleDeleteRequest}
           />
         ),
       },
     ],
-    [handleCopy, handleDeleteRequest, mcpIntegrationMap]
+    [handleCopy, handleDeleteRequest, handleDuplicate, mcpIntegrationMap]
   )
 
   return (
@@ -632,41 +699,18 @@ export function AgentsTable() {
           }
         />
       </TooltipProvider>
-      <AlertDialog
+      <AgentPresetDeleteDialog
         open={deleteDialogOpen}
         onOpenChange={(nextOpen) => {
-          if (deleteAgentPresetIsPending) {
-            return
-          }
           setDeleteDialogOpen(nextOpen)
           if (!nextOpen) {
             setSelectedPreset(null)
           }
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete this agent?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action permanently removes{" "}
-              {selectedPreset?.name ? `"${selectedPreset.name}"` : "the agent"}
-              {" and cannot be undone."}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteAgentPresetIsPending}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={handleDeleteConfirm}
-              disabled={deleteAgentPresetIsPending}
-            >
-              {deleteAgentPresetIsPending ? "Deleting..." : "Delete agent"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        presetName={selectedPreset?.name ?? "the agent"}
+        isDeleting={deleteAgentPresetIsPending}
+        onConfirm={handleDeleteConfirm}
+      />
     </>
   )
 }

--- a/frontend/src/components/agents/agents-table.tsx
+++ b/frontend/src/components/agents/agents-table.tsx
@@ -701,7 +701,13 @@ export function AgentsTable() {
         ),
       },
     ],
-    [handleCopy, handleDeleteRequest, handleDuplicate, mcpIntegrationMap]
+    [
+      duplicatingPresetId,
+      handleCopy,
+      handleDeleteRequest,
+      handleDuplicate,
+      mcpIntegrationMap,
+    ]
   )
 
   return (

--- a/frontend/src/components/dashboard/table-actions.tsx
+++ b/frontend/src/components/dashboard/table-actions.tsx
@@ -2,6 +2,7 @@
 
 import {
   Copy,
+  CopyPlus,
   DownloadIcon,
   ExternalLink,
   FolderKanban,
@@ -36,12 +37,14 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 
 export function WorkflowActions({
   item,
+  onDuplicateWorkflow,
   setSelectedWorkflow,
   setActiveDialog,
   showMoveToFolder = true,
   availableTags,
 }: {
   item: WorkflowDirectoryItem
+  onDuplicateWorkflow: (item: WorkflowDirectoryItem) => void
   setSelectedWorkflow: (workflow: WorkflowReadMinimal) => void
   setActiveDialog?: (activeDialog: ActiveDialog | null) => void
   showMoveToFolder?: boolean
@@ -225,6 +228,16 @@ export function WorkflowActions({
       >
         <Copy className="mr-2 size-3.5" />
         Copy workflow ID
+      </ContextMenuItem>
+      <ContextMenuItem
+        className="text-xs"
+        onClick={(event) => {
+          event.stopPropagation()
+          onDuplicateWorkflow(item)
+        }}
+      >
+        <CopyPlus className="mr-2 size-3.5" />
+        Duplicate workflow
       </ContextMenuItem>
       <ContextMenuSeparator />
       <DeleteWorkflowAlertDialogTrigger asChild>

--- a/frontend/src/components/dashboard/table-actions.tsx
+++ b/frontend/src/components/dashboard/table-actions.tsx
@@ -38,6 +38,7 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 export function WorkflowActions({
   item,
   onDuplicateWorkflow,
+  duplicateDisabled = false,
   setSelectedWorkflow,
   setActiveDialog,
   showMoveToFolder = true,
@@ -45,6 +46,7 @@ export function WorkflowActions({
 }: {
   item: WorkflowDirectoryItem
   onDuplicateWorkflow: (item: WorkflowDirectoryItem) => void
+  duplicateDisabled?: boolean
   setSelectedWorkflow: (workflow: WorkflowReadMinimal) => void
   setActiveDialog?: (activeDialog: ActiveDialog | null) => void
   showMoveToFolder?: boolean
@@ -231,6 +233,7 @@ export function WorkflowActions({
       </ContextMenuItem>
       <ContextMenuItem
         className="text-xs"
+        disabled={duplicateDisabled || !enabledExport}
         onClick={(event) => {
           event.stopPropagation()
           onDuplicateWorkflow(item)

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -67,14 +67,21 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { toast } from "@/components/ui/use-toast"
 import { useWorkflowsPagination } from "@/hooks/pagination/use-workflows-pagination"
 import { useEntitlements } from "@/hooks/use-entitlements"
 import {
   type DirectoryItem,
+  useFolders,
   useGetDirectoryItems,
+  useWorkflowManager,
   useWorkflowTags,
 } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
+import {
+  buildDuplicatedWorkflowDefinition,
+  exportWorkflowDefinition,
+} from "@/lib/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 const DEFAULT_LIMIT = 20
@@ -778,6 +785,7 @@ function WorkflowsListRow({
   item,
   onOpenWorkflow,
   onOpenFolder,
+  onDuplicateWorkflow,
   setSelectedWorkflow,
   setSelectedFolder,
   setActiveDialog,
@@ -786,6 +794,7 @@ function WorkflowsListRow({
   item: DirectoryItem
   onOpenWorkflow: (workflowId: string) => void
   onOpenFolder: (path: string) => void
+  onDuplicateWorkflow: (item: WorkflowDirectoryItem) => void
   setSelectedWorkflow: (workflow: WorkflowReadMinimal | null) => void
   setSelectedFolder: (folder: FolderDirectoryItem | null) => void
   setActiveDialog: (activeDialog: ActiveDialog | null) => void
@@ -857,6 +866,7 @@ function WorkflowsListRow({
         {/* Reuse the existing workflow action set, now rendered in right-click menu */}
         <WorkflowActions
           item={item}
+          onDuplicateWorkflow={onDuplicateWorkflow}
           availableTags={availableTags}
           showMoveToFolder
           setSelectedWorkflow={setSelectedWorkflow}
@@ -898,6 +908,15 @@ export function WorkflowsDashboard() {
   const [selectedFolder, setSelectedFolder] =
     useState<FolderDirectoryItem | null>(null)
 
+  const { createWorkflow, moveWorkflow, addWorkflowTag } = useWorkflowManager(
+    undefined,
+    {
+      listEnabled: false,
+    }
+  )
+  const { folders } = useFolders(workspaceId, {
+    enabled: view === "list",
+  })
   const { tags } = useWorkflowTags(workspaceId)
 
   const tagNameByRef = useMemo(() => {
@@ -948,6 +967,10 @@ export function WorkflowsDashboard() {
     useGetDirectoryItems(currentPath, workspaceId, {
       enabled: view === "folders",
     })
+  const folderPathById = useMemo(
+    () => new Map((folders ?? []).map((folder) => [folder.id, folder.path])),
+    [folders]
+  )
 
   const baseRoute = `/workspaces/${workspaceId}/workflows`
 
@@ -978,6 +1001,76 @@ export function WorkflowsDashboard() {
     nextParams.set("path", normalizeFolderPath(path))
     router.push(buildRoute(nextParams))
   }
+
+  const handleDuplicateWorkflow = useCallback(
+    async (item: WorkflowDirectoryItem) => {
+      try {
+        const exportedDefinition = await exportWorkflowDefinition({
+          workspaceId,
+          workflowId: item.id,
+          draft: true,
+        })
+        const duplicatedDefinition = buildDuplicatedWorkflowDefinition(
+          exportedDefinition,
+          item.title
+        )
+        const createdWorkflow = await createWorkflow({
+          workspaceId,
+          formData: {
+            file: new Blob([JSON.stringify(duplicatedDefinition)], {
+              type: "application/json",
+            }),
+            use_workflow_id: false,
+          },
+        })
+        const targetFolderPath =
+          view === "folders"
+            ? currentPath
+            : item.folder_id
+              ? (folderPathById.get(item.folder_id) ?? "/")
+              : "/"
+
+        await moveWorkflow({
+          workflowId: createdWorkflow.id,
+          workspaceId,
+          requestBody: {
+            folder_path: targetFolderPath,
+          },
+        })
+
+        for (const tag of item.tags ?? []) {
+          await addWorkflowTag({
+            workflowId: createdWorkflow.id,
+            workspaceId,
+            requestBody: {
+              tag_id: tag.id,
+            },
+          })
+        }
+
+        router.push(
+          `/workspaces/${workspaceId}/workflows/${createdWorkflow.id}`
+        )
+      } catch (error) {
+        console.error("Failed to duplicate workflow:", error)
+        toast({
+          title: "Duplicate failed",
+          description: "Could not duplicate workflow. Please try again.",
+          variant: "destructive",
+        })
+      }
+    },
+    [
+      addWorkflowTag,
+      createWorkflow,
+      currentPath,
+      folderPathById,
+      moveWorkflow,
+      router,
+      view,
+      workspaceId,
+    ]
+  )
 
   const matchesFilters = useCallback(
     (item: DirectoryItem): boolean => {
@@ -1248,6 +1341,7 @@ export function WorkflowsDashboard() {
                       )
                     }}
                     onOpenFolder={handleOpenFolder}
+                    onDuplicateWorkflow={handleDuplicateWorkflow}
                     setSelectedWorkflow={setSelectedWorkflow}
                     setSelectedFolder={setSelectedFolder}
                     setActiveDialog={setActiveDialog}

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -786,6 +786,7 @@ function WorkflowsListRow({
   onOpenWorkflow,
   onOpenFolder,
   onDuplicateWorkflow,
+  duplicateDisabled = false,
   setSelectedWorkflow,
   setSelectedFolder,
   setActiveDialog,
@@ -795,6 +796,7 @@ function WorkflowsListRow({
   onOpenWorkflow: (workflowId: string) => void
   onOpenFolder: (path: string) => void
   onDuplicateWorkflow: (item: WorkflowDirectoryItem) => void
+  duplicateDisabled?: boolean
   setSelectedWorkflow: (workflow: WorkflowReadMinimal | null) => void
   setSelectedFolder: (folder: FolderDirectoryItem | null) => void
   setActiveDialog: (activeDialog: ActiveDialog | null) => void
@@ -867,6 +869,7 @@ function WorkflowsListRow({
         <WorkflowActions
           item={item}
           onDuplicateWorkflow={onDuplicateWorkflow}
+          duplicateDisabled={duplicateDisabled}
           availableTags={availableTags}
           showMoveToFolder
           setSelectedWorkflow={setSelectedWorkflow}
@@ -914,7 +917,7 @@ export function WorkflowsDashboard() {
       listEnabled: false,
     }
   )
-  const { folders } = useFolders(workspaceId, {
+  const { folders, foldersIsLoading } = useFolders(workspaceId, {
     enabled: view === "list",
   })
   const { tags } = useWorkflowTags(workspaceId)
@@ -1027,8 +1030,12 @@ export function WorkflowsDashboard() {
           view === "folders"
             ? currentPath
             : item.folder_id
-              ? (folderPathById.get(item.folder_id) ?? "/")
+              ? folderPathById.get(item.folder_id)
               : "/"
+
+        if (targetFolderPath === undefined) {
+          throw new Error("Source workflow folder is not loaded yet")
+        }
 
         await moveWorkflow({
           workflowId: createdWorkflow.id,
@@ -1342,6 +1349,12 @@ export function WorkflowsDashboard() {
                     }}
                     onOpenFolder={handleOpenFolder}
                     onDuplicateWorkflow={handleDuplicateWorkflow}
+                    duplicateDisabled={
+                      item.type === "workflow" &&
+                      view === "list" &&
+                      item.folder_id != null &&
+                      (foldersIsLoading || !folderPathById.has(item.folder_id))
+                    }
                     setSelectedWorkflow={setSelectedWorkflow}
                     setSelectedFolder={setSelectedFolder}
                     setActiveDialog={setActiveDialog}

--- a/frontend/src/lib/agent-presets.ts
+++ b/frontend/src/lib/agent-presets.ts
@@ -1,4 +1,54 @@
+import type { AgentPresetCreate, AgentPresetRead } from "@/client"
+import { slugify } from "@/lib/utils"
+
 export type AgentPresetFormMode = "create" | "edit"
+
+export function getDuplicateItemName(name: string, fallback: string): string {
+  const trimmedName = name.trim()
+  return `Copy of ${trimmedName || fallback}`
+}
+
+export function buildDuplicateAgentSlug(
+  slug: string,
+  existingSlugs: Iterable<string>
+): string {
+  const normalizedSourceSlug = slugify(slug.trim(), "-") || "agent"
+  const baseSlug =
+    slugify(`copy-of-${normalizedSourceSlug}`, "-") || "copy-of-agent"
+  const slugSet = new Set(existingSlugs)
+
+  if (!slugSet.has(baseSlug)) {
+    return baseSlug
+  }
+
+  let suffix = 2
+  while (slugSet.has(`${baseSlug}-${suffix}`)) {
+    suffix += 1
+  }
+  return `${baseSlug}-${suffix}`
+}
+
+export function buildDuplicateAgentPresetPayload(
+  preset: AgentPresetRead,
+  existingSlugs: Iterable<string>
+): AgentPresetCreate {
+  return {
+    name: getDuplicateItemName(preset.name, "agent"),
+    slug: buildDuplicateAgentSlug(preset.slug || preset.name, existingSlugs),
+    description: preset.description ?? null,
+    instructions: preset.instructions ?? null,
+    model_name: preset.model_name,
+    model_provider: preset.model_provider,
+    base_url: preset.base_url ?? null,
+    output_type: preset.output_type ?? null,
+    actions: preset.actions ?? null,
+    namespaces: preset.namespaces ?? null,
+    tool_approvals: preset.tool_approvals ?? null,
+    mcp_integrations: preset.mcp_integrations ?? null,
+    retries: preset.retries,
+    enable_internet_access: preset.enable_internet_access,
+  }
+}
 
 export function canSubmitAgentPresetForm({
   mode,

--- a/frontend/src/lib/workflow.ts
+++ b/frontend/src/lib/workflow.ts
@@ -1,8 +1,53 @@
 import type { ReactFlowJsonObject } from "@xyflow/react"
-
 import { isEphemeral } from "@/components/builder/canvas/canvas"
+import { client } from "@/lib/api"
 
 export const CHILD_WORKFLOW_ACTION_TYPE = "core.workflow.execute" as const
+
+type WorkflowDefinitionExport = {
+  workspace_id?: string | null
+  workflow_id?: string | null
+  version?: number
+  definition: {
+    title: string
+    [key: string]: unknown
+  }
+  layout?: unknown
+  case_trigger?: unknown
+}
+
+export async function exportWorkflowDefinition(params: {
+  workspaceId: string
+  workflowId: string
+  draft?: boolean
+}): Promise<WorkflowDefinitionExport> {
+  const response = await client.get<WorkflowDefinitionExport>(
+    `/workflows/${params.workflowId}/export`,
+    {
+      params: {
+        workspace_id: params.workspaceId,
+        format: "json",
+        draft: params.draft ?? false,
+      },
+    }
+  )
+
+  return response.data
+}
+
+export function buildDuplicatedWorkflowDefinition(
+  definition: WorkflowDefinitionExport,
+  title: string
+): WorkflowDefinitionExport {
+  return {
+    ...definition,
+    workflow_id: null,
+    definition: {
+      ...definition.definition,
+      title: `Copy of ${title.trim() || definition.definition.title.trim() || "workflow"}`,
+    },
+  }
+}
 
 /**
  * Prune the graph object to remove ephemeral nodes and edges.

--- a/frontend/tests/agent-preset-delete-dialog.test.tsx
+++ b/frontend/tests/agent-preset-delete-dialog.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { AgentPresetDeleteDialog } from "@/components/agents/agent-preset-delete-dialog"
+
+describe("AgentPresetDeleteDialog", () => {
+  it("requires an exact preset name match before enabling delete", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <AgentPresetDeleteDialog
+        open={true}
+        onOpenChange={() => {}}
+        presetName="Triage agent"
+        isDeleting={false}
+        onConfirm={() => {}}
+      />
+    )
+
+    const deleteButton = screen.getByRole("button", { name: "Delete agent" })
+    const input = screen.getByPlaceholderText('Type "Triage agent" to confirm')
+
+    expect(deleteButton).toBeDisabled()
+
+    await user.type(input, "Triage")
+    expect(deleteButton).toBeDisabled()
+
+    await user.clear(input)
+    await user.type(input, "Triage agent")
+    expect(deleteButton).toBeEnabled()
+  })
+})

--- a/frontend/tests/agent-preset-delete-dialog.test.tsx
+++ b/frontend/tests/agent-preset-delete-dialog.test.tsx
@@ -28,4 +28,30 @@ describe("AgentPresetDeleteDialog", () => {
     await user.type(input, "Triage agent")
     expect(deleteButton).toBeEnabled()
   })
+
+  it('requires typing "DELETE" when the preset has no name', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <AgentPresetDeleteDialog
+        open={true}
+        onOpenChange={() => {}}
+        presetName=""
+        isDeleting={false}
+        onConfirm={() => {}}
+      />
+    )
+
+    const deleteButton = screen.getByRole("button", { name: "Delete agent" })
+    const input = screen.getByPlaceholderText('Type "DELETE" to confirm')
+
+    expect(deleteButton).toBeDisabled()
+
+    await user.type(input, "delete")
+    expect(deleteButton).toBeDisabled()
+
+    await user.clear(input)
+    await user.type(input, "DELETE")
+    expect(deleteButton).toBeEnabled()
+  })
 })

--- a/frontend/tests/agent-presets-builder.test.tsx
+++ b/frontend/tests/agent-presets-builder.test.tsx
@@ -1,4 +1,8 @@
-import { canSubmitAgentPresetForm } from "@/lib/agent-presets"
+import {
+  buildDuplicateAgentPresetPayload,
+  buildDuplicateAgentSlug,
+  canSubmitAgentPresetForm,
+} from "@/lib/agent-presets"
 
 describe("canSubmitAgentPresetForm", () => {
   it("keeps save disabled for new presets until model config is present", () => {
@@ -47,5 +51,52 @@ describe("canSubmitAgentPresetForm", () => {
         modelName: "   ",
       })
     ).toBe(false)
+  })
+
+  it("builds stable duplicate agent slugs with numeric suffixes", () => {
+    expect(buildDuplicateAgentSlug("triage-agent", [])).toBe(
+      "copy-of-triage-agent"
+    )
+    expect(
+      buildDuplicateAgentSlug("triage-agent", ["copy-of-triage-agent"])
+    ).toBe("copy-of-triage-agent-2")
+    expect(
+      buildDuplicateAgentSlug("triage-agent", [
+        "copy-of-triage-agent",
+        "copy-of-triage-agent-2",
+      ])
+    ).toBe("copy-of-triage-agent-3")
+  })
+
+  it("copies agent preset payload fields while renaming the duplicate", () => {
+    const duplicated = buildDuplicateAgentPresetPayload(
+      {
+        id: "preset-1",
+        workspace_id: "ws-1",
+        name: "Triage agent",
+        slug: "triage-agent",
+        description: "Handles inbound incidents",
+        instructions: "Investigate alerts",
+        model_name: "gpt-4o-mini",
+        model_provider: "openai",
+        base_url: null,
+        output_type: null,
+        actions: ["core.http_request"],
+        namespaces: ["core.http_request"],
+        tool_approvals: { "core.http_request": true },
+        mcp_integrations: ["mcp-1"],
+        retries: 2,
+        enable_internet_access: true,
+        created_at: "2026-03-13T12:00:00Z",
+        updated_at: "2026-03-13T12:00:00Z",
+      },
+      ["triage-agent"]
+    )
+
+    expect(duplicated.name).toBe("Copy of Triage agent")
+    expect(duplicated.slug).toBe("copy-of-triage-agent")
+    expect(duplicated.instructions).toBe("Investigate alerts")
+    expect(duplicated.actions).toEqual(["core.http_request"])
+    expect(duplicated.enable_internet_access).toBe(true)
   })
 })

--- a/frontend/tests/workflow.test.ts
+++ b/frontend/tests/workflow.test.ts
@@ -1,4 +1,7 @@
-import { pruneGraphObject } from "@/lib/workflow"
+import {
+  buildDuplicatedWorkflowDefinition,
+  pruneGraphObject,
+} from "@/lib/workflow"
 
 // Mock the canvas module to avoid circular dependencies
 jest.mock("@/components/builder/canvas/canvas", () => ({
@@ -67,5 +70,25 @@ describe("pruneGraphObject", () => {
         edges: [{ id: "edge1", source: "node1", target: "node2" }],
       })
     ).toThrow("Workflow cannot be saved without a trigger node")
+  })
+})
+
+describe("buildDuplicatedWorkflowDefinition", () => {
+  it("clears workflow_id and renames the duplicated workflow", () => {
+    const duplicated = buildDuplicatedWorkflowDefinition(
+      {
+        workflow_id: "wf_123",
+        definition: {
+          title: "Child",
+          description: "Original workflow",
+        },
+        layout: { nodes: [] },
+      },
+      "Child"
+    )
+
+    expect(duplicated.workflow_id).toBeNull()
+    expect(duplicated.definition.title).toBe("Copy of Child")
+    expect(duplicated.layout).toEqual({ nodes: [] })
   })
 })


### PR DESCRIPTION
## Summary
This change adds first-class duplication actions for workflows and agent presets, and hardens agent deletion so accidental clicks do not immediately remove a preset.

On the workflows dashboard, users can now duplicate a workflow directly from the row context menu. The duplicate is created from the current draft export, renamed to `Copy of ...`, moved into the same folder context, has its tags re-applied, and opens immediately in the workflow editor.

On the agents side, both the detail-page overflow menu and the agents table row menu now expose a `Duplicate agent` action. The duplicate copies the preset configuration into a newly created preset, assigns it a `Copy of ...` name, generates a unique `copy-of-...` slug with numeric suffixes as needed, and opens the new preset immediately.

## Problem
The workflows table exposed destructive and maintenance actions but did not provide a direct duplicate path, which made cloning an existing workflow unnecessarily manual. Agent presets had the same gap, and their delete affordance was especially easy to trigger by mistake because the existing confirmation required only a single click from the overflow menu.

In practice, that meant users had to rebuild or manually export/import workflows and agent presets just to branch from an existing configuration, while also carrying more risk of fat-fingering a preset deletion.

## Root cause
The frontend had all of the primitive APIs needed to duplicate both resource types, but there was no composed UI flow that stitched them together. The workflow context menu only surfaced export, move, tag, and delete actions, while the agent menus only offered delete. The existing agent delete dialog also did not use a typed confirmation pattern.

## Fix
The frontend now includes shared duplication helpers for workflow exports and agent preset payload cloning. Workflow duplication composes the existing draft export endpoint with the create workflow endpoint, then reapplies folder placement and workflow tags before routing to the new workflow. Agent duplication composes the existing preset read/create flows and centralizes the naming and slug rules in reusable helpers.

The agent delete flow now uses a shared typed confirmation dialog in both menu entry points. The destructive action stays disabled until the user types the exact preset name, and the confirmation input resets when the dialog closes or the selected preset changes.

## Validation
I validated the change with the existing frontend checks and focused tests:

- `pnpm -C frontend test -- --runInBand workflow.test.ts agent-presets-builder.test.tsx agent-preset-delete-dialog.test.tsx`
- `pnpm -C frontend run typecheck`
- `pnpm -C frontend check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds one-click duplication for workflows and agent presets, plus a safer agent delete flow with typed confirmation. Copies open immediately and keep relevant context.

- **New Features**
  - Workflows: Duplicate from the row/context menu using the current draft export; keeps folder and tags; opens in the editor; disables the action if folder info isn’t loaded to avoid misplacement.
  - Agents: Duplicate from the details and table menus; copies config; names as "Copy of ..."; generates a unique `copy-of-...` slug with numeric suffixes; opens the new preset.
  - Safer delete: Agent delete now requires typing the exact name (or "DELETE" if unnamed); the action stays disabled until matched; input resets on close or when the preset changes.

<sup>Written for commit 757c4211a043f8d85ab9385d1416cda164eeb319. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

