### PR TITLE
fix(ui): use backend entitlements for agent preset action locking

### DIFF
--- a/frontend/src/components/builder/canvas/canvas-toolbar.tsx
+++ b/frontend/src/components/builder/canvas/canvas-toolbar.tsx
@@ -150,20 +150,8 @@ const TRANSFORM_TOP = [
 const SQL_TOP = ["core.duckdb.execute_sql", "core.sql.execute_query"]
 const AI_TOP = ["ai.action", "ai.ranker", "ai.slackbot"]
 const AGENT_TOP = ["ai.agent", "ai.preset_agent"]
-const FORCE_LOCKED_PRESET_ACTIONS = new Set([
-  "ai.agent.create_preset",
-  "ai.agent.delete_preset",
-  "ai.agent.get_preset",
-  "ai.agent.list_presets",
-  "ai.agent.update_preset",
-  "ai.preset_agent",
-])
-
 function isLockedAction(action: RegistryActionReadMinimal): boolean {
-  return (
-    FORCE_LOCKED_PRESET_ACTIONS.has(action.action) ||
-    (action.availability?.locked ?? false)
-  )
+  return action.availability?.locked ?? false
 }
 
 const WORKFLOW_EXTRA_ACTIONS = new Set([

--- a/frontend/src/components/builder/canvas/selector-node.tsx
+++ b/frontend/src/components/builder/canvas/selector-node.tsx
@@ -52,20 +52,8 @@ const SEARCH_KEY_INDEX: Record<(typeof SEARCH_KEYS)[number], number> =
     {} as Record<(typeof SEARCH_KEYS)[number], number>
   )
 
-const FORCE_LOCKED_PRESET_ACTIONS = new Set([
-  "ai.agent.create_preset",
-  "ai.agent.delete_preset",
-  "ai.agent.get_preset",
-  "ai.agent.list_presets",
-  "ai.agent.update_preset",
-  "ai.preset_agent",
-])
-
 function isLockedAction(action: RegistryActionReadMinimal): boolean {
-  return (
-    FORCE_LOCKED_PRESET_ACTIONS.has(action.action) ||
-    (action.availability?.locked ?? false)
-  )
+  return action.availability?.locked ?? false
 }
 
 function filterActions(actions: RegistryActionReadMinimal[], search: string) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use backend entitlements to lock agent preset actions instead of hard-coded UI rules, so the canvas shows the correct locked state for each user. This aligns the toolbar and selector with the server’s `availability.locked` flag.

- **Bug Fixes**
  - Removed the `FORCE_LOCKED_PRESET_ACTIONS` list and now rely only on `action.availability?.locked`.
  - Applied in the canvas toolbar and selector node to reflect real user entitlements.

<sup>Written for commit 56627104415f6516f5e47b221f4f07c7ead0341d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

