### PR TITLE
fix(registry): support enterprise SSH users in git URLs

### DIFF
--- a/frontend/src/components/admin/platform-registry-settings.tsx
+++ b/frontend/src/components/admin/platform-registry-settings.tsx
@@ -17,18 +17,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { useAdminRegistrySettings } from "@/hooks/use-admin"
-
-// Matches backend GIT_SSH_URL_REGEX pattern
-const GIT_SSH_URL_REGEX =
-  /^git\+ssh:\/\/git@[^/:]+(?::\d+)?\/[^/@]+?(?:\/[^/@]+?)+?(?:\.git)?(?:@[^/@]+)?$/
+import { validateGitSshUrl } from "@/lib/git"
 
 const formSchema = z.object({
   git_repo_url: z
     .string()
-    .refine((val) => val === "" || GIT_SSH_URL_REGEX.test(val), {
-      message:
-        "Must be a Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)",
-    })
+    .superRefine((val, ctx) => validateGitSshUrl(val || null, ctx))
     .optional()
     .nullable()
     .or(z.literal("")),
@@ -102,7 +96,7 @@ export function PlatformRegistrySettings() {
               <FormLabel>Git repository URL</FormLabel>
               <FormControl>
                 <Input
-                  placeholder="git+ssh://git@github.com/org/repo.git"
+                  placeholder="git+ssh://someuser@git.example.com/org/repo.git"
                   {...field}
                   value={field.value ?? ""}
                 />

--- a/frontend/src/components/organization/org-settings-custom-registry.tsx
+++ b/frontend/src/components/organization/org-settings-custom-registry.tsx
@@ -106,7 +106,7 @@ export function OrgSettingsCustomRegistryForm() {
               <FormLabel>Remote repository URL</FormLabel>
               <FormControl>
                 <Input
-                  placeholder="git+ssh://git@gitlab.example.com:2222/org/team/repo.git"
+                  placeholder="git+ssh://someuser@git.example.com:2222/org/team/repo.git"
                   {...field}
                   value={field.value ?? ""}
                 />
@@ -120,7 +120,7 @@ export function OrgSettingsCustomRegistryForm() {
                 <span>
                   Format:{" "}
                   <span className="font-mono tracking-tight">
-                    {"git+ssh://git@<hostname>[:<port>]/<org>/<repo>.git"}
+                    {"git+ssh://<user>@<hostname>[:<port>]/<org>/<repo>.git"}
                   </span>
                 </span>
               </FormDescription>

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -71,7 +71,7 @@ export function WorkspaceSyncSettings({
                 <FormLabel>Remote repository URL</FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="git+ssh://git@my-host/my-org/my-repo.git"
+                    placeholder="git+ssh://someuser@git.example.com/my-org/my-repo.git"
                     {...field}
                     value={field.value ?? ""}
                   />

--- a/frontend/src/lib/git.ts
+++ b/frontend/src/lib/git.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 export const GIT_SSH_URL_REGEX =
-  /^git\+ssh:\/\/git@(?<hostname>[^/:]+)(?::(?<port>\d+))?\/(?<path>[^/@]+(?:\/[^/@]+)+)(?:\.git)?(?:@(?<ref>[^/@]+))?$/
+  /^git\+ssh:\/\/(?<user>[^/@:]+)@(?<hostname>[^/:]+)(?::(?<port>\d+))?\/(?<path>[^/@]+(?:\/[^/@]+)+)(?:\.git)?(?:@(?<ref>[^@]+))?$/
 
 // Mirrors the backend validation in tracecat/git/constants.py but enforces at least
 // an <org>/<repo> path structure on the client.
@@ -22,15 +22,17 @@ export function validateGitSshUrl(
     return
   }
 
-  if (!url.includes("git@")) {
+  const protocolWithoutScheme = url.replace("git+ssh://", "")
+
+  if (!protocolWithoutScheme.includes("@")) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "URL must include 'git@' user specification",
+      message: "URL must include an SSH user (e.g., git@ or someuser@)",
     })
     return
   }
 
-  const afterProtocol = url.replace("git+ssh://git@", "")
+  const afterProtocol = protocolWithoutScheme
   const firstSlashIndex = afterProtocol.indexOf("/")
 
   if (firstSlashIndex === -1) {
@@ -88,6 +90,6 @@ export function validateGitSshUrl(
   ctx.addIssue({
     code: z.ZodIssueCode.custom,
     message:
-      "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)",
+      "Must be a valid Git SSH URL (e.g., git+ssh://<user>@github.com/org/repo.git)",
   })
 }

--- a/frontend/tests/git.test.ts
+++ b/frontend/tests/git.test.ts
@@ -5,17 +5,19 @@ describe("GIT_SSH_URL_REGEX", () => {
     "git+ssh://git@github.com/user/repo.git",
     "git+ssh://git@gitlab.company.com/team/project.git",
     "git+ssh://git@example.com/org/repo.git",
+    "git+ssh://someuser@git.example.com/org/repo.git",
     "git+ssh://git@github.com:2222/user/repo.git",
     "git+ssh://git@gitlab.com/org/team/subteam/repo.git",
     "git+ssh://git@github.com/user/repo",
     "git+ssh://git@github.com/user/repo.git@main",
+    "git+ssh://git@github.com/user/repo.git@feature/custom-branch",
   ]
 
   const invalidUrls = [
     "git+ssh://git@/user/repo.git",
     "https://github.com/user/repo.git",
     "ssh://git@github.com/user/repo.git",
-    "git+ssh://github.com/user/repo.git", // Missing git@ user
+    "git+ssh://github.com/user/repo.git", // Missing SSH user
     "git+ssh://git@github.com:not_a_port/user/repo.git", // Invalid port
     "git+ssh://git@github.com/repo.git", // Missing org segment
     "git+ssh://git@github.com:/org/repo/subdir.git", // Missing port

--- a/frontend/tests/org-settings-custom-registry-form.test.ts
+++ b/frontend/tests/org-settings-custom-registry-form.test.ts
@@ -22,6 +22,20 @@ describe("gitFormSchema git_repo_url superRefine", () => {
     }
   })
 
+  it("accepts a valid git+ssh URL with a non-default SSH user", () => {
+    const result = customRegistryFormSchema.safeParse({
+      ...baseFormData,
+      git_repo_url: "git+ssh://someuser@git.example.com/org/repo.git",
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.git_repo_url).toBe(
+        "git+ssh://someuser@git.example.com/org/repo.git"
+      )
+    }
+  })
+
   it.each([
     [
       "missing protocol",
@@ -31,7 +45,7 @@ describe("gitFormSchema git_repo_url superRefine", () => {
     [
       "missing git user",
       "git+ssh://github.com/org/repo.git",
-      "URL must include 'git@' user specification",
+      "URL must include an SSH user (e.g., git@ or someuser@)",
     ],
     [
       "missing repository path",
@@ -78,7 +92,7 @@ describe("gitFormSchema git_repo_url superRefine", () => {
       expect(
         result.error.issues.map((issue: ZodIssue) => issue.message)
       ).toContain(
-        "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"
+        "Must be a valid Git SSH URL (e.g., git+ssh://<user>@github.com/org/repo.git)"
       )
     }
   })

--- a/frontend/tests/org-workspace-settings-form.test.ts
+++ b/frontend/tests/org-workspace-settings-form.test.ts
@@ -6,6 +6,8 @@ describe("syncSettingsSchema git_repo_url validation", () => {
     "git+ssh://git@gitlab.company.com:2222/team/project.git",
     "git+ssh://git@gitlab.com/group/subgroup/repo.git",
     "git+ssh://git@example.com/org/repo",
+    "git+ssh://someuser@git.example.com/org/repo.git",
+    "git+ssh://git@github.com/org/repo.git@feature/custom-branch",
   ])("accepts valid git SSH URL %s", (url) => {
     const result = syncSettingsSchema.safeParse({
       git_repo_url: url,
@@ -25,8 +27,8 @@ describe("syncSettingsSchema git_repo_url validation", () => {
     ],
     [
       "user",
-      "git+ssh://user@github.com/org/repo.git",
-      "URL must include 'git@' user specification",
+      "git+ssh://github.com/org/repo.git",
+      "URL must include an SSH user (e.g., git@ or someuser@)",
     ],
     ["path", "git+ssh://git@github.com", "URL must include a repository path"],
     [
@@ -47,7 +49,7 @@ describe("syncSettingsSchema git_repo_url validation", () => {
     [
       "trailing ref",
       "git+ssh://git@github.com/org/repo.git@@",
-      "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)",
+      "Must be a valid Git SSH URL (e.g., git+ssh://<user>@github.com/org/repo.git)",
     ],
   ])("rejects invalid git SSH URL with bad %s", (_, url, message) => {
     const result = syncSettingsSchema.safeParse({

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -36,6 +36,19 @@ class TestGitUrl:
         git_url = GitUrl(host="github.com", org="myorg", repo="myrepo")
         assert git_url.to_url() == "git+ssh://git@github.com/myorg/myrepo.git"
 
+    def test_git_url_to_url_with_custom_user(self):
+        """Test GitUrl preserves non-default SSH users."""
+        git_url = GitUrl(
+            host="git.example.com",
+            org="myorg",
+            repo="myrepo",
+            user="someuser",
+        )
+        assert (
+            git_url.to_url()
+            == "git+ssh://someuser@git.example.com/myorg/myrepo.git"
+        )
+
     def test_git_url_to_url_with_ref(self):
         """Test GitUrl to_url method with ref."""
         git_url = GitUrl(host="github.com", org="myorg", repo="myrepo", ref="main")
@@ -144,6 +157,25 @@ class TestParseGitUrl:
         assert git_url.org == "workspace"
         assert git_url.repo == "myrepo"
         assert git_url.ref == "develop"
+
+    def test_parse_github_enterprise_url_with_custom_user(self):
+        """Test parsing GitHub Enterprise URLs that use a non-git SSH user."""
+        url = "git+ssh://someuser@git.example.com/acme/platform/custom-registry.git"
+        git_url = parse_git_url(url)
+        assert git_url.user == "someuser"
+        assert git_url.host == "git.example.com"
+        assert git_url.org == "acme/platform"
+        assert git_url.repo == "custom-registry"
+        assert git_url.ref is None
+
+    def test_parse_url_with_slash_ref(self):
+        """Test parsing refs that include path separators."""
+        url = "git+ssh://git@github.com/myorg/myrepo.git@feature/custom-branch"
+        git_url = parse_git_url(url)
+        assert git_url.host == "github.com"
+        assert git_url.org == "myorg"
+        assert git_url.repo == "myrepo"
+        assert git_url.ref == "feature/custom-branch"
 
     def test_parse_url_allowed_domains(self):
         """Test parsing with allowed domains."""

--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -327,8 +327,10 @@ async def test_update_audit_payload_attribute_setting(
         "git+ssh://git@gitlab.example.com:2222/org/repo.git",
         "git+ssh://git@gitlab.com/org/team/subteam/repo.git",
         "git+ssh://git@github.com/org/repo.git@main",
+        "git+ssh://git@github.com/org/repo.git@feature/custom-branch",
         "git+ssh://git@github.com/org/repo",  # Without .git suffix
         "git+ssh://git@example.com/very/deep/nested/org/repo.git",
+        "git+ssh://someuser@git.example.com/very/deep/nested/org/repo.git",
     ],
 )
 async def test_git_settings_valid_ssh_urls(
@@ -355,7 +357,7 @@ async def test_git_settings_valid_ssh_urls(
     "invalid_url",
     [
         "https://github.com/org/repo.git",  # Wrong protocol
-        "git+ssh://user@github.com/org/repo.git",  # Wrong user
+        "git+ssh://github.com/org/repo.git",  # Missing SSH user
         "git+ssh://git@github.com/",  # No path
         "git+ssh://git@/org/repo.git",  # No host
         "git://git@github.com/org/repo.git",  # Missing +ssh

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -402,6 +402,27 @@ def test_validate_args_mode_parameter(tmp_path):
                 ref=None,
             ),
         ),
+        # GitHub Enterprise with a scoped SSH user
+        (
+            "git+ssh://someuser@git.example.com/org/repo",
+            GitUrl(
+                host="git.example.com",
+                org="org",
+                repo="repo",
+                user="someuser",
+                ref=None,
+            ),
+        ),
+        # Branch names may include slashes
+        (
+            "git+ssh://git@github.com/org/repo@feature/custom-branch",
+            GitUrl(
+                host="github.com",
+                org="org",
+                repo="repo",
+                ref="feature/custom-branch",
+            ),
+        ),
         # # Private GitLab nested in a subdirectory
         # (
         #     "git+ssh://git@internal.tracecat/org/group/repo",
@@ -437,14 +458,10 @@ def test_parse_git_url(url: str, expected: GitUrl):
             "git+ssh://git@github.com/org",
             id="Missing repository name",
         ),
-        pytest.param(
-            "git+ssh://git@github.com/org/repo@branch/extra",
-            id="Invalid branch format with extra path component",
-        ),
     ],
 )
 def test_parse_git_url_invalid(url: str):
-    allowed_domains = {"github.com", "gitlab.com"}
+    allowed_domains = {"github.com", "gitlab.com", "git.example.com"}
     with pytest.raises(ValueError):
         parse_git_url(url, allowed_domains=allowed_domains)
 

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -10,10 +10,12 @@ from tracecat.registry.repositories.schemas import RegistryRepositoryCreate
         "git+ssh://git@github.com/user/repo.git",
         "git+ssh://git@gitlab.company.com/team/project.git",
         "git+ssh://git@example.com/org/repo.git",
+        "git+ssh://someuser@git.example.com/org/repo.git",
         "git+ssh://git@github.com:2222/user/repo.git",  # With port
         "git+ssh://git@gitlab.com/org/team/subteam/repo.git",  # Nested groups
         "git+ssh://git@github.com/user/repo",  # Without .git suffix
         "git+ssh://git@github.com/user/repo.git@main",  # With branch ref
+        "git+ssh://git@github.com/user/repo.git@feature/custom-branch",  # Slash ref
     ],
 )
 def test_registry_repository_create_valid_urls(url: str) -> None:
@@ -34,7 +36,7 @@ def test_registry_repository_create_valid_urls(url: str) -> None:
         # Non-git+ssh URLs
         "https://github.com/user/repo.git",
         "ssh://git@github.com/user/repo.git",
-        # Missing git@ user
+        # Missing SSH user
         "git+ssh://github.com/user/repo.git",
     ],
 )

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -272,6 +272,8 @@ class TestWorkspaceService:
         "git+ssh://git@gitlab.company.com:2222/team/project.git",
         "git+ssh://git@gitlab.com/group/subgroup/repo.git",
         "git+ssh://git@example.com/org/repo",
+        "git+ssh://someuser@git.example.com/org/repo.git",
+        "git+ssh://git@github.com/org/repo.git@feature/custom-branch",
     ],
 )
 def test_workspace_settings_update_accepts_valid_git_urls(valid_url: str) -> None:
@@ -285,7 +287,7 @@ def test_workspace_settings_update_accepts_valid_git_urls(valid_url: str) -> Non
     "invalid_url",
     [
         "https://github.com/org/repo.git",
-        "git+ssh://user@github.com/org/repo.git",
+        "git+ssh://github.com/org/repo.git",
         "git+ssh://git@github.com",
         "git+ssh://git@github.com:not_a_port/org/repo.git",
         "git+ssh://git@github.com:/org/repo.git",

--- a/tracecat/git/constants.py
+++ b/tracecat/git/constants.py
@@ -1,6 +1,6 @@
 import re
 
 GIT_SSH_URL_REGEX = re.compile(
-    r"^git\+ssh://git@(?P<host>[^/:]+)(?::(?P<port>\d+))?/(?P<path>[^/@]+?(?:/[^/@]+?)+?)(?:\.git)?(?:@(?P<ref>[^/@]+))?$"
+    r"^git\+ssh://(?P<user>[^/@:]+)@(?P<host>[^/:]+)(?::(?P<port>\d+))?/(?P<path>[^/@]+?(?:/[^/@]+?)+?)(?:\.git)?(?:@(?P<ref>[^@]+))?$"
 )
-"""Git SSH URL with git user, optional numeric port, and multi-segment paths. Uses lazy quantifiers to exclude .git from path capture."""
+"""Git SSH URL with arbitrary SSH user, optional numeric port, and multi-segment paths."""

--- a/tracecat/git/types.py
+++ b/tracecat/git/types.py
@@ -8,9 +8,10 @@ class GitUrl:
     host: str
     org: str
     repo: str
+    user: str = "git"
     ref: str | None = None
 
     def to_url(self) -> str:
         """Convert GitUrl to string representation."""
-        base = f"git+ssh://git@{self.host}/{self.org}/{self.repo}.git"
+        base = f"git+ssh://{self.user}@{self.host}/{self.org}/{self.repo}.git"
         return f"{base}@{self.ref}" if self.ref else base

--- a/tracecat/git/utils.py
+++ b/tracecat/git/utils.py
@@ -35,12 +35,17 @@ def parse_git_url(url: str, *, allowed_domains: set[str] | None = None) -> GitUr
         ValueError: If the URL is not a valid repository URL or host not in allowed domains.
     """
     if match := GIT_SSH_URL_REGEX.match(url):
+        user = match.group("user")
         host = match.group("host")
         port = match.group("port")
         path = match.group("path")
         ref = match.group("ref")
 
-        if not isinstance(host, str) or not isinstance(path, str):
+        if (
+            not isinstance(user, str)
+            or not isinstance(host, str)
+            or not isinstance(path, str)
+        ):
             raise ValueError(f"Invalid Git URL: {url}")
 
         # Combine host and port if port is present
@@ -61,7 +66,7 @@ def parse_git_url(url: str, *, allowed_domains: set[str] | None = None) -> GitUr
                 f"Domain {full_host} not in allowed domains. Must be configured in `git_allowed_domains` organization setting."
             )
 
-        return GitUrl(host=full_host, org=org, repo=repo, ref=ref)
+        return GitUrl(host=full_host, org=org, repo=repo, user=user, ref=ref)
 
     raise ValueError(f"Unsupported URL format: {url}. Must be a valid Git SSH URL.")
 
@@ -256,6 +261,7 @@ async def prepare_git_url(
             host=parsed_url.host,
             org=parsed_url.org,
             repo=parsed_url.repo,
+            user=parsed_url.user,
             ref=sha,
         )
     except ValueError as e:

--- a/tracecat/registry/repositories/schemas.py
+++ b/tracecat/registry/repositories/schemas.py
@@ -66,7 +66,7 @@ class RegistryRepositoryCreate(BaseModel):
         # Delegate to shared regex to ensure consistency across validators
         if not GIT_SSH_URL_REGEX.match(v):
             raise TracecatValidationError(
-                "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"
+                "Must be a valid Git SSH URL (e.g., git+ssh://<user>@github.com/org/repo.git)"
             )
         return v
 

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -41,7 +41,7 @@ class GitSettingsUpdate(BaseSettingsGroup):
         # Use shared regex from git utils to ensure consistency across the codebase
         if not GIT_SSH_URL_REGEX.match(value):
             raise ValueError(
-                "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"
+                "Must be a valid Git SSH URL (e.g., git+ssh://<user>@github.com/org/repo.git)"
             )
 
         return value

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -83,7 +83,7 @@ class WorkspaceSettingsUpdate(Schema):
 
         if not GIT_SSH_URL_REGEX.match(value):
             raise ValueError(
-                "Must be a valid Git SSH URL (e.g., git+ssh://git@github.com/org/repo.git)"
+                "Must be a valid Git SSH URL (e.g., git+ssh://<user>@github.com/org/repo.git)"
             )
 
         return value


### PR DESCRIPTION
### Motivation
- The existing Git SSH URL validation assumed the SSH user is `git@`, which rejected GitHub Enterprise and other hosts that use a different SSH user (e.g., `someuser@git.example.com`) and caused clone/auth problems when a deploy key was scoped to a non-`git` user.
- Update validation and parsing so backend and frontend accept arbitrary SSH usernames and preserve them through clone/sync flows.

### Description
- Broadened the shared Git SSH regex to capture an arbitrary SSH user and ref segments that may contain `/` in `tracecat/git/constants.py` and `frontend/src/lib/git.ts`.
- Added `user` to `GitUrl` (default `git`) and updated `to_url()` to include the SSH user in `tracecat/git/types.py`.
- Updated `parse_git_url()` to extract and return the SSH `user` and threaded `user` through places that reconstruct URLs (e.g., `prepare_git_url()` in `tracecat/git/utils.py`).
- Replaced a hard-coded `git@` check in the admin frontend component with the shared `validateGitSshUrl()` helper and updated placeholders/examples to show arbitrary SSH users in multiple UI forms.
- Normalized validation messages in backend schemas (`tracecat/registry/repositories/schemas.py`, `tracecat/settings/schemas.py`, `tracecat/workspaces/schemas.py`) to reference `<user>@host` rather than implying `git@` is required.
- Added/updated unit and frontend regression tests to cover GitHub Enterprise-style SSH users and refs containing slashes (backend tests in `tests/unit/*`, frontend tests in `frontend/tests/*`).
- Noted a separate, unchanged area: `WorkflowStoreService` and GitHub App flows remain GitHub.com-specific (they still restrict allowed domains to `github.com` and use the default `GithubIntegration` client), which is outside the scope of this change.

### Testing
- Ran frontend lint/type checks and tests: `pnpm -C frontend exec biome check --write ...` and `pnpm -C frontend test -- --runInBand tests/git.test.ts tests/org-workspace-settings-form.test.ts tests/org-settings-custom-registry-form.test.ts`; all frontend tests passed.
- Ran Python static checks and type checks: `uv run ruff check --fix ...` and `uv run basedpyright --warnings --threads 4 ...`; these succeeded with no new issues.
- Executed a focused Python validation script that exercises `parse_git_url()`, model validators, and `GitUrl.to_url()`; this passed locally in the environment used for the change.
- Ran the full Python unit test set for git-related modules with `uv run pytest` but the overall pytest run could not complete in this environment because PostgreSQL is not available at `localhost:5432`, causing database-backed tests to fail to start; database-free tests and the ad-hoc validation succeeded.
- Summary: frontend checks/tests and type checks passed; backend unit tests that do not require a live Postgres passed in the environment; full pytest requires a running Postgres instance to complete (known environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16ef8d81c83338674eb86b4a06476)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support arbitrary SSH usernames in Git SSH URLs and allow branch refs with slashes, fixing clone/sync failures for GitHub Enterprise and other custom-host setups.

- **Bug Fixes**
  - Updated shared Git SSH regex to accept any SSH user and `@ref` with slashes in both backend and `frontend/src/lib/git.ts`.
  - Added `user` to `GitUrl` (defaults to `git`) and propagated through `parse_git_url`, `to_url`, and `prepare_git_url`.
  - Replaced hard-coded `git@` checks with `validateGitSshUrl()` and updated placeholders/messages to use `<user>@<host>`.
  - Expanded unit and UI tests for enterprise users and slash refs; aligned backend schema messages to the new format.

<sup>Written for commit a5cf6ef34b7c8b06130e629f32bee8aef31b611c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

