### PR TITLE
feat(agent): add configurable failure mode for agent activity retries

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -42,6 +42,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.agent.types import AgentConfig
     from tracecat.agent.workflow_config import agent_config_from_payload
+    from tracecat.agent.workflow_schemas import RunAgentActivityFailureMode
     from tracecat.auth.types import Role
     from tracecat.config import TRACECAT__AGENT_SANDBOX_TIMEOUT
     from tracecat.contexts import ctx_role
@@ -67,6 +68,10 @@ class AgentWorkflowArgs(BaseModel):
 
     role: Role
     agent_args: RunAgentArgs
+    run_agent_failure_mode: RunAgentActivityFailureMode = Field(
+        default=RunAgentActivityFailureMode.FAIL_FAST,
+        description="How run_agent_activity failures should be surfaced to Temporal.",
+    )
     # Session metadata
     title: str = Field(default="New Chat", description="Session title")
     entity_type: AgentSessionEntity = Field(
@@ -92,6 +97,12 @@ class WorkflowApprovalSubmission(BaseModel):
     approvals: ApprovalMap
     approved_by: uuid.UUID | None = None
     decision_metadata: dict[str, dict[str, Any]] | None = None
+
+
+_RUN_AGENT_RETRY_POLICY_BY_FAILURE_MODE = {
+    RunAgentActivityFailureMode.FAIL_FAST: RETRY_POLICIES["activity:fail_fast"],
+    RunAgentActivityFailureMode.RETRY: RETRY_POLICIES["activity:fail_slow"],
+}
 
 
 def _resolve_agent_output(
@@ -422,6 +433,7 @@ class DurableAgentWorkflow:
             allowed_actions=allowed_actions,
             sdk_session_id=self._sdk_session_id,
             sdk_session_data=self._sdk_session_data,
+            run_agent_failure_mode=args.run_agent_failure_mode,
             is_fork=is_fork,
         )
 
@@ -438,7 +450,9 @@ class DurableAgentWorkflow:
                     seconds=TRACECAT__AGENT_SANDBOX_TIMEOUT
                 ),
                 heartbeat_timeout=timedelta(seconds=60),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                retry_policy=_RUN_AGENT_RETRY_POLICY_BY_FAILURE_MODE[
+                    args.run_agent_failure_mode
+                ],
             )
 
             if not result.success:
@@ -527,6 +541,7 @@ class DurableAgentWorkflow:
                     allowed_actions=allowed_actions,
                     sdk_session_id=self._sdk_session_id,
                     sdk_session_data=self._sdk_session_data,
