### PR TITLE
feat(ui): Add trigger context event and move builder payload editor

### DIFF
--- a/frontend/src/components/builder/canvas/trigger-node.tsx
+++ b/frontend/src/components/builder/canvas/trigger-node.tsx
@@ -1,5 +1,6 @@
 import type { Node, NodeProps } from "@xyflow/react"
 import {
+  AlertTriangleIcon,
   CalendarCheck,
   CalendarClockIcon,
   Shield,
@@ -17,6 +18,7 @@ import {
   type TriggerPanelTab,
   TriggerPanelTabs,
 } from "@/components/builder/panel/trigger-panel-tabs"
+import { CodeEditor } from "@/components/editor/codemirror/code-editor"
 import { getIcon } from "@/components/icons"
 import {
   Card,
@@ -45,6 +47,7 @@ import { useEntitlements } from "@/hooks/use-entitlements"
 import { useCaseTrigger, useSchedules } from "@/lib/hooks"
 import { durationToHumanReadable } from "@/lib/time"
 import { cn } from "@/lib/utils"
+import { validateTriggerPayload } from "@/lib/workflow-trigger-payload"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 
@@ -66,6 +69,8 @@ export default React.memo(function TriggerNode({
     workspaceId,
     workflowId,
     actionPanelRef,
+    triggerPayload,
+    setTriggerPayload,
     setTriggerPanelTab,
   } = useWorkflowBuilder()
   const { breakpoint, style } = useTriggerNodeZoomBreakpoint()
@@ -179,126 +184,170 @@ export default React.memo(function TriggerNode({
     return null
   }
 
-  return (
-    <Card
-      ref={cardRef}
-      onClickCapture={handleDefaultPanelOpen}
-      className={cn(
-        "w-64",
-        nodeStyles.common,
-        selected ? nodeStyles.selected : nodeStyles.hover
-      )}
-    >
-      <CardHeader className="p-4">
-        <div className="flex w-full items-center space-x-4">
-          {getIcon(type, {
-            className: "size-10 p-2",
-          })}
+  const triggerPayloadError = validateTriggerPayload(triggerPayload)
 
-          <div className="flex w-full flex-1 justify-between space-x-12">
-            <div className="flex flex-col">
-              <CardTitle className="flex w-full items-center justify-between text-xs font-medium leading-none">
-                <div
-                  className={cn(
-                    style.fontSize,
-                    breakpoint !== "large" && "w-full"
-                  )}
-                >
-                  {title}
-                </div>
-              </CardTitle>
-              {style.showContent && (
-                <CardDescription className="mt-2 text-xs text-muted-foreground">
-                  Workflow trigger
-                </CardDescription>
-              )}
-            </div>
-            <div className="flex items-start gap-1">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    {workflow.webhook.api_key?.is_active ? (
-                      <Shield className="size-4 text-emerald-400" />
-                    ) : workflow.webhook.api_key ? (
-                      <Shield className="size-4 text-amber-400" />
-                    ) : (
-                      <ShieldOff className="size-4 text-muted-foreground/70" />
+  return (
+    <div ref={cardRef} className="flex items-start gap-4">
+      <Card
+        onClickCapture={handleDefaultPanelOpen}
+        className={cn(
+          "w-64",
+          nodeStyles.common,
+          selected ? nodeStyles.selected : nodeStyles.hover
+        )}
+      >
+        <CardHeader className="p-4">
+          <div className="flex w-full items-center space-x-4">
+            {getIcon(type, {
+              className: "size-10 p-2",
+            })}
+
+            <div className="flex w-full flex-1 justify-between space-x-12">
+              <div className="flex flex-col">
+                <CardTitle className="flex w-full items-center justify-between text-xs font-medium leading-none">
+                  <div
+                    className={cn(
+                      style.fontSize,
+                      breakpoint !== "large" && "w-full"
                     )}
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={4}>
-                    {workflow.webhook.api_key?.is_active
-                      ? "Webhook is protected"
-                      : workflow.webhook.api_key
-                        ? "API key revoked"
-                        : "Webhook is unprotected"}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+                  >
+                    {title}
+                  </div>
+                </CardTitle>
+                {style.showContent && (
+                  <CardDescription className="mt-2 text-xs text-muted-foreground">
+                    Workflow trigger
+                  </CardDescription>
+                )}
+              </div>
+              <div className="flex items-start gap-1">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      {workflow.webhook.api_key?.is_active ? (
+                        <Shield className="size-4 text-emerald-400" />
+                      ) : workflow.webhook.api_key ? (
+                        <Shield className="size-4 text-amber-400" />
+                      ) : (
+                        <ShieldOff className="size-4 text-muted-foreground/70" />
+                      )}
+                    </TooltipTrigger>
+                    <TooltipContent side="top" sideOffset={4}>
+                      {workflow.webhook.api_key?.is_active
+                        ? "Webhook is protected"
+                        : workflow.webhook.api_key
+                          ? "API key revoked"
+                          : "Webhook is unprotected"}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
             </div>
           </div>
-        </div>
-      </CardHeader>
-      {style.showContent && (
-        <>
-          <Separator />
-          <div className="p-4">
-            <div className="space-y-4">
-              {/* Webhook status */}
-              <div
-                className={cn(
-                  "flex h-8 cursor-pointer items-center justify-center gap-1 rounded-lg border text-xs text-muted-foreground",
-                  workflow?.webhook.status === "offline"
-                    ? "bg-muted-foreground/5 text-muted-foreground/50"
-                    : "bg-background text-emerald-500"
-                )}
-                onClick={() => openTriggerPanel(TriggerPanelTabs.webhook)}
-              >
-                <WebhookIcon className="size-3" />
-                <span>Webhook</span>
-                <span
-                  className={cn(
-                    "ml-2 inline-block size-2 rounded-full ",
-                    workflow.webhook.status === "online"
-                      ? "bg-emerald-500"
-                      : "bg-gray-300"
-                  )}
-                />
-              </div>
-              {caseAddonsEnabled && (
+        </CardHeader>
+        {style.showContent && (
+          <>
+            <Separator />
+            <div className="p-4">
+              <div className="space-y-4">
+                {/* Webhook status */}
                 <div
                   className={cn(
                     "flex h-8 cursor-pointer items-center justify-center gap-1 rounded-lg border text-xs text-muted-foreground",
-                    isCaseTriggerEnabled
-                      ? "bg-background text-emerald-500"
-                      : "bg-muted-foreground/5 text-muted-foreground/50"
+                    workflow?.webhook.status === "offline"
+                      ? "bg-muted-foreground/5 text-muted-foreground/50"
+                      : "bg-background text-emerald-500"
                   )}
-                  onClick={() =>
-                    openTriggerPanel(TriggerPanelTabs.caseTriggers)
-                  }
+                  onClick={() => openTriggerPanel(TriggerPanelTabs.webhook)}
                 >
-                  <SquarePlay className="size-3" />
-                  <span>Case triggers</span>
+                  <WebhookIcon className="size-3" />
+                  <span>Webhook</span>
                   <span
                     className={cn(
-                      "ml-2 inline-block size-2 rounded-full",
-                      isCaseTriggerEnabled ? "bg-emerald-500" : "bg-gray-300"
+                      "ml-2 inline-block size-2 rounded-full ",
+                      workflow.webhook.status === "online"
+                        ? "bg-emerald-500"
+                        : "bg-gray-300"
                     )}
                   />
                 </div>
-              )}
-              {/* Schedule table */}
-              <div
-                className="rounded-lg border cursor-pointer"
-                onClick={() => openTriggerPanel(TriggerPanelTabs.schedules)}
-              >
-                <TriggerNodeSchedulesTable workflowId={workflow.id} />
+                {caseAddonsEnabled && (
+                  <div
+                    className={cn(
+                      "flex h-8 cursor-pointer items-center justify-center gap-1 rounded-lg border text-xs text-muted-foreground",
+                      isCaseTriggerEnabled
+                        ? "bg-background text-emerald-500"
+                        : "bg-muted-foreground/5 text-muted-foreground/50"
+                    )}
+                    onClick={() =>
+                      openTriggerPanel(TriggerPanelTabs.caseTriggers)
+                    }
+                  >
+                    <SquarePlay className="size-3" />
+                    <span>Case triggers</span>
+                    <span
+                      className={cn(
+                        "ml-2 inline-block size-2 rounded-full",
+                        isCaseTriggerEnabled ? "bg-emerald-500" : "bg-gray-300"
+                      )}
+                    />
+                  </div>
+                )}
+                {/* Schedule table */}
+                <div
+                  className="rounded-lg border cursor-pointer"
+                  onClick={() => openTriggerPanel(TriggerPanelTabs.schedules)}
+                >
+                  <TriggerNodeSchedulesTable workflowId={workflow.id} />
+                </div>
               </div>
             </div>
+          </>
+        )}
+        <TriggerSourceHandle />
+      </Card>
+
+      {style.showContent && (
+        <div
+          className="w-[360px] rounded-xl border bg-background p-3"
+          onClick={(event) => {
+            event.stopPropagation()
+          }}
+        >
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-medium text-foreground">
+                Trigger payload
+              </p>
+              <p className="text-[11px] text-muted-foreground">
+                Draft runs use this JSON as the `TRIGGER` payload.
+              </p>
+            </div>
           </div>
-        </>
+          <CodeEditor
+            value={triggerPayload}
+            language="json"
+            onChange={setTriggerPayload}
+            className={cn(
+              "[&_.cm-editor]:border-input [&_.cm-editor]:bg-background",
+              "[&_.cm-scroller]:min-h-[220px] [&_.cm-scroller]:max-h-[320px] [&_.cm-scroller]:overflow-auto"
+            )}
+          />
+          <div className="mt-2 flex items-start gap-2 text-[11px]">
+            {triggerPayloadError ? (
+              <>
+                <AlertTriangleIcon className="mt-0.5 size-3 shrink-0 text-rose-500" />
+                <span className="text-rose-500">{triggerPayloadError}</span>
+              </>
+            ) : (
+              <span className="text-muted-foreground">
+                Saved to cookies for this workflow in this browser.
+              </span>
+            )}
+          </div>
+        </div>
       )}
-      <TriggerSourceHandle />
-    </Card>
+    </div>
   )
 })
 

--- a/frontend/src/components/builder/canvas/trigger-node.tsx
+++ b/frontend/src/components/builder/canvas/trigger-node.tsx
@@ -309,7 +309,7 @@ export default React.memo(function TriggerNode({
 
       {style.showContent && (
         <div
-          className="w-[360px] rounded-xl border bg-background p-3"
+          className="nodrag nopan nowheel w-[360px] rounded-xl border bg-background p-3"
           onClick={(event) => {
             event.stopPropagation()
           }}
@@ -341,7 +341,7 @@ export default React.memo(function TriggerNode({
               </>
             ) : (
               <span className="text-muted-foreground">
-                Saved to cookies for this workflow in this browser.
+                Saved in this browser for this workflow.
               </span>
             )}
           </div>

--- a/frontend/src/components/builder/events/events-workflow.tsx
+++ b/frontend/src/components/builder/events/events-workflow.tsx
@@ -53,6 +53,7 @@ import {
   refToLabel,
   WF_COMPLETED_EVENT_REF,
   WF_FAILURE_EVENT_REF,
+  WF_TRIGGER_EVENT_REF,
   type WorkflowExecutionEventCompact,
   type WorkflowExecutionReadCompact,
 } from "@/lib/event-history"
@@ -350,6 +351,15 @@ export function WorkflowEvents({
           : loopMeta
       const instanceCount = relatedEvents.length
       const childWorkflowRunLink = getChildWorkflowRunLink(relatedEvents)
+      const isWorkflowFailureEvent = actionRef === WF_FAILURE_EVENT_REF
+      const isWorkflowResultEvent = actionRef === WF_COMPLETED_EVENT_REF
+      const canViewInput =
+        isActionRefValid(actionRef) || actionRef === WF_TRIGGER_EVENT_REF
+      const canViewResult =
+        isActionRefValid(actionRef) ||
+        isWorkflowFailureEvent ||
+        isWorkflowResultEvent
+      const canFocusAction = isActionRefValid(actionRef)
 
       return {
         key: actionRef,
@@ -405,7 +415,7 @@ export function WorkflowEvents({
               )}
             >
               <DropdownMenuItem
-                disabled={!isActionRefValid(actionRef)}
+                disabled={!canViewInput}
                 onClick={(e) => {
                   e.stopPropagation()
                   sidebarRef.current?.setOpen(true)
@@ -417,11 +427,7 @@ export function WorkflowEvents({
                 <span>View last input</span>
               </DropdownMenuItem>
               <DropdownMenuItem
-                disabled={
-                  !isActionRefValid(actionRef) &&
-                  actionRef !== WF_FAILURE_EVENT_REF &&
-                  actionRef !== WF_COMPLETED_EVENT_REF
-                }
+                disabled={!canViewResult}
                 onClick={(e) => {
                   e.stopPropagation()
                   sidebarRef.current?.setOpen(true)
@@ -433,13 +439,13 @@ export function WorkflowEvents({
                 <span>View last result</span>
               </DropdownMenuItem>
               <DropdownMenuItem
-                disabled={!isActionRefValid(actionRef)}
+                disabled={!canFocusAction}
                 onClick={(e) => {
                   e.stopPropagation()
                   centerNode(actionRef)
                 }}
               >
-                {!isActionRefValid(actionRef) ? (
+                {!canFocusAction ? (
                   <EyeOffIcon className="size-3" />
                 ) : (
                   <ScanEyeIcon className="size-3" />

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -27,7 +27,6 @@ import type {
   WorkflowDslPublish,
 } from "@/client"
 import { ApiError, workflowsListWorkflowBranches } from "@/client"
-import { CodeEditor } from "@/components/editor/codemirror/code-editor"
 import { ExportMenuItem } from "@/components/export-workflow-dropdown-item"
 import { Spinner } from "@/components/loading/spinner"
 import {
@@ -68,11 +67,6 @@ import {
 import { Input } from "@/components/ui/input"
 import { Kbd } from "@/components/ui/kbd"
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -98,6 +92,10 @@ import {
   useWorkflowManager,
 } from "@/lib/hooks"
 import { cn, copyToClipboard } from "@/lib/utils"
+import {
+  parseTriggerPayload,
+  validateTriggerPayload,
+} from "@/lib/workflow-trigger-payload"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
@@ -349,27 +347,6 @@ function TabSwitcher({ workflowId }: { workflowId: string }) {
   )
 }
 
-const workflowControlsFormSchema = z.object({
-  payload: z.string().superRefine((val, ctx) => {
-    try {
-      JSON.parse(val)
-    } catch (error) {
-      if (error instanceof Error) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Invalid JSON format: ${error.message}`,
-        })
-      } else {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Invalid JSON format: Unknown error occurred",
-        })
-      }
-    }
-  }),
-})
-type TWorkflowControlsForm = z.infer<typeof workflowControlsFormSchema>
-
 const publishFormSchema = z.object({
   message: z.string().optional(),
   branch: z.string().trim().min(1, "Target branch is required"),
@@ -495,37 +472,34 @@ function WorkflowManualTrigger({
   disabled: boolean
   workflowId: string
 }) {
-  const { expandSidebarAndFocusEvents, setCurrentExecutionId } =
+  const { expandSidebarAndFocusEvents, setCurrentExecutionId, triggerPayload } =
     useWorkflowBuilder()
   // Always use draft execution endpoint - runs the current draft workflow graph
   const { createDraftExecution, createDraftExecutionIsPending } =
     useCreateDraftWorkflowExecution(workflowId)
-  const [open, setOpen] = React.useState(false)
-  const [lastTriggerInput, setLastTriggerInput] = React.useState<string | null>(
-    null
-  )
   const [manualTriggerErrors, setManualTriggerErrors] = React.useState<
     ValidationResult[] | null
   >(null)
   const [isTriggering, setIsTriggering] = React.useState(false)
-  const form = useForm<TWorkflowControlsForm>({
-    resolver: zodResolver(workflowControlsFormSchema),
-    defaultValues: {
-      payload:
-        lastTriggerInput ||
-        JSON.stringify({ sampleWebhookParam: "sampleValue" }, null, 2),
-    },
-  })
 
-  const runWorkflow = async ({ payload }: Partial<TWorkflowControlsForm>) => {
+  React.useEffect(() => {
+    setManualTriggerErrors(null)
+  }, [triggerPayload])
+
+  const runWorkflow = async () => {
     if (disabled || createDraftExecutionIsPending) return
+    const payloadError = validateTriggerPayload(triggerPayload)
+    if (payloadError) {
+      setManualTriggerErrors([toDslApiErrorResult(payloadError)])
+      return
+    }
     setIsTriggering(true)
     setTimeout(() => setIsTriggering(false), 1000)
     setManualTriggerErrors(null)
     try {
       const result = await createDraftExecution({
         workflow_id: workflowId,
-        inputs: payload ? JSON.parse(payload) : undefined,
+        inputs: parseTriggerPayload(triggerPayload),
       })
 
       // Store the execution ID directly
@@ -557,118 +531,38 @@ function WorkflowManualTrigger({
     }
   }
 
-  const runWithPayload = async ({ payload }: TWorkflowControlsForm) => {
-    // Make the API call to start the workflow
-    setLastTriggerInput(payload)
-    try {
-      await runWorkflow({ payload })
-    } finally {
-      setOpen(false)
-    }
-  }
-
   const executionPending = createDraftExecutionIsPending || isTriggering
   return (
-    <Form {...form}>
-      <ValidationErrorView
-        side="bottom"
-        validationErrors={manualTriggerErrors || []}
-        noErrorTooltip={
-          <span>
-            {disabled
-              ? "Cannot run workflow."
-              : executionPending
-                ? "Starting workflow execution..."
-                : "Run the current draft workflow with trigger inputs."}
-          </span>
-        }
+    <ValidationErrorView
+      side="bottom"
+      validationErrors={manualTriggerErrors || []}
+      noErrorTooltip={
+        <span>
+          {disabled
+            ? "Cannot run workflow."
+            : executionPending
+              ? "Starting workflow execution..."
+              : "Run the current draft workflow with the trigger payload from the trigger node."}
+        </span>
+      }
+    >
+      <Button
+        type="button"
+        variant={manualTriggerErrors ? "destructive" : "default"}
+        className="h-7 gap-2 px-3 py-0 text-xs"
+        disabled={disabled || executionPending}
+        onClick={runWorkflow}
       >
-        <div
-          className={cn(
-            "flex h-7 divide-x rounded-lg border border-input overflow-hidden",
-            manualTriggerErrors
-              ? "divide-white/30 dark:divide-black/30"
-              : "divide-white/20 dark:divide-black/40"
-          )}
-        >
-          {/* Main Button */}
-          <Button
-            type="button"
-            variant={manualTriggerErrors ? "destructive" : "default"}
-            className="h-full gap-2 rounded-r-none border-none px-3 py-0 text-xs"
-            disabled={disabled || executionPending}
-            onClick={() => runWorkflow({ payload: undefined })}
-          >
-            {executionPending ? (
-              <Spinner className="size-3" segmentColor="currentColor" />
-            ) : manualTriggerErrors ? (
-              <AlertTriangleIcon className="size-3" />
-            ) : (
-              <PlayIcon className="size-3" />
-            )}
-            <span>Run</span>
-          </Button>
-          {/* Dropdown Button */}
-          <Popover
-            open={open && !disabled}
-            onOpenChange={(newOpen) => !disabled && setOpen(newOpen)}
-          >
-            <PopoverTrigger asChild>
-              <Button
-                type="button"
-                variant={manualTriggerErrors ? "destructive" : "default"}
-                className="h-full w-7 rounded-l-none border-none px-1 py-0 text-xs font-bold"
-                disabled={disabled || executionPending}
-              >
-                <ChevronDownIcon className="size-3" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-fit max-w-xl p-3 sm:max-w-2xl">
-              <form onSubmit={form.handleSubmit(runWithPayload)}>
-                <div className="flex h-fit flex-col">
-                  <span className="mb-2 text-xs text-muted-foreground">
-                    Edit the JSON payload below.
-                  </span>
-                  <FormField
-                    control={form.control}
-                    name="payload"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormControl>
-                          <CodeEditor
-                            value={field.value}
-                            language="json"
-                            onChange={field.onChange}
-                            className="[&_.cm-editor]:!border [&_.cm-editor]:!border-input [&_.cm-editor]:!bg-background [&_.cm-editor]:rounded-md [&_.cm-scroller]:max-h-96 [&_.cm-scroller]:overflow-auto [&_.cm-scroller]:h-auto sm:[&_.cm-scroller]:max-h-[500px]"
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <Button
-                    type="submit"
-                    variant="default"
-                    disabled={executionPending}
-                    className="group mt-2 flex h-7 items-center px-3 py-0 text-xs"
-                  >
-                    {executionPending ? (
-                      <Spinner
-                        className="mr-2 size-3.5"
-                        segmentColor="currentColor"
-                      />
-                    ) : (
-                      <PlayIcon className="mr-2 size-3.5" />
-                    )}
-                    <span>{executionPending ? "Starting..." : "Run"}</span>
-                  </Button>
-                </div>
-              </form>
-            </PopoverContent>
-          </Popover>
-        </div>
-      </ValidationErrorView>
-    </Form>
+        {executionPending ? (
+          <Spinner className="size-3" segmentColor="currentColor" />
+        ) : manualTriggerErrors ? (
+          <AlertTriangleIcon className="size-3" />
+        ) : (
+          <PlayIcon className="size-3" />
+        )}
+        <span>Run</span>
+      </Button>
+    </ValidationErrorView>
   )
 }
 

--- a/frontend/src/lib/event-history.ts
+++ b/frontend/src/lib/event-history.ts
@@ -16,6 +16,8 @@ export type WorkflowExecutionReadCompact =
   WorkflowExecutionReadCompact_Any__Union_AgentOutput__Any___Any_
 
 // Safe because refs are slugified. Use `workflow` to namespace from regular action refs.
+export const WF_TRIGGER_EVENT_REF = "__workflow_trigger__"
+export const WF_TRIGGER_EVENT_LABEL = "Trigger"
 export const WF_FAILURE_EVENT_REF = "__workflow_failure__"
 export const WF_FAILURE_EVENT_LABEL = "Workflow Failure"
 export const WF_COMPLETED_EVENT_REF = "__workflow_completed__"
@@ -312,6 +314,9 @@ export function isAgentOutput(
  * @returns The formatted display label for the action ref
  */
 export function refToLabel(actionRef: string) {
+  if (actionRef === WF_TRIGGER_EVENT_REF) {
+    return WF_TRIGGER_EVENT_LABEL
+  }
   if (actionRef === WF_FAILURE_EVENT_REF) {
     return WF_FAILURE_EVENT_LABEL
   }

--- a/frontend/src/lib/workflow-trigger-payload.ts
+++ b/frontend/src/lib/workflow-trigger-payload.ts
@@ -1,9 +1,5 @@
-import Cookies from "js-cookie"
-
 export const DEFAULT_TRIGGER_PAYLOAD = "{}"
 const TRIGGER_PAYLOAD_STORAGE_PREFIX = "tracecat:builder:trigger-payload"
-const LEGACY_TRIGGER_PAYLOAD_COOKIE_PREFIX =
-  "__tracecat:builder:trigger-payload"
 
 interface TriggerPayloadStorageScope {
   userId: string | null
@@ -17,14 +13,6 @@ export function triggerPayloadStorageKey({
   workflowId,
 }: TriggerPayloadStorageScope): string {
   return `${TRIGGER_PAYLOAD_STORAGE_PREFIX}:${userId ?? "anonymous"}:${workspaceId}:${workflowId}`
-}
-
-function legacyTriggerPayloadCookieKey({
-  userId,
-  workspaceId,
-  workflowId,
-}: TriggerPayloadStorageScope): string {
-  return `${LEGACY_TRIGGER_PAYLOAD_COOKIE_PREFIX}:${userId ?? "anonymous"}:${workspaceId}:${workflowId}`
 }
 
 export function readPersistedTriggerPayload({
@@ -47,29 +35,10 @@ export function readPersistedTriggerPayload({
       return stored
     }
   } catch {
-    // Fall back to the legacy cookie path when localStorage is unavailable.
-  }
-
-  try {
-    const legacyCookieKey = legacyTriggerPayloadCookieKey({
-      userId,
-      workspaceId,
-      workflowId,
-    })
-    const legacyValue = Cookies.get(legacyCookieKey)
-    if (!legacyValue) {
-      return DEFAULT_TRIGGER_PAYLOAD
-    }
-    try {
-      window.localStorage.setItem(storageKey, legacyValue)
-      Cookies.remove(legacyCookieKey, { path: "/" })
-    } catch {
-      // Keep the legacy cookie intact if migration cannot complete.
-    }
-    return legacyValue
-  } catch {
     return DEFAULT_TRIGGER_PAYLOAD
   }
+
+  return DEFAULT_TRIGGER_PAYLOAD
 }
 
 export function writePersistedTriggerPayload({
@@ -88,12 +57,6 @@ export function writePersistedTriggerPayload({
     window.localStorage.setItem(
       triggerPayloadStorageKey({ userId, workspaceId, workflowId }),
       triggerPayload
-    )
-    Cookies.remove(
-      legacyTriggerPayloadCookieKey({ userId, workspaceId, workflowId }),
-      {
-        path: "/",
-      }
     )
   } catch {
     // Ignore storage failures (e.g. blocked storage or quota exceeded)

--- a/frontend/src/lib/workflow-trigger-payload.ts
+++ b/frontend/src/lib/workflow-trigger-payload.ts
@@ -1,4 +1,104 @@
+import Cookies from "js-cookie"
+
 export const DEFAULT_TRIGGER_PAYLOAD = "{}"
+const TRIGGER_PAYLOAD_STORAGE_PREFIX = "tracecat:builder:trigger-payload"
+const LEGACY_TRIGGER_PAYLOAD_COOKIE_PREFIX =
+  "__tracecat:builder:trigger-payload"
+
+interface TriggerPayloadStorageScope {
+  userId: string | null
+  workspaceId: string
+  workflowId: string | null
+}
+
+export function triggerPayloadStorageKey({
+  userId,
+  workspaceId,
+  workflowId,
+}: TriggerPayloadStorageScope): string {
+  return `${TRIGGER_PAYLOAD_STORAGE_PREFIX}:${userId ?? "anonymous"}:${workspaceId}:${workflowId}`
+}
+
+function legacyTriggerPayloadCookieKey({
+  userId,
+  workspaceId,
+  workflowId,
+}: TriggerPayloadStorageScope): string {
+  return `${LEGACY_TRIGGER_PAYLOAD_COOKIE_PREFIX}:${userId ?? "anonymous"}:${workspaceId}:${workflowId}`
+}
+
+export function readPersistedTriggerPayload({
+  userId,
+  workspaceId,
+  workflowId,
+}: TriggerPayloadStorageScope): string {
+  if (!workflowId || typeof window === "undefined") {
+    return DEFAULT_TRIGGER_PAYLOAD
+  }
+
+  const storageKey = triggerPayloadStorageKey({
+    userId,
+    workspaceId,
+    workflowId,
+  })
+  try {
+    const stored = window.localStorage.getItem(storageKey)
+    if (stored !== null) {
+      return stored
+    }
+  } catch {
+    // Fall back to the legacy cookie path when localStorage is unavailable.
+  }
+
+  try {
+    const legacyCookieKey = legacyTriggerPayloadCookieKey({
+      userId,
+      workspaceId,
+      workflowId,
+    })
+    const legacyValue = Cookies.get(legacyCookieKey)
+    if (!legacyValue) {
+      return DEFAULT_TRIGGER_PAYLOAD
+    }
+    try {
+      window.localStorage.setItem(storageKey, legacyValue)
+      Cookies.remove(legacyCookieKey, { path: "/" })
+    } catch {
+      // Keep the legacy cookie intact if migration cannot complete.
+    }
+    return legacyValue
+  } catch {
+    return DEFAULT_TRIGGER_PAYLOAD
+  }
+}
+
+export function writePersistedTriggerPayload({
+  userId,
+  workspaceId,
+  workflowId,
+  triggerPayload,
+}: TriggerPayloadStorageScope & {
+  triggerPayload: string
+}): void {
+  if (!workflowId || typeof window === "undefined") {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(
+      triggerPayloadStorageKey({ userId, workspaceId, workflowId }),
+      triggerPayload
+    )
+    Cookies.remove(
+      legacyTriggerPayloadCookieKey({ userId, workspaceId, workflowId }),
+      {
+        path: "/",
+      }
+    )
+  } catch {
+    // Ignore storage failures (e.g. blocked storage or quota exceeded)
+  }
+}
 
 export function validateTriggerPayload(payload: string): string | null {
   const normalized = payload.trim()

--- a/frontend/src/lib/workflow-trigger-payload.ts
+++ b/frontend/src/lib/workflow-trigger-payload.ts
@@ -1,0 +1,25 @@
+export const DEFAULT_TRIGGER_PAYLOAD = "{}"
+
+export function validateTriggerPayload(payload: string): string | null {
+  const normalized = payload.trim()
+  if (!normalized) {
+    return null
+  }
+  try {
+    JSON.parse(normalized)
+    return null
+  } catch (error) {
+    if (error instanceof Error) {
+      return `Invalid JSON format: ${error.message}`
+    }
+    return "Invalid JSON format: Unknown error occurred"
+  }
+}
+
+export function parseTriggerPayload(payload: string): unknown {
+  const normalized = payload.trim()
+  if (!normalized) {
+    return undefined
+  }
+  return JSON.parse(normalized)
+}

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -7,6 +7,7 @@ import {
   useOnSelectionChange,
   useReactFlow,
 } from "@xyflow/react"
+import Cookies from "js-cookie"
 import React, {
   createContext,
   type ReactNode,
@@ -27,9 +28,12 @@ import {
   DEFAULT_TRIGGER_PANEL_TAB,
   type TriggerPanelTab,
 } from "@/components/builder/panel/trigger-panel-tabs"
+import { useAuth } from "@/hooks/use-auth"
+import { DEFAULT_TRIGGER_PAYLOAD } from "@/lib/workflow-trigger-payload"
 import { useWorkflow } from "@/providers/workflow"
 
 const SELECTED_NODE_STORAGE_PREFIX = "tracecat:builder:selected-node"
+const TRIGGER_PAYLOAD_COOKIE_PREFIX = "__tracecat:builder:trigger-payload"
 
 function selectedNodeStorageKey({
   workspaceId,
@@ -91,6 +95,72 @@ function writePersistedSelectedNode({
   }
 }
 
+function triggerPayloadCookieKey({
+  userId,
+  workspaceId,
+  workflowId,
+}: {
+  userId: string | null
+  workspaceId: string
+  workflowId: string | null
+}): string {
+  return `${TRIGGER_PAYLOAD_COOKIE_PREFIX}:${userId ?? "anonymous"}:${workspaceId}:${workflowId}`
+}
+
+function readPersistedTriggerPayload({
+  userId,
+  workspaceId,
+  workflowId,
+}: {
+  userId: string | null
+  workspaceId: string
+  workflowId: string | null
+}): string {
+  if (!workflowId || typeof window === "undefined") {
+    return DEFAULT_TRIGGER_PAYLOAD
+  }
+
+  try {
+    return (
+      Cookies.get(
+        triggerPayloadCookieKey({ userId, workspaceId, workflowId })
+      ) ?? DEFAULT_TRIGGER_PAYLOAD
+    )
+  } catch {
+    return DEFAULT_TRIGGER_PAYLOAD
+  }
+}
+
+function writePersistedTriggerPayload({
+  userId,
+  workspaceId,
+  workflowId,
+  triggerPayload,
+}: {
+  userId: string | null
+  workspaceId: string
+  workflowId: string | null
+  triggerPayload: string
+}): void {
+  if (!workflowId || typeof window === "undefined") {
+    return
+  }
+
+  try {
+    Cookies.set(
+      triggerPayloadCookieKey({ userId, workspaceId, workflowId }),
+      triggerPayload,
+      {
+        expires: 365,
+        path: "/",
+        sameSite: "lax",
+      }
+    )
+  } catch {
+    // Ignore storage failures (e.g. blocked cookies)
+  }
+}
+
 interface ReactFlowContextType {
   reactFlow: ReactFlowInstance
   workflowId: string
@@ -114,6 +184,8 @@ interface ReactFlowContextType {
   setSelectedActionEventRef: React.Dispatch<SetStateAction<string | undefined>>
   currentExecutionId: string | null
   setCurrentExecutionId: React.Dispatch<SetStateAction<string | null>>
+  triggerPayload: string
+  setTriggerPayload: React.Dispatch<SetStateAction<string>>
   actionDrafts: Record<string, unknown>
   setActionDraft: (actionId: string, draft: unknown) => void
   clearActionDraft: (actionId: string) => void
@@ -132,6 +204,8 @@ export const WorkflowBuilderProvider: React.FC<
 > = ({ children }) => {
   const reactFlowInstance = useReactFlow()
   const { workspaceId, workflowId, error } = useWorkflow()
+  const { user } = useAuth()
+  const userId = user?.id ?? null
 
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [selectedActionEventRef, setSelectedActionEventRef] = useState<
@@ -146,6 +220,9 @@ export const WorkflowBuilderProvider: React.FC<
   const [currentExecutionId, setCurrentExecutionId] = useState<string | null>(
     null
   )
+  const [triggerPayload, setTriggerPayload] = useState<string>(
+    DEFAULT_TRIGGER_PAYLOAD
+  )
   // In-memory map of actionId -> last edited form values.
   // This lets the action panel restore unsaved edits when the user
   // switches between nodes without touching the backend.
@@ -156,6 +233,10 @@ export const WorkflowBuilderProvider: React.FC<
   const lastPersistedSelectionRef = useRef<{
     key: string
     value: string | null
+  } | null>(null)
+  const lastPersistedTriggerPayloadRef = useRef<{
+    key: string
+    value: string
   } | null>(null)
 
   useEffect(() => {
@@ -177,8 +258,23 @@ export const WorkflowBuilderProvider: React.FC<
     setSelectedNodeId(restoredSelection)
     setCurrentExecutionId(null)
     setActionDrafts({})
+    const restoredTriggerPayload = readPersistedTriggerPayload({
+      userId,
+      workspaceId,
+      workflowId,
+    })
+    const triggerPayloadKey = triggerPayloadCookieKey({
+      userId,
+      workspaceId,
+      workflowId,
+    })
+    lastPersistedTriggerPayloadRef.current = {
+      key: triggerPayloadKey,
+      value: restoredTriggerPayload,
+    }
+    setTriggerPayload(restoredTriggerPayload)
     setTriggerPanelTab(DEFAULT_TRIGGER_PANEL_TAB)
-  }, [workspaceId, workflowId])
+  }, [userId, workspaceId, workflowId])
 
   useEffect(() => {
     if (!workflowId) {
@@ -199,6 +295,38 @@ export const WorkflowBuilderProvider: React.FC<
       value: selectedNodeId,
     }
   }, [workspaceId, workflowId, selectedNodeId])
+
+  useEffect(() => {
+    if (!workflowId) {
+      return
+    }
+    const key = triggerPayloadCookieKey({ userId, workspaceId, workflowId })
+    const lastPersisted = lastPersistedTriggerPayloadRef.current
+    if (
+      lastPersisted &&
+      lastPersisted.key === key &&
+      lastPersisted.value === triggerPayload
+    ) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      writePersistedTriggerPayload({
+        userId,
+        workspaceId,
+        workflowId,
+        triggerPayload,
+      })
+      lastPersistedTriggerPayloadRef.current = {
+        key,
+        value: triggerPayload,
+      }
+    }, 250)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [userId, workspaceId, workflowId, triggerPayload])
 
   const setReactFlowNodes = useCallback(
     (nodes: Node[] | ((nodes: Node[]) => Node[])) => {
@@ -313,6 +441,8 @@ export const WorkflowBuilderProvider: React.FC<
       toggleActionPanel,
       currentExecutionId,
       setCurrentExecutionId,
+      triggerPayload,
+      setTriggerPayload,
       actionDrafts,
       setActionDraft,
       clearActionDraft,
@@ -339,6 +469,8 @@ export const WorkflowBuilderProvider: React.FC<
       toggleActionPanel,
       currentExecutionId,
       setCurrentExecutionId,
+      triggerPayload,
+      setTriggerPayload,
       actionDrafts,
       setActionDraft,
       clearActionDraft,

--- a/frontend/src/providers/builder.tsx
+++ b/frontend/src/providers/builder.tsx
@@ -7,7 +7,6 @@ import {
   useOnSelectionChange,
   useReactFlow,
 } from "@xyflow/react"
-import Cookies from "js-cookie"
 import React, {
   createContext,
   type ReactNode,
@@ -29,11 +28,15 @@ import {
   type TriggerPanelTab,
 } from "@/components/builder/panel/trigger-panel-tabs"
 import { useAuth } from "@/hooks/use-auth"
-import { DEFAULT_TRIGGER_PAYLOAD } from "@/lib/workflow-trigger-payload"
+import {
+  DEFAULT_TRIGGER_PAYLOAD,
+  readPersistedTriggerPayload,
+  triggerPayloadStorageKey,
+  writePersistedTriggerPayload,
+} from "@/lib/workflow-trigger-payload"
 import { useWorkflow } from "@/providers/workflow"
 
 const SELECTED_NODE_STORAGE_PREFIX = "tracecat:builder:selected-node"
-const TRIGGER_PAYLOAD_COOKIE_PREFIX = "__tracecat:builder:trigger-payload"
 
 function selectedNodeStorageKey({
   workspaceId,
@@ -95,72 +98,6 @@ function writePersistedSelectedNode({
   }
 }
 
-function triggerPayloadCookieKey({
-  userId,
-  workspaceId,
-  workflowId,
-}: {
-  userId: string | null
-  workspaceId: string
-  workflowId: string | null
-}): string {
-  return `${TRIGGER_PAYLOAD_COOKIE_PREFIX}:${userId ?? "anonymous"}:${workspaceId}:${workflowId}`
-}
-
-function readPersistedTriggerPayload({
-  userId,
-  workspaceId,
-  workflowId,
-}: {
-  userId: string | null
-  workspaceId: string
-  workflowId: string | null
-}): string {
-  if (!workflowId || typeof window === "undefined") {
-    return DEFAULT_TRIGGER_PAYLOAD
-  }
-
-  try {
-    return (
-      Cookies.get(
-        triggerPayloadCookieKey({ userId, workspaceId, workflowId })
-      ) ?? DEFAULT_TRIGGER_PAYLOAD
-    )
-  } catch {
-    return DEFAULT_TRIGGER_PAYLOAD
-  }
-}
-
-function writePersistedTriggerPayload({
-  userId,
-  workspaceId,
-  workflowId,
-  triggerPayload,
-}: {
-  userId: string | null
-  workspaceId: string
-  workflowId: string | null
-  triggerPayload: string
-}): void {
-  if (!workflowId || typeof window === "undefined") {
-    return
-  }
-
-  try {
-    Cookies.set(
-      triggerPayloadCookieKey({ userId, workspaceId, workflowId }),
-      triggerPayload,
-      {
-        expires: 365,
-        path: "/",
-        sameSite: "lax",
-      }
-    )
-  } catch {
-    // Ignore storage failures (e.g. blocked cookies)
-  }
-}
-
 interface ReactFlowContextType {
   reactFlow: ReactFlowInstance
   workflowId: string
@@ -204,7 +141,7 @@ export const WorkflowBuilderProvider: React.FC<
 > = ({ children }) => {
   const reactFlowInstance = useReactFlow()
   const { workspaceId, workflowId, error } = useWorkflow()
-  const { user } = useAuth()
+  const { user, userIsLoading } = useAuth()
   const userId = user?.id ?? null
 
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
@@ -220,9 +157,10 @@ export const WorkflowBuilderProvider: React.FC<
   const [currentExecutionId, setCurrentExecutionId] = useState<string | null>(
     null
   )
-  const [triggerPayload, setTriggerPayload] = useState<string>(
+  const [triggerPayloadState, setTriggerPayloadState] = useState<string>(
     DEFAULT_TRIGGER_PAYLOAD
   )
+  const triggerPayload = triggerPayloadState
   // In-memory map of actionId -> last edited form values.
   // This lets the action panel restore unsaved edits when the user
   // switches between nodes without touching the backend.
@@ -238,12 +176,37 @@ export const WorkflowBuilderProvider: React.FC<
     key: string
     value: string
   } | null>(null)
+  const triggerPayloadDirtyRef = useRef(false)
+  const suppressNextTriggerPayloadPersistRef = useRef(false)
+
+  const setTriggerPayload = useCallback(
+    (value: SetStateAction<string>) => {
+      setTriggerPayloadState((current) => {
+        const nextValue =
+          typeof value === "function"
+            ? (value as (current: string) => string)(current)
+            : value
+        if (nextValue !== current) {
+          triggerPayloadDirtyRef.current = true
+        }
+        return nextValue
+      })
+    },
+    [setTriggerPayloadState]
+  )
 
   useEffect(() => {
     // Restore the last selection for this workflow in the current browser
     // session, then clear transient per-workflow UI state.
     if (!workflowId) {
       setSelectedNodeId(null)
+      setCurrentExecutionId(null)
+      setActionDrafts({})
+      setTriggerPayloadState(DEFAULT_TRIGGER_PAYLOAD)
+      setTriggerPanelTab(DEFAULT_TRIGGER_PANEL_TAB)
+      lastPersistedTriggerPayloadRef.current = null
+      triggerPayloadDirtyRef.current = false
+      suppressNextTriggerPayloadPersistRef.current = false
       return
     }
     const restoredSelection = readPersistedSelectedNode({
@@ -258,23 +221,52 @@ export const WorkflowBuilderProvider: React.FC<
     setSelectedNodeId(restoredSelection)
     setCurrentExecutionId(null)
     setActionDrafts({})
+    setTriggerPayloadState(DEFAULT_TRIGGER_PAYLOAD)
+    lastPersistedTriggerPayloadRef.current = null
+    triggerPayloadDirtyRef.current = false
+    suppressNextTriggerPayloadPersistRef.current = false
+    setTriggerPanelTab(DEFAULT_TRIGGER_PANEL_TAB)
+  }, [workspaceId, workflowId])
+
+  useEffect(() => {
+    if (!workflowId || userIsLoading) {
+      return
+    }
+
+    const key = triggerPayloadStorageKey({ userId, workspaceId, workflowId })
+    const lastPersisted = lastPersistedTriggerPayloadRef.current
+    if (lastPersisted?.key === key) {
+      return
+    }
+
+    if (triggerPayloadDirtyRef.current) {
+      writePersistedTriggerPayload({
+        userId,
+        workspaceId,
+        workflowId,
+        triggerPayload: triggerPayloadState,
+      })
+      lastPersistedTriggerPayloadRef.current = {
+        key,
+        value: triggerPayloadState,
+      }
+      triggerPayloadDirtyRef.current = false
+      return
+    }
+
     const restoredTriggerPayload = readPersistedTriggerPayload({
       userId,
       workspaceId,
       workflowId,
     })
-    const triggerPayloadKey = triggerPayloadCookieKey({
-      userId,
-      workspaceId,
-      workflowId,
-    })
     lastPersistedTriggerPayloadRef.current = {
-      key: triggerPayloadKey,
+      key,
       value: restoredTriggerPayload,
     }
-    setTriggerPayload(restoredTriggerPayload)
-    setTriggerPanelTab(DEFAULT_TRIGGER_PANEL_TAB)
-  }, [userId, workspaceId, workflowId])
+    triggerPayloadDirtyRef.current = false
+    suppressNextTriggerPayloadPersistRef.current = true
+    setTriggerPayloadState(restoredTriggerPayload)
+  }, [userIsLoading, userId, workspaceId, workflowId, triggerPayloadState])
 
   useEffect(() => {
     if (!workflowId) {
@@ -297,15 +289,19 @@ export const WorkflowBuilderProvider: React.FC<
   }, [workspaceId, workflowId, selectedNodeId])
 
   useEffect(() => {
-    if (!workflowId) {
+    if (!workflowId || userIsLoading) {
       return
     }
-    const key = triggerPayloadCookieKey({ userId, workspaceId, workflowId })
+    if (suppressNextTriggerPayloadPersistRef.current) {
+      suppressNextTriggerPayloadPersistRef.current = false
+      return
+    }
+    const key = triggerPayloadStorageKey({ userId, workspaceId, workflowId })
     const lastPersisted = lastPersistedTriggerPayloadRef.current
     if (
       lastPersisted &&
       lastPersisted.key === key &&
-      lastPersisted.value === triggerPayload
+      lastPersisted.value === triggerPayloadState
     ) {
       return
     }
@@ -315,18 +311,19 @@ export const WorkflowBuilderProvider: React.FC<
         userId,
         workspaceId,
         workflowId,
-        triggerPayload,
+        triggerPayload: triggerPayloadState,
       })
       lastPersistedTriggerPayloadRef.current = {
         key,
-        value: triggerPayload,
+        value: triggerPayloadState,
       }
+      triggerPayloadDirtyRef.current = false
     }, 250)
 
     return () => {
       window.clearTimeout(timeoutId)
     }
-  }, [userId, workspaceId, workflowId, triggerPayload])
+  }, [userIsLoading, userId, workspaceId, workflowId, triggerPayloadState])
 
   const setReactFlowNodes = useCallback(
     (nodes: Node[] | ((nodes: Node[]) => Node[])) => {

--- a/frontend/tests/event-history.test.ts
+++ b/frontend/tests/event-history.test.ts
@@ -1,11 +1,19 @@
 import {
   groupEventsByActionRef,
+  refToLabel,
   WF_COMPLETED_EVENT_REF,
   WF_FAILURE_EVENT_REF,
+  WF_TRIGGER_EVENT_REF,
   type WorkflowExecutionEventCompact,
 } from "@/lib/event-history"
 
 describe("event-history", () => {
+  describe("WF_TRIGGER_EVENT_REF", () => {
+    it("should export the correct sentinel value", () => {
+      expect(WF_TRIGGER_EVENT_REF).toBe("__workflow_trigger__")
+    })
+  })
+
   describe("WF_FAILURE_EVENT_REF", () => {
     it("should export the correct sentinel value", () => {
       expect(WF_FAILURE_EVENT_REF).toBe("__workflow_failure__")
@@ -15,6 +23,12 @@ describe("event-history", () => {
   describe("WF_COMPLETED_EVENT_REF", () => {
     it("should export the correct sentinel value", () => {
       expect(WF_COMPLETED_EVENT_REF).toBe("__workflow_completed__")
+    })
+  })
+
+  describe("refToLabel", () => {
+    it("should label the trigger sentinel as Trigger", () => {
+      expect(refToLabel(WF_TRIGGER_EVENT_REF)).toBe("Trigger")
     })
   })
 
@@ -75,6 +89,18 @@ describe("event-history", () => {
           schedule_time: "2023-01-01T10:00:00Z",
           start_time: "2023-01-01T10:00:00Z",
           close_time: null,
+          curr_event_type: "WORKFLOW_EXECUTION_STARTED",
+          status: "COMPLETED",
+          action_name: "Workflow",
+          action_ref: WF_TRIGGER_EVENT_REF,
+          action_input: { key: "value" },
+          action_result: null,
+        },
+        {
+          source_event_id: 2,
+          schedule_time: "2023-01-01T10:00:00Z",
+          start_time: "2023-01-01T10:00:00Z",
+          close_time: null,
           curr_event_type: "WORKFLOW_EXECUTION_FAILED",
           status: "FAILED",
           action_name: "Workflow",
@@ -83,7 +109,7 @@ describe("event-history", () => {
           action_result: null,
         },
         {
-          source_event_id: 2,
+          source_event_id: 3,
           schedule_time: "2023-01-01T10:00:01Z",
           start_time: "2023-01-01T10:00:01Z",
           close_time: null,
@@ -95,7 +121,7 @@ describe("event-history", () => {
           action_result: null,
         },
         {
-          source_event_id: 3,
+          source_event_id: 4,
           schedule_time: "2023-01-01T10:00:02Z",
           start_time: "2023-01-01T10:00:02Z",
           close_time: null,
@@ -110,6 +136,10 @@ describe("event-history", () => {
 
       const result = groupEventsByActionRef(events)
 
+      expect(result[WF_TRIGGER_EVENT_REF]).toHaveLength(1)
+      expect(result[WF_TRIGGER_EVENT_REF][0].action_ref).toBe(
+        WF_TRIGGER_EVENT_REF
+      )
       expect(result[WF_FAILURE_EVENT_REF]).toHaveLength(2)
       expect(result[WF_FAILURE_EVENT_REF][0].action_ref).toBe(
         WF_FAILURE_EVENT_REF

--- a/frontend/tests/workflow-trigger-payload.test.ts
+++ b/frontend/tests/workflow-trigger-payload.test.ts
@@ -1,0 +1,37 @@
+import {
+  DEFAULT_TRIGGER_PAYLOAD,
+  parseTriggerPayload,
+  validateTriggerPayload,
+} from "@/lib/workflow-trigger-payload"
+
+describe("workflow-trigger-payload", () => {
+  describe("DEFAULT_TRIGGER_PAYLOAD", () => {
+    it("defaults to an empty JSON object", () => {
+      expect(DEFAULT_TRIGGER_PAYLOAD).toBe("{}")
+    })
+  })
+
+  describe("validateTriggerPayload", () => {
+    it("accepts valid JSON", () => {
+      expect(validateTriggerPayload('{"foo":"bar"}')).toBeNull()
+    })
+
+    it("accepts blank payloads", () => {
+      expect(validateTriggerPayload("   ")).toBeNull()
+    })
+
+    it("returns a readable error for invalid JSON", () => {
+      expect(validateTriggerPayload("{")).toContain("Invalid JSON format")
+    })
+  })
+
+  describe("parseTriggerPayload", () => {
+    it("parses valid JSON values", () => {
+      expect(parseTriggerPayload('{"foo":"bar"}')).toEqual({ foo: "bar" })
+    })
+
+    it("returns undefined for blank payloads", () => {
+      expect(parseTriggerPayload(" ")).toBeUndefined()
+    })
+  })
+})

--- a/frontend/tests/workflow-trigger-payload.test.ts
+++ b/frontend/tests/workflow-trigger-payload.test.ts
@@ -1,13 +1,77 @@
+import Cookies from "js-cookie"
 import {
   DEFAULT_TRIGGER_PAYLOAD,
   parseTriggerPayload,
+  readPersistedTriggerPayload,
+  triggerPayloadStorageKey,
   validateTriggerPayload,
+  writePersistedTriggerPayload,
 } from "@/lib/workflow-trigger-payload"
 
 describe("workflow-trigger-payload", () => {
+  const scope = {
+    userId: "user-123",
+    workspaceId: "workspace-123",
+    workflowId: "workflow-123",
+  }
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    Cookies.remove(
+      `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`,
+      {
+        path: "/",
+      }
+    )
+  })
+
   describe("DEFAULT_TRIGGER_PAYLOAD", () => {
     it("defaults to an empty JSON object", () => {
       expect(DEFAULT_TRIGGER_PAYLOAD).toBe("{}")
+    })
+  })
+
+  describe("trigger payload persistence", () => {
+    it("stores payloads in localStorage instead of cookies", () => {
+      const largePayload = JSON.stringify({
+        message: "x".repeat(10_000),
+      })
+
+      writePersistedTriggerPayload({
+        ...scope,
+        triggerPayload: largePayload,
+      })
+
+      expect(window.localStorage.getItem(triggerPayloadStorageKey(scope))).toBe(
+        largePayload
+      )
+      expect(readPersistedTriggerPayload(scope)).toBe(largePayload)
+      expect(
+        Cookies.get(
+          `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`
+        )
+      ).toBeUndefined()
+    })
+
+    it("migrates legacy cookie values into localStorage", () => {
+      const legacyPayload = '{"legacy":true}'
+      Cookies.set(
+        `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`,
+        legacyPayload,
+        {
+          path: "/",
+        }
+      )
+
+      expect(readPersistedTriggerPayload(scope)).toBe(legacyPayload)
+      expect(window.localStorage.getItem(triggerPayloadStorageKey(scope))).toBe(
+        legacyPayload
+      )
+      expect(
+        Cookies.get(
+          `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`
+        )
+      ).toBeUndefined()
     })
   })
 

--- a/frontend/tests/workflow-trigger-payload.test.ts
+++ b/frontend/tests/workflow-trigger-payload.test.ts
@@ -1,4 +1,3 @@
-import Cookies from "js-cookie"
 import {
   DEFAULT_TRIGGER_PAYLOAD,
   parseTriggerPayload,
@@ -17,12 +16,6 @@ describe("workflow-trigger-payload", () => {
 
   beforeEach(() => {
     window.localStorage.clear()
-    Cookies.remove(
-      `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`,
-      {
-        path: "/",
-      }
-    )
   })
 
   describe("DEFAULT_TRIGGER_PAYLOAD", () => {
@@ -46,32 +39,6 @@ describe("workflow-trigger-payload", () => {
         largePayload
       )
       expect(readPersistedTriggerPayload(scope)).toBe(largePayload)
-      expect(
-        Cookies.get(
-          `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`
-        )
-      ).toBeUndefined()
-    })
-
-    it("migrates legacy cookie values into localStorage", () => {
-      const legacyPayload = '{"legacy":true}'
-      Cookies.set(
-        `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`,
-        legacyPayload,
-        {
-          path: "/",
-        }
-      )
-
-      expect(readPersistedTriggerPayload(scope)).toBe(legacyPayload)
-      expect(window.localStorage.getItem(triggerPayloadStorageKey(scope))).toBe(
-        legacyPayload
-      )
-      expect(
-        Cookies.get(
-          `__tracecat:builder:trigger-payload:${scope.userId}:${scope.workspaceId}:${scope.workflowId}`
-        )
-      ).toBeUndefined()
     })
   })
 

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -25,6 +25,7 @@ from tracecat.db.models import Workspace
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.schemas import StreamID
 from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowUUID
+from tracecat.storage.object import InlineObject
 from tracecat.workflow.executions.enums import (
     TriggerType,
     WorkflowEventType,
@@ -37,6 +38,7 @@ from tracecat.workflow.executions.schemas import (
 from tracecat.workflow.executions.service import (
     WF_COMPLETED_REF,
     WF_FAILURE_REF,
+    WF_TRIGGER_REF,
     WorkflowExecutionsService,
 )
 from tracecat.workspaces.service import WorkspaceService
@@ -153,6 +155,11 @@ def create_mock_history_event(
         completed_attrs = Mock()
         completed_attrs.scheduled_event_id = attributes.get("scheduled_event_id", 1)
         event.activity_task_completed_event_attributes = completed_attrs
+
+    elif event_type == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED:
+        started_attrs = Mock()
+        started_attrs.input = attributes.get("workflow_input", Mock())
+        event.workflow_execution_started_event_attributes = started_attrs
 
     return event
 
@@ -281,6 +288,184 @@ class TestWorkflowExecutionEvents:
             assert event.close_time == expected_time
 
             mock_get_result.assert_awaited_once_with(completed_event)
+
+    async def test_workflow_trigger_synthetic_event_creation(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Test that workflow start creates a synthetic trigger event."""
+        started_event = create_mock_history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,  # type: ignore
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield started_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        mock_handle.describe = AsyncMock(
+            return_value=Mock(raw_description=Mock(pending_activities=[]))
+        )
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        trigger_payload = {"case_id": "case-123", "severity": "high"}
+        trigger_inputs = InlineObject(data=trigger_payload, typename="dict")
+        mock_storage = Mock()
+        mock_storage.retrieve = AsyncMock(return_value=trigger_payload)
+
+        with (
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.DSLRunArgs",
+                return_value=Mock(trigger_inputs=trigger_inputs),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_object_storage",
+                return_value=mock_storage,
+            ),
+        ):
+            events = await workflow_executions_service.list_workflow_execution_events_compact(
+                workflow_exec_id
+            )
+
+        assert len(events) == 1
+        event = events[0]
+
+        expected_time = datetime.datetime.fromtimestamp(1640995200, tz=datetime.UTC)
+        assert event.action_ref == WF_TRIGGER_REF
+        assert event.action_name == WF_TRIGGER_REF
+        assert event.curr_event_type == WorkflowEventType.WORKFLOW_EXECUTION_STARTED
+        assert event.status == WorkflowExecutionEventStatus.COMPLETED
+        assert event.action_input == trigger_payload
+        assert event.schedule_time == expected_time
+        assert event.start_time == expected_time
+        assert event.close_time == expected_time
+        mock_storage.retrieve.assert_awaited_once_with(trigger_inputs)
+
+    async def test_workflow_trigger_synthetic_event_creation_without_inputs(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Test that workflow trigger event is still emitted when inputs are empty."""
+        started_event = create_mock_history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,  # type: ignore
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield started_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        mock_handle.describe = AsyncMock(
+            return_value=Mock(raw_description=Mock(pending_activities=[]))
+        )
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        mock_storage = Mock()
+        mock_storage.retrieve = AsyncMock()
+
+        with (
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.DSLRunArgs",
+                return_value=Mock(trigger_inputs=None),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_object_storage",
+                return_value=mock_storage,
+            ),
+        ):
+            events = await workflow_executions_service.list_workflow_execution_events_compact(
+                workflow_exec_id
+            )
+
+        assert len(events) == 1
+        event = events[0]
+        assert event.action_ref == WF_TRIGGER_REF
+        assert event.action_input is None
+        mock_storage.retrieve.assert_not_called()
+
+    async def test_compact_trigger_event_sorts_before_later_actions(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Test trigger sentinel ordering relative to later action events."""
+        started_event = create_mock_history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,  # type: ignore
+        )
+        scheduled_event = create_mock_history_event(
+            event_id=2,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
+            activity_id="body-1",
+            activity_name="test_action",
+            event_time_seconds=1640995260,
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield started_event
+            yield scheduled_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        mock_handle.describe = AsyncMock(
+            return_value=Mock(raw_description=Mock(pending_activities=[]))
+        )
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        action_event = WorkflowExecutionEventCompact(
+            source_event_id=2,
+            schedule_time=datetime.datetime.fromtimestamp(1640995260, tz=datetime.UTC),
+            start_time=datetime.datetime.fromtimestamp(1640995260, tz=datetime.UTC),
+            close_time=datetime.datetime.fromtimestamp(1640995261, tz=datetime.UTC),
+            curr_event_type=WorkflowEventType.ACTIVITY_TASK_COMPLETED,
+            status=WorkflowExecutionEventStatus.COMPLETED,
+            action_name="core.test",
+            action_ref="body",
+            action_input=None,
+            action_result={"ok": True},
+            stream_id=StreamID("<root>"),
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.DSLRunArgs",
+                return_value=Mock(trigger_inputs=None),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+                AsyncMock(return_value=action_event),
+            ),
+        ):
+            events = await workflow_executions_service.list_workflow_execution_events_compact(
+                workflow_exec_id
+            )
+
+        assert [event.action_ref for event in events] == [WF_TRIGGER_REF, "body"]
 
     async def test_workflow_execution_without_failures_no_synthetic_events(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -12,9 +12,11 @@ Objectives
 """
 
 import datetime
+import hashlib
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
+import orjson
 import pytest
 from temporalio.api.enums.v1 import EventType, PendingActivityState
 from temporalio.client import Client, WorkflowHandle
@@ -25,7 +27,7 @@ from tracecat.db.models import Workspace
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.schemas import StreamID
 from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowUUID
-from tracecat.storage.object import InlineObject
+from tracecat.storage.object import ExternalObject, InlineObject, ObjectRef
 from tracecat.workflow.executions.enums import (
     TriggerType,
     WorkflowEventType,
@@ -315,8 +317,6 @@ class TestWorkflowExecutionEvents:
 
         trigger_payload = {"case_id": "case-123", "severity": "high"}
         trigger_inputs = InlineObject(data=trigger_payload, typename="dict")
-        mock_storage = Mock()
-        mock_storage.retrieve = AsyncMock(return_value=trigger_payload)
 
         with (
             patch(
@@ -326,10 +326,6 @@ class TestWorkflowExecutionEvents:
             patch(
                 "tracecat.workflow.executions.service.DSLRunArgs",
                 return_value=Mock(trigger_inputs=trigger_inputs),
-            ),
-            patch(
-                "tracecat.workflow.executions.service.get_object_storage",
-                return_value=mock_storage,
             ),
         ):
             events = await workflow_executions_service.list_workflow_execution_events_compact(
@@ -348,7 +344,6 @@ class TestWorkflowExecutionEvents:
         assert event.schedule_time == expected_time
         assert event.start_time == expected_time
         assert event.close_time == expected_time
-        mock_storage.retrieve.assert_awaited_once_with(trigger_inputs)
 
     async def test_workflow_trigger_synthetic_event_creation_without_inputs(
         self,
@@ -374,9 +369,6 @@ class TestWorkflowExecutionEvents:
             return_value=mock_handle
         )
 
-        mock_storage = Mock()
-        mock_storage.retrieve = AsyncMock()
-
         with (
             patch(
                 "tracecat.workflow.executions.service.extract_first",
@@ -385,10 +377,6 @@ class TestWorkflowExecutionEvents:
             patch(
                 "tracecat.workflow.executions.service.DSLRunArgs",
                 return_value=Mock(trigger_inputs=None),
-            ),
-            patch(
-                "tracecat.workflow.executions.service.get_object_storage",
-                return_value=mock_storage,
             ),
         ):
             events = await workflow_executions_service.list_workflow_execution_events_compact(
@@ -399,7 +387,64 @@ class TestWorkflowExecutionEvents:
         event = events[0]
         assert event.action_ref == WF_TRIGGER_REF
         assert event.action_input is None
-        mock_storage.retrieve.assert_not_called()
+
+    async def test_workflow_trigger_externalized_payload_uses_ref_backend(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Trigger payload resolution uses the backend encoded in the object ref."""
+        started_event = create_mock_history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,  # type: ignore
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield started_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        mock_handle.describe = AsyncMock(
+            return_value=Mock(raw_description=Mock(pending_activities=[]))
+        )
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        trigger_payload = {"case_id": "case-123", "severity": "high"}
+        serialized_payload = orjson.dumps(trigger_payload)
+        trigger_inputs = ExternalObject(
+            ref=ObjectRef(
+                bucket="workflow-results",
+                key="workspace-123/run-123/trigger.json",
+                size_bytes=len(serialized_payload),
+                sha256=hashlib.sha256(serialized_payload).hexdigest(),
+            ),
+            typename="dict",
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.DSLRunArgs",
+                return_value=Mock(trigger_inputs=trigger_inputs),
+            ),
+            patch(
+                "tracecat.storage.backends.s3.cached_blob_download",
+                AsyncMock(return_value=serialized_payload),
+            ) as mock_cached_blob_download,
+        ):
+            events = await workflow_executions_service.list_workflow_execution_events_compact(
+                workflow_exec_id
+            )
+
+        assert len(events) == 1
+        assert events[0].action_input == trigger_payload
+        mock_cached_blob_download.assert_awaited_once()
 
     async def test_compact_trigger_event_sorts_before_later_actions(
         self,

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -61,6 +61,7 @@ from tracecat.storage.object import (
     StoredObjectValidator,
     collection_item_key,
     get_object_storage,
+    retrieve_stored_object,
 )
 from tracecat.validation.schemas import ValidationDetail
 
@@ -334,7 +335,7 @@ async def materialize_context(ctx: ExecutionContext) -> MaterializedExecutionCon
     if trigger := ctx.get("TRIGGER"):
         trigger_task_idx = len(action_refs)  # Index after all action tasks
         validated = StoredObjectValidator.validate_python(trigger)
-        coros.append(get_object_storage().retrieve(validated))
+        coros.append(retrieve_stored_object(validated))
 
     # Collect results and map back to their refs
     try:

--- a/tracecat/storage/collection.py
+++ b/tracecat/storage/collection.py
@@ -33,7 +33,7 @@ from tracecat.storage.object import (
     CollectionObject,
     ObjectRef,
     StoredObjectValidator,
-    get_object_storage,
+    retrieve_stored_object,
 )
 from tracecat.storage.utils import (
     cached_blob_download,
@@ -346,8 +346,7 @@ async def get_collection_item(collection: CollectionObject, index: int) -> Any:
         return item
 
     stored = StoredObjectValidator.validate_python(item)
-    storage = get_object_storage()
-    return await storage.retrieve(stored)
+    return await retrieve_stored_object(stored)
 
 
 async def materialize_collection_values(
@@ -376,11 +375,10 @@ async def materialize_collection_values(
         return items
 
     # element_kind == "stored_object": retrieve each handle
-    storage = get_object_storage()
     values: list[Any] = []
     for item in items:
         stored = StoredObjectValidator.validate_python(item)
-        value = await storage.retrieve(stored)
+        value = await retrieve_stored_object(stored)
         values.append(value)
 
     return values

--- a/tracecat/storage/object.py
+++ b/tracecat/storage/object.py
@@ -20,8 +20,8 @@ Usage:
             # Data was externalized to blob storage
             pass
 
-    # Or simply retrieve (works for both variants)
-    data = await storage.retrieve(stored)
+    # Or retrieve from the backend encoded in the object reference
+    data = await retrieve_stored_object(stored)
 """
 
 from __future__ import annotations
@@ -293,6 +293,38 @@ class ObjectStorage(ABC):
         raise NotImplementedError
 
 
+def get_object_storage_for(stored: StoredObject) -> ObjectStorage:
+    """Resolve the storage backend encoded in a StoredObject reference."""
+    match stored:
+        case InlineObject():
+            return get_object_storage()
+        case ExternalObject(ref=ref) | CollectionObject(manifest_ref=ref):
+            match ref.backend:
+                case "s3":
+                    from tracecat.storage.backends import S3ObjectStorage
+
+                    return S3ObjectStorage(
+                        bucket=ref.bucket,
+                        threshold_bytes=config.TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES,
+                    )
+                case _:
+                    raise ValueError(
+                        f"Unsupported object storage backend: {ref.backend}"
+                    )
+
+
+async def retrieve_stored_object(stored: StoredObject) -> Any:
+    """Retrieve a StoredObject using the backend encoded in its reference."""
+    match stored:
+        case InlineObject(data=data):
+            return data
+        case ExternalObject() | CollectionObject():
+            storage = get_object_storage_for(stored)
+            return await storage.retrieve(stored)
+        case _:
+            raise TypeError(f"Expected StoredObject, got {type(stored).__name__}")
+
+
 # === Dependency Injection === #
 
 _object_storage: ObjectStorage | None = None
@@ -401,6 +433,8 @@ __all__ = [
     "StoredObjectValidator",
     # DI
     "get_object_storage",
+    "get_object_storage_for",
+    "retrieve_stored_object",
     "reset_object_storage",
     "set_object_storage",
     # Key helpers

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -228,15 +228,14 @@ async def resolve_to_inline(stored: StoredObject) -> InlineObject:
         CollectionObject,
         ExternalObject,
         InlineObject,
-        get_object_storage,
+        retrieve_stored_object,
     )
 
     match stored:
         case InlineObject():
             return stored
         case ExternalObject() | CollectionObject():
-            storage = get_object_storage()
-            data = await storage.retrieve(stored)
+            data = await retrieve_stored_object(stored)
             return InlineObject(data=data)
         case _:
             raise TypeError(f"Expected StoredObject, got {type(stored).__name__}")

--- a/tracecat/workflow/executions/constants.py
+++ b/tracecat/workflow/executions/constants.py
@@ -1,3 +1,6 @@
+WF_TRIGGER_REF = "__workflow_trigger__"
+"""Sentinel constant for workflow-level trigger context in compact events."""
+
 WF_FAILURE_REF = "__workflow_failure__"
 """Sentinel constant for workflow-level failures in compact events."""
 

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -74,7 +74,11 @@ from tracecat.workflow.executions.common import (
     is_scheduled_event,
     is_start_event,
 )
-from tracecat.workflow.executions.constants import WF_COMPLETED_REF, WF_FAILURE_REF
+from tracecat.workflow.executions.constants import (
+    WF_COMPLETED_REF,
+    WF_FAILURE_REF,
+    WF_TRIGGER_REF,
+)
 from tracecat.workflow.executions.enums import (
     ExecutionType,
     TemporalSearchAttr,
@@ -146,6 +150,13 @@ def _extract_while_metadata(
         should_continue = payload.get("continue")
         return None, (should_continue if isinstance(should_continue, bool) else None)
     return None, None
+
+
+async def _resolve_trigger_context(trigger_inputs: StoredObject | None) -> Any | None:
+    """Materialize stored trigger inputs for compact history views."""
+    if trigger_inputs is None:
+        return None
+    return await get_object_storage().retrieve(trigger_inputs)
 
 
 class WorkflowExecutionsService:
@@ -553,6 +564,24 @@ class WorkflowExecutionsService:
                         event.activity_task_scheduled_event_attributes.activity_id
                     )
                     activity2eventid[activity_id] = event.event_id
+            elif event.event_type is EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED:
+                attrs = event.workflow_execution_started_event_attributes
+                run_args_data = await extract_first(attrs.input)
+                dsl_run_args = DSLRunArgs(**run_args_data)
+                event_time = event.event_time.ToDatetime(datetime.UTC)
+                id2event[event.event_id] = WorkflowExecutionEventCompact(
+                    source_event_id=event.event_id,
+                    schedule_time=event_time,
+                    start_time=event_time,
+                    close_time=event_time,
+                    curr_event_type=WorkflowEventType.WORKFLOW_EXECUTION_STARTED,
+                    status=WorkflowExecutionEventStatus.COMPLETED,
+                    action_name=WF_TRIGGER_REF,
+                    action_ref=WF_TRIGGER_REF,
+                    action_input=await _resolve_trigger_context(
+                        dsl_run_args.trigger_inputs
+                    ),
+                )
             # ── synthetic compact event for top-level workflow failure ──
             elif event.event_type is EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
                 failure = EventFailure.from_history_event(event)

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -61,6 +61,7 @@ from tracecat.storage.object import (
     StoredObject,
     StoredObjectValidator,
     get_object_storage,
+    retrieve_stored_object,
 )
 from tracecat.workflow.executions.common import (
     HISTORY_TO_WF_EVENT_TYPE,
@@ -156,7 +157,7 @@ async def _resolve_trigger_context(trigger_inputs: StoredObject | None) -> Any |
     """Materialize stored trigger inputs for compact history views."""
     if trigger_inputs is None:
         return None
-    return await get_object_storage().retrieve(trigger_inputs)
+    return await retrieve_stored_object(trigger_inputs)
 
 
 class WorkflowExecutionsService:


### PR DESCRIPTION
## Summary
This change fixes two related workflow trigger issues in the builder and run views.

First, compact workflow execution history now synthesizes a dedicated workflow-level `Trigger` event from `WORKFLOW_EXECUTION_STARTED`. That makes the runtime `TRIGGER` context visible in the builder events sidebar and in the workflow/runs event detail view, instead of only showing downstream action events and the final workflow result.

Second, the builder no longer uses the header run-button dropdown for editing trigger payloads. That UX was cramped for larger JSON payloads and the split run controls were easy to misread. The trigger payload editor now lives beside the trigger node as a full JSON editor, and draft runs use that stored payload directly.

## Root cause and user impact
The compact execution serializer only created synthetic workflow-level events for workflow completion and workflow failure. Because it never projected the workflow start payload into compact history, the UI had no event to render for trigger context in either the builder events view or the workflow/runs detail view.

Separately, the builder stored draft-run payload input locally in the nav dropdown rather than in trigger-specific builder state. That made the payload editor visually constrained, introduced a second run interaction beside the main Run button, and disconnected payload editing from the trigger itself.

## What changed
The backend now emits a synthetic `__workflow_trigger__` compact event when a workflow starts, materializing stored trigger inputs before returning them as `action_input`. The existing workflow completion and failure sentinels are unchanged.

The shared frontend event-history helpers now recognize the new trigger sentinel and label it as `Trigger`, so both the builder events sidebar and workflow/runs event views pick it up automatically through the existing compact history flow.

On the builder side, draft trigger payload state moved into shared builder context. The trigger node now renders a JSON editor on its right side for editing that payload, validates JSON inline, persists it in cookies scoped by user, workspace, and workflow, and the header Run button now consumes that single source of truth when starting draft executions.

## Validation
I validated the change with the following checks:

- pre-commit hooks during commit, including Ruff, Python type checks, frontend Biome, and frontend type check
- `uv run basedpyright --warnings --threads 4 tracecat/workflow/executions/service.py tests/unit/test_workflow_executions.py`
- `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/test_workflow_executions.py -k 'workflow_failure_synthetic_event_creation or workflow_completed_synthetic_event_creation or workflow_trigger_synthetic_event_creation or compact_trigger_event_sorts_before_later_actions'`
- `pnpm -C frontend test -- --runInBand --runTestsByPath tests/workflow-trigger-payload.test.ts tests/event-history.test.ts tests/events-workflow.test.tsx`
- `pnpm -C frontend run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the workflow trigger context visible in event history and moves trigger payload editing next to the trigger node for a clearer, single-source-of-truth run experience.

- **New Features**
  - Backend emits a compact `__workflow_trigger__` event on workflow start, materializing stored trigger inputs as `action_input` and resolving externalized payloads via the object ref’s backend. Frontend labels it as “Trigger,” includes it in builder and runs views, enables “View last input/result,” and orders it before later actions.
  - Builder adds a full JSON payload editor beside the trigger node with inline validation and localStorage persistence scoped by user, workspace, and workflow. The header Run button now uses this payload for draft runs, removing the dropdown editor.

- **Refactors**
  - Dropped the cookie fallback for trigger payload persistence; use localStorage only.

<sup>Written for commit 99af1567d2d4ecba9639515ad34f8df4e1027422. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

