### PR TITLE
fix(ui): invalidate org-members after RBAC user assignment changes

### DIFF
--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -6376,6 +6376,14 @@ export function useRbacUserAssignments(options?: {
   const queryClient = useQueryClient()
   const enabled = options?.enabled ?? true
 
+  const invalidateAssignmentQueries = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["rbac-user-assignments"] }),
+      queryClient.invalidateQueries({ queryKey: ["user-scopes"] }),
+      queryClient.invalidateQueries({ queryKey: ["org-members"] }),
+    ])
+  }
+
   // List user assignments
   const {
     data: userAssignments,
@@ -6403,9 +6411,8 @@ export function useRbacUserAssignments(options?: {
   } = useMutation({
     mutationFn: async (params: UserRoleAssignmentCreate) =>
       await rbacCreateUserAssignment({ requestBody: params }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["rbac-user-assignments"] })
-      queryClient.invalidateQueries({ queryKey: ["user-scopes"] })
+    onSuccess: async () => {
+      await invalidateAssignmentQueries()
       toast({
         title: "User assignment created",
         description: "Role assigned to user successfully.",
@@ -6463,9 +6470,8 @@ export function useRbacUserAssignments(options?: {
       ...params
     }: UserRoleAssignmentUpdate & { assignmentId: string }) =>
       await rbacUpdateUserAssignment({ assignmentId, requestBody: params }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["rbac-user-assignments"] })
-      queryClient.invalidateQueries({ queryKey: ["user-scopes"] })
+    onSuccess: async () => {
+      await invalidateAssignmentQueries()
       toast({
         title: "User assignment updated",
         description: "User assignment updated successfully.",
@@ -6506,9 +6512,8 @@ export function useRbacUserAssignments(options?: {
   } = useMutation({
     mutationFn: async (assignmentId: string) =>
       await rbacDeleteUserAssignment({ assignmentId }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["rbac-user-assignments"] })
-      queryClient.invalidateQueries({ queryKey: ["user-scopes"] })
+    onSuccess: async () => {
+      await invalidateAssignmentQueries()
       toast({
         title: "User assignment deleted",
         description: "User assignment removed successfully.",


### PR DESCRIPTION
### Motivation
- Organization members list did not refresh immediately when editing user roles/scopes, causing stale UI after RBAC changes.
- Ensure org settings reflect role/scope updates right after create/update/delete of user assignments.

### Description
- Added a shared `invalidateAssignmentQueries` helper inside `useRbacUserAssignments` to centralize invalidation logic and await completion. (modified `frontend/src/lib/hooks.tsx`)
- The helper invalidates `rbac-user-assignments`, `user-scopes`, and `org-members` query keys to ensure both assignment lists and member entries are refreshed.
- Updated `onSuccess` handlers for create, update, and delete user-assignment mutations to `await invalidateAssignmentQueries()` before showing success toasts so the UI reflects changes immediately.

### Testing
- Ran frontend checks with `pnpm -C frontend check`, which completed successfully (no fixes applied).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30946c3e48320b7c7152a21a3712a)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale org members after RBAC role/scope changes by invalidating related queries and waiting for refresh before showing success toasts. Org settings now update immediately after creating, updating, or deleting user assignments.

- **Bug Fixes**
  - Added `invalidateAssignmentQueries` in `useRbacUserAssignments` to invalidate `rbac-user-assignments`, `user-scopes`, and `org-members`.
  - Updated all assignment mutation `onSuccess` handlers to await invalidation for immediate UI refresh.

<sup>Written for commit 548fe5927cc4e3bafc01c45b9ad150c067e58463. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