+                    run_agent_failure_mode=args.run_agent_failure_mode,
                     is_approval_continuation=True,
                 )
                 self._turn += 1

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -11,6 +11,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.executor.activity import (
@@ -29,6 +30,7 @@ from tracecat.agent.session.activities import (
 )
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_schemas import RunAgentActivityFailureMode
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 
@@ -418,6 +420,33 @@ class TestRunAgentActivity:
             result = await run_agent_activity(mock_executor_input)
 
             assert result.success is False
+
+    @pytest.mark.anyio
+    async def test_raises_on_execution_error_when_retry_mode_enabled(
+        self, mock_executor_input: AgentExecutorInput
+    ):
+        """Test that retry mode surfaces failures as Temporal exceptions."""
+        expected_result = AgentExecutorResult(
+            success=False,
+            error="Agent execution failed: timeout",
+        )
+        mock_executor_input.run_agent_failure_mode = RunAgentActivityFailureMode.RETRY
+
+        with (
+            patch("tracecat.agent.executor.activity.activity") as mock_activity,
+            patch(
+                "tracecat.agent.executor.activity.SandboxedAgentExecutor"
+            ) as mock_executor_cls,
+        ):
+            mock_activity.heartbeat = MagicMock()
+            mock_executor = MagicMock()
+            mock_executor.run = AsyncMock(return_value=expected_result)
+            mock_executor_cls.return_value = mock_executor
+
+            with pytest.raises(
+                ApplicationError, match="Agent execution failed: timeout"
+            ):
+                await run_agent_activity(mock_executor_input)
 
     @pytest.mark.anyio
     async def test_sends_heartbeats(self, mock_executor_input: AgentExecutorInput):

--- a/tests/unit/test_agent_session_search_attributes.py
+++ b/tests/unit/test_agent_session_search_attributes.py
@@ -14,6 +14,7 @@ from temporalio.common import TypedSearchAttributes
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_schemas import RunAgentActivityFailureMode
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import BasicChatRequest, ChatRequest
 from tracecat.db.models import AgentSession
@@ -124,6 +125,8 @@ async def test_run_turn_stamps_tracecat_search_attributes(
     assert pairs[TemporalSearchAttr.TRIGGERED_BY_USER_ID.value] == str(
         role_with_user.user_id
     )
+    workflow_args = temporal_client.start_workflow.await_args.args[1]
+    assert workflow_args.run_agent_failure_mode is RunAgentActivityFailureMode.FAIL_FAST
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -9,18 +9,24 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from temporalio.common import TypedSearchAttributes
+from temporalio.exceptions import ApplicationError
 from tracecat_ee.agent.workflows.durable import (
     UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,
     AgentWorkflowArgs,
     DurableAgentWorkflow,
 )
 
+from tracecat.agent.executor.activity import AgentExecutorResult
 from tracecat.agent.preset.activities import ResolveAgentPresetConfigActivityInput
 from tracecat.agent.schemas import AgentOutput, RunAgentArgs
+from tracecat.agent.session.activities import CreateSessionResult, LoadSessionResult
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.workflow_config import agent_config_to_payload
+from tracecat.agent.workflow_schemas import RunAgentActivityFailureMode
 from tracecat.auth.types import Role
+from tracecat.dsl.common import RETRY_POLICIES
+from tracecat.registry.lock.types import RegistryLock
 from tracecat.workflow.executions.enums import (
     ExecutionType,
     TemporalSearchAttr,
@@ -225,3 +231,73 @@ async def test_build_config_prefers_pinned_preset_version_id() -> None:
     assert cfg.model_provider == pinned_config.model_provider
     assert cfg.actions == ["core.http_request"]
     assert cfg.instructions == "base instructions\nappend this"
+
+
+@pytest.mark.anyio
+async def test_run_with_nsjail_uses_retry_policy_for_retry_mode() -> None:
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute", "secret:read"}),
+    )
+    workflow_args = _build_workflow_args(role)
+    workflow_args.run_agent_failure_mode = RunAgentActivityFailureMode.RETRY
+    workflow_instance = DurableAgentWorkflow(workflow_args)
+    cfg = cast(Any, workflow_args.agent_args.config)
+
+    build_result = SimpleNamespace(
+        tool_definitions={},
+        registry_lock=RegistryLock(origins={}, actions={}),
+        user_mcp_claims=None,
+        allowed_internal_tools=None,
+    )
+
+    execute_activity_mock = AsyncMock(
+        side_effect=[
+            CreateSessionResult(
+                session_id=workflow_args.agent_args.session_id,
+                success=True,
+            ),
+            LoadSessionResult(
+                found=False,
+                sdk_session_id=None,
+                sdk_session_data=None,
+            ),
+            AgentExecutorResult(success=False, error="sandbox failed"),
+        ]
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.info",
+            return_value=SimpleNamespace(
+                workflow_id=f"agent/{workflow_args.agent_args.session_id}"
+            ),
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.execute_activity",
+            execute_activity_mock,
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.execute_activity_method",
+            AsyncMock(return_value=build_result),
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.mint_mcp_token",
+            return_value="mcp-token",
+        ),
+        patch(
+            "tracecat_ee.agent.workflows.durable.mint_llm_token",
+            return_value="llm-token",
+        ),
+    ):
+        with pytest.raises(ApplicationError, match="Agent execution failed"):
+            await workflow_instance._run_with_nsjail(workflow_args, cfg)
+
+    run_agent_call = execute_activity_mock.await_args_list[2]
+    assert run_agent_call.kwargs["retry_policy"] == RETRY_POLICIES["activity:fail_slow"]
+    executor_input = run_agent_call.args[1]
+    assert executor_input.run_agent_failure_mode is RunAgentActivityFailureMode.RETRY

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from pydantic import AliasChoices, BaseModel, Field
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.common.config import (
     TRACECAT__AGENT_SANDBOX_MEMORY_MB,
@@ -53,6 +54,7 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.tokens import MCPTokenClaims
 from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_schemas import RunAgentActivityFailureMode
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
 from tracecat.executor import registry_resolver
@@ -84,6 +86,10 @@ class AgentExecutorInput(BaseModel):
     # Session resume data (from previous run, includes tool_result for approval flow)
     sdk_session_id: str | None = None
     sdk_session_data: str | None = None
+    run_agent_failure_mode: RunAgentActivityFailureMode = Field(
+        default=RunAgentActivityFailureMode.FAIL_FAST,
+        description="How run_agent_activity should surface execution failures.",
+    )
     # True when resuming after approval decision (continuation prompt should be internal)
     is_approval_continuation: bool = False
     # True when forking from parent session (SDK should use fork_session=True)
@@ -571,6 +577,8 @@ async def run_agent_activity(
             )
     else:
         activity.heartbeat(f"Agent execution failed: {result.error}")
+        if input.run_agent_failure_mode is RunAgentActivityFailureMode.RETRY:
+            raise ApplicationError(result.error or "Agent execution failed")
 
     return result
 

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -37,6 +37,7 @@ from tracecat.agent.session.schemas import (
 from tracecat.agent.session.title_generator import generate_session_title
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig, ClaudeSDKMessageTA, StreamKey
+from tracecat.agent.workflow_schemas import RunAgentActivityFailureMode
 from tracecat.audit.logger import audit_log
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.cases.prompts import CaseCopilotPrompts
@@ -996,6 +997,7 @@ class AgentSessionService(BaseWorkspaceService):
             workflow_args = AgentWorkflowArgs(
                 role=self.role,
                 agent_args=args,
+                run_agent_failure_mode=RunAgentActivityFailureMode.FAIL_FAST,
                 title=agent_session.title,
                 entity_type=AgentSessionEntity(agent_session.entity_type),
                 entity_id=agent_session.entity_id,

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -6,11 +6,19 @@ across Temporal workflow/activity boundaries predictably.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, model_validator
 
 _LEGACY_AGENT_CONFIG_KEYS = frozenset({"deps_type", "custom_tools"})
+
+
+class RunAgentActivityFailureMode(StrEnum):
+    """How run_agent_activity should surface execution failures to Temporal."""
+
+    FAIL_FAST = "fail_fast"
+    RETRY = "retry"
 
 
 def _normalize_legacy_mcp_server_payload(value: Any) -> Any:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -43,6 +43,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.schemas import RunAgentArgs
     from tracecat.agent.session.types import AgentSessionEntity
     from tracecat.agent.types import AgentConfig
+    from tracecat.agent.workflow_schemas import RunAgentActivityFailureMode
     from tracecat.concurrency import cooperative
     from tracecat.contexts import (
         ctx_interaction,
@@ -955,6 +956,7 @@ class DSLWorkflow:
                             max_tool_calls=action_args.max_tool_calls,
                             use_workspace_credentials=action_args.use_workspace_credentials,
                         ),
+                        run_agent_failure_mode=RunAgentActivityFailureMode.RETRY,
                         title=self.dsl.title,
                         entity_type=AgentSessionEntity.WORKFLOW,
                         entity_id=self.run_context.wf_id,
@@ -1018,6 +1020,7 @@ class DSLWorkflow:
                             max_tool_calls=0,
                             use_workspace_credentials=action_args.use_workspace_credentials,
                         ),
+                        run_agent_failure_mode=RunAgentActivityFailureMode.RETRY,
                         title=self.dsl.title,
                         entity_type=AgentSessionEntity.WORKFLOW,
                         entity_id=self.run_context.wf_id,
@@ -1094,6 +1097,7 @@ class DSLWorkflow:
                             max_tool_calls=preset_action_args.max_tool_calls,
                             use_workspace_credentials=preset_action_args.use_workspace_credentials,
                         ),
+                        run_agent_failure_mode=RunAgentActivityFailureMode.RETRY,
                         title=self.dsl.title,
                         entity_type=AgentSessionEntity.WORKFLOW,
                         entity_id=self.run_context.wf_id,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a configurable failure mode for `run_agent_activity` to control how failures surface to Temporal and when to retry. Default stays fail-fast for chats; DSL workflows opt into retries.

- **New Features**
  - Introduced `RunAgentActivityFailureMode` with `FAIL_FAST` and `RETRY`.
  - Plumbed `run_agent_failure_mode` through `AgentWorkflowArgs` and `AgentExecutorInput`.
  - Durable workflow maps modes to retry policies: `FAIL_FAST` → `activity:fail_fast`, `RETRY` → `activity:fail_slow`.
  - `run_agent_activity` now raises `ApplicationError` on failure when mode is `RETRY`, triggering Temporal retries.
  - Defaults: session service uses `FAIL_FAST`; `tracecat/dsl/workflow.py` sets `RETRY` for agent tasks.

<sup>Written for commit c4b13de87a0c7a76d2ec9f77195fb912abff14eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

