### PR TITLE
fix(workflows): preserve imported runtime metadata

### DIFF
--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -262,6 +262,98 @@ async def test_workflow_import_ignores_empty_case_trigger(test_role: Role):
 
 
 @pytest.mark.anyio
+async def test_workflow_import_preserves_error_path_dependencies(
+    test_role: Role,
+) -> None:
+    dsl = ExternalWorkflowDefinition(
+        definition=DSLInput(
+            **{
+                "title": "error_path_import",
+                "description": "Workflow import with error path dependencies",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "reshape",
+                        "action": "core.transform.reshape",
+                        "args": {"value": 1},
+                    },
+                    {
+                        "ref": "reshape2",
+                        "action": "core.transform.reshape",
+                        "args": {"value": 2},
+                        "depends_on": ["reshape"],
+                    },
+                    {
+                        "ref": "reshape3",
+                        "action": "core.transform.reshape",
+                        "args": {"value": 3},
+                        "depends_on": ["reshape.error"],
+                    },
+                ],
+                "returns": "${{ ACTIONS.reshape2.result }}",
+            }
+        )
+    )
+
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await service.create_workflow_from_external_definition(
+            dsl.model_dump(mode="json")
+        )
+        stored_workflow = await service.get_workflow(WorkflowUUID.new(workflow.id))
+
+        assert stored_workflow is not None
+
+        actions_by_ref = {action.ref: action for action in stored_workflow.actions}
+        assert actions_by_ref["reshape3"].upstream_edges == [
+            {
+                "source_id": str(actions_by_ref["reshape"].id),
+                "source_type": "udf",
+                "source_handle": "error",
+            }
+        ]
+
+        round_tripped = await service.build_dsl_from_workflow(stored_workflow)
+        reshape3 = next(
+            action for action in round_tripped.actions if action.ref == "reshape3"
+        )
+        assert reshape3.depends_on == ["reshape.error"]
+
+
+@pytest.mark.anyio
+async def test_workflow_import_preserves_error_handler(test_role: Role) -> None:
+    dsl = ExternalWorkflowDefinition(
+        definition=DSLInput(
+            **{
+                "title": "error_handler_import",
+                "description": "Workflow import with error handler",
+                "entrypoint": {"expects": {}, "ref": None},
+                "actions": [
+                    {
+                        "ref": "reshape",
+                        "action": "core.transform.reshape",
+                        "args": {"value": 1},
+                    }
+                ],
+                "returns": "${{ ACTIONS.reshape.result }}",
+                "error_handler": "notify_ops",
+            }
+        )
+    )
+
+    async with WorkflowsManagementService.with_session(test_role) as service:
+        workflow = await service.create_workflow_from_external_definition(
+            dsl.model_dump(mode="json")
+        )
+        stored_workflow = await service.get_workflow(WorkflowUUID.new(workflow.id))
+
+        assert stored_workflow is not None
+        assert stored_workflow.error_handler == "notify_ops"
+
+        round_tripped = await service.build_dsl_from_workflow(stored_workflow)
+        assert round_tripped.error_handler == "notify_ops"
+
+
+@pytest.mark.anyio
 async def test_workflow_import_applies_layout(test_role: Role):
     dsl = ExternalWorkflowDefinition(
         definition=DSLInput(

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -18,6 +18,7 @@ from tracecat.db.models import (
 from tracecat.dsl.common import DSLConfig, DSLEntrypoint, DSLInput
 from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import ActionStatement
+from tracecat.expressions.expectations import ExpectedField
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig
 from tracecat.workflow.case_triggers.service import CaseTriggersService
@@ -365,6 +366,71 @@ class TestWorkflowImportService:
         definitions = result.scalars().all()
         assert len(definitions) == 2  # Original + updated
         assert definitions[0].version == 2  # Latest version
+
+    @pytest.mark.anyio
+    async def test_import_workflow_overwrite_refreshes_runtime_metadata(
+        self,
+        import_service: WorkflowImportService,
+        remote_workflow_definition: RemoteWorkflowDefinition,
+        session: AsyncSession,
+    ) -> None:
+        """Overwrite should refresh runtime-relevant draft workflow metadata."""
+        initial_dsl = remote_workflow_definition.definition.model_copy(deep=True)
+        initial_dsl.entrypoint = DSLEntrypoint(
+            ref="test_action",
+            expects={
+                "old_input": ExpectedField(type="str", description="Old input"),
+            },
+        )
+        initial_dsl.returns = "${{ ACTIONS.second_action.result }}"
+        initial_dsl.config = DSLConfig(environment="default", timeout=300)
+        initial_dsl.error_handler = "old_error_handler"
+
+        initial_remote = remote_workflow_definition.model_copy(deep=True)
+        initial_remote.definition = initial_dsl
+
+        first_result = await import_service.import_workflows_atomic(
+            remote_workflows=[initial_remote],
+            commit_sha="abc123",
+        )
+        assert first_result.success is True
+
+        updated_dsl = initial_dsl.model_copy(deep=True)
+        updated_dsl.entrypoint = DSLEntrypoint(
+            ref="second_action",
+            expects={
+                "new_input": ExpectedField(type="int", description="New input"),
+            },
+        )
+        updated_dsl.returns = {"wrapped": "${{ ACTIONS.second_action.result }}"}
+        updated_dsl.config = DSLConfig(environment="staging", timeout=900)
+        updated_dsl.error_handler = "new_error_handler"
+
+        updated_remote = remote_workflow_definition.model_copy(deep=True)
+        updated_remote.definition = updated_dsl
+
+        second_result = await import_service.import_workflows_atomic(
+            remote_workflows=[updated_remote],
+            commit_sha="def456",
+        )
+        assert second_result.success is True
+
+        wf_id = WorkflowUUID.new("wf_testworkflow001")
+        stmt = select(Workflow).where(Workflow.id == wf_id)
+        result = await session.execute(stmt)
+        workflow = result.scalars().first()
+        assert workflow is not None
+
+        assert workflow.expects == updated_dsl.entrypoint.model_dump().get("expects")
+        assert workflow.returns == updated_dsl.returns
+        assert workflow.config == updated_dsl.config.model_dump()
+        assert workflow.error_handler == "new_error_handler"
+
+        built_dsl = await import_service.wf_mgmt.build_dsl_from_workflow(workflow)
+        assert built_dsl.entrypoint.expects == updated_dsl.entrypoint.expects
+        assert built_dsl.returns == updated_dsl.returns
+        assert built_dsl.config == updated_dsl.config
+        assert built_dsl.error_handler == "new_error_handler"
 
     @pytest.mark.anyio
     async def test_import_workflow_overwrite_default_behavior(

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -31,6 +31,7 @@ from tracecat.dsl.common import (
     DSLEntrypoint,
     DSLInput,
     build_action_statements_from_actions,
+    edge_components_from_dep,
 )
 from tracecat.dsl.schemas import DSLConfig, ExecutionContext, RunContext
 from tracecat.dsl.view import RFGraph
@@ -80,6 +81,18 @@ class WorkflowsManagementService(BaseWorkspaceService):
     """Manages CRUD operations for Workflows."""
 
     service_name = "workflows"
+
+    @staticmethod
+    def _workflow_fields_from_dsl(dsl: DSLInput) -> dict[str, Any]:
+        """Project runtime-relevant workflow fields from a DSLInput."""
+        return {
+            "title": dsl.title,
+            "description": dsl.description,
+            "expects": dsl.entrypoint.model_dump().get("expects"),
+            "returns": dsl.returns,
+            "config": dsl.config.model_dump(),
+            "error_handler": dsl.error_handler,
+        }
 
     @staticmethod
     def _build_schedule_summary_subqueries() -> tuple[sa.Subquery, sa.Subquery]:
@@ -909,15 +922,10 @@ class WorkflowsManagementService(BaseWorkspaceService):
         resolved_lock = await lock_service.resolve_lock_with_bindings(action_names)
         registry_lock = resolved_lock.model_dump()
 
-        entrypoint = dsl.entrypoint.model_dump()
         workflow_kwargs = {
-            "title": dsl.title,
-            "description": dsl.description,
             "workspace_id": self.workspace_id,
-            "returns": dsl.returns,
-            "config": dsl.config.model_dump(),
-            "expects": entrypoint.get("expects"),
             "registry_lock": registry_lock,
+            **self._workflow_fields_from_dsl(dsl),
         }
         if workflow_id:
             workflow_kwargs["id"] = workflow_id
@@ -1015,12 +1023,13 @@ class WorkflowsManagementService(BaseWorkspaceService):
 
             if act_stmt.depends_on:
                 for dep_ref in act_stmt.depends_on:
-                    if dep_action := ref_to_action.get(dep_ref):
+                    src_ref, edge_type = edge_components_from_dep(dep_ref)
+                    if dep_action := ref_to_action.get(src_ref):
                         upstream_edges.append(
                             ActionEdge(
                                 source_id=str(dep_action.id),
                                 source_type="udf",
-                                source_handle="success",
+                                source_handle=edge_type.value,
                             )
                         )
             else:

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -292,18 +292,20 @@ class WorkflowImportService(BaseWorkspaceService):
         self, existing_workflow: Workflow, remote_workflow: RemoteWorkflowDefinition
     ) -> None:
         """Update existing workflow with new definition and related entities."""
+        dsl = remote_workflow.definition
+
         # 1. Add new WorkflowDefinition (versioned)
         defn_service = WorkflowDefinitionsService(session=self.session, role=self.role)
         wf_id = WorkflowUUID.new(existing_workflow.id)
         defn = await defn_service.create_workflow_definition(
-            wf_id, remote_workflow.definition, alias=remote_workflow.alias, commit=False
+            wf_id, dsl, alias=remote_workflow.alias, commit=False
         )
 
         # 2. Update workflow metadata
         existing_workflow.version = defn.version
-        existing_workflow.title = remote_workflow.definition.title
-        existing_workflow.description = remote_workflow.definition.description
         existing_workflow.alias = remote_workflow.alias
+        for field, value in self.wf_mgmt._workflow_fields_from_dsl(dsl).items():
+            setattr(existing_workflow, field, value)
 
         # 3. Delete existing actions and recreate from DSL
         # (Actions are tightly coupled to the DSL definition)
@@ -313,7 +315,6 @@ class WorkflowImportService(BaseWorkspaceService):
             await self.session.flush()
 
         # 4. Recreate actions from DSL
-        dsl = remote_workflow.definition
         actions = await self.wf_mgmt.create_actions_from_dsl(dsl, existing_workflow.id)
         existing_workflow.actions = actions
 


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes workflow import drift in the runtime-relevant metadata path.

- preserve `error_handler` when importing a workflow export
- keep `.error` dependency edges linked during import
- refresh `expects`, `returns`, `config`, and `error_handler` when Git sync overwrites an existing workflow so draft execution paths do not run a hybrid workflow
- add focused regression coverage for error-path dependencies, error-handler import, and Git sync overwrite metadata refresh

## Related Issues

N/A

## Screenshots / Recordings

N/A

## Steps to QA

1. Import a workflow export with `definition.error_handler` set and verify the imported workflow retains the handler.
2. Import a workflow export with `depends_on: ["reshape.error"]` and verify the error edge is still linked after import.
3. Re-import a Git-synced workflow with changed `expects`, `returns`, `config`, and `error_handler`.
4. Verify the overwritten workflow reflects those values when rebuilt through the draft workflow path.
5. Run `TRACECAT__SERVICE_KEY=test uv run pytest tests/unit/test_export.py tests/unit/test_workflow_import_service.py -q`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `error_handler` and `.error` edges during import, and refreshes runtime metadata on Git sync to prevent hybrid drafts.

- **Bug Fixes**
  - Keep `error_handler` from imported DSL and in round-trips.
  - Preserve `.error` dependency edges by parsing the handle and setting the correct `source_handle`.
  - On Git sync overwrite, refresh runtime fields: `expects`, `returns`, `config`, and `error_handler`.

<sup>Written for commit 3fc53cbddffce9df037b5eb6788fab9ff3521a11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

