### PR TITLE
fix(frontend): stop workflow graph layout drift

### DIFF
--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -12,7 +12,6 @@ import {
   type NodeRemoveChange,
   type OnConnectStartParams,
   Panel,
-  Position,
   ReactFlow,
   type ReactFlowInstance,
   useEdgesState,
@@ -32,7 +31,6 @@ import { v4 as uuid4 } from "uuid"
 
 import "@xyflow/react/dist/style.css"
 
-import Dagre from "@dagrejs/dagre"
 import { MoveHorizontalIcon, MoveVerticalIcon, PlusIcon } from "lucide-react"
 import type {
   GraphOperation,
@@ -62,11 +60,10 @@ import { useGraph, useGraphOperations } from "@/lib/hooks"
 import { pruneGraphObject } from "@/lib/workflow"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
+import { getLayoutedElements } from "./graph-layout"
 
-const dagreGraph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
 const defaultNodeWidth = 172
 const defaultNodeHeight = 36
-const triggerNodeAutoLayoutGap = 64
 
 const fitViewOptions: FitViewOptions = {
   minZoom: 0.75,
@@ -74,83 +71,6 @@ const fitViewOptions: FitViewOptions = {
 }
 
 const getId = () => uuid4()
-
-/**
- * Taken from https://reactflow.dev/examples/layout/dagre
- * @param nodes
- * @param edges
- * @param direction
- * @returns
- */
-function getLayoutedElements(
-  nodes: Node[],
-  edges: Edge[],
-  direction = "TB"
-): {
-  nodes: Node[]
-  edges: Edge[]
-} {
-  const isHorizontal = direction === "LR"
-  dagreGraph.setGraph({ rankdir: direction, nodesep: 250, ranksep: 300 })
-
-  nodes.forEach((node) => {
-    dagreGraph.setNode(node.id, {
-      width: node.width ?? defaultNodeWidth,
-      height: node.height ?? defaultNodeHeight,
-    })
-  })
-
-  edges.forEach((edge) => {
-    dagreGraph.setEdge(edge.source, edge.target)
-  })
-
-  Dagre.layout(dagreGraph)
-
-  const newNodes = nodes.map((node) => {
-    const nodeWithPosition = dagreGraph.node(node.id)
-    const height = node.height ?? defaultNodeHeight
-    const width = node.width ?? defaultNodeWidth
-    const newNode = {
-      ...node,
-      targetPosition: isHorizontal ? Position.Left : Position.Top,
-      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
-      // We are shifting the dagre node position (anchor=center center) to the top left
-      // so it matches the React Flow node anchor point (top left).
-      position: {
-        x: nodeWithPosition.x - width / 2,
-        y: nodeWithPosition.y - height / 2,
-      },
-    }
-
-    return newNode
-  })
-
-  if (!isHorizontal) {
-    const triggerNode = newNodes.find((node) => node.type === TriggerTypename)
-    if (triggerNode) {
-      const triggerY = triggerNode.position.y
-      const adjustedNodes = newNodes.map((node) => {
-        if (node.id === triggerNode.id) {
-          return node
-        }
-        if (node.position.y <= triggerY) {
-          return node
-        }
-        return {
-          ...node,
-          position: {
-            ...node.position,
-            y: node.position.y + triggerNodeAutoLayoutGap,
-          },
-        }
-      })
-
-      return { nodes: adjustedNodes, edges }
-    }
-  }
-
-  return { nodes: newNodes, edges }
-}
 
 export type NodeTypename = "udf" | "trigger" | "selector"
 export type NodeType = ActionNodeType | TriggerNodeType | SelectorNodeType

--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -60,7 +60,7 @@ import { useGraph, useGraphOperations } from "@/lib/hooks"
 import { pruneGraphObject } from "@/lib/workflow"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
-import { getLayoutedElements } from "./graph-layout"
+import { getLayoutedElements, mergeHydratedNodes } from "./graph-layout"
 
 const defaultNodeWidth = 172
 const defaultNodeHeight = 36
@@ -192,15 +192,7 @@ export const WorkflowCanvas = React.forwardRef<
       setGraphVersion(graph.version)
       const { nodes: rfNodes, edges: rfEdges } =
         buildNodesAndEdgesFromGraph(graph)
-      setNodes((nodes) => {
-        const selectedNodeIds = new Set(
-          nodes.filter((node) => node.selected).map((node) => node.id)
-        )
-        return rfNodes.map((node) => ({
-          ...node,
-          selected: selectedNodeIds.has(node.id),
-        }))
-      })
+      setNodes((nodes) => mergeHydratedNodes(nodes, rfNodes))
       setEdges(rfEdges)
       setHydratedWorkflowId(workflowId ?? null)
     },
@@ -223,15 +215,7 @@ export const WorkflowCanvas = React.forwardRef<
       // Build nodes and edges from graph API response
       const { nodes: graphNodes, edges: graphEdges } =
         buildNodesAndEdgesFromGraph(graphData)
-      setNodes((nodes) => {
-        const selectedNodeIds = new Set(
-          nodes.filter((node) => node.selected).map((node) => node.id)
-        )
-        return graphNodes.map((node) => ({
-          ...node,
-          selected: selectedNodeIds.has(node.id),
-        }))
-      })
+      setNodes((nodes) => mergeHydratedNodes(nodes, graphNodes))
       setEdges(graphEdges)
       setGraphVersion(graphData.version)
 

--- a/frontend/src/components/builder/canvas/graph-layout.ts
+++ b/frontend/src/components/builder/canvas/graph-layout.ts
@@ -1,0 +1,93 @@
+import Dagre from "@dagrejs/dagre"
+import { type Edge, type Node, Position } from "@xyflow/react"
+
+const defaultNodeWidth = 172
+const defaultNodeHeight = 36
+const builderNodeWidth = 256
+const triggerNodeAutoLayoutGap = 64
+
+function getDefaultNodeWidth(node: Node): number {
+  if (node.type === "trigger" || node.type === "udf") {
+    return builderNodeWidth
+  }
+  return defaultNodeWidth
+}
+
+export function getNodeLayoutDimensions(node: Node): {
+  width: number
+  height: number
+} {
+  return {
+    width: node.measured?.width ?? node.width ?? getDefaultNodeWidth(node),
+    height: node.measured?.height ?? node.height ?? defaultNodeHeight,
+  }
+}
+
+/**
+ * Taken from https://reactflow.dev/examples/layout/dagre
+ */
+export function getLayoutedElements(
+  nodes: Node[],
+  edges: Edge[],
+  direction = "TB"
+): {
+  nodes: Node[]
+  edges: Edge[]
+} {
+  const dagreGraph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
+  const isHorizontal = direction === "LR"
+  dagreGraph.setGraph({ rankdir: direction, nodesep: 250, ranksep: 300 })
+
+  nodes.forEach((node) => {
+    const { width, height } = getNodeLayoutDimensions(node)
+    dagreGraph.setNode(node.id, { width, height })
+  })
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target)
+  })
+
+  Dagre.layout(dagreGraph)
+
+  const newNodes = nodes.map((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id)
+    const { width, height } = getNodeLayoutDimensions(node)
+
+    return {
+      ...node,
+      targetPosition: isHorizontal ? Position.Left : Position.Top,
+      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+      // Dagre uses a center anchor while React Flow uses top-left.
+      position: {
+        x: nodeWithPosition.x - width / 2,
+        y: nodeWithPosition.y - height / 2,
+      },
+    }
+  })
+
+  if (isHorizontal) {
+    return { nodes: newNodes, edges }
+  }
+
+  const triggerNode = newNodes.find((node) => node.type === "trigger")
+  if (!triggerNode) {
+    return { nodes: newNodes, edges }
+  }
+
+  const triggerY = triggerNode.position.y
+  return {
+    nodes: newNodes.map((node) => {
+      if (node.id === triggerNode.id || node.position.y <= triggerY) {
+        return node
+      }
+      return {
+        ...node,
+        position: {
+          ...node.position,
+          y: node.position.y + triggerNodeAutoLayoutGap,
+        },
+      }
+    }),
+    edges,
+  }
+}

