### PR TITLE
fix(agents): unify preset execution limits

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -2,7 +2,12 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from tracecat import config
+from tracecat.agent.schemas import (
+    DEFAULT_PRESET_AGENT_MAX_REQUESTS,
+    DEFAULT_PRESET_AGENT_MAX_TOOL_CALLS,
+    AgentMaxRequests,
+    AgentMaxToolCalls,
+)
 from tracecat.agent.types import OutputType
 
 
@@ -14,18 +19,8 @@ class AgentActionArgs(BaseModel):
     instructions: str | None = None
     output_type: OutputType | None = None
     model_settings: dict[str, Any] | None = None
-    max_tool_calls: int = Field(
-        default=15,
-        ge=1,
-        le=config.TRACECAT__AGENT_MAX_TOOL_CALLS,
-        description="The maximum number of tool calls to make per agent run",
-    )
-    max_requests: int = Field(
-        default=45,
-        ge=1,
-        le=config.TRACECAT__AGENT_MAX_REQUESTS,
-        description="The maximum number of model requests to make per agent run",
-    )
+    max_tool_calls: AgentMaxToolCalls = DEFAULT_PRESET_AGENT_MAX_TOOL_CALLS
+    max_requests: AgentMaxRequests = DEFAULT_PRESET_AGENT_MAX_REQUESTS
     retries: int = 3
     base_url: str | None = None
     tool_approvals: dict[str, bool] | None = None
@@ -41,18 +36,8 @@ class PresetAgentActionArgs(BaseModel):
     user_prompt: str
     actions: list[str] | None = None
     instructions: str | None = None
