### PR TITLE
infra: Tune EKS sizing for agent executor workloads

### DIFF
--- a/deployments/eks/README.md
+++ b/deployments/eks/README.md
@@ -27,17 +27,18 @@ Network hardening:
 
 ## Default deployment profile (~100 concurrent users)
 
-- Nodes: `13 x m7g.2xlarge` (`10` on-demand + `3` spot by default)
-- Guardrail requirement (rollout peak + reserved headroom): `46.5 vCPU`, `95.5 GiB RAM`
-- Scheduled capacity (on-demand only): `80 vCPU`, `320 GiB RAM`
-- Scheduled capacity (on-demand + spot): `104 vCPU`, `416 GiB RAM`
-- Percent headroom (on-demand only): `~42% CPU`, `~70% RAM` (`33.5 vCPU`, `224.5 GiB RAM`)
-- Estimated cost: `$4500/month`
+- Nodes: `5 x 4xlarge Graviton nodes` (`4` on-demand + `1` spot by default, defaulting to `m8g`/`m7g`/`m6g`)
+- Guardrail requirement (rollout peak + reserved headroom): `52.5 vCPU`, `119.5 GiB RAM`
+- Scheduled capacity (on-demand only): `60 vCPU`, `240 GiB RAM`
+- Scheduled capacity (on-demand + spot): `75 vCPU`, `300 GiB RAM`
+- Percent headroom (on-demand only): `~13% CPU`, `~50% RAM` (`7.5 vCPU`, `120.5 GiB RAM`)
+- Cost posture: materially lower node overhead than the previous `13 x m7g.2xlarge` profile while still keeping rollout headroom on on-demand capacity alone
 
 Definitions used above:
 - `guardrail model`: The plan-time capacity checks in `deployments/eks/modules/eks/main.tf` that compare required capacity vs configured node capacity.
 - `rollout peak`: Replica requests with rollout surge applied (`rollout_surge_percent`, default `25`), across API/worker/executor/agentExecutor/UI.
 - `reserved headroom`: Extra fixed capacity reserved for system/auxiliary workloads (`capacity_reserved_cpu_millicores`, `capacity_reserved_memory_mib`, `capacity_reserved_pod_eni`).
+- `schedulable per node`: `15 vCPU / 60 GiB`, which leaves explicit kube-system and DaemonSet margin on each default 4xlarge Graviton node.
 
 ```bash
 # Replica counts
@@ -54,27 +55,27 @@ worker_cpu_request_millicores=2000
 worker_memory_request_mib=2048
 executor_cpu_request_millicores=4000
 executor_memory_request_mib=8192
-agent_executor_cpu_request_millicores=2000
-agent_executor_memory_request_mib=8192
+agent_executor_cpu_request_millicores=4000
+agent_executor_memory_request_mib=16384
 ui_cpu_request_millicores=500
 ui_memory_request_mib=512
 
-# Node groups: 10 on-demand + 3 spot, all m7g.2xlarge
-node_instance_types='["m7g.2xlarge"]'
+# Node groups: 4 on-demand + 1 spot, same-shape Graviton 4xlarge pool
+node_instance_types='["m8g.4xlarge","m7g.4xlarge","m6g.4xlarge"]'
 node_architecture="arm64"
 node_ami_type="AL2023_ARM_64_STANDARD"
-node_min_size=10
-node_desired_size=10
-node_max_size=16
+node_min_size=4
+node_desired_size=4
+node_max_size=6
 spot_node_group_enabled=true
-spot_node_instance_types='["m7g.2xlarge"]'
-spot_node_min_size=3
-spot_node_desired_size=3
-spot_node_max_size=6
+spot_node_instance_types='["m8g.4xlarge","m7g.4xlarge","m6g.4xlarge"]'
+spot_node_min_size=1
+spot_node_desired_size=1
+spot_node_max_size=2
 
 # Capacity guardrail inputs
-node_schedulable_cpu_millicores_per_node=8000
-node_schedulable_memory_mib_per_node=32768
+node_schedulable_cpu_millicores_per_node=15000
+node_schedulable_memory_mib_per_node=61440
 pod_eni_capacity_per_node=16
 rollout_surge_percent=25
 capacity_reserved_cpu_millicores=3000
@@ -89,6 +90,13 @@ elasticache_node_type="cache.t4g.medium"
 rds_database_insights_mode="advanced"
 ```
 
+This profile is tuned for larger nodes with simpler packing:
+
+- A single `agent-executor` pod requests `4 vCPU / 16 GiB`, so it fits comfortably on any of the default 4xlarge Graviton node types alongside an `executor`, `worker`, or `api` pod.
+- All default node types stay at the same `16 vCPU / 64 GiB` shape so Cluster Autoscaler scheduling remains predictable.
+- The `4` on-demand nodes are sufficient for rollout peak plus reserve on their own; the extra spot node is opportunistic buffer rather than a hard dependency.
+- Compared with the old `m7g.2xlarge` mix, this keeps the same workload shape while reducing node count and per-node fragmentation.
+
 ## Capacity strategy (on-demand vs spot)
 
 The EKS module uses managed node groups with capacity labels to steer scheduling:
@@ -101,9 +109,15 @@ When the spot node group is enabled, Terraform injects scheduling defaults into 
 - **Preferred node affinity** for `tracecat.com/capacity=spot` (soft preference).
 - **Topology spread** across `tracecat.com/capacity` with `whenUnsatisfiable=ScheduleAnyway` to balance across on-demand and spot when both are available.
 
-You can disable spot by setting `spot_node_group_enabled=false` or change the mix by adjusting the on-demand and spot sizes.
+You can disable spot by setting `spot_node_group_enabled=false` or change the mix by adjusting the on-demand and spot sizes. The default mix assumes the on-demand group should be able to absorb rollout peak even if spot capacity disappears.
 
 Terraform includes plan-time capacity guardrails that verify the desired node count can support the configured replicas and resource requests at rollout peak (with a 25% surge). If capacity is insufficient, `terraform plan` will emit a warning. See `modules/eks/main.tf` for the check blocks.
+
+Instance type selection notes:
+
+- The on-demand managed node group uses the list order as priority, so the default order prefers `m8g.4xlarge`, then `m7g.4xlarge`, then `m6g.4xlarge`.
+- The Spot managed node group uses Amazon EKS Spot allocation strategy defaults (`price-capacity-optimized` on newer clusters), so list order is not a strong priority signal there; the value of multiple types is broader capacity-pool coverage.
+- If a target region does not support one of these instance families, remove it from both lists for that environment.
 
 ### Architecture requirement
 

--- a/deployments/eks/modules/eks/main.tf
+++ b/deployments/eks/modules/eks/main.tf
@@ -103,6 +103,22 @@ locals {
     local.ui_rollout_replicas
   )
 
+  max_tracecat_pod_cpu_millicores = max(
+    var.api_cpu_request_millicores,
+    var.worker_cpu_request_millicores,
+    var.executor_cpu_request_millicores,
+    var.agent_executor_cpu_request_millicores,
+    var.ui_cpu_request_millicores
+  )
+
+  max_tracecat_pod_memory_mib = max(
+    var.api_memory_request_mib,
+    var.worker_memory_request_mib,
+    var.executor_memory_request_mib,
+    var.agent_executor_memory_request_mib,
+    var.ui_memory_request_mib
+  )
+
   desired_node_count = var.node_desired_size + (var.spot_node_group_enabled ? var.spot_node_desired_size : 0)
 
   desired_cpu_capacity_millicores = local.desired_node_count * var.node_schedulable_cpu_millicores_per_node
@@ -155,6 +171,28 @@ check "tracecat_rollout_pod_eni_capacity" {
       local.desired_pod_eni_capacity,
       local.desired_node_count,
       var.pod_eni_capacity_per_node
+    )
+  }
+}
+
+check "tracecat_single_pod_cpu_fits_node" {
+  assert {
+    condition = local.max_tracecat_pod_cpu_millicores <= var.node_schedulable_cpu_millicores_per_node
+    error_message = format(
+      "Largest Tracecat pod CPU request is %dm, but only %dm schedulable CPU is modeled per node. Increase node size or lower per-pod CPU requests.",
+      local.max_tracecat_pod_cpu_millicores,
+      var.node_schedulable_cpu_millicores_per_node
+    )
+  }
+}
+
+check "tracecat_single_pod_memory_fits_node" {
+  assert {
+    condition = local.max_tracecat_pod_memory_mib <= var.node_schedulable_memory_mib_per_node
+    error_message = format(
+      "Largest Tracecat pod memory request is %dMi, but only %dMi schedulable memory is modeled per node. Increase node size or lower per-pod memory requests.",
+      local.max_tracecat_pod_memory_mib,
+      var.node_schedulable_memory_mib_per_node
     )
   }
 }

