### PR TITLE
fix: codex mcp

### DIFF
--- a/deployments/fargate/modules/ecs/alb.tf
+++ b/deployments/fargate/modules/ecs/alb.tf
@@ -120,6 +120,20 @@ resource "aws_wafv2_web_acl" "this" {
         }
 
         rule_action_override {
+          name = "GenericRFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
+          name = "GenericRFI_QUERYARGUMENTS"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
           name = "EC2MetaDataSSRF_BODY"
           action_to_use {
             count {}
@@ -352,7 +366,7 @@ resource "aws_wafv2_web_acl" "this" {
 
   rule {
     name     = "BlockSSRFExceptMcpOAuth"
-    priority = 8
+    priority = 9
 
     action {
       block {}
@@ -406,10 +420,69 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
+  # Custom rule to block IPv4 URL inclusion except for MCP OAuth endpoints.
+  # Local MCP clients can legitimately register loopback redirect URIs such as
+  # 127.0.0.1 in DCR bodies and authorization query strings.
+  rule {
+    name     = "BlockRFIExceptMcpOAuth"
+    priority = 8
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          or_statement {
+            statement {
+              label_match_statement {
+                scope = "LABEL"
+                key   = "awswaf:managed:aws:core-rule-set:GenericRFI_Body"
+              }
+            }
+
+            statement {
+              label_match_statement {
+                scope = "LABEL"
+                key   = "awswaf:managed:aws:core-rule-set:GenericRFI_QueryArguments"
+              }
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              regex_pattern_set_reference_statement {
+                arn = aws_wafv2_regex_pattern_set.mcp_oauth_endpoints[0].arn
+
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockRFIExceptMcpOAuth"
+      sampled_requests_enabled   = true
+    }
+  }
+
   # Custom rule to block oversized query strings except for attachment uploads
   rule {
     name     = "BlockQueryStringSizeExceptAttachments"
-    priority = 9
+    priority = 10
 
     action {
       block {}
@@ -473,7 +546,7 @@ resource "aws_wafv2_regex_pattern_set" "mcp_oauth_endpoints" {
   count = var.enable_waf ? 1 : 0
 
   name        = "mcp-oauth-endpoints-pattern"
-  description = "Matches MCP OAuth endpoints that carry localhost redirect URIs"
+  description = "Matches MCP OAuth endpoints that carry loopback redirect URIs"
   scope       = "REGIONAL"
 
   regular_expression {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow MCP OAuth flows that use loopback redirect URIs (e.g., 127.0.0.1) by refining WAF rules, while keeping RFI/SSRF protections intact. This unblocks local MCP clients without widening exposure.

- **Bug Fixes**
  - Added custom WAF rule `BlockRFIExceptMcpOAuth` to block RFI but exempt MCP OAuth endpoints matched by `mcp-oauth-endpoints-pattern`.
  - Changed managed CRS actions for `GenericRFI_BODY` and `GenericRFI_QUERYARGUMENTS` to count-only; rely on the custom rule for blocking.
  - Adjusted rule priorities: SSRF rule to 9, query-string-size rule to 10.
  - Clarified pattern set description to “loopback redirect URIs” and bumped `deployments/k8s` submodule.

<sup>Written for commit 5a2ad5cfb382df683936f57401084e5fffc078c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

