### PR TITLE
fix(compose): preserve local registry pythonpath

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -187,7 +187,7 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
-      PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       # Sandbox
       TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}
       TRACECAT__SANDBOX_NSJAIL_PATH: /usr/local/bin/nsjail
@@ -323,7 +323,7 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
-      PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       # Sandbox
       TRACECAT__EXECUTOR_BACKEND: ${TRACECAT__EXECUTOR_BACKEND:-direct}
       TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -206,7 +206,7 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
-      PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       # Sandbox
       TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}
       TRACECAT__SANDBOX_NSJAIL_PATH: /usr/local/bin/nsjail
@@ -343,7 +343,7 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
-      PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       # Sandbox
       TRACECAT__EXECUTOR_BACKEND: ${TRACECAT__EXECUTOR_BACKEND:-direct}
       TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,7 +196,7 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
-      PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       # Sandbox
       TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}
       TRACECAT__SANDBOX_NSJAIL_PATH: /usr/local/bin/nsjail
@@ -333,7 +333,7 @@ services:
         # Local registry
         TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
         TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED}
-        PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}
+        PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
         # Sandbox
         TRACECAT__EXECUTOR_BACKEND: ${TRACECAT__EXECUTOR_BACKEND:-direct}
         TRACECAT__DISABLE_NSJAIL: ${TRACECAT__DISABLE_NSJAIL:-true}


### PR DESCRIPTION
### Motivation
- Compose files used a fallback-only `PYTHONPATH` expression so a host-provided `PYTHONPATH` could omit `/app/local_registry`, breaking local registry imports for executor/worker services. 
- Ensure `/app/local_registry` is always appended to `PYTHONPATH` when containers run so local `packages`/registry code remains importable in dev/local environments.

### Description
- Replace `PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}` with `PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry` to append the local-registry path while preserving any host-provided `PYTHONPATH` value. 
- Apply the same change consistently across `docker-compose.local.yml`, `docker-compose.dev.yml`, and `docker-compose.yml` for all affected service environment blocks. 
- Reviewed related deployment Terraform entrypoints for equivalent configuration and found no changes required in this patch.

### Testing
- Run a file-level assertion with `python -c '...expected="PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry"; ...'` to verify every compose `PYTHONPATH` entry matches the new expression, and the script succeeded. 
- Use `rg` to enumerate occurrences of `PYTHONPATH`/`local_registry` across compose files to confirm all instances were updated, and the search shows the updated interpolation in each file. 
- Additional quick checks with `sed`/`nl` were used to inspect the updated lines in-place and all expected entries were present and correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c002f621548333b89be6fb29448526)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PYTHONPATH handling in Docker Compose so the local registry stays importable. We now append `/home/apiuser/.local:/app/local_registry` and preserve any host-provided `PYTHONPATH` for executor and worker services.

- **Bug Fixes**
  - Replaced `PYTHONPATH: ${PYTHONPATH:-/home/apiuser/.local:/app/local_registry}` with `PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry`.
  - Applied across `docker-compose.yml`, `docker-compose.dev.yml`, and `docker-compose.local.yml`.

<sup>Written for commit d7f1a435475a5741df2a4574ccdb104136c3f99c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