--- a/frontend/src/components/builder/canvas/graph-layout.ts
+++ b/frontend/src/components/builder/canvas/graph-layout.ts
@@ -91,3 +91,25 @@ export function getLayoutedElements(
     edges,
   }
 }
+
+export function mergeHydratedNodes(
+  currentNodes: Node[],
+  hydratedNodes: Node[]
+): Node[] {
+  const currentNodesById = new Map(currentNodes.map((node) => [node.id, node]))
+
+  return hydratedNodes.map((node) => {
+    const currentNode = currentNodesById.get(node.id)
+    if (!currentNode) {
+      return node
+    }
+
+    return {
+      ...node,
+      selected: currentNode.selected ?? node.selected,
+      measured: currentNode.measured ?? node.measured,
+      width: currentNode.width ?? node.width,
+      height: currentNode.height ?? node.height,
+    }
+  })
+}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -475,6 +475,20 @@ type GraphOpParams = {
   operations: GraphOperation[]
 }
 
+const structuralGraphOperationTypes = new Set<GraphOperation["type"]>([
+  "add_node",
+  "update_node",
+  "delete_node",
+  "add_edge",
+  "delete_edge",
+])
+
+function shouldSyncGraphCache(operations: GraphOperation[]): boolean {
+  return operations.some((operation) =>
+    structuralGraphOperationTypes.has(operation.type)
+  )
+}
+
 /**
  * Hook to fetch graph data for a workflow.
  */
