### PR TITLE
fix(agents): truncate Anthropic tool_call IDs for OpenAI compatibility

### DIFF
--- a/tests/unit/test_litellm_compat.py
+++ b/tests/unit/test_litellm_compat.py
@@ -1,0 +1,138 @@
+"""Tests for LiteLLM monkeypatches (tool_call_id truncation)."""
+
+from __future__ import annotations
+
+from tracecat.agent.litellm_compat import (
+    OPENAI_MAX_TOOL_CALL_ID_LENGTH,
+    _truncate_tool_call_ids_in_messages,
+    truncate_tool_call_id,
+)
+
+
+class TestTruncateToolCallId:
+    def test_short_id_unchanged(self):
+        """IDs within the 40-char limit should pass through unchanged."""
+        short_id = "call_abc123"
+        assert truncate_tool_call_id(short_id) == short_id
+
+    def test_exact_limit_unchanged(self):
+        """IDs exactly at the 40-char limit should pass through unchanged."""
+        exact_id = "a" * OPENAI_MAX_TOOL_CALL_ID_LENGTH
+        assert truncate_tool_call_id(exact_id) == exact_id
+
+    def test_long_id_truncated(self):
+        """IDs exceeding 40 chars should be truncated with hash suffix."""
+        long_id = "toolu_01ABC" + "x" * 110  # ~121 chars, like Anthropic IDs
+        result = truncate_tool_call_id(long_id)
+        assert len(result) == OPENAI_MAX_TOOL_CALL_ID_LENGTH
+        assert result.startswith("toolu_01ABC")
+        assert "_" in result
+
+    def test_truncation_is_deterministic(self):
+        """Same input should always produce the same truncated ID."""
+        long_id = "toolu_" + "a" * 120
+        assert truncate_tool_call_id(long_id) == truncate_tool_call_id(long_id)
+
+    def test_different_ids_produce_different_truncations(self):
+        """Different long IDs should (almost certainly) produce different hashes."""
+        id_a = "toolu_01" + "a" * 110
+        id_b = "toolu_01" + "b" * 110
+        assert truncate_tool_call_id(id_a) != truncate_tool_call_id(id_b)
+
+
+class TestTruncateToolCallIdsInMessages:
+    def test_no_tool_calls_is_noop(self):
+        """Messages without tool calls should be unchanged."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        _truncate_tool_call_ids_in_messages(messages)
+        assert messages[0]["content"] == "hello"
+        assert messages[1]["content"] == "hi"
+
+    def test_short_ids_unchanged(self):
+        """Short tool_call IDs should not be modified."""
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_short",
+                        "type": "function",
+                        "function": {"name": "foo"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_short", "content": "result"},
+        ]
+        _truncate_tool_call_ids_in_messages(messages)
+        assert messages[0]["tool_calls"][0]["id"] == "call_short"
+        assert messages[1]["tool_call_id"] == "call_short"
+
+    def test_long_ids_truncated_and_paired(self):
+        """Long tool_call IDs should be truncated consistently in both messages."""
+        long_id = "toolu_01ABC" + "x" * 110
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": long_id, "type": "function", "function": {"name": "foo"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": long_id, "content": "result"},
+        ]
+        _truncate_tool_call_ids_in_messages(messages)
+
+        truncated_id = messages[0]["tool_calls"][0]["id"]
+        assert len(truncated_id) == OPENAI_MAX_TOOL_CALL_ID_LENGTH
+        assert truncated_id != long_id
+        # Tool message ID must match
+        assert messages[1]["tool_call_id"] == truncated_id
+
+    def test_multiple_tool_calls_in_single_message(self):
+        """Multiple tool calls in one assistant message should all be truncated."""
+        id_a = "toolu_" + "a" * 120
+        id_b = "toolu_" + "b" * 120
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": id_a, "type": "function", "function": {"name": "foo"}},
+                    {"id": id_b, "type": "function", "function": {"name": "bar"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": id_a, "content": "result_a"},
+            {"role": "tool", "tool_call_id": id_b, "content": "result_b"},
+        ]
+        _truncate_tool_call_ids_in_messages(messages)
+
+        truncated_a = messages[0]["tool_calls"][0]["id"]
+        truncated_b = messages[0]["tool_calls"][1]["id"]
+        assert len(truncated_a) == OPENAI_MAX_TOOL_CALL_ID_LENGTH
+        assert len(truncated_b) == OPENAI_MAX_TOOL_CALL_ID_LENGTH
+        assert truncated_a != truncated_b
+        assert messages[1]["tool_call_id"] == truncated_a
+        assert messages[2]["tool_call_id"] == truncated_b
+
+    def test_mixed_short_and_long_ids(self):
+        """Only long IDs should be truncated; short ones left alone."""
+        short_id = "call_short"
+        long_id = "toolu_" + "x" * 120
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": short_id, "type": "function", "function": {"name": "foo"}},
+                    {"id": long_id, "type": "function", "function": {"name": "bar"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": short_id, "content": "result_short"},
+            {"role": "tool", "tool_call_id": long_id, "content": "result_long"},
+        ]
+        _truncate_tool_call_ids_in_messages(messages)
+
+        assert messages[0]["tool_calls"][0]["id"] == short_id
+        assert len(messages[0]["tool_calls"][1]["id"]) == OPENAI_MAX_TOOL_CALL_ID_LENGTH
+        assert messages[1]["tool_call_id"] == short_id
+        assert messages[2]["tool_call_id"] == messages[0]["tool_calls"][1]["id"]

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -13,12 +13,16 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.types.utils import CallTypesLiteral
 
+from tracecat.agent.litellm_compat import apply_patch
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.tokens import verify_llm_token
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.identifiers import OrganizationID, WorkspaceID
 from tracecat.logger import logger
+
+# Apply monkeypatches for LiteLLM adapter compatibility fixes
+apply_patch()
 
 # -----------------------------------------------------------------------------
 # Credential Fetching via AgentManagementService

--- a/tracecat/agent/litellm_compat.py
+++ b/tracecat/agent/litellm_compat.py
@@ -1,0 +1,111 @@
+"""Monkeypatches for LiteLLM's Anthropic pass-through adapter.
+
+Fixes tool_call_id length incompatibility when routing Anthropic-format
+requests to OpenAI models. Anthropic tool_use IDs can be ~116 chars,
+but OpenAI enforces a 40-char max on tool_call_id fields.
+
+The existing adapter truncates tool *names* (64-char limit) but passes
+tool_call IDs through unchanged. This patch adds deterministic ID
+truncation using the same hash-based approach.
+
+Applied at module import time in gateway.py (loaded inside LiteLLM process).
+
+Upstream tracking:
+- https://github.com/BerriAI/litellm/issues/17904
+- https://github.com/BerriAI/litellm/issues/22317
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# OpenAI enforces max 40 chars for tool_call_id
+OPENAI_MAX_TOOL_CALL_ID_LENGTH = 40
+_TOOL_ID_HASH_LENGTH = 8
+_TOOL_ID_PREFIX_LENGTH = (
+    OPENAI_MAX_TOOL_CALL_ID_LENGTH - _TOOL_ID_HASH_LENGTH - 1  # 31
+)
+
+
+def truncate_tool_call_id(tool_id: str) -> str:
+    """Truncate a tool_call_id to fit OpenAI's 40-char limit.
+
+    Uses format: {31-char-prefix}_{8-char-hash} to avoid collisions.
+    """
+    if len(tool_id) <= OPENAI_MAX_TOOL_CALL_ID_LENGTH:
+        return tool_id
+    id_hash = hashlib.sha256(tool_id.encode()).hexdigest()[:_TOOL_ID_HASH_LENGTH]
+    return f"{tool_id[:_TOOL_ID_PREFIX_LENGTH]}_{id_hash}"
+
+
+def _truncate_tool_call_ids_in_messages(messages: Sequence[Any]) -> None:
+    """Truncate tool_call IDs in-place across OpenAI-format messages.
+
+    Builds a mapping from original → truncated IDs, then rewrites both:
+    - assistant message tool_calls[].id
+    - tool message tool_call_id
+
+    This ensures IDs stay paired after truncation.
+    """
+    # First pass: collect all tool_call IDs from assistant messages
+    id_mapping: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant" and (tool_calls := msg.get("tool_calls")):
+            for tc in tool_calls:
+                original_id = tc.get("id", "")
+                if len(original_id) > OPENAI_MAX_TOOL_CALL_ID_LENGTH:
+                    truncated = truncate_tool_call_id(original_id)
+                    id_mapping[original_id] = truncated
+
+    if not id_mapping:
+        return
+
+    # Second pass: rewrite IDs in both assistant and tool messages
+    for msg in messages:
+        if msg.get("role") == "assistant" and (tool_calls := msg.get("tool_calls")):
+            for tc in tool_calls:
+                original_id = tc.get("id", "")
+                if original_id in id_mapping:
+                    tc["id"] = id_mapping[original_id]
+        elif msg.get("role") == "tool":
+            original_id = msg.get("tool_call_id", "")
+            if original_id in id_mapping:
+                msg["tool_call_id"] = id_mapping[original_id]
+
+    logger.info(
+        "Truncated %d tool_call_id(s) for OpenAI compatibility",
+        len(id_mapping),
+    )
+
+
+def apply_patch() -> None:
+    """Apply monkeypatches to LiteLLM's Anthropic adapter.
+
+    Patches translate_anthropic_to_openai to truncate tool_call IDs
+    in the translated messages before they're sent to OpenAI.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+        LiteLLMAnthropicMessagesAdapter,
+    )
+
+    original_translate = LiteLLMAnthropicMessagesAdapter.translate_anthropic_to_openai
+
+    def patched_translate_anthropic_to_openai(self, anthropic_message_request):
+        openai_request, tool_name_mapping = original_translate(
+            self, anthropic_message_request
+        )
+        # Post-process: truncate tool_call IDs in the translated messages
+        if messages := openai_request.get("messages"):
+            _truncate_tool_call_ids_in_messages(messages)
+        return openai_request, tool_name_mapping
+
+    LiteLLMAnthropicMessagesAdapter.translate_anthropic_to_openai = (
+        patched_translate_anthropic_to_openai
+    )
+
+    logger.info("Applied LiteLLM tool_call_id truncation patch")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Truncate `Anthropic` tool_call IDs to OpenAI’s 40-char limit to prevent request failures when routing through `litellm`. Adds a deterministic, hash-based truncation and applies it during Anthropic→OpenAI message translation.

- **Bug Fixes**
  - Added `tracecat.agent.litellm_compat` with `apply_patch()` to truncate tool_call IDs (prefix + 8-char hash) within translated messages.
  - Kept assistant `tool_calls[].id` and tool `tool_call_id` in sync during truncation.
  - Applied the patch in `tracecat/agent/gateway.py` and added unit tests in `tests/unit/test_litellm_compat.py`.

<sup>Written for commit bcd53de5b34eb98887f4ba55a98a5e5e47da08d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

