### PR TITLE
feat(mcp): Reduce verbosity of list_agent_presets

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3196,6 +3196,106 @@ async def test_export_csv_rejects_stdio_transport(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_list_agent_presets_returns_lightweight_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    now = datetime.now(UTC)
+    presets = [
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            workspace_id=workspace_id,
+            name="Security triage",
+            slug="security-triage",
+            description="Investigate alerts",
+            instructions="Very long system prompt",
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            actions=["tools.alpha"],
+            namespaces=["tools"],
+            current_version_id=None,
+            created_at=now,
+            updated_at=now,
+        )
+    ]
+
+    class _PresetService:
+        async def list_presets(self) -> list[SimpleNamespace]:
+            return presets
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    result = await _tool(mcp_server.list_agent_presets)(workspace_id=str(workspace_id))
+
+    assert _payload(result) == [{"slug": "security-triage", "name": "Security triage"}]
+
+
+@pytest.mark.anyio
+async def test_get_agent_preset_returns_full_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    now = datetime.now(UTC)
+    preset = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        name="Security triage",
+        slug="security-triage",
+        description="Investigate alerts",
+        instructions="Very long system prompt",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        base_url=None,
+        output_type=None,
+        actions=["tools.alpha"],
+        namespaces=["tools"],
+        tool_approvals={"tools.alpha": False},
+        mcp_integrations=[str(uuid.uuid4())],
+        retries=3,
+        enable_internet_access=False,
+        current_version_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _PresetService:
+        async def get_preset_by_slug(self, preset_slug: str) -> SimpleNamespace:
+            assert preset_slug == "security-triage"
+            return preset
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    result = await _tool(mcp_server.get_agent_preset)(
+        workspace_id=str(workspace_id),
+        preset_slug="security-triage",
+    )
+
+    payload = _payload(result)
+    assert payload["slug"] == "security-triage"
+    assert payload["instructions"] == "Very long system prompt"
+    assert payload["actions"] == ["tools.alpha"]
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("last_stream_id", "expected_start_id"),
     [

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -1828,7 +1828,8 @@ when the workflow fits within that limit; otherwise it returns
 2. `list_integrations` — inspect workspace MCP integrations and broader provider status
 3. `list_actions` / `get_action_context` — choose preset tools and inspect arg schemas
 4. `create_agent_preset` — create a reusable preset
-5. `list_agent_presets` / `run_agent_preset` — inspect and test saved presets
+5. `list_agent_presets` — find reusable agents you can invoke by slug without loading their full prompts or tool configs
+6. `get_agent_preset` / `run_agent_preset` — fetch a preset's full configuration when you need to inspect it, or run it once you know which slug to use
 
 ## Debugging workflow runs
 After running a workflow, use `list_workflow_executions` to see recent runs and their \
@@ -5679,10 +5680,12 @@ async def _collect_agent_response(
 
 @mcp.tool()
 async def list_agent_presets(workspace_id: str) -> str:
-    """List agent presets in a workspace with their capabilities.
+    """List saved agent presets with lightweight metadata.
 
-    Returns each preset's slug, name, description, model, instructions,
-    configured actions (tools), and namespaces.
+    Use this tool to quickly see which reusable agents are available in the
+    workspace and which slug to pass to `run_agent_preset`. It intentionally
+    omits prompts and tool configuration to avoid bloating MCP client context;
+    call `get_agent_preset` only when you need the full preset definition.
     """
     try:
         _, role = await _resolve_workspace_role(workspace_id)
@@ -5691,17 +5694,10 @@ async def list_agent_presets(workspace_id: str) -> str:
         return _json(
             [
                 {
-                    "id": str(p.id),
-                    "slug": p.slug,
-                    "name": p.name,
-                    "description": p.description,
-                    "model_name": p.model_name,
-                    "model_provider": p.model_provider,
-                    "instructions": p.instructions,
-                    "actions": p.actions,
-                    "namespaces": p.namespaces,
+                    "slug": preset.slug,
+                    "name": preset.name,
                 }
-                for p in presets
+                for preset in presets
             ]
         )
     except ToolError:
@@ -5709,6 +5705,25 @@ async def list_agent_presets(workspace_id: str) -> str:
     except Exception as e:
         logger.error("Failed to list agent presets", error=str(e))
         raise ToolError(f"Failed to list agent presets: {e}") from None
+
+
+@mcp.tool()
+async def get_agent_preset(workspace_id: str, preset_slug: str) -> str:
+    """Get the full configuration for a saved agent preset by slug."""
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with AgentPresetService.with_session(role=role) as svc:
+            preset = await svc.get_preset_by_slug(preset_slug)
+        if not preset:
+            raise ToolError(f"Agent preset '{preset_slug}' not found")
+        return _json(AgentPresetRead.model_validate(preset).model_dump(mode="json"))
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(
+            "Failed to get agent preset", error=str(e), preset_slug=preset_slug
+        )
+        raise ToolError(f"Failed to get agent preset: {e}") from None
 
 
 @mcp.tool()

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -5680,12 +5680,9 @@ async def _collect_agent_response(
 
 @mcp.tool()
 async def list_agent_presets(workspace_id: str) -> str:
-    """List saved agent presets with lightweight metadata.
+    """List saved agent preset slugs and names.
 
-    Use this tool to quickly see which reusable agents are available in the
-    workspace and which slug to pass to `run_agent_preset`. It intentionally
-    omits prompts and tool configuration to avoid bloating MCP client context;
-    call `get_agent_preset` only when you need the full preset definition.
+    Use `get_agent_preset` for the full preset definition.
     """
     try:
         _, role = await _resolve_workspace_role(workspace_id)


### PR DESCRIPTION
### Motivation
- Prevent returning large prompt/tool configuration in the quick preset listing to avoid bloating MCP client context. 
- Provide a separate tool to fetch the full preset configuration when the client needs it.

### Description
- Change `list_agent_presets` to return lightweight metadata only (`slug` and `name`) instead of full preset fields. 
- Add a new `get_agent_preset` tool that retrieves a preset by slug and returns the full configuration as JSON using `AgentPresetRead.model_validate(...).model_dump(mode="json")`, and raises `ToolError` if not found. 
- Update help/inline documentation to clarify that `list_agent_presets` is for discovering available slugs and `get_agent_preset` is for fetching full definitions.

### Testing
- Added unit tests `test_list_agent_presets_returns_lightweight_metadata` and `test_get_agent_preset_returns_full_configuration` in `tests/unit/test_mcp_server.py`. 
- Ran the new tests with `pytest` (module-level tests for `tests/unit/test_mcp_server.py`) and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babe919a808333bc16af80106829d8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return only lightweight metadata from `list_agent_presets` to keep MCP clients lean, and add `get_agent_preset` to fetch full preset configs on demand. This makes preset discovery faster and reduces client context size.

- **New Features**
  - Added `get_agent_preset(workspace_id, preset_slug)` to return the full preset configuration as JSON; raises `ToolError` if not found.
  - Shortened and clarified docstrings/help: use `list_agent_presets` to discover slugs; use `get_agent_preset` to inspect details or before running.

- **Migration**
  - `list_agent_presets` now returns only `[{"slug", "name"}]`.
  - If you relied on full fields from `list_agent_presets`, call `get_agent_preset` after selecting a slug.

<sup>Written for commit 5b07ccaaed6f35f58f4f99c55cfc1a0d8b3acca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