--- a/deployments/eks/modules/eks/variables.tf
+++ b/deployments/eks/modules/eks/variables.tf
@@ -42,7 +42,7 @@ variable "alb_ssl_policy" {
 variable "node_instance_types" {
   description = "Instance types for the EKS node group"
   type        = list(string)
-  default     = ["m7g.2xlarge"]
+  default     = ["m8g.4xlarge", "m7g.4xlarge", "m6g.4xlarge"]
 }
 
 variable "node_architecture" {
@@ -81,19 +81,19 @@ variable "node_ami_type" {
 variable "node_desired_size" {
   description = "Desired number of nodes in the node group"
   type        = number
-  default     = 10
+  default     = 4
 }
 
 variable "node_min_size" {
   description = "Minimum number of nodes in the node group"
   type        = number
-  default     = 10
+  default     = 4
 }
 
 variable "node_max_size" {
   description = "Maximum number of nodes in the node group"
   type        = number
-  default     = 16
+  default     = 6
 }
 
 variable "node_disk_size" {
@@ -111,25 +111,25 @@ variable "spot_node_group_enabled" {
 variable "spot_node_instance_types" {
   description = "Instance types for the spot managed node group."
   type        = list(string)
-  default     = ["m7g.2xlarge"]
+  default     = ["m8g.4xlarge", "m7g.4xlarge", "m6g.4xlarge"]
 }
 
 variable "spot_node_desired_size" {
   description = "Desired number of nodes in the spot managed node group."
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "spot_node_min_size" {
   description = "Minimum number of nodes in the spot managed node group."
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "spot_node_max_size" {
   description = "Maximum number of nodes in the spot managed node group."
   type        = number
-  default     = 6
+  default     = 2
 }
 
 # Tracecat Configuration
@@ -416,13 +416,13 @@ variable "executor_memory_request_mib" {
 variable "agent_executor_cpu_request_millicores" {
   description = "Agent executor CPU request in millicores"
   type        = number
-  default     = 2000
+  default     = 4000
 }
 
 variable "agent_executor_memory_request_mib" {
   description = "Agent executor memory request in MiB"
   type        = number
-  default     = 8192
+  default     = 16384
 }
 
 variable "ui_cpu_request_millicores" {
@@ -441,13 +441,13 @@ variable "ui_memory_request_mib" {
 variable "node_schedulable_cpu_millicores_per_node" {
   description = "Schedulable CPU per worker node in millicores used for rollout capacity guardrails"
   type        = number
-  default     = 8000
+  default     = 15000
 }
 
 variable "node_schedulable_memory_mib_per_node" {
   description = "Schedulable memory per worker node in MiB used for rollout capacity guardrails"
   type        = number
-  default     = 32768
+  default     = 61440
 }
 
 variable "pod_eni_capacity_per_node" {

--- a/deployments/eks/variables.tf
+++ b/deployments/eks/variables.tf
@@ -62,7 +62,7 @@ variable "cluster_version" {
 variable "node_instance_types" {
   description = "Instance types for the EKS node group"
   type        = list(string)
-  default     = ["m7g.2xlarge"]
+  default     = ["m8g.4xlarge", "m7g.4xlarge", "m6g.4xlarge"]
 }
 
 variable "node_architecture" {
@@ -101,19 +101,19 @@ variable "node_ami_type" {
 variable "node_desired_size" {
   description = "Desired number of nodes in the node group"
   type        = number
-  default     = 10
+  default     = 4
 }
 
 variable "node_min_size" {
   description = "Minimum number of nodes in the node group"
   type        = number
-  default     = 10
+  default     = 4
 }
 
 variable "node_max_size" {
   description = "Maximum number of nodes in the node group"
   type        = number
-  default     = 16
+  default     = 6
 }
 
 variable "node_disk_size" {
@@ -131,25 +131,25 @@ variable "spot_node_group_enabled" {
 variable "spot_node_instance_types" {
   description = "Instance types for the spot managed node group."
   type        = list(string)
-  default     = ["m7g.2xlarge"]
+  default     = ["m8g.4xlarge", "m7g.4xlarge", "m6g.4xlarge"]
 }
 
 variable "spot_node_desired_size" {
   description = "Desired number of nodes in the spot managed node group."
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "spot_node_min_size" {
   description = "Minimum number of nodes in the spot managed node group."
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "spot_node_max_size" {
   description = "Maximum number of nodes in the spot managed node group."
   type        = number
-  default     = 6
+  default     = 2
 }
 
 # Tracecat Configuration
@@ -420,13 +420,13 @@ variable "executor_memory_request_mib" {
 variable "agent_executor_cpu_request_millicores" {
   description = "Agent executor CPU request in millicores"
   type        = number
-  default     = 2000
+  default     = 4000
 }
 
 variable "agent_executor_memory_request_mib" {
   description = "Agent executor memory request in MiB"
   type        = number
-  default     = 4096
+  default     = 16384
 }
 
 variable "ui_cpu_request_millicores" {
@@ -445,13 +445,13 @@ variable "ui_memory_request_mib" {
 variable "node_schedulable_cpu_millicores_per_node" {
   description = "Schedulable CPU per worker node in millicores used for rollout capacity guardrails"
   type        = number
-  default     = 8000
+  default     = 15000
 }
 
 variable "node_schedulable_memory_mib_per_node" {
   description = "Schedulable memory per worker node in MiB used for rollout capacity guardrails"
   type        = number
-  default     = 32768
+  default     = 61440
 }
 
 variable "pod_eni_capacity_per_node" {

--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -38,6 +38,8 @@ Terraform stack for Tracecat on AWS ECS Fargate (`>1.0.0-beta.xx`).
 - `worker_desired_count=2`
 - `executor_desired_count=2`
 - `agent_executor_desired_count=1`
+- `agent_executor_cpu=4096`
+- `agent_executor_memory=16384`
 - `tracecat_db_instance_class=db.t4g.medium`
 - `tracecat_db_allocated_storage=20`
 - `temporal_db_instance_class=db.t4g.2xlarge`

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -511,7 +511,7 @@ variable "agent_executor_cpu" {
 
 variable "agent_executor_memory" {
   type    = string
-  default = "8192"
+  default = "16384"
 }
 
 variable "agent_executor_desired_count" {

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -465,7 +465,7 @@ variable "agent_executor_cpu" {
 
 variable "agent_executor_memory" {
   type    = string
-  default = "8192"
+  default = "16384"
 }
 
 variable "agent_executor_desired_count" {

--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -275,13 +275,20 @@ urls:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `api.replicas` | `1` | API service replicas |
-| `worker.replicas` | `1` | Temporal worker replicas |
-| `executor.replicas` | `1` | Action executor replicas |
-| `agentExecutor.replicas` | `1` | Agent executor replicas |
+| `api.replicas` | `2` | API service replicas |
+| `worker.replicas` | `4` | Temporal worker replicas |
+| `executor.replicas` | `4` | Action executor replicas |
+| `agentExecutor.replicas` | `2` | Agent executor replicas |
 | `ui.replicas` | `1` | UI service replicas |
 
 Each service also supports `resources.requests.cpu`, `resources.requests.memory`, `resources.limits.cpu`, and `resources.limits.memory`. See `values.yaml` for defaults.
+
+Notable defaults in `values.yaml`:
+- `api`: `2000m / 4096Mi`
+- `worker`: `2000m / 2048Mi`
+- `executor`: `4000m / 8192Mi`
+- `agentExecutor`: `4000m / 16384Mi`
+- `ui`: `500m / 512Mi`
 
 ### Sandbox (nsjail)
 

--- a/deployments/helm/tracecat/values.yaml
+++ b/deployments/helm/tracecat/values.yaml
@@ -320,11 +320,11 @@ agentExecutor:
     annotations: {}
   resources:
     requests:
-      cpu: "2000m"
-      memory: "4096Mi"
+      cpu: "4000m"
+      memory: "16384Mi"
     limits:
-      cpu: "2000m"
-      memory: "4096Mi"
+      cpu: "4000m"
+      memory: "16384Mi"
   queue: "shared-agent-queue"
   workerPoolSize: ""
   llmProxyReadTimeout: "300"


### PR DESCRIPTION
Summary
- outline the new default 4xlarge Graviton node mix (m8g/m7g/m6g), lower node counts, and emphasize the cheaper m8g.4xlarge priority while keeping rollout headroom
- raise agent executor resource requests to 4 vCPU/16 GiB and document the bundle in the EKS/Helm/Fargate defaults so the 16 GiB executor fits comfortably
- add node guardrails that ensure the largest Tracecat pod still fits the modeled schedulable resources per node and update schedulable capacity estimates
- refresh Helm and README guidance (replica counts, resource hints, scheduling notes) to reflect the new sizing strategy and reassure this remains EKS best practice

Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the default EKS profile to a smaller 4xlarge Graviton pool (with `m8g` preferred) and raises the agent executor to 4 vCPU/16 GiB to reduce cost and improve packing. Adds Terraform guardrails to ensure the largest pod fits a node, and updates Helm/Fargate defaults and docs.

- **Refactors**
  - Default EKS nodes: 4 on-demand + 1 spot with `["m8g.4xlarge","m7g.4xlarge","m6g.4xlarge"]` (prefer `m8g`).
  - Guardrails: model 15 vCPU/60 GiB schedulable per node; add single‑pod CPU/memory fit checks; refresh rollout capacity math.
  - Agent executor requests set to `4000m/16384Mi` in Terraform, Helm `values.yaml`, and Fargate; Helm replicas now `api=2`, `worker=4`, `executor=4`, `agentExecutor=2`.
  - Docs updated for capacity math, spot strategy, and instance type selection.

- **Migration**
  - No action if using defaults; on-demand covers rollout peak, spot is buffer.
  - If overriding types, keep 4xlarge shape and ensure per‑node schedulable >= 4 vCPU / 16 GiB (and ~15 vCPU / 60 GiB modeled).
  - Remove unsupported families per region from both on‑demand and spot lists.

<sup>Written for commit e3707c436bce691924e902dd12798720cdd67690. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

