### PR TITLE
fix(mcp): merge required OIDC scopes into client registration and aut…

### DIFF
--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -105,7 +105,12 @@ def test_create_mcp_auth_metadata_advertises_public_client_auth(
     assert payload["authorization_endpoint"] == "https://mcp.example.com/authorize"
     assert payload["token_endpoint"] == "https://mcp.example.com/token"
     assert payload["registration_endpoint"] == "https://mcp.example.com/register"
-    assert payload["scopes_supported"] == ["openid", "profile", "email"]
+    assert payload["scopes_supported"] == [
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+    ]
     assert "none" in payload["token_endpoint_auth_methods_supported"]
 
 
@@ -147,7 +152,12 @@ def test_create_mcp_auth_protected_resource_metadata_uses_mcp_path(
     payload = response.json()
     assert payload["resource"] == "https://mcp.example.com/mcp"
     assert payload["authorization_servers"] == ["https://mcp.example.com/"]
-    assert payload["scopes_supported"] == ["openid", "profile", "email"]
+    assert payload["scopes_supported"] == [
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+    ]
 
 
 def test_create_mcp_auth_metadata_matches_public_client_registration(
@@ -174,7 +184,7 @@ def test_create_mcp_auth_metadata_matches_public_client_registration(
     registration = registration_response.json()
     assert registration["token_endpoint_auth_method"] == "none"
     assert registration.get("client_secret") is None
-    assert registration["scope"] == "openid profile email"
+    assert registration["scope"] == "openid profile email offline_access"
     assert (
         registration["token_endpoint_auth_method"]
         in metadata["token_endpoint_auth_methods_supported"]
@@ -201,6 +211,29 @@ def test_create_mcp_auth_registration_accepts_platform_oidc_scopes(
     assert registration_response.status_code == 201
     registration = registration_response.json()
     assert registration["scope"] == "openid profile email"
+
+
+def test_create_mcp_auth_registration_merges_oidc_scopes_into_partial_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clients that register with a partial scope set are accepted."""
+    client = _build_test_client(monkeypatch)
+
+    registration_response = client.post(
+        "/register",
+        json={
+            "client_name": "claude-web",
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "scope": "openid",
+        },
+    )
+
+    assert registration_response.status_code == 201
+    registration = registration_response.json()
+    assert registration["scope"] == "openid"
 
 
 def test_create_mcp_auth_raises_when_base_url_missing(

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -597,6 +597,12 @@ def create_mcp_auth() -> AuthProvider:
     if not oidc_config.issuer:
         raise ValueError("OIDC_ISSUER must be configured for the MCP server.")
 
+    # Full scope set for registration, authorization, and client loading.
+    # Includes offline_access so the IdP issues refresh tokens.
+    _required_scopes = append_scope_if_missing(
+        list(oidc_config.scopes), _MCP_REFRESH_SCOPE
+    )
+
     class TracecatOIDCProxy(OIDCProxy):
         """OIDC proxy with user-existence validation and a custom consent page."""
 
@@ -605,18 +611,17 @@ def create_mcp_auth() -> AuthProvider:
             client: OAuthClientInformationFull,
             params: AuthorizationParams,
         ) -> str:
-            """Inject refresh scope by default for MCP clients.
+            """Merge all required OIDC scopes into the authorization request.
 
-            Request `offline_access` optimistically even if the upstream OIDC
-            metadata omits it. Some providers issue refresh tokens despite not
-            advertising the scope in discovery metadata. If the provider truly
-            rejects the scope, `_retry_without_refresh_scope()` handles a single
-            retry without it.
+            Request ``offline_access`` optimistically even if the upstream OIDC
+            metadata omits it — some providers issue refresh tokens despite not
+            advertising the scope in discovery metadata.  If the provider truly
+            rejects the scope, ``_retry_without_refresh_scope()`` handles a
+            single retry without it.
             """
-            scopes = merge_unique_scopes(list(params.scopes or []), oidc_config.scopes)
-            scopes = append_scope_if_missing(scopes, _MCP_REFRESH_SCOPE)
-            params_with_refresh = params.model_copy(update={"scopes": scopes})
-            return await super().authorize(client, params_with_refresh)
+            scopes = merge_unique_scopes(list(params.scopes or []), _required_scopes)
+            params_with_scopes = params.model_copy(update={"scopes": scopes})
+            return await super().authorize(client, params_with_scopes)
 
         async def _retry_without_refresh_scope(
             self,
@@ -928,10 +933,16 @@ def create_mcp_auth() -> AuthProvider:
         client_storage=client_storage,
         fallback_access_token_expiry_seconds=_MCP_ACCESS_TOKEN_FALLBACK_EXPIRY_SECONDS,
     )
-    advertised_scopes = list(oidc_config.scopes)
+    # Patch client_registration_options so the MCP SDK's registration
+    # handler advertises and accepts the full scope set (including
+    # offline_access).  Do NOT pass required_scopes to the constructor
+    # — it flows into the JWT verifier which then rejects any token
+    # missing those scopes, breaking tokens issued before a scope
+    # change.  Scope merging is handled by our get_client(),
+    # register_client(), and authorize() overrides instead.
     if auth.client_registration_options is not None:
-        auth.client_registration_options.valid_scopes = advertised_scopes
-        auth.client_registration_options.default_scopes = advertised_scopes
+        auth.client_registration_options.valid_scopes = _required_scopes
+        auth.client_registration_options.default_scopes = _required_scopes
     return auth
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Merge required OIDC scopes into authorization and advertise them in client registration so refresh tokens work reliably. Auth metadata now lists the full scope set while keeping backward compatibility by not enforcing scopes in the verifier.

- **Bug Fixes**
  - Merge required scopes (including `offline_access`) into authorization requests.
  - Advertise full scopes in metadata and registration options (`valid_scopes`/`default_scopes`).
  - Accept partial scope sets during registration; do not force-merge into the stored `scope`.
  - Do not pass required scopes to the verifier; tests updated for metadata and partial-scope registration.

<sup>Written for commit 8f205e2a1faac868a57d01bfcca5fc653480d513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

