### PR TITLE
fix(mcp): bump row spacing between workflow nodes

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -441,9 +441,9 @@ def test_auto_generate_layout_round_trips_through_extract():
     assert action_positions is not None
     assert "step1" in action_positions
     assert "step2" in action_positions
-    # step1 at depth 0 → y=150, step2 at depth 1 → y=300
-    assert action_positions["step1"][1] == 150
-    assert action_positions["step2"][1] == 300
+    # step1 at depth 0 → y=300, step2 at depth 1 → y=600
+    assert action_positions["step1"][1] == 300
+    assert action_positions["step2"][1] == 600
 
 
 @pytest.mark.anyio

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -1233,7 +1233,7 @@ def _auto_generate_layout(
     Walks the dependency graph to assign each action a depth (row), then
     spreads siblings horizontally. The trigger node sits at the top.
     """
-    NODE_HEIGHT = 150  # vertical spacing between rows
+    NODE_HEIGHT = 300  # vertical spacing between rows
     NODE_WIDTH = 300  # horizontal spacing between columns
 
     # Build dependency graph


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase vertical row spacing between workflow nodes in the MCP auto-layout from 150 to 300 to reduce crowding and improve readability. Updated the round-trip layout test to expect y positions at 300 and 600.

<sup>Written for commit c188a5998de0627144c1511c5defc7bdf36eb4a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

