### PR TITLE
feat(agent): add Novita provider support

### DIFF
--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -155,7 +155,7 @@ class TracecatCallbackHandler(CustomLogger):
         _inject_provider_credentials(data, provider, creds)
         if (
             model_base_url := user_api_key_dict.metadata.get("base_url")
-        ) and provider in {"openai", "anthropic", "custom-model-provider"}:
+        ) and provider in {"openai", "anthropic", "custom-model-provider", "novita"}:
             # Preset/config base_url should override provider credential base URL
             data["api_base"] = model_base_url
 
@@ -203,6 +203,22 @@ def _inject_provider_credentials(
 ) -> None:
     """Inject provider-specific credentials into request."""
     match provider:
+        case "novita":
+            api_key = creds.get("NOVITA_API_KEY")
+            if not api_key:
+                logger.warning(
+                    "Required credential key missing for provider", provider=provider
+                )
+                raise ProxyException(
+                    message="Provider credentials incomplete",
+                    type="auth_error",
+                    param=None,
+                    code=401,
+                )
+            data["api_key"] = api_key
+            if base_url := creds.get("NOVITA_BASE_URL"):
+                data["api_base"] = base_url
+
         case "openai":
             api_key = creds.get("OPENAI_API_KEY")
             if not api_key:

--- a/tracecat/agent/providers.py
+++ b/tracecat/agent/providers.py
@@ -56,6 +56,15 @@ def get_model(
                     base_url=base_url, api_key=secrets.get("OPENAI_API_KEY")
                 ),
             )
+        case "novita":
+            model = OpenAIChatModel(
+                model_name=model_name,
+                provider=OpenAIProvider(
+                    base_url="https://api.novita.ai/openai/v1",
+                    api_key=secrets.get("NOVITA_API_KEY"),
+                ),
+            )
+
         case "ollama":
             model = OpenAIChatModel(
                 model_name=model_name,


### PR DESCRIPTION
- Add 'novita' provider case to get_model() in providers.py
- Novita uses OpenAI-compatible API at https://api.novita.ai/openai/v1
- Add Novita credentials injection to gateway's _inject_provider_credentials()
- Support NOVITA_API_KEY and NOVITA_BASE_URL credentials
- Add 'novita' to base_url override set in TracecatCallbackHandler.pre_call_hook


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Novita provider support via its OpenAI-compatible API, enabling chat requests to route through Novita. Includes credential injection and base URL override support.

- **New Features**
  - Added `novita` to `get_model()` using `https://api.novita.ai/openai/v1`.
  - Injects Novita credentials in the gateway: requires `NOVITA_API_KEY`, optional `NOVITA_BASE_URL`.
  - Allows preset `base_url` to override provider URL for `novita` in `pre_call_hook`.

<sup>Written for commit a62a366b36e89a8a9a6dbe382053ef04a25c5314. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

