### PR TITLE
fix(mcp): MCP preset tools and pagination

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -264,10 +264,16 @@
     <ResponseField name="agents_create_agent_preset" type="tool">
   Create an agent preset in the selected workspace.
     </ResponseField>
+    <ResponseField name="agents_update_agent_preset" type="tool">
+  Update an existing agent preset in the selected workspace.
+    </ResponseField>
     <ResponseField name="agents_list_agent_presets" type="tool">
   List saved agent preset slugs and names.
 
   Use `get_agent_preset` for the full preset definition.
+    </ResponseField>
+    <ResponseField name="agents_get_agent_preset" type="tool">
+  Get the full configuration for a saved agent preset by slug.
     </ResponseField>
     <ResponseField name="agents_run_agent_preset" type="tool">
   Run an agent preset with a prompt and return text or approval status.

--- a/tests/unit/api/test_api_workflow_execution_search.py
+++ b/tests/unit/api/test_api_workflow_execution_search.py
@@ -16,6 +16,7 @@ def _empty_page() -> WorkflowExecutionsPage:
     return WorkflowExecutionsPage(
         items=[],
         next_cursor=None,
+        prev_cursor=None,
         has_more=False,
         has_previous=False,
     )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3225,6 +3225,64 @@ async def test_search_table_rows_returns_paginated_payload(
 
 
 @pytest.mark.anyio
+async def test_list_workflow_executions_forwards_prev_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    workflow_id = mcp_server.WorkflowUUID.new_uuid4()
+    start_time = datetime.now(UTC)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _ExecutionService:
+        async def list_executions_paginated(
+            self,
+            *,
+            pagination: Any,
+            workflow_id: Any,
+        ) -> SimpleNamespace:
+            assert pagination.limit == 20
+            assert pagination.cursor == "cursor-2"
+            assert workflow_id == mcp_server.WorkflowUUID.new(str(workflow_id))
+            return SimpleNamespace(
+                items=[
+                    SimpleNamespace(
+                        id="wf_example/exec_123",
+                        run_id="run-123",
+                        status=1,
+                        start_time=start_time,
+                        close_time=None,
+                        typed_search_attributes=None,
+                    )
+                ],
+                next_cursor="cursor-3",
+                prev_cursor="cursor-1",
+                has_more=True,
+                has_previous=True,
+            )
+
+    async def _connect(*, role: Any) -> _ExecutionService:
+        assert role is not None
+        return _ExecutionService()
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server.WorkflowExecutionsService, "connect", _connect)
+
+    payload = _payload(
+        await _tool(mcp_server.list_workflow_executions)(
+            workspace_id=str(workspace_id),
+            workflow_id=str(workflow_id),
+            cursor="cursor-2",
+        )
+    )
+    assert payload["prev_cursor"] == "cursor-1"
+    assert payload["has_previous"] is True
+    assert payload["next_cursor"] == "cursor-3"
+
+
+@pytest.mark.anyio
 async def test_concurrent_workspace_calls_do_not_cross(monkeypatch):
     """Concurrent tool calls for different workspaces resolve independently."""
     resolved: dict[str, uuid.UUID] = {}

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1674,8 +1674,8 @@ async def test_list_secrets_metadata_returns_keys_not_values(monkeypatch):
         workspace_id=str(uuid.uuid4()),
     )
     payload = _payload(result)
