### PR TITLE
infra: Remove provider assume-role vars from Fargate

### DIFF
--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -71,6 +71,8 @@ export TF_VAR_tracecat_image_tag=1.0.0-beta.35
 terraform apply
 ```
 
+For Terraform Cloud direct OIDC runs, the target account and role come from `TFC_AWS_RUN_ROLE_ARN`. This stack now uses the ambient AWS credentials from the execution environment and no longer accepts `aws_account_id` / `aws_role_name` inputs for a second provider-side assume-role hop.
+
 ## Self-contained migrations
 
 - API task startup includes an internal migrations init container.

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -3,9 +3,6 @@ terraform {
 }
 
 locals {
-  # Only set aws_role_arn if both aws_account_id and aws_role_name are provided
-  aws_role_arn = var.aws_account_id != null && var.aws_role_name != null ? "arn:aws:iam::${var.aws_account_id}:role/${var.aws_role_name}" : null
-
   tracecat_db_instance_class    = coalesce(var.tracecat_db_instance_class, var.db_instance_class, "db.t4g.medium")
   temporal_db_instance_class    = coalesce(var.temporal_db_instance_class, var.db_instance_class, "db.t4g.2xlarge")
   tracecat_db_allocated_storage = coalesce(var.tracecat_db_allocated_storage, var.db_allocated_storage, 20)
@@ -16,7 +13,6 @@ module "network" {
   source = "./modules/network"
 
   aws_region     = var.aws_region
-  aws_role_arn   = local.aws_role_arn
   domain_name    = var.domain_name
   hosted_zone_id = var.hosted_zone_id
 }
@@ -25,8 +21,7 @@ module "ecs" {
   source = "./modules/ecs"
 
   # AWS provider
-  aws_region   = var.aws_region
-  aws_role_arn = local.aws_role_arn
+  aws_region = var.aws_region
 
   # Network configuration from network module
   vpc_id                  = module.network.vpc_id
@@ -127,53 +122,53 @@ module "ecs" {
   temporal_api_key_arn = var.temporal_api_key_arn
 
   # Compute / memory
-  api_cpu                                  = var.api_cpu
-  api_memory                               = var.api_memory
-  worker_cpu                               = var.worker_cpu
-  worker_memory                            = var.worker_memory
-  worker_desired_count                     = var.worker_desired_count
-  agent_worker_cpu                         = var.agent_worker_cpu
-  agent_worker_memory                      = var.agent_worker_memory
-  agent_worker_desired_count               = var.agent_worker_desired_count
-  agent_queue                              = var.agent_queue
-  executor_cpu                             = var.executor_cpu
-  executor_memory                          = var.executor_memory
-  executor_desired_count                   = var.executor_desired_count
-  executor_client_timeout                  = var.executor_client_timeout
-  executor_queue                           = var.executor_queue
-  executor_worker_pool_size                = var.executor_worker_pool_size
-  agent_executor_cpu                       = var.agent_executor_cpu
-  agent_executor_memory                    = var.agent_executor_memory
-  agent_executor_desired_count             = var.agent_executor_desired_count
-  agent_executor_queue                     = var.agent_executor_queue
-  agent_executor_max_concurrent_activities = var.agent_executor_max_concurrent_activities
-  agent_executor_worker_pool_size          = var.agent_executor_worker_pool_size
-  llm_proxy_read_timeout                   = var.llm_proxy_read_timeout
-  litellm_num_workers                      = var.litellm_num_workers
-  litellm_credential_cache_ttl_seconds     = var.litellm_credential_cache_ttl_seconds
-  litellm_healthcheck_interval_seconds     = var.litellm_healthcheck_interval_seconds
-  litellm_healthcheck_timeout_seconds      = var.litellm_healthcheck_timeout_seconds
+  api_cpu                                     = var.api_cpu
+  api_memory                                  = var.api_memory
+  worker_cpu                                  = var.worker_cpu
+  worker_memory                               = var.worker_memory
+  worker_desired_count                        = var.worker_desired_count
+  agent_worker_cpu                            = var.agent_worker_cpu
+  agent_worker_memory                         = var.agent_worker_memory
+  agent_worker_desired_count                  = var.agent_worker_desired_count
+  agent_queue                                 = var.agent_queue
+  executor_cpu                                = var.executor_cpu
+  executor_memory                             = var.executor_memory
+  executor_desired_count                      = var.executor_desired_count
+  executor_client_timeout                     = var.executor_client_timeout
+  executor_queue                              = var.executor_queue
+  executor_worker_pool_size                   = var.executor_worker_pool_size
+  agent_executor_cpu                          = var.agent_executor_cpu
+  agent_executor_memory                       = var.agent_executor_memory
+  agent_executor_desired_count                = var.agent_executor_desired_count
+  agent_executor_queue                        = var.agent_executor_queue
+  agent_executor_max_concurrent_activities    = var.agent_executor_max_concurrent_activities
+  agent_executor_worker_pool_size             = var.agent_executor_worker_pool_size
+  llm_proxy_read_timeout                      = var.llm_proxy_read_timeout
+  litellm_num_workers                         = var.litellm_num_workers
+  litellm_credential_cache_ttl_seconds        = var.litellm_credential_cache_ttl_seconds
+  litellm_healthcheck_interval_seconds        = var.litellm_healthcheck_interval_seconds
+  litellm_healthcheck_timeout_seconds         = var.litellm_healthcheck_timeout_seconds
   litellm_healthcheck_connect_timeout_seconds = var.litellm_healthcheck_connect_timeout_seconds
   litellm_healthcheck_read_timeout_seconds    = var.litellm_healthcheck_read_timeout_seconds
   litellm_healthcheck_write_timeout_seconds   = var.litellm_healthcheck_write_timeout_seconds
   litellm_healthcheck_pool_timeout_seconds    = var.litellm_healthcheck_pool_timeout_seconds
-  litellm_healthcheck_failure_threshold    = var.litellm_healthcheck_failure_threshold
-  litellm_status_log_interval_seconds      = var.litellm_status_log_interval_seconds
-  ui_cpu                                   = var.ui_cpu
-  ui_memory                                = var.ui_memory
-  temporal_cpu                             = var.temporal_cpu
-  temporal_memory                          = var.temporal_memory
-  temporal_num_history_shards              = var.temporal_num_history_shards
-  temporal_db_tls_enabled                  = var.temporal_db_tls_enabled
-  temporal_db_tls_enable_host_verification = var.temporal_db_tls_enable_host_verification
-  temporal_db_force_ssl                    = var.temporal_db_force_ssl
-  caddy_cpu                                = var.caddy_cpu
-  caddy_memory                             = var.caddy_memory
-  tracecat_db_instance_class               = local.tracecat_db_instance_class
-  temporal_db_instance_class               = local.temporal_db_instance_class
-  tracecat_db_allocated_storage            = local.tracecat_db_allocated_storage
-  temporal_db_allocated_storage            = local.temporal_db_allocated_storage
-  db_engine_version                        = var.db_engine_version
+  litellm_healthcheck_failure_threshold       = var.litellm_healthcheck_failure_threshold
+  litellm_status_log_interval_seconds         = var.litellm_status_log_interval_seconds
+  ui_cpu                                      = var.ui_cpu
+  ui_memory                                   = var.ui_memory
+  temporal_cpu                                = var.temporal_cpu
+  temporal_memory                             = var.temporal_memory
+  temporal_num_history_shards                 = var.temporal_num_history_shards
+  temporal_db_tls_enabled                     = var.temporal_db_tls_enabled
+  temporal_db_tls_enable_host_verification    = var.temporal_db_tls_enable_host_verification
+  temporal_db_force_ssl                       = var.temporal_db_force_ssl
+  caddy_cpu                                   = var.caddy_cpu
+  caddy_memory                                = var.caddy_memory
+  tracecat_db_instance_class                  = local.tracecat_db_instance_class
+  temporal_db_instance_class                  = local.temporal_db_instance_class
+  tracecat_db_allocated_storage               = local.tracecat_db_allocated_storage
+  temporal_db_allocated_storage               = local.temporal_db_allocated_storage
+  db_engine_version                           = var.db_engine_version
 
   # MCP Service
   enable_mcp                      = var.enable_mcp

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -153,31 +153,31 @@ locals {
       local.tracecat_db_configs,
       local.tracecat_db_configs_executor,
       {
-        TRACECAT__API_URL                                  = local.internal_api_url
-        TRACECAT__DB_ENDPOINT                              = local.core_db_hostname
-        TRACECAT__EXECUTOR_BACKEND                         = "direct"
-        TRACECAT__AGENT_QUEUE                              = var.agent_queue
-        TRACECAT__AGENT_EXECUTOR_QUEUE                     = var.agent_executor_queue
-        TRACECAT__EXECUTOR_QUEUE                           = var.executor_queue
-        TRACECAT__AGENT_EXECUTOR_MAX_CONCURRENT_ACTIVITIES = var.agent_executor_max_concurrent_activities
-        TRACECAT__EXECUTOR_WORKER_POOL_SIZE                = var.agent_executor_worker_pool_size
-        TRACECAT__EXECUTOR_CLIENT_TIMEOUT                  = var.executor_client_timeout
-        TRACECAT__LLM_PROXY_READ_TIMEOUT                   = var.llm_proxy_read_timeout
-        TRACECAT__LITELLM_NUM_WORKERS                      = var.litellm_num_workers
-        TRACECAT__LITELLM_CREDENTIAL_CACHE_TTL_SECONDS     = var.litellm_credential_cache_ttl_seconds
-        TRACECAT__LITELLM_HEALTHCHECK_INTERVAL_SECONDS     = var.litellm_healthcheck_interval_seconds
-        TRACECAT__LITELLM_HEALTHCHECK_TIMEOUT_SECONDS      = var.litellm_healthcheck_timeout_seconds
+        TRACECAT__API_URL                                     = local.internal_api_url
+        TRACECAT__DB_ENDPOINT                                 = local.core_db_hostname
+        TRACECAT__EXECUTOR_BACKEND                            = "direct"
+        TRACECAT__AGENT_QUEUE                                 = var.agent_queue
+        TRACECAT__AGENT_EXECUTOR_QUEUE                        = var.agent_executor_queue
+        TRACECAT__EXECUTOR_QUEUE                              = var.executor_queue
+        TRACECAT__AGENT_EXECUTOR_MAX_CONCURRENT_ACTIVITIES    = var.agent_executor_max_concurrent_activities
+        TRACECAT__EXECUTOR_WORKER_POOL_SIZE                   = var.agent_executor_worker_pool_size
+        TRACECAT__EXECUTOR_CLIENT_TIMEOUT                     = var.executor_client_timeout
+        TRACECAT__LLM_PROXY_READ_TIMEOUT                      = var.llm_proxy_read_timeout
+        TRACECAT__LITELLM_NUM_WORKERS                         = var.litellm_num_workers
+        TRACECAT__LITELLM_CREDENTIAL_CACHE_TTL_SECONDS        = var.litellm_credential_cache_ttl_seconds
+        TRACECAT__LITELLM_HEALTHCHECK_INTERVAL_SECONDS        = var.litellm_healthcheck_interval_seconds
+        TRACECAT__LITELLM_HEALTHCHECK_TIMEOUT_SECONDS         = var.litellm_healthcheck_timeout_seconds
         TRACECAT__LITELLM_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS = var.litellm_healthcheck_connect_timeout_seconds
         TRACECAT__LITELLM_HEALTHCHECK_READ_TIMEOUT_SECONDS    = var.litellm_healthcheck_read_timeout_seconds
         TRACECAT__LITELLM_HEALTHCHECK_WRITE_TIMEOUT_SECONDS   = var.litellm_healthcheck_write_timeout_seconds
         TRACECAT__LITELLM_HEALTHCHECK_POOL_TIMEOUT_SECONDS    = var.litellm_healthcheck_pool_timeout_seconds
-        TRACECAT__LITELLM_HEALTHCHECK_FAILURE_THRESHOLD    = var.litellm_healthcheck_failure_threshold
-        TRACECAT__LITELLM_STATUS_LOG_INTERVAL_SECONDS      = var.litellm_status_log_interval_seconds
-        TRACECAT__UNSAFE_DISABLE_SM_MASKING                = "false"
-        TRACECAT__DISABLE_NSJAIL                           = "true"
-        TRACECAT__SANDBOX_NSJAIL_PATH                      = "/usr/local/bin/nsjail"
-        TRACECAT__SANDBOX_ROOTFS_PATH                      = "/var/lib/tracecat/sandbox-rootfs"
-        TRACECAT__SANDBOX_CACHE_DIR                        = "/var/lib/tracecat/sandbox-cache"
+        TRACECAT__LITELLM_HEALTHCHECK_FAILURE_THRESHOLD       = var.litellm_healthcheck_failure_threshold
+        TRACECAT__LITELLM_STATUS_LOG_INTERVAL_SECONDS         = var.litellm_status_log_interval_seconds
+        TRACECAT__UNSAFE_DISABLE_SM_MASKING                   = "false"
+        TRACECAT__DISABLE_NSJAIL                              = "true"
+        TRACECAT__SANDBOX_NSJAIL_PATH                         = "/usr/local/bin/nsjail"
+        TRACECAT__SANDBOX_ROOTFS_PATH                         = "/var/lib/tracecat/sandbox-rootfs"
+        TRACECAT__SANDBOX_CACHE_DIR                           = "/var/lib/tracecat/sandbox-cache"
       }
     ) :
     { name = k, value = tostring(v) } if v != null

--- a/deployments/fargate/modules/ecs/main.tf
+++ b/deployments/fargate/modules/ecs/main.tf
@@ -23,10 +23,4 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  dynamic "assume_role" {
-    for_each = var.aws_role_arn != null ? [1] : []
-    content {
-      role_arn = var.aws_role_arn
-    }
-  }
 }

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -5,12 +5,6 @@ variable "aws_region" {
   description = "AWS region (secrets and hosted zone must be in the same region)"
 }
 
-variable "aws_role_arn" {
-  type        = string
-  description = "The ARN of the AWS role to assume"
-  default     = null
-}
-
 ### Networking
 
 variable "is_internal" {

--- a/deployments/fargate/modules/network/main.tf
+++ b/deployments/fargate/modules/network/main.tf
@@ -19,10 +19,4 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  dynamic "assume_role" {
-    for_each = var.aws_role_arn != null ? [1] : []
-    content {
-      role_arn = var.aws_role_arn
-    }
-  }
 }

--- a/deployments/fargate/modules/network/variables.tf
+++ b/deployments/fargate/modules/network/variables.tf
@@ -5,12 +5,6 @@ variable "aws_region" {
   description = "AWS region (secrets and hosted zone must be in the same region)"
 }
 
-variable "aws_role_arn" {
-  type        = string
-  description = "The ARN of the AWS role to assume"
-  default     = null
-}
-
 ## DNS
 
 variable "domain_name" {

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -5,18 +5,6 @@ variable "aws_region" {
   description = "AWS region (secrets and hosted zone must be in the same region)"
 }
 
-variable "aws_account_id" {
-  type        = string
-  description = "(Optional) Account ID to deploy Tracecat into. Only required if deploying cross-account."
-  default     = null
-}
-
-variable "aws_role_name" {
-  type        = string
-  description = "(Optional) AWS role name for Terraform to assume to deploy Tracecat. Only required if deploying cross-account."
-  default     = null
-}
-
 ### DNS
 
 variable "domain_name" {


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the extra provider assume-role hop from the Fargate Terraform stack. The stack now uses the ambient AWS credentials (or Terraform Cloud OIDC) and no longer accepts cross-account assume-role inputs.

- **Refactors**
  - Removed `aws_account_id`, `aws_role_name`, and `aws_role_arn` variables.
  - Dropped provider `assume_role` blocks from `modules/network` and `modules/ecs`.
  - Updated README to clarify `TFC_AWS_RUN_ROLE_ARN` for Terraform Cloud OIDC.

- **Migration**
  - Delete `aws_account_id`, `aws_role_name`, and `aws_role_arn` from your `tfvars` and pipelines.
  - Ensure ambient AWS credentials are available to Terraform.
  - For Terraform Cloud OIDC, set `TFC_AWS_RUN_ROLE_ARN` for the target account/role.

<sup>Written for commit 139a20b88bc2b3a4c8facc9127fbe2f9c794d1a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