@@ -508,11 +522,12 @@ export function useGraphOperations(workspaceId: string, workflowId: string) {
           operations,
         },
       }),
-    onSuccess: (graph) => {
-      // Update the graph cache with the new version
-      queryClient.setQueryData(["graph", workspaceId, workflowId], graph)
-      // Also invalidate workflow to pick up any action changes
-      queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
+    onSuccess: (graph, variables) => {
+      if (shouldSyncGraphCache(variables.operations)) {
+        // Update the graph cache with the latest structural state.
+        queryClient.setQueryData(["graph", workspaceId, workflowId], graph)
+        queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
+      }
     },
     onError: (error) => {
       console.error("Failed to apply graph operations:", error)

--- a/frontend/tests/graph-layout.test.ts
+++ b/frontend/tests/graph-layout.test.ts
@@ -2,6 +2,7 @@ import type { Edge, Node } from "@xyflow/react"
 import {
   getLayoutedElements,
   getNodeLayoutDimensions,
+  mergeHydratedNodes,
 } from "@/components/builder/canvas/graph-layout"
 
 function createNode(id: string, type: string, overrides?: Partial<Node>): Node {
@@ -89,5 +90,54 @@ describe("getLayoutedElements", () => {
 
     expect(trigger?.position.y).toBe(0)
     expect(action?.position.y).toBe(400)
+  })
+})
+
+describe("mergeHydratedNodes", () => {
+  it("preserves measured dimensions, width, height, and selection for matching nodes", () => {
+    const currentNodes = [
+      createNode("trigger-1", "trigger", {
+        selected: true,
+        measured: { width: 256, height: 48 },
+        width: 256,
+        height: 48,
+      }),
+      createNode("action-1", "udf", {
+        measured: { width: 320, height: 64 },
+        width: 320,
+        height: 64,
+      }),
+    ]
+    const hydratedNodes = [
+      createNode("trigger-1", "trigger", {
+        selected: false,
+        position: { x: 10, y: 20 },
+      }),
+      createNode("action-1", "udf", {
+        position: { x: 30, y: 40 },
+      }),
+      createNode("action-2", "udf", {
+        position: { x: 50, y: 60 },
+      }),
+    ]
+
+    expect(mergeHydratedNodes(currentNodes, hydratedNodes)).toEqual([
+      createNode("trigger-1", "trigger", {
+        selected: true,
+        position: { x: 10, y: 20 },
+        measured: { width: 256, height: 48 },
+        width: 256,
+        height: 48,
+      }),
+      createNode("action-1", "udf", {
+        position: { x: 30, y: 40 },
+        measured: { width: 320, height: 64 },
+        width: 320,
+        height: 64,
+      }),
+      createNode("action-2", "udf", {
+        position: { x: 50, y: 60 },
+      }),
+    ])
   })
 })

--- a/frontend/tests/graph-layout.test.ts
+++ b/frontend/tests/graph-layout.test.ts
@@ -1,0 +1,93 @@
+import type { Edge, Node } from "@xyflow/react"
+import {
+  getLayoutedElements,
+  getNodeLayoutDimensions,
+} from "@/components/builder/canvas/graph-layout"
+
+function createNode(id: string, type: string, overrides?: Partial<Node>): Node {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: {},
+    ...overrides,
+  } as Node
+}
+
+function createEdge(source: string, target: string): Edge {
+  return {
+    id: `${source}-${target}`,
+    source,
+    target,
+  }
+}
+
+describe("getNodeLayoutDimensions", () => {
+  it("prefers measured dimensions over width and fallback values", () => {
+    const node = createNode("trigger-1", "trigger", {
+      measured: { width: 256, height: 48 },
+      width: 172,
+      height: 36,
+    })
+
+    expect(getNodeLayoutDimensions(node)).toEqual({
+      width: 256,
+      height: 48,
+    })
+  })
+})
+
+describe("getLayoutedElements", () => {
+  it("uses measured widths when converting dagre positions to top-left coordinates", () => {
+    const { nodes } = getLayoutedElements(
+      [
+        createNode("trigger-1", "trigger", {
+          measured: { width: 256, height: 36 },
+        }),
+        createNode("action-1", "udf", {
+          measured: { width: 256, height: 36 },
+        }),
+      ],
+      [createEdge("trigger-1", "action-1")]
+    )
+
+    expect(nodes.map((node) => node.position)).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 400 },
+    ])
+  })
+
+  it("does not leak dagre state between successive layouts", () => {
+    getLayoutedElements(
+      [
+        createNode("trigger", "trigger"),
+        createNode("action-a", "udf"),
+        createNode("action-b", "udf"),
+      ],
+      [createEdge("trigger", "action-a"), createEdge("trigger", "action-b")]
+    )
+
+    const { nodes } = getLayoutedElements(
+      [createNode("trigger", "trigger"), createNode("action-a", "udf")],
+      [createEdge("trigger", "action-a")]
+    )
+
+    expect(nodes.map((node) => node.position)).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 400 },
+    ])
+  })
+
+  it("keeps the trigger auto-layout gap for vertical layouts", () => {
+    const { nodes } = getLayoutedElements(
+      [createNode("trigger-1", "trigger"), createNode("action-1", "udf")],
+      [createEdge("trigger-1", "action-1")]
+    )
+
+    const trigger = nodes.find((node) => node.type === "trigger")
+    const action = nodes.find((node) => node.type === "udf")
+
+    expect(trigger?.position.y).toBe(0)
+    expect(action?.position.y).toBe(400)
+  })
+})

