### PR TITLE
fix(registry): support disabling SSH host key checks

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/ssh.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ssh.py
@@ -29,6 +29,16 @@ class SSHCommandResult(TypedDict):
     exit_status: int
 
 
+class _TransientMissingHostKeyPolicy(paramiko.MissingHostKeyPolicy):
+    """Accept unknown host keys for this client without persisting them."""
+
+    def missing_host_key(  # noqa: D102
+        self, client: paramiko.SSHClient, hostname: str, key: paramiko.PKey
+    ) -> None:
+        del client, hostname, key
+        return None
+
+
 def _load_private_key(private_key: str) -> paramiko.PKey:
     key_stream = io.StringIO(private_key)
     key_types = (
@@ -112,8 +122,8 @@ def execute_command(
     """Execute a command over SSH and return stdout, stderr, and exit status.
 
     By default, unknown host keys are rejected; provide `host_public_key` to trust
-    a host. Set `host_key_checking=False` to disable application-level pinning
-    while still using Paramiko's default host key policy.
+    a host. Set `host_key_checking=False` to accept an unknown host key for this
+    action run only, without persisting trust across runs or workers.
     """
     private_key = secrets.get("PRIVATE_KEY")
     pkey = _load_private_key(private_key)
@@ -138,14 +148,16 @@ def execute_command(
                 client.set_missing_host_key_policy(paramiko.RejectPolicy())
             else:
                 warnings.warn(
-                    "host_key_checking=False disables application-level host key "
-                    "pinning for this action run, but unknown SSH host keys are "
-                    "still subject to Paramiko's default safe policy. Neither PID "
-                    "isolation nor nsjail protects against SSH man-in-the-middle "
-                    "attacks; prefer host_public_key pinning for production use.",
+                    "host_key_checking=False temporarily trusts unknown SSH host "
+                    "keys for this action run only. The accepted key is not "
+                    "persisted across action runs or shared workers, but neither "
+                    "PID isolation nor nsjail protects against SSH man-in-the-"
+                    "middle attacks; prefer host_public_key pinning for "
+                    "production use.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
+                client.set_missing_host_key_policy(_TransientMissingHostKeyPolicy())
 
             client.connect(
                 hostname=host,

--- a/packages/tracecat-registry/tracecat_registry/core/ssh.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ssh.py
@@ -3,6 +3,7 @@
 import io
 import os
 import tempfile
+import warnings
 from typing import Annotated, TypedDict
 
 import paramiko
@@ -91,7 +92,8 @@ def execute_command(
     host_key_checking: Annotated[
         bool,
         Doc(
-            "Whether to verify the remote host key before connecting. Disable only for first-contact or otherwise trusted hosts."
+            "Whether to verify the remote host key before connecting. Disable only for first-contact or otherwise trusted hosts; "
+            "PID isolation and nsjail do not protect against SSH man-in-the-middle attacks."
         ),
     ] = True,
     password: Annotated[
@@ -135,6 +137,14 @@ def execute_command(
                 client.load_host_keys(known_hosts_path)
                 client.set_missing_host_key_policy(paramiko.RejectPolicy())
             else:
+                warnings.warn(
+                    "host_key_checking=False temporarily trusts unknown SSH host keys "
+                    "for this action run. Neither PID isolation nor nsjail protects "
+                    "against SSH man-in-the-middle attacks; prefer host_public_key "
+                    "pinning for production use.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
                 client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
             client.connect(

--- a/packages/tracecat-registry/tracecat_registry/core/ssh.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ssh.py
@@ -77,17 +77,23 @@ def execute_command(
         str,
         Doc("SSH host to connect to."),
     ],
-    host_public_key: Annotated[
-        str,
-        Doc(
-            "Expected public host key for the target host in '<key_type> <base64>' format. "
-            "For non-22 ports, the entry is stored as [host]:port."
-        ),
-    ],
     username: Annotated[
         str,
         Doc("SSH username."),
     ],
+    host_public_key: Annotated[
+        str | None,
+        Doc(
+            "Expected public host key for the target host in '<key_type> <base64>' format. "
+            "Required when host_key_checking is enabled. For non-22 ports, the entry is stored as [host]:port."
+        ),
+    ] = None,
+    host_key_checking: Annotated[
+        bool,
+        Doc(
+            "Whether to verify the remote host key before connecting. Disable only for first-contact or otherwise trusted hosts."
+        ),
+    ] = True,
     password: Annotated[
         str | None,
         Doc("Password for the SSH user."),
@@ -103,7 +109,9 @@ def execute_command(
 ) -> SSHCommandResult:
     """Execute a command over SSH and return stdout, stderr, and exit status.
 
-    Unknown host keys are rejected; provide `host_public_key` to trust a host.
+    By default, unknown host keys are rejected; provide `host_public_key` to trust
+    a host. Set `host_key_checking=False` to accept unknown host keys for this
+    action run.
     """
     private_key = secrets.get("PRIVATE_KEY")
     pkey = _load_private_key(private_key)
@@ -111,17 +119,23 @@ def execute_command(
     with paramiko.SSHClient() as client:
         known_hosts_path: str | None = None
         try:
-            known_hosts_data = _build_known_hosts(host, port, host_public_key)
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                delete=False,
-                encoding="utf-8",
-            ) as known_hosts_file:
-                known_hosts_file.write(known_hosts_data)
-                known_hosts_path = known_hosts_file.name
-            client.load_host_keys(known_hosts_path)
-
-            client.set_missing_host_key_policy(paramiko.RejectPolicy())
+            if host_key_checking:
+                if host_public_key is None:
+                    raise ValueError(
+                        "host_public_key is required when host_key_checking is enabled."
+                    )
+                known_hosts_data = _build_known_hosts(host, port, host_public_key)
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    delete=False,
+                    encoding="utf-8",
+                ) as known_hosts_file:
+                    known_hosts_file.write(known_hosts_data)
+                    known_hosts_path = known_hosts_file.name
+                client.load_host_keys(known_hosts_path)
+                client.set_missing_host_key_policy(paramiko.RejectPolicy())
+            else:
+                client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
             client.connect(
                 hostname=host,

--- a/packages/tracecat-registry/tracecat_registry/core/ssh.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ssh.py
@@ -29,6 +29,16 @@ class SSHCommandResult(TypedDict):
     exit_status: int
 
 
+class _TransientMissingHostKeyPolicy(paramiko.MissingHostKeyPolicy):
+    """Accept unknown host keys for a single client without persisting trust."""
+
+    def missing_host_key(  # noqa: D102
+        self, client: paramiko.SSHClient, hostname: str, key: paramiko.PKey
+    ) -> None:
+        del client, hostname, key
+        return None
+
+
 def _load_private_key(private_key: str) -> paramiko.PKey:
     key_stream = io.StringIO(private_key)
     key_types = (
@@ -140,12 +150,13 @@ def execute_command(
                 warnings.warn(
                     "host_key_checking=False temporarily trusts unknown SSH host keys "
                     "for this action run. Neither PID isolation nor nsjail protects "
-                    "against SSH man-in-the-middle attacks; prefer host_public_key "
-                    "pinning for production use.",
+                    "against SSH man-in-the-middle attacks, but the accepted key is "
+                    "not persisted across action runs or shared workers. Prefer "
+                    "host_public_key pinning for production use.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
-                client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                client.set_missing_host_key_policy(_TransientMissingHostKeyPolicy())
 
             client.connect(
                 hostname=host,

--- a/packages/tracecat-registry/tracecat_registry/core/ssh.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ssh.py
@@ -29,16 +29,6 @@ class SSHCommandResult(TypedDict):
     exit_status: int
 
 
-class _TransientMissingHostKeyPolicy(paramiko.MissingHostKeyPolicy):
-    """Accept unknown host keys for a single client without persisting trust."""
-
-    def missing_host_key(  # noqa: D102
-        self, client: paramiko.SSHClient, hostname: str, key: paramiko.PKey
-    ) -> None:
-        del client, hostname, key
-        return None
-
-
 def _load_private_key(private_key: str) -> paramiko.PKey:
     key_stream = io.StringIO(private_key)
     key_types = (
@@ -122,8 +112,8 @@ def execute_command(
     """Execute a command over SSH and return stdout, stderr, and exit status.
 
     By default, unknown host keys are rejected; provide `host_public_key` to trust
-    a host. Set `host_key_checking=False` to accept unknown host keys for this
-    action run.
+    a host. Set `host_key_checking=False` to disable application-level pinning
+    while still using Paramiko's default host key policy.
     """
     private_key = secrets.get("PRIVATE_KEY")
     pkey = _load_private_key(private_key)
@@ -148,15 +138,14 @@ def execute_command(
                 client.set_missing_host_key_policy(paramiko.RejectPolicy())
             else:
                 warnings.warn(
-                    "host_key_checking=False temporarily trusts unknown SSH host keys "
-                    "for this action run. Neither PID isolation nor nsjail protects "
-                    "against SSH man-in-the-middle attacks, but the accepted key is "
-                    "not persisted across action runs or shared workers. Prefer "
-                    "host_public_key pinning for production use.",
+                    "host_key_checking=False disables application-level host key "
+                    "pinning for this action run, but unknown SSH host keys are "
+                    "still subject to Paramiko's default safe policy. Neither PID "
+                    "isolation nor nsjail protects against SSH man-in-the-middle "
+                    "attacks; prefer host_public_key pinning for production use.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
-                client.set_missing_host_key_policy(_TransientMissingHostKeyPolicy())
 
             client.connect(
                 hostname=host,

--- a/tests/unit/test_registry_core_ssh.py
+++ b/tests/unit/test_registry_core_ssh.py
@@ -41,7 +41,7 @@ def test_execute_command_rejects_missing_host_key_when_checking_enabled(
     mock_ssh_client.connect.assert_not_called()
 
 
-def test_execute_command_uses_auto_add_policy_when_host_key_checking_disabled(
+def test_execute_command_uses_transient_accept_policy_when_host_key_checking_disabled(
     monkeypatch: pytest.MonkeyPatch,
     mock_ssh_client: MagicMock,
 ) -> None:
@@ -49,17 +49,17 @@ def test_execute_command_uses_auto_add_policy_when_host_key_checking_disabled(
     monkeypatch.setattr(registry_ssh, "_load_private_key", lambda private_key: MagicMock())
     monkeypatch.setattr(paramiko, "SSHClient", lambda: mock_ssh_client)
 
-    with pytest.warns(RuntimeWarning, match="host_key_checking=False temporarily"):
+    with pytest.warns(RuntimeWarning, match="not persisted across action runs"):
         result = registry_ssh.execute_command(
             command="hostname",
             host="example.com",
             username="root",
             host_key_checking=False,
-        )
+    )
 
     mock_ssh_client.load_host_keys.assert_not_called()
     policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
-    assert isinstance(policy, paramiko.AutoAddPolicy)
+    assert isinstance(policy, registry_ssh._TransientMissingHostKeyPolicy)
     assert result == {"stdout": "hello\n", "stderr": "", "exit_status": 0}
 
 

--- a/tests/unit/test_registry_core_ssh.py
+++ b/tests/unit/test_registry_core_ssh.py
@@ -49,12 +49,13 @@ def test_execute_command_uses_auto_add_policy_when_host_key_checking_disabled(
     monkeypatch.setattr(registry_ssh, "_load_private_key", lambda private_key: MagicMock())
     monkeypatch.setattr(paramiko, "SSHClient", lambda: mock_ssh_client)
 
-    result = registry_ssh.execute_command(
-        command="hostname",
-        host="example.com",
-        username="root",
-        host_key_checking=False,
-    )
+    with pytest.warns(RuntimeWarning, match="host_key_checking=False temporarily"):
+        result = registry_ssh.execute_command(
+            command="hostname",
+            host="example.com",
+            username="root",
+            host_key_checking=False,
+        )
 
     mock_ssh_client.load_host_keys.assert_not_called()
     policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]

--- a/tests/unit/test_registry_core_ssh.py
+++ b/tests/unit/test_registry_core_ssh.py
@@ -41,7 +41,7 @@ def test_execute_command_rejects_missing_host_key_when_checking_enabled(
     mock_ssh_client.connect.assert_not_called()
 
 
-def test_execute_command_retains_default_policy_when_host_key_checking_disabled(
+def test_execute_command_uses_transient_policy_when_host_key_checking_disabled(
     monkeypatch: pytest.MonkeyPatch,
     mock_ssh_client: MagicMock,
 ) -> None:
@@ -49,7 +49,7 @@ def test_execute_command_retains_default_policy_when_host_key_checking_disabled(
     monkeypatch.setattr(registry_ssh, "_load_private_key", lambda private_key: MagicMock())
     monkeypatch.setattr(paramiko, "SSHClient", lambda: mock_ssh_client)
 
-    with pytest.warns(RuntimeWarning, match="default safe policy"):
+    with pytest.warns(RuntimeWarning, match="not persisted across action runs"):
         result = registry_ssh.execute_command(
             command="hostname",
             host="example.com",
@@ -58,7 +58,8 @@ def test_execute_command_retains_default_policy_when_host_key_checking_disabled(
         )
 
     mock_ssh_client.load_host_keys.assert_not_called()
-    mock_ssh_client.set_missing_host_key_policy.assert_not_called()
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, registry_ssh._TransientMissingHostKeyPolicy)
     assert result == {"stdout": "hello\n", "stderr": "", "exit_status": 0}
 
 

--- a/tests/unit/test_registry_core_ssh.py
+++ b/tests/unit/test_registry_core_ssh.py
@@ -41,7 +41,7 @@ def test_execute_command_rejects_missing_host_key_when_checking_enabled(
     mock_ssh_client.connect.assert_not_called()
 
 
-def test_execute_command_uses_transient_accept_policy_when_host_key_checking_disabled(
+def test_execute_command_retains_default_policy_when_host_key_checking_disabled(
     monkeypatch: pytest.MonkeyPatch,
     mock_ssh_client: MagicMock,
 ) -> None:
@@ -49,17 +49,16 @@ def test_execute_command_uses_transient_accept_policy_when_host_key_checking_dis
     monkeypatch.setattr(registry_ssh, "_load_private_key", lambda private_key: MagicMock())
     monkeypatch.setattr(paramiko, "SSHClient", lambda: mock_ssh_client)
 
-    with pytest.warns(RuntimeWarning, match="not persisted across action runs"):
+    with pytest.warns(RuntimeWarning, match="default safe policy"):
         result = registry_ssh.execute_command(
             command="hostname",
             host="example.com",
             username="root",
             host_key_checking=False,
-    )
+        )
 
     mock_ssh_client.load_host_keys.assert_not_called()
-    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
-    assert isinstance(policy, registry_ssh._TransientMissingHostKeyPolicy)
+    mock_ssh_client.set_missing_host_key_policy.assert_not_called()
     assert result == {"stdout": "hello\n", "stderr": "", "exit_status": 0}
 
 

--- a/tests/unit/test_registry_core_ssh.py
+++ b/tests/unit/test_registry_core_ssh.py
@@ -1,0 +1,84 @@
+"""Tests for registry SSH actions."""
+
+from unittest.mock import MagicMock
+
+import paramiko
+import pytest
+from tracecat_registry.core import ssh as registry_ssh
+
+
+@pytest.fixture
+def mock_ssh_client() -> MagicMock:
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = False
+
+    stdin = MagicMock()
+    stdout = MagicMock()
+    stderr = MagicMock()
+    stdout.read.return_value = b"hello\n"
+    stderr.read.return_value = b""
+    stdout.channel.recv_exit_status.return_value = 0
+    client.exec_command.return_value = (stdin, stdout, stderr)
+    return client
+
+
+def test_execute_command_rejects_missing_host_key_when_checking_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_ssh_client: MagicMock,
+) -> None:
+    monkeypatch.setattr(registry_ssh.secrets, "get", lambda key: "private-key")
+    monkeypatch.setattr(registry_ssh, "_load_private_key", lambda private_key: MagicMock())
+    monkeypatch.setattr(paramiko, "SSHClient", lambda: mock_ssh_client)
+
+    with pytest.raises(ValueError, match="host_public_key is required"):
+        registry_ssh.execute_command(
+            command="hostname",
+            host="example.com",
+            username="root",
+        )
+
+    mock_ssh_client.connect.assert_not_called()
+
+
+def test_execute_command_uses_auto_add_policy_when_host_key_checking_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_ssh_client: MagicMock,
+) -> None:
+    monkeypatch.setattr(registry_ssh.secrets, "get", lambda key: "private-key")
+    monkeypatch.setattr(registry_ssh, "_load_private_key", lambda private_key: MagicMock())
+    monkeypatch.setattr(paramiko, "SSHClient", lambda: mock_ssh_client)
+
+    result = registry_ssh.execute_command(
+        command="hostname",
+        host="example.com",
+        username="root",
+        host_key_checking=False,
+    )
+
+    mock_ssh_client.load_host_keys.assert_not_called()
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, paramiko.AutoAddPolicy)
+    assert result == {"stdout": "hello\n", "stderr": "", "exit_status": 0}
+
+
+def test_execute_command_uses_known_hosts_when_host_key_checking_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_ssh_client: MagicMock,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(registry_ssh.secrets, "get", lambda key: "private-key")
+    monkeypatch.setattr(registry_ssh, "_load_private_key", lambda private_key: MagicMock())
+    monkeypatch.setattr(paramiko, "SSHClient", lambda: mock_ssh_client)
+    monkeypatch.setattr(registry_ssh.tempfile, "NamedTemporaryFile", lambda **kwargs: open(tmp_path / "known_hosts", "w", encoding="utf-8"))
+
+    registry_ssh.execute_command(
+        command="hostname",
+        host="example.com",
+        username="root",
+        host_public_key="ssh-ed25519 AAAA",
+    )
+
+    mock_ssh_client.load_host_keys.assert_called_once_with(str(tmp_path / "known_hosts"))
+    policy = mock_ssh_client.set_missing_host_key_policy.call_args.args[0]
+    assert isinstance(policy, paramiko.RejectPolicy)


### PR DESCRIPTION
### Motivation
- Users reported `core.ssh.execute_command` fails on first-time SSH connections because the executor container has no `known_hosts` entry and there was no way to auto-add the host key.

### Description
- Add a `host_key_checking: bool = True` parameter to `core.ssh.execute_command` and make `host_public_key` optional when checking is disabled in `packages/tracecat-registry/tracecat_registry/core/ssh.py`.
- When `host_key_checking=True` the function requires `host_public_key`, writes a temporary `known_hosts` file and uses `paramiko.RejectPolicy()`; when `host_key_checking=False` it uses `paramiko.AutoAddPolicy()` to accept first-contact hosts.
- Add focused unit tests in `tests/unit/test_registry_core_ssh.py` covering the missing-key rejection, the auto-add flow, and the known-hosts flow.

### Testing
- Ran `uv run ruff check --fix packages/tracecat-registry/tracecat_registry/core/ssh.py tests/unit/test_registry_core_ssh.py` and fixed lint issues successfully.
- Ran `uv run basedpyright packages/tracecat-registry/tracecat_registry/core/ssh.py tests/unit/test_registry_core_ssh.py` which completed without errors.
- Ran `uv run pytest --noconftest tests/unit/test_registry_core_ssh.py` and the three new tests passed; running the broader `uv run pytest tests/unit/test_registry_core_ssh.py tests/unit/test_ssh.py` in this environment failed due to the shared test setup requiring PostgreSQL on `localhost:5432`, which was not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babba6a07c83339ed0f0c12514c754)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an option to disable app-level SSH host key pinning in `core.ssh.execute_command` to ease first-time connections. Default stays strict with a temp `known_hosts`; when disabled we warn and accept the host key transiently without persisting trust.

- **Bug Fixes**
  - Add `host_key_checking` (default True); `host_public_key` required when enabled and optional when disabled.
  - When enabled: write temp `known_hosts` and use `paramiko.RejectPolicy()`.
  - When disabled: emit `RuntimeWarning` and set `_TransientMissingHostKeyPolicy` to accept unknown keys for this run only; do not load `known_hosts` or persist trust.
  - Add unit tests for missing-key validation, transient-policy path, and known-hosts path.

<sup>Written for commit 44b06022f8f3cdd573612f4e3392028a9d60531f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

