### PR TITLE
fix(cases): include reply context in comment triggers

### DIFF
--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -362,10 +362,45 @@ class TestCaseCommentsService:
         assert workflow_publish["case_id"] == str(test_case.id)
         assert workflow_publish["workspace_id"] == str(test_case.workspace_id)
         assert workflow_publish["extra_fields"]["comment_id"] == str(created_comment.id)
+        assert workflow_publish["extra_fields"]["comment"] == "Run this workflow"
+        assert workflow_publish["extra_fields"]["parent_id"] is None
         assert workflow_publish["extra_fields"]["wf_exec_id"] == (
             created_comment.workflow_wf_exec_id
         )
         assert workflow_publish["extra_fields"]["text"] == "Run this workflow"
+
+    async def test_create_workflow_backed_reply_publishes_parent_context(
+        self,
+        case_comments_service: CaseCommentsService,
+        test_case: Case,
+        workflow: Workflow,
+    ) -> None:
+        parent_comment = await case_comments_service.create_comment(
+            test_case,
+            CaseCommentCreate(content="Parent comment"),
+        )
+
+        with patch(
+            "tracecat.cases.service.publish_case_event_payload",
+            new=AsyncMock(),
+        ) as publish_mock:
+            created_reply = await case_comments_service.create_comment(
+                test_case,
+                CaseCommentCreate(
+                    content="Reply workflow",
+                    parent_id=parent_comment.id,
+                    workflow_id=WorkflowUUID.new(workflow.id),
+                ),
+            )
+
+        workflow_publish = next(
+            kwargs
+            for _, kwargs in publish_mock.await_args_list
+            if kwargs.get("extra_fields", {}).get("workflow_id") == str(workflow.id)
+        )
+        assert workflow_publish["extra_fields"]["comment_id"] == str(created_reply.id)
+        assert workflow_publish["extra_fields"]["parent_id"] == str(parent_comment.id)
+        assert workflow_publish["extra_fields"]["comment"] == "Reply workflow"
 
     async def test_create_workflow_backed_comment_marks_failed_when_publish_fails(
         self,

--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -362,6 +362,48 @@ async def test_process_explicit_workflow_commits_before_setting_done_key():
     client.set.assert_awaited_once()
 
 
+def test_build_explicit_comment_payload_includes_reply_context() -> None:
+    consumer = CaseTriggerConsumer(client=AsyncMock())
+    case = cast(
+        Case,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            tags=[],
+        ),
+    )
+    event = cast(
+        CaseEvent,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            created_at=None,
+            type="comment_reply_created",
+            user_id=uuid.uuid4(),
+        ),
+    )
+    comment_id = uuid.uuid4()
+    parent_id = uuid.uuid4()
+
+    payload = consumer._build_explicit_comment_payload(
+        case=case,
+        event=event,
+        fields={
+            "comment": "Reply workflow",
+            "parent_id": str(parent_id),
+            "triggered_by_type": "user",
+        },
+        comment_id=comment_id,
+    )
+
+    assert payload["case_id"] == str(case.id)
+    assert payload["comment"] == "Reply workflow"
+    assert payload["comment_id"] == str(comment_id)
+    assert payload["parent_id"] == str(parent_id)
+    assert payload["thread_root_id"] == str(parent_id)
+    assert payload["is_reply"] is True
+    assert payload["text"] == "Reply workflow"
+
+
 @pytest.mark.anyio
 async def test_dispatch_selected_workflow_marks_comment_failed_on_start_error(
     session: AsyncSession,
@@ -574,6 +616,14 @@ async def test_dispatch_selected_workflow_treats_already_started_as_success(
 
     assert processed is True
     exec_service.create_workflow_execution_wait_for_start.assert_awaited_once()
+    payload = exec_service.create_workflow_execution_wait_for_start.await_args.kwargs[
+        "payload"
+    ]
+    assert payload["comment"] == "Replay this workflow"
+    assert payload["comment_id"] == str(comment.id)
+    assert payload["parent_id"] is None
+    assert payload["thread_root_id"] == str(comment.id)
+    assert payload["is_reply"] is False
 
     await session.refresh(comment)
     persisted = comment

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1799,6 +1799,7 @@ class CaseCommentsService(BaseWorkspaceService):
                             if comment.parent_id is not None
                             else None
                         ),
+                        "comment": comment.content,
                         "text": comment.content,
                         "workflow_id": str(workflow.id),
                         "wf_exec_id": wf_exec_id,

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -476,12 +476,19 @@ class CaseTriggerConsumer:
         triggered_by_user_id = fields.get("triggered_by_user_id")
         triggered_by_service_id = fields.get("triggered_by_service_id")
         parent_id = fields.get("parent_id")
+        comment = fields.get("comment") or fields.get("text", "")
+        thread_root_id = parent_id or (
+            str(comment_id) if comment_id is not None else None
+        )
 
         return {
             "case_id": str(case.id),
+            "comment": comment,
             "comment_id": str(comment_id) if comment_id is not None else None,
             "parent_id": parent_id,
-            "text": fields.get("text", ""),
+            "thread_root_id": thread_root_id,
+            "is_reply": parent_id is not None,
+            "text": comment,
             "workspace_id": str(case.workspace_id),
             "triggered_by": {
                 "type": fields.get("triggered_by_type") or "service",


### PR DESCRIPTION
### Motivation
- Workflows triggered by comment events lacked reply metadata and could not reliably reply back to the originating comment thread; the payload only contained `case_id` and `text`/`comment` content. 
- Add explicit reply context (IDs and flags) so workflow entrypoints receive `comment_id`, `parent_id`, `thread_root_id`, and `is_reply` for both top-level comments and replies.

### Description
- Include a `comment` field in the workflow-backed publish payload so `extra_fields` contains both `comment` and `text` alongside `comment_id` and `parent_id` (`tracecat/cases/service.py`).
- Extend the explicit comment workflow payload builder `_build_explicit_comment_payload` to emit `comment`, `comment_id`, `parent_id`, `thread_root_id`, `is_reply`, and keep `text` for compatibility (`tracecat/cases/triggers/consumer.py`).
- Add unit assertions and tests verifying the published `extra_fields` and consumer payload for both top-level comments and replies (`tests/unit/test_case_comments_service.py`, `tests/unit/test_case_trigger_consumer.py`).
- Run code formatting and linting fixes to keep style consistent.

### Testing
- Ran lint/format checks with `uv run ruff check` and `uv run ruff format --check` for the modified files and they passed.
- Verified Python syntax with `python -m py_compile` on modified files and it succeeded.
- Executed a targeted runtime payload assertion using `uv run python -c` to validate `_build_explicit_comment_payload` produces the expected reply context and it passed.
- Attempted unit test runs with `uv run pytest` focused on the modified test cases, but the test runs failed to start in this environment because a local PostgreSQL instance at `localhost:5432` was not available, so full pytest verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babe3653748333b95cceefe74ba887)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add reply context to comment-triggered workflows so automations can reply in the right thread. Exposes `comment`, `comment_id`, `parent_id`, `thread_root_id`, and `is_reply`, while keeping `text` for compatibility.

- **Bug Fixes**
  - Include `comment` and `parent_id` in workflow-backed publish payload (`tracecat/cases/service.py`).
  - Build explicit payload with `comment`, `comment_id`, `parent_id`, `thread_root_id`, `is_reply`, and mirror into `text` (`tracecat/cases/triggers/consumer.py`).
  - Add unit tests for top-level comments and replies across publish and consumer paths.

<sup>Written for commit da1a5eec18d9075250c9c09872afb534e1d47cb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