--- a/frontend/tests/use-graph-operations.test.tsx
+++ b/frontend/tests/use-graph-operations.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import {
+  type GraphOperation,
+  graphApplyGraphOperations,
+  graphGetGraph,
+} from "@/client"
+import { useGraphOperations } from "@/lib/hooks"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    graphApplyGraphOperations: jest.fn(),
+    graphGetGraph: jest.fn(),
+  }
+})
+
+const mockGraphApplyGraphOperations =
+  graphApplyGraphOperations as jest.MockedFunction<
+    typeof graphApplyGraphOperations
+  >
+
+const mockGraphGetGraph = graphGetGraph as jest.MockedFunction<
+  typeof graphGetGraph
+>
+
+function createGraphResponse(version: number, nodeX = 0) {
+  return {
+    version,
+    nodes: [
+      {
+        id: "trigger-workflow-1",
+        type: "trigger",
+        position: { x: nodeX, y: 0 },
+        data: {},
+      },
+    ],
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+  }
+}
+
+describe("useGraphOperations", () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    jest.clearAllMocks()
+    mockGraphGetGraph.mockResolvedValue(
+      createGraphResponse(1) as Awaited<ReturnType<typeof graphGetGraph>>
+    )
+  })
+
+  it("does not rewrite the graph cache for non-structural graph operations", async () => {
+    const cachedGraph = createGraphResponse(1)
+    const returnedGraph = createGraphResponse(1, 400)
+    queryClient.setQueryData(
+      ["graph", "workspace-1", "workflow-1"],
+      cachedGraph
+    )
+    const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries")
+
+    mockGraphApplyGraphOperations.mockResolvedValue(
+      returnedGraph as Awaited<ReturnType<typeof graphApplyGraphOperations>>
+    )
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(
+      () => useGraphOperations("workspace-1", "workflow-1"),
+      { wrapper }
+    )
+
+    const operations: GraphOperation[] = [
+      {
+        type: "move_nodes",
+        payload: {
+          positions: [{ action_id: "action-1", x: 400, y: 200 }],
+        },
+      },
+    ]
+
+    await result.current.applyGraphOperations({
+      baseVersion: 1,
+      operations,
+    })
+
+    await waitFor(() => {
+      expect(mockGraphApplyGraphOperations).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      queryClient.getQueryData(["graph", "workspace-1", "workflow-1"])
+    ).toBe(cachedGraph)
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled()
+  })
+
+  it("updates the graph cache for structural graph operations", async () => {
+    const cachedGraph = createGraphResponse(1)
+    const returnedGraph = createGraphResponse(2, 240)
+    queryClient.setQueryData(
+      ["graph", "workspace-1", "workflow-1"],
+      cachedGraph
+    )
+    const invalidateQueriesSpy = jest.spyOn(queryClient, "invalidateQueries")
+
+    mockGraphApplyGraphOperations.mockResolvedValue(
+      returnedGraph as Awaited<ReturnType<typeof graphApplyGraphOperations>>
+    )
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(
+      () => useGraphOperations("workspace-1", "workflow-1"),
+      { wrapper }
+    )
+
+    const operations: GraphOperation[] = [
+      {
+        type: "add_node",
+        payload: {
+          type: "core.test",
+          title: "Test node",
+          position_x: 240,
+          position_y: 120,
+        },
+      },
+    ]
+
+    await result.current.applyGraphOperations({
+      baseVersion: 1,
+      operations,
+    })
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData(["graph", "workspace-1", "workflow-1"])
+      ).toStrictEqual(returnedGraph)
+    })
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["workflow", "workflow-1"],
+    })
+  })
+})


