### PR TITLE
fix(rbac): loosen rbac scopes for git sync

### DIFF
--- a/tests/unit/test_github_app.py
+++ b/tests/unit/test_github_app.py
@@ -18,7 +18,11 @@ from tracecat.git.types import GitUrl
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import SecretKeyValue
 from tracecat.secrets.service import SecretsService
-from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
+from tracecat.vcs.github.app import (
+    GitHubAppError,
+    GitHubAppSecretState,
+    GitHubAppService,
+)
 from tracecat.vcs.github.schemas import (
     GitHubAppConfig,
     GitHubAppCredentials,
@@ -139,7 +143,7 @@ class TestGitHubAppService:
         """Test retrieving GitHub App credentials."""
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = Mock()
-            mock_service.get_org_secret_by_name = AsyncMock(return_value=mock_secret)
+            mock_service.get_github_app_org_secret = AsyncMock(return_value=mock_secret)
             mock_service.decrypt_keys = Mock(
                 return_value=[
                     SecretKeyValue(
@@ -176,7 +180,7 @@ class TestGitHubAppService:
         """Test retrieving GitHub App credentials when not found."""
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = AsyncMock()
-            mock_service.get_org_secret_by_name.side_effect = TracecatNotFoundError(
+            mock_service.get_github_app_org_secret.side_effect = TracecatNotFoundError(
                 "Secret not found"
             )
             mock_secrets_service.return_value = mock_service
@@ -220,7 +224,7 @@ class TestGitHubAppService:
 
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = Mock()
-            mock_service.get_org_secret_by_name = AsyncMock(return_value=mock_secret)
+            mock_service.get_github_app_org_secret = AsyncMock(return_value=mock_secret)
             mock_service.decrypt_keys = Mock(
                 return_value=[
                     SecretKeyValue(
@@ -255,12 +259,12 @@ class TestGitHubAppService:
 
     @pytest.mark.anyio
     async def test_get_github_app_credentials_status_exists(
-        self, github_service, mock_credentials, mock_secret
+        self, github_admin_service, mock_credentials, mock_secret
     ):
         """Test getting credentials status when they exist."""
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = Mock()
-            mock_service.get_org_secret_by_name = AsyncMock(return_value=mock_secret)
+            mock_service.get_github_app_org_secret = AsyncMock(return_value=mock_secret)
             mock_service.decrypt_keys = Mock(
                 return_value=[
                     SecretKeyValue(
@@ -279,7 +283,7 @@ class TestGitHubAppService:
             )
             mock_secrets_service.return_value = mock_service
 
-            status = await github_service.get_github_app_credentials_status()
+            status = await github_admin_service.get_github_app_credentials_status()
 
             assert status["exists"] is True
             assert status["is_corrupted"] is False
@@ -412,9 +416,40 @@ class TestGitHubAppService:
         with (
             patch.object(
                 github_service,
-                "get_github_app_credentials",
-                return_value=mock_credentials,
+                "_get_github_app_secret_state",
+                return_value=(GitHubAppSecretState.VALID, Mock(), mock_credentials),
             ),
+            patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration,
+            patch("tracecat.vcs.github.app.asyncio.to_thread") as mock_to_thread,
+        ):
+            mock_integration = Mock()
+            mock_integration.get_repo_installation.return_value = mock_installation
+            mock_gh_integration.return_value = mock_integration
+            mock_to_thread.return_value = mock_installation
+
+            client = await github_service.get_github_client_for_repo(mock_repo_url)
+
+            assert client == mock_github_client
+            mock_to_thread.assert_called_once()
+            mock_installation.get_github_for_installation.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_get_github_client_for_repo_allows_workspace_admin(
+        self, github_service, github_admin_service, mock_credentials, mock_repo_url
+    ):
+        """Workspace admins with workflow sync access should be able to sync via GitHub."""
+        await github_admin_service.register_app(
+            app_id=mock_credentials.app_id,
+            private_key_pem=mock_credentials.private_key,
+            webhook_secret=mock_credentials.webhook_secret,
+            client_id=mock_credentials.client_id,
+        )
+
+        mock_github_client = Mock(spec=Github)
+        mock_installation = Mock()
+        mock_installation.get_github_for_installation.return_value = mock_github_client
+
+        with (
             patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration,
             patch("tracecat.vcs.github.app.asyncio.to_thread") as mock_to_thread,
         ):
@@ -437,8 +472,8 @@ class TestGitHubAppService:
         with (
             patch.object(
                 github_service,
-                "get_github_app_credentials",
-                return_value=mock_credentials,
+                "_get_github_app_secret_state",
+                return_value=(GitHubAppSecretState.VALID, Mock(), mock_credentials),
             ),
             patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration,
             patch("tracecat.vcs.github.app.asyncio.to_thread") as mock_to_thread,
@@ -460,8 +495,8 @@ class TestGitHubAppService:
         with (
             patch.object(
                 github_service,
-                "get_github_app_credentials",
-                return_value=mock_credentials,
+                "_get_github_app_secret_state",
+                return_value=(GitHubAppSecretState.VALID, Mock(), mock_credentials),
             ),
             patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration,
             patch("tracecat.vcs.github.app.asyncio.to_thread") as mock_to_thread,

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 
 import pytest
 
@@ -22,8 +22,13 @@ type AsyncEndpoint = Callable[..., Awaitable[object]]
 
 
 async def _assert_endpoint_requires_scope(
-    endpoint: AsyncEndpoint, required_scope: str
+    endpoint: AsyncEndpoint, required_scopes: str | Sequence[str]
 ) -> None:
+    allowed_scopes = (
+        frozenset({required_scopes})
+        if isinstance(required_scopes, str)
+        else frozenset(required_scopes)
+    )
     no_scope_role = Role(
         type="user",
         service_id="tracecat-api",
@@ -39,7 +44,7 @@ async def _assert_endpoint_requires_scope(
     allowed_role = Role(
         type="user",
         service_id="tracecat-api",
-        scopes=frozenset({required_scope}),
+        scopes=allowed_scopes,
     )
     token = ctx_role.set(allowed_role)
     try:
@@ -140,17 +145,21 @@ async def test_organization_invitation_scope_guards(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ("endpoint", "required_scope"),
+    ("endpoint", "required_scopes"),
     [
-        (workflow_store_router.publish_workflow, "workflow:update"),
-        (workflow_store_router.list_workflow_commits, "workflow:read"),
-        (workflow_store_router.pull_workflows, "workflow:update"),
+        (
+            workflow_store_router.publish_workflow,
+            ("workflow:update", "workflow:sync"),
+        ),
+        (workflow_store_router.list_workflow_commits, "workflow:sync"),
+        (workflow_store_router.list_workflow_branches, "workflow:sync"),
+        (workflow_store_router.pull_workflows, ("workflow:update", "workflow:sync")),
     ],
 )
 async def test_workflow_store_scope_guards(
-    endpoint: AsyncEndpoint, required_scope: str
+    endpoint: AsyncEndpoint, required_scopes: str | Sequence[str]
 ) -> None:
-    await _assert_endpoint_requires_scope(endpoint, required_scope)
+    await _assert_endpoint_requires_scope(endpoint, required_scopes)
 
 
 @pytest.mark.anyio

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -45,6 +45,7 @@ VIEWER_SCOPES: frozenset[str] = frozenset(
 
 EDITOR_SCOPES: frozenset[str] = VIEWER_SCOPES | frozenset(
     {
+        "workflow:sync",
         "workflow:create",
         "workflow:update",
         "workflow:execute",
@@ -148,6 +149,7 @@ ORG_OWNER_SCOPES: frozenset[str] = frozenset(
         # Full resource control
         "inbox:read",
         "workflow:read",
+        "workflow:sync",
         "workflow:create",
         "workflow:update",
         "workflow:delete",
@@ -239,6 +241,7 @@ ORG_ADMIN_SCOPES: frozenset[str] = frozenset(
         # Full resource control
         "inbox:read",
         "workflow:read",
+        "workflow:sync",
         "workflow:create",
         "workflow:update",
         "workflow:delete",
@@ -321,6 +324,7 @@ WORKSPACE_OPERATIONAL_SCOPES: frozenset[str] = frozenset(
     {
         "inbox:read",
         "workflow:read",
+        "workflow:sync",
         "workflow:create",
         "workflow:update",
         "workflow:delete",

--- a/tracecat/authz/seeding.py
+++ b/tracecat/authz/seeding.py
@@ -186,6 +186,12 @@ SYSTEM_SCOPE_DEFINITIONS: list[ScopeDefinition] = [
     ScopeDefinition(
         "workflow:read", "workflow", "read", "View workflows and their details"
     ),
+    ScopeDefinition(
+        "workflow:sync",
+        "workflow",
+        "sync",
+        "Sync workflows with the configured Git repository",
+    ),
     ScopeDefinition("workflow:create", "workflow", "create", "Create new workflows"),
     ScopeDefinition(
         "workflow:update", "workflow", "update", "Modify existing workflows"

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -337,8 +337,7 @@ class SecretsService(BaseOrgService):
         result = await self.session.execute(statement)
         return result.scalar_one()
 
-    @require_scope("org:secret:read")
-    async def get_org_secret_by_name(
+    async def _get_org_secret_by_name(
         self,
         secret_name: str,
         environment: str | None = None,
@@ -363,6 +362,20 @@ class SecretsService(BaseOrgService):
                 f"Organization secret {secret_name!r} (env: {environment!r}) not found when searching by name."
                 " Please double check that the name was correctly input."
             ) from e
+
+    @require_scope("org:secret:read")
+    async def get_org_secret_by_name(
+        self,
+        secret_name: str,
+        environment: str | None = None,
+    ) -> OrganizationSecret:
+        """Retrieve an organization-wide secret by its name."""
+        return await self._get_org_secret_by_name(secret_name, environment)
+
+    @require_scope("workflow:sync")
+    async def get_github_app_org_secret(self) -> OrganizationSecret:
+        """Retrieve the GitHub App organization secret for workflow sync."""
+        return await self._get_org_secret_by_name("github-app-credentials")
 
     @require_scope("org:secret:create")
     @audit_log(resource_type="organization_secret", action="create")

--- a/tracecat/vcs/github/app.py
+++ b/tracecat/vcs/github/app.py
@@ -193,9 +193,7 @@ class GitHubAppService(BaseOrgService):
         """Classify the stored GitHub App secret without failing on corruption."""
         secrets_service = SecretsService(session=self.session, role=self.role)
         try:
-            secret = await secrets_service.get_org_secret_by_name(
-                "github-app-credentials"
-            )
+            secret = await secrets_service.get_github_app_org_secret()
         except TracecatNotFoundError:
             return GitHubAppSecretState.MISSING, None, None
 
@@ -485,6 +483,7 @@ class GitHubAppService(BaseOrgService):
         raise GitHubAppError("Failed to retrieve GitHub App credentials")
 
     @requires_entitlement(Entitlement.GIT_SYNC)
+    @require_scope("workflow:sync")
     async def get_github_client_for_repo(self, repo_url: GitUrl) -> Github:
         """Get authenticated PyGithub client for a specific repository.
 
@@ -497,7 +496,19 @@ class GitHubAppService(BaseOrgService):
         Raises:
             GitHubAppError: If authentication fails or app not installed
         """
-        credentials = await self.get_github_app_credentials()
+        secret_state, _secret, credentials = await self._get_github_app_secret_state()
+        match secret_state:
+            case GitHubAppSecretState.MISSING:
+                raise GitHubAppError(
+                    "Failed to retrieve GitHub App credentials: credentials not found"
+                )
+            case GitHubAppSecretState.CORRUPTED:
+                raise GitHubAppError(
+                    "Failed to retrieve GitHub App credentials: invalid credential data"
+                )
+
+        if credentials is None:
+            raise GitHubAppError("Failed to retrieve GitHub App credentials")
 
         # Normalize private key format to handle common formatting issues
         raw_private_key = credentials.private_key.get_secret_value()

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -33,7 +33,7 @@ router = APIRouter(prefix="/workflows", tags=["workflows"])
     "/{workflow_id}/publish",
     response_model=WorkflowDslPublishResult,
 )
-@require_scope("workflow:update")
+@require_scope("workflow:update", "workflow:sync")
 async def publish_workflow(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
@@ -85,7 +85,7 @@ async def publish_workflow(
 
 
 @router.get("/sync/commits", response_model=list[GitCommitInfo])
-@require_scope("workflow:read")
+@require_scope("workflow:sync")
 async def list_workflow_commits(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
@@ -177,7 +177,7 @@ async def list_workflow_commits(
 
 
 @router.get("/sync/branches", response_model=list[GitBranchInfo])
-@require_scope("workflow:read")
+@require_scope("workflow:sync")
 async def list_workflow_branches(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
@@ -247,7 +247,7 @@ async def list_workflow_branches(
 
 
 @router.post("/sync/pull", response_model=PullResult)
-@require_scope("workflow:update")
+@require_scope("workflow:update", "workflow:sync")
 async def pull_workflows(
     role: WorkspaceUserRole,
     session: AsyncDBSession,

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -30,7 +30,7 @@ from tracecat.workspaces.service import WorkspaceService
 class WorkflowStoreService(BaseWorkspaceService):
     service_name = "workflow_store"
 
-    @require_scope("workflow:update")
+    @require_scope("workflow:update", "workflow:sync")
     async def publish_workflow_dsl(
         self,
         *,


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `workflow:sync` scope and applies it to Git sync endpoints and GitHub client creation. Workspace admins with workflow sync access can sync without org secret read; errors are clearer when credentials are missing or corrupted.

- **Bug Fixes**
  - Added `workflow:sync` scope; seeded and included in Editor/Admin roles.
  - Guarded Git sync routes and GitHub client creation with `workflow:sync` (publish, pull, commits, branches).
  - Scoped GitHub App org secret access to `workflow:sync`; general org secret reads remain limited to org settings readers.
  - Return specific errors for missing vs corrupted GitHub App credentials; block client creation when invalid.

<sup>Written for commit b04cd1289dad94d42cb590ae1e8c8868b7523d68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



