### PR TITLE
refactor: pull litellm out of the agent executor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,10 @@ TEMPORAL__API_KEY=
 # --- Executor ---
 TRACECAT__EXECUTOR_BACKEND=direct
 TRACECAT__DISABLE_NSJAIL=true
+# LiteLLM bind port inside the compose network
+TRACECAT__LITELLM_PORT=4000
+# Managed LiteLLM service URL used inside the compose network
+TRACECAT__LITELLM_BASE_URL=http://litellm:4000
 
 # --- Workflow Artifacts ---
 # Retention period in days for workflow artifacts in blob storage.

--- a/deployments/eks/main.tf
+++ b/deployments/eks/main.tf
@@ -85,6 +85,7 @@ module "eks" {
   agent_executor_replicas                  = var.agent_executor_replicas
   agent_executor_queue                     = var.agent_executor_queue
   agent_executor_backend                   = var.agent_executor_backend
+  litellm_replicas                         = var.litellm_replicas
   ui_replicas                              = var.ui_replicas
   api_cpu_request_millicores               = var.api_cpu_request_millicores
   api_memory_request_mib                   = var.api_memory_request_mib
@@ -94,6 +95,8 @@ module "eks" {
   executor_memory_request_mib              = var.executor_memory_request_mib
   agent_executor_cpu_request_millicores    = var.agent_executor_cpu_request_millicores
   agent_executor_memory_request_mib        = var.agent_executor_memory_request_mib
+  litellm_cpu_request_millicores           = var.litellm_cpu_request_millicores
+  litellm_memory_request_mib               = var.litellm_memory_request_mib
   ui_cpu_request_millicores                = var.ui_cpu_request_millicores
   ui_memory_request_mib                    = var.ui_memory_request_mib
   node_schedulable_cpu_millicores_per_node = var.node_schedulable_cpu_millicores_per_node

--- a/deployments/eks/modules/eks/helm.tf
+++ b/deployments/eks/modules/eks/helm.tf
@@ -314,6 +314,11 @@ resource "helm_release" "tracecat" {
   }
 
   set {
+    name  = "litellm.replicas"
+    value = var.litellm_replicas
+  }
+
+  set {
     name  = "ui.replicas"
     value = var.ui_replicas
   }
@@ -397,6 +402,26 @@ resource "helm_release" "tracecat" {
   set {
     name  = "agentExecutor.resources.limits.memory"
     value = "${var.agent_executor_memory_request_mib}Mi"
+  }
+
+  set {
+    name  = "litellm.resources.requests.cpu"
+    value = "${var.litellm_cpu_request_millicores}m"
+  }
+
+  set {
+    name  = "litellm.resources.requests.memory"
+    value = "${var.litellm_memory_request_mib}Mi"
+  }
+
+  set {
+    name  = "litellm.resources.limits.cpu"
+    value = "${var.litellm_cpu_request_millicores}m"
+  }
+
+  set {
+    name  = "litellm.resources.limits.memory"
+    value = "${var.litellm_memory_request_mib}Mi"
   }
 
   set {

--- a/deployments/eks/modules/eks/main.tf
+++ b/deployments/eks/modules/eks/main.tf
@@ -77,6 +77,7 @@ locals {
   worker_rollout_replicas         = var.worker_replicas + ceil(var.worker_replicas * local.rollout_surge_fraction)
   executor_rollout_replicas       = var.executor_replicas + ceil(var.executor_replicas * local.rollout_surge_fraction)
   agent_executor_rollout_replicas = var.agent_executor_replicas + ceil(var.agent_executor_replicas * local.rollout_surge_fraction)
+  litellm_rollout_replicas        = var.litellm_replicas + ceil(var.litellm_replicas * local.rollout_surge_fraction)
   ui_rollout_replicas             = var.ui_replicas + ceil(var.ui_replicas * local.rollout_surge_fraction)
 
   tracecat_rollout_peak_cpu_millicores = (
@@ -84,6 +85,7 @@ locals {
     local.worker_rollout_replicas * var.worker_cpu_request_millicores +
     local.executor_rollout_replicas * var.executor_cpu_request_millicores +
     local.agent_executor_rollout_replicas * var.agent_executor_cpu_request_millicores +
+    local.litellm_rollout_replicas * var.litellm_cpu_request_millicores +
     local.ui_rollout_replicas * var.ui_cpu_request_millicores
   )
 
@@ -92,6 +94,7 @@ locals {
     local.worker_rollout_replicas * var.worker_memory_request_mib +
     local.executor_rollout_replicas * var.executor_memory_request_mib +
     local.agent_executor_rollout_replicas * var.agent_executor_memory_request_mib +
+    local.litellm_rollout_replicas * var.litellm_memory_request_mib +
     local.ui_rollout_replicas * var.ui_memory_request_mib
   )
 
@@ -100,6 +103,7 @@ locals {
     local.worker_rollout_replicas +
     local.executor_rollout_replicas +
     local.agent_executor_rollout_replicas +
+    local.litellm_rollout_replicas +
     local.ui_rollout_replicas
   )
 
@@ -108,6 +112,7 @@ locals {
     var.worker_cpu_request_millicores,
     var.executor_cpu_request_millicores,
     var.agent_executor_cpu_request_millicores,
+    var.litellm_cpu_request_millicores,
     var.ui_cpu_request_millicores
   )
 
@@ -116,6 +121,7 @@ locals {
     var.worker_memory_request_mib,
     var.executor_memory_request_mib,
     var.agent_executor_memory_request_mib,
+    var.litellm_memory_request_mib,
     var.ui_memory_request_mib
   )
 

--- a/deployments/eks/modules/eks/variables.tf
+++ b/deployments/eks/modules/eks/variables.tf
@@ -370,6 +370,12 @@ variable "agent_executor_backend" {
   default     = "ephemeral"
 }
 
+variable "litellm_replicas" {
+  description = "Number of LiteLLM replicas"
+  type        = number
+  default     = 2
+}
+
 variable "ui_replicas" {
   description = "Number of UI replicas"
   type        = number
@@ -423,6 +429,18 @@ variable "agent_executor_memory_request_mib" {
   description = "Agent executor memory request in MiB"
   type        = number
   default     = 16384
+}
+
+variable "litellm_cpu_request_millicores" {
+  description = "LiteLLM CPU request in millicores"
+  type        = number
+  default     = 1000
+}
+
+variable "litellm_memory_request_mib" {
+  description = "LiteLLM memory request in MiB"
+  type        = number
+  default     = 2048
 }
 
 variable "ui_cpu_request_millicores" {

--- a/deployments/eks/variables.tf
+++ b/deployments/eks/variables.tf
@@ -374,6 +374,12 @@ variable "agent_executor_backend" {
   default     = "ephemeral"
 }
 
+variable "litellm_replicas" {
+  description = "Number of LiteLLM replicas"
+  type        = number
+  default     = 2
+}
+
 variable "ui_replicas" {
   description = "Number of UI replicas"
   type        = number
@@ -427,6 +433,18 @@ variable "agent_executor_memory_request_mib" {
   description = "Agent executor memory request in MiB"
   type        = number
   default     = 16384
+}
+
+variable "litellm_cpu_request_millicores" {
+  description = "LiteLLM CPU request in millicores"
+  type        = number
+  default     = 1000
+}
+
+variable "litellm_memory_request_mib" {
+  description = "LiteLLM memory request in MiB"
+  type        = number
+  default     = 2048
 }
 
 variable "ui_cpu_request_millicores" {

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -141,6 +141,9 @@ module "ecs" {
   agent_executor_cpu                       = var.agent_executor_cpu
   agent_executor_memory                    = var.agent_executor_memory
   agent_executor_desired_count             = var.agent_executor_desired_count
+  litellm_cpu                              = var.litellm_cpu
+  litellm_memory                           = var.litellm_memory
+  litellm_desired_count                    = var.litellm_desired_count
   agent_queue                              = var.agent_queue
   agent_executor_worker_pool_size          = var.agent_executor_worker_pool_size
   llm_proxy_read_timeout                   = var.llm_proxy_read_timeout

--- a/deployments/fargate/modules/ecs/ecs-agent-executor.tf
+++ b/deployments/fargate/modules/ecs/ecs-agent-executor.tf
@@ -65,6 +65,7 @@ resource "aws_ecs_service" "tracecat_agent_executor" {
 
   depends_on = [
     aws_ecs_service.temporal_service,
-    aws_ecs_service.tracecat_api
+    aws_ecs_service.tracecat_api,
+    aws_ecs_service.tracecat_litellm
   ]
 }

--- a/deployments/fargate/modules/ecs/ecs-litellm.tf
+++ b/deployments/fargate/modules/ecs/ecs-litellm.tf
@@ -1,0 +1,103 @@
+# ECS Task Definition for LiteLLM service
+resource "aws_ecs_task_definition" "litellm_task_definition" {
+  family                   = "TracecatLiteLLMTaskDefinition"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.litellm_cpu
+  memory                   = var.litellm_memory
+  execution_role_arn       = aws_iam_role.worker_execution.arn
+  task_role_arn            = aws_iam_role.executor_task.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name    = "TracecatLiteLLMContainer"
+      image   = "${var.tracecat_image}:${local.tracecat_image_tag}"
+      command = ["python", "-m", "tracecat.agent.litellm"]
+      portMappings = [
+        {
+          containerPort = 4000
+          hostPort      = 4000
+          name          = "http"
+          appProtocol   = "http"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "litellm"
+        }
+      }
+      environment = local.litellm_env
+      secrets     = local.tracecat_base_secrets
+    }
+  ])
+}
+
+resource "aws_ecs_service" "tracecat_litellm" {
+  name                 = "tracecat-litellm"
+  cluster              = aws_ecs_cluster.tracecat_cluster.id
+  task_definition      = aws_ecs_task_definition.litellm_task_definition.arn
+  launch_type          = "FARGATE"
+  desired_count        = var.litellm_desired_count
+  force_new_deployment = var.force_new_deployment
+
+  network_configuration {
+    subnets = var.private_subnet_ids
+    security_groups = [
+      aws_security_group.core.id,
+      aws_security_group.core_db.id,
+      aws_security_group.redis.id
+    ]
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = local.local_dns_namespace
+
+    service {
+      port_name      = "http"
+      discovery_name = "litellm-service"
+      timeout {
+        per_request_timeout_seconds = 3600
+        idle_timeout_seconds        = 3600
+      }
+      client_alias {
+        port     = 4000
+        dns_name = "litellm-service"
+      }
+    }
+
+    log_configuration {
+      log_driver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = "service-connect-litellm"
+      }
+    }
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 2
+    base              = 0
+  }
+
+  depends_on = [
+    aws_ecs_service.temporal_service,
+    aws_ecs_service.tracecat_api
+  ]
+}

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -8,6 +8,8 @@ locals {
   public_app_url   = "https://${var.domain_name}"
   public_api_url   = "https://${var.domain_name}/api"
   internal_api_url = "http://api-service:8000" # Service connect DNS name
+  litellm_port     = "4000"
+  litellm_url      = "http://litellm-service:${local.litellm_port}" # Service connect DNS name
 
   temporal_cluster_url   = var.temporal_cluster_url
   temporal_cluster_queue = var.temporal_cluster_queue
@@ -138,11 +140,26 @@ locals {
         TRACECAT__AGENT_QUEUE               = var.agent_queue
         TRACECAT__EXECUTOR_WORKER_POOL_SIZE = var.agent_executor_worker_pool_size
         TRACECAT__LLM_PROXY_READ_TIMEOUT    = var.llm_proxy_read_timeout
+        TRACECAT__LITELLM_BASE_URL          = local.litellm_url
         TRACECAT__UNSAFE_DISABLE_SM_MASKING = "false"
         TRACECAT__DISABLE_NSJAIL            = "true"
         TRACECAT__SANDBOX_NSJAIL_PATH       = "/usr/local/bin/nsjail"
         TRACECAT__SANDBOX_ROOTFS_PATH       = "/var/lib/tracecat/sandbox-rootfs"
         TRACECAT__SANDBOX_CACHE_DIR         = "/var/lib/tracecat/sandbox-cache"
+      }
+    ) :
+    { name = k, value = tostring(v) } if v != null
+  ]
+
+  litellm_env = [
+    for k, v in merge(
+      local.tracecat_common_env,
+      local.tracecat_db_configs,
+      {
+        TRACECAT__LITELLM_PORT     = local.litellm_port
+        TRACECAT__LITELLM_BASE_URL = local.litellm_url
+        TRACECAT__API_URL          = local.internal_api_url
+        TRACECAT__DB_ENDPOINT      = local.core_db_hostname
       }
     ) :
     { name = k, value = tostring(v) } if v != null

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -520,6 +520,22 @@ variable "agent_executor_desired_count" {
   default     = 1
 }
 
+variable "litellm_cpu" {
+  type    = string
+  default = "1024"
+}
+
+variable "litellm_memory" {
+  type    = string
+  default = "2048"
+}
+
+variable "litellm_desired_count" {
+  type        = number
+  description = "Desired number of LiteLLM instances to run"
+  default     = 2
+}
+
 variable "agent_queue" {
   type        = string
   description = "Task queue for agent executor workers"

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -474,6 +474,22 @@ variable "agent_executor_desired_count" {
   default     = 1
 }
 
+variable "litellm_cpu" {
+  type    = string
+  default = "1024"
+}
+
+variable "litellm_memory" {
+  type    = string
+  default = "2048"
+}
+
+variable "litellm_desired_count" {
+  type        = number
+  description = "Desired number of LiteLLM instances to run"
+  default     = 2
+}
+
 variable "agent_queue" {
   type        = string
   description = "Task queue for agent executor workers"

--- a/deployments/helm/tracecat/templates/_helpers.tpl
+++ b/deployments/helm/tracecat/templates/_helpers.tpl
@@ -322,6 +322,13 @@ Internal API URL - used for service-to-service communication
 {{- end }}
 
 {{/*
+Internal LiteLLM URL - used by runtimes and agent executor consumers
+*/}}
+{{- define "tracecat.internalLiteLLMUrl" -}}
+{{- printf "http://%s-litellm:%d" (include "tracecat.fullname" .) (.Values.litellm.port | int) }}
+{{- end }}
+
+{{/*
 Internal Blob Storage URL
 */}}
 {{- define "tracecat.blobStorageEndpoint" -}}
@@ -821,6 +828,8 @@ Merges: common + temporal + postgres + redis + agent-executor-specific
   value: {{ .Values.agentExecutor.workerPoolSize | quote }}
 - name: TRACECAT__LLM_PROXY_READ_TIMEOUT
   value: {{ .Values.agentExecutor.llmProxyReadTimeout | quote }}
+- name: TRACECAT__LITELLM_BASE_URL
+  value: {{ include "tracecat.internalLiteLLMUrl" . | quote }}
 {{- end }}
 
 {{/*

--- a/deployments/helm/tracecat/templates/litellm-deployment.yaml
+++ b/deployments/helm/tracecat/templates/litellm-deployment.yaml
@@ -1,0 +1,68 @@
+{{- include "tracecat.validateRequiredSecrets" . -}}
+{{- include "tracecat.validateInfrastructure" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tracecat.fullname" . }}-litellm
+  labels:
+    {{- include "tracecat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+spec:
+  replicas: {{ .Values.litellm.replicas }}
+  selector:
+    matchLabels:
+      {{- include "tracecat.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: litellm
+  template:
+    metadata:
+      labels:
+        {{- include "tracecat.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: litellm
+        tracecat.com/access-postgres: "true"
+        tracecat.com/access-redis: "true"
+      {{- if or .Values.reloader.enabled .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.reloader.enabled }}
+        reloader.stakater.com/auto: "true"
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      serviceAccountName: {{ include "tracecat.serviceAccountName" . }}
+      {{- include "tracecat.podScheduling" (dict "root" . "component" "litellm") | nindent 6 }}
+      containers:
+        - name: litellm
+          image: "{{ .Values.image.repository }}:{{ include "tracecat.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "tracecat.agent.litellm"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.litellm.port }}
+              protocol: TCP
+          env:
+            - name: TRACECAT__LITELLM_PORT
+              value: {{ .Values.litellm.port | quote }}
+            - name: TRACECAT__LITELLM_BASE_URL
+              value: {{ include "tracecat.internalLiteLLMUrl" . | quote }}
+            - name: TRACECAT__API_URL
+              value: {{ include "tracecat.internalApiUrl" . | quote }}
+            {{- include "tracecat.env.common" . | nindent 12 }}
+            {{- include "tracecat.env.postgres" . | nindent 12 }}
+            {{- include "tracecat.env.redis" . | nindent 12 }}
+            {{- include "tracecat.env.secrets" . | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.litellm.resources | nindent 12 }}

--- a/deployments/helm/tracecat/templates/litellm-service.yaml
+++ b/deployments/helm/tracecat/templates/litellm-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tracecat.fullname" . }}-litellm
+  labels:
+    {{- include "tracecat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.litellm.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tracecat.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm

--- a/deployments/helm/tracecat/values.yaml
+++ b/deployments/helm/tracecat/values.yaml
@@ -332,6 +332,17 @@ agentExecutor:
     enabled: false
     thresholdKb: 16
 
+litellm:
+  replicas: 2
+  port: 4000
+  resources:
+    requests:
+      cpu: "1000m"
+      memory: "2048Mi"
+    limits:
+      cpu: "1000m"
+      memory: "2048Mi"
+
 mcp:
   enabled: false
   replicas: 2

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -227,6 +227,41 @@ services:
       minio:
         condition: service_healthy
 
+  litellm:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    restart: unless-stopped
+    environment:
+      TRACECAT__LITELLM_PORT: ${TRACECAT__LITELLM_PORT}
+      TRACECAT__LITELLM_BASE_URL: ${TRACECAT__LITELLM_BASE_URL}
+      LOG_LEVEL: ${LOG_LEVEL}
+      TRACECAT__APP_ENV: ${TRACECAT__APP_ENV}
+      TRACECAT__DB_ENCRYPTION_KEY: ${TRACECAT__DB_ENCRYPTION_KEY} # Sensitive
+      TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
+      TRACECAT__DB_URI: ${TRACECAT__DB_URI} # Sensitive
+      TRACECAT__SERVICE_KEY: ${TRACECAT__SERVICE_KEY} # Sensitive
+      PYTHONPATH: /app:/app/packages/tracecat-registry:/app/packages/tracecat-ee
+    volumes:
+      - ./tracecat:/app/tracecat
+      - ./packages:/app/packages
+      - ./alembic:/app/alembic
+    command: ["python", "-m", "tracecat.agent.litellm"]
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import os, socket; port=int(os.environ['TRACECAT__LITELLM_PORT']); s=socket.create_connection(('127.0.0.1', port), timeout=5); s.close()\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
   agent-executor:
     build:
       context: .
@@ -255,6 +290,7 @@ services:
       TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
       TRACECAT__EE_MULTI_TENANT: ${TRACECAT__EE_MULTI_TENANT:-false}
       TRACECAT__API_URL: ${TRACECAT__API_URL:-http://api:8000}
+      TRACECAT__LITELLM_BASE_URL: ${TRACECAT__LITELLM_BASE_URL}
       # Compression (must match worker for codec compatibility)
       TRACECAT__CONTEXT_COMPRESSION_ENABLED: ${TRACECAT__CONTEXT_COMPRESSION_ENABLED:-false}
       TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB: ${TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB:-16}
@@ -294,6 +330,8 @@ services:
       - sandbox-cache:/var/lib/tracecat/sandbox-cache
     command: ["python", "-m", "tracecat.agent.worker"]
     depends_on:
+      litellm:
+        condition: service_healthy
       migrations:
         condition: service_completed_successfully
       api:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -245,6 +245,41 @@ services:
       minio:
         condition: service_healthy
 
+  litellm:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    restart: unless-stopped
+    networks:
+      - core
+      - core-db
+      - temporal
+    environment:
+      TRACECAT__LITELLM_PORT: ${TRACECAT__LITELLM_PORT}
+      TRACECAT__LITELLM_BASE_URL: ${TRACECAT__LITELLM_BASE_URL}
+      LOG_LEVEL: ${LOG_LEVEL}
+      TRACECAT__APP_ENV: production
+      TRACECAT__DB_ENCRYPTION_KEY: ${TRACECAT__DB_ENCRYPTION_KEY} # Sensitive
+      TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
+      TRACECAT__DB_URI: ${TRACECAT__DB_URI} # Sensitive
+      TRACECAT__SERVICE_KEY: ${TRACECAT__SERVICE_KEY} # Sensitive
+      PYTHONPATH: /app:/app/packages/tracecat-registry:/app/packages/tracecat-ee
+    command: ["python", "-m", "tracecat.agent.litellm"]
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import os, socket; port=int(os.environ['TRACECAT__LITELLM_PORT']); s=socket.create_connection(('127.0.0.1', port), timeout=5); s.close()\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
   agent-executor:
     build:
       context: .
@@ -277,6 +312,7 @@ services:
       TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
       TRACECAT__EE_MULTI_TENANT: ${TRACECAT__EE_MULTI_TENANT:-false}
       TRACECAT__API_URL: ${TRACECAT__API_URL:-http://api:8000}
+      TRACECAT__LITELLM_BASE_URL: ${TRACECAT__LITELLM_BASE_URL}
       # Compression (must match worker for codec compatibility)
       TRACECAT__CONTEXT_COMPRESSION_ENABLED: ${TRACECAT__CONTEXT_COMPRESSION_ENABLED:-false}
       TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB: ${TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB:-16}
@@ -314,6 +350,8 @@ services:
       - sandbox-cache:/var/lib/tracecat/sandbox-cache
     command: ["python", "-m", "tracecat.agent.worker"]
     depends_on:
+      litellm:
+        condition: service_healthy
       migrations:
         condition: service_completed_successfully
       temporal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,83 +238,118 @@ services:
       minio:
         condition: service_healthy
 
+  litellm:
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.33}
+    restart: unless-stopped
+    networks:
+      - core
+      - core-db
+      - temporal
+    environment:
+      TRACECAT__LITELLM_PORT: ${TRACECAT__LITELLM_PORT}
+      TRACECAT__LITELLM_BASE_URL: ${TRACECAT__LITELLM_BASE_URL}
+      LOG_LEVEL: ${LOG_LEVEL}
+      TRACECAT__APP_ENV: production
+      TRACECAT__DB_ENCRYPTION_KEY: ${TRACECAT__DB_ENCRYPTION_KEY} # Sensitive
+      TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
+      TRACECAT__DB_URI: ${TRACECAT__DB_URI} # Sensitive
+      TRACECAT__SERVICE_KEY: ${TRACECAT__SERVICE_KEY} # Sensitive
+      PYTHONPATH: /app:/app/packages/tracecat-registry:/app/packages/tracecat-ee
+    command: ["python", "-m", "tracecat.agent.litellm"]
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import os, socket; port=int(os.environ['TRACECAT__LITELLM_PORT']); s=socket.create_connection(('127.0.0.1', port), timeout=5); s.close()\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
   agent-executor:
-      image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.33}
-      restart: unless-stopped
-      networks:
-        - core
-        - core-db
-        - temporal
-      # Required for nsjail sandbox (uncomment if using nsjail)
-      # cap_add:
-      #   - SYS_ADMIN
-      # security_opt:
-      #   - seccomp:unconfined
-      # # Required for pasta userspace networking (creates TAP device in sandbox netns)
-      # devices:
-      #   - /dev/net/tun:/dev/net/tun
-      environment:
-        # Common
-        LOG_LEVEL: ${LOG_LEVEL}
-        TRACECAT__APP_ENV: production
-        TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID: ${TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID:-}
-        TRACECAT__AWS_ASSUME_ROLE_PRINCIPAL_ARN: ${TRACECAT__AWS_ASSUME_ROLE_PRINCIPAL_ARN:-}
-        TRACECAT__DB_ENCRYPTION_KEY: ${TRACECAT__DB_ENCRYPTION_KEY} # Sensitive
-        TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
-        TRACECAT__DB_URI: ${TRACECAT__DB_URI} # Sensitive
-        TRACECAT__SERVICE_KEY: ${TRACECAT__SERVICE_KEY} # Sensitive
-        TRACECAT__SIGNING_SECRET: ${TRACECAT__SIGNING_SECRET} # Sensitive
-        TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
-        TRACECAT__EE_MULTI_TENANT: ${TRACECAT__EE_MULTI_TENANT:-false}
-        TRACECAT__API_URL: ${TRACECAT__API_URL:-http://api:8000}
-        # Compression (must match worker for codec compatibility)
-        TRACECAT__CONTEXT_COMPRESSION_ENABLED: ${TRACECAT__CONTEXT_COMPRESSION_ENABLED:-false}
-        TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB: ${TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB:-16}
-        TRACECAT__RESULT_EXTERNALIZATION_ENABLED: "true"
-        TRACECAT__COLLECTION_MANIFESTS_ENABLED: "true"
-        TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES: ${TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES}
-        # Registry
-        TRACECAT__UNSAFE_DISABLE_SM_MASKING: ${TRACECAT__UNSAFE_DISABLE_SM_MASKING:-false}
-        # Local registry
-        TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
-        TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
-        # Sandbox
-        TRACECAT__EXECUTOR_BACKEND: ${TRACECAT__EXECUTOR_BACKEND:-direct}
-        TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}
-        TRACECAT__SANDBOX_NSJAIL_PATH: /usr/local/bin/nsjail
-        TRACECAT__SANDBOX_ROOTFS_PATH: /var/lib/tracecat/sandbox-rootfs
-        TRACECAT__SANDBOX_CACHE_DIR: /var/lib/tracecat/sandbox-cache
-        # Temporal
-        TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
-        TEMPORAL__CLUSTER_NAMESPACE: ${TEMPORAL__CLUSTER_NAMESPACE}
-        TEMPORAL__API_KEY: ${TEMPORAL__API_KEY}
-        # Agent Worker configuration
-        TRACECAT__AGENT_QUEUE: ${TRACECAT__AGENT_QUEUE:-shared-agent-queue}
-        TRACECAT__LLM_PROXY_READ_TIMEOUT: ${TRACECAT__LLM_PROXY_READ_TIMEOUT:-300}
-        # Pool size auto-scales based on available CPUs if not set
-        TRACECAT__EXECUTOR_WORKER_POOL_SIZE: ${TRACECAT__EXECUTOR_WORKER_POOL_SIZE:-}
-        # Redis
-        REDIS_URL: ${REDIS_URL}
-        # Blob storage (MinIO/S3)
-        TRACECAT__BLOB_STORAGE_ENDPOINT: ${TRACECAT__BLOB_STORAGE_ENDPOINT:-http://minio:9000}
-        TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW: ${TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW:-tracecat-workflow}
-        TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS: ${TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS:-tracecat-attachments}
-        TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY: ${TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY:-tracecat-registry}
-        MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-        MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      volumes:
-        - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
-        - sandbox-cache:/var/lib/tracecat/sandbox-cache
-      command: ["python", "-m", "tracecat.agent.worker"]
-      depends_on:
-        migrations:
-          condition: service_completed_successfully
-        temporal:
-          condition: service_healthy
-        redis:
-          condition: service_healthy
-        minio:
-          condition: service_healthy
+    image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.33}
+    restart: unless-stopped
+    networks:
+      - core
+      - core-db
+      - temporal
+    # Required for nsjail sandbox (uncomment if using nsjail)
+    # cap_add:
+    #   - SYS_ADMIN
+    # security_opt:
+    #   - seccomp:unconfined
+    # # Required for pasta userspace networking (creates TAP device in sandbox netns)
+    # devices:
+    #   - /dev/net/tun:/dev/net/tun
+    environment:
+      # Common
+      LOG_LEVEL: ${LOG_LEVEL}
+      TRACECAT__APP_ENV: production
+      TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID: ${TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID:-}
+      TRACECAT__AWS_ASSUME_ROLE_PRINCIPAL_ARN: ${TRACECAT__AWS_ASSUME_ROLE_PRINCIPAL_ARN:-}
+      TRACECAT__DB_ENCRYPTION_KEY: ${TRACECAT__DB_ENCRYPTION_KEY} # Sensitive
+      TRACECAT__DB_SSLMODE: ${TRACECAT__DB_SSLMODE}
+      TRACECAT__DB_URI: ${TRACECAT__DB_URI} # Sensitive
+      TRACECAT__SERVICE_KEY: ${TRACECAT__SERVICE_KEY} # Sensitive
+      TRACECAT__SIGNING_SECRET: ${TRACECAT__SIGNING_SECRET} # Sensitive
+      TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
+      TRACECAT__EE_MULTI_TENANT: ${TRACECAT__EE_MULTI_TENANT:-false}
+      TRACECAT__API_URL: ${TRACECAT__API_URL:-http://api:8000}
+      TRACECAT__LITELLM_BASE_URL: ${TRACECAT__LITELLM_BASE_URL}
+      # Compression (must match worker for codec compatibility)
+      TRACECAT__CONTEXT_COMPRESSION_ENABLED: ${TRACECAT__CONTEXT_COMPRESSION_ENABLED:-false}
+      TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB: ${TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB:-16}
+      TRACECAT__RESULT_EXTERNALIZATION_ENABLED: "true"
+      TRACECAT__COLLECTION_MANIFESTS_ENABLED: "true"
+      TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES: ${TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES}
+      # Registry
+      TRACECAT__UNSAFE_DISABLE_SM_MASKING: ${TRACECAT__UNSAFE_DISABLE_SM_MASKING:-false}
+      # Local registry
+      TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
+      TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
+      # Sandbox
+      TRACECAT__EXECUTOR_BACKEND: ${TRACECAT__EXECUTOR_BACKEND:-direct}
+      TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}
+      TRACECAT__SANDBOX_NSJAIL_PATH: /usr/local/bin/nsjail
+      TRACECAT__SANDBOX_ROOTFS_PATH: /var/lib/tracecat/sandbox-rootfs
+      TRACECAT__SANDBOX_CACHE_DIR: /var/lib/tracecat/sandbox-cache
+      # Temporal
+      TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
+      TEMPORAL__CLUSTER_NAMESPACE: ${TEMPORAL__CLUSTER_NAMESPACE}
+      TEMPORAL__API_KEY: ${TEMPORAL__API_KEY}
+      # Agent Worker configuration
+      TRACECAT__AGENT_QUEUE: ${TRACECAT__AGENT_QUEUE:-shared-agent-queue}
+      TRACECAT__LLM_PROXY_READ_TIMEOUT: ${TRACECAT__LLM_PROXY_READ_TIMEOUT:-300}
+      # Pool size auto-scales based on available CPUs if not set
+      TRACECAT__EXECUTOR_WORKER_POOL_SIZE: ${TRACECAT__EXECUTOR_WORKER_POOL_SIZE:-}
+      # Redis
+      REDIS_URL: ${REDIS_URL}
+      # Blob storage (MinIO/S3)
+      TRACECAT__BLOB_STORAGE_ENDPOINT: ${TRACECAT__BLOB_STORAGE_ENDPOINT:-http://minio:9000}
+      TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW: ${TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW:-tracecat-workflow}
+      TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS: ${TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS:-tracecat-attachments}
+      TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY: ${TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY:-tracecat-registry}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
+      - sandbox-cache:/var/lib/tracecat/sandbox-cache
+    command: ["python", "-m", "tracecat.agent.worker"]
+    depends_on:
+      litellm:
+        condition: service_healthy
+      migrations:
+        condition: service_completed_successfully
+      temporal:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
 
   mcp:
     image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.33}

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -306,6 +306,8 @@ build_env() {
     export REDIS_PORT_HOST
     export TEMPORAL_PORT
     export API_PORT
+    export TRACECAT__LITELLM_PORT="${TRACECAT__LITELLM_PORT:-4000}"
+    export TRACECAT__LITELLM_BASE_URL="${TRACECAT__LITELLM_BASE_URL:-http://litellm:${TRACECAT__LITELLM_PORT}}"
     export TEMPORAL_UI_PORT
     export MINIO_PORT
     export MINIO_CONSOLE_PORT
@@ -317,7 +319,6 @@ build_env() {
     export TRACECAT__PUBLIC_API_URL="${PUBLIC_API_URL}"
     export NEXT_PUBLIC_APP_URL="${PUBLIC_APP_URL}"
     export NEXT_PUBLIC_API_URL="${PUBLIC_API_URL}"
-
     # Caddy configuration
     export BASE_DOMAIN=":${PUBLIC_APP_PORT}"
 

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -1,10 +1,16 @@
 from typing import cast
 
 import pytest
+from fastapi import Request
 from litellm.caching.dual_cache import DualCache
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from starlette.datastructures import URL
 
-from tracecat.agent.gateway import TracecatCallbackHandler, _inject_provider_credentials
+from tracecat.agent.gateway import (
+    TracecatCallbackHandler,
+    _inject_provider_credentials,
+    user_api_key_auth,
+)
 
 
 def test_gemini_injects_api_key_and_prefixes_model():
@@ -215,3 +221,80 @@ async def test_pre_call_hook_uses_preset_base_url_over_custom_provider_credentia
 
     assert result["api_key"] == "test-custom-key"
     assert result["api_base"] == "https://preset.custom.example/v1"
+
+
+@pytest.mark.anyio
+async def test_user_api_key_auth_rejects_invalid_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.agent.gateway.verify_llm_token",
+        lambda _: (_ for _ in ()).throw(ValueError("bad token")),
+    )
+
+    with pytest.raises(ProxyException, match="Invalid or expired token"):
+        await user_api_key_auth(request=cast(Request, object()), api_key="bad-token")
+
+
+@pytest.mark.anyio
+async def test_user_api_key_auth_allows_healthcheck_without_token() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/health",
+            "headers": [],
+            "query_string": b"",
+            "client": ("127.0.0.1", 12345),
+            "server": ("localhost", 4000),
+            "scheme": "http",
+        }
+    )
+
+    auth = await user_api_key_auth(request=request, api_key="")
+
+    assert auth.api_key == "litellm-healthcheck"
+    assert auth.request_route == URL("http://localhost:4000/health").path
+
+
+@pytest.mark.anyio
+async def test_pre_call_hook_filters_model_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def mock_get_provider_credentials(**_: object) -> dict[str, str]:
+        return {"OPENAI_API_KEY": "test-openai-key"}
+
+    monkeypatch.setattr(
+        "tracecat.agent.gateway.get_provider_credentials",
+        mock_get_provider_credentials,
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="llm-token",
+        metadata={
+            "workspace_id": "00000000-0000-0000-0000-000000000001",
+            "organization_id": "00000000-0000-0000-0000-000000000002",
+            "model": "gpt-5",
+            "provider": "openai",
+            "model_settings": {
+                "temperature": 0.2,
+                "seed": 7,
+                "api_key": "should-not-pass",
+                "metadata": {"unsafe": True},
+            },
+            "use_workspace_credentials": True,
+        },
+    )
+
+    handler = TracecatCallbackHandler()
+    result = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=cast(DualCache, object()),
+        data={},
+        call_type="completion",
+    )
+
+    assert result["temperature"] == 0.2
+    assert result["seed"] == 7
+    assert "metadata" not in result
+    assert result["api_key"] == "test-openai-key"

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from tracecat.agent.sandbox.llm_proxy import LLMSocketProxy
+
+
+def test_llm_socket_proxy_uses_configured_default_url(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.agent.sandbox.llm_proxy.get_default_litellm_url",
+        lambda: "http://litellm:4000",
+    )
+
+    proxy = LLMSocketProxy(socket_path=Path("/tmp/test-llm.sock"))
+
+    assert proxy.litellm_url == "http://litellm:4000"

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -27,7 +27,10 @@ from tracecat.agent.common.types import (
 from tracecat.agent.common.types import (
     MCPToolDefinition as SharedMCPToolDefinition,
 )
-from tracecat.agent.runtime.claude_code.runtime import ClaudeAgentRuntime
+from tracecat.agent.runtime.claude_code.runtime import (
+    ClaudeAgentRuntime,
+    get_litellm_url,
+)
 from tracecat.agent.types import AgentConfig
 
 
@@ -153,6 +156,28 @@ def make_hook_context() -> HookContext:
 def get_hook_output(result: SyncHookJSONOutput) -> dict[str, Any]:
     """Extract hookSpecificOutput from result."""
     return cast(dict[str, Any], result.get("hookSpecificOutput", {}))
+
+
+def test_get_litellm_url_uses_bridge_port_when_network_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.agent.runtime.claude_code.runtime.TRACECAT__DISABLE_NSJAIL", True
+    )
+    monkeypatch.setenv("TRACECAT__LLM_BRIDGE_PORT", "4312")
+
+    assert get_litellm_url(enable_internet_access=False) == "http://127.0.0.1:4312"
+
+
+def test_get_litellm_url_uses_managed_service_url_when_internet_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.agent.runtime.claude_code.runtime.TRACECAT__DISABLE_NSJAIL", False
+    )
+    monkeypatch.setenv("TRACECAT__LITELLM_URL", "http://litellm:4000/")
+
+    assert get_litellm_url(enable_internet_access=True) == "http://litellm:4000"
 
 
 class TestClaudeAgentRuntimeRun:

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -24,6 +24,14 @@ from tracecat.logger import logger
 # Apply monkeypatches for LiteLLM adapter compatibility fixes
 apply_patch()
 
+_UNAUTHENTICATED_PATHS = frozenset(
+    {
+        "/health",
+        "/health/liveliness",
+        "/health/readiness",
+    }
+)
+
 # -----------------------------------------------------------------------------
 # Credential Fetching via AgentManagementService
 # -----------------------------------------------------------------------------
@@ -47,9 +55,10 @@ async def get_provider_credentials(
     )
 
     async with AgentManagementService.with_session(role=role) as service:
-        if use_workspace_creds:
-            return await service.get_workspace_provider_credentials(provider)
-        return await service.get_provider_credentials(provider)
+        return await service.get_runtime_provider_credentials(
+            provider,
+            use_workspace_credentials=use_workspace_creds,
+        )
 
 
 # -----------------------------------------------------------------------------
@@ -63,6 +72,12 @@ async def user_api_key_auth(request: Request, api_key: str) -> UserAPIKeyAuth:
     The api_key parameter is the Bearer token sent by the SDK, which is
     actually our JWT token minted by the agent executor.
     """
+    if request.url.path in _UNAUTHENTICATED_PATHS:
+        return UserAPIKeyAuth(
+            api_key="litellm-healthcheck",
+            request_route=request.url.path,
+        )
+
     try:
         claims = verify_llm_token(api_key)
     except ValueError as e:

--- a/tracecat/agent/litellm.py
+++ b/tracecat/agent/litellm.py
@@ -1,0 +1,75 @@
+"""Launcher for the managed LiteLLM service.
+
+Runs LiteLLM on the Tracecat image while preserving the config path shape that
+LiteLLM expects for custom auth and callback module resolution.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def prepare_runtime_config() -> Path:
+    """Create the runtime config path LiteLLM resolves hooks against."""
+    source_config = Path(__file__).with_name("litellm_config.yaml")
+    if not source_config.exists():
+        raise FileNotFoundError(f"LiteLLM config not found: {source_config}")
+
+    runtime_config = Path("/app/litellm_config.yaml")
+    temp_symlink = runtime_config.with_suffix(f".yaml.{os.getpid()}.tmp")
+    try:
+        temp_symlink.symlink_to(source_config)
+        temp_symlink.replace(runtime_config)
+    except FileExistsError:
+        pass
+    finally:
+        if temp_symlink.exists() or temp_symlink.is_symlink():
+            temp_symlink.unlink()
+
+    return runtime_config
+
+
+def build_exec_env() -> dict[str, str]:
+    """Build the environment for the managed LiteLLM process."""
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH", "")
+    app_paths = "/app:/app/packages/tracecat-registry:/app/packages/tracecat-ee"
+    env["PYTHONPATH"] = f"{app_paths}:{pythonpath}" if pythonpath else app_paths
+    return env
+
+
+def get_bind_host() -> str:
+    """Return the bind host for the managed LiteLLM process.
+
+    TRACECAT__LITELLM_BASE_URL is primarily a consumer-facing URL. If its
+    hostname is a concrete local bind address, reuse it; otherwise bind to all
+    interfaces.
+    """
+    if base_url := os.environ.get("TRACECAT__LITELLM_BASE_URL"):
+        parsed = urlparse(base_url)
+        if parsed.hostname in {"0.0.0.0", "127.0.0.1", "localhost"}:
+            return parsed.hostname
+    return "0.0.0.0"
+
+
+def main() -> None:
+    """Launch LiteLLM with the Tracecat-managed gateway config."""
+    runtime_config = prepare_runtime_config()
+    host = get_bind_host()
+    port = os.environ.get("TRACECAT__LITELLM_PORT") or "4000"
+    cmd = [
+        "litellm",
+        "--host",
+        host,
+        "--port",
+        port,
+        "--config",
+        str(runtime_config),
+    ]
+    os.execvpe(cmd[0], cmd, build_exec_env())
+
+
+if __name__ == "__main__":
+    main()

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -56,22 +56,34 @@ from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 from tracecat.agent.runtime.claude_code.adapter import ClaudeSDKAdapter
 from tracecat.logger import logger
 
-# Default LiteLLM port for NSJail mode and internet-enabled mode
+# Default LiteLLM port for bridge-backed sandbox modes.
 # In direct mode with network isolation, the bridge uses a dynamic port
-# passed via TRACECAT__LLM_BRIDGE_PORT environment variable
+# passed via TRACECAT__LLM_BRIDGE_PORT environment variable.
 LITELLM_DEFAULT_PORT = 4000
 
 
-def get_litellm_url() -> str:
+def get_litellm_url(*, enable_internet_access: bool) -> str:
     """Get the LiteLLM URL based on runtime mode.
 
-    - NSJail mode: Uses fixed port 4000 (network namespace isolated)
-    - Direct mode (network isolated): Uses dynamic port from env var
-    - Internet enabled: Uses default port 4000 (direct gateway access)
+    - Network isolated: use the local LLM bridge on localhost
+    - Internet enabled: connect directly to the managed LiteLLM service URL
     """
 
+    if not enable_internet_access:
+        if TRACECAT__DISABLE_NSJAIL:
+            # Direct mode: check for dynamic port from LLM bridge
+            port = os.environ.get(
+                "TRACECAT__LLM_BRIDGE_PORT", str(LITELLM_DEFAULT_PORT)
+            )
+            return f"http://127.0.0.1:{port}"
+        return f"http://127.0.0.1:{LITELLM_DEFAULT_PORT}"
+
+    if litellm_url := (
+        os.environ.get("TRACECAT__LITELLM_URL")
+        or os.environ.get("TRACECAT__LITELLM_BASE_URL")
+    ):
+        return litellm_url.rstrip("/")
     if TRACECAT__DISABLE_NSJAIL:
-        # Direct mode: check for dynamic port from LLM bridge
         port = os.environ.get("TRACECAT__LLM_BRIDGE_PORT", str(LITELLM_DEFAULT_PORT))
         return f"http://127.0.0.1:{port}"
     return f"http://127.0.0.1:{LITELLM_DEFAULT_PORT}"
@@ -541,7 +553,9 @@ class ClaudeAgentRuntime:
                 fork_session=fork_session,  # If True, creates new session from parent's history
                 env={
                     "ANTHROPIC_AUTH_TOKEN": payload.litellm_auth_token,
-                    "ANTHROPIC_BASE_URL": get_litellm_url(),
+                    "ANTHROPIC_BASE_URL": get_litellm_url(
+                        enable_internet_access=payload.config.enable_internet_access
+                    ),
                 },
                 model=payload.config.model_name,
                 system_prompt=self._build_system_prompt(payload.config.instructions),

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -412,6 +412,10 @@ def build_agent_env_map(config: AgentSandboxConfig) -> dict[str, str]:
         AgentSandboxValidationError: If any env var key or value is invalid.
     """
     env_map: dict[str, str] = {**AGENT_SANDBOX_BASE_ENV}
+    if litellm_base_url := os.environ.get("TRACECAT__LITELLM_BASE_URL"):
+        env_map["TRACECAT__LITELLM_BASE_URL"] = litellm_base_url
+    if litellm_url := os.environ.get("TRACECAT__LITELLM_URL"):
+        env_map["TRACECAT__LITELLM_URL"] = litellm_url
 
     for key, value in config.env_vars.items():
         _validate_env_key(key)

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -1,9 +1,9 @@
 """LLM socket proxy for agent executor.
 
 This module provides a Unix socket server that runs on the host side and
-proxies HTTP traffic to the LiteLLM proxy at localhost:4000. The socket
-is mounted into the NSJail sandbox, allowing the sandboxed agent runtime
-to communicate with LiteLLM without direct network access.
+proxies HTTP traffic to the managed LiteLLM service. The socket is mounted
+into the NSJail sandbox, allowing the sandboxed agent runtime to communicate
+with LiteLLM without direct network access.
 
 The proxy handles:
 - HTTP/1.1 request parsing from the Unix socket
@@ -24,11 +24,14 @@ from pathlib import Path
 
 import httpx
 
-from tracecat.config import TRACECAT__LLM_PROXY_READ_TIMEOUT
+from tracecat.config import TRACECAT__LITELLM_URL, TRACECAT__LLM_PROXY_READ_TIMEOUT
 from tracecat.logger import logger
 
-# LiteLLM proxy runs on localhost:4000
-LITELLM_URL = "http://127.0.0.1:4000"
+
+def get_default_litellm_url() -> str:
+    """Return the configured managed LiteLLM service URL."""
+    return TRACECAT__LITELLM_URL.rstrip("/")
+
 
 # Socket filename (created in job's socket directory)
 LLM_SOCKET_NAME = "llm.sock"
@@ -73,18 +76,18 @@ class LLMSocketProxy:
     def __init__(
         self,
         socket_path: Path,
-        litellm_url: str = LITELLM_URL,
+        litellm_url: str | None = None,
         on_error: Callable[[str], None] | None = None,
     ):
         """Initialize the LLM socket proxy.
 
         Args:
             socket_path: Path where the Unix socket will be created.
-            litellm_url: URL of the LiteLLM proxy (default: http://127.0.0.1:4000).
+            litellm_url: URL of the managed LiteLLM service.
             on_error: Callback invoked when an error (e.g., auth failure) is detected.
         """
         self.socket_path = socket_path
-        self.litellm_url = litellm_url
+        self.litellm_url = litellm_url or get_default_litellm_url()
         self._server: asyncio.Server | None = None
         self._client: httpx.AsyncClient | None = None
         self._on_error = on_error

--- a/tracecat/agent/sandbox/nsjail.py
+++ b/tracecat/agent/sandbox/nsjail.py
@@ -248,6 +248,10 @@ async def _spawn_direct_runtime(
         # Use host's HOME for Claude SDK session storage
         "HOME": os.environ.get("HOME", "/tmp"),
     }
+    if litellm_base_url := os.environ.get("TRACECAT__LITELLM_BASE_URL"):
+        env["TRACECAT__LITELLM_BASE_URL"] = litellm_base_url
+    if litellm_url := os.environ.get("TRACECAT__LITELLM_URL"):
+        env["TRACECAT__LITELLM_URL"] = litellm_url
     if llm_socket_path is not None:
         # If the runtime uses LLMBridge (internet access disabled), it must connect
         # to the orchestrator-side LLM socket.

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -5,7 +5,6 @@ instances. It is separate from the main DSLWorker to allow independent scaling
 and isolation of agent workloads.
 
 Services started at init:
-- LiteLLM proxy subprocess (multi-tenant credential injection)
 - Trusted MCP HTTP server (Unix socket for tool execution)
 
 Architecture:
@@ -32,7 +31,6 @@ import os
 import signal
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 
 from temporalio import workflow
 from temporalio.worker import Worker
@@ -104,103 +102,7 @@ interrupt_event = asyncio.Event()
 # Service Lifecycle
 # ============================================================================
 
-_litellm_process: asyncio.subprocess.Process | None = None
-_litellm_stderr_task: asyncio.Task[None] | None = None
 _mcp_server_task: asyncio.Task[None] | None = None
-
-
-async def _stream_litellm_stderr(process: asyncio.subprocess.Process) -> None:
-    """Stream LiteLLM stderr to logger."""
-    if process.stderr is None:
-        return
-    try:
-        async for line in process.stderr:
-            decoded = line.decode("utf-8", errors="replace").rstrip()
-            if decoded:
-                logger.info("LiteLLM stderr", line=decoded)
-    except Exception as e:
-        logger.warning("LiteLLM stderr stream ended", error=str(e))
-
-
-async def start_litellm_proxy() -> None:
-    """Start the LiteLLM proxy subprocess."""
-    global _litellm_process, _litellm_stderr_task
-
-    # Use the config file from the tracecat.agent package
-    source_config = Path(__file__).parent / "litellm_config.yaml"
-    if not source_config.exists():
-        logger.error("LiteLLM config not found", config_path=str(source_config))
-        return
-
-    # LiteLLM resolves custom_auth/callbacks paths relative to config file directory.
-    # Create symlink at /app so that "tracecat.agent.gateway" resolves correctly
-    # (dirname(/app/litellm_config.yaml) + tracecat/agent/gateway.py = /app/tracecat/agent/gateway.py)
-    # Use atomic rename to prevent TOCTOU race condition
-    runtime_config = Path("/app/litellm_config.yaml")
-    temp_symlink = runtime_config.with_suffix(f".yaml.{os.getpid()}.tmp")
-    try:
-        temp_symlink.symlink_to(source_config)
-        temp_symlink.replace(runtime_config)  # Atomic rename
-    except FileExistsError:
-        # Another process already created the symlink
-        pass
-    finally:
-        # Clean up temp symlink if it still exists
-        if temp_symlink.exists() or temp_symlink.is_symlink():
-            temp_symlink.unlink()
-
-    logger.info("Starting LiteLLM proxy")
-
-    cmd = [
-        "litellm",
-        "--port",
-        "4000",
-        "--config",
-        str(runtime_config),
-    ]
-
-    # Pass current environment with PYTHONPATH set to include /app
-    # This allows LiteLLM to import tracecat modules for custom auth/callbacks
-    env = os.environ.copy()
-    pythonpath = env.get("PYTHONPATH", "")
-    app_paths = "/app:/app/packages/tracecat-registry:/app/packages/tracecat-ee"
-    env["PYTHONPATH"] = f"{app_paths}:{pythonpath}" if pythonpath else app_paths
-
-    _litellm_process = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=env,
-    )
-
-    # Start background task to stream stderr
-    _litellm_stderr_task = asyncio.create_task(_stream_litellm_stderr(_litellm_process))
-
-    logger.info("LiteLLM proxy started")
-
-
-async def stop_litellm_proxy() -> None:
-    """Stop the LiteLLM proxy subprocess."""
-    global _litellm_process, _litellm_stderr_task
-
-    # Cancel stderr streaming task
-    if _litellm_stderr_task:
-        _litellm_stderr_task.cancel()
-        try:
-            await _litellm_stderr_task
-        except asyncio.CancelledError:
-            pass
-        _litellm_stderr_task = None
-
-    if _litellm_process and _litellm_process.returncode is None:
-        logger.info("Stopping LiteLLM proxy")
-        _litellm_process.terminate()
-        try:
-            await asyncio.wait_for(_litellm_process.wait(), timeout=5.0)
-        except TimeoutError:
-            _litellm_process.kill()
-            await _litellm_process.wait()
-        _litellm_process = None
 
 
 async def start_mcp_server() -> None:
@@ -301,7 +203,6 @@ async def main() -> None:
     )
 
     # Initialize services before accepting tasks
-    await start_litellm_proxy()
     await start_mcp_server()
 
     try:
@@ -353,7 +254,6 @@ async def main() -> None:
     finally:
         logger.info("Shutting down services")
         await stop_mcp_server()
-        await stop_litellm_proxy()
 
 
 def _signal_handler(sig: int, _frame: object) -> None:

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -626,6 +626,19 @@ TRACECAT__LLM_PROXY_READ_TIMEOUT = float(
 )
 """Read timeout for the LLM socket proxy in seconds (default: 5 minutes)."""
 
+TRACECAT__LITELLM_PORT = int(os.environ.get("TRACECAT__LITELLM_PORT") or 4000)
+"""Bind port for the managed LiteLLM service."""
+
+TRACECAT__LITELLM_BASE_URL = os.environ.get(
+    "TRACECAT__LITELLM_BASE_URL", f"http://127.0.0.1:{TRACECAT__LITELLM_PORT}"
+)
+"""Internal base URL for the managed LiteLLM service."""
+
+TRACECAT__LITELLM_URL = (
+    os.environ.get("TRACECAT__LITELLM_URL") or TRACECAT__LITELLM_BASE_URL
+)
+"""Internal URL for the managed LiteLLM service."""
+
 TRACECAT__AGENT_QUEUE = os.environ.get("TRACECAT__AGENT_QUEUE", "shared-agent-queue")
 """Task queue for the AgentWorker (Temporal workflow queue).
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pulled LiteLLM out of the agent executor into a standalone, managed service. This adds first-class deployments (Helm/EKS/ECS and Compose) and routes all runtimes through a shared LiteLLM endpoint.

- **Refactors**
  - Added a new launcher `python -m tracecat.agent.litellm`; removed the LiteLLM subprocess from `agent.worker`.
  - Runtimes and the sandbox now use `TRACECAT__LITELLM_URL`/`TRACECAT__LITELLM_BASE_URL`; the local bridge is still used when network access is disabled.
  - Infra: new Helm Deployment/Service, EKS variables for replicas/resources, ECS Fargate service with Service Connect, and a `litellm` service in Compose with health checks; agent-executor now depends on it.
  - Gateway/auth: health endpoints allow unauthenticated checks; credentials come from `get_runtime_provider_credentials`; model settings are filtered before passing to providers. Tests were added/updated.

- **Migration**
  - Set env vars: `TRACECAT__LITELLM_PORT` (default 4000), `TRACECAT__LITELLM_BASE_URL` (e.g., http://litellm:4000). Optionally set `TRACECAT__LITELLM_URL` for direct clients.
  - Helm: configure `litellm.replicas`, `litellm.resources`, and `litellm.port` in values, then upgrade.
  - EKS/ECS: provide `litellm_*` variables (CPU/memory/replicas or desired count) and apply Terraform. The service is reachable as `litellm-service` via Service Connect.
  - Compose: bring up the new `litellm` service; agent-executor already depends on it. Update `.env` with the new variables.

<sup>Written for commit 2482b43e03ca50b6599b62993a32d5f20384ce98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

