### PR TITLE
fix(tables): sanitize default value literals

### DIFF
--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -5,8 +5,10 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from asyncpg import DuplicateColumnError
 from fastapi import status
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import ProgrammingError
 
 from tracecat.auth.types import Role
 from tracecat.cases import router as cases_router
@@ -380,6 +382,31 @@ async def test_delete_case_field_invalid_identifier_returns_400(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "Identifier must" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_update_case_field_duplicate_name_returns_409(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    with patch.object(cases_router, "CaseFieldsService") as mock_service_cls:
+        mock_service = AsyncMock()
+        duplicate_error = DuplicateColumnError("Column already exists")
+        programming_error = ProgrammingError("", {}, duplicate_error)
+        programming_error.__cause__ = duplicate_error
+        mock_service.update_field.side_effect = programming_error
+        mock_service_cls.return_value = mock_service
+
+        response = client.patch(
+            "/case-fields/existing_field",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"name": "duplicate_name"},
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["detail"] == (
+        "A field with the name 'duplicate_name' already exists"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -340,6 +340,49 @@ async def test_create_case_validation_error(
 
 
 @pytest.mark.anyio
+async def test_update_case_field_invalid_identifier_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    with patch.object(cases_router, "CaseFieldsService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.update_field.side_effect = ValueError(
+            "Identifier must contain only letters, numbers, and underscores"
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.patch(
+            "/case-fields/bad-field",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"default": "value"},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Identifier must" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_delete_case_field_invalid_identifier_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    with patch.object(cases_router, "CaseFieldsService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.delete_field.side_effect = ValueError(
+            "Identifier must contain only letters, numbers, and underscores"
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.delete(
+            "/case-fields/bad-field",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Identifier must" in response.json()["detail"]
+
+
+@pytest.mark.anyio
 async def test_get_case_success(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/test_case_fields_integration.py
+++ b/tests/unit/test_case_fields_integration.py
@@ -4,7 +4,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
-from tracecat.cases.schemas import CaseCreate, CaseFieldCreate, CaseUpdate
+from tracecat.cases.schemas import (
+    CaseCreate,
+    CaseFieldCreate,
+    CaseFieldUpdate,
+    CaseUpdate,
+)
 from tracecat.cases.service import CaseFieldsService, CasesService
 from tracecat.db.models import Case, User
 from tracecat.pagination import CursorPaginationParams
@@ -282,6 +287,24 @@ class TestCaseFieldsIntegration:
         )
         fields_after_delete = await cases_service.fields.get_fields(deleted_case)
         assert fields_after_delete is None
+
+    async def test_update_field_rejects_sql_injection_like_field_id(
+        self,
+        case_fields_service: CaseFieldsService,
+    ) -> None:
+        """Reject field IDs that are not valid SQL identifiers before DDL runs."""
+        await case_fields_service.create_field(
+            CaseFieldCreate(
+                name="safe_field",
+                type=SqlType.TEXT,
+            )
+        )
+
+        with pytest.raises(ValueError, match="Identifier must"):
+            await case_fields_service.update_field(
+                'safe_field"; DROP TABLE case_fields; --',
+                CaseFieldUpdate(default="still text"),
+            )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -23,7 +23,11 @@ from tracecat.tables.schemas import (
     TableRowInsert,
     TableUpdate,
 )
-from tracecat.tables.service import TableEditorService, TablesService
+from tracecat.tables.service import (
+    TableEditorService,
+    TablesService,
+    sanitize_identifier,
+)
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -550,6 +554,13 @@ class TestHandleDefaultValue:
         assert rendered.startswith("'")
         assert rendered.endswith("'::jsonb")
         assert "SELECT pg_sleep(1)" in rendered
+
+
+class TestSanitizeIdentifier:
+    @pytest.mark.parametrize("identifier", ["", '";drop', "123field", "__field"])
+    def test_rejects_invalid_identifiers(self, identifier: str) -> None:
+        with pytest.raises(ValueError):
+            sanitize_identifier(identifier)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -27,6 +27,7 @@ from tracecat.tables.service import (
     TableEditorService,
     TablesService,
     sanitize_identifier,
+    validate_identifier,
 )
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -557,10 +558,21 @@ class TestHandleDefaultValue:
 
 
 class TestSanitizeIdentifier:
-    @pytest.mark.parametrize("identifier", ["", '";drop', "123field", "__field"])
-    def test_rejects_invalid_identifiers(self, identifier: str) -> None:
+    @pytest.mark.parametrize(
+        ("identifier", "expected"),
+        [
+            ("display_name", "display_name"),
+            ("bad-name", "badname"),
+            ('";drop', "drop"),
+        ],
+    )
+    def test_normalizes_identifiers(self, identifier: str, expected: str) -> None:
+        assert sanitize_identifier(identifier) == expected
+
+    @pytest.mark.parametrize("identifier", ["", '";drop', "123field"])
+    def test_rejects_identifiers_without_valid_sql_shape(self, identifier: str) -> None:
         with pytest.raises(ValueError):
-            sanitize_identifier(identifier)
+            validate_identifier(identifier)
 
 
 @pytest.mark.anyio
@@ -699,6 +711,27 @@ class TestTableColumns:
 
         inserted = await editor.insert_row(TableRowInsert(data={}))
         assert inserted["nickname"] == "O'Brien"
+
+    async def test_update_column_handles_legacy_metadata_name(
+        self, tables_service: TablesService
+    ) -> None:
+        """Legacy metadata names should still resolve to the physical column."""
+        table = await tables_service.create_table(
+            TableCreate(name="legacy_column_name")
+        )
+        column = await tables_service.create_column(
+            table,
+            TableColumnCreate(name="badname", type=SqlType.TEXT, nullable=True),
+        )
+        column.name = "bad-name"
+        await tables_service.session.flush()
+
+        updated_column = await tables_service.update_column(
+            column,
+            TableColumnUpdate(name="display_name"),
+        )
+
+        assert updated_column.name == "display_name"
 
     async def test_create_column_sql_injection_payload_is_stored_as_text_literal(
         self, tables_service: TablesService

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1012,6 +1012,39 @@ class TestTableRows:
                 values=["Bob"],
             )
 
+    async def test_lookup_row_allows_system_id_column(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """System columns should remain available to lookup_rows."""
+        inserted = await tables_service.insert_row(
+            table, TableRowInsert(data={"name": "Bob", "age": 40})
+        )
+
+        results = await tables_service.lookup_rows(
+            table_name=table.name,
+            columns=["id"],
+            values=[inserted["id"]],
+        )
+
+        assert len(results) == 1
+        assert results[0]["id"] == inserted["id"]
+
+    async def test_exists_rows_allows_system_id_column(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """System columns should remain available to exists_rows."""
+        inserted = await tables_service.insert_row(
+            table, TableRowInsert(data={"name": "Bob", "age": 40})
+        )
+
+        exists = await tables_service.exists_rows(
+            table_name=table.name,
+            columns=["id"],
+            values=[inserted["id"]],
+        )
+
+        assert exists is True
+
     async def test_list_rows(self, tables_service: TablesService, table: Table) -> None:
         """Test listing rows with cursor-based pagination."""
         # Insert multiple test rows

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -14,7 +14,7 @@ from tracecat.db.models import Table
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginationParams
-from tracecat.tables.common import parse_postgres_default
+from tracecat.tables.common import handle_default_value, parse_postgres_default
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import (
     TableColumnCreate,
@@ -448,6 +448,77 @@ class TestParsePostgresDefault:
         assert parse_default(raw) == expected
 
 
+class TestHandleDefaultValue:
+    @pytest.mark.parametrize(
+        ("sql_type", "default", "expected"),
+        [
+            pytest.param(
+                SqlType.TEXT,
+                "O'Brien",
+                "'O''Brien'",
+                id="text-escapes-single-quote",
+            ),
+            pytest.param(
+                SqlType.SELECT,
+                "O'Brien",
+                "'O''Brien'",
+                id="select-escapes-single-quote",
+            ),
+            pytest.param(
+                SqlType.INTEGER,
+                "42",
+                "42",
+                id="integer-literal",
+            ),
+            pytest.param(
+                SqlType.NUMERIC,
+                "3.14159",
+                "3.14159",
+                id="numeric-literal",
+            ),
+            pytest.param(
+                SqlType.UUID,
+                "00000000-0000-0000-0000-000000000000",
+                "'00000000-0000-0000-0000-000000000000'::uuid",
+                id="uuid-literal",
+            ),
+        ],
+    )
+    def test_formats_literal_safe_defaults(
+        self, sql_type: SqlType, default: Any, expected: str
+    ) -> None:
+        assert handle_default_value(sql_type, default) == expected
+
+    @pytest.mark.parametrize(
+        ("sql_type", "default", "error_message"),
+        [
+            pytest.param(
+                SqlType.INTEGER,
+                "1 + 2",
+                "Invalid integer default value",
+                id="integer-expression",
+            ),
+            pytest.param(
+                SqlType.NUMERIC,
+                "1 / 0.5",
+                "Invalid numeric default value",
+                id="numeric-expression",
+            ),
+            pytest.param(
+                SqlType.UUID,
+                "00000000-0000-0000-0000-000000000000' || current_user || '",
+                "Invalid UUID default value",
+                id="uuid-expression",
+            ),
+        ],
+    )
+    def test_rejects_non_literal_defaults(
+        self, sql_type: SqlType, default: Any, error_message: str
+    ) -> None:
+        with pytest.raises(TypeError, match=error_message):
+            handle_default_value(sql_type, default)
+
+
 @pytest.mark.anyio
 class TestTableColumns:
     async def test_create_and_get_column(self, tables_service: TablesService) -> None:
@@ -517,6 +588,70 @@ class TestTableColumns:
         assert retrieved_column.nullable is False
         assert retrieved_column.default == "default_value"
         assert retrieved_column.type == SqlType.TEXT
+
+    async def test_create_column_default_with_single_quote(
+        self, tables_service: TablesService
+    ) -> None:
+        """Quoted text defaults should be stored as string literals, not SQL."""
+        table = await tables_service.create_table(
+            TableCreate(name="quoted_default_create")
+        )
+
+        await tables_service.create_column(
+            table,
+            TableColumnCreate(
+                name="nickname",
+                type=SqlType.TEXT,
+                nullable=True,
+                default="O'Brien",
+            ),
+        )
+
+        inserted = await tables_service.insert_row(table, TableRowInsert(data={}))
+        assert inserted["nickname"] == "O'Brien"
+
+    async def test_update_column_default_with_single_quote(
+        self, tables_service: TablesService
+    ) -> None:
+        """TablesService updates should safely apply quoted defaults."""
+        table = await tables_service.create_table(
+            TableCreate(name="quoted_default_update")
+        )
+        column = await tables_service.create_column(
+            table,
+            TableColumnCreate(name="nickname", type=SqlType.TEXT, nullable=True),
+        )
+
+        await tables_service.update_column(
+            column,
+            TableColumnUpdate(name="display_name", default="O'Brien"),
+        )
+
+        inserted = await tables_service.insert_row(table, TableRowInsert(data={}))
+        assert inserted["display_name"] == "O'Brien"
+
+    async def test_table_editor_update_column_default_with_single_quote(
+        self, tables_service: TablesService
+    ) -> None:
+        """TableEditorService should also escape quoted defaults."""
+        table = await tables_service.create_table(
+            TableCreate(name="quoted_default_editor_update")
+        )
+        await tables_service.create_column(
+            table,
+            TableColumnCreate(name="nickname", type=SqlType.TEXT, nullable=True),
+        )
+        editor = TableEditorService(
+            tables_service.session,
+            tables_service.role,
+            table_name=table.name,
+            schema_name=tables_service._get_schema_name(),
+        )
+
+        await editor.update_column("nickname", TableColumnUpdate(default="O'Brien"))
+
+        inserted = await editor.insert_row(TableRowInsert(data={}))
+        assert inserted["nickname"] == "O'Brien"
 
     async def test_create_single_column_unique_index(
         self, tables_service: TablesService, table: Table

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -537,6 +537,12 @@ class TestHandleDefaultValue:
                 id="integer-infinity",
             ),
             pytest.param(
+                SqlType.INTEGER,
+                "1e500000",
+                "Invalid integer default value",
+                id="integer-out-of-range-exponent",
+            ),
+            pytest.param(
                 SqlType.NUMERIC,
                 "1 / 0.5",
                 "Invalid numeric default value",

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -157,6 +157,26 @@ class TestTablesService:
         retrieved_by_id = await tables_service.get_table(created_table.id)
         assert retrieved_by_id.id == created_table.id
 
+    async def test_get_table_by_name_rejects_invalid_alias(
+        self, tables_service: TablesService
+    ) -> None:
+        """Invalid external names should not alias to a different stored table name."""
+        await tables_service.create_table(TableCreate(name="badname"))
+
+        with pytest.raises(ValueError, match="Identifier must"):
+            await tables_service.get_table_by_name("bad-name")
+
+    async def test_get_table_by_name_allows_exact_legacy_metadata_name(
+        self, tables_service: TablesService
+    ) -> None:
+        """Legacy metadata names should still resolve when matched exactly."""
+        table = await tables_service.create_table(TableCreate(name="legacyname"))
+        table.name = "legacy-name"
+        await tables_service.session.flush()
+
+        resolved = await tables_service.get_table_by_name("legacy-name")
+        assert resolved.id == table.id
+
     async def test_editor_can_create_table(
         self, tables_service_editor: TablesService
     ) -> None:
@@ -980,6 +1000,17 @@ class TestTableRows:
         result = results[0]
         assert result["name"] == "Bob"
         assert result["age"] == 40
+
+    async def test_lookup_row_rejects_invalid_column_alias(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Invalid external column names should not alias to a different column."""
+        with pytest.raises(ValueError, match="Identifier must"):
+            await tables_service.lookup_rows(
+                table_name=table.name,
+                columns=["na-me"],
+                values=["Bob"],
+            )
 
     async def test_list_rows(self, tables_service: TablesService, table: Table) -> None:
         """Test listing rows with cursor-based pagination."""

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -422,6 +422,7 @@ class TestParsePostgresDefault:
         [
             (None, None),
             ("'attack'::text", "attack"),
+            ("'O''Brien'::text", "O'Brien"),
             ("0::integer", "0"),
             ("true::boolean", "true"),
             ("'2024-01-01'::timestamp", "2024-01-01"),
@@ -482,6 +483,12 @@ class TestHandleDefaultValue:
                 "'00000000-0000-0000-0000-000000000000'::uuid",
                 id="uuid-literal",
             ),
+            pytest.param(
+                SqlType.JSONB,
+                {"author": "O'Brien"},
+                "'{\"author\":\"O''Brien\"}'::jsonb",
+                id="jsonb-literal",
+            ),
         ],
     )
     def test_formats_literal_safe_defaults(
@@ -499,10 +506,22 @@ class TestHandleDefaultValue:
                 id="integer-expression",
             ),
             pytest.param(
+                SqlType.INTEGER,
+                "Infinity",
+                "Invalid integer default value",
+                id="integer-infinity",
+            ),
+            pytest.param(
                 SqlType.NUMERIC,
                 "1 / 0.5",
                 "Invalid numeric default value",
                 id="numeric-expression",
+            ),
+            pytest.param(
+                SqlType.NUMERIC,
+                "Infinity",
+                "Invalid numeric default value",
+                id="numeric-infinity",
             ),
             pytest.param(
                 SqlType.UUID,
@@ -515,8 +534,22 @@ class TestHandleDefaultValue:
     def test_rejects_non_literal_defaults(
         self, sql_type: SqlType, default: Any, error_message: str
     ) -> None:
-        with pytest.raises(TypeError, match=error_message):
+        with pytest.raises(ValueError, match=error_message):
             handle_default_value(sql_type, default)
+
+    def test_text_sql_injection_payload_is_rendered_as_literal(self) -> None:
+        payload = "'; SELECT pg_sleep(1); --"
+        assert (
+            handle_default_value(SqlType.TEXT, payload)
+            == "'''; SELECT pg_sleep(1); --'"
+        )
+
+    def test_jsonb_sql_injection_payload_is_rendered_as_literal(self) -> None:
+        payload = {"query": "'; SELECT pg_sleep(1); --"}
+        rendered = handle_default_value(SqlType.JSONB, payload)
+        assert rendered.startswith("'")
+        assert rendered.endswith("'::jsonb")
+        assert "SELECT pg_sleep(1)" in rendered
 
 
 @pytest.mark.anyio
@@ -597,7 +630,7 @@ class TestTableColumns:
             TableCreate(name="quoted_default_create")
         )
 
-        await tables_service.create_column(
+        column = await tables_service.create_column(
             table,
             TableColumnCreate(
                 name="nickname",
@@ -606,6 +639,7 @@ class TestTableColumns:
                 default="O'Brien",
             ),
         )
+        assert column.default == "O'Brien"
 
         inserted = await tables_service.insert_row(table, TableRowInsert(data={}))
         assert inserted["nickname"] == "O'Brien"
@@ -626,6 +660,8 @@ class TestTableColumns:
             column,
             TableColumnUpdate(name="display_name", default="O'Brien"),
         )
+        updated_column = await tables_service.get_column(table.id, column.id)
+        assert updated_column.default == "O'Brien"
 
         inserted = await tables_service.insert_row(table, TableRowInsert(data={}))
         assert inserted["display_name"] == "O'Brien"
@@ -652,6 +688,48 @@ class TestTableColumns:
 
         inserted = await editor.insert_row(TableRowInsert(data={}))
         assert inserted["nickname"] == "O'Brien"
+
+    async def test_create_column_sql_injection_payload_is_stored_as_text_literal(
+        self, tables_service: TablesService
+    ) -> None:
+        """Text defaults that look like SQL must round-trip as plain text."""
+        payload = "'; SELECT pg_sleep(1); --"
+        table = await tables_service.create_table(
+            TableCreate(name="default_sql_injection_create")
+        )
+
+        column = await tables_service.create_column(
+            table,
+            TableColumnCreate(
+                name="notes",
+                type=SqlType.TEXT,
+                nullable=True,
+                default=payload,
+            ),
+        )
+
+        assert column.default == payload
+        inserted = await tables_service.insert_row(table, TableRowInsert(data={}))
+        assert inserted["notes"] == payload
+
+    async def test_update_column_rejects_sql_injection_payload_for_integer_default(
+        self, tables_service: TablesService
+    ) -> None:
+        """Typed defaults should reject SQL-expression payloads instead of rendering them."""
+        payload = "1; SELECT pg_sleep(1); --"
+        table = await tables_service.create_table(
+            TableCreate(name="default_sql_injection_update")
+        )
+        column = await tables_service.create_column(
+            table,
+            TableColumnCreate(name="attempts", type=SqlType.INTEGER, nullable=True),
+        )
+
+        with pytest.raises(ValueError, match="Invalid integer default value"):
+            await tables_service.update_column(
+                column,
+                TableColumnUpdate(default=payload),
+            )
 
     async def test_create_single_column_unique_index(
         self, tables_service: TablesService, table: Table

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -784,6 +784,15 @@ async def update_field(
             status_code=HTTP_400_BAD_REQUEST,
             detail=str(exc),
         ) from exc
+    except ProgrammingError as err:
+        while (cause := err.__cause__) is not None:
+            err = cause
+        if isinstance(err, DuplicateColumnError):
+            raise HTTPException(
+                status_code=HTTP_409_CONFLICT,
+                detail=f"A field with the name '{params.name}' already exists",
+            ) from err
+        raise
 
 
 @case_fields_router.delete("/{field_id}", status_code=HTTP_204_NO_CONTENT)

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -777,7 +777,13 @@ async def update_field(
 ) -> None:
     """Update a case field."""
     service = CaseFieldsService(session, role)
-    await service.update_field(field_id, params)
+    try:
+        await service.update_field(field_id, params)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
 
 @case_fields_router.delete("/{field_id}", status_code=HTTP_204_NO_CONTENT)
@@ -790,7 +796,13 @@ async def delete_field(
 ) -> None:
     """Delete a case field."""
     service = CaseFieldsService(session, role)
-    await service.delete_field(field_id)
+    try:
+        await service.delete_field(field_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
 
 # Case Events

--- a/tracecat/custom_fields/service.py
+++ b/tracecat/custom_fields/service.py
@@ -13,7 +13,11 @@ from tracecat.custom_fields.schemas import CustomFieldCreate, CustomFieldUpdate
 from tracecat.db.locks import derive_lock_key_from_parts, pg_advisory_lock
 from tracecat.identifiers.workflow import WorkspaceUUID
 from tracecat.service import BaseWorkspaceService
-from tracecat.tables.service import TableEditorService, sanitize_identifier
+from tracecat.tables.service import (
+    TableEditorService,
+    sanitize_identifier,
+    validate_identifier,
+)
 
 
 class CustomFieldsService(BaseWorkspaceService, ABC):
@@ -122,6 +126,7 @@ class CustomFieldsService(BaseWorkspaceService, ABC):
         """Update a custom field column."""
 
         await self._ensure_schema_ready()
+        validate_identifier(field_id)
         await self.editor.update_column(field_id, params)
         await self.session.commit()
 
@@ -138,6 +143,7 @@ class CustomFieldsService(BaseWorkspaceService, ABC):
         await self._ensure_schema_ready()
         if field_id in self._reserved_columns:
             raise ValueError(f"Field {field_id} is a reserved field")
+        validate_identifier(field_id)
         await self.editor.delete_column(field_id)
         await self.session.commit()
 

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -12,6 +12,9 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from tracecat.tables.enums import SqlType
 
+POSTGRES_BIGINT_MIN = -(2**63)
+POSTGRES_BIGINT_MAX = 2**63 - 1
+
 
 def is_valid_sql_type(type: str | SqlType) -> bool:
     """Check if the type is a valid SQL type for user-defined columns."""
@@ -136,6 +139,13 @@ def coerce_default_value(type: SqlType, default: Any) -> Any:
                     f"Invalid integer default value: {default!r}"
                 )
             if decimal_value != decimal_value.to_integral_value():
+                raise InvalidDefaultValueError(
+                    f"Invalid integer default value: {default!r}"
+                )
+            if (
+                decimal_value < POSTGRES_BIGINT_MIN
+                or decimal_value > POSTGRES_BIGINT_MAX
+            ):
                 raise InvalidDefaultValueError(
                     f"Invalid integer default value: {default!r}"
                 )

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Sequence
 from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any
 from uuid import UUID
 
@@ -110,7 +111,8 @@ def handle_default_value(type: SqlType, default: Any) -> str:
             default_value = f"'{json_literal.replace("'", "''")}'::jsonb"
         case SqlType.TEXT | SqlType.SELECT:
             # For string types, ensure proper quoting
-            default_value = f"'{default}'"
+            escaped_default = str(default).replace("'", "''")
+            default_value = f"'{escaped_default}'"
         case SqlType.DATE:
             d = coerce_to_date(default)
             default_value = f"'{d.isoformat()}'::date"
@@ -121,12 +123,28 @@ def handle_default_value(type: SqlType, default: Any) -> str:
         case SqlType.BOOLEAN:
             # For boolean, convert to lowercase string representation
             default_value = str(bool(default)).lower()
-        case SqlType.INTEGER | SqlType.NUMERIC:
-            # For numeric types, use the value directly
-            default_value = str(default)
+        case SqlType.INTEGER:
+            # Only allow numeric literals for integer defaults.
+            try:
+                decimal_value = Decimal(str(default))
+            except (InvalidOperation, TypeError, ValueError) as exc:
+                raise TypeError(f"Invalid integer default value: {default!r}") from exc
+            if decimal_value != decimal_value.to_integral_value():
+                raise TypeError(f"Invalid integer default value: {default!r}")
+            default_value = str(int(decimal_value))
+        case SqlType.NUMERIC:
+            # Only allow numeric literals for numeric defaults.
+            try:
+                default_value = str(Decimal(str(default)))
+            except (InvalidOperation, TypeError, ValueError) as exc:
+                raise TypeError(f"Invalid numeric default value: {default!r}") from exc
         case SqlType.UUID:
             # For UUID, ensure proper quoting
-            default_value = f"'{default}'::uuid"
+            try:
+                uuid_value = UUID(str(default))
+            except (TypeError, ValueError) as exc:
+                raise TypeError(f"Invalid UUID default value: {default!r}") from exc
+            default_value = f"'{uuid_value}'::uuid"
         case _:
             raise TypeError(f"Unsupported SQL type for default value: {type}")
     return default_value

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 import orjson
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB
 
 from tracecat.tables.enums import SqlType
@@ -85,69 +86,151 @@ def coerce_optional_to_date(
     return coerce_to_date(value)
 
 
-def handle_default_value(type: SqlType, default: Any) -> str:
-    """Handle converting default values to SQL-compatible strings based on type.
+class InvalidDefaultValueError(ValueError):
+    """Raised when a user-provided table default cannot be coerced safely."""
 
-    SECURITY NOTICE: Only used in a SQL DDL statement where parameter binding is not supported.
 
-    Args:
-        type: The SQL type to format the default value for
-        default: The default value to format
+def _compile_sql_literal(value: Any, sql_type: sa.types.TypeEngine) -> str:
+    expr = sa.literal(value, type_=sql_type)
+    compiled = expr.compile(
+        dialect=postgresql.dialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    return str(compiled)
 
-    Returns:
-        A properly escaped and formatted SQL literal string
 
-    Raises:
-        TypeError: If the SQL type is not supported
-    """
+def coerce_default_value(type: SqlType, default: Any) -> Any:
+    """Coerce a user-provided default into a validated Python value."""
     match type:
         case SqlType.MULTI_SELECT:
-            coerced_default = coerce_multi_select_value(default)
-            json_literal = orjson.dumps(coerced_default).decode()
-            return f"'{json_literal.replace("'", "''")}'::jsonb"
+            return coerce_multi_select_value(default)
         case SqlType.JSONB:
-            # For JSONB, ensure default is properly quoted and cast
-            json_literal = orjson.dumps(default).decode()
-            default_value = f"'{json_literal.replace("'", "''")}'::jsonb"
+            return default
         case SqlType.TEXT | SqlType.SELECT:
-            # For string types, ensure proper quoting
-            escaped_default = str(default).replace("'", "''")
-            default_value = f"'{escaped_default}'"
+            return str(default)
         case SqlType.DATE:
-            d = coerce_to_date(default)
-            default_value = f"'{d.isoformat()}'::date"
+            return coerce_to_date(default)
         case SqlType.TIMESTAMP | SqlType.TIMESTAMPTZ:
-            # For timestamp with timezone, ensure proper format and quoting
-            dt = coerce_to_utc_datetime(default)
-            default_value = f"'{dt.isoformat()}'::timestamptz"
+            return coerce_to_utc_datetime(default)
         case SqlType.BOOLEAN:
-            # For boolean, convert to lowercase string representation
-            default_value = str(bool(default)).lower()
+            if isinstance(default, bool):
+                return default
+            match str(default).lower():
+                case "true" | "1":
+                    return True
+                case "false" | "0":
+                    return False
+                case _:
+                    raise InvalidDefaultValueError(
+                        f"Invalid boolean default value: {default!r}"
+                    )
         case SqlType.INTEGER:
-            # Only allow numeric literals for integer defaults.
             try:
                 decimal_value = Decimal(str(default))
             except (InvalidOperation, TypeError, ValueError) as exc:
-                raise TypeError(f"Invalid integer default value: {default!r}") from exc
+                raise InvalidDefaultValueError(
+                    f"Invalid integer default value: {default!r}"
+                ) from exc
+            if not decimal_value.is_finite():
+                raise InvalidDefaultValueError(
+                    f"Invalid integer default value: {default!r}"
+                )
             if decimal_value != decimal_value.to_integral_value():
-                raise TypeError(f"Invalid integer default value: {default!r}")
-            default_value = str(int(decimal_value))
+                raise InvalidDefaultValueError(
+                    f"Invalid integer default value: {default!r}"
+                )
+            return int(decimal_value)
         case SqlType.NUMERIC:
-            # Only allow numeric literals for numeric defaults.
             try:
-                default_value = str(Decimal(str(default)))
+                decimal_value = Decimal(str(default))
             except (InvalidOperation, TypeError, ValueError) as exc:
-                raise TypeError(f"Invalid numeric default value: {default!r}") from exc
+                raise InvalidDefaultValueError(
+                    f"Invalid numeric default value: {default!r}"
+                ) from exc
+            if not decimal_value.is_finite():
+                raise InvalidDefaultValueError(
+                    f"Invalid numeric default value: {default!r}"
+                )
+            return decimal_value
         case SqlType.UUID:
-            # For UUID, ensure proper quoting
             try:
-                uuid_value = UUID(str(default))
+                return UUID(str(default))
             except (TypeError, ValueError) as exc:
-                raise TypeError(f"Invalid UUID default value: {default!r}") from exc
-            default_value = f"'{uuid_value}'::uuid"
+                raise InvalidDefaultValueError(
+                    f"Invalid UUID default value: {default!r}"
+                ) from exc
         case _:
-            raise TypeError(f"Unsupported SQL type for default value: {type}")
-    return default_value
+            raise InvalidDefaultValueError(
+                f"Unsupported SQL type for default value: {type}"
+            )
+
+
+def normalize_default_value(type: SqlType, default: Any) -> Any:
+    """Normalize a validated default into a JSON-serializable metadata value."""
+    match type:
+        case SqlType.MULTI_SELECT | SqlType.JSONB:
+            return default
+        case SqlType.BOOLEAN:
+            return str(default).lower()
+        case SqlType.DATE | SqlType.TIMESTAMP | SqlType.TIMESTAMPTZ:
+            return default.isoformat()
+        case SqlType.INTEGER | SqlType.NUMERIC | SqlType.TEXT | SqlType.SELECT:
+            return str(default)
+        case SqlType.UUID:
+            return str(default)
+        case _:
+            raise InvalidDefaultValueError(
+                f"Unsupported SQL type for default value: {type}"
+            )
+
+
+def render_default_value(type: SqlType, default: Any) -> str:
+    """Render a validated default as a SQL literal for PostgreSQL DDL.
+
+    SECURITY NOTICE: Only used in a SQL DDL statement where parameter binding is not supported.
+    """
+    match type:
+        case SqlType.MULTI_SELECT:
+            json_literal = orjson.dumps(default).decode()
+            return f"{_compile_sql_literal(json_literal, sa.String())}::jsonb"
+        case SqlType.JSONB:
+            json_literal = orjson.dumps(default).decode()
+            return f"{_compile_sql_literal(json_literal, sa.String())}::jsonb"
+        case SqlType.TEXT | SqlType.SELECT:
+            return _compile_sql_literal(default, sa.String())
+        case SqlType.DATE:
+            return f"{_compile_sql_literal(default, sa.Date())}::date"
+        case SqlType.TIMESTAMP | SqlType.TIMESTAMPTZ:
+            rendered_default = _compile_sql_literal(
+                default, sa.TIMESTAMP(timezone=True)
+            )
+            return f"{rendered_default}::timestamptz"
+        case SqlType.BOOLEAN:
+            return _compile_sql_literal(default, sa.Boolean())
+        case SqlType.INTEGER:
+            return _compile_sql_literal(default, sa.BigInteger())
+        case SqlType.NUMERIC:
+            return _compile_sql_literal(default, sa.Numeric())
+        case SqlType.UUID:
+            return f"{_compile_sql_literal(str(default), sa.String())}::uuid"
+        case _:
+            raise InvalidDefaultValueError(
+                f"Unsupported SQL type for default value: {type}"
+            )
+
+
+def prepare_default_value(type: SqlType, default: Any) -> tuple[Any, str]:
+    """Validate a default once and return metadata + DDL representations."""
+    coerced_default = coerce_default_value(type, default)
+    normalized_default = normalize_default_value(type, coerced_default)
+    rendered_default = render_default_value(type, coerced_default)
+    return normalized_default, rendered_default
+
+
+def handle_default_value(type: SqlType, default: Any) -> str:
+    """Backward-compatible wrapper for SQL literal rendering."""
+    _, rendered_default = prepare_default_value(type, default)
+    return rendered_default
 
 
 def to_sql_clause(value: Any, name: str, sql_type: SqlType) -> sa.BindParameter:
@@ -232,7 +315,7 @@ def parse_postgres_default(default_value: str | None) -> str | None:
 
     # Remove surrounding quotes if present
     if default_value.startswith("'") and default_value.endswith("'"):
-        default_value = default_value[1:-1]
+        default_value = default_value[1:-1].replace("''", "'")
 
     return default_value
 

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -126,7 +126,7 @@ async def create_table(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="An error occurred while creating the table",
             ) from exc
-    except (TypeError, ValueError) as exc:
+    except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -126,7 +126,7 @@ async def create_table(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="An error occurred while creating the table",
             ) from exc
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -146,6 +146,11 @@ async def get_table_metadata(
     service = TablesService(session, role=role)
     try:
         table = await service.get_table_by_name(table_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -250,6 +255,11 @@ async def search_rows(
     service = TablesService(session, role=role)
     try:
         table = await service.get_table_by_name(table_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -290,6 +300,11 @@ async def insert_row(
     service = TablesService(session, role=role)
     try:
         table = await service.get_table_by_name(table_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -318,6 +333,11 @@ async def insert_rows_batch(
     service = TablesService(session, role=role)
     try:
         table = await service.get_table_by_name(table_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -353,6 +373,11 @@ async def update_row(
     service = TablesService(session, role=role)
     try:
         table = await service.get_table_by_name(table_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -386,6 +411,11 @@ async def delete_row(
     service = TablesService(session, role=role)
     try:
         table = await service.get_table_by_name(table_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -419,6 +449,11 @@ async def download_table(
     service = TablesService(session, role=role)
     try:
         table = await service.get_table_by_name(table_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -132,7 +132,7 @@ async def create_table(
     service = TablesService(session, role=role)
     try:
         await service.create_table(params)
-    except (TypeError, ValueError) as e:
+    except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -271,7 +271,7 @@ async def create_column(
         ) from e
     try:
         await service.create_column(table, params)
-    except (TypeError, ValueError) as e:
+    except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -315,7 +315,7 @@ async def update_column(
         ) from e
     try:
         await service.update_column(column, params)
-    except (TypeError, ValueError) as e:
+    except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -132,6 +132,11 @@ async def create_table(
     service = TablesService(session, role=role)
     try:
         await service.create_table(params)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except ProgrammingError as e:
         # Drill down to the root cause
         while (cause := e.__cause__) is not None:
@@ -266,6 +271,11 @@ async def create_column(
         ) from e
     try:
         await service.create_column(table, params)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except ProgrammingError as e:
         # Drill down to the root cause
         while (cause := e.__cause__) is not None:
@@ -305,7 +315,7 @@ async def update_column(
         ) from e
     try:
         await service.update_column(column, params)
-    except ValueError as e:
+    except (TypeError, ValueError) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),

--- a/tracecat/tables/schemas.py
+++ b/tracecat/tables/schemas.py
@@ -14,6 +14,16 @@ from tracecat.tables.common import (
 )
 from tracecat.tables.enums import SqlType
 
+IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _validate_identifier_name(value: str, *, kind: str) -> str:
+    if not IDENTIFIER_PATTERN.match(value):
+        raise ValueError(
+            f"{kind} name must contain only letters, numbers, and underscores, and start with a letter or underscore"
+        )
+    return value
+
 
 class TableColumnRead(BaseModel):
     """Definition for a table column."""
@@ -50,12 +60,7 @@ class TableColumnCreate(BaseModel):
     @classmethod
     def validate_column_name(cls, value: str) -> str:
         """Validate column name to prevent SQL injection."""
-        # Only allow alphanumeric characters and underscores
-        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", value):
-            raise ValueError(
-                "Column name must contain only letters, numbers, and underscores, and start with a letter or underscore"
-            )
-        return value
+        return _validate_identifier_name(value, kind="Column")
 
     @model_validator(mode="after")
     def validate_enum_options(self) -> "TableColumnCreate":
@@ -110,6 +115,13 @@ class TableColumnUpdate(BaseModel):
         description="Whether the column is an index",
     )
     options: list[str] | None = Field(default=None)
+
+    @field_validator("name")
+    @classmethod
+    def validate_column_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_identifier_name(value, kind="Column")
 
     @model_validator(mode="after")
     def normalise_options(self) -> "TableColumnUpdate":
@@ -230,12 +242,7 @@ class TableCreate(BaseModel):
     @classmethod
     def validate_table_name(cls, value: str) -> str:
         """Validate table name to prevent SQL injection."""
-        # Only allow alphanumeric characters and underscores
-        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", value):
-            raise ValueError(
-                "Table name must contain only letters, numbers, and underscores, and start with a letter or underscore"
-            )
-        return value
+        return _validate_identifier_name(value, kind="Table")
 
 
 class TableUpdate(BaseModel):
@@ -250,13 +257,11 @@ class TableUpdate(BaseModel):
 
     @field_validator("name")
     @classmethod
-    def validate_table_name(cls, value: str) -> str:
+    def validate_table_name(cls, value: str | None) -> str | None:
         """Validate table name to prevent SQL injection."""
-        if value is not None and not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", value):
-            raise ValueError(
-                "Table name must contain only letters, numbers, and underscores, and start with a letter or underscore"
-            )
-        return value
+        if value is None:
+            return None
+        return _validate_identifier_name(value, kind="Table")
 
 
 class TableImportResponse(BaseModel):

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -48,9 +48,9 @@ from tracecat.tables.common import (
     coerce_to_date,
     coerce_to_utc_datetime,
     convert_value,
-    handle_default_value,
     is_valid_sql_type,
     normalize_column_options,
+    prepare_default_value,
     to_sql_clause,
 )
 from tracecat.tables.enums import SqlType
@@ -426,15 +426,18 @@ class BaseTablesService(BaseWorkspaceService):
 
         # Handle default value based on type
         default_value = params.default
+        rendered_default = None
         if default_value is not None:
-            default_value = handle_default_value(sql_type, default_value)
+            default_value, rendered_default = prepare_default_value(
+                sql_type, default_value
+            )
         # Create the column metadata first
         column = TableColumn(
             table_id=table.id,
             name=column_name,
             type=sql_type.value,
             nullable=params.nullable,
-            default=default_value,  # Store original default in metadata
+            default=default_value,
             options=normalized_options,
         )
         self.session.add(column)
@@ -453,8 +456,8 @@ class BaseTablesService(BaseWorkspaceService):
         column_def = [f"{column_name} {column_type_sql}"]
         if not params.nullable:
             column_def.append("NOT NULL")
-        if default_value is not None:
-            column_def.append(f"DEFAULT {default_value}")
+        if rendered_default is not None:
+            column_def.append(f"DEFAULT {rendered_default}")
 
         column_def_str = " ".join(column_def)
 
@@ -521,12 +524,12 @@ class BaseTablesService(BaseWorkspaceService):
             elif target_type not in (SqlType.SELECT, SqlType.MULTI_SELECT):
                 set_fields["options"] = None
 
+        old_name = self._sanitize_identifier(column.name)
+        new_name = self._sanitize_identifier(set_fields.get("name", column.name))
+        new_type = set_fields.get("type", column.type)
+
         # Handle physical column changes if name or type is being updated
         if "name" in set_fields or "type" in set_fields:
-            old_name = self._sanitize_identifier(column.name)
-            new_name = self._sanitize_identifier(set_fields.get("name", column.name))
-            new_type = set_fields.get("type", column.type)
-
             if not is_valid_sql_type(new_type):
                 raise ValueError(f"Invalid type: {new_type}")
 
@@ -554,46 +557,38 @@ class BaseTablesService(BaseWorkspaceService):
                         (full_table_name, new_name, physical_type),
                     )
                 )
-            if "nullable" in set_fields:
-                constraint = (
-                    "DROP NOT NULL" if set_fields["nullable"] else "SET NOT NULL"
+        if "nullable" in set_fields:
+            constraint = "DROP NOT NULL" if set_fields["nullable"] else "SET NOT NULL"
+            await conn.execute(
+                sa.DDL(
+                    # SAFE f-string: constraint is a controlled literal string ("DROP NOT NULL" or "SET NOT NULL")
+                    # No user input is interpolated here - only predefined SQL keywords
+                    f"ALTER TABLE %s ALTER COLUMN %s {constraint}",
+                    (full_table_name, new_name),
                 )
+            )
+        if "default" in set_fields:
+            updated_default = set_fields["default"]
+            if updated_default is None:
                 await conn.execute(
                     sa.DDL(
-                        # SAFE f-string: constraint is a controlled literal string ("DROP NOT NULL" or "SET NOT NULL")
-                        # No user input is interpolated here - only predefined SQL keywords
-                        f"ALTER TABLE %s ALTER COLUMN %s {constraint}",
+                        "ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT",
                         (full_table_name, new_name),
                     )
                 )
-            if "default" in set_fields:
-                updated_default = set_fields["default"]
-                if updated_default is None:
-                    await conn.execute(
-                        sa.DDL(
-                            "ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT",
-                            (full_table_name, new_name),
-                        )
+            else:
+                normalized_default, formatted_default = prepare_default_value(
+                    SqlType(new_type if "type" in set_fields else column.type),
+                    updated_default,
+                )
+                set_fields["default"] = normalized_default
+                await conn.execute(
+                    sa.DDL(
+                        # SAFE f-string: formatted_default is compiler-rendered from a typed value.
+                        f"ALTER TABLE %s ALTER COLUMN %s SET DEFAULT {formatted_default}",
+                        (full_table_name, new_name),
                     )
-                else:
-                    # SECURITY NOTE: PostgreSQL DDL does not support parameter binding for DEFAULT clauses.
-                    # We must use string interpolation here, but it's SAFE because:
-                    # 1. handle_default_value() sanitizes and properly formats the value based on SQL type
-                    # 2. It applies proper quoting, escaping, and type casting (e.g., 'value'::text, 123, true)
-                    # 3. The function validates the SQL type and rejects invalid inputs
-                    # 4. This is the ONLY way to set DEFAULT values in PostgreSQL DDL statements
-                    formatted_default = handle_default_value(
-                        SqlType(new_type if "type" in set_fields else column.type),
-                        updated_default,
-                    )
-                    await conn.execute(
-                        sa.DDL(
-                            # SAFE f-string: formatted_default is pre-sanitized by handle_default_value()
-                            # Other parameters (table/column names) still use secure parameter binding
-                            f"ALTER TABLE %s ALTER COLUMN %s SET DEFAULT {formatted_default}",
-                            (full_table_name, new_name),
-                        )
-                    )
+                )
 
         # Update the column metadata
         for key, value in set_fields.items():
@@ -1802,8 +1797,11 @@ class TableEditorService(BaseWorkspaceService):
 
         # Handle default value based on type
         default_value = params.default
+        rendered_default = None
         if default_value is not None:
-            default_value = handle_default_value(params.type, default_value)
+            default_value, rendered_default = prepare_default_value(
+                params.type, default_value
+            )
 
         # Build the column definition string
         # Map SELECT -> TEXT, MULTI_SELECT -> JSONB for physical storage
@@ -1816,8 +1814,8 @@ class TableEditorService(BaseWorkspaceService):
         column_def = [f"{params.name} {column_type_sql}"]
         if not params.nullable:
             column_def.append("NOT NULL")
-        if default_value is not None:
-            column_def.append(f"DEFAULT {default_value}")
+        if rendered_default is not None:
+            column_def.append(f"DEFAULT {rendered_default}")
 
         column_def_str = " ".join(column_def)
 
@@ -1897,19 +1895,13 @@ class TableEditorService(BaseWorkspaceService):
                     )
                 )
             else:
-                # SECURITY NOTE: PostgreSQL DDL does not support parameter binding for DEFAULT clauses.
-                # We must use string interpolation here, but it's SAFE because:
-                # 1. handle_default_value() sanitizes and properly formats the value based on SQL type
-                # 2. It applies proper quoting, escaping, and type casting (e.g., 'value'::text, 123, true)
-                # 3. The function validates the SQL type and rejects invalid inputs
-                # 4. This is the ONLY way to set DEFAULT values in PostgreSQL DDL statements
-                formatted_default = handle_default_value(
+                normalized_default, formatted_default = prepare_default_value(
                     SqlType(set_fields.get("type", "TEXT")), updated_default
                 )
+                set_fields["default"] = normalized_default
                 await conn.execute(
                     sa.DDL(
-                        # SAFE f-string: formatted_default is pre-sanitized by handle_default_value()
-                        # Other parameters (table/column names) still use secure parameter binding
+                        # SAFE f-string: formatted_default is compiler-rendered from a typed value.
                         f"ALTER TABLE %s ALTER COLUMN %s SET DEFAULT {formatted_default}",
                         (full_table_name, new_name),
                     )

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -364,6 +364,7 @@ class BaseTablesService(BaseWorkspaceService):
                     new_name=params.name,
                 )
                 raise
+            set_fields["name"] = sanitized_new_name
         # Update DB Table
         for key, value in set_fields.items():
             setattr(table, key, value)
@@ -591,6 +592,8 @@ class BaseTablesService(BaseWorkspaceService):
                 )
 
         # Update the column metadata
+        if "name" in set_fields:
+            set_fields["name"] = new_name
         for key, value in set_fields.items():
             setattr(column, key, value)
 
@@ -1791,7 +1794,7 @@ class TableEditorService(BaseWorkspaceService):
             ValueError: If the column type is invalid
         """
 
-        column_name = sanitize_identifier(params.name)
+        column_name = validate_identifier(params.name)
 
         # Validate SQL type first
         if not is_valid_sql_type(params.type):
@@ -1848,13 +1851,13 @@ class TableEditorService(BaseWorkspaceService):
         set_fields = params.model_dump(exclude_unset=True)
         conn = await self.session.connection()
 
-        sanitized_column_name = sanitize_identifier(column_name)
+        sanitized_column_name = validate_identifier(column_name)
         new_name = sanitized_column_name
         full_table_name = self._full_table_name()
 
         # Execute ALTER statements using safe DDL construction
         if "name" in set_fields:
-            new_name = sanitize_identifier(set_fields["name"])
+            new_name = validate_identifier(set_fields["name"])
             await conn.execute(
                 sa.DDL(
                     "ALTER TABLE %s RENAME COLUMN %s TO %s",
@@ -1914,7 +1917,7 @@ class TableEditorService(BaseWorkspaceService):
 
     async def delete_column(self, column_name: str) -> None:
         """Remove a column from an existing table."""
-        sanitized_column = sanitize_identifier(column_name)
+        sanitized_column = validate_identifier(column_name)
 
         # Drop the column from the physical table using DDL
         conn = await self.session.connection()
@@ -2111,13 +2114,23 @@ class TableEditorService(BaseWorkspaceService):
 
 
 def sanitize_identifier(identifier: str) -> str:
-    """Sanitize table/column names to prevent SQL injection."""
+    """Normalize a stored identifier to its physical SQL name."""
+    sanitized = "".join(c for c in identifier if c.isalnum() or c == "_")
+    if not sanitized:
+        raise ValueError("Identifier must contain at least one letter")
+    if not (sanitized[0].isalpha() or sanitized[0] == "_"):
+        raise ValueError("Identifier must start with a letter or underscore")
+    return sanitized.lower()
+
+
+def validate_identifier(identifier: str) -> str:
+    """Validate an external identifier before using it in DDL operations."""
     if not identifier:
         raise ValueError("Identifier must contain at least one letter")
     if not all(c.isalnum() or c == "_" for c in identifier):
         raise ValueError(
             "Identifier must contain only letters, numbers, and underscores"
         )
-    if not identifier[0].isalpha():
-        raise ValueError("Identifier must start with a letter")
+    if not (identifier[0].isalpha() or identifier[0] == "_"):
+        raise ValueError("Identifier must start with a letter or underscore")
     return identifier.lower()

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -1791,6 +1791,8 @@ class TableEditorService(BaseWorkspaceService):
             ValueError: If the column type is invalid
         """
 
+        column_name = sanitize_identifier(params.name)
+
         # Validate SQL type first
         if not is_valid_sql_type(params.type):
             raise ValueError(f"Invalid type: {params.type}")
@@ -1811,7 +1813,7 @@ class TableEditorService(BaseWorkspaceService):
             column_type_sql = SqlType.JSONB.value
         else:
             column_type_sql = params.type.value
-        column_def = [f"{params.name} {column_type_sql}"]
+        column_def = [f"{column_name} {column_type_sql}"]
         if not params.nullable:
             column_def.append("NOT NULL")
         if rendered_default is not None:
@@ -1846,7 +1848,8 @@ class TableEditorService(BaseWorkspaceService):
         set_fields = params.model_dump(exclude_unset=True)
         conn = await self.session.connection()
 
-        new_name = column_name
+        sanitized_column_name = sanitize_identifier(column_name)
+        new_name = sanitized_column_name
         full_table_name = self._full_table_name()
 
         # Execute ALTER statements using safe DDL construction
@@ -1855,7 +1858,7 @@ class TableEditorService(BaseWorkspaceService):
             await conn.execute(
                 sa.DDL(
                     "ALTER TABLE %s RENAME COLUMN %s TO %s",
-                    (full_table_name, column_name, new_name),
+                    (full_table_name, sanitized_column_name, new_name),
                 )
             )
         if "type" in set_fields:
@@ -2109,8 +2112,12 @@ class TableEditorService(BaseWorkspaceService):
 
 def sanitize_identifier(identifier: str) -> str:
     """Sanitize table/column names to prevent SQL injection."""
-    # Remove any non-alphanumeric characters except underscores
-    sanitized = "".join(c for c in identifier if c.isalnum() or c == "_")
-    if not sanitized[0].isalpha():
+    if not identifier:
+        raise ValueError("Identifier must contain at least one letter")
+    if not all(c.isalnum() or c == "_" for c in identifier):
+        raise ValueError(
+            "Identifier must contain only letters, numbers, and underscores"
+        )
+    if not identifier[0].isalpha():
         raise ValueError("Identifier must start with a letter")
-    return sanitized.lower()
+    return identifier.lower()

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -83,8 +83,22 @@ class BaseTablesService(BaseWorkspaceService):
         self.ws_uuid = WorkspaceUUID.new(self.workspace_id)
 
     def _sanitize_identifier(self, identifier: str) -> str:
-        """Sanitize table/column names to prevent SQL injection."""
+        """Normalize a stored identifier to its physical SQL name."""
         return sanitize_identifier(identifier)
+
+    def _resolve_external_column_name(self, table: Table, column_name: str) -> str:
+        """Resolve an external column name against metadata without aliasing invalid names."""
+        column_names = {column.name for column in table.columns}
+        if column_name in column_names:
+            return column_name
+
+        normalized_name = validate_identifier(column_name)
+        if normalized_name in column_names:
+            return normalized_name
+
+        raise ValueError(
+            f"Column '{column_name}' does not exist in table '{table.name}'"
+        )
 
     def _get_schema_name(self, workspace_id: WorkspaceUUID | None = None) -> str:
         """Generate the schema name for a workspace."""
@@ -262,12 +276,25 @@ class BaseTablesService(BaseWorkspaceService):
             The requested Table
 
         Raises:
+            ValueError: If the provided table name is not a valid external identifier
             TracecatNotFoundError: If the table does not exist
         """
-        sanitized_name = self._sanitize_identifier(table_name)
         statement = select(Table).where(
             Table.workspace_id == self.ws_uuid,
-            Table.name == sanitized_name,
+            Table.name == table_name,
+        )
+        result = await self.session.execute(statement)
+        table = result.scalars().first()
+        if table is not None:
+            return table
+
+        normalized_name = validate_identifier(table_name)
+        if normalized_name == table_name:
+            raise TracecatNotFoundError(f"Table '{table_name}' not found")
+
+        statement = select(Table).where(
+            Table.workspace_id == self.ws_uuid,
+            Table.name == normalized_name,
         )
         result = await self.session.execute(statement)
         table = result.scalars().first()
@@ -290,7 +317,7 @@ class BaseTablesService(BaseWorkspaceService):
             ValueError: If table name is invalid
         """
         schema_name = self._get_schema_name(self.ws_uuid)
-        table_name = self._sanitize_identifier(params.name)
+        table_name = validate_identifier(params.name)
 
         # Create schema if it doesn't exist
         conn = await self.session.connection()
@@ -349,7 +376,7 @@ class BaseTablesService(BaseWorkspaceService):
             try:
                 conn = await self.session.connection()
                 old_full_table_name = self._full_table_name(table.name)
-                sanitized_new_name = self._sanitize_identifier(new_name)
+                sanitized_new_name = validate_identifier(new_name)
                 await conn.execute(
                     sa.DDL(
                         "ALTER TABLE %s RENAME TO %s",
@@ -416,7 +443,7 @@ class BaseTablesService(BaseWorkspaceService):
         Raises:
             ValueError: If the column type is invalid
         """
-        column_name = self._sanitize_identifier(params.name)
+        column_name = validate_identifier(params.name)
         full_table_name = self._full_table_name(table.name)
 
         # Validate SQL type first
@@ -612,7 +639,8 @@ class BaseTablesService(BaseWorkspaceService):
         full_table_name = self._full_table_name(table.name)
 
         # Sanitize column names to prevent SQL injection
-        sanitized_column = self._sanitize_identifier(column_name)
+        resolved_column_name = self._resolve_external_column_name(table, column_name)
+        sanitized_column = self._sanitize_identifier(resolved_column_name)
 
         # Create a descriptive name for the index
         # Format: uq_[table_name]_[col1]_[col2]_etc
@@ -940,9 +968,17 @@ class BaseTablesService(BaseWorkspaceService):
             raise ValueError("Values and column names must have the same length")
 
         schema_name = self._get_schema_name()
-        sanitized_table_name = self._sanitize_identifier(table_name)
+        table = await self.get_table_by_name(table_name)
+        sanitized_table_name = self._sanitize_identifier(table.name)
 
-        cols = [sa.column(self._sanitize_identifier(c)) for c in columns]
+        resolved_columns = [
+            self._resolve_external_column_name(table, column_name)
+            for column_name in columns
+        ]
+        cols = [
+            sa.column(self._sanitize_identifier(column_name))
+            for column_name in resolved_columns
+        ]
         stmt = (
             sa.select(sa.text("*"))
             .select_from(sa.table(sanitized_table_name, schema=schema_name))
@@ -1019,10 +1055,18 @@ class BaseTablesService(BaseWorkspaceService):
             raise ValueError("Values and column names must have the same length")
 
         schema_name = self._get_schema_name()
-        sanitized_table_name = self._sanitize_identifier(table_name)
+        table = await self.get_table_by_name(table_name)
+        sanitized_table_name = self._sanitize_identifier(table.name)
 
         table_clause = sa.table(sanitized_table_name, schema=schema_name)
-        cols = [sa.column(self._sanitize_identifier(c)) for c in columns]
+        resolved_columns = [
+            self._resolve_external_column_name(table, column_name)
+            for column_name in columns
+        ]
+        cols = [
+            sa.column(self._sanitize_identifier(column_name))
+            for column_name in resolved_columns
+        ]
         condition = sa.and_(
             *[col == value for col, value in zip(cols, values, strict=True)]
         )

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -71,6 +71,7 @@ _RETRYABLE_DB_EXCEPTIONS = (
     InvalidCachedStatementError,
     InFailedSQLTransactionError,
 )
+_TABLE_SYSTEM_COLUMNS = frozenset({"id", "created_at", "updated_at"})
 
 
 class BaseTablesService(BaseWorkspaceService):
@@ -88,7 +89,7 @@ class BaseTablesService(BaseWorkspaceService):
 
     def _resolve_external_column_name(self, table: Table, column_name: str) -> str:
         """Resolve an external column name against metadata without aliasing invalid names."""
-        column_names = {column.name for column in table.columns}
+        column_names = {column.name for column in table.columns} | _TABLE_SYSTEM_COLUMNS
         if column_name in column_names:
             return column_name
 


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes SQL expression injection in table column defaults by sanitizing and validating defaults before they are embedded in `ALTER TABLE ... DEFAULT ...` DDL.

Changes in scope:
- Escape single quotes for `TEXT` and `SELECT` defaults.
- Accept only numeric literals for `INTEGER` and `NUMERIC` defaults.
- Validate `UUID` defaults before they are interpolated into DDL.
- Return `400` for rejected defaults in the public and internal table create/update routes.
- Add regression coverage for literal formatting and quoted defaults on create/update paths.

## Related Issues

Fixes the lookup-table default literal injection issue.

## Screenshots / Recordings

N/A

## Steps to QA

1. Create or update a table column with a text default like `O'Brien` and verify inserts store the literal string rather than evaluating SQL.
2. Try numeric or UUID defaults containing expressions such as `1 + 2` or `00000000-0000-0000-0000-000000000000' || current_user || '` and verify the API returns `400`.
3. Run `uv run pytest tests/unit/test_tables_service.py`.
4. Run `uv run ruff check tracecat/tables/common.py tracecat/tables/router.py tracecat/tables/internal_router.py tests/unit/test_tables_service.py`.
5. Run `uv run basedpyright tracecat/tables/common.py tracecat/tables/router.py tracecat/tables/internal_router.py tests/unit/test_tables_service.py`.
