### PR TITLE
fix(secrets): correct create/update scope decorators

### DIFF
--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -254,7 +254,7 @@ class SecretsService(BaseOrgService):
                 " Please double check that the name was correctly input."
             ) from e
 
-    @require_scope("secret:update")
+    @require_scope("secret:create")
     @audit_log(resource_type="secret", action="create")
     async def create_secret(self, params: SecretCreate) -> None:
         """Create a workspace secret."""
@@ -277,7 +277,7 @@ class SecretsService(BaseOrgService):
         self.session.add(secret)
         await self.session.commit()
 
-    @require_scope("secret:create")
+    @require_scope("secret:update")
     @audit_log(resource_type="secret", action="update")
     async def update_secret(self, secret: Secret, params: SecretUpdate) -> None:
         """Update a workspace secret."""


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

The required scopes for `update_secret` and `create_secret` appear to have been swapped in `service.py`.

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed swapped scope decorators for secret create/update so the correct permissions are enforced. This restores expected access control and prevents unauthorized operations.

- **Bug Fixes**
  - `create_secret` now requires `secret:create`; `update_secret` now requires `secret:update` (previously reversed).

<sup>Written for commit 9b931ea2187584f51a889cbe467e37f22214203f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

