### PR TITLE
feat(entitlements): enforce entitlements in UI

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -14634,6 +14634,28 @@ export const $ReceiveInteractionResponse = {
   title: "ReceiveInteractionResponse",
 } as const
 
+export const $RegistryActionAvailability = {
+  properties: {
+    locked: {
+      type: "boolean",
+      title: "Locked",
+      description: "Whether this action is locked behind an upgraded plan",
+      default: false,
+    },
+    missing_entitlements: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Missing Entitlements",
+      description: "Entitlements required to unlock this action",
+    },
+  },
+  type: "object",
+  title: "RegistryActionAvailability",
+  description: "Availability metadata for a registry action.",
+} as const
+
 export const $RegistryActionInterface = {
   properties: {
     expects: {
@@ -14924,6 +14946,10 @@ export const $RegistryActionReadMinimal = {
       ],
       title: "Display Group",
       description: "The presentation group of the action",
+    },
+    availability: {
+      $ref: "#/components/schemas/RegistryActionAvailability",
+      description: "Availability metadata for this action",
     },
     action: {
       type: "string",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -453,6 +453,7 @@ import type {
   RbacUpdateUserAssignmentResponse,
   RegistryActionsGetRegistryActionData,
   RegistryActionsGetRegistryActionResponse,
+  RegistryActionsListRegistryActionsData,
   RegistryActionsListRegistryActionsResponse,
   RegistryRepositoriesCompareRegistryVersionsData,
   RegistryRepositoriesCompareRegistryVersionsResponse,
@@ -6222,16 +6223,25 @@ export const registryRepositoriesGetPreviousRegistryVersion = (
 /**
  * List Registry Actions
  * List all actions from registry index.
+ * @param data The data for the request.
+ * @param data.includeLocked Include actions locked by missing entitlements
  * @returns RegistryActionReadMinimal Successful Response
  * @throws ApiError
  */
-export const registryActionsListRegistryActions =
-  (): CancelablePromise<RegistryActionsListRegistryActionsResponse> => {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/registry/actions",
-    })
-  }
+export const registryActionsListRegistryActions = (
+  data: RegistryActionsListRegistryActionsData = {}
+): CancelablePromise<RegistryActionsListRegistryActionsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/registry/actions",
+    query: {
+      include_locked: data.includeLocked,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
 
 /**
  * Get Registry Action

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4549,6 +4549,20 @@ export type ReceiveInteractionResponse = {
   message: string
 }
 
+/**
+ * Availability metadata for a registry action.
+ */
+export type RegistryActionAvailability = {
+  /**
+   * Whether this action is locked behind an upgraded plan
+   */
+  locked?: boolean
+  /**
+   * Entitlements required to unlock this action
+   */
+  missing_entitlements?: Array<string>
+}
+
 export type RegistryActionInterface = {
   expects: {
     [key: string]: unknown
@@ -4675,6 +4689,10 @@ export type RegistryActionReadMinimal = {
    * The presentation group of the action
    */
   display_group?: string | null
+  /**
+   * Availability metadata for this action
+   */
+  availability?: RegistryActionAvailability
   /**
    * The full action identifier.
    */
@@ -9447,6 +9465,13 @@ export type RegistryRepositoriesGetPreviousRegistryVersionData = {
 export type RegistryRepositoriesGetPreviousRegistryVersionResponse =
   tracecat__registry__repositories__schemas__RegistryVersionRead | null
 
+export type RegistryActionsListRegistryActionsData = {
+  /**
+   * Include actions locked by missing entitlements
+   */
+  includeLocked?: boolean
+}
+
 export type RegistryActionsListRegistryActionsResponse =
   Array<RegistryActionReadMinimal>
 
@@ -13737,11 +13762,16 @@ export type $OpenApiTs = {
   }
   "/registry/actions": {
     get: {
+      req: RegistryActionsListRegistryActionsData
       res: {
         /**
          * Successful Response
          */
         200: Array<RegistryActionReadMinimal>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
       }
     }
   }

--- a/frontend/src/components/builder/canvas/canvas-toolbar.tsx
+++ b/frontend/src/components/builder/canvas/canvas-toolbar.tsx
@@ -13,10 +13,7 @@ import {
 import { useCallback, useMemo, useState } from "react"
 import type { RegistryActionReadMinimal } from "@/client"
 import { getIcon } from "@/components/icons"
-import {
-  LockedFeatureChip,
-  LockedFeatureModal,
-} from "@/components/locked-feature-modal"
+import { LockedFeatureModal } from "@/components/locked-feature-modal"
 import { Button } from "@/components/ui/button"
 import {
   Command,
@@ -150,6 +147,21 @@ const TRANSFORM_TOP = [
 const SQL_TOP = ["core.duckdb.execute_sql", "core.sql.execute_query"]
 const AI_TOP = ["ai.action", "ai.ranker", "ai.slackbot"]
 const AGENT_TOP = ["ai.agent", "ai.preset_agent"]
+const FORCE_LOCKED_PRESET_ACTIONS = new Set([
+  "ai.agent.create_preset",
+  "ai.agent.delete_preset",
+  "ai.agent.get_preset",
+  "ai.agent.list_presets",
+  "ai.agent.update_preset",
+  "ai.preset_agent",
+])
+
+function isLockedAction(action: RegistryActionReadMinimal): boolean {
+  return (
+    FORCE_LOCKED_PRESET_ACTIONS.has(action.action) ||
+    (action.availability?.locked ?? false)
+  )
+}
 
 const WORKFLOW_EXTRA_ACTIONS = new Set([
   "core.transform.scatter",
@@ -369,7 +381,7 @@ function ToolbarCategoryDropdown({
 
   const handleSelect = useCallback(
     (action: RegistryActionReadMinimal) => {
-      if (action.availability?.locked ?? false) {
+      if (isLockedAction(action)) {
         setOpen(false)
         setSearch("")
         setLockedFeatureOpen(true)
@@ -403,7 +415,7 @@ function ToolbarCategoryDropdown({
   }
 
   function renderActionItem(action: RegistryActionReadMinimal) {
-    const isLocked = action.availability?.locked ?? false
+    const isLocked = isLockedAction(action)
 
     return (
       <CommandItem
@@ -411,18 +423,15 @@ function ToolbarCategoryDropdown({
         value={action.action}
         onSelect={() => handleSelect(action)}
         className={cn(
-          "flex cursor-pointer items-center gap-3 py-2",
+          "flex w-full cursor-pointer items-center gap-3 py-2",
           isLocked && "text-muted-foreground"
         )}
       >
         {renderActionIcon(action)}
-        <div className="flex min-w-0 flex-col">
-          <div className="flex items-center gap-2">
-            <span className="truncate text-xs font-medium">
-              {action.default_title ?? action.action}
-            </span>
-            {isLocked ? <LockedFeatureChip className="shrink-0" /> : null}
-          </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-xs font-medium">
+            {action.default_title ?? action.action}
+          </span>
           <span className="truncate text-xs text-muted-foreground">
             {action.action}
           </span>

--- a/frontend/src/components/builder/canvas/canvas-toolbar.tsx
+++ b/frontend/src/components/builder/canvas/canvas-toolbar.tsx
@@ -13,6 +13,10 @@ import {
 import { useCallback, useMemo, useState } from "react"
 import type { RegistryActionReadMinimal } from "@/client"
 import { getIcon } from "@/components/icons"
+import {
+  LockedFeatureChip,
+  LockedFeatureModal,
+} from "@/components/locked-feature-modal"
 import { Button } from "@/components/ui/button"
 import {
   Command,
@@ -266,7 +270,7 @@ export interface CanvasToolbarProps {
 
 export function CanvasToolbar({ onAddAction }: CanvasToolbarProps) {
   const { registryActions, registryActionsIsLoading } =
-    useBuilderRegistryActions()
+    useBuilderRegistryActions({ includeLocked: true })
 
   const actionsByCategory = useMemo(() => {
     if (!registryActions) return new Map<string, RegistryActionReadMinimal[]>()
@@ -347,6 +351,7 @@ function ToolbarCategoryDropdown({
   Icon,
 }: ToolbarCategoryDropdownProps) {
   const [open, setOpen] = useState(false)
+  const [lockedFeatureOpen, setLockedFeatureOpen] = useState(false)
   const [search, setSearch] = useState("")
   const isAiCategory = category.id === "ai"
   const isAgentCategory = category.id === "agent"
@@ -364,6 +369,12 @@ function ToolbarCategoryDropdown({
 
   const handleSelect = useCallback(
     (action: RegistryActionReadMinimal) => {
+      if (action.availability?.locked ?? false) {
+        setOpen(false)
+        setSearch("")
+        setLockedFeatureOpen(true)
+        return
+      }
       onAddAction(action)
       setOpen(false)
       setSearch("")
@@ -392,18 +403,26 @@ function ToolbarCategoryDropdown({
   }
 
   function renderActionItem(action: RegistryActionReadMinimal) {
+    const isLocked = action.availability?.locked ?? false
+
     return (
       <CommandItem
         key={action.action}
         value={action.action}
         onSelect={() => handleSelect(action)}
-        className="flex cursor-pointer items-center gap-3 py-2"
+        className={cn(
+          "flex cursor-pointer items-center gap-3 py-2",
+          isLocked && "text-muted-foreground"
+        )}
       >
         {renderActionIcon(action)}
         <div className="flex min-w-0 flex-col">
-          <span className="truncate text-xs font-medium">
-            {action.default_title ?? action.action}
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="truncate text-xs font-medium">
+              {action.default_title ?? action.action}
+            </span>
+            {isLocked ? <LockedFeatureChip className="shrink-0" /> : null}
+          </div>
           <span className="truncate text-xs text-muted-foreground">
             {action.action}
           </span>
@@ -413,52 +432,58 @@ function ToolbarCategoryDropdown({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn("size-9", categoryStyle?.buttonClass)}
-              disabled={isLoading || actions.length === 0}
-            >
-              <Icon className="size-5" />
-            </Button>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          {category.label}
-        </TooltipContent>
-      </Tooltip>
-      <PopoverContent
-        side="top"
-        align={category.align ?? "start"}
-        className="w-fit min-w-48 max-w-80 p-0"
-        sideOffset={8}
-      >
-        <Command shouldFilter={false}>
-          {category.hasSearch && (
-            <CommandInput
-              placeholder={`Search ${category.label.toLowerCase()}...`}
-              value={search}
-              onValueChange={setSearch}
-              className="text-xs"
-            />
-          )}
-          <CommandList>
-            <CommandEmpty className="py-4 text-center text-xs text-muted-foreground">
-              No actions found
-            </CommandEmpty>
-            <CommandGroup
-              heading={`${category.label} actions`}
-              className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium"
-            >
-              {filteredActions.map((action) => renderActionItem(action))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <>
+      <LockedFeatureModal
+        open={lockedFeatureOpen}
+        onOpenChange={setLockedFeatureOpen}
+      />
+      <Popover open={open} onOpenChange={setOpen}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn("size-9", categoryStyle?.buttonClass)}
+                disabled={isLoading || actions.length === 0}
+              >
+                <Icon className="size-5" />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {category.label}
+          </TooltipContent>
+        </Tooltip>
+        <PopoverContent
+          side="top"
+          align={category.align ?? "start"}
+          className="w-fit min-w-48 max-w-80 p-0"
+          sideOffset={8}
+        >
+          <Command shouldFilter={false}>
+            {category.hasSearch && (
+              <CommandInput
+                placeholder={`Search ${category.label.toLowerCase()}...`}
+                value={search}
+                onValueChange={setSearch}
+                className="text-xs"
+              />
+            )}
+            <CommandList>
+              <CommandEmpty className="py-4 text-center text-xs text-muted-foreground">
+                No actions found
+              </CommandEmpty>
+              <CommandGroup
+                heading={`${category.label} actions`}
+                className="[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium"
+              >
+                {filteredActions.map((action) => renderActionItem(action))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </>
   )
 }

--- a/frontend/src/components/builder/canvas/selector-node.tsx
+++ b/frontend/src/components/builder/canvas/selector-node.tsx
@@ -12,6 +12,10 @@ import type { GraphOperation, RegistryActionReadMinimal } from "@/client"
 import { isEphemeral } from "@/components/builder/canvas/canvas"
 import { getIcon } from "@/components/icons"
 import {
+  LockedFeatureChip,
+  LockedFeatureModal,
+} from "@/components/locked-feature-modal"
+import {
   Command,
   CommandEmpty,
   CommandGroup,
@@ -213,7 +217,7 @@ function ActionCommandSelector({
   inputValue: string
 }) {
   const { registryActions, registryActionsIsLoading, registryActionsError } =
-    useBuilderRegistryActions()
+    useBuilderRegistryActions({ includeLocked: true })
 
   if (!registryActions || registryActionsIsLoading) {
     return (
@@ -309,9 +313,14 @@ function ActionCommandGroup({
   const filterResults = useMemo(() => {
     return filterActions(sortedActions, inputValue)
   }, [sortedActions, inputValue])
+  const [lockedFeatureOpen, setLockedFeatureOpen] = React.useState(false)
 
   const handleSelect = useCallback(
     async (registryAction: RegistryActionReadMinimal) => {
+      if (registryAction.availability?.locked ?? false) {
+        setLockedFeatureOpen(true)
+        return
+      }
       if (!workflowId) {
         return
       }
@@ -465,59 +474,83 @@ function ActionCommandGroup({
   )
 
   return (
-    <CommandGroup heading={group} className="text-xs">
-      {filterResults.map((result) => {
-        const action = result.obj
+    <>
+      <LockedFeatureModal
+        open={lockedFeatureOpen}
+        onOpenChange={setLockedFeatureOpen}
+      />
+      <CommandGroup heading={group} className="text-xs">
+        {filterResults.map((result) => {
+          const action = result.obj
+          const isLocked = action.availability?.locked ?? false
 
-        if (highlight) {
-          // Get fuzzysort results by key name (resilient to SEARCH_KEYS reordering)
-          const actionResult = result[SEARCH_KEY_INDEX.action]
-          const titleResult = result[SEARCH_KEY_INDEX.default_title]
+          if (highlight) {
+            // Get fuzzysort results by key name (resilient to SEARCH_KEYS reordering)
+            const actionResult = result[SEARCH_KEY_INDEX.action]
+            const titleResult = result[SEARCH_KEY_INDEX.default_title]
+
+            return (
+              <CommandItem
+                key={action.action}
+                className={cn(
+                  "flex items-center gap-3 py-2 text-xs",
+                  isLocked && "text-muted-foreground"
+                )}
+                onSelect={async () => await handleSelect(action)}
+              >
+                {getIcon(action.action, {
+                  className: "size-8 rounded-md border p-1.5",
+                })}
+                <div className="flex min-w-0 flex-col">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-xs font-medium">
+                      <HighlightedText
+                        result={titleResult}
+                        text={action.default_title ?? action.action}
+                      />
+                    </span>
+                    {isLocked ? (
+                      <LockedFeatureChip className="shrink-0" />
+                    ) : null}
+                  </div>
+                  <span className="truncate text-xs text-muted-foreground">
+                    <HighlightedText
+                      result={actionResult}
+                      text={action.action}
+                    />
+                  </span>
+                </div>
+              </CommandItem>
+            )
+          }
 
           return (
             <CommandItem
               key={action.action}
-              className="flex items-center gap-3 py-2 text-xs"
+              className={cn(
+                "flex items-center gap-3 py-2 text-xs",
+                isLocked && "text-muted-foreground"
+              )}
               onSelect={async () => await handleSelect(action)}
             >
               {getIcon(action.action, {
                 className: "size-8 rounded-md border p-1.5",
               })}
               <div className="flex min-w-0 flex-col">
-                <span className="truncate text-xs font-medium">
-                  <HighlightedText
-                    result={titleResult}
-                    text={action.default_title ?? action.action}
-                  />
-                </span>
-                <span className="truncate text-xs text-muted-foreground">
-                  <HighlightedText result={actionResult} text={action.action} />
-                </span>
-              </div>
-            </CommandItem>
-          )
-        } else {
-          return (
-            <CommandItem
-              key={action.action}
-              className="flex items-center gap-3 py-2 text-xs"
-              onSelect={async () => await handleSelect(action)}
-            >
-              {getIcon(action.action, {
-                className: "size-8 rounded-md border p-1.5",
-              })}
-              <div className="flex min-w-0 flex-col">
-                <span className="truncate text-xs font-medium">
-                  {action.default_title}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-xs font-medium">
+                    {action.default_title}
+                  </span>
+                  {isLocked ? <LockedFeatureChip className="shrink-0" /> : null}
+                </div>
                 <span className="truncate text-xs text-muted-foreground">
                   {action.action}
                 </span>
               </div>
             </CommandItem>
           )
-        }
-      })}
-    </CommandGroup>
+        })}
+      </CommandGroup>
+    </>
   )
 }

--- a/frontend/src/components/builder/canvas/selector-node.tsx
+++ b/frontend/src/components/builder/canvas/selector-node.tsx
@@ -11,10 +11,7 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react"
 import type { GraphOperation, RegistryActionReadMinimal } from "@/client"
 import { isEphemeral } from "@/components/builder/canvas/canvas"
 import { getIcon } from "@/components/icons"
-import {
-  LockedFeatureChip,
-  LockedFeatureModal,
-} from "@/components/locked-feature-modal"
+import { LockedFeatureModal } from "@/components/locked-feature-modal"
 import {
   Command,
   CommandEmpty,
@@ -54,6 +51,22 @@ const SEARCH_KEY_INDEX: Record<(typeof SEARCH_KEYS)[number], number> =
     },
     {} as Record<(typeof SEARCH_KEYS)[number], number>
   )
+
+const FORCE_LOCKED_PRESET_ACTIONS = new Set([
+  "ai.agent.create_preset",
+  "ai.agent.delete_preset",
+  "ai.agent.get_preset",
+  "ai.agent.list_presets",
+  "ai.agent.update_preset",
+  "ai.preset_agent",
+])
+
+function isLockedAction(action: RegistryActionReadMinimal): boolean {
+  return (
+    FORCE_LOCKED_PRESET_ACTIONS.has(action.action) ||
+    (action.availability?.locked ?? false)
+  )
+}
 
 function filterActions(actions: RegistryActionReadMinimal[], search: string) {
   const results = fuzzysort.go<RegistryActionReadMinimal>(search, actions, {
@@ -317,7 +330,7 @@ function ActionCommandGroup({
 
   const handleSelect = useCallback(
     async (registryAction: RegistryActionReadMinimal) => {
-      if (registryAction.availability?.locked ?? false) {
+      if (isLockedAction(registryAction)) {
         setLockedFeatureOpen(true)
         return
       }
@@ -482,7 +495,7 @@ function ActionCommandGroup({
       <CommandGroup heading={group} className="text-xs">
         {filterResults.map((result) => {
           const action = result.obj
-          const isLocked = action.availability?.locked ?? false
+          const isLocked = isLockedAction(action)
 
           if (highlight) {
             // Get fuzzysort results by key name (resilient to SEARCH_KEYS reordering)
@@ -493,7 +506,7 @@ function ActionCommandGroup({
               <CommandItem
                 key={action.action}
                 className={cn(
-                  "flex items-center gap-3 py-2 text-xs",
+                  "flex w-full items-center gap-3 py-2 text-xs",
                   isLocked && "text-muted-foreground"
                 )}
                 onSelect={async () => await handleSelect(action)}
@@ -501,18 +514,13 @@ function ActionCommandGroup({
                 {getIcon(action.action, {
                   className: "size-8 rounded-md border p-1.5",
                 })}
-                <div className="flex min-w-0 flex-col">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-xs font-medium">
-                      <HighlightedText
-                        result={titleResult}
-                        text={action.default_title ?? action.action}
-                      />
-                    </span>
-                    {isLocked ? (
-                      <LockedFeatureChip className="shrink-0" />
-                    ) : null}
-                  </div>
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-xs font-medium">
+                    <HighlightedText
+                      result={titleResult}
+                      text={action.default_title ?? action.action}
+                    />
+                  </span>
                   <span className="truncate text-xs text-muted-foreground">
                     <HighlightedText
                       result={actionResult}
@@ -528,7 +536,7 @@ function ActionCommandGroup({
             <CommandItem
               key={action.action}
               className={cn(
-                "flex items-center gap-3 py-2 text-xs",
+                "flex w-full items-center gap-3 py-2 text-xs",
                 isLocked && "text-muted-foreground"
               )}
               onSelect={async () => await handleSelect(action)}
@@ -536,13 +544,10 @@ function ActionCommandGroup({
               {getIcon(action.action, {
                 className: "size-8 rounded-md border p-1.5",
               })}
-              <div className="flex min-w-0 flex-col">
-                <div className="flex items-center gap-2">
-                  <span className="truncate text-xs font-medium">
-                    {action.default_title}
-                  </span>
-                  {isLocked ? <LockedFeatureChip className="shrink-0" /> : null}
-                </div>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-xs font-medium">
+                  {action.default_title}
+                </span>
                 <span className="truncate text-xs text-muted-foreground">
                   {action.action}
                 </span>

--- a/frontend/src/components/builder/panel/action-panel-fields.tsx
+++ b/frontend/src/components/builder/panel/action-panel-fields.tsx
@@ -23,6 +23,10 @@ import { CodeEditor } from "@/components/editor/codemirror/code-editor"
 import { YamlStyledEditor } from "@/components/editor/codemirror/yaml-editor"
 import { ExpressionInput } from "@/components/editor/expression-input"
 import { getIcon } from "@/components/icons"
+import {
+  LockedFeatureChip,
+  LockedFeatureModal,
+} from "@/components/locked-feature-modal"
 import { type FieldTypeTab, PolyField } from "@/components/polymorphic-field"
 import {
   CustomTagInput,
@@ -74,6 +78,7 @@ import {
   type TracecatEditorComponent,
   type TracecatJsonSchema,
 } from "@/lib/schema"
+import { cn } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 export interface FormComponentProps {
@@ -587,9 +592,10 @@ function SingleActionTypeField({
   searchKeys: (keyof RegistryActionReadMinimal)[]
 }) {
   const [open, setOpen] = useState(false)
+  const [lockedFeatureOpen, setLockedFeatureOpen] = useState(false)
   const [searchValue, setSearchValue] = useState("")
   const { registryActions, registryActionsIsLoading } =
-    useBuilderRegistryActions()
+    useBuilderRegistryActions({ includeLocked: true })
 
   const filterActions = useCallback(
     (actions: RegistryActionReadMinimal[], search: string) => {
@@ -636,104 +642,123 @@ function SingleActionTypeField({
     return registryActions?.find((action) => action.action === field.value)
   }, [registryActions, field.value])
 
-  const handleSelect = (actionKey: string) => {
-    field.onChange(actionKey)
-    onChange(actionKey)
+  const handleSelect = (action: RegistryActionReadMinimal) => {
+    if (action.availability?.locked ?? false) {
+      setOpen(false)
+      setLockedFeatureOpen(true)
+      return
+    }
+
+    field.onChange(action.action)
+    onChange(action.action)
     setOpen(false)
     setSearchValue("")
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className="w-full justify-between text-left font-normal"
-        >
-          <div className="flex items-center gap-2 truncate">
-            {selectedAction ? (
-              getIcon(selectedAction.action, {
-                className: "size-4 shrink-0",
-              })
-            ) : (
-              <TypeIcon className="size-4 shrink-0" />
-            )}
-            <span className="truncate">
-              {selectedAction
-                ? selectedAction.default_title || selectedAction.action
-                : "Select action type..."}
-            </span>
-          </div>
-          <ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[400px] p-0" align="start">
-        <Command shouldFilter={false}>
-          <CommandInput
-            placeholder="Search actions..."
-            value={searchValue}
-            onValueChange={setSearchValue}
-          />
-          <ScrollArea className="h-[300px]">
-            <CommandList>
-              <CommandEmpty className="py-6 text-center text-xs text-muted-foreground">
-                {registryActionsIsLoading
-                  ? "Loading actions..."
-                  : "No actions found."}
-              </CommandEmpty>
-              {sortedActions.map((result) => {
-                const action = result.obj
-                return (
-                  <CommandItem
-                    key={action.action}
-                    value={action.action}
-                    onSelect={() => handleSelect(action.action)}
-                    className="cursor-pointer p-2"
-                  >
-                    <div className="flex w-full flex-col gap-1">
-                      <div className="flex items-center gap-2">
-                        {getIcon(action.action, {
-                          className: "size-4 shrink-0 text-muted-foreground",
-                        })}
-                        <span className="font-medium">
-                          {action.default_title || action.name}
-                        </span>
-                        {action.type === "template" && (
-                          <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                            template
+    <>
+      <LockedFeatureModal
+        open={lockedFeatureOpen}
+        onOpenChange={setLockedFeatureOpen}
+      />
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between text-left font-normal"
+          >
+            <div className="flex items-center gap-2 truncate">
+              {selectedAction ? (
+                getIcon(selectedAction.action, {
+                  className: "size-4 shrink-0",
+                })
+              ) : (
+                <TypeIcon className="size-4 shrink-0" />
+              )}
+              <span className="truncate">
+                {selectedAction
+                  ? selectedAction.default_title || selectedAction.action
+                  : "Select action type..."}
+              </span>
+            </div>
+            <ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[400px] p-0" align="start">
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="Search actions..."
+              value={searchValue}
+              onValueChange={setSearchValue}
+            />
+            <ScrollArea className="h-[300px]">
+              <CommandList>
+                <CommandEmpty className="py-6 text-center text-xs text-muted-foreground">
+                  {registryActionsIsLoading
+                    ? "Loading actions..."
+                    : "No actions found."}
+                </CommandEmpty>
+                {sortedActions.map((result) => {
+                  const action = result.obj
+                  const isLocked = action.availability?.locked ?? false
+
+                  return (
+                    <CommandItem
+                      key={action.action}
+                      value={action.action}
+                      onSelect={() => handleSelect(action)}
+                      className={cn(
+                        "cursor-pointer p-2",
+                        isLocked && "text-muted-foreground"
+                      )}
+                    >
+                      <div className="flex w-full flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                          {getIcon(action.action, {
+                            className: "size-4 shrink-0 text-muted-foreground",
+                          })}
+                          <span className="font-medium">
+                            {action.default_title || action.name}
                           </span>
-                        )}
+                          {isLocked ? (
+                            <LockedFeatureChip className="shrink-0" />
+                          ) : null}
+                          {action.type === "template" && (
+                            <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                              template
+                            </span>
+                          )}
+                        </div>
+                        <p className="line-clamp-2 text-xs text-muted-foreground">
+                          {action.description}
+                        </p>
+                        <span className="font-mono text-xs text-muted-foreground/70">
+                          {action.action}
+                        </span>
                       </div>
-                      <p className="line-clamp-2 text-xs text-muted-foreground">
-                        {action.description}
-                      </p>
-                      <span className="font-mono text-xs text-muted-foreground/70">
-                        {action.action}
-                      </span>
-                    </div>
-                  </CommandItem>
-                )
-              })}
-            </CommandList>
-          </ScrollArea>
-        </Command>
-      </PopoverContent>
-    </Popover>
+                    </CommandItem>
+                  )
+                })}
+              </CommandList>
+            </ScrollArea>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </>
   )
 }
 
 function MultipleActionTypeField({
   field,
   onChange,
-  searchKeys,
 }: {
   field: ControllerRenderProps<FieldValues>
   onChange: (value: string[]) => void
-  searchKeys: (keyof RegistryActionReadMinimal)[]
 }) {
-  const { registryActions } = useBuilderRegistryActions()
+  const [lockedFeatureOpen, setLockedFeatureOpen] = useState(false)
+  const { registryActions } = useBuilderRegistryActions({ includeLocked: true })
 
   // Map actions to suggestions format for MultiTagCommandInput
   const suggestions = useMemo(() => {
@@ -748,19 +773,27 @@ function MultipleActionTypeField({
           icon: getIcon(action.action, {
             className: "size-6 p-[3px] border-[0.5px]",
           }),
+          locked: action.availability?.locked ?? false,
+          onSelect: () => setLockedFeatureOpen(true),
         }))
         .sort((a, b) => a.value.localeCompare(b.value)) || []
     )
   }, [registryActions])
 
   return (
-    <MultiTagCommandInput
-      value={field.value}
-      onChange={onChange}
-      suggestions={suggestions}
-      searchKeys={searchKeys as (keyof Suggestion)[]}
-      placeholder="Start typing to search actions..."
-    />
+    <>
+      <LockedFeatureModal
+        open={lockedFeatureOpen}
+        onOpenChange={setLockedFeatureOpen}
+      />
+      <MultiTagCommandInput
+        value={field.value}
+        onChange={onChange}
+        suggestions={suggestions}
+        searchKeys={["value", "label", "description", "group"]}
+        placeholder="Start typing to search actions..."
+      />
+    </>
   )
 }
 
@@ -786,7 +819,6 @@ export function ActionTypeField({
       <MultipleActionTypeField
         field={field}
         onChange={onChange as (value: string[]) => void}
-        searchKeys={searchKeys}
       />
     )
   }

--- a/frontend/src/components/locked-feature-modal.tsx
+++ b/frontend/src/components/locked-feature-modal.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { ArrowUpRight, Lock } from "lucide-react"
+import type { ReactNode } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
+
+const LOCKED_FEATURE_BULLETS = [
+  "Get production-ready automations with enterprise agents, metrics, and premium workflow tools.",
+  "Access RBAC, SLAs, governance, and features built for production environments.",
+]
+
+interface LockedFeatureModalProps {
+  children?: ReactNode
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export function LockedFeatureModal({
+  children,
+  open,
+  onOpenChange,
+}: LockedFeatureModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {children ? <DialogTrigger asChild>{children}</DialogTrigger> : null}
+      <DialogContent
+        title="Upgrade to unlock this feature"
+        className="max-w-sm gap-0 overflow-hidden border-border p-0 shadow-none"
+      >
+        <DialogHeader className="space-y-2 border-b px-5 py-5 text-left">
+          <div className="flex items-center gap-2">
+            <div className="flex size-7 items-center justify-center rounded-md border bg-muted/40">
+              <Lock className="size-3.5 text-muted-foreground" />
+            </div>
+            <DialogTitle className="text-base font-semibold">
+              Upgrade to unlock this feature
+            </DialogTitle>
+          </div>
+          <DialogDescription className="text-sm">
+            Upgrade for enterprise agents, metrics, and other advanced features.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 px-5 py-4">
+          <ul className="space-y-2 pl-4 text-sm text-muted-foreground">
+            {LOCKED_FEATURE_BULLETS.map((bullet) => (
+              <li key={bullet} className="list-disc">
+                {bullet}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <DialogFooter className="border-t px-5 py-4 sm:justify-start sm:space-x-0">
+          <Button
+            variant="outline"
+            size="sm"
+            asChild
+            className="w-full justify-center"
+          >
+            <a
+              href="https://tracecat.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more <ArrowUpRight className="size-4" />
+            </a>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function LockedFeatureChip({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 translate-y-px items-center justify-center text-muted-foreground",
+        className
+      )}
+    >
+      <Lock className="size-3 text-muted-foreground" />
+    </span>
+  )
+}

--- a/frontend/src/components/locked-feature-modal.tsx
+++ b/frontend/src/components/locked-feature-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ArrowUpRight, Lock } from "lucide-react"
-import type { ReactNode } from "react"
+import type { ReactElement } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -21,7 +21,7 @@ const LOCKED_FEATURE_BULLETS = [
 ]
 
 interface LockedFeatureModalProps {
-  children?: ReactNode
+  children?: ReactElement
   open?: boolean
   onOpenChange?: (open: boolean) => void
 }

--- a/frontend/src/components/registry/workspace-actions-inventory.tsx
+++ b/frontend/src/components/registry/workspace-actions-inventory.tsx
@@ -24,6 +24,10 @@ import {
 } from "@/components/catalog/catalog-header"
 import { getIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
+import {
+  LockedFeatureChip,
+  LockedFeatureModal,
+} from "@/components/locked-feature-modal"
 import { AlertNotification } from "@/components/notifications"
 import { actionTypeToLabel } from "@/components/registry/icons"
 import {
@@ -63,7 +67,7 @@ import { toast } from "@/components/ui/use-toast"
 import { useAdminRegistryStatus } from "@/hooks/use-admin"
 import { useAuth } from "@/hooks/use-auth"
 import { useRegistryActions, useRegistryRepositories } from "@/lib/hooks"
-import { copyToClipboard } from "@/lib/utils"
+import { cn, copyToClipboard } from "@/lib/utils"
 
 type ActionTypeFilter = RegistryActionReadMinimal["type"] | "all"
 type ActionSortField = "name" | "action" | "namespace"
@@ -101,6 +105,10 @@ function buildSearchText(action: RegistryActionReadMinimal): string {
 
 function getActionDisplayName(action: RegistryActionReadMinimal): string {
   return action.default_title ?? action.name
+}
+
+function isLockedAction(action: RegistryActionReadMinimal): boolean {
+  return action.availability?.locked ?? false
 }
 
 function getActionSortValue(
@@ -245,7 +253,7 @@ export function WorkspaceActionsInventory() {
   const canAdministerOrg = useScopeCheck("org:update")
   const canReadPlatformRegistryMetadata = user?.isPlatformAdmin() ?? false
   const { registryActions, registryActionsIsLoading, registryActionsError } =
-    useRegistryActions()
+    useRegistryActions({ includeLocked: true })
   const { repos, reposIsLoading, reposError } = useRegistryRepositories()
   const { status: platformStatus, isLoading: platformStatusIsLoading } =
     useAdminRegistryStatus({ enabled: canReadPlatformRegistryMetadata })
@@ -255,6 +263,7 @@ export function WorkspaceActionsInventory() {
   const [originFilter, setOriginFilter] = useState("all")
   const [sortField, setSortField] = useState<ActionSortField>("action")
   const [sortDirection, setSortDirection] = useState<ActionSortDirection>("asc")
+  const [lockedFeatureDialogOpen, setLockedFeatureDialogOpen] = useState(false)
   const [expandedOrigins, setExpandedOrigins] = useState<
     Record<string, boolean>
   >({})
@@ -561,6 +570,10 @@ export function WorkspaceActionsInventory() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <LockedFeatureModal
+        open={lockedFeatureDialogOpen}
+        onOpenChange={setLockedFeatureDialogOpen}
+      />
       <CatalogHeader
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
@@ -622,21 +635,58 @@ export function WorkspaceActionsInventory() {
                       {group.actions.map((action) => {
                         const typeLabel = actionTypeToLabel[action.type].label
                         const actionTitle = getActionDisplayName(action)
+                        const isLocked = isLockedAction(action)
 
-                        return (
-                          <Item
-                            key={action.id}
-                            variant="default"
-                            size="sm"
-                            className="w-full flex-nowrap rounded-none border-none px-3 py-1.5 text-left"
-                          >
-                            <ItemMedia className="translate-y-0 self-center">
+                        const badges = (
+                          <>
+                            <Badge
+                              variant="secondary"
+                              className="h-5 px-2 text-[10px] font-normal"
+                            >
+                              {typeLabel}
+                            </Badge>
+                            <Badge
+                              variant="secondary"
+                              className="h-5 px-2 text-[10px] font-normal"
+                            >
+                              {action.namespace}
+                            </Badge>
+                          </>
+                        )
+
+                        const rowContent = (
+                          <>
+                            <ItemMedia
+                              className={cn(
+                                "translate-y-0 self-center",
+                                isLocked && "opacity-70"
+                              )}
+                            >
                               {getIcon(action.action, {
-                                className: "size-6 rounded border",
+                                className: cn(
+                                  "size-6 rounded border",
+                                  isLocked && "opacity-70"
+                                ),
                               })}
                             </ItemMedia>
                             <ItemContent className="min-w-0 gap-0">
-                              <ItemTitle className="flex w-full min-w-0 items-center gap-2 text-xs">
+                              <ItemTitle
+                                className={cn(
+                                  "flex w-full min-w-0 items-center gap-2 text-xs",
+                                  isLocked && "text-muted-foreground"
+                                )}
+                              >
+                                {isLocked ? (
+                                  <button
+                                    type="button"
+                                    className="shrink-0 rounded-full border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                    onClick={() =>
+                                      setLockedFeatureDialogOpen(true)
+                                    }
+                                  >
+                                    <LockedFeatureChip />
+                                  </button>
+                                ) : null}
                                 <span className="truncate">{actionTitle}</span>
                               </ItemTitle>
                               <ItemDescription className="truncate font-mono text-[11px]">
@@ -644,18 +694,7 @@ export function WorkspaceActionsInventory() {
                               </ItemDescription>
                             </ItemContent>
                             <ItemActions className="ml-auto flex shrink-0 items-center gap-1.5 pl-3">
-                              <Badge
-                                variant="secondary"
-                                className="h-5 px-2 text-[10px] font-normal"
-                              >
-                                {typeLabel}
-                              </Badge>
-                              <Badge
-                                variant="secondary"
-                                className="h-5 px-2 text-[10px] font-normal"
-                              >
-                                {action.namespace}
-                              </Badge>
+                              {badges}
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
                                   <Button
@@ -693,6 +732,30 @@ export function WorkspaceActionsInventory() {
                                 </DropdownMenuContent>
                               </DropdownMenu>
                             </ItemActions>
+                          </>
+                        )
+
+                        if (isLocked) {
+                          return (
+                            <Item
+                              key={action.id}
+                              variant="default"
+                              size="sm"
+                              className="w-full flex-nowrap rounded-none border-none px-3 py-1.5 text-left text-muted-foreground"
+                            >
+                              {rowContent}
+                            </Item>
+                          )
+                        }
+
+                        return (
+                          <Item
+                            key={action.id}
+                            variant="default"
+                            size="sm"
+                            className="w-full flex-nowrap rounded-none border-none px-3 py-1.5 text-left"
+                          >
+                            {rowContent}
                           </Item>
                         )
                       })}

--- a/frontend/src/components/registry/workspace-actions-inventory.tsx
+++ b/frontend/src/components/registry/workspace-actions-inventory.tsx
@@ -80,6 +80,13 @@ type TracecatVersionState =
   | { status: "error" }
 
 const PLATFORM_VERSION_FETCH_LIMIT = 200
+const FORCE_LOCKED_ACTIONS = new Set([
+  "ai.agent.create_preset",
+  "ai.agent.delete_preset",
+  "ai.agent.get_preset",
+  "ai.agent.list_presets",
+  "ai.agent.update_preset",
+])
 
 type RegistryActionGroup = {
   origin: string
@@ -108,7 +115,10 @@ function getActionDisplayName(action: RegistryActionReadMinimal): string {
 }
 
 function isLockedAction(action: RegistryActionReadMinimal): boolean {
-  return action.availability?.locked ?? false
+  return (
+    FORCE_LOCKED_ACTIONS.has(action.action) ||
+    (action.availability?.locked ?? false)
+  )
 }
 
 function getActionSortValue(
@@ -676,6 +686,7 @@ export function WorkspaceActionsInventory() {
                                   isLocked && "text-muted-foreground"
                                 )}
                               >
+                                <span className="truncate">{actionTitle}</span>
                                 {isLocked ? (
                                   <button
                                     type="button"
@@ -687,7 +698,6 @@ export function WorkspaceActionsInventory() {
                                     <LockedFeatureChip />
                                   </button>
                                 ) : null}
-                                <span className="truncate">{actionTitle}</span>
                               </ItemTitle>
                               <ItemDescription className="truncate font-mono text-[11px]">
                                 {action.action}

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -23,6 +23,10 @@ import { useEffect, useRef, useState } from "react"
 import type { AgentPresetReadMinimal } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
 import { CreateCaseDialog } from "@/components/cases/case-create-dialog"
+import {
+  LockedFeatureChip,
+  LockedFeatureModal,
+} from "@/components/locked-feature-modal"
 import { AppMenu } from "@/components/sidebar/app-menu"
 import { SidebarUserNav } from "@/components/sidebar/sidebar-user-nav"
 import { Button } from "@/components/ui/button"
@@ -69,9 +73,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const caseId = params?.caseId
   const casesListPath = `${basePath}/cases`
   const isCasesList = pathname === casesListPath
-  const { hasEntitlement } = useEntitlements()
+  const { hasEntitlement, isLoading: entitlementsIsLoading } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
   const [createCaseDialogOpen, setCreateCaseDialogOpen] = useState(false)
+  const [lockedFeatureDialogOpen, setLockedFeatureDialogOpen] = useState(false)
 
   useEffect(() => {
     setSidebarOpenRef.current = setSidebarOpen
@@ -185,6 +190,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarHeaderContent workspaceId={workspaceId} />
       </SidebarHeader>
       <SidebarContent>
+        <LockedFeatureModal
+          open={lockedFeatureDialogOpen}
+          onOpenChange={setLockedFeatureDialogOpen}
+        />
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -275,7 +284,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </Collapsible>
         )}
 
-        {agentAddonsEnabled && canViewAgents === true && (
+        {canViewAgents === true && (
           <Collapsible defaultOpen className="group/collapsible">
             <SidebarGroup className="group/agents relative">
               <SidebarGroupLabel asChild>
@@ -284,44 +293,77 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   <ChevronDown className="ml-auto size-4 transition-transform group-data-[state=open]/collapsible:rotate-180" />
                 </CollapsibleTrigger>
               </SidebarGroupLabel>
-              <SidebarGroupAction
-                aria-label="Create agent"
-                onClick={openNewAgentBuilder}
-                className={[
-                  "right-10 opacity-0 pointer-events-none transition-opacity",
-                  "group-hover/agents:opacity-100 group-hover/agents:pointer-events-auto",
-                  "group-focus-within/agents:opacity-100 group-focus-within/agents:pointer-events-auto",
-                ].join(" ")}
-              >
-                <Plus />
-              </SidebarGroupAction>
+              {agentAddonsEnabled ? (
+                <SidebarGroupAction
+                  aria-label="Create agent"
+                  onClick={openNewAgentBuilder}
+                  className={[
+                    "right-10 opacity-0 pointer-events-none transition-opacity",
+                    "group-hover/agents:opacity-100 group-hover/agents:pointer-events-auto",
+                    "group-focus-within/agents:opacity-100 group-focus-within/agents:pointer-events-auto",
+                  ].join(" ")}
+                >
+                  <Plus />
+                </SidebarGroupAction>
+              ) : null}
               <CollapsibleContent>
                 <SidebarGroupContent>
-                  {presetsIsLoading ? (
+                  {entitlementsIsLoading ? (
                     <div className="px-2 py-3 text-xs text-muted-foreground">
                       Loading agents…
                     </div>
-                  ) : presets && presets.length > 0 ? (
-                    <SidebarMenu>
-                      {presets.map((preset) => (
-                        <AgentPresetSidebarItem
-                          key={preset.id}
-                          preset={preset}
-                          isActive={
-                            pathname === `${basePath}/agents/${preset.id}`
-                          }
-                          href={`${basePath}/agents/${preset.id}`}
-                        />
-                      ))}
-                    </SidebarMenu>
+                  ) : agentAddonsEnabled ? (
+                    presetsIsLoading ? (
+                      <div className="px-2 py-3 text-xs text-muted-foreground">
+                        Loading agents…
+                      </div>
+                    ) : presets && presets.length > 0 ? (
+                      <SidebarMenu>
+                        {presets.map((preset) => (
+                          <AgentPresetSidebarItem
+                            key={preset.id}
+                            preset={preset}
+                            isActive={
+                              pathname === `${basePath}/agents/${preset.id}`
+                            }
+                            href={`${basePath}/agents/${preset.id}`}
+                          />
+                        ))}
+                      </SidebarMenu>
+                    ) : (
+                      <Button
+                        variant="link"
+                        className="h-auto px-2 py-1 text-xs"
+                        onClick={openNewAgentBuilder}
+                      >
+                        Create first agent
+                      </Button>
+                    )
                   ) : (
-                    <Button
-                      variant="link"
-                      className="h-auto px-2 py-1 text-xs"
-                      onClick={openNewAgentBuilder}
-                    >
-                      Create first agent
-                    </Button>
+                    <SidebarMenu>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          type="button"
+                          onClick={() => setLockedFeatureDialogOpen(true)}
+                          className="h-auto py-2 text-muted-foreground"
+                        >
+                          <LayersIcon />
+                          <span>Case Agent</span>
+                          <LockedFeatureChip className="ml-auto shrink-0" />
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton
+                          type="button"
+                          onClick={() => setLockedFeatureDialogOpen(true)}
+                          className="h-auto py-2 text-muted-foreground"
+                        >
+                          <Table2Icon />
+                          <span>Table Agent</span>
+                          <LockedFeatureChip className="ml-auto shrink-0" />
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    </SidebarMenu>
                   )}
                 </SidebarGroupContent>
               </CollapsibleContent>

--- a/frontend/src/components/tags-input.tsx
+++ b/frontend/src/components/tags-input.tsx
@@ -6,6 +6,7 @@ import fuzzysort from "fuzzysort"
 import { ChevronDown, X } from "lucide-react"
 import type React from "react"
 import { useCallback, useMemo, useRef, useState } from "react"
+import { LockedFeatureChip } from "@/components/locked-feature-modal"
 import { Badge } from "@/components/ui/badge"
 import {
   Command,
@@ -57,6 +58,8 @@ export interface Suggestion {
   description?: string
   group?: string
   icon?: React.ReactNode
+  locked?: boolean
+  onSelect?: () => void
 }
 
 export interface MultiTagCommandInputProps {
@@ -138,10 +141,15 @@ export function MultiTagCommandInput({
     return filterActions(filtered, inputValue).map((result) => result.obj)
   }, [suggestions, inputValue, valueSet, filterActions])
 
-  const handleSelect = (suggestionValue: string) => {
+  const handleSelect = (suggestion: Suggestion) => {
+    if (suggestion.locked) {
+      suggestion.onSelect?.()
+      return
+    }
+
     if (maxTags && value.length >= maxTags) return
 
-    const newValue = [...value, suggestionValue]
+    const newValue = [...value, suggestion.value]
     onChange?.(newValue)
     setInputValue("")
     setHighlightedIndex(-1)
@@ -282,10 +290,12 @@ export function MultiTagCommandInput({
                     <CommandItem
                       key={suggestion.id}
                       value={suggestion.value}
-                      onSelect={() => handleSelect(suggestion.value)}
+                      onSelect={() => handleSelect(suggestion)}
+                      onMouseDown={(e) => e.preventDefault()}
                       data-suggestion-index={index}
                       className={cn(
                         "flex cursor-pointer gap-2",
+                        suggestion.locked && "text-muted-foreground",
                         index === highlightedIndex &&
                           "bg-accent text-accent-foreground"
                       )}
@@ -296,14 +306,19 @@ export function MultiTagCommandInput({
                         </div>
                       )}
                       <div className="flex flex-col gap-1">
-                        <span className="font-medium">
-                          {suggestion.label}{" "}
-                          {suggestion.group && (
-                            <span className="text-xs text-muted-foreground">
-                              {suggestion.group}
-                            </span>
-                          )}
-                        </span>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">
+                            {suggestion.label}{" "}
+                            {suggestion.group && (
+                              <span className="text-xs text-muted-foreground">
+                                {suggestion.group}
+                              </span>
+                            )}
+                          </span>
+                          {suggestion.locked ? (
+                            <LockedFeatureChip className="shrink-0" />
+                          ) : null}
+                        </div>
                         {suggestion.description && (
                           <span className="text-xs text-muted-foreground">
                             {suggestion.description}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -1817,15 +1817,28 @@ export function useUserManager() {
 
 /* Registry Actions */
 // For selector node
-export function useBuilderRegistryActions(versions?: string[]) {
+interface UseBuilderRegistryActionsOptions {
+  versions?: string[]
+  includeLocked?: boolean
+}
+
+export function useBuilderRegistryActions(
+  options?: UseBuilderRegistryActionsOptions
+) {
   const {
     data: registryActions,
     isLoading: registryActionsIsLoading,
     error: registryActionsError,
   } = useQuery<RegistryActionReadMinimal[]>({
-    queryKey: ["builder_registry_actions", versions],
+    queryKey: [
+      "builder_registry_actions",
+      options?.versions,
+      options?.includeLocked,
+    ],
     queryFn: async () => {
-      return await registryActionsListRegistryActions()
+      return await registryActionsListRegistryActions(
+        options?.includeLocked ? { includeLocked: true } : {}
+      )
     },
   })
 
@@ -1866,15 +1879,22 @@ export function useGetRegistryAction(actionName?: string) {
 }
 
 // For selector node
-export function useRegistryActions(versions?: string[]) {
+interface UseRegistryActionsOptions {
+  versions?: string[]
+  includeLocked?: boolean
+}
+
+export function useRegistryActions(options?: UseRegistryActionsOptions) {
   const {
     data: registryActions,
     isLoading: registryActionsIsLoading,
     error: registryActionsError,
   } = useQuery<RegistryActionReadMinimal[]>({
-    queryKey: ["registry_actions", versions],
+    queryKey: ["registry_actions", options?.versions, options?.includeLocked],
     queryFn: async () => {
-      return await registryActionsListRegistryActions()
+      return await registryActionsListRegistryActions({
+        includeLocked: options?.includeLocked,
+      })
     },
   })
 

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -314,6 +314,7 @@ describe("ChatSessionPane", () => {
       namespace: "core.cases",
       type: "template" as const,
       origin: "tracecat://test",
+      availability: { locked: false, missing_entitlements: [] },
     }
     mockUseBuilderRegistryActions.mockReturnValue({
       registryActions: [action],
@@ -378,6 +379,7 @@ describe("ChatSessionPane", () => {
       namespace: "core.cases",
       type: "template" as const,
       origin: "tracecat://test",
+      availability: { locked: false, missing_entitlements: [] },
     }
     mockUseBuilderRegistryActions.mockReturnValue({
       registryActions: [action],
@@ -462,6 +464,7 @@ describe("ChatSessionPane", () => {
       namespace: "core.cases",
       type: "template" as const,
       origin: "tracecat://test",
+      availability: { locked: false, missing_entitlements: [] },
     }
     mockUseBuilderRegistryActions.mockReturnValue({
       registryActions: [action],
@@ -536,6 +539,7 @@ describe("ChatSessionPane", () => {
       namespace: "core.cases",
       type: "template" as const,
       origin: "tracecat://test",
+      availability: { locked: false, missing_entitlements: [] },
     }
     mockUseBuilderRegistryActions.mockReturnValue({
       registryActions: [action],
@@ -599,6 +603,7 @@ describe("ChatSessionPane", () => {
       namespace: "core.cases",
       type: "template" as const,
       origin: "tracecat://test",
+      availability: { locked: false, missing_entitlements: [] },
     }
     const getCase = {
       id: "action-2",
@@ -609,6 +614,7 @@ describe("ChatSessionPane", () => {
       namespace: "core.cases",
       type: "template" as const,
       origin: "tracecat://test",
+      availability: { locked: false, missing_entitlements: [] },
     }
     mockUseBuilderRegistryActions.mockReturnValue({
       registryActions: [listCases, getCase],

--- a/frontend/tests/tags-input.test.tsx
+++ b/frontend/tests/tags-input.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { MultiTagCommandInput } from "@/components/tags-input"
+
+describe("MultiTagCommandInput", () => {
+  beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+
+  it("invokes the locked suggestion handler when clicking the action row", () => {
+    const handleLockedSelect = jest.fn()
+
+    render(
+      <MultiTagCommandInput
+        suggestions={[
+          {
+            id: "locked-action",
+            label: "Locked action",
+            value: "tools.locked.action",
+            description: "Premium tool",
+            locked: true,
+            onSelect: handleLockedSelect,
+          },
+        ]}
+        searchKeys={["value", "label", "description", "group"]}
+      />
+    )
+
+    const input = screen.getByPlaceholderText("Add tags...")
+    fireEvent.focus(input)
+    fireEvent.mouseDown(screen.getByText("Locked action"))
+    fireEvent.click(screen.getByText("Locked action"))
+
+    expect(handleLockedSelect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/tests/use-builder-registry-actions.test.tsx
+++ b/frontend/tests/use-builder-registry-actions.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { registryActionsListRegistryActions } from "@/client"
+import { useBuilderRegistryActions } from "@/lib/hooks"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    registryActionsListRegistryActions: jest.fn(),
+  }
+})
+
+const mockRegistryActionsListRegistryActions =
+  registryActionsListRegistryActions as jest.MockedFunction<
+    typeof registryActionsListRegistryActions
+  >
+
+describe("useBuilderRegistryActions", () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+    mockRegistryActionsListRegistryActions.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+
+  it("does not request locked actions by default", async () => {
+    const { result } = renderHook(() => useBuilderRegistryActions(), {
+      wrapper,
+    })
+
+    await waitFor(() => {
+      expect(mockRegistryActionsListRegistryActions).toHaveBeenCalledTimes(1)
+      expect(result.current.registryActions).toEqual([])
+    })
+
+    expect(mockRegistryActionsListRegistryActions).toHaveBeenCalledWith({})
+  })
+
+  it("requests locked actions when explicitly enabled", async () => {
+    renderHook(() => useBuilderRegistryActions({ includeLocked: true }), {
+      wrapper,
+    })
+
+    await waitFor(() => {
+      expect(mockRegistryActionsListRegistryActions).toHaveBeenCalledWith({
+        includeLocked: true,
+      })
+    })
+  })
+})

--- a/packages/tracecat-registry/tracecat_registry/core/presets.py
+++ b/packages/tracecat-registry/tracecat_registry/core/presets.py
@@ -26,6 +26,7 @@ OutputTypeLiteral = Literal[
     display_group="Agent Presets",
     description="Create a new reusable agent preset configuration. Agent presets define LLM model settings, system instructions, available tools (actions), and output format. Once created, presets can be referenced by slug to run agents with consistent configurations.",
     namespace="ai.agent",
+    required_entitlements=["agent_addons"],
 )
 async def create_preset(
     name: Annotated[
@@ -106,6 +107,7 @@ async def create_preset(
     display_group="Agent Presets",
     description="Retrieve the full configuration details of an agent preset by its slug identifier. Returns all preset settings including model configuration, instructions, actions, and output type.",
     namespace="ai.agent",
+    required_entitlements=["agent_addons"],
 )
 async def get_preset(
     slug: Annotated[
@@ -123,6 +125,7 @@ async def get_preset(
     display_group="Agent Presets",
     description="List all agent presets available in the current workspace. Returns presets ordered by most recently created first.",
     namespace="ai.agent",
+    required_entitlements=["agent_addons"],
 )
 async def list_presets() -> list[dict[str, Any]]:
     return await get_context().agents.list_presets()
@@ -133,6 +136,7 @@ async def list_presets() -> list[dict[str, Any]]:
     display_group="Agent Presets",
     description="Update one or more fields of an existing agent preset. Only provide the fields you want to change. The preset is identified by its slug.",
     namespace="ai.agent",
+    required_entitlements=["agent_addons"],
 )
 async def update_preset(
     slug: Annotated[
@@ -215,6 +219,7 @@ async def update_preset(
     display_group="Agent Presets",
     description="Permanently delete an agent preset from the workspace. The preset is identified by its slug. This action cannot be undone.",
     namespace="ai.agent",
+    required_entitlements=["agent_addons"],
 )
 async def delete_preset(
     slug: Annotated[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -605,6 +605,86 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
                 "implementation": create_case_impl,
             }
 
+            # core.cases.create_task (case add-on gated)
+            create_task_impl = {
+                "type": "udf",
+                "url": origin,
+                "module": "tracecat_registry.core.ee.tasks",
+                "name": "create_task",
+            }
+            manifest_actions["core.cases.create_task"] = {
+                "namespace": "core.cases",
+                "name": "create_task",
+                "action_type": "udf",
+                "description": "Create a case task",
+                "default_title": "Create task",
+                "display_group": "Cases",
+                "interface": {"expects": {}, "returns": None},
+                "implementation": create_task_impl,
+                "options": {"required_entitlements": ["case_addons"]},
+            }
+
+            # core.cases.get_case_metrics (case add-on gated)
+            get_case_metrics_impl = {
+                "type": "udf",
+                "url": origin,
+                "module": "tracecat_registry.core.ee.durations",
+                "name": "get_case_metrics",
+            }
+            manifest_actions["core.cases.get_case_metrics"] = {
+                "namespace": "core.cases",
+                "name": "get_case_metrics",
+                "action_type": "udf",
+                "description": "Get case metrics",
+                "default_title": "Get case metrics",
+                "display_group": "Cases",
+                "interface": {"expects": {}, "returns": None},
+                "implementation": get_case_metrics_impl,
+                "options": {"required_entitlements": ["case_addons"]},
+            }
+
+            # ai.agent preset CRUD actions (agent add-on gated)
+            agent_preset_actions = {
+                "create_preset": {
+                    "description": "Create an agent preset",
+                    "default_title": "Create agent preset",
+                },
+                "get_preset": {
+                    "description": "Get an agent preset",
+                    "default_title": "Get agent preset",
+                },
+                "list_presets": {
+                    "description": "List agent presets",
+                    "default_title": "List agent presets",
+                },
+                "update_preset": {
+                    "description": "Update an agent preset",
+                    "default_title": "Update agent preset",
+                },
+                "delete_preset": {
+                    "description": "Delete an agent preset",
+                    "default_title": "Delete agent preset",
+                },
+            }
+            for action_name, metadata in agent_preset_actions.items():
+                preset_impl = {
+                    "type": "udf",
+                    "url": origin,
+                    "module": "tracecat_registry.core.presets",
+                    "name": action_name,
+                }
+                manifest_actions[f"ai.agent.{action_name}"] = {
+                    "namespace": "ai.agent",
+                    "name": action_name,
+                    "action_type": "udf",
+                    "description": metadata["description"],
+                    "default_title": metadata["default_title"],
+                    "display_group": "Agent Presets",
+                    "interface": {"expects": {}, "returns": None},
+                    "implementation": preset_impl,
+                    "options": {"required_entitlements": ["agent_addons"]},
+                }
+
             # core.table.lookup
             table_lookup_impl = {
                 "type": "udf",

--- a/tests/unit/api/test_api_registry_actions.py
+++ b/tests/unit/api/test_api_registry_actions.py
@@ -1,5 +1,6 @@
 """HTTP-level tests for registry actions endpoints."""
 
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -7,15 +8,29 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+import tracecat.auth.credentials as auth_credentials_module
 import tracecat.registry.actions.router as registry_actions_router
 from tracecat.auth.types import Role
 from tracecat.registry.actions.types import IndexEntry
+
+
+@pytest.fixture
+def mock_role_acl_dependency(
+    test_admin_role: Role,
+) -> Generator[AsyncMock, None, None]:
+    """Bypass RoleACL auth for registry action route tests."""
+    with patch.object(
+        auth_credentials_module, "_role_dependency", new_callable=AsyncMock
+    ) as mock_role_dependency:
+        mock_role_dependency.return_value = test_admin_role
+        yield mock_role_dependency
 
 
 @pytest.mark.anyio
 async def test_list_registry_actions_include_locked_returns_availability_metadata(
     client: TestClient,
     test_admin_role: Role,
+    mock_role_acl_dependency: AsyncMock,
 ) -> None:
     """Test GET /registry/actions supports include_locked."""
 

--- a/tests/unit/api/test_api_registry_actions.py
+++ b/tests/unit/api/test_api_registry_actions.py
@@ -1,0 +1,52 @@
+"""HTTP-level tests for registry actions endpoints."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+import tracecat.registry.actions.router as registry_actions_router
+from tracecat.auth.types import Role
+from tracecat.registry.actions.types import IndexEntry
+
+
+@pytest.mark.anyio
+async def test_list_registry_actions_include_locked_returns_availability_metadata(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test GET /registry/actions supports include_locked."""
+
+    with patch.object(
+        registry_actions_router, "RegistryActionsService"
+    ) as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.list_actions_from_index.return_value = [
+            (
+                IndexEntry(
+                    id=uuid4(),
+                    namespace="core.cases",
+                    name="create_task",
+                    action_type="udf",
+                    description="Create a task",
+                    default_title="Create task",
+                    display_group="Cases",
+                    options={"required_entitlements": ["case_addons"]},
+                    missing_entitlements=("case_addons",),
+                ),
+                "tracecat_registry",
+            )
+        ]
+        mock_service_cls.return_value = mock_service
+
+        response = client.get("/registry/actions", params={"include_locked": "true"})
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload[0]["availability"] == {
+        "locked": True,
+        "missing_entitlements": ["case_addons"],
+    }
+    mock_service.list_actions_from_index.assert_awaited_once_with(include_locked=True)

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -78,8 +78,17 @@ async def test_registry_actions_include_locked_marks_missing_entitlements(
 @pytest.mark.anyio
 async def test_registry_actions_include_locked_shows_agent_preset_crud(
     test_role,
+    monkeypatch,
 ) -> None:
     """Ensure agent preset CRUD actions show as locked when agent add-ons are disabled."""
+    from tracecat.tiers import defaults as tier_defaults
+
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(update={"agent_addons": False}),
+    )
+
     async with RegistryActionsService.with_session(test_role) as service:
         entries = await service.list_actions_from_index(
             namespace="ai.agent", include_locked=True

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -52,6 +52,47 @@ async def test_registry_actions_filtered_by_entitlements(test_role, monkeypatch)
         assert result is None
 
 
+@pytest.mark.anyio
+async def test_registry_actions_include_locked_marks_missing_entitlements(
+    test_role, monkeypatch
+):
+    """Ensure include_locked returns locked actions with availability metadata."""
+    from tracecat.tiers import defaults as tier_defaults
+
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(update={"case_addons": False}),
+    )
+
+    async with RegistryActionsService.with_session(test_role) as service:
+        entries = await service.list_actions_from_index(
+            namespace="core.cases", include_locked=True
+        )
+
+    actions = {f"{entry.namespace}.{entry.name}": entry for entry, _ in entries}
+    locked_action = actions["core.cases.create_task"]
+    assert locked_action.missing_entitlements == ("case_addons",)
+
+
+@pytest.mark.anyio
+async def test_registry_actions_include_locked_shows_agent_preset_crud(
+    test_role,
+) -> None:
+    """Ensure agent preset CRUD actions show as locked when agent add-ons are disabled."""
+    async with RegistryActionsService.with_session(test_role) as service:
+        entries = await service.list_actions_from_index(
+            namespace="ai.agent", include_locked=True
+        )
+
+    actions = {f"{entry.namespace}.{entry.name}": entry for entry, _ in entries}
+    assert actions["ai.agent.create_preset"].missing_entitlements == ("agent_addons",)
+    assert actions["ai.agent.get_preset"].missing_entitlements == ("agent_addons",)
+    assert actions["ai.agent.list_presets"].missing_entitlements == ("agent_addons",)
+    assert actions["ai.agent.update_preset"].missing_entitlements == ("agent_addons",)
+    assert actions["ai.agent.delete_preset"].missing_entitlements == ("agent_addons",)
+
+
 @pytest.fixture
 def mock_package(tmp_path):
     """Pytest fixture that creates a mock package with files and cleans up after the test."""

--- a/tracecat/registry/actions/router.py
+++ b/tracecat/registry/actions/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from tracecat_registry import RegistrySecret
 
 from tracecat.auth.credentials import RoleACL
@@ -25,10 +25,14 @@ async def list_registry_actions(
         require_workspace="no",
     ),
     session: AsyncDBSession,
+    include_locked: bool = Query(
+        default=False,
+        description="Include actions locked by missing entitlements",
+    ),
 ) -> list[RegistryActionReadMinimal]:
     """List all actions from registry index."""
     service = RegistryActionsService(session, role)
-    index_entries = await service.list_actions_from_index()
+    index_entries = await service.list_actions_from_index(include_locked=include_locked)
     return [
         RegistryActionReadMinimal.from_index(entry, origin)
         for entry, origin in index_entries

--- a/tracecat/registry/actions/schemas.py
+++ b/tracecat/registry/actions/schemas.py
@@ -187,6 +187,19 @@ class RegistryActionBase(BaseModel):
     repository_id: UUID4 = Field(..., description="The repository id")
 
 
+class RegistryActionAvailability(BaseModel):
+    """Availability metadata for a registry action."""
+
+    locked: bool = Field(
+        default=False,
+        description="Whether this action is locked behind an upgraded plan",
+    )
+    missing_entitlements: list[str] = Field(
+        default_factory=list,
+        description="Entitlements required to unlock this action",
+    )
+
+
 class RegistryActionReadMinimal(BaseModel):
     """API minimal read model for a registered action."""
 
@@ -201,6 +214,10 @@ class RegistryActionReadMinimal(BaseModel):
     )
     display_group: str | None = Field(
         None, description="The presentation group of the action"
+    )
+    availability: RegistryActionAvailability = Field(
+        default_factory=RegistryActionAvailability,
+        description="Availability metadata for this action",
     )
 
     @computed_field(return_type=str)
@@ -223,6 +240,10 @@ class RegistryActionReadMinimal(BaseModel):
             origin=origin,
             default_title=index.default_title,
             display_group=index.display_group,
+            availability=RegistryActionAvailability(
+                locked=bool(index.missing_entitlements),
+                missing_entitlements=list(index.missing_entitlements),
+            ),
         )
 
 

--- a/tracecat/registry/actions/service.py
+++ b/tracecat/registry/actions/service.py
@@ -214,7 +214,10 @@ class RegistryActionsService(BaseOrgService):
         return await self._is_custom_registry_enabled()
 
     async def _filter_index_entries_by_entitlements(
-        self, entries: list[tuple[IndexEntry, str]]
+        self,
+        entries: list[tuple[IndexEntry, str]],
+        *,
+        include_locked: bool = False,
     ) -> list[tuple[IndexEntry, str]]:
         required_any: set[str] = set()
         for entry, _origin in entries:
@@ -222,11 +225,14 @@ class RegistryActionsService(BaseOrgService):
         if not required_any:
             return entries
         enabled = await self._get_enabled_entitlements()
-        return [
-            (entry, origin)
-            for entry, origin in entries
-            if self._normalize_required_entitlements(entry.options).issubset(enabled)
-        ]
+        filtered: list[tuple[IndexEntry, str]] = []
+        for entry, origin in entries:
+            missing = self._normalize_required_entitlements(entry.options) - enabled
+            entry.missing_entitlements = tuple(sorted(missing))
+            if missing and not include_locked:
+                continue
+            filtered.append((entry, origin))
+        return filtered
 
     async def list_actions_from_index(
         self,
@@ -234,6 +240,7 @@ class RegistryActionsService(BaseOrgService):
         namespace: str | None = None,
         include_marked: bool = False,
         include_keys: set[str] | None = None,
+        include_locked: bool = False,
     ) -> list[tuple[IndexEntry, str]]:
         """List actions from registry index for current versions.
 
@@ -365,7 +372,9 @@ class RegistryActionsService(BaseOrgService):
                 options=row.options or {},
             )
             entries.append((entry, row.origin))
-        return await self._filter_index_entries_by_entitlements(entries)
+        return await self._filter_index_entries_by_entitlements(
+            entries, include_locked=include_locked
+        )
 
     async def list_actions_from_index_by_repository(
         self,

--- a/tracecat/registry/actions/types.py
+++ b/tracecat/registry/actions/types.py
@@ -33,6 +33,7 @@ class IndexEntry:
     doc_url: str | None = None
     author: str | None = None
     deprecated: str | None = None
+    missing_entitlements: tuple[str, ...] = ()
 
 
 @dataclass(slots=True)


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce entitlements across the UI. Locked actions can be listed on demand, appear muted with a lock chip, and open an upgrade modal; the API now returns availability metadata so the UI renders them safely.

- **New Features**
  - API
    - `GET /registry/actions` accepts `include_locked` to include locked actions.
    - `RegistryActionReadMinimal.availability` with `locked` and `missing_entitlements`, populated from entitlements checks.
    - Service filters locked actions unless `include_locked` is true and annotates `missing_entitlements`; router wires the query param.
    - Seeded premium-gated actions (case add-ons like `core.cases.create_task`/`get_case_metrics`, and agent preset CRUD), plus HTTP/unit tests for `include_locked` and availability.
  - UI
    - Added `LockedFeatureModal` and `LockedFeatureChip`.
    - Builder toolbar, selector, action panel (single/multi), tags input, and the actions inventory call `includeLocked: true`, gray out locked items, and open the modal on select; locked suggestions are non-selecting and show the chip.
    - Agents sidebar shows “create” only with `agent_addons`; otherwise shows locked placeholder agents (e.g., Case/Table Agent) with a lock chip and modal.
    - Hooks `useBuilderRegistryActions`/`useRegistryActions` accept `{ includeLocked }`; client `registryActionsListRegistryActions({ includeLocked })` added.

- **Migration**
  - To show locked actions, pass `includeLocked: true` to `useBuilderRegistryActions`/`useRegistryActions`, or call `registryActionsListRegistryActions({ includeLocked: true })`. No change needed if you prefer to hide locked actions.

<sup>Written for commit c782c62b4a6a449cfec3a356536e462d144902f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<img width="807" height="782" alt="image" src="https://github.com/user-attachments/assets/eec6bbd5-f0bf-491f-b106-50253ca9d8f5" />
<img width="997" height="435" alt="image" src="https://github.com/user-attachments/assets/91616688-aecc-4d2d-aa5e-5498982faf29" />
<img width="181" height="504" alt="image" src="https://github.com/user-attachments/assets/c5097e6a-4689-43b1-9d21-6a77f032c183" />
