### PR TITLE
chore(agents): migrate mcp udfs to new agent runtime

### DIFF
--- a/tests/unit/test_agent_internal_router.py
+++ b/tests/unit/test_agent_internal_router.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from tracecat.agent import internal_router
+from tracecat.agent.schemas import AgentOutput, InternalRunAgentRequest, RunUsage
+from tracecat.agent.types import AgentConfig
+from tracecat.auth.types import Role
+from tracecat.contexts import ctx_role
+
+
+@pytest.fixture
+def agent_role() -> Role:
+    return Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+
+
+@pytest.fixture
+def agent_output() -> AgentOutput:
+    return AgentOutput(
+        output={"ok": True},
+        message_history=None,
+        duration=1.23,
+        usage=RunUsage(requests=1, input_tokens=5, output_tokens=7),
+        session_id=uuid.uuid4(),
+    )
+
+
+@pytest.mark.anyio
+async def test_run_agent_endpoint_routes_mcp_runs_to_durable_workflow(
+    agent_role: Role,
+    agent_output: AgentOutput,
+) -> None:
+    params = InternalRunAgentRequest.model_validate(
+        {
+            "user_prompt": "Investigate Jira ticket",
+            "config": {
+                "model_name": "claude-3-5-sonnet-20241022",
+                "model_provider": "anthropic",
+                "mcp_servers": [
+                    {"name": "jira", "url": "https://mcp.example.com/v1/mcp"}
+                ],
+            },
+        }
+    )
+    mock_agent_svc = Mock()
+    mock_agent_svc.presets = None
+
+    token = ctx_role.set(agent_role)
+    try:
+        with (
+            patch.object(
+                internal_router,
+                "AgentManagementService",
+                return_value=mock_agent_svc,
+            ),
+            patch.object(
+                internal_router,
+                "_provider_secrets_context",
+            ) as mock_provider_context,
+            patch.object(
+                internal_router,
+                "_run_mcp_agent_workflow",
+                AsyncMock(return_value=agent_output),
+            ) as mock_workflow_run,
+            patch.object(
+                internal_router,
+                "runtime_run_agent",
+                AsyncMock(
+                    side_effect=AssertionError("runtime_run_agent should not be called")
+                ),
+            ),
+        ):
+            mock_provider_context.return_value.__aenter__ = AsyncMock(return_value=None)
+            mock_provider_context.return_value.__aexit__ = AsyncMock(return_value=None)
+            result = await internal_router.run_agent_endpoint(
+                role=agent_role,
+                session=AsyncMock(),
+                params=params,
+            )
+
+        assert result["output"] == {"ok": True}
+        mock_workflow_run.assert_awaited_once()
+    finally:
+        ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_run_agent_endpoint_routes_ollama_mcp_runs_to_pydantic_ai(
+    agent_role: Role,
+    agent_output: AgentOutput,
+) -> None:
+    params = InternalRunAgentRequest.model_validate(
+        {
+            "user_prompt": "Use the local MCP server",
+            "config": {
+                "model_name": "llama3.2",
+                "model_provider": "ollama",
+                "mcp_servers": [
+                    {"name": "jira", "url": "https://mcp.example.com/v1/mcp"}
+                ],
+            },
+        }
+    )
+    mock_agent_svc = Mock()
+    mock_agent_svc.presets = None
+
+    token = ctx_role.set(agent_role)
+    try:
+        with (
+            patch.object(
+                internal_router,
+                "AgentManagementService",
+                return_value=mock_agent_svc,
+            ),
+            patch.object(
+                internal_router,
+                "_provider_secrets_context",
+            ) as mock_provider_context,
+            patch.object(
+                internal_router,
+                "runtime_run_agent",
+                AsyncMock(return_value=agent_output),
+            ) as mock_runtime_run,
+            patch.object(
+                internal_router,
+                "_run_mcp_agent_workflow",
+                AsyncMock(
+                    side_effect=AssertionError(
+                        "_run_mcp_agent_workflow should not be called"
+                    )
+                ),
+            ),
+        ):
+            mock_provider_context.return_value.__aenter__ = AsyncMock(return_value=None)
+            mock_provider_context.return_value.__aexit__ = AsyncMock(return_value=None)
+            result = await internal_router.run_agent_endpoint(
+                role=agent_role,
+                session=AsyncMock(),
+                params=params,
+            )
+
+        assert result["output"] == {"ok": True}
+        mock_runtime_run.assert_awaited_once()
+    finally:
+        ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_run_agent_endpoint_rejects_missing_credentials_before_durable_mcp_run(
+    agent_role: Role,
+) -> None:
+    params = InternalRunAgentRequest.model_validate(
+        {
+            "user_prompt": "Investigate Jira ticket",
+            "config": {
+                "model_name": "claude-3-5-sonnet-20241022",
+                "model_provider": "anthropic",
+                "mcp_servers": [
+                    {"name": "jira", "url": "https://mcp.example.com/v1/mcp"}
+                ],
+            },
+        }
+    )
+    mock_agent_svc = Mock()
+    mock_agent_svc.presets = None
+
+    token = ctx_role.set(agent_role)
+    try:
+        with (
+            patch.object(
+                internal_router,
+                "AgentManagementService",
+                return_value=mock_agent_svc,
+            ),
+            patch.object(
+                internal_router,
+                "_provider_secrets_context",
+            ) as mock_provider_context,
+            patch.object(
+                internal_router,
+                "_run_mcp_agent_workflow",
+                AsyncMock(
+                    side_effect=AssertionError(
+                        "_run_mcp_agent_workflow should not be called"
+                    )
+                ),
+            ),
+        ):
+            mock_provider_context.return_value.__aenter__ = AsyncMock(
+                side_effect=ValueError("No credentials found for provider 'anthropic'.")
+            )
+            mock_provider_context.return_value.__aexit__ = AsyncMock(return_value=None)
+            with pytest.raises(HTTPException) as exc_info:
+                await internal_router.run_agent_endpoint(
+                    role=agent_role,
+                    session=AsyncMock(),
+                    params=params,
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "No credentials found for provider 'anthropic'." in str(
+            exc_info.value.detail
+        )
+    finally:
+        ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_run_agent_endpoint_rejects_invalid_output_type_before_durable_mcp_run(
+    agent_role: Role,
+) -> None:
+    params = InternalRunAgentRequest.model_validate(
+        {
+            "user_prompt": "Investigate Jira ticket",
+            "config": {
+                "model_name": "claude-3-5-sonnet-20241022",
+                "model_provider": "anthropic",
+                "output_type": "json",
+                "mcp_servers": [
+                    {"name": "jira", "url": "https://mcp.example.com/v1/mcp"}
+                ],
+            },
+        }
+    )
+    mock_agent_svc = Mock()
+    mock_agent_svc.presets = None
+
+    token = ctx_role.set(agent_role)
+    try:
+        with (
+            patch.object(
+                internal_router,
+                "AgentManagementService",
+                return_value=mock_agent_svc,
+            ),
+            patch.object(
+                internal_router,
+                "_run_mcp_agent_workflow",
+                AsyncMock(
+                    side_effect=AssertionError(
+                        "_run_mcp_agent_workflow should not be called"
+                    )
+                ),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await internal_router.run_agent_endpoint(
+                    role=agent_role,
+                    session=AsyncMock(),
+                    params=params,
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid output_type" in str(exc_info.value.detail)
+    finally:
+        ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_run_agent_endpoint_routes_non_mcp_runs_to_pydantic_ai(
+    agent_role: Role,
+    agent_output: AgentOutput,
+) -> None:
+    params = InternalRunAgentRequest.model_validate(
+        {
+            "user_prompt": "Summarize the findings",
+            "config": {
+                "model_name": "claude-3-5-sonnet-20241022",
+                "model_provider": "anthropic",
+                "actions": ["core.cases.list_cases"],
+            },
+        }
+    )
+    mock_agent_svc = Mock()
+    mock_agent_svc.presets = None
+
+    token = ctx_role.set(agent_role)
+    try:
+        with (
+            patch.object(
+                internal_router,
+                "AgentManagementService",
+                return_value=mock_agent_svc,
+            ),
+            patch.object(
+                internal_router,
+                "_provider_secrets_context",
+            ) as mock_provider_context,
+            patch.object(
+                internal_router,
+                "runtime_run_agent",
+                AsyncMock(return_value=agent_output),
+            ) as mock_runtime_run,
+            patch.object(
+                internal_router,
+                "_run_mcp_agent_workflow",
+                AsyncMock(
+                    side_effect=AssertionError(
+                        "_run_mcp_agent_workflow should not be called"
+                    )
+                ),
+            ),
+        ):
+            mock_provider_context.return_value.__aenter__ = AsyncMock(return_value=None)
+            mock_provider_context.return_value.__aexit__ = AsyncMock(return_value=None)
+            result = await internal_router.run_agent_endpoint(
+                role=agent_role,
+                session=AsyncMock(),
+                params=params,
+            )
+
+        assert result["output"] == {"ok": True}
+        mock_runtime_run.assert_awaited_once()
+    finally:
+        ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_run_agent_endpoint_routes_preset_mcp_runs_to_durable_workflow(
+    agent_role: Role,
+    agent_output: AgentOutput,
+) -> None:
+    params = InternalRunAgentRequest(
+        user_prompt="Open the relevant issue",
+        preset_slug="jira-analyst",
+    )
+    mock_agent_svc = Mock()
+    mock_agent_svc.presets = SimpleNamespace(
+        resolve_agent_preset_config=AsyncMock(
+            return_value=AgentConfig(
+                model_name="claude-3-5-sonnet-20241022",
+                model_provider="anthropic",
+                mcp_servers=[
+                    {
+                        "type": "http",
+                        "name": "jira",
+                        "url": "https://mcp.example.com/v1/mcp",
+                    }
+                ],
+            )
+        )
+    )
+
+    token = ctx_role.set(agent_role)
+    try:
+        with (
+            patch.object(
+                internal_router,
+                "AgentManagementService",
+                return_value=mock_agent_svc,
+            ),
+            patch.object(
+                internal_router,
+                "_provider_secrets_context",
+            ) as mock_provider_context,
+            patch.object(
+                internal_router,
+                "_run_mcp_agent_workflow",
+                AsyncMock(return_value=agent_output),
+            ) as mock_workflow_run,
+            patch.object(
+                internal_router,
+                "runtime_run_agent",
+                AsyncMock(
+                    side_effect=AssertionError("runtime_run_agent should not be called")
+                ),
+            ),
+        ):
+            mock_provider_context.return_value.__aenter__ = AsyncMock(return_value=None)
+            mock_provider_context.return_value.__aexit__ = AsyncMock(return_value=None)
+            result = await internal_router.run_agent_endpoint(
+                role=agent_role,
+                session=AsyncMock(),
+                params=params,
+            )
+
+        assert result["output"] == {"ok": True}
+        mock_agent_svc.presets.resolve_agent_preset_config.assert_awaited_once_with(
+            slug="jira-analyst",
+            preset_version=None,
+        )
+        mock_workflow_run.assert_awaited_once()
+    finally:
+        ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_run_mcp_agent_workflow_executes_durable_workflow(
+    agent_role: Role,
+) -> None:
+    session_id = uuid.uuid4()
+    workflow_result = AgentOutput(
+        output={"ok": True},
+        message_history=[],
+        duration=2.5,
+        usage=RunUsage(requests=2, input_tokens=12, output_tokens=34),
+        session_id=session_id,
+    )
+    config = AgentConfig(
+        model_name="claude-3-5-sonnet-20241022",
+        model_provider="anthropic",
+        mcp_servers=[
+            {"type": "http", "name": "jira", "url": "https://mcp.example.com/v1/mcp"}
+        ],
+    )
+    mock_client = Mock()
+    mock_client.execute_workflow = AsyncMock(return_value=workflow_result)
+
+    with patch.object(
+        internal_router, "get_temporal_client", AsyncMock(return_value=mock_client)
+    ):
+        result = await internal_router._run_mcp_agent_workflow(
+            role=agent_role,
+            session_id=session_id,
+            user_prompt="Use Jira MCP",
+            config=config,
+            max_requests=12,
+            max_tool_calls=6,
+        )
+
+    assert result == workflow_result
+    mock_client.execute_workflow.assert_awaited_once()
+    _workflow_fn, workflow_args = mock_client.execute_workflow.await_args.args[:2]
+    assert workflow_args.role == agent_role
+    assert workflow_args.agent_args.user_prompt == "Use Jira MCP"
+    assert workflow_args.agent_args.session_id == session_id
+    assert workflow_args.agent_args.max_requests == 12
+    assert workflow_args.agent_args.max_tool_calls == 6
+    assert workflow_args.entity_type == internal_router.AgentSessionEntity.WORKFLOW
+
+
+@pytest.mark.anyio
+async def test_run_mcp_agent_workflow_rejects_tool_approvals(
+    agent_role: Role,
+) -> None:
+    config = AgentConfig(
+        model_name="claude-3-5-sonnet-20241022",
+        model_provider="anthropic",
+        mcp_servers=[
+            {"type": "http", "name": "jira", "url": "https://mcp.example.com/v1/mcp"}
+        ],
+        tool_approvals={"core.http_request": True},
+    )
+
+    with pytest.raises(ValueError, match="Tool approvals are not supported"):
+        await internal_router._run_mcp_agent_workflow(
+            role=agent_role,
+            session_id=uuid.uuid4(),
+            user_prompt="Use Jira MCP",
+            config=config,
+            max_requests=12,
+            max_tool_calls=6,
+        )

--- a/tracecat/agent/internal_router.py
+++ b/tracecat/agent/internal_router.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import uuid
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, status
+from temporalio.common import TypedSearchAttributes
+from tracecat_ee.agent.types import AgentWorkflowID
+from tracecat_ee.agent.workflows.durable import AgentWorkflowArgs, DurableAgentWorkflow
 from tracecat_registry import secrets as registry_secrets
 
+from tracecat import config as app_config
 from tracecat.agent.exceptions import AgentRunError
 from tracecat.agent.runtime.pydantic_ai.runtime import run_agent as runtime_run_agent
 from tracecat.agent.schemas import (
@@ -16,17 +21,27 @@ from tracecat.agent.schemas import (
     InternalRankItemsPairwiseRequest,
     InternalRankItemsRequest,
     InternalRunAgentRequest,
+    RunAgentArgs,
 )
 from tracecat.agent.service import AgentManagementService
+from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig, OutputType
 from tracecat.ai.ranker import rank_items as ranker_rank_items
 from tracecat.ai.ranker import rank_items_pairwise as ranker_rank_items_pairwise
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
+from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_role, ctx_session_id
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.dsl.client import get_temporal_client
+from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.logger import logger
 from tracecat.tiers.entitlements import Entitlement, check_entitlement
+from tracecat.workflow.executions.enums import (
+    ExecutionType,
+    TemporalSearchAttr,
+    TriggerType,
+)
 
 router = APIRouter(
     prefix="/internal/agent",
@@ -104,6 +119,81 @@ def _normalize_output_type(
     )
 
 
+def _build_direct_agent_search_attributes(role: Role) -> TypedSearchAttributes:
+    """Build direct-run search attributes for internal MCP-backed agent workflows."""
+    pairs = [
+        TriggerType.MANUAL.to_temporal_search_attr_pair(),
+        ExecutionType.PUBLISHED.to_temporal_search_attr_pair(),
+    ]
+    if role.user_id is not None:
+        pairs.append(
+            TemporalSearchAttr.TRIGGERED_BY_USER_ID.create_pair(str(role.user_id))
+        )
+    if role.workspace_id is not None:
+        pairs.append(
+            TemporalSearchAttr.WORKSPACE_ID.create_pair(str(role.workspace_id))
+        )
+    return TypedSearchAttributes(search_attributes=pairs)
+
+
+async def _run_mcp_agent_workflow(
+    *,
+    role: ExecutorWorkspaceRole,
+    session_id: uuid.UUID,
+    user_prompt: str,
+    config: AgentConfig,
+    max_requests: int,
+    max_tool_calls: int | None,
+) -> AgentOutput:
+    """Execute MCP-backed agent runs through the durable Claude workflow path."""
+    if config.tool_approvals:
+        raise ValueError(
+            "Tool approvals are not supported for internal MCP agent runs."
+        )
+
+    workflow_run_id = uuid.uuid4()
+    workflow_id = AgentWorkflowID(workflow_run_id)
+    workflow_args = AgentWorkflowArgs(
+        role=role,
+        agent_args=RunAgentArgs(
+            user_prompt=user_prompt,
+            session_id=session_id,
+            config=config,
+            max_requests=max_requests,
+            max_tool_calls=max_tool_calls,
+            use_workspace_credentials=True,
+        ),
+        title="Workflow run",
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=session_id,
+        tools=config.actions,
+    )
+
+    try:
+        client = await get_temporal_client()
+        result = await client.execute_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=str(workflow_id),
+            task_queue=app_config.TRACECAT__AGENT_QUEUE,
+            execution_timeout=timedelta(hours=1),
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            search_attributes=_build_direct_agent_search_attributes(role),
+        )
+    except Exception as e:
+        logger.exception(
+            "Durable MCP agent workflow failed",
+            workflow_id=str(workflow_id),
+            session_id=str(session_id),
+            error=str(e),
+        )
+        raise AgentRunError(exc_cls=type(e), exc_msg=str(e)) from e
+
+    if isinstance(result, AgentOutput):
+        return result
+    return AgentOutput.model_validate(result)
+
+
 @router.post("/run", status_code=status.HTTP_200_OK)
 @require_scope("agent:execute")
 async def run_agent_endpoint(
@@ -120,28 +210,55 @@ async def run_agent_endpoint(
     try:
         agent_svc = AgentManagementService(session, role=role)
         config = await _resolve_run_config(params, agent_svc)
-        mcp_servers = config.mcp_servers
 
-        if config and config.tool_approvals:
+        if config.tool_approvals:
             await check_entitlement(session, role, Entitlement.AGENT_ADDONS)
 
-        async with _provider_secrets_context(agent_svc, config.model_provider):
-            result: AgentOutput = await runtime_run_agent(
-                user_prompt=params.user_prompt,
-                model_name=config.model_name,
-                model_provider=config.model_provider,
-                actions=config.actions,
-                namespaces=config.namespaces,
-                tool_approvals=config.tool_approvals,
-                mcp_servers=mcp_servers,
-                instructions=config.instructions,
-                output_type=_normalize_output_type(config.output_type),
-                model_settings=config.model_settings,
-                max_tool_calls=params.max_tool_calls or 40,
-                max_requests=params.max_requests,
-                retries=config.retries,
-                base_url=config.base_url,
+        normalized_output_type = _normalize_output_type(config.output_type)
+        config.output_type = normalized_output_type
+
+        if (
+            config.mcp_servers
+            and config.model_provider
+            not in _PROVIDERS_WITH_OPTIONAL_WORKSPACE_CREDENTIALS
+        ):
+            mcp_servers = config.mcp_servers
+            logger.info(
+                "Routing internal agent run through durable Claude workflow",
+                session_id=session_id,
+                mcp_server_count=len(mcp_servers),
             )
+            async with _provider_secrets_context(agent_svc, config.model_provider):
+                result = await _run_mcp_agent_workflow(
+                    role=role,
+                    session_id=session_id,
+                    user_prompt=params.user_prompt,
+                    config=config,
+                    max_requests=params.max_requests,
+                    max_tool_calls=params.max_tool_calls or 40,
+                )
+        else:
+            logger.info(
+                "Routing internal agent run through PydanticAI runtime",
+                session_id=session_id,
+            )
+            async with _provider_secrets_context(agent_svc, config.model_provider):
+                result = await runtime_run_agent(
+                    user_prompt=params.user_prompt,
+                    model_name=config.model_name,
+                    model_provider=config.model_provider,
+                    actions=config.actions,
+                    namespaces=config.namespaces,
+                    tool_approvals=config.tool_approvals,
+                    mcp_servers=config.mcp_servers,
+                    instructions=config.instructions,
+                    output_type=normalized_output_type,
+                    model_settings=config.model_settings,
+                    max_tool_calls=params.max_tool_calls or 40,
+                    max_requests=params.max_requests,
+                    retries=config.retries,
+                    base_url=config.base_url,
+                )
         return result.model_dump(mode="json")
     except AgentRunError as e:
         logger.exception("Agent run error", error=e)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrates MCP-backed agent runs to the durable agent workflow. Non-Ollama MCP runs now execute via Temporal; Ollama MCP and non-MCP runs continue on the `pydantic-ai` runtime.

- **Refactors**
  - Route MCP runs (except `ollama`) to `DurableAgentWorkflow` with `RunAgentArgs`, 1h timeout, `workflow:fail_fast` retry, and search attributes built by `_build_direct_agent_search_attributes`.
  - Keep other runs on `runtime_run_agent` and normalize `output_type` before execution.
  - Disallow tool approvals for durable MCP runs; still check the entitlement when approvals are present.
  - Use workspace credentials via `_provider_secrets_context`; return `HTTP 400` when provider credentials are missing.
  - Add `_run_mcp_agent_workflow` to execute through Temporal (`id` from `AgentWorkflowID`, queue `TRACECAT__AGENT_QUEUE`, `AgentSessionEntity.WORKFLOW`).
  - Add unit tests covering routing for MCP/non-MCP and `ollama`, preset resolution, missing credentials, invalid output type, and workflow arguments/results.

<sup>Written for commit ca7ad5ce242a4aca91b4ff6a24c81728ade0119c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