-    assert len(payload) == 1
-    assert payload[0]["keys"] == ["API_KEY"]
+    assert payload["items"][0]["keys"] == ["API_KEY"]
+    assert payload["has_more"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -2011,7 +2011,7 @@ async def test_list_workflow_tags(monkeypatch):
 
     result = await _tool(mcp_server.list_workflow_tags)(workspace_id=str(uuid.uuid4()))
     payload = _payload(result)
-    assert payload == [
+    assert payload["items"] == [
         {
             "id": str(tags[0].id),
             "name": "Critical",
@@ -2141,8 +2141,8 @@ async def test_list_case_tags(monkeypatch):
 
     result = await _tool(mcp_server.list_case_tags)(workspace_id=str(uuid.uuid4()))
     payload = _payload(result)
-    assert payload[0]["ref"] == "malware"
-    assert payload[0]["color"] == "#ff8800"
+    assert payload["items"][0]["ref"] == "malware"
+    assert payload["items"][0]["color"] == "#ff8800"
 
 
 @pytest.mark.anyio
@@ -2313,10 +2313,10 @@ async def test_list_case_fields(monkeypatch):
 
     result = await _tool(mcp_server.list_case_fields)(workspace_id=str(uuid.uuid4()))
     payload = _payload(result)
-    assert payload[0]["id"] == "status_reason"
-    assert payload[0]["type"] == "TEXT"
-    assert payload[1]["type"] == "SELECT"
-    assert payload[1]["options"] == ["low", "high"]
+    assert payload["items"][0]["id"] == "status_reason"
+    assert payload["items"][0]["type"] == "TEXT"
+    assert payload["items"][1]["type"] == "SELECT"
+    assert payload["items"][1]["options"] == ["low", "high"]
 
 
 @pytest.mark.anyio
@@ -2807,6 +2807,10 @@ async def test_action_catalog_resource(monkeypatch):
         async def list_actions_from_index(self, **_kwargs):
             return entries
 
+        async def search_actions_from_index(self, _query, *, limit=None):
+            _ = limit
+            return entries
+
         async def get_action_from_index(self, _action_name):
             return indexed_action
 
@@ -2866,6 +2870,10 @@ async def test_list_actions_browse_without_query(monkeypatch):
         async def list_actions_from_index(self, **_kwargs):
             return entries
 
+        async def search_actions_from_index(self, _query, *, limit=None):
+            _ = limit
+            return entries
+
         async def get_action_from_index(self, _action_name):
             return indexed_action
 
@@ -2883,9 +2891,10 @@ async def test_list_actions_browse_without_query(monkeypatch):
         workspace_id=str(uuid.uuid4()),
     )
     payload = _payload(result)
-    assert len(payload) == 2
-    assert payload[0]["action_name"] == "core.http_request"
-    assert payload[1]["action_name"] == "tools.slack.post_message"
+    assert len(payload["items"]) == 2
+    assert payload["items"][0]["action_name"] == "core.http_request"
+    assert payload["items"][1]["action_name"] == "tools.slack.post_message"
+    assert payload["has_more"] is False
 
 
 @pytest.mark.anyio
@@ -2937,8 +2946,80 @@ async def test_list_actions_browse_with_namespace(monkeypatch):
         namespace="tools.slack",
     )
     payload = _payload(result)
-    assert len(payload) == 1
+    assert len(payload["items"]) == 1
     assert captured_kwargs.get("namespace") == "tools.slack"
+
+
+@pytest.mark.anyio
+async def test_list_actions_paginates_and_rejects_mismatched_cursor(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _secret_inventory(_role):
+        return {}
+
+    class _IndexEntry:
+        def __init__(self, namespace, name, description):
+            self.namespace = namespace
+            self.name = name
+            self.description = description
+
+    entries = [
+        (_IndexEntry("core", "one", "One"), "platform"),
+        (_IndexEntry("core", "two", "Two"), "platform"),
+        (_IndexEntry("core", "three", "Three"), "platform"),
+    ]
+    indexed_action = SimpleNamespace(
+        manifest=SimpleNamespace(),
+        index_entry=SimpleNamespace(options=None),
+    )
+
+    class _RegistryService:
+        async def list_actions_from_index(self, **_kwargs):
+            return entries
+
+        async def search_actions_from_index(self, _query, *, limit=None):
+            _ = limit
+            return entries
+
+        async def get_action_from_index(self, _action_name):
+            return indexed_action
+
+        def aggregate_secrets_from_manifest(self, _manifest, _action_name):
+            return []
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(
+        "tracecat.registry.actions.service.RegistryActionsService.with_session",
+        lambda role: _AsyncContext(_RegistryService()),
+    )
+
+    first_page = _payload(
+        await _tool(mcp_server.list_actions)(
+            workspace_id=str(uuid.uuid4()),
+            limit=2,
+        )
+    )
+    assert len(first_page["items"]) == 2
+    assert first_page["has_more"] is True
+    assert first_page["next_cursor"] is not None
+
+    second_page = _payload(
+        await _tool(mcp_server.list_actions)(
+            workspace_id=str(uuid.uuid4()),
+            limit=2,
+            cursor=first_page["next_cursor"],
+        )
+    )
+    assert [item["action_name"] for item in second_page["items"]] == ["core.three"]
+
+    with pytest.raises(ToolError, match="Cursor no longer matches current filters"):
+        await _tool(mcp_server.list_actions)(
+            workspace_id=str(uuid.uuid4()),
+            query="two",
+            cursor=first_page["next_cursor"],
+        )
 
 
 @pytest.mark.anyio
@@ -2954,7 +3035,7 @@ async def test_list_workspaces_applies_org_scope(monkeypatch):
     result = await _tool(mcp_server.list_workspaces)()
     payload = _payload(result)
 
-    assert len(payload) == 1
+    assert len(payload["items"]) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -2982,10 +3063,15 @@ async def test_list_workspaces_returns_multi_org_workspaces(monkeypatch):
     result = await _tool(mcp_server.list_workspaces)()
     payload = _payload(result)
 
-    assert len(payload) == 2
-    returned_ids = {w["id"] for w in payload}
+    assert len(payload["items"]) == 2
+    returned_ids = {w["id"] for w in payload["items"]}
     assert str(WS_A) in returned_ids
     assert str(WS_B) in returned_ids
+
+
+def test_tool_namespace_mapping_includes_get_agent_preset() -> None:
+    assert mcp_server._TOOL_NAMESPACE_BY_NAME["get_agent_preset"] == "agents"
+    assert mcp_server._TOOL_NAMESPACE_BY_NAME["update_agent_preset"] == "agents"
 
 
 @pytest.mark.anyio
@@ -3022,6 +3108,120 @@ async def test_create_table_routes_to_correct_workspace(monkeypatch):
     assert len(captured_roles) == 2
     assert captured_roles[0].workspace_id == WS_A
     assert captured_roles[1].workspace_id == WS_B
+
+
+@pytest.mark.anyio
+async def test_list_workflow_tree_paginates_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, SimpleNamespace()
+
+    class _Item:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def model_dump(self, *, mode: str = "json") -> dict[str, Any]:
+            assert mode == "json"
+            return self._payload
+
+    class _FolderService:
+        async def get_directory_items(
+            self, path: str, order_by: str = "desc"
+        ) -> list[_Item]:
+            assert order_by == "desc"
+            if path == "/":
+                return [
+                    _Item({"type": "folder", "path": "/a/", "name": "a"}),
+                    _Item(
+                        {
+                            "type": "workflow",
+                            "id": str(uuid.uuid4()),
+                            "title": "Root workflow",
+                            "alias": None,
+                            "status": "offline",
+                            "tags": [],
+                        }
+                    ),
+                ]
+            return []
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.WorkflowFolderService,
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+
+    first_page = _payload(
+        await _tool(mcp_server.list_workflow_tree)(
+            workspace_id=str(workspace_id),
+            limit=1,
+        )
+    )
+    assert len(first_page["items"]) == 1
+    assert first_page["has_more"] is True
+    assert first_page["next_cursor"] is not None
+    assert first_page["root_path"] == "/"
+
+
+@pytest.mark.anyio
+async def test_search_table_rows_returns_paginated_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    table_id = uuid.uuid4()
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, SimpleNamespace()
+
+    captured: dict[str, Any] = {}
+
+    class _TableService:
+        async def get_table(self, parsed_table_id: uuid.UUID) -> SimpleNamespace:
+            assert parsed_table_id == table_id
+            return SimpleNamespace(id=table_id)
+
+        async def search_rows(
+            self,
+            _table: Any,
+            *,
+            search_term: str | None = None,
+            limit: int | None = None,
+            cursor: str | None = None,
+        ) -> Any:
+            captured["search_term"] = search_term
+            captured["limit"] = limit
+            captured["cursor"] = cursor
+            return mcp_server.MCPPaginatedResponse[dict[str, Any]](
+                items=[{"city": "NYC"}],
+                next_cursor="cursor-1",
+                prev_cursor=None,
+                has_more=True,
+                has_previous=False,
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.TablesService,
+        "with_session",
+        lambda role: _AsyncContext(_TableService()),
+    )
+
+    payload = _payload(
+        await _tool(mcp_server.search_table_rows)(
+            workspace_id=str(workspace_id),
+            table_id=str(table_id),
+            search_term="ny",
+            limit=25,
+            cursor="cursor-0",
+        )
+    )
+    assert payload["items"] == [{"city": "NYC"}]
+    assert payload["next_cursor"] == "cursor-1"
+    assert captured == {"search_term": "ny", "limit": 25, "cursor": "cursor-0"}
 
 
 @pytest.mark.anyio
@@ -3237,7 +3437,13 @@ async def test_list_agent_presets_returns_lightweight_metadata(
 
     result = await _tool(mcp_server.list_agent_presets)(workspace_id=str(workspace_id))
 
-    assert _payload(result) == [{"slug": "security-triage", "name": "Security triage"}]
+    assert _payload(result) == {
+        "items": [{"slug": "security-triage", "name": "Security triage"}],
+        "next_cursor": None,
+        "prev_cursor": None,
+        "has_more": False,
+        "has_previous": False,
+    }
 
 
 @pytest.mark.anyio
@@ -3459,6 +3665,94 @@ async def test_list_integrations_returns_mcp_and_provider_inventory(
     assert payload["oauth_providers"][0]["integration_status"] == "connected"
     assert payload["oauth_providers"][1]["provider_id"] == "custom-crm"
     assert payload["oauth_providers"][1]["integration_status"] == "not_configured"
+    assert (
+        payload["truncation"]["collections"]["mcp_integrations"]["truncated"] is False
+    )
+
+
+@pytest.mark.anyio
+async def test_get_workflow_authoring_context_truncates_embedded_collections(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    async def _secret_inventory(_role: Any) -> dict[str, set[str]]:
+        return {"alpha": {"TOKEN"}, "beta": {"TOKEN"}}
+
+    class _IndexEntry:
+        def __init__(self, namespace: str, name: str) -> None:
+            self.namespace = namespace
+            self.name = name
+
+    indexed_action = SimpleNamespace(manifest=SimpleNamespace())
+
+    class _RegistryService:
+        async def get_action_from_index(self, _action_name: str) -> Any:
+            return indexed_action
+
+        async def search_actions_from_index(
+            self, _query: str, limit: int = 20
+        ) -> list[tuple[_IndexEntry, str]]:
+            _ = limit
+            return [
+                (_IndexEntry("tools", "one"), "platform"),
+                (_IndexEntry("tools", "two"), "platform"),
+            ]
+
+        def aggregate_secrets_from_manifest(
+            self, _manifest: Any, action_name: str
+        ) -> list[Any]:
+            return [RegistrySecret(name=action_name, keys=["TOKEN"])]
+
+    class _VariablesService:
+        async def list_variables(self, environment: str) -> list[Any]:
+            assert environment == "default"
+            return [
+                SimpleNamespace(
+                    name="var_one", values={"k": "v"}, environment="default"
+                ),
+                SimpleNamespace(
+                    name="var_two", values={"k": "v"}, environment="default"
+                ),
+            ]
+
+    class _Tool:
+        description = "desc"
+        parameters_json_schema = {"type": "object", "properties": {}}
+
+    async def _create_tool(*_args: Any) -> _Tool:
+        return _Tool()
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_MCP_EMBEDDED_COLLECTION_LIMIT", 1)
+    monkeypatch.setattr(mcp_server, "create_tool_from_registry", _create_tool)
+    monkeypatch.setattr(
+        "tracecat.registry.actions.service.RegistryActionsService.with_session",
+        lambda role: _AsyncContext(_RegistryService()),
+    )
+    monkeypatch.setattr(
+        mcp_server.VariablesService,
+        "with_session",
+        lambda role: _AsyncContext(_VariablesService()),
+    )
+
+    payload = _payload(
+        await _tool(mcp_server.get_workflow_authoring_context)(
+            workspace_id=str(workspace_id),
+            query="tools",
+        )
+    )
+    assert len(payload["actions"]) == 1
+    assert len(payload["variable_hints"]) == 1
+    assert len(payload["secret_hints"]) == 1
+    assert payload["truncation"]["collections"]["actions"]["truncated"] is True
+    assert payload["truncation"]["collections"]["variable_hints"]["truncated"] is True
+    assert payload["truncation"]["collections"]["secret_hints"]["truncated"] is True
 
 
 @pytest.mark.anyio
@@ -3549,6 +3843,7 @@ async def test_get_agent_preset_authoring_context_includes_output_type_guidance(
     assert "str" in payload["output_type_context"]["supported_literals"]
     assert payload["output_type_context"]["accepts_json_schema"] is True
     assert payload["output_type_context"]["examples"]["structured"]["type"] == "object"
+    assert payload["truncation"]["collections"]["models"]["truncated"] is False
 
 
 @pytest.mark.anyio
@@ -3634,6 +3929,207 @@ async def test_create_agent_preset_uses_default_model_and_passes_optional_fields
     assert params.enable_internet_access is True
     assert payload["model_name"] == "gpt-4o-mini"
     assert payload["output_type"]["type"] == "object"
+
+
+@pytest.mark.anyio
+async def test_update_agent_preset_updates_existing_preset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    updated: dict[str, Any] = {}
+    now = datetime.now(UTC)
+    preset = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        name="Security triage",
+        slug="security-triage",
+        description="Investigate alerts",
+        instructions="Original prompt",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        base_url=None,
+        output_type=None,
+        actions=["tools.alpha"],
+        namespaces=["tools"],
+        tool_approvals={"tools.alpha": False},
+        mcp_integrations=[str(uuid.uuid4())],
+        retries=3,
+        enable_internet_access=False,
+        current_version_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _PresetService:
+        async def get_preset_by_slug(self, preset_slug: str) -> SimpleNamespace:
+            assert preset_slug == "security-triage"
+            return preset
+
+        async def update_preset(
+            self, current_preset: Any, params: Any
+        ) -> SimpleNamespace:
+            assert current_preset is preset
+            updated["params"] = params
+            updated_fields = {
+                **preset.__dict__,
+                "instructions": params.instructions,
+                "actions": params.actions,
+                "mcp_integrations": params.mcp_integrations,
+                "retries": params.retries,
+                "enable_internet_access": params.enable_internet_access,
+                "updated_at": datetime.now(UTC),
+            }
+            return SimpleNamespace(**updated_fields)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    integration_id = str(uuid.uuid4())
+    result = await _tool(mcp_server.update_agent_preset)(
+        workspace_id=str(workspace_id),
+        preset_slug="security-triage",
+        instructions="Updated prompt",
+        actions=["tools.bravo"],
+        mcp_integration_ids=[integration_id],
+        retries=5,
+        enable_internet_access=True,
+    )
+
+    payload = _payload(result)
+    params = updated["params"]
+    assert params.instructions == "Updated prompt"
+    assert params.actions == ["tools.bravo"]
+    assert params.mcp_integrations == [integration_id]
+    assert params.retries == 5
+    assert params.enable_internet_access is True
+    assert payload["instructions"] == "Updated prompt"
+    assert payload["actions"] == ["tools.bravo"]
+    assert payload["mcp_integrations"] == [integration_id]
+    assert payload["retries"] == 5
+    assert payload["enable_internet_access"] is True
+
+
+@pytest.mark.anyio
+async def test_update_agent_preset_resolves_explicit_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    now = datetime.now(UTC)
+    preset = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        name="Security triage",
+        slug="security-triage",
+        description=None,
+        instructions="Original prompt",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        base_url=None,
+        output_type=None,
+        actions=None,
+        namespaces=None,
+        tool_approvals=None,
+        mcp_integrations=None,
+        retries=3,
+        enable_internet_access=False,
+        current_version_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+    captured: dict[str, Any] = {}
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    async def _resolve_model(
+        resolved_role: Any,
+        *,
+        model_name: str | None,
+        model_provider: str | None,
+    ) -> tuple[str, str]:
+        assert resolved_role is role
+        assert model_name == "o3-mini"
+        assert model_provider == "openai"
+        return "o3-mini", "openai"
+
+    class _PresetService:
+        async def get_preset_by_slug(self, preset_slug: str) -> SimpleNamespace:
+            assert preset_slug == "security-triage"
+            return preset
+
+        async def update_preset(
+            self, current_preset: Any, params: Any
+        ) -> SimpleNamespace:
+            assert current_preset is preset
+            captured["params"] = params
+            updated_fields = {
+                **preset.__dict__,
+                "model_name": params.model_name,
+                "model_provider": params.model_provider,
+                "updated_at": datetime.now(UTC),
+            }
+            return SimpleNamespace(**updated_fields)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_resolve_agent_preset_model", _resolve_model)
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    result = await _tool(mcp_server.update_agent_preset)(
+        workspace_id=str(workspace_id),
+        preset_slug="security-triage",
+        model_name="o3-mini",
+        model_provider="openai",
+    )
+
+    payload = _payload(result)
+    params = captured["params"]
+    assert params.model_name == "o3-mini"
+    assert params.model_provider == "openai"
+    assert payload["model_name"] == "o3-mini"
+    assert payload["model_provider"] == "openai"
+
+
+@pytest.mark.anyio
+async def test_update_agent_preset_requires_existing_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _PresetService:
+        async def get_preset_by_slug(self, preset_slug: str) -> None:
+            assert preset_slug == "missing-preset"
+            return None
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    with pytest.raises(ToolError, match="Agent preset 'missing-preset' not found"):
+        await _tool(mcp_server.update_agent_preset)(
+            workspace_id=str(workspace_id),
+            preset_slug="missing-preset",
+            instructions="Updated prompt",
+        )
 
 
 @pytest.mark.anyio
@@ -3819,6 +4315,7 @@ def test_mcp_instructions_include_agent_preset_authoring_tools() -> None:
     assert "get_agent_preset_authoring_context" in mcp_server._MCP_INSTRUCTIONS
     assert "list_integrations" in mcp_server._MCP_INSTRUCTIONS
     assert "create_agent_preset" in mcp_server._MCP_INSTRUCTIONS
+    assert "update_agent_preset" in mcp_server._MCP_INSTRUCTIONS
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -27,6 +27,7 @@ from tracecat.db.models import Workspace
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.schemas import StreamID
 from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowUUID
+from tracecat.pagination import CursorPaginationParams
 from tracecat.storage.object import ExternalObject, InlineObject, ObjectRef
 from tracecat.workflow.executions.enums import (
     TriggerType,
@@ -1812,3 +1813,60 @@ class TestWorkflowStartAcknowledgement:
         assert (
             mock_client.start_workflow.await_args.kwargs["id"] == response["wf_exec_id"]
         )
+
+
+@pytest.mark.anyio
+async def test_list_executions_paginated_emits_prev_cursor_history(
+    workflow_executions_service: WorkflowExecutionsService,
+    mock_client: Mock,
+) -> None:
+    first_page_items = [Mock(id="wf_first/exec_1")]
+    second_page_items = [Mock(id="wf_first/exec_2")]
+    calls: list[bytes | None] = []
+
+    class _Iterator:
+        def __init__(self, items: list[Any], next_page_token: bytes | None) -> None:
+            self.current_page = items
+            self.next_page_token = next_page_token
+
+        async def fetch_next_page(self, *, page_size: int) -> None:
+            assert page_size == 1
+
+    def _list_workflows(
+        *,
+        query: str | None = None,
+        page_size: int,
+        next_page_token: bytes | None = None,
+    ) -> _Iterator:
+        _ = query
+        assert page_size == 1
+        calls.append(next_page_token)
+        if next_page_token is None:
+            return _Iterator(first_page_items, b"page-2")
+        if next_page_token == b"page-2":
+            return _Iterator(second_page_items, b"page-3")
+        raise AssertionError(f"Unexpected page token: {next_page_token!r}")
+
+    mock_client.list_workflows = Mock(side_effect=_list_workflows)
+
+    first_page = await workflow_executions_service.list_executions_paginated(
+        pagination=CursorPaginationParams(limit=1),
+    )
+    assert first_page.prev_cursor is None
+    assert first_page.has_previous is False
+    assert first_page.next_cursor is not None
+
+    second_page = await workflow_executions_service.list_executions_paginated(
+        pagination=CursorPaginationParams(limit=1, cursor=first_page.next_cursor),
+    )
+    assert second_page.items == second_page_items
+    assert second_page.prev_cursor is not None
+    assert second_page.has_previous is True
+
+    rewound_page = await workflow_executions_service.list_executions_paginated(
+        pagination=CursorPaginationParams(limit=1, cursor=second_page.prev_cursor),
+    )
+    assert rewound_page.items == first_page_items
+    assert rewound_page.has_previous is False
+    assert rewound_page.prev_cursor is None
+    assert calls == [None, b"page-2", None]

--- a/tracecat/mcp/README.md
+++ b/tracecat/mcp/README.md
@@ -3,9 +3,12 @@
 This document lists the currently registered MCP tools in
 `tracecat/mcp/server.py` (the functions decorated with `@mcp.tool()`).
 
+All top-level collection tools now return a paginated object with:
+`items`, `next_cursor`, `prev_cursor`, `has_more`, and `has_previous`.
+
 ## Workflow tools
 
-- `list_workspaces()`
+- `list_workspaces(limit=20, cursor=None)`
 - `create_workflow(workspace_id, title, description="", definition_yaml=None)`
 - `get_workflow(workspace_id, workflow_id, include_definition_yaml=False)`
 - `get_workflow_file(workspace_id, workflow_id, draft=True)`
@@ -13,12 +16,13 @@ This document lists the currently registered MCP tools in
 - `create_workflow_from_uploaded_file(workspace_id, artifact_id, title=None, description="", use_workflow_id=False)`
 - `update_workflow_from_uploaded_file(workspace_id, workflow_id, artifact_id, title=None, description=None, status=None, alias=None, error_handler=None, update_mode=None)`
 - `update_workflow(workspace_id, workflow_id, title=None, description=None, status=None, alias=None, error_handler=None, definition_yaml=None, update_mode="patch")`
-- `list_workflows(workspace_id, status=None, limit=50, search=None)`
+- `list_workflows(workspace_id, status=None, limit=50, search=None, cursor=None)`
+- `list_workflow_tree(workspace_id, path="/", depth=1, include_workflows=True, limit=20, cursor=None)`
 - `validate_workflow(workspace_id, workflow_id)`
 - `publish_workflow(workspace_id, workflow_id)`
 - `run_draft_workflow(workspace_id, workflow_id, inputs=None, title=None, description=None)`
 - `run_published_workflow(workspace_id, workflow_id, inputs=None)`
-- `list_workflow_executions(workspace_id, workflow_id, limit=20)`
+- `list_workflow_executions(workspace_id, workflow_id, limit=20, cursor=None)`
 - `get_workflow_execution(workspace_id, execution_id)`
 
 ### Workflow file transfer notes
@@ -40,11 +44,14 @@ This document lists the currently registered MCP tools in
 
 ## Action discovery and authoring context
 
-- `list_actions(workspace_id, query=None, namespace=None, limit=50)`
+- `list_actions(workspace_id, query=None, namespace=None, limit=50, cursor=None)`
 - `get_action_context(workspace_id, action_name)`
 - `get_workflow_authoring_context(workspace_id, action_names_json=None, query=None)`
 - `prepare_template_file_upload(workspace_id, relative_path)`
 - `validate_template_action(workspace_id, artifact_id, check_db=False)`
+
+`get_workflow_authoring_context` now caps embedded collections and returns
+truncation metadata under `truncation.collections`.
 
 ## Webhook and case trigger tools
 
@@ -55,40 +62,40 @@ This document lists the currently registered MCP tools in
 
 ## Workflow tag tools
 
-- `list_workflow_tags(workspace_id)`
+- `list_workflow_tags(workspace_id, limit=20, cursor=None)`
 - `create_workflow_tag(workspace_id, name, color=None)`
 - `update_workflow_tag(workspace_id, tag_id, name=None, color=None)`
 - `delete_workflow_tag(workspace_id, tag_id)`
-- `list_tags_for_workflow(workspace_id, workflow_id)`
+- `list_tags_for_workflow(workspace_id, workflow_id, limit=20, cursor=None)`
 - `add_workflow_tag(workspace_id, workflow_id, tag_id)`
 - `remove_workflow_tag(workspace_id, workflow_id, tag_id)`
 
 ## Case tag tools
 
-- `list_case_tags(workspace_id)`
+- `list_case_tags(workspace_id, limit=20, cursor=None)`
 - `create_case_tag(workspace_id, name, color=None)`
 - `update_case_tag(workspace_id, tag_id, name=None, color=None)`
 - `delete_case_tag(workspace_id, tag_id)`
-- `list_tags_for_case(workspace_id, case_id)`
+- `list_tags_for_case(workspace_id, case_id, limit=20, cursor=None)`
 - `add_case_tag(workspace_id, case_id, tag_identifier)`
 - `remove_case_tag(workspace_id, case_id, tag_identifier)`
 
 ## Case field tools
 
-- `list_case_fields(workspace_id)`
+- `list_case_fields(workspace_id, limit=20, cursor=None)`
 - `create_case_field(workspace_id, name, type, options=None)`
 - `update_case_field(workspace_id, field_id, name=None, type=None, options=None)`
 - `delete_case_field(workspace_id, field_id)`
 
 ## Table tools
 
-- `list_tables(workspace_id)`
+- `list_tables(workspace_id, limit=20, cursor=None)`
 - `create_table(workspace_id, name, columns_json=None)`
 - `get_table(workspace_id, table_id)`
 - `update_table(workspace_id, table_id, name=None)`
 - `insert_table_row(workspace_id, table_id, row_json, upsert=False)`
 - `update_table_row(workspace_id, table_id, row_id, row_json)`
-- `search_table_rows(workspace_id, table_id, search_term=None, limit=100, offset=0)`
+- `search_table_rows(workspace_id, table_id, search_term=None, limit=100, cursor=None)`
 - `export_csv(workspace_id, table_id, include_header=True)`
 
 ### Template and CSV file transfer notes
@@ -99,7 +106,20 @@ This document lists the currently registered MCP tools in
 
 ## Variable and secret metadata tools
 
-- `list_variables(workspace_id, environment=DEFAULT_SECRETS_ENVIRONMENT)`
+- `list_variables(workspace_id, environment=DEFAULT_SECRETS_ENVIRONMENT, limit=20, cursor=None)`
 - `get_variable(workspace_id, variable_name, environment=DEFAULT_SECRETS_ENVIRONMENT)`
-- `list_secrets_metadata(workspace_id, environment=DEFAULT_SECRETS_ENVIRONMENT)`
+- `list_secrets_metadata(workspace_id, environment=DEFAULT_SECRETS_ENVIRONMENT, limit=20, cursor=None)`
 - `get_secret_metadata(workspace_id, secret_name, environment=DEFAULT_SECRETS_ENVIRONMENT)`
+
+## Integration and agent tools
+
+- `list_integrations(workspace_id)`
+- `get_agent_preset_authoring_context(workspace_id)`
+- `create_agent_preset(workspace_id, name, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_internet_access=None)`
+- `update_agent_preset(workspace_id, preset_slug, name=None, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_internet_access=None)`
+- `list_agent_presets(workspace_id, limit=20, cursor=None)`
+- `get_agent_preset(workspace_id, preset_slug)`
+- `run_agent_preset(workspace_id, preset_slug, prompt, preset_version=None, timeout_seconds=120)`
+
+`list_integrations` and `get_agent_preset_authoring_context` keep object
+responses but cap embedded collections and expose `truncation.collections`.

--- a/tracecat/mcp/README.md
+++ b/tracecat/mcp/README.md
@@ -3,8 +3,10 @@
 This document lists the currently registered MCP tools in
 `tracecat/mcp/server.py` (the functions decorated with `@mcp.tool()`).
 
-All top-level collection tools now return a paginated object with:
+Top-level list/search tools return a paginated object with:
 `items`, `next_cursor`, `prev_cursor`, `has_more`, and `has_previous`.
+Object-style authoring/context tools remain object responses and document their
+own embedded collection truncation behavior below.
 
 ## Workflow tools
 

--- a/tracecat/mcp/schemas.py
+++ b/tracecat/mcp/schemas.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from tracecat.dsl.common import DSLInput
+
+T = TypeVar("T")
 
 
 class LayoutPosition(BaseModel):
@@ -154,3 +156,22 @@ class WorkflowRunResponse(BaseModel):
     workflow_id: str
     execution_id: str
     message: str
+
+
+class MCPPaginatedResponse[T](BaseModel):
+    items: list[T]
+    next_cursor: str | None = Field(default=None)
+    prev_cursor: str | None = Field(default=None)
+    has_more: bool = Field(default=False)
+    has_previous: bool = Field(default=False)
+
+
+class MCPTruncationInfo(BaseModel):
+    limit: int
+    total: int
+    returned: int
+    truncated: bool
+
+
+class MCPTruncationSummary(BaseModel):
+    collections: dict[str, MCPTruncationInfo] = Field(default_factory=dict)

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -8,13 +8,14 @@ highly unsafe and should only be used for local development.
 from __future__ import annotations
 
 import asyncio
+import base64
 import csv
 import hashlib
 import json
 import re
 import uuid
 from collections import defaultdict, deque
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from io import StringIO
@@ -47,7 +48,11 @@ from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 from tracecat import config
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
-from tracecat.agent.preset.schemas import AgentPresetCreate, AgentPresetRead
+from tracecat.agent.preset.schemas import (
+    AgentPresetCreate,
+    AgentPresetRead,
+    AgentPresetUpdate,
+)
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.session.schemas import AgentSessionCreate
@@ -104,7 +109,12 @@ from tracecat.mcp.middleware import (
     WatchtowerMonitorMiddleware,
     get_mcp_client_id,
 )
-from tracecat.pagination import CursorPaginationParams
+from tracecat.mcp.schemas import (
+    MCPPaginatedResponse,
+    MCPTruncationInfo,
+    MCPTruncationSummary,
+)
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 from tracecat.registry.actions.schemas import TemplateAction
 from tracecat.registry.actions.service import (
     RegistryActionsService,
@@ -1844,8 +1854,9 @@ when the workflow fits within that limit; otherwise it returns
 2. `list_integrations` — inspect workspace MCP integrations and broader provider status
 3. `list_actions` / `get_action_context` — choose preset tools and inspect arg schemas
 4. `create_agent_preset` — create a reusable preset
-5. `list_agent_presets` — find reusable agents you can invoke by slug without loading their full prompts or tool configs
-6. `get_agent_preset` / `run_agent_preset` — fetch a preset's full configuration when you need to inspect it, or run it once you know which slug to use
+5. `update_agent_preset` — revise an existing preset by slug when its prompts, tools, or model settings need to change
+6. `list_agent_presets` — find reusable agents you can invoke by slug without loading their full prompts or tool configs
+7. `get_agent_preset` / `run_agent_preset` — fetch a preset's full configuration when you need to inspect it, or run it once you know which slug to use
 
 ## Debugging workflow runs
 After running a workflow, use `list_workflow_executions` to see recent runs and their \
@@ -2382,6 +2393,123 @@ def _json(obj: Any) -> str:
     return json.dumps(obj, default=str)
 
 
+def _normalize_limit(
+    limit: int | None,
+    *,
+    default: int,
+    max_limit: int,
+) -> int:
+    """Clamp a requested MCP list limit to a safe range."""
+    if limit is None:
+        return default
+    return max(config.TRACECAT__LIMIT_MIN, min(limit, max_limit))
+
+
+def _pagination_fingerprint(tool_name: str, **filters: Any) -> str:
+    """Build a stable fingerprint for cursor validation."""
+    payload = {"tool_name": tool_name, "filters": filters}
+    serialized = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _encode_offset_cursor(offset: int, fingerprint: str) -> str:
+    """Encode an in-memory pagination cursor."""
+    payload = {"offset": offset, "fingerprint": fingerprint}
+    serialized = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
+    return base64.urlsafe_b64encode(serialized).decode("ascii")
+
+
+def _decode_offset_cursor(cursor: str, *, expected_fingerprint: str) -> int:
+    """Decode an in-memory pagination cursor."""
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+        payload = json.loads(decoded)
+    except Exception as e:
+        raise ToolError("Invalid cursor format") from e
+
+    if payload.get("fingerprint") != expected_fingerprint:
+        raise ToolError(
+            "Cursor no longer matches current filters. Retry without cursor."
+        )
+
+    offset = payload.get("offset")
+    if not isinstance(offset, int) or offset < 0:
+        raise ToolError("Invalid cursor format")
+    return offset
+
+
+def _paginate_items[T](
+    items: Sequence[T],
+    *,
+    tool_name: str,
+    limit: int,
+    cursor: str | None = None,
+    filters: dict[str, Any] | None = None,
+) -> MCPPaginatedResponse[T]:
+    """Paginate an in-memory collection with cursor validation."""
+    normalized_items = list(items)
+    fingerprint = _pagination_fingerprint(tool_name, **(filters or {}))
+    start = (
+        _decode_offset_cursor(cursor, expected_fingerprint=fingerprint)
+        if cursor is not None
+        else 0
+    )
+    end = start + limit
+    next_cursor = (
+        _encode_offset_cursor(end, fingerprint) if end < len(normalized_items) else None
+    )
+    prev_start = max(0, start - limit)
+    prev_cursor = _encode_offset_cursor(prev_start, fingerprint) if start > 0 else None
+    return MCPPaginatedResponse[T](
+        items=normalized_items[start:end],
+        next_cursor=next_cursor,
+        prev_cursor=prev_cursor,
+        has_more=next_cursor is not None,
+        has_previous=start > 0,
+    )
+
+
+def _serialize_paginated_response[T](
+    page: MCPPaginatedResponse[T] | CursorPaginatedResponse[T],
+) -> dict[str, Any]:
+    """Serialize a paginated response to a JSON-safe dict."""
+    return page.model_dump(mode="json")
+
+
+def _truncate_embedded_list[T](
+    items: Sequence[T],
+    *,
+    limit: int,
+) -> tuple[list[T], MCPTruncationInfo]:
+    """Cap an embedded list and return truncation metadata."""
+    normalized_items = list(items)
+    returned = normalized_items[:limit]
+    return returned, MCPTruncationInfo(
+        limit=limit,
+        total=len(normalized_items),
+        returned=len(returned),
+        truncated=len(normalized_items) > limit,
+    )
+
+
+def _truncate_named_sections(
+    sections: dict[str, Sequence[Any]],
+    *,
+    limit: int,
+) -> tuple[dict[str, list[Any]], MCPTruncationSummary]:
+    """Cap multiple embedded collections and summarize truncation."""
+    truncated_sections: dict[str, list[Any]] = {}
+    summary = MCPTruncationSummary()
+    for name, items in sections.items():
+        truncated_items, info = _truncate_embedded_list(items, limit=limit)
+        truncated_sections[name] = truncated_items
+        summary.collections[name] = info
+    return truncated_sections, summary
+
+
+_MCP_EMBEDDED_COLLECTION_LIMIT = min(50, config.TRACECAT__LIMIT_CURSOR_MAX)
+
+
 def _workflow_tag_payload(tag: Any) -> dict[str, Any]:
     """Serialize a workflow tag definition."""
     return TagRead.model_validate(tag, from_attributes=True).model_dump(mode="json")
@@ -2617,7 +2745,9 @@ _TOOL_NAMESPACE_BY_NAME: dict[str, str] = {
     "list_integrations": "integrations",
     "get_agent_preset_authoring_context": "agents",
     "create_agent_preset": "agents",
+    "update_agent_preset": "agents",
     "list_agent_presets": "agents",
+    "get_agent_preset": "agents",
     "run_agent_preset": "agents",
 }
 
@@ -2650,14 +2780,27 @@ mcp.tool = cast(Any, _namespaced_tool)
 
 
 @mcp.tool()
-async def list_workspaces() -> str:
+async def list_workspaces(
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List all workspaces accessible to the authenticated user.
 
     Returns a JSON array of workspace objects with id, name, and role.
     """
     try:
         workspaces = await list_workspaces_for_request()
-        return _json(workspaces)
+        page = _paginate_items(
+            workspaces,
+            tool_name="list_workspaces",
+            limit=_normalize_limit(
+                limit,
+                default=config.TRACECAT__LIMIT_DEFAULT,
+                max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+            ),
+            cursor=cursor,
+        )
+        return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -3186,41 +3329,43 @@ async def list_workflows(
     status: str | None = None,
     limit: int = 50,
     search: str | None = None,
+    cursor: str | None = None,
 ) -> str:
     """List workflows in a workspace."""
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
-        limit = max(1, min(limit, 200))
+        limit = _normalize_limit(limit, default=50, max_limit=200)
         async with WorkflowsManagementService.with_session(role=role) as svc:
-            page = await svc.list_workflows(CursorPaginationParams(limit=limit))
-            workflows: list[dict[str, Any]] = []
-            for workflow, latest_defn, _trigger_summary in page.items:
-                if status and workflow.status != status:
-                    continue
-                if search:
-                    needle = search.lower()
-                    if (
-                        needle not in workflow.title.lower()
-                        and needle not in (workflow.description or "").lower()
-                    ):
-                        continue
-                workflows.append(
-                    {
-                        "id": str(workflow.id),
-                        "title": workflow.title,
-                        "description": workflow.description,
-                        "status": workflow.status,
-                        "version": workflow.version,
-                        "alias": workflow.alias,
-                        "latest_definition_version": (
-                            latest_defn.version if latest_defn else None
-                        ),
-                    }
+            page = await svc.list_workflows(
+                CursorPaginationParams(limit=limit, cursor=cursor),
+                status=status,
+                search=search,
+            )
+            return _json(
+                _serialize_paginated_response(
+                    MCPPaginatedResponse[dict[str, Any]](
+                        items=[
+                            {
+                                "id": str(workflow.id),
+                                "title": workflow.title,
+                                "description": workflow.description,
+                                "status": workflow.status,
+                                "version": workflow.version,
+                                "alias": workflow.alias,
+                                "latest_definition_version": (
+                                    latest_defn.version if latest_defn else None
+                                ),
+                            }
+                            for workflow, latest_defn, _trigger_summary in page.items
+                        ],
+                        next_cursor=page.next_cursor,
+                        prev_cursor=page.prev_cursor,
+                        has_more=page.has_more,
+                        has_previous=page.has_previous,
+                    )
                 )
-                if len(workflows) >= limit:
-                    break
-            return _json(workflows)
+            )
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -3234,6 +3379,8 @@ async def list_workflow_tree(
     path: str = "/",
     depth: int = 1,
     include_workflows: bool = True,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
 ) -> str:
     """List workflow folders and workflows under a path.
 
@@ -3289,13 +3436,25 @@ async def list_workflow_tree(
                             }
                         )
 
-            return _json(
-                {
-                    "root_path": root_path,
-                    "depth": "unlimited" if depth == 0 else depth,
-                    "items": items,
-                }
+            page = _paginate_items(
+                items,
+                tool_name="list_workflow_tree",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+                filters={
+                    "path": root_path,
+                    "depth": depth,
+                    "include_workflows": include_workflows,
+                },
             )
+            payload = _serialize_paginated_response(page)
+            payload["root_path"] = root_path
+            payload["depth"] = "unlimited" if depth == 0 else depth
+            return _json(payload)
     except ToolError:
         raise
     except ValueError as e:
@@ -3490,6 +3649,7 @@ async def list_actions(
     query: str | None = None,
     namespace: str | None = None,
     limit: int = 50,
+    cursor: str | None = None,
 ) -> str:
     """Search or browse available actions and return compact context metadata.
 
@@ -3517,11 +3677,11 @@ async def list_actions(
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
-        limit = max(1, min(limit, 200))
+        limit = _normalize_limit(limit, default=50, max_limit=200)
         workspace_inventory = await _load_secret_inventory(role)
         async with RegistryActionsService.with_session(role=role) as svc:
             if query:
-                entries = await svc.search_actions_from_index(query, limit=limit)
+                entries = await svc.search_actions_from_index(query, limit=None)
             else:
                 entries = await svc.list_actions_from_index(namespace=namespace)
             items: list[dict[str, Any]] = []
@@ -3547,7 +3707,14 @@ async def list_actions(
                         "missing_requirements": missing,
                     }
                 )
-            return _json(items[:limit])
+            page = _paginate_items(
+                items,
+                tool_name="list_actions",
+                limit=limit,
+                cursor=cursor,
+                filters={"query": query, "namespace": namespace},
+            )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -3712,14 +3879,24 @@ async def get_workflow_authoring_context(
                 }
             )
 
-        return _json(
+        truncated_sections, truncation = _truncate_named_sections(
             {
                 "actions": action_contexts,
                 "variable_hints": variable_hints,
                 "secret_hints": secret_hints,
+            },
+            limit=_MCP_EMBEDDED_COLLECTION_LIMIT,
+        )
+
+        return _json(
+            {
+                "actions": truncated_sections["actions"],
+                "variable_hints": truncated_sections["variable_hints"],
+                "secret_hints": truncated_sections["secret_hints"],
                 "notes": [
                     "configured means required secret names and required key names exist in the default environment",
                 ],
+                "truncation": truncation.model_dump(mode="json"),
             }
         )
     except ToolError:
@@ -4190,6 +4367,7 @@ async def list_workflow_executions(
     workspace_id: str,
     workflow_id: str,
     limit: int = 20,
+    cursor: str | None = None,
 ) -> str:
     """List recent executions for a workflow.
 
@@ -4208,12 +4386,15 @@ async def list_workflow_executions(
     try:
         _, role = await _resolve_workspace_role(workspace_id)
         wf_id = WorkflowUUID.new(workflow_id)
-        limit = max(1, min(limit, 100))
+        limit = _normalize_limit(limit, default=20, max_limit=100)
 
         exec_service = await WorkflowExecutionsService.connect(role=role)
-        executions = await exec_service.list_executions(workflow_id=wf_id, limit=limit)
+        executions = await exec_service.list_executions_paginated(
+            pagination=CursorPaginationParams(limit=limit, cursor=cursor),
+            workflow_id=wf_id,
+        )
         items: list[dict[str, Any]] = []
-        for execution in executions:
+        for execution in executions.items:
             trigger_type = None
             execution_type = None
             try:
@@ -4238,7 +4419,17 @@ async def list_workflow_executions(
                     "execution_type": str(execution_type) if execution_type else None,
                 }
             )
-        return _json(items)
+        return _json(
+            _serialize_paginated_response(
+                MCPPaginatedResponse[dict[str, Any]](
+                    items=items,
+                    next_cursor=executions.next_cursor,
+                    prev_cursor=None,
+                    has_more=executions.has_more,
+                    has_previous=executions.has_previous,
+                )
+            )
+        )
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -4552,7 +4743,11 @@ async def update_case_trigger(
 
 
 @mcp.tool()
-async def list_workflow_tags(workspace_id: str) -> str:
+async def list_workflow_tags(
+    workspace_id: str,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List workflow tag definitions in a workspace.
 
     Returns a JSON array of tag objects with `id`, `name`, `ref`, and `color`.
@@ -4562,7 +4757,17 @@ async def list_workflow_tags(workspace_id: str) -> str:
         _, role = await _resolve_workspace_role(workspace_id)
         async with TagsService.with_session(role=role) as svc:
             tags = await svc.list_tags()
-            return _json([_workflow_tag_payload(tag) for tag in tags])
+            page = _paginate_items(
+                [_workflow_tag_payload(tag) for tag in tags],
+                tool_name="list_workflow_tags",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+            )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -4661,7 +4866,12 @@ async def delete_workflow_tag(workspace_id: str, tag_id: str) -> str:
 
 
 @mcp.tool()
-async def list_tags_for_workflow(workspace_id: str, workflow_id: str) -> str:
+async def list_tags_for_workflow(
+    workspace_id: str,
+    workflow_id: str,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List tags attached to a workflow.
 
     Returns a JSON array of tag objects with `id`, `name`, `ref`, and `color`.
@@ -4672,7 +4882,18 @@ async def list_tags_for_workflow(workspace_id: str, workflow_id: str) -> str:
         wf_id = WorkflowUUID.new(workflow_id)
         async with WorkflowTagsService.with_session(role=role) as svc:
             tags = await svc.list_tags_for_workflow(wf_id)
-            return _json([_workflow_tag_payload(tag) for tag in tags])
+            page = _paginate_items(
+                [_workflow_tag_payload(tag) for tag in tags],
+                tool_name="list_tags_for_workflow",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+                filters={"workflow_id": workflow_id},
+            )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -4754,7 +4975,11 @@ async def remove_workflow_tag(
 
 
 @mcp.tool()
-async def list_case_tags(workspace_id: str) -> str:
+async def list_case_tags(
+    workspace_id: str,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List case tag definitions in a workspace.
 
     Returns a JSON array of tag objects with `id`, `name`, `ref`, and `color`.
@@ -4764,7 +4989,17 @@ async def list_case_tags(workspace_id: str) -> str:
         _, role = await _resolve_workspace_role(workspace_id)
         async with CaseTagsService.with_session(role=role) as svc:
             tags = await svc.list_workspace_tags()
-            return _json([_case_tag_payload(tag) for tag in tags])
+            page = _paginate_items(
+                [_case_tag_payload(tag) for tag in tags],
+                tool_name="list_case_tags",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+            )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -4863,7 +5098,12 @@ async def delete_case_tag(workspace_id: str, tag_id: str) -> str:
 
 
 @mcp.tool()
-async def list_tags_for_case(workspace_id: str, case_id: str) -> str:
+async def list_tags_for_case(
+    workspace_id: str,
+    case_id: str,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List tags attached to a case.
 
     Returns a JSON array of tag objects with `id`, `name`, `ref`, and `color`.
@@ -4874,7 +5114,18 @@ async def list_tags_for_case(workspace_id: str, case_id: str) -> str:
         parsed_case_id = uuid.UUID(case_id)
         async with CaseTagsService.with_session(role=role) as svc:
             tags = await svc.list_tags_for_case(parsed_case_id)
-            return _json([_case_tag_payload(tag) for tag in tags])
+            page = _paginate_items(
+                [_case_tag_payload(tag) for tag in tags],
+                tool_name="list_tags_for_case",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+                filters={"case_id": case_id},
+            )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -4951,7 +5202,11 @@ async def remove_case_tag(
 
 
 @mcp.tool()
-async def list_case_fields(workspace_id: str) -> str:
+async def list_case_fields(
+    workspace_id: str,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List case field definitions in a workspace.
 
     Returns a JSON array of field objects with `id`, `type`, `description`,
@@ -4963,12 +5218,20 @@ async def list_case_fields(workspace_id: str) -> str:
         async with CaseFieldsService.with_session(role=role) as svc:
             columns = await svc.list_fields()
             field_schema = await svc.get_field_schema()
-            return _json(
+            page = _paginate_items(
                 [
                     _case_field_payload(column, field_schema=field_schema)
                     for column in columns
-                ]
+                ],
+                tool_name="list_case_fields",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
             )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -5087,16 +5350,28 @@ async def delete_case_field(workspace_id: str, field_id: str) -> str:
 
 
 @mcp.tool()
-async def list_tables(workspace_id: str) -> str:
+async def list_tables(
+    workspace_id: str,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List workspace tables."""
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
         async with TablesService.with_session(role=role) as svc:
             tables = await svc.list_tables()
-            return _json(
-                [{"id": str(table.id), "name": table.name} for table in tables]
+            page = _paginate_items(
+                [{"id": str(table.id), "name": table.name} for table in tables],
+                tool_name="list_tables",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
             )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -5261,22 +5536,22 @@ async def search_table_rows(
     table_id: str,
     search_term: str | None = None,
     limit: int = 100,
-    offset: int = 0,
+    cursor: str | None = None,
 ) -> str:
     """Search rows in a table."""
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
-        limit = max(1, min(limit, 1000))
-        _ = max(0, offset)  # offset reserved for future cursor support
+        limit = _normalize_limit(limit, default=100, max_limit=1000)
         async with TablesService.with_session(role=role) as svc:
             table = await svc.get_table(uuid.UUID(table_id))
             page = await svc.search_rows(
                 table,
                 search_term=search_term,
                 limit=limit,
+                cursor=cursor,
             )
-            return _json(page.items)
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -5374,6 +5649,8 @@ async def export_csv(
 async def list_variables(
     workspace_id: str,
     environment: str = DEFAULT_SECRETS_ENVIRONMENT,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
 ) -> str:
     """List workspace variables."""
 
@@ -5381,7 +5658,7 @@ async def list_variables(
         _, role = await _resolve_workspace_role(workspace_id)
         async with VariablesService.with_session(role=role) as svc:
             variables = await svc.list_variables(environment=environment)
-            return _json(
+            page = _paginate_items(
                 [
                     {
                         "id": str(variable.id),
@@ -5391,8 +5668,17 @@ async def list_variables(
                         "keys": sorted(variable.values.keys()),
                     }
                     for variable in variables
-                ]
+                ],
+                tool_name="list_variables",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+                filters={"environment": environment},
             )
+            return _json(_serialize_paginated_response(page))
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -5434,6 +5720,8 @@ async def get_variable(
 async def list_secrets_metadata(
     workspace_id: str,
     environment: str = DEFAULT_SECRETS_ENVIRONMENT,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
 ) -> str:
     """List secret metadata without secret values."""
 
@@ -5456,7 +5744,18 @@ async def list_secrets_metadata(
                         "tags": secret.tags,
                     }
                 )
-            return _json(result)
+            page = _paginate_items(
+                result,
+                tool_name="list_secrets_metadata",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+                filters={"environment": environment},
+            )
+            return _json(_serialize_paginated_response(page))
     except ToolError:
         raise
     except ValueError as e:
@@ -5545,37 +5844,59 @@ async def _build_agent_preset_authoring_context(role: Any) -> dict[str, Any]:
         ],
     }
 
+    integrations = await _build_integrations_inventory(role)
+    truncated_sections, truncation = _truncate_named_sections(
+        {
+            "models": [
+                model.model_dump(mode="json")
+                for _, model in sorted(models.items(), key=lambda item: item[0])
+            ],
+            "agent_credentials.providers": agent_credentials["providers"],
+            "workspace_variables": [
+                {
+                    "name": variable.name,
+                    "keys": sorted(variable.values.keys()),
+                    "environment": variable.environment,
+                }
+                for variable in variables
+            ],
+            "workspace_secret_hints": [
+                {
+                    "name": secret_name,
+                    "keys": sorted(keys),
+                    "environment": DEFAULT_SECRETS_ENVIRONMENT,
+                }
+                for secret_name, keys in sorted(workspace_inventory.items())
+            ],
+            "integrations.mcp_integrations": integrations["mcp_integrations"],
+            "integrations.oauth_providers": integrations["oauth_providers"],
+        },
+        limit=_MCP_EMBEDDED_COLLECTION_LIMIT,
+    )
+
+    integrations["mcp_integrations"] = truncated_sections[
+        "integrations.mcp_integrations"
+    ]
+    integrations["oauth_providers"] = truncated_sections["integrations.oauth_providers"]
+
     return {
         "default_model": default_model,
-        "models": [
-            model.model_dump(mode="json")
-            for _, model in sorted(models.items(), key=lambda item: item[0])
-        ],
+        "models": truncated_sections["models"],
         "provider_status_org": provider_status_org,
         "provider_status_workspace": provider_status_workspace,
-        "agent_credentials": agent_credentials,
-        "workspace_variables": [
-            {
-                "name": variable.name,
-                "keys": sorted(variable.values.keys()),
-                "environment": variable.environment,
-            }
-            for variable in variables
-        ],
-        "workspace_secret_hints": [
-            {
-                "name": secret_name,
-                "keys": sorted(keys),
-                "environment": DEFAULT_SECRETS_ENVIRONMENT,
-            }
-            for secret_name, keys in sorted(workspace_inventory.items())
-        ],
-        "integrations": await _build_integrations_inventory(role),
+        "agent_credentials": {
+            **agent_credentials,
+            "providers": truncated_sections["agent_credentials.providers"],
+        },
+        "workspace_variables": truncated_sections["workspace_variables"],
+        "workspace_secret_hints": truncated_sections["workspace_secret_hints"],
+        "integrations": integrations,
         "output_type_context": _build_output_type_context(),
         "notes": [
             "provider_status_org describes organization-scoped model credentials.",
             "provider_status_workspace describes workspace-scoped model credentials used by some agent flows.",
         ],
+        "truncation": truncation.model_dump(mode="json"),
     }
 
 
@@ -5585,7 +5906,18 @@ async def list_integrations(workspace_id: str) -> str:
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
-        return _json(await _build_integrations_inventory(role))
+        inventory = await _build_integrations_inventory(role)
+        truncated_sections, truncation = _truncate_named_sections(
+            {
+                "mcp_integrations": inventory["mcp_integrations"],
+                "oauth_providers": inventory["oauth_providers"],
+            },
+            limit=_MCP_EMBEDDED_COLLECTION_LIMIT,
+        )
+        inventory["mcp_integrations"] = truncated_sections["mcp_integrations"]
+        inventory["oauth_providers"] = truncated_sections["oauth_providers"]
+        inventory["truncation"] = truncation.model_dump(mode="json")
+        return _json(inventory)
     except ToolError:
         raise
     except ValueError as e:
@@ -5683,6 +6015,84 @@ async def create_agent_preset(
         raise ToolError(f"Failed to create agent preset: {e}") from None
 
 
+@mcp.tool()
+async def update_agent_preset(
+    workspace_id: str,
+    preset_slug: str,
+    name: str | None = None,
+    slug: str | None = None,
+    description: str | None = None,
+    instructions: str | None = None,
+    model_name: str | None = None,
+    model_provider: str | None = None,
+    base_url: str | None = None,
+    output_type: OutputType | None = None,
+    actions: list[str] | None = None,
+    namespaces: list[str] | None = None,
+    tool_approvals: dict[str, bool] | None = None,
+    mcp_integration_ids: list[str] | None = None,
+    retries: int | None = None,
+    enable_internet_access: bool | None = None,
+) -> str:
+    """Update an existing agent preset in the selected workspace."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        update_data: dict[str, Any] = {}
+        optional_fields = {
+            "name": name,
+            "slug": slug,
+            "description": description,
+            "instructions": instructions,
+            "base_url": base_url,
+            "output_type": output_type,
+            "actions": actions,
+            "namespaces": namespaces,
+            "tool_approvals": tool_approvals,
+            "mcp_integrations": mcp_integration_ids,
+            "retries": retries,
+            "enable_internet_access": enable_internet_access,
+        }
+        update_data.update(
+            {
+                field: value
+                for field, value in optional_fields.items()
+                if value is not None
+            }
+        )
+        if model_name is not None or model_provider is not None:
+            (
+                resolved_model_name,
+                resolved_model_provider,
+            ) = await _resolve_agent_preset_model(
+                role,
+                model_name=model_name,
+                model_provider=model_provider,
+            )
+            update_data["model_name"] = resolved_model_name
+            update_data["model_provider"] = resolved_model_provider
+        params = AgentPresetUpdate.model_validate(update_data)
+        async with AgentPresetService.with_session(role=role) as svc:
+            preset = await svc.get_preset_by_slug(preset_slug)
+            if not preset:
+                raise ToolError(f"Agent preset '{preset_slug}' not found")
+            updated_preset = await svc.update_preset(preset, params)
+        return _json(
+            AgentPresetRead.model_validate(updated_preset).model_dump(mode="json")
+        )
+    except ToolError:
+        raise
+    except ValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error(
+            "Failed to update agent preset", error=str(e), preset_slug=preset_slug
+        )
+        raise ToolError(f"Failed to update agent preset: {e}") from None
+
+
 def _parse_iso8601_duration(duration_str: str) -> timedelta:
     """Parse a simple ISO 8601 duration string into a timedelta.
 
@@ -5756,7 +6166,11 @@ async def _collect_agent_response(
 
 
 @mcp.tool()
-async def list_agent_presets(workspace_id: str) -> str:
+async def list_agent_presets(
+    workspace_id: str,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> str:
     """List saved agent preset slugs and names.
 
     Use `get_agent_preset` for the full preset definition.
@@ -5765,15 +6179,23 @@ async def list_agent_presets(workspace_id: str) -> str:
         _, role = await _resolve_workspace_role(workspace_id)
         async with AgentPresetService.with_session(role=role) as svc:
             presets = await svc.list_presets()
-        return _json(
+        page = _paginate_items(
             [
                 {
                     "slug": preset.slug,
                     "name": preset.name,
                 }
                 for preset in presets
-            ]
+            ],
+            tool_name="list_agent_presets",
+            limit=_normalize_limit(
+                limit,
+                default=config.TRACECAT__LIMIT_DEFAULT,
+                max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+            ),
+            cursor=cursor,
         )
+        return _json(_serialize_paginated_response(page))
     except ToolError:
         raise
     except Exception as e:

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -4424,7 +4424,7 @@ async def list_workflow_executions(
                 MCPPaginatedResponse[dict[str, Any]](
                     items=items,
                     next_cursor=executions.next_cursor,
-                    prev_cursor=None,
+                    prev_cursor=executions.prev_cursor,
                     has_more=executions.has_more,
                     has_previous=executions.has_previous,
                 )

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -530,7 +530,7 @@ async def search_workflow_executions(
     return CursorPaginatedResponse(
         items=items,
         next_cursor=page.next_cursor,
-        prev_cursor=None,
+        prev_cursor=page.prev_cursor,
         has_more=page.has_more,
         has_previous=page.has_previous,
         total_estimate=None,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -116,6 +116,7 @@ class WorkflowExecutionNotFoundError(ValueError):
 class WorkflowExecutionsPage:
     items: list[WorkflowExecution]
     next_cursor: str | None
+    prev_cursor: str | None
     has_more: bool
     has_previous: bool
 
@@ -299,10 +300,27 @@ class WorkflowExecutionsService:
         return hashlib.sha256(canonical).hexdigest()
 
     @staticmethod
-    def _encode_query_cursor(next_page_token: bytes, fingerprint: str) -> str:
+    def _encode_query_cursor(
+        page_token: bytes | None,
+        fingerprint: str,
+        *,
+        history: Sequence[bytes | None] | None = None,
+    ) -> str:
         payload = {
-            "token": base64.urlsafe_b64encode(next_page_token).decode("ascii"),
+            "token": (
+                base64.urlsafe_b64encode(page_token).decode("ascii")
+                if page_token is not None
+                else None
+            ),
             "fingerprint": fingerprint,
+            "history": [
+                (
+                    base64.urlsafe_b64encode(token).decode("ascii")
+                    if token is not None
+                    else None
+                )
+                for token in (history or [])
+            ],
         }
         encoded = base64.urlsafe_b64encode(
             orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
@@ -310,15 +328,33 @@ class WorkflowExecutionsService:
         return encoded.decode("ascii")
 
     @staticmethod
-    def _decode_query_cursor(cursor: str) -> tuple[bytes, str]:
+    def _decode_query_cursor(
+        cursor: str,
+    ) -> tuple[bytes | None, str, list[bytes | None]]:
         try:
             decoded = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
             data = json.loads(decoded)
             token_text = data["token"]
             fingerprint = data["fingerprint"]
-            if not isinstance(token_text, str) or not isinstance(fingerprint, str):
+            history_text = data.get("history", [])
+            if token_text is not None and not isinstance(token_text, str):
                 raise ValueError("Malformed workflow executions cursor")
-            return base64.urlsafe_b64decode(token_text.encode("ascii")), fingerprint
+            if not isinstance(fingerprint, str) or not isinstance(history_text, list):
+                raise ValueError("Malformed workflow executions cursor")
+            history: list[bytes | None] = []
+            for entry in history_text:
+                if entry is None:
+                    history.append(None)
+                elif isinstance(entry, str):
+                    history.append(base64.urlsafe_b64decode(entry.encode("ascii")))
+                else:
+                    raise ValueError("Malformed workflow executions cursor")
+            token = (
+                base64.urlsafe_b64decode(token_text.encode("ascii"))
+                if token_text is not None
+                else None
+            )
+            return token, fingerprint, history
         except Exception as e:
             raise ValueError("Invalid workflow executions cursor") from e
 
@@ -393,9 +429,9 @@ class WorkflowExecutionsService:
 
         fingerprint = self._build_query_fingerprint(query=query, relation=relation)
         next_page_token: bytes | None = None
-        has_previous = pagination.cursor is not None
+        history: list[bytes | None] = []
         if pagination.cursor is not None:
-            next_page_token, cursor_fingerprint = self._decode_query_cursor(
+            next_page_token, cursor_fingerprint, history = self._decode_query_cursor(
                 pagination.cursor
             )
             if cursor_fingerprint != fingerprint:
@@ -419,16 +455,26 @@ class WorkflowExecutionsService:
                 execution for execution in executions if execution.parent_id is not None
             ]
 
+        prev_cursor = None
         next_cursor = None
         if iterator.next_page_token:
             next_cursor = self._encode_query_cursor(
-                iterator.next_page_token, fingerprint
+                iterator.next_page_token,
+                fingerprint,
+                history=[*history, next_page_token],
+            )
+        if history:
+            prev_cursor = self._encode_query_cursor(
+                history[-1],
+                fingerprint,
+                history=history[:-1],
             )
         return WorkflowExecutionsPage(
             items=executions,
             next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
             has_more=next_cursor is not None,
-            has_previous=has_previous,
+            has_previous=prev_cursor is not None,
         )
 
     def _role_workspace_id(self) -> str | None:

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import sqlalchemy as sa
 import yaml
 from pydantic import ValidationError
-from sqlalchemy import and_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import selectinload
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
@@ -291,7 +291,12 @@ class WorkflowsManagementService(BaseWorkspaceService):
         return res
 
     async def list_workflows(
-        self, params: CursorPaginationParams, *, tags: list[str] | None = None
+        self,
+        params: CursorPaginationParams,
+        *,
+        tags: list[str] | None = None,
+        status: str | None = None,
+        search: str | None = None,
     ) -> CursorPaginatedResponse[
         tuple[
             Workflow,
@@ -370,6 +375,17 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 sa.cast(Workflow.id, sa.UUID) == schedule_preview_subq.c.workflow_id,
             )
         )
+
+        if status is not None:
+            stmt = stmt.where(Workflow.status == status)
+        if search:
+            search_pattern = f"%{search}%"
+            stmt = stmt.where(
+                or_(
+                    Workflow.title.ilike(search_pattern),
+                    Workflow.description.ilike(search_pattern),
+                )
+            )
 
         # Apply tag filtering if specified
         if tags:


### PR DESCRIPTION
This change fixes two MCP regressions and closes a functional gap in the agent preset tools.

The first issue was an import-time failure in the MCP server caused by the `get_agent_preset` tool being present without a matching namespace mapping. That broke test collection before any MCP tool could run. The second issue was that several MCP collection tools still returned unbounded arrays, which made clients like the actions browser dump extremely large payloads. On top of that, agent preset authoring exposed create, list, get, and run operations, but it did not expose any MCP path for updating an existing preset once it had been created.

The root cause was that the MCP surface area had grown in a few places without the shared contracts being tightened at the same time. The tool registry did not enforce full namespace coverage, collection tools were inconsistent about pagination, and the preset authoring workflow stopped at creation. In practice that meant some MCP clients could fail during server startup, some list operations could flood the client with thousands of lines, and saved agent presets could only be replaced indirectly instead of being revised in place.

This patch standardizes the MCP collection contract around bounded cursor pagination with `items`, `next_cursor`, `prev_cursor`, `has_more`, and `has_previous`. It adds typed pagination and truncation schemas, moves workflow filtering into the paginated query path so cursors stay correct, caps embedded collections in authoring/context responses, and updates the generated MCP docs to describe the new responses. It also adds the missing namespace registration, exposes `update_agent_preset` through MCP using the existing preset service validation logic, and extends the MCP tests to cover pagination behavior, cursor mismatch handling, preset retrieval, preset updates, and the preset authoring instructions.

I validated the change with focused Python checks against the touched MCP surface: `uv run ruff check --fix tracecat/mcp/server.py tests/unit/test_mcp_server.py`, `uv run ruff format tracecat/mcp/server.py tests/unit/test_mcp_server.py`, `uv run basedpyright --warnings tracecat/mcp/server.py`, and `uv run pytest tests/unit/test_mcp_server.py -q`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes MCP pagination across list/search tools, adds `update_agent_preset`, and fixes previous-cursor handling for workflow executions. List responses now return cursor objects; authoring/context endpoints cap large embedded lists with truncation metadata.

- **New Features**
  - Added `update_agent_preset` (updates by slug; resolves `model_name`/`model_provider` when provided) and exposed `get_agent_preset` under the `agents` namespace.
  - Introduced `MCPPaginatedResponse` and limit/cursor helpers; top‑level lists now return `items`, `next_cursor`, `prev_cursor`, `has_more`, `has_previous` (e.g., `list_workspaces`, `list_workflows` with server‑side `search`/`status`, `list_workflow_tree`, `list_actions`, `list_workflow_executions`, tags/fields/tables, `search_table_rows`, `list_variables`, `list_secrets_metadata`, `list_agent_presets`).
  - Added embedded collection truncation with `truncation.collections` to `get_workflow_authoring_context` and `list_integrations` (and the agent preset authoring context).

- **Bug Fixes**
  - Fixed MCP tool namespace mapping and docs for `get_agent_preset` and `update_agent_preset`; standardized list payloads to the new paginated shape and reject mismatched cursors in `list_actions`.
  - Fixed `prev_cursor`/`has_previous` propagation for workflow executions (MCP tool and HTTP search), ensuring back/forward navigation works correctly.

<sup>Written for commit 6aa491df5ce0b35e7a4db7d6dd8c579d1ad8c78c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

