### PR TITLE
fix(agents): canonicalize registry mcp server names at runtime boundary

### DIFF
--- a/tests/unit/test_agent_mcp_utils.py
+++ b/tests/unit/test_agent_mcp_utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+
+
+def test_normalize_mcp_tool_name_canonical_registry_prefix() -> None:
+    assert (
+        normalize_mcp_tool_name("mcp__tracecat-registry__tools__slack__post_message")
+        == "tools.slack.post_message"
+    )
+
+
+def test_normalize_mcp_tool_name_legacy_registry_prefix() -> None:
+    assert (
+        normalize_mcp_tool_name("mcp__tracecat_registry__tools__slack__post_message")
+        == "tools.slack.post_message"
+    )
+
+
+def test_normalize_mcp_tool_name_canonical_registry_user_mcp_prefix() -> None:
+    assert (
+        normalize_mcp_tool_name("mcp__tracecat-registry__mcp__Linear__list_issues")
+        == "mcp.Linear.list_issues"
+    )
+
+
+def test_normalize_mcp_tool_name_legacy_registry_user_mcp_prefix() -> None:
+    assert (
+        normalize_mcp_tool_name("mcp__tracecat_registry__mcp__Linear__list_issues")
+        == "mcp.Linear.list_issues"
+    )

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -5,8 +5,10 @@ Tests the runtime execution with mocked Claude SDK.
 
 from __future__ import annotations
 
