### PR TITLE
fix(temporal): fail immediately when workflow definition is missing

### DIFF
--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -3391,7 +3391,7 @@ async def test_workflow_error_handler_success(
     [
         pytest.param(
             "wf-00000000000000000000000000000000",
-            "TracecatException: Workflow definition not found for wf_0000000000000000000000, version=None",
+            "Workflow definition not found for wf_0000000000000000000000, version=None",
             id="id-no-match",
         ),
         pytest.param(

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -8,7 +8,7 @@ from temporalio.exceptions import ApplicationError
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
-from tracecat.exceptions import EntitlementRequired, TracecatException
+from tracecat.exceptions import EntitlementRequired
 from tracecat.identifiers.workflow import WorkflowID
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
@@ -122,7 +122,7 @@ async def get_workflow_definition_activity(
         if not defn:
             msg = f"Workflow definition not found for {input.workflow_id.short()}, version={input.version}"
             logger.error(msg)
-            raise TracecatException(msg)
+            raise ApplicationError(msg, non_retryable=True)
         dsl = DSLInput(**defn.content)
     # Convert from DB dict type to RegistryLock (JSONB deserializes to dict)
     registry_lock = (


### PR DESCRIPTION
## Summary
- Make `get_workflow_definition_activity` fail immediately (non-retryable) when a workflow definition is missing, instead of retrying 6 times via Temporal
- Uses `ApplicationError(non_retryable=True)` instead of `TracecatException`

## Context
Sentry TEMPORAL-S8: a scheduled workflow (`wf_7dbyxZolG7T5Frgvb2idTe`) with no committed definition was firing every minute, producing 6 retry errors per execution. The definition lookup will never succeed on retry since the data simply doesn't exist.

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Trigger a workflow that has no committed definition and confirm it fails immediately without retries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the activity immediately when a workflow definition is missing so Temporal doesn’t retry and spam errors. This reduces noise and unnecessary load.

- **Bug Fixes**
  - In `get_workflow_definition_activity`, raise `ApplicationError(non_retryable=True)` when no definition is found (replacing `TracecatException`), and update tests to expect the new error message.

<sup>Written for commit 1d3796ae6938f61d744cee65b52c2cd0634443f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

