### PR TITLE
build: Pin pyasn1 and requests for security fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,8 @@ members = ["packages/*"]
 # - grpcio-tools pinned in tracecat-registry
 # - chardet 7.0 removed chardet.universaldetector, breaking polyfile 0.5.6
 override-dependencies = [
+    "pyasn1==0.6.3",
+    "requests==2.33.0",
     "uvicorn==0.35.0",
     "boto3==1.40.61",
     "python-multipart==0.0.22",

--- a/uv.lock
+++ b/uv.lock
@@ -21,8 +21,10 @@ overrides = [
     { name = "grpcio", specifier = "==1.75.1" },
     { name = "grpcio-tools", specifier = "==1.75.1" },
     { name = "pillow", specifier = "==12.1.1" },
+    { name = "pyasn1", specifier = "==0.6.3" },
     { name = "pyjwt", specifier = "==2.12.1" },
     { name = "python-multipart", specifier = "==0.0.22" },
+    { name = "requests", specifier = "==2.33.0" },
     { name = "rich", specifier = "==13.9.4" },
     { name = "uvicorn", specifier = "==0.35.0" },
 ]
@@ -1609,6 +1611,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -3192,11 +3195,11 @@ memory = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
 ]
 
 [[package]]
@@ -3888,7 +3891,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -3896,9 +3899,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This change addresses the dependabot security finding for `pyasn1` and `requests` in the uv-managed Python workspace.

The issue was that both packages were present only as transitive dependencies in the resolved environment, so the repository was not explicitly forcing the patched versions during future resolves. That meant the lockfile could remain on vulnerable versions even though none of the current top-level packages actually required those older releases.

The fix adds exact workspace-level uv override pins for `pyasn1==0.6.3` and `requests==2.33.0` in the root `pyproject.toml`, then regenerates `uv.lock` with `uv sync`. This keeps the project dependency surface unchanged while forcing the safe versions everywhere they appear transitively.

For users, the effect is that fresh syncs and future lock refreshes now consistently resolve the patched packages instead of relying on the previous lockfile state. No API or runtime behavior changes are intended beyond the dependency updates.

Validation for this change was done with `uv sync`, `uv tree --locked --package pyasn1`, `uv tree --locked --package requests`, and `uv lock --check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `pyasn1` to 0.6.3 and `requests` to 2.33.0 using uv overrides to address security advisories and ensure future resolves use patched versions. No functional changes.

- **Dependencies**
  - Added `override-dependencies` in the root `pyproject.toml`.
  - Regenerated `uv.lock` to apply the pins.

<sup>Written for commit 2b7fe916d2033a8e80160e2775ab57c6c85e5779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

