### PR TITLE
feat(ui): Refine workflow builder run and JSON viewer interactions

### DIFF
--- a/frontend/src/components/builder/canvas/trigger-node.tsx
+++ b/frontend/src/components/builder/canvas/trigger-node.tsx
@@ -57,6 +57,13 @@ export type TriggerNodeData = {
 export type TriggerNodeType = Node<TriggerNodeData, "trigger">
 export const TriggerTypename = "trigger" as const
 
+const TRIGGER_NODE_WIDTH = 256
+const TRIGGER_PAYLOAD_PANEL_GAP = 16
+const TRIGGER_PAYLOAD_PANEL_MIN_WIDTH = 320
+const TRIGGER_PAYLOAD_PANEL_MIN_HEIGHT = 240
+const TRIGGER_PAYLOAD_PANEL_DEFAULT_WIDTH = 360
+const TRIGGER_PAYLOAD_PANEL_DEFAULT_HEIGHT = 320
+
 export default React.memo(function TriggerNode({
   id,
   type,
@@ -180,6 +187,7 @@ export default React.memo(function TriggerNode({
     }
     pendingHeightAdjustmentRef.current = false
   }, [pushNodesDown, style.showContent])
+
   if (!workflow) {
     return null
   }
@@ -187,8 +195,9 @@ export default React.memo(function TriggerNode({
   const triggerPayloadError = validateTriggerPayload(triggerPayload)
 
   return (
-    <div ref={cardRef} className="flex items-start gap-4">
+    <div className="relative w-64 overflow-visible">
       <Card
+        ref={cardRef}
         onClickCapture={handleDefaultPanelOpen}
         className={cn(
           "w-64",
@@ -309,40 +318,33 @@ export default React.memo(function TriggerNode({
 
       {style.showContent && (
         <div
-          className="nodrag nopan nowheel w-[360px] rounded-xl border bg-background p-3"
+          className="nodrag nopan nowheel absolute left-0 top-0 z-10 resize overflow-hidden rounded-xl border bg-background p-2"
+          style={{
+            width: TRIGGER_PAYLOAD_PANEL_DEFAULT_WIDTH,
+            height: TRIGGER_PAYLOAD_PANEL_DEFAULT_HEIGHT,
+            minWidth: TRIGGER_PAYLOAD_PANEL_MIN_WIDTH,
+            minHeight: TRIGGER_PAYLOAD_PANEL_MIN_HEIGHT,
+            transform: `translate(${TRIGGER_NODE_WIDTH + TRIGGER_PAYLOAD_PANEL_GAP}px, 0px)`,
+          }}
           onClick={(event) => {
             event.stopPropagation()
           }}
         >
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-xs font-medium text-foreground">
-                Trigger payload
-              </p>
-              <p className="text-[11px] text-muted-foreground">
-                Draft runs use this JSON as the `TRIGGER` payload.
-              </p>
-            </div>
-          </div>
-          <CodeEditor
-            value={triggerPayload}
-            language="json"
-            onChange={setTriggerPayload}
-            className={cn(
-              "[&_.cm-editor]:border-input [&_.cm-editor]:bg-background",
-              "[&_.cm-scroller]:min-h-[220px] [&_.cm-scroller]:max-h-[320px] [&_.cm-scroller]:overflow-auto"
-            )}
-          />
-          <div className="mt-2 flex items-start gap-2 text-[11px]">
-            {triggerPayloadError ? (
-              <>
+          <div className="flex h-full min-h-0 flex-col">
+            <CodeEditor
+              value={triggerPayload}
+              language="json"
+              onChange={setTriggerPayload}
+              className={cn(
+                "flex-1 [&_.cm-editor]:h-full [&_.cm-editor]:border-input [&_.cm-editor]:bg-background",
+                "[&_.cm-scroller]:h-full [&_.cm-scroller]:min-h-0 [&_.cm-scroller]:overflow-auto"
+              )}
+            />
+            {triggerPayloadError && (
+              <div className="mt-2 flex items-start gap-2 px-3 pb-3 text-[11px]">
                 <AlertTriangleIcon className="mt-0.5 size-3 shrink-0 text-rose-500" />
                 <span className="text-rose-500">{triggerPayloadError}</span>
-              </>
-            ) : (
-              <span className="text-muted-foreground">
-                Saved in this browser for this workflow.
-              </span>
+              </div>
             )}
           </div>
         </div>

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -51,6 +51,7 @@ import {
   groupEventsByActionRef,
   parseStreamId,
   refToLabel,
+  WF_TRIGGER_EVENT_REF,
   type WorkflowExecutionEventCompact,
   type WorkflowExecutionReadCompact,
 } from "@/lib/event-history"
@@ -189,7 +190,8 @@ function ActionInteractionEventDetails({
       <JsonViewWithControls
         src={interaction.response_payload}
         defaultExpanded={true}
-        copyPrefix={`ACTIONS.${eventRef}.interaction`}
+        copyPrefix={getEventCopyPrefix(eventRef, "interaction")}
+        copyMode="jsonpath-and-payload"
       />
     </div>
   )
@@ -212,6 +214,9 @@ export function SuccessEvent({
   defaultExpanded?: boolean
   defaultTab?: "nested" | "flat"
 }) {
+  const shouldShowTriggerInput =
+    type === "result" && eventRef === WF_TRIGGER_EVENT_REF
+
   switch (type) {
     case "input":
       return (
@@ -219,9 +224,22 @@ export function SuccessEvent({
           src={event.action_input}
           defaultExpanded={defaultExpanded}
           defaultTab={defaultTab}
+          copyPrefix={getEventCopyPrefix(eventRef, "input")}
+          copyMode="jsonpath-and-payload"
         />
       )
     case "result":
+      if (shouldShowTriggerInput) {
+        return (
+          <JsonViewWithControls
+            src={event.action_input}
+            defaultExpanded={defaultExpanded}
+            defaultTab={defaultTab}
+            copyPrefix={getEventCopyPrefix(eventRef, "input")}
+            copyMode="jsonpath-and-payload"
+          />
+        )
+      }
       return (
         <ActionResultViewer
           result={event.action_result}
@@ -276,6 +294,8 @@ function ActionResultViewer({
         executionId={executionId}
         eventId={eventId}
         collection={result}
+        copyMode="jsonpath-and-payload"
+        copyPrefix={getEventCopyPrefix(eventRef, "result")}
       />
     )
   }
@@ -285,9 +305,28 @@ function ActionResultViewer({
       src={result}
       defaultExpanded={defaultExpanded}
       defaultTab={defaultTab}
-      copyPrefix={`ACTIONS.${eventRef}.result`}
+      copyPrefix={getEventCopyPrefix(eventRef, "result")}
+      copyMode="jsonpath-and-payload"
     />
   )
+}
+
+function getEventCopyPrefix(
+  eventRef: string,
+  kind: "input" | "result" | "interaction"
+): string {
+  if (eventRef === WF_TRIGGER_EVENT_REF) {
+    return "TRIGGER"
+  }
+
+  switch (kind) {
+    case "input":
+      return `ACTIONS.${eventRef}`
+    case "interaction":
+      return `ACTIONS.${eventRef}.interaction`
+    case "result":
+      return `ACTIONS.${eventRef}.result`
+  }
 }
 
 function StreamDetails({

--- a/frontend/src/components/executions/collection-object-result.tsx
+++ b/frontend/src/components/executions/collection-object-result.tsx
@@ -71,10 +71,14 @@ export function CollectionObjectResult({
   executionId,
   eventId,
   collection,
+  copyMode = "jsonpath-only",
+  copyPrefix,
 }: {
   executionId: string
   eventId: number
   collection: CollectionObject
+  copyMode?: "jsonpath-only" | "jsonpath-and-payload"
+  copyPrefix?: string
 }) {
   const workspaceId = useWorkspaceId()
   const [offset, setOffset] = useState(0)
@@ -224,6 +228,11 @@ export function CollectionObjectResult({
                       <JsonViewWithControls
                         src={item.stored.data}
                         defaultExpanded={true}
+                        copyMode={copyMode}
+                        copyPrefix={getCollectionItemCopyPrefix(
+                          copyPrefix,
+                          item.index
+                        )}
                       />
                     </div>
                   ) : (
@@ -231,6 +240,11 @@ export function CollectionObjectResult({
                       <JsonViewWithControls
                         src={item.stored}
                         defaultExpanded={true}
+                        copyMode={copyMode}
+                        copyPrefix={getCollectionItemCopyPrefix(
+                          copyPrefix,
+                          item.index
+                        )}
                       />
                     </div>
                   )
@@ -288,4 +302,14 @@ export function CollectionObjectResult({
       </div>
     </div>
   )
+}
+
+function getCollectionItemCopyPrefix(
+  copyPrefix: string | undefined,
+  itemIndex: number
+): string | undefined {
+  if (!copyPrefix) {
+    return undefined
+  }
+  return `${copyPrefix}[${itemIndex}]`
 }

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -7,7 +7,10 @@ import { CollectionObjectResult } from "@/components/executions/collection-objec
 import { ExternalObjectResult } from "@/components/executions/external-object-result"
 import { JsonViewWithControls } from "@/components/json-viewer"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
+import {
+  WF_TRIGGER_EVENT_REF,
+  type WorkflowExecutionEventCompact,
+} from "@/lib/event-history"
 import {
   isCollectionStoredObject,
   isExternalStoredObject,
@@ -106,7 +109,14 @@ export function WorkflowExecutionEventDetailView({
                 value="input"
                 className="m-0 flex-1 overflow-auto data-[state=active]:overflow-auto"
               >
-                <JsonViewContent src={event.action_input} />
+                <JsonViewContent
+                  src={event.action_input}
+                  copyPrefix={getExecutionEventCopyPrefix(
+                    event.action_ref,
+                    "input"
+                  )}
+                  copyMode="jsonpath-and-payload"
+                />
               </TabsContent>
             )}
             {hasResult && (
@@ -125,9 +135,21 @@ export function WorkflowExecutionEventDetailView({
                     executionId={executionId}
                     eventId={event.source_event_id}
                     collection={event.action_result}
+                    copyPrefix={getExecutionEventCopyPrefix(
+                      event.action_ref,
+                      "result"
+                    )}
+                    copyMode="jsonpath-and-payload"
                   />
                 ) : (
-                  <JsonViewContent src={event.action_result} />
+                  <JsonViewContent
+                    src={event.action_result}
+                    copyPrefix={getExecutionEventCopyPrefix(
+                      event.action_ref,
+                      "result"
+                    )}
+                    copyMode="jsonpath-and-payload"
+                  />
                 )}
               </TabsContent>
             )}
@@ -146,10 +168,35 @@ export function WorkflowExecutionEventDetailView({
   )
 }
 
-function JsonViewContent({ src }: { src: unknown }): JSX.Element {
+function JsonViewContent({
+  src,
+  copyPrefix,
+  copyMode = "jsonpath-only",
+}: {
+  src: unknown
+  copyPrefix?: string
+  copyMode?: "jsonpath-only" | "jsonpath-and-payload"
+}): JSX.Element {
   return (
     <div className="p-3">
-      <JsonViewWithControls src={src} defaultExpanded={true} />
+      <JsonViewWithControls
+        src={src}
+        defaultExpanded={true}
+        copyPrefix={copyPrefix}
+        copyMode={copyMode}
+      />
     </div>
   )
+}
+
+function getExecutionEventCopyPrefix(
+  actionRef: string,
+  kind: "input" | "result"
+): string {
+  if (actionRef === WF_TRIGGER_EVENT_REF) {
+    return "TRIGGER"
+  }
+  return kind === "input"
+    ? `ACTIONS.${actionRef}`
+    : `ACTIONS.${actionRef}.result`
 }

--- a/frontend/src/components/json-viewer.tsx
+++ b/frontend/src/components/json-viewer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CheckCheckIcon, CopyIcon } from "lucide-react"
+import { CheckCheckIcon, CopyIcon, LinkIcon } from "lucide-react"
 import React from "react"
 import JsonView from "react18-json-view"
 import type { NodeMeta } from "react18-json-view/dist/types"
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
@@ -89,12 +90,15 @@ function flattenObject(
 }
 
 type JsonViewWithControlsTabs = "flat" | "nested"
+type JsonViewCopyMode = "jsonpath-only" | "jsonpath-and-payload"
+
 interface JsonViewWithControlsProps {
   src: unknown
   defaultExpanded?: boolean
   defaultTab?: JsonViewWithControlsTabs
   showControls?: boolean
   copyPrefix?: string
+  copyMode?: JsonViewCopyMode
   className?: string
 }
 
@@ -104,6 +108,7 @@ export function JsonViewWithControls({
   defaultTab = "flat",
   showControls = true,
   copyPrefix,
+  copyMode = "jsonpath-only",
   className,
 }: JsonViewWithControlsProps): JSX.Element {
   const [isExpanded, setIsExpanded] = React.useState(defaultExpanded)
@@ -196,22 +201,33 @@ export function JsonViewWithControls({
               src={source ?? null}
               className="break-all text-xs"
               theme="atom"
+              CustomOperation={
+                copyMode === "jsonpath-and-payload"
+                  ? ({ node }) => <CopyPayloadButton node={node} />
+                  : undefined
+              }
               CopyComponent={({ onClick, className }) => (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <CopyIcon
-                      className={cn(
-                        "m-0 size-3 p-0 text-muted-foreground",
-                        className
-                      )}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        onClick(e)
-                      }}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent>Copy JSONPath</TooltipContent>
-                </Tooltip>
+                <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Copy JSONPath"
+                        className={cn(
+                          "m-0 inline-flex size-3 items-center justify-center p-0 text-muted-foreground hover:text-foreground",
+                          className
+                        )}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onClick(e)
+                        }}
+                      >
+                        <LinkIcon className="size-3" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Copy JSONPath</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               )}
               CopiedComponent={({ className, style }) => (
                 <CheckCheckIcon
@@ -224,7 +240,10 @@ export function JsonViewWithControls({
                 nodeMeta: NodeMeta | undefined
               ) => {
                 const { currentPath } = nodeMeta || {}
-                const copyValue = buildJsonPath(currentPath || [], copyPrefix)
+                const copyValue =
+                  value === "flat"
+                    ? buildFlattenedJsonPath(currentPath || [], copyPrefix)
+                    : buildJsonPath(currentPath || [], copyPrefix)
                 return copyValue
               }}
             />
@@ -235,10 +254,50 @@ export function JsonViewWithControls({
   )
 }
 
+function CopyPayloadButton({ node }: { node: unknown }): JSX.Element {
+  const [copied, setCopied] = React.useState(false)
+
+  const handleCopy = React.useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      await navigator.clipboard.writeText(serializeJsonPayload(node))
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 3000)
+    },
+    [node]
+  )
+
+  return (
+    <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label="Copy JSON payload"
+            className="json-view--copy inline-flex size-3 items-center justify-center p-0 pl-1.5 text-muted-foreground hover:text-foreground"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <CheckCheckIcon className="size-3 text-muted-foreground" />
+            ) : (
+              <CopyIcon className="size-3" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Copy JSON payload</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
 function isNumeric(str: string): boolean {
   return /^\d+$/.test(str)
 }
-function buildJsonPath(path: string[], prefix?: string): string | undefined {
+
+export function buildJsonPath(
+  path: string[],
+  prefix?: string
+): string | undefined {
   // Combine the arrays
   if (path.length === 0 && !prefix) {
     return undefined
@@ -268,4 +327,33 @@ function buildJsonPath(path: string[], prefix?: string): string | undefined {
     }
     return `${accPath}.${safeSegment}`
   }, seed)
+}
+
+export function buildFlattenedJsonPath(
+  path: string[],
+  prefix?: string
+): string | undefined {
+  const suffix = path.join(".")
+
+  if (!suffix && !prefix) {
+    return undefined
+  }
+  if (!suffix) {
+    return prefix
+  }
+  if (!prefix) {
+    return suffix
+  }
+  if (suffix.startsWith("[")) {
+    return `${prefix}${suffix}`
+  }
+  return `${prefix}.${suffix}`
+}
+
+export function serializeJsonPayload(node: unknown): string {
+  try {
+    return JSON.stringify(node, null, 2) ?? String(node)
+  } catch {
+    return String(node)
+  }
 }

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -549,16 +549,16 @@ function WorkflowManualTrigger({
       <Button
         type="button"
         variant={manualTriggerErrors ? "destructive" : "default"}
-        className="h-7 gap-2 px-3 py-0 text-xs"
+        className="h-7 justify-center gap-2 rounded-lg px-5 py-0 text-xs font-medium"
         disabled={disabled || executionPending}
         onClick={runWorkflow}
       >
         {executionPending ? (
-          <Spinner className="size-3" segmentColor="currentColor" />
+          <Spinner className="size-3.5" segmentColor="currentColor" />
         ) : manualTriggerErrors ? (
-          <AlertTriangleIcon className="size-3" />
+          <AlertTriangleIcon className="size-3.5" />
         ) : (
-          <PlayIcon className="size-3" />
+          <PlayIcon className="size-3.5" />
         )}
         <span>Run</span>
       </Button>

--- a/frontend/tests/collection-object-result.test.tsx
+++ b/frontend/tests/collection-object-result.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from "@testing-library/react"
+import type React from "react"
+import { workflowExecutionsGetWorkflowExecutionCollectionPage } from "@/client"
+import { CollectionObjectResult } from "@/components/executions/collection-object-result"
+import {
+  isExternalStoredObject,
+  isInlineStoredObject,
+} from "@/lib/stored-object"
+
+jest.mock("@/client", () => ({
+  workflowExecutionsGetWorkflowExecutionCollectionPage: jest.fn(),
+}))
+
+jest.mock("@/components/code-block", () => ({
+  CodeBlock: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+jest.mock("@/components/executions/external-object-result", () => ({
+  ExternalObjectResult: () => null,
+}))
+
+jest.mock("@/components/json-viewer", () => ({
+  JsonViewWithControls: ({
+    src,
+    copyMode,
+    copyPrefix,
+  }: {
+    src: unknown
+    copyMode?: string
+    copyPrefix?: string
+  }) => (
+    <div
+      data-testid="json-view"
+      data-copy-mode={copyMode}
+      data-copy-prefix={copyPrefix}
+    >
+      {JSON.stringify(src)}
+    </div>
+  ),
+}))
+
+jest.mock("@/lib/stored-object", () => ({
+  isExternalStoredObject: jest.fn(() => false),
+  isInlineStoredObject: jest.fn(() => true),
+}))
+
+jest.mock("@/providers/workspace-id", () => ({
+  useWorkspaceId: () => "workspace-1",
+}))
+
+const mockGetCollectionPage =
+  workflowExecutionsGetWorkflowExecutionCollectionPage as jest.MockedFunction<
+    typeof workflowExecutionsGetWorkflowExecutionCollectionPage
+  >
+const mockIsExternalStoredObject =
+  isExternalStoredObject as jest.MockedFunction<typeof isExternalStoredObject>
+const mockIsInlineStoredObject = isInlineStoredObject as jest.MockedFunction<
+  typeof isInlineStoredObject
+>
+
+describe("CollectionObjectResult", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsExternalStoredObject.mockReturnValue(false)
+    mockIsInlineStoredObject.mockReturnValue(true)
+    mockGetCollectionPage.mockResolvedValue({
+      collection: {
+        count: 1,
+        chunk_size: 25,
+        element_kind: "stored_object",
+      },
+      items: [
+        {
+          index: 0,
+          kind: "stored_object_ref",
+          stored: {
+            data: { foo: "bar" },
+          },
+          value_size_bytes: 32,
+          truncated: false,
+        },
+      ],
+      next_offset: null,
+    } as never)
+  })
+
+  it("passes the dual copy mode to inline JSON previews", async () => {
+    render(
+      <CollectionObjectResult
+        executionId="exec-1"
+        eventId={1}
+        collection={
+          {
+            count: 1,
+            chunk_size: 25,
+            element_kind: "stored_object",
+          } as never
+        }
+        copyMode="jsonpath-and-payload"
+        copyPrefix="ACTIONS.reshape.result"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("json-view")).toHaveAttribute(
+        "data-copy-mode",
+        "jsonpath-and-payload"
+      )
+      expect(screen.getByTestId("json-view")).toHaveAttribute(
+        "data-copy-prefix",
+        "ACTIONS.reshape.result[0]"
+      )
+    })
+  })
+})

--- a/frontend/tests/event-details.test.tsx
+++ b/frontend/tests/event-details.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react"
+import type React from "react"
+import { WorkflowExecutionEventDetailView } from "@/components/executions/event-details"
+import type { WorkflowExecutionEventCompact } from "@/lib/event-history"
+import {
+  isCollectionStoredObject,
+  isExternalStoredObject,
+} from "@/lib/stored-object"
+
+jest.mock("@/components/code-block", () => ({
+  CodeBlock: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+jest.mock("@/components/executions/collection-object-result", () => ({
+  CollectionObjectResult: ({ copyMode }: { copyMode?: string }) => (
+    <div data-testid="collection-result" data-copy-mode={copyMode} />
+  ),
+}))
+
+jest.mock("@/components/executions/external-object-result", () => ({
+  ExternalObjectResult: () => null,
+}))
+
+jest.mock("@/components/json-viewer", () => ({
+  JsonViewWithControls: ({
+    src,
+    copyMode,
+    copyPrefix,
+  }: {
+    src: unknown
+    copyMode?: string
+    copyPrefix?: string
+  }) => (
+    <div
+      data-testid="json-view"
+      data-copy-mode={copyMode}
+      data-copy-prefix={copyPrefix}
+    >
+      {JSON.stringify(src)}
+    </div>
+  ),
+}))
+
+jest.mock("@/lib/stored-object", () => ({
+  isCollectionStoredObject: jest.fn(() => false),
+  isExternalStoredObject: jest.fn(() => false),
+}))
+
+const mockIsCollectionStoredObject =
+  isCollectionStoredObject as jest.MockedFunction<
+    typeof isCollectionStoredObject
+  >
+const mockIsExternalStoredObject =
+  isExternalStoredObject as jest.MockedFunction<typeof isExternalStoredObject>
+
+function createEvent(
+  overrides: Partial<WorkflowExecutionEventCompact> = {}
+): WorkflowExecutionEventCompact {
+  return {
+    source_event_id: 1,
+    schedule_time: "2026-03-13T17:16:35Z",
+    start_time: "2026-03-13T17:16:35Z",
+    close_time: "2026-03-13T17:16:35Z",
+    curr_event_type: "ACTIVITY_TASK_COMPLETED",
+    status: "COMPLETED",
+    action_name: "Reshape",
+    action_ref: "reshape",
+    action_input: { some: "trigger" },
+    action_result: { transformed: true },
+    action_error: null,
+    ...overrides,
+  } as WorkflowExecutionEventCompact
+}
+
+describe("WorkflowExecutionEventDetailView", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsCollectionStoredObject.mockReturnValue(false)
+    mockIsExternalStoredObject.mockReturnValue(false)
+  })
+
+  it("passes dual copy mode to the input JSON viewer", () => {
+    render(
+      <WorkflowExecutionEventDetailView
+        event={createEvent({ action_result: null })}
+        executionId="exec-1"
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-mode",
+      "jsonpath-and-payload"
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "ACTIONS.reshape"
+    )
+  })
+
+  it("passes result prefixes to the result JSON viewer", () => {
+    render(
+      <WorkflowExecutionEventDetailView
+        event={createEvent({ action_input: null })}
+        executionId="exec-1"
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "ACTIONS.reshape.result"
+    )
+  })
+
+  it("uses TRIGGER prefixes for trigger input", () => {
+    render(
+      <WorkflowExecutionEventDetailView
+        event={createEvent({
+          action_ref: "__workflow_trigger__",
+          action_name: "Trigger",
+          action_result: null,
+        })}
+        executionId="exec-1"
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "TRIGGER"
+    )
+  })
+
+  it("passes dual copy mode to collection results", () => {
+    mockIsCollectionStoredObject.mockReturnValue(true)
+
+    render(
+      <WorkflowExecutionEventDetailView
+        event={createEvent({
+          action_input: null,
+          action_result: { object_type: "collection" },
+        })}
+        executionId="exec-1"
+      />
+    )
+
+    expect(screen.getByTestId("collection-result")).toHaveAttribute(
+      "data-copy-mode",
+      "jsonpath-and-payload"
+    )
+  })
+})

--- a/frontend/tests/event-details.test.tsx
+++ b/frontend/tests/event-details.test.tsx
@@ -18,8 +18,18 @@ jest.mock("@/components/code-block", () => ({
 }))
 
 jest.mock("@/components/executions/collection-object-result", () => ({
-  CollectionObjectResult: ({ copyMode }: { copyMode?: string }) => (
-    <div data-testid="collection-result" data-copy-mode={copyMode} />
+  CollectionObjectResult: ({
+    copyMode,
+    copyPrefix,
+  }: {
+    copyMode?: string
+    copyPrefix?: string
+  }) => (
+    <div
+      data-testid="collection-result"
+      data-copy-mode={copyMode}
+      data-copy-prefix={copyPrefix}
+    />
   ),
 }))
 
@@ -151,6 +161,10 @@ describe("WorkflowExecutionEventDetailView", () => {
     expect(screen.getByTestId("collection-result")).toHaveAttribute(
       "data-copy-mode",
       "jsonpath-and-payload"
+    )
+    expect(screen.getByTestId("collection-result")).toHaveAttribute(
+      "data-copy-prefix",
+      "ACTIONS.reshape.result"
     )
   })
 })

--- a/frontend/tests/events-selected-action.test.tsx
+++ b/frontend/tests/events-selected-action.test.tsx
@@ -1,0 +1,388 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react"
+import type React from "react"
+import {
+  ActionEventPane,
+  SuccessEvent,
+} from "@/components/builder/events/events-selected-action"
+import {
+  WF_TRIGGER_EVENT_REF,
+  type WorkflowExecutionEventCompact,
+} from "@/lib/event-history"
+import { isCollectionStoredObject } from "@/lib/stored-object"
+import { useWorkflowBuilder } from "@/providers/builder"
+
+jest.mock("@ai-sdk/react", () => ({
+  useChat: jest.fn(() => ({
+    messages: [],
+    status: "ready",
+  })),
+}))
+
+jest.mock("ai", () => ({
+  DefaultChatTransport: jest.fn(),
+}))
+
+jest.mock("@/components/ai-elements/conversation", () => ({
+  Conversation: ({ children }: { children: React.ReactNode }) => children,
+  ConversationContent: ({ children }: { children: React.ReactNode }) =>
+    children,
+  ConversationScrollButton: () => null,
+}))
+
+jest.mock("@/components/chat/chat-session-pane", () => ({
+  MessagePart: () => null,
+}))
+
+jest.mock("@/components/code-block", () => ({
+  CodeBlock: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock("@/components/events/workflow-event-status", () => ({
+  getWorkflowEventIcon: () => null,
+}))
+
+jest.mock("@/components/executions/collection-object-result", () => ({
+  CollectionObjectResult: ({
+    copyMode,
+    copyPrefix,
+  }: {
+    copyMode?: string
+    copyPrefix?: string
+  }) => (
+    <div
+      data-testid="collection-result"
+      data-copy-mode={copyMode}
+      data-copy-prefix={copyPrefix}
+    />
+  ),
+}))
+
+jest.mock("@/components/executions/external-object-result", () => ({
+  ExternalObjectResult: () => <div data-testid="external-result" />,
+}))
+
+jest.mock("@/components/json-viewer", () => ({
+  JsonViewWithControls: ({
+    src,
+    copyMode,
+    copyPrefix,
+  }: {
+    src: unknown
+    copyMode?: string
+    copyPrefix?: string
+  }) => (
+    <pre
+      data-testid="json-view"
+      data-copy-mode={copyMode}
+      data-copy-prefix={copyPrefix}
+    >
+      {JSON.stringify(src)}
+    </pre>
+  ),
+}))
+
+jest.mock("@/components/loading/spinner", () => ({
+  Spinner: () => null,
+}))
+
+jest.mock("@/components/notifications", () => ({
+  AlertNotification: () => null,
+}))
+
+jest.mock("@/components/separator", () => ({
+  InlineDotSeparator: () => null,
+}))
+
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}))
+
+jest.mock("@/components/ui/carousel", () => ({
+  Carousel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CarouselContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CarouselItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectValue: () => null,
+}))
+
+jest.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabsList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}))
+
+jest.mock("@/components/ui/use-toast", () => ({
+  toast: jest.fn(),
+}))
+
+jest.mock("@/hooks/use-chat", () => ({
+  parseChatError: jest.fn(),
+}))
+
+jest.mock("@/lib/agents", () => ({
+  isUIMessageArray: jest.fn(() => false),
+}))
+
+jest.mock("@/lib/api", () => ({
+  getBaseUrl: jest.fn(() => "http://localhost:3000"),
+}))
+
+jest.mock("@/lib/stored-object", () => ({
+  isCollectionStoredObject: jest.fn(() => false),
+  isExternalStoredObject: jest.fn(() => false),
+}))
+
+jest.mock("@/providers/builder", () => ({
+  useWorkflowBuilder: jest.fn(() => ({
+    workspaceId: "workspace-1",
+    workflowId: "workflow-1",
+    selectedActionEventRef: "reshape",
+    setSelectedActionEventRef: jest.fn(),
+  })),
+}))
+
+const mockIsCollectionStoredObject =
+  isCollectionStoredObject as jest.MockedFunction<
+    typeof isCollectionStoredObject
+  >
+const mockUseWorkflowBuilder = useWorkflowBuilder as jest.MockedFunction<
+  typeof useWorkflowBuilder
+>
+
+function createEvent(
+  overrides: Partial<WorkflowExecutionEventCompact> = {}
+): WorkflowExecutionEventCompact {
+  return {
+    source_event_id: 1,
+    schedule_time: "2026-03-13T17:16:35Z",
+    start_time: "2026-03-13T17:16:35Z",
+    close_time: "2026-03-13T17:16:35Z",
+    curr_event_type: "WORKFLOW_EXECUTION_STARTED",
+    status: "COMPLETED",
+    action_name: "Workflow",
+    action_ref: WF_TRIGGER_EVENT_REF,
+    action_input: { some: "trigger" },
+    action_result: null,
+    ...overrides,
+  } as WorkflowExecutionEventCompact
+}
+
+describe("SuccessEvent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsCollectionStoredObject.mockReturnValue(false)
+    mockUseWorkflowBuilder.mockReturnValue({
+      workspaceId: "workspace-1",
+      workflowId: "workflow-1",
+      selectedActionEventRef: "reshape",
+      setSelectedActionEventRef: jest.fn(),
+    } as never)
+  })
+
+  it("renders trigger input on the result tab", () => {
+    render(
+      <SuccessEvent
+        event={createEvent()}
+        type="result"
+        eventRef={WF_TRIGGER_EVENT_REF}
+        executionId="exec-1"
+        eventId={1}
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveTextContent(
+      '{"some":"trigger"}'
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-mode",
+      "jsonpath-and-payload"
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "TRIGGER"
+    )
+    expect(
+      screen.queryByText("This action returned no result (null).")
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders trigger input on the input tab unchanged", () => {
+    render(
+      <SuccessEvent
+        event={createEvent()}
+        type="input"
+        eventRef={WF_TRIGGER_EVENT_REF}
+        executionId="exec-1"
+        eventId={1}
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveTextContent(
+      '{"some":"trigger"}'
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-mode",
+      "jsonpath-and-payload"
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "TRIGGER"
+    )
+  })
+
+  it("renders non-trigger results unchanged", () => {
+    render(
+      <SuccessEvent
+        event={createEvent({
+          action_ref: "reshape",
+          action_name: "Reshape",
+          action_input: { some: "trigger" },
+          action_result: { transformed: true },
+          curr_event_type: "ACTIVITY_TASK_COMPLETED",
+        })}
+        type="result"
+        eventRef="reshape"
+        executionId="exec-1"
+        eventId={2}
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveTextContent(
+      '{"transformed":true}'
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-mode",
+      "jsonpath-and-payload"
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "ACTIONS.reshape.result"
+    )
+    expect(screen.getByTestId("json-view")).not.toHaveTextContent(
+      '{"some":"trigger"}'
+    )
+  })
+
+  it("passes dual copy mode to collection results", () => {
+    mockIsCollectionStoredObject.mockReturnValue(true)
+
+    render(
+      <SuccessEvent
+        event={createEvent({
+          action_ref: "reshape",
+          action_name: "Reshape",
+          action_result: { object_type: "collection" },
+          curr_event_type: "ACTIVITY_TASK_COMPLETED",
+        })}
+        type="result"
+        eventRef="reshape"
+        executionId="exec-1"
+        eventId={2}
+      />
+    )
+
+    expect(screen.getByTestId("collection-result")).toHaveAttribute(
+      "data-copy-mode",
+      "jsonpath-and-payload"
+    )
+    expect(screen.getByTestId("collection-result")).toHaveAttribute(
+      "data-copy-prefix",
+      "ACTIONS.reshape.result"
+    )
+  })
+
+  it("passes dual copy mode to interaction viewers", () => {
+    render(
+      <ActionEventPane
+        execution={
+          {
+            id: "exec-1",
+            status: "COMPLETED",
+            events: [
+              createEvent({
+                action_ref: "reshape",
+                action_name: "Reshape",
+              }),
+            ],
+            interactions: [
+              {
+                action_ref: "reshape",
+                response_payload: { approved: true },
+              },
+            ],
+          } as never
+        }
+        type="interaction"
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-mode",
+      "jsonpath-and-payload"
+    )
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "ACTIONS.reshape.interaction"
+    )
+  })
+
+  it("uses ACTIONS.<ref> prefixes for action input", () => {
+    render(
+      <SuccessEvent
+        event={createEvent({
+          action_ref: "reshape",
+          action_name: "Reshape",
+        })}
+        type="input"
+        eventRef="reshape"
+        executionId="exec-1"
+        eventId={1}
+      />
+    )
+
+    expect(screen.getByTestId("json-view")).toHaveAttribute(
+      "data-copy-prefix",
+      "ACTIONS.reshape"
+    )
+  })
+})

--- a/frontend/tests/json-viewer.test.tsx
+++ b/frontend/tests/json-viewer.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react"
+import type { ComponentProps, ComponentType, MouseEvent } from "react"
+import {
+  buildFlattenedJsonPath,
+  buildJsonPath,
+  JsonViewWithControls,
+  serializeJsonPayload,
+} from "@/components/json-viewer"
+import { TooltipProvider } from "@/components/ui/tooltip"
+
+jest.mock("react18-json-view", () => {
+  return {
+    __esModule: true,
+    default: ({
+      src,
+      CopyComponent,
+      CustomOperation,
+      customizeCopy,
+    }: {
+      src: unknown
+      CopyComponent: ComponentType<{
+        onClick: (event: MouseEvent<HTMLButtonElement>) => void
+        className: string
+      }>
+      CustomOperation?: ComponentType<{ node: unknown }>
+      customizeCopy: (
+        node: unknown,
+        nodeMeta?: { currentPath: string[] }
+      ) => string
+    }) => {
+      const jsonPathNode =
+        typeof src === "object" &&
+        src !== null &&
+        !Array.isArray(src) &&
+        "foo" in src
+          ? (src as { foo: unknown }).foo
+          : src
+      const currentPath =
+        typeof src === "object" &&
+        src !== null &&
+        !Array.isArray(src) &&
+        "foo" in src
+          ? ["foo"]
+          : []
+
+      return (
+        <div data-testid="mock-json-view">
+          <CopyComponent
+            className="json-view--copy"
+            onClick={(event: MouseEvent<HTMLButtonElement>) => {
+              event.stopPropagation()
+              void navigator.clipboard.writeText(
+                customizeCopy(jsonPathNode, { currentPath })
+              )
+            }}
+          />
+          {CustomOperation ? <CustomOperation node={src} /> : null}
+        </div>
+      )
+    },
+  }
+})
+
+describe("JsonViewWithControls", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function renderViewer(props: ComponentProps<typeof JsonViewWithControls>) {
+    return render(
+      <TooltipProvider>
+        <JsonViewWithControls {...props} />
+      </TooltipProvider>
+    )
+  }
+
+  it("renders only the JSONPath action by default", () => {
+    renderViewer({
+      src: { foo: "bar" },
+      defaultExpanded: true,
+    })
+
+    expect(screen.getAllByLabelText("Copy JSONPath")).not.toHaveLength(0)
+    expect(screen.queryByLabelText("Copy JSON payload")).not.toBeInTheDocument()
+  })
+
+  it("renders both copy actions in dual mode", () => {
+    renderViewer({
+      src: { foo: "bar" },
+      defaultExpanded: true,
+      copyMode: "jsonpath-and-payload",
+    })
+
+    expect(screen.getAllByLabelText("Copy JSONPath")).not.toHaveLength(0)
+    expect(screen.getAllByLabelText("Copy JSON payload")).not.toHaveLength(0)
+  })
+
+  it("serializes object payloads as valid JSON", () => {
+    expect(serializeJsonPayload({ foo: "bar" })).toBe('{\n  "foo": "bar"\n}')
+  })
+
+  it("serializes string payloads as valid JSON", () => {
+    expect(serializeJsonPayload("bar")).toBe('"bar"')
+  })
+
+  it("serializes number payloads as valid JSON", () => {
+    expect(serializeJsonPayload(42)).toBe("42")
+  })
+
+  it("builds JSONPath values with the existing prefix behavior", () => {
+    expect(buildJsonPath(["foo"], "ACTIONS.reshape.result")).toBe(
+      "ACTIONS.reshape.result.foo"
+    )
+  })
+
+  it("quotes special-character path segments", () => {
+    expect(buildJsonPath(["this.is.one.field"], "ACTIONS.reshape.result")).toBe(
+      'ACTIONS.reshape.result."this.is.one.field"'
+    )
+  })
+
+  it("preserves already-escaped flattened paths", () => {
+    expect(
+      buildFlattenedJsonPath(
+        ['foo."this.is.one.field"[0]'],
+        "ACTIONS.reshape.result"
+      )
+    ).toBe('ACTIONS.reshape.result.foo."this.is.one.field"[0]')
+  })
+})


### PR DESCRIPTION
## Summary
This branch refines a few workflow builder interactions that were bundled together locally.

The primary user-facing fix is in the JSON results viewer used from the builder events sidebar and the workflow runs detail view. Those viewers now expose separate hover actions for copying the JSON payload and copying the corresponding expression path, while preserving the execution-context prefixes users expect when they paste those paths into workflow expressions.

The branch also includes the in-progress builder UI adjustments that were already present in the worktree: the trigger payload editor is now rendered as a resizable floating panel next to the trigger node, and the manual Run button styling in the builder header has been tightened for consistency.

## Problem
Users previously only had a single copy affordance in the JSON viewer, and it copied a path rather than the payload itself. During the first pass at adding a second copy action, the JSONPath copy behavior regressed on some surfaces: copied paths could lose their execution-context root and degrade into bare field paths, which made them less useful in Tracecat expressions.

There was also a path escaping issue for keys containing special characters such as dots. Those keys need to be quoted automatically so pasted paths remain valid and unambiguous.

## Root cause
The JSON viewer wrapper was using a shared path builder without enough context from each surface about whether the payload was coming from `TRIGGER`, an action input, an action result, or an interaction payload. On top of that, the flattened view already stores escaped path fragments as keys, so rebuilding those paths with the generic segment escaper could double-handle special-character keys.

## Fix
The JSON viewer now supports an opt-in dual-copy mode that renders a link icon for path copy and a copy icon for payload copy. Payload copy serializes valid JSON to the clipboard and keeps local copied-state feedback on the payload icon.

For path copy, the builder and workflow-runs surfaces now pass the correct execution-context prefixes back into the shared viewer:

- `TRIGGER.<path>` for trigger payloads
- `ACTIONS.<ref>.<path>` for action inputs
- `ACTIONS.<ref>.result.<path>` for action results
- `ACTIONS.<ref>.interaction.<path>` for interaction payloads

The flattened view now uses a dedicated path joiner so already-escaped flattened keys are preserved, while nested view paths continue to quote special-character segments automatically.

The collection result viewer was also threaded with the same scoped copy behavior so inline collection items inherit the right path roots, including item indices.

Outside the JSON viewer work, the existing local builder changes were kept intact in this PR:

- the trigger payload editor is rendered as a floating resizable panel beside the trigger node
- the manual Run button spacing, icon sizing, and shape were refined in the builder header

## Validation
I validated the frontend changes with:

- `pnpm -C frontend test -- --runInBand json-viewer.test.tsx event-details.test.tsx collection-object-result.test.tsx events-selected-action.test.tsx`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`

These tests cover the shared JSON viewer behavior, the builder event-pane wiring, the workflow-runs event detail wiring, and collection item path propagation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the JSON results viewer with separate copy actions and correct scoped JSONPath prefixes across builder and run views. Refined the builder with a resizable trigger payload panel and consistent Run button styling.

- **New Features**
  - Added dual-copy mode in `JsonViewWithControls`: link icon copies JSONPath; copy icon copies the JSON payload. Enabled across builder events, run details, interactions, and collection results (item prefixes include indices). Trigger “Result” tab now shows the trigger input JSON.
  - Trigger payload editor is now a resizable floating panel next to the trigger node; Run button sizing and spacing are consistent.

- **Bug Fixes**
  - Restored scoped JSONPath copying with correct prefixes: `TRIGGER`, `ACTIONS.<ref>`, `ACTIONS.<ref>.result`, `ACTIONS.<ref>.interaction`.
  - Fixed path escaping for keys with special characters and preserved flattened keys to avoid double-escaping.

<sup>Written for commit e19b352f91cee739b6ea09ad1c5dcfdc971baa3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

