### PR TITLE
fix(frontend): wrap long sync repository URLs

### DIFF
--- a/frontend/src/components/registry/dialogs/repository-sync-dialog.tsx
+++ b/frontend/src/components/registry/dialogs/repository-sync-dialog.tsx
@@ -80,21 +80,21 @@ export function SyncRepositoryDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
+      <AlertDialogContent className="max-w-2xl">
         <AlertDialogHeader>
           <AlertDialogTitle>Sync repository</AlertDialogTitle>
           <AlertDialogDescription>
-            <span className="flex flex-col space-y-2">
+            <span className="flex flex-col space-y-3">
               <span>
-                You are about to pull the latest version of the repository{" "}
+                You are about to pull the latest version of the repository.
               </span>
-              <b className="font-mono tracking-tighter">
+              <span className="max-w-full rounded-md border px-3 py-2 font-mono text-sm font-semibold tracking-tight text-foreground break-all whitespace-normal">
                 {selectedRepo?.origin}
-              </b>
+              </span>
               {selectedRepo?.commit_sha && (
-                <span className="text-sm text-muted-foreground">
-                  <span>Current SHA: </span>
-                  <span className="font-mono text-xs bg-secondary text-secondary-foreground px-2 py-1 rounded">
+                <span className="flex flex-wrap items-start gap-2 text-sm text-muted-foreground">
+                  <span>Current SHA:</span>
+                  <span className="rounded bg-secondary px-2 py-1 font-mono text-xs text-secondary-foreground break-all whitespace-normal">
                     {selectedRepo.commit_sha}
                   </span>
                 </span>


### PR DESCRIPTION
### Motivation
- Prevent modal layout breakage when repository `origin` contains very long Git URLs or identifiers by constraining width and enabling wrapping in the sync dialog.

### Description
- Widened the alert dialog container by adding `className="max-w-2xl"` to `AlertDialogContent` so the dialog has more horizontal room.
- Rendered the repository `origin` as a bordered monospace block with `break-all` and `whitespace-normal` to force wrapping and avoid overflow (`frontend/src/components/registry/dialogs/repository-sync-dialog.tsx`).
- Updated the Current SHA row to a `flex flex-wrap` layout and added `break-all`/`whitespace-normal` to the SHA badge so long SHAs do not push the dialog horizontally.

### Testing
- Ran formatter/lint autofix with `pnpm -C frontend exec biome check --write src/components/registry/dialogs/repository-sync-dialog.tsx`, which passed and applied formatting.
- Started frontend typecheck with `pnpm -C frontend run typecheck`; it was initiated but did not complete in this environment.
- Changes committed with message `fix(frontend): wrap long sync repository URLs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2b3dd49c8333bdc72d6d6609dc78)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow in the repository sync dialog by wrapping long repository `origin` URLs and commit SHAs, and widening the modal to prevent layout breakage.

- **Bug Fixes**
  - Set `max-w-2xl` on `AlertDialogContent` to give the modal more room.
  - Render `origin` in a bordered monospace block with `break-all` and `whitespace-normal` for wrapping.
  - Made “Current SHA” row `flex flex-wrap` and added wrapping to the SHA badge.

<sup>Written for commit fa9c1c5e96e2db7849c3f2f293dee8849db08d82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

