### PR TITLE
fix(ui): stdio arguments text size

### DIFF
--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -810,7 +810,7 @@ export function MCPIntegrationDialog({
                                               ? "@modelcontextprotocol/server-github"
                                               : "Additional argument"
                                           }
-                                          className="font-mono text-sm"
+                                          className="font-mono text-xs"
                                         />
                                       </FormControl>
                                       <FormMessage />


### PR DESCRIPTION
## Summary
The add MCP integration dialog rendered stdio argument inputs with `text-sm`, which made command arguments appear larger than the compact command-oriented styling used elsewhere in the form.

For users configuring stdio MCP servers, that made long argument values take more visual space and reduced scanability when reviewing multiple arguments in order.

## Root cause
The `stdio_args` field in `frontend/src/components/integrations/mcp-integration-dialog.tsx` explicitly used `className="font-mono text-sm"`, so the stdio argument rows did not match the smaller monospace treatment expected for these values.

## Fix
This change updates the stdio argument inputs to use `className="font-mono text-xs"`. The adjustment is intentionally narrow and affects only the stdio argument rows in the Add/Edit MCP integration dialog.

## Validation
I validated the change with:

- `pnpm -C frontend exec biome check --write .`
- `pnpm -C frontend run typecheck`
- the repository pre-commit hooks triggered during `git commit`