### PR DESCRIPTION
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes workflow graph layout drift in the builder.

Changes included:
- use measured React Flow node dimensions during Dagre layout instead of relying on stale `width` / `height` fallbacks
- create a fresh Dagre graph per auto-layout call so stale nodes and edges cannot affect later layouts
- preserve measured node metadata when hydrating the canvas from graph responses
- avoid rewriting the React Query graph cache for layout-only and viewport-only graph operations

Implementation was split into three reviewable commits:
- `4e26a9b66` Fix workflow graph auto-layout sizing
- `d21897978` Preserve measured node state on graph refresh
- `ac40eca6f` Avoid graph cache churn for layout-only saves

Verified locally with:
- `pnpm -C frontend test -- graph-layout.test.ts use-graph-operations.test.tsx`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`

## Related Issues


## Screenshots / Recordings

N/A

## Steps to QA

1. Open a workflow in the builder with a trigger and one or more downstream steps.
2. Use the auto-arrange control multiple times.
3. Verify downstream steps do not continue drifting to the right.
4. Move nodes or pan/zoom the canvas, then reopen the workflow.
5. Verify node positions remain stable and auto-arrange still produces the same layout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow builder graph layout drift. Auto-arrange now produces stable positions across refreshes and repeated runs, and layout/viewport-only actions no longer churn the graph cache.

- **Bug Fixes**
  - Use measured `@xyflow/react` node sizes for Dagre layout instead of stale fallbacks.
  - Build a fresh `@dagrejs/dagre` graph for each layout to prevent state leaks between runs.
  - Preserve measured node metadata when hydrating the canvas from graph responses.
  - Only sync the `@tanstack/react-query` graph cache for structural changes; skip for layout/viewport updates.

<sup>Written for commit ac40eca6f43ce51da04f7bfc443af611f213dda2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