+import tempfile
 import uuid
 from dataclasses import replace
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -261,13 +263,13 @@ class TestClaudeAgentRuntimeRun:
         mock_socket_writer.send_done.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_adds_registry_mcp_alias_on_resume(
+    async def test_canonicalizes_registry_mcp_alias_on_resume(
         self,
         mock_socket_writer: MagicMock,
         mock_claude_sdk_client: MagicMock,
         sample_init_payload: RuntimeInitPayload,
     ) -> None:
-        """Test that resumed sessions include the registry MCP alias."""
+        """Test that resumed sessions only mount the canonical registry MCP name."""
         captured_options: list[Any] = []
 
         def _mock_client_ctor(*_args: Any, **kwargs: Any) -> MagicMock:
@@ -297,7 +299,35 @@ class TestClaudeAgentRuntimeRun:
         mcp_servers = captured_options[0].mcp_servers
         assert isinstance(mcp_servers, dict)
         assert "tracecat-registry" in mcp_servers
-        assert "tracecat_registry" in mcp_servers
+        assert "tracecat_registry" not in mcp_servers
+
+    @pytest.mark.anyio
+    async def test_write_session_file_canonicalizes_registry_mcp_aliases(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        """Test that resume JSONL is rewritten to the canonical registry MCP name."""
+        runtime = ClaudeAgentRuntime(mock_socket_writer)
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._cwd = (
+            Path(tempfile.gettempdir())
+            / "tracecat-agent-test-canonicalize-registry-mcp-alias"
+        )
+        sdk_session_data = (
+            '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+            '"name":"mcp__tracecat_registry__execute_tool","input":{"tool_name":'
+            '"mcp__tracecat_registry__core__http_request"}}]}}\n'
+        )
+
+        session_file = await runtime._write_session_file(
+            sdk_session_id,
+            sdk_session_data,
+        )
+
+        session_text = session_file.read_text()
+        assert "mcp__tracecat-registry__execute_tool" in session_text
+        assert "mcp__tracecat-registry__core__http_request" in session_text
+        assert "mcp__tracecat_registry__" not in session_text
 
 
 class TestClaudeAgentRuntimePreToolUseHook:

--- a/tracecat/agent/mcp/utils.py
+++ b/tracecat/agent/mcp/utils.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 from tracecat.agent.common.types import MCPToolDefinition
 
+REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
+LEGACY_REGISTRY_MCP_SERVER_NAME = "tracecat_registry"
+
 
 def action_name_to_mcp_tool_name(action_name: str) -> str:
     """Convert action name (dots) to MCP tool name format (underscores).
@@ -34,11 +37,15 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
 
     Handles Tracecat registry tools:
     - mcp__tracecat-registry__tools__slack__post_message -> tools.slack.post_message
+    - mcp__tracecat_registry__tools__slack__post_message -> tools.slack.post_message
     - mcp.tracecat-registry.core.cases.create_case -> core.cases.create_case
+    - mcp.tracecat_registry.core.cases.create_case -> core.cases.create_case
 
     Handles user MCP servers routed through the proxy:
     - mcp__tracecat-registry__mcp__Linear__list_issues -> mcp.Linear.list_issues
+    - mcp__tracecat_registry__mcp__Linear__list_issues -> mcp.Linear.list_issues
     - mcp.tracecat-registry.mcp.Linear.list_issues -> mcp.Linear.list_issues
+    - mcp.tracecat_registry.mcp.Linear.list_issues -> mcp.Linear.list_issues
 
     Other MCP tool names are returned as-is.
 
@@ -50,24 +57,40 @@ def normalize_mcp_tool_name(mcp_tool_name: str) -> str:
     """
     # Handle user MCP tools routed through proxy (dot-separated, persisted)
     # Pattern: mcp.tracecat-registry.mcp.{server}.{tool}
-    if mcp_tool_name.startswith("mcp.tracecat-registry.mcp."):
+    if mcp_tool_name.startswith(
+        f"mcp.{REGISTRY_MCP_SERVER_NAME}.mcp."
+    ) or mcp_tool_name.startswith(f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}.mcp."):
         # Extract mcp.{server}.{tool} part
-        return mcp_tool_name.replace("mcp.tracecat-registry.", "", 1)
+        return mcp_tool_name.replace(f"mcp.{REGISTRY_MCP_SERVER_NAME}.", "", 1).replace(
+            f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}.", "", 1
+        )
 
     # Handle user MCP tools routed through proxy (underscore-separated, runtime)
     # Pattern: mcp__tracecat-registry__mcp__{server}__{tool}
-    if mcp_tool_name.startswith("mcp__tracecat-registry__mcp__"):
+    if mcp_tool_name.startswith(
+        f"mcp__{REGISTRY_MCP_SERVER_NAME}__mcp__"
+    ) or mcp_tool_name.startswith(f"mcp__{LEGACY_REGISTRY_MCP_SERVER_NAME}__mcp__"):
         # Extract mcp__{server}__{tool} part and convert to mcp.{server}.{tool}
-        tool_part = mcp_tool_name.replace("mcp__tracecat-registry__", "")
+        tool_part = mcp_tool_name.replace(
+            f"mcp__{REGISTRY_MCP_SERVER_NAME}__", ""
+        ).replace(f"mcp__{LEGACY_REGISTRY_MCP_SERVER_NAME}__", "")
         return mcp_tool_name_to_action_name(tool_part)
 
     # Handle dot-separated format (persisted messages) for registry tools
-    if mcp_tool_name.startswith("mcp.tracecat-registry."):
-        return mcp_tool_name.replace("mcp.tracecat-registry.", "", 1)
+    if mcp_tool_name.startswith(
+        f"mcp.{REGISTRY_MCP_SERVER_NAME}."
+    ) or mcp_tool_name.startswith(f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}."):
+        return mcp_tool_name.replace(f"mcp.{REGISTRY_MCP_SERVER_NAME}.", "", 1).replace(
+            f"mcp.{LEGACY_REGISTRY_MCP_SERVER_NAME}.", "", 1
+        )
 
     # Handle underscore-separated format (runtime MCP tool names) for registry tools
-    if mcp_tool_name.startswith("mcp__tracecat-registry__"):
-        tool_part = mcp_tool_name.replace("mcp__tracecat-registry__", "")
+    if mcp_tool_name.startswith(
+        f"mcp__{REGISTRY_MCP_SERVER_NAME}__"
+    ) or mcp_tool_name.startswith(f"mcp__{LEGACY_REGISTRY_MCP_SERVER_NAME}__"):
+        tool_part = mcp_tool_name.replace(
+            f"mcp__{REGISTRY_MCP_SERVER_NAME}__", ""
+        ).replace(f"mcp__{LEGACY_REGISTRY_MCP_SERVER_NAME}__", "")
         return mcp_tool_name_to_action_name(tool_part)
 
     # Generic MCP prefix stripping for any other servers

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -102,11 +102,14 @@ INTERNET_TOOLS = [
     "WebFetch",
 ]
 
-# Registry MCP server name aliases for backward compatibility.
-# Different execution/resume paths may reference either hyphen or underscore
-# forms, so we keep both aliases valid.
+# Registry MCP server naming.
+# We canonicalize persisted session history to the hyphen form at the
+# resume boundary so runtime configuration only exposes one logical server.
 REGISTRY_MCP_SERVER_NAME = "tracecat-registry"
-REGISTRY_MCP_SERVER_NAME_ALIAS = "tracecat_registry"
+REGISTRY_MCP_TOOL_PREFIX = f"mcp__{REGISTRY_MCP_SERVER_NAME}__"
+REGISTRY_MCP_DOT_PREFIX = f"mcp.{REGISTRY_MCP_SERVER_NAME}."
+LEGACY_REGISTRY_MCP_TOOL_PREFIX = "mcp__tracecat_registry__"
+LEGACY_REGISTRY_MCP_DOT_PREFIX = "mcp.tracecat_registry."
 
 
 class ClaudeAgentRuntime:
@@ -172,6 +175,7 @@ class ClaudeAgentRuntime:
     ) -> Path:
         """Write session data to local filesystem for SDK resume."""
         session_file_path = self._get_session_file_path(sdk_session_id)
+        sdk_session_data = self._canonicalize_sdk_session_data(sdk_session_data)
 
         # Ensure the file ends with a newline so JSONL readers don't treat the last
         # record as truncated (some implementations are strict about this).
@@ -185,6 +189,12 @@ class ClaudeAgentRuntime:
         await asyncio.to_thread(_write)
         logger.debug("Wrote session file", path=str(session_file_path))
         return session_file_path
+
+    def _canonicalize_sdk_session_data(self, sdk_session_data: str) -> str:
+        """Canonicalize legacy registry MCP aliases in JSONL session history."""
+        return sdk_session_data.replace(
+            LEGACY_REGISTRY_MCP_TOOL_PREFIX, REGISTRY_MCP_TOOL_PREFIX
+        ).replace(LEGACY_REGISTRY_MCP_DOT_PREFIX, REGISTRY_MCP_DOT_PREFIX)
 
     def _is_internal_session_line(self, line_data: dict[str, Any]) -> bool:
         """Determine if a session line is internal (not shown in UI timeline).
@@ -474,9 +484,6 @@ class ClaudeAgentRuntime:
                     auth_token=payload.mcp_auth_token,
                 )
                 mcp_servers[REGISTRY_MCP_SERVER_NAME] = proxy_config
-                # Guard against alias drift in resumed session history/tool calls.
-                if payload.sdk_session_id:
-                    mcp_servers[REGISTRY_MCP_SERVER_NAME_ALIAS] = proxy_config
 
             stderr_queue: asyncio.Queue[str] = asyncio.Queue()
             if payload.config.mcp_servers:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Canonicalizes the Tracecat registry MCP server name to the hyphen form at the runtime boundary and when persisting session history to prevent alias drift. Resumed sessions are rewritten to the canonical form, and only the canonical server is mounted.

- **Bug Fixes**
  - Rewrites resume JSONL from `mcp__tracecat_registry__`/`mcp.tracecat_registry.` to `mcp__tracecat-registry__`/`mcp.tracecat-registry.`.
  - Removes the legacy `tracecat_registry` alias; only `tracecat-registry` is mounted.
  - Extends `normalize_mcp_tool_name` to handle both legacy and canonical prefixes for registry tools and proxied user MCP tools (dot and underscore forms).
  - Adds unit tests for normalization and session canonicalization.

<sup>Written for commit 1861181ad05291164393f36889692282b554f824. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