-    max_tool_calls: int = Field(
-        default=15,
-        ge=1,
-        le=config.TRACECAT__AGENT_MAX_TOOL_CALLS,
-        description="The maximum number of tool calls to make per agent run",
-    )
-    max_requests: int = Field(
-        default=45,
-        ge=1,
-        le=config.TRACECAT__AGENT_MAX_REQUESTS,
-        description="The maximum number of model requests to make per agent run",
-    )
+    max_tool_calls: AgentMaxToolCalls = DEFAULT_PRESET_AGENT_MAX_TOOL_CALLS
+    max_requests: AgentMaxRequests = DEFAULT_PRESET_AGENT_MAX_REQUESTS
     use_workspace_credentials: bool = Field(
         default=True,
         description="If True, use workspace-scoped credentials; otherwise org-level",

--- a/tests/unit/test_agent_schema_limits.py
+++ b/tests/unit/test_agent_schema_limits.py
@@ -1,0 +1,50 @@
+import uuid
+
+import pytest
+from pydantic import ValidationError
+from tracecat_ee.agent.schemas import PresetAgentActionArgs
+
+from tracecat import config
+from tracecat.agent.schemas import RunAgentArgs
+from tracecat.agent.types import AgentConfig
+
+
+def _agent_config() -> AgentConfig:
+    return AgentConfig(
+        model_name="gpt-5-mini",
+        model_provider="openai",
+    )
+
+
+def test_preset_agent_action_args_rejects_limits_above_config() -> None:
+    with pytest.raises(ValidationError):
+        PresetAgentActionArgs(
+            preset="triage",
+            user_prompt="Analyze this alert",
+            max_tool_calls=config.TRACECAT__AGENT_MAX_TOOL_CALLS + 1,
+            max_requests=config.TRACECAT__AGENT_MAX_REQUESTS + 1,
+        )
+
+
+def test_run_agent_args_rejects_limits_above_config() -> None:
+    with pytest.raises(ValidationError):
+        RunAgentArgs(
+            user_prompt="Analyze this alert",
+            session_id=uuid.uuid4(),
+            config=_agent_config(),
+            max_tool_calls=config.TRACECAT__AGENT_MAX_TOOL_CALLS + 1,
+            max_requests=config.TRACECAT__AGENT_MAX_REQUESTS + 1,
+        )
+
+
+def test_run_agent_args_allows_zero_tool_calls() -> None:
+    args = RunAgentArgs(
+        user_prompt="Analyze this alert",
+        session_id=uuid.uuid4(),
+        config=_agent_config(),
+        max_tool_calls=0,
+        max_requests=3,
+    )
+
+    assert args.max_tool_calls == 0
+    assert args.max_requests == 3

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import uuid
 from typing import (
+    Annotated,
     Any,
     Literal,
     NotRequired,
@@ -19,6 +20,38 @@ from pydantic_ai.tools import DeferredToolResults
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
+from tracecat.config import (
+    TRACECAT__AGENT_MAX_REQUESTS,
+    TRACECAT__AGENT_MAX_TOOL_CALLS,
+)
+
+DEFAULT_PRESET_AGENT_MAX_REQUESTS = 45
+DEFAULT_PRESET_AGENT_MAX_TOOL_CALLS = 15
+
+AgentMaxRequests = Annotated[
+    int,
+    Field(
+        ge=1,
+        le=TRACECAT__AGENT_MAX_REQUESTS,
+        description="The maximum number of model requests to make per agent run",
+    ),
+]
+AgentMaxToolCalls = Annotated[
+    int | None,
+    Field(
+        ge=1,
+        le=TRACECAT__AGENT_MAX_TOOL_CALLS,
+        description="The maximum number of tool calls to make per agent run",
+    ),
+]
+RunAgentMaxToolCalls = Annotated[
+    int | None,
+    Field(
+        ge=0,
+        le=TRACECAT__AGENT_MAX_TOOL_CALLS,
+        description="The maximum number of tool calls to make per agent run",
+    ),
+]
 
 
 class ModelInfo(BaseModel):
@@ -38,9 +71,9 @@ class RunAgentArgs(BaseModel):
     """Slug for the preset configuration (if using a preset)."""
     preset_version: int | None = None
     """Optional preset version number to pin for this execution."""
-    max_requests: int | None = None
+    max_requests: AgentMaxRequests = TRACECAT__AGENT_MAX_REQUESTS
     """Maximum number of requests for the agent."""
-    max_tool_calls: int | None = None
+    max_tool_calls: RunAgentMaxToolCalls = TRACECAT__AGENT_MAX_TOOL_CALLS
     """Maximum number of tool calls for the agent."""
     deferred_tool_results: DeferredToolResults | None = None
     """Results for deferred tool calls from a previous run (CE handshake)."""
@@ -273,8 +306,8 @@ class InternalRunAgentRequest(BaseModel):
     config: AgentConfigSchema | None = None
     preset_slug: str | None = None
     preset_version: int | None = None
-    max_requests: int = Field(default=120, le=120)
-    max_tool_calls: int | None = Field(default=None, le=40)
+    max_requests: AgentMaxRequests = TRACECAT__AGENT_MAX_REQUESTS
+    max_tool_calls: AgentMaxToolCalls = None
 
     @model_validator(mode="after")
     def validate_config_or_preset(self) -> InternalRunAgentRequest:

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -27,7 +27,11 @@ from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
 from tracecat.agent.preset.service import AgentPresetService
-from tracecat.agent.schemas import RunAgentArgs
+from tracecat.agent.schemas import (
+    DEFAULT_PRESET_AGENT_MAX_REQUESTS,
+    DEFAULT_PRESET_AGENT_MAX_TOOL_CALLS,
+    RunAgentArgs,
+)
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.session.schemas import (
     AgentSessionCreate,
@@ -982,11 +986,19 @@ class AgentSessionService(BaseWorkspaceService):
             use_workspace_credentials = (
                 agent_session.entity_type != AgentSessionEntity.COPILOT
             )
+            if agent_session.entity_type == AgentSessionEntity.AGENT_PRESET:
+                max_requests = DEFAULT_PRESET_AGENT_MAX_REQUESTS
+                max_tool_calls = DEFAULT_PRESET_AGENT_MAX_TOOL_CALLS
+            else:
+                max_requests = config.TRACECAT__AGENT_MAX_REQUESTS
+                max_tool_calls = config.TRACECAT__AGENT_MAX_TOOL_CALLS
 
             args = RunAgentArgs(
                 user_prompt=user_prompt or "",
                 session_id=session_id,
                 config=agent_config,
+                max_requests=max_requests,
+                max_tool_calls=max_tool_calls,
                 use_workspace_credentials=use_workspace_credentials,
             )
 


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR unifies agent execution limit validation across preset execution entrypoints.

It moves the shared `max_requests` / `max_tool_calls` constraints into `tracecat.agent.schemas`, reuses them from the EE agent action schemas, and makes `AGENT_PRESET` session runs apply the same preset defaults used by the workflow/UDF path.

It also adds a regression test covering:
- preset/UDF validation rejects values above `TRACECAT__AGENT_MAX_REQUESTS` and `TRACECAT__AGENT_MAX_TOOL_CALLS`
- `RunAgentArgs` enforces the same upper bounds
- `RunAgentArgs` still allows `max_tool_calls=0` for AI-only runs

## Related Issues

None.

## Screenshots / Recordings

N/A

## Steps to QA

1. Run `uv run ruff check tracecat/agent/schemas.py tracecat/agent/session/service.py packages/tracecat-ee/tracecat_ee/agent/schemas.py tests/unit/test_agent_schema_limits.py`.
2. Run `uv run basedpyright tracecat/agent/schemas.py tracecat/agent/session/service.py packages/tracecat-ee/tracecat_ee/agent/schemas.py tests/unit/test_agent_schema_limits.py`.
3. Run `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_agent_schema_limits.py tests/unit/test_build_agent_args.py`.
4. Verify an MCP `run_agent_preset` session now uses the preset-path defaults rather than falling back to the generic session behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies agent execution limit validation and defaults across all entrypoints. Preset sessions now use consistent defaults and respect global caps.

- **Bug Fixes**
  - Centralized `max_requests`/`max_tool_calls` constraints in `tracecat.agent.schemas` as `AgentMaxRequests`, `AgentMaxToolCalls`, and `RunAgentMaxToolCalls`, with shared defaults `DEFAULT_PRESET_AGENT_MAX_REQUESTS=45` and `DEFAULT_PRESET_AGENT_MAX_TOOL_CALLS=15`.
  - Updated `tracecat_ee.agent.schemas` to reuse the shared types; removed duplicated Field constraints.
  - `AGENT_PRESET` sessions now apply preset defaults instead of falling back to generic session limits, and all paths enforce `TRACECAT__AGENT_MAX_REQUESTS` and `TRACECAT__AGENT_MAX_TOOL_CALLS`.
  - `RunAgentArgs` and internal request schemas enforce config upper bounds and still allow `max_tool_calls=0` for model-only runs.
  - Added unit tests to reject values above config and cover the zero tool-call case.

<sup>Written for commit 10becde9be1c5c0164e4a0529ca420d660d438cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

